### PR TITLE
feat(admin): P6 — Evidence Integrity, Content and Asset Operations Maturity

### DIFF
--- a/reports/capacity/latest-evidence-summary.json
+++ b/reports/capacity/latest-evidence-summary.json
@@ -1,1 +1,89 @@
-{ "schema": 2, "metrics": {}, "generatedAt": null }
+{
+  "schema": 3,
+  "generatedAt": "2026-04-28T23:31:45.828Z",
+  "sources": {
+    "capacity_evidence": {
+      "file": "reports/capacity/evidence/",
+      "found": true
+    },
+    "admin_smoke": {
+      "file": "reports/admin-smoke/latest.json",
+      "found": false
+    },
+    "bootstrap_smoke": {
+      "file": "reports/bootstrap-smoke/latest.json",
+      "found": false
+    },
+    "csp_status": {
+      "file": "worker/src/security-headers.js",
+      "found": true
+    },
+    "d1_migrations": {
+      "file": "worker/migrations/",
+      "found": true
+    },
+    "build_version": {
+      "file": "package.json",
+      "found": true
+    },
+    "kpi_reconcile": {
+      "file": "reports/kpi-reconcile/latest.json",
+      "found": false
+    }
+  },
+  "metrics": {
+    "certified_30_learner_beta": {
+      "tier": "certified_30_learner_beta",
+      "ok": false,
+      "dryRun": false,
+      "learners": 30,
+      "finishedAt": "2026-04-28T21:33:08.171Z",
+      "commit": "1c56e069c4bd95828328410bec3fef81564677ca",
+      "failures": [
+        "maxBootstrapP95Ms"
+      ],
+      "thresholdsPassed": false,
+      "fileName": "30-learner-beta-v2-20260428-p5-warm.json"
+    },
+    "certified_60_learner_stretch": {
+      "tier": "certified_60_learner_stretch",
+      "ok": false,
+      "dryRun": false,
+      "learners": 60,
+      "finishedAt": null,
+      "commit": "42ec29b41ba9cca9fc39d38cc29f08e6c71d4cf9",
+      "failures": [],
+      "thresholdsPassed": null,
+      "fileName": "60-learner-stretch-preflight-20260428.json"
+    },
+    "csp_status": {
+      "tier": "csp_status",
+      "ok": false,
+      "dryRun": false,
+      "mode": "report-only",
+      "finishedAt": null,
+      "commit": null,
+      "failures": [
+        "csp_mode_is_report-only"
+      ]
+    },
+    "d1_migrations": {
+      "tier": "d1_migrations",
+      "ok": true,
+      "dryRun": false,
+      "count": 14,
+      "finishedAt": null,
+      "commit": null,
+      "failures": []
+    },
+    "build_version": {
+      "tier": "build_version",
+      "ok": true,
+      "dryRun": false,
+      "version": "0.1.0",
+      "finishedAt": null,
+      "commit": null,
+      "failures": []
+    }
+  }
+}

--- a/scripts/generate-evidence-summary.mjs
+++ b/scripts/generate-evidence-summary.mjs
@@ -1,13 +1,22 @@
 #!/usr/bin/env node
 // generate-evidence-summary.mjs
 //
-// Reads evidence files from reports/capacity/evidence/ and emits a summary
-// at reports/capacity/latest-evidence-summary.json.  Uses the schema version
-// from scripts/lib/capacity-evidence.mjs for forward-compatibility.
+// Schema 3: Multi-source evidence aggregator.
+// Reads evidence from multiple source directories and emits a unified summary
+// at reports/capacity/latest-evidence-summary.json.
+//
+// Sources:
+//   - Capacity tiers     → reports/capacity/evidence/*.json
+//   - Admin smoke        → reports/admin-smoke/latest.json
+//   - Bootstrap smoke    → reports/bootstrap-smoke/latest.json
+//   - CSP status         → worker/src/security-headers.js (CSP_ENFORCEMENT_MODE)
+//   - D1 migrations      → worker/migrations/ (file count)
+//   - Build version      → package.json version
+//   - KPI reconcile      → reports/kpi-reconcile/latest.json
 //
 // Usage:  node scripts/generate-evidence-summary.mjs [--verbose]
 
-import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { readdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { resolve, join } from 'node:path';
 import { EVIDENCE_SCHEMA_VERSION } from './lib/capacity-evidence.mjs';
 
@@ -15,7 +24,6 @@ const ROOT = resolve(import.meta.url.startsWith('file://')
   ? new URL('..', import.meta.url).pathname.replace(/^\/([A-Z]:)/i, '$1')
   : process.cwd());
 
-const EVIDENCE_DIR = join(ROOT, 'reports', 'capacity', 'evidence');
 const OUTPUT_PATH = join(ROOT, 'reports', 'capacity', 'latest-evidence-summary.json');
 
 const verbose = process.argv.includes('--verbose');
@@ -24,7 +32,13 @@ function log(...args) {
   if (verbose) console.error('[evidence-summary]', ...args);
 }
 
-function readEvidenceFiles() {
+// ---------------------------------------------------------------------------
+// Source: capacity evidence tier files
+// ---------------------------------------------------------------------------
+
+const EVIDENCE_DIR = join(ROOT, 'reports', 'capacity', 'evidence');
+
+function readCapacityEvidenceFiles() {
   let entries;
   try {
     entries = readdirSync(EVIDENCE_DIR).filter((f) => f.endsWith('.json'));
@@ -54,7 +68,7 @@ function classifyTier(fileName) {
   return 'unknown';
 }
 
-function buildMetrics(files) {
+function buildCapacityMetrics(files) {
   const metrics = {};
   for (const { name, data } of files) {
     const tier = classifyTier(name);
@@ -85,17 +99,202 @@ function buildMetrics(files) {
   return metrics;
 }
 
-function run() {
-  const files = readEvidenceFiles();
-  log(`Found ${files.length} evidence file(s).`);
+// ---------------------------------------------------------------------------
+// Source: JSON report file (admin-smoke, bootstrap-smoke, kpi-reconcile)
+// ---------------------------------------------------------------------------
 
-  const metrics = buildMetrics(files);
+/**
+ * Read a JSON report file and extract a metric entry.
+ * @param {string} filePath - absolute path to the JSON file
+ * @param {string} tierKey - the tier key to assign (e.g. 'admin_smoke')
+ * @returns {{ metric: object|null, found: boolean }}
+ */
+function readJsonSource(filePath, tierKey) {
+  if (!existsSync(filePath)) {
+    return { metric: null, found: false };
+  }
+  try {
+    const content = readFileSync(filePath, 'utf8');
+    const data = JSON.parse(content);
+    if (!data || typeof data !== 'object') {
+      log(`Source ${filePath}: parsed but not an object`);
+      return { metric: null, found: true };
+    }
+    return {
+      metric: {
+        tier: tierKey,
+        ok: Boolean(data.ok),
+        dryRun: Boolean(data.dryRun),
+        learners: data.learners ?? data?.reportMeta?.learners ?? null,
+        finishedAt: data.finishedAt || data?.reportMeta?.finishedAt || null,
+        commit: data.commit || data?.reportMeta?.commit || null,
+        failures: Array.isArray(data.failures) ? data.failures : [],
+        fileName: filePath.replace(ROOT + '/', '').replace(ROOT + '\\', ''),
+      },
+      found: true,
+    };
+  } catch (err) {
+    log(`Source ${filePath}: malformed — ${err.message}`);
+    return { metric: null, found: true };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Source: CSP enforcement mode (static analysis)
+// ---------------------------------------------------------------------------
+
+function readCspStatus() {
+  const secHeadersPath = join(ROOT, 'worker', 'src', 'security-headers.js');
+  if (!existsSync(secHeadersPath)) {
+    return { metric: null, found: false };
+  }
+  try {
+    const content = readFileSync(secHeadersPath, 'utf8');
+    const match = content.match(/CSP_ENFORCEMENT_MODE\s*=\s*['"]([^'"]+)['"]/);
+    const mode = match ? match[1] : 'unknown';
+    return {
+      metric: {
+        tier: 'csp_status',
+        ok: mode === 'enforced',
+        dryRun: false,
+        mode,
+        finishedAt: null,
+        commit: null,
+        failures: mode === 'enforced' ? [] : [`csp_mode_is_${mode}`],
+      },
+      found: true,
+    };
+  } catch (err) {
+    log(`CSP source read failed: ${err.message}`);
+    return { metric: null, found: true };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Source: D1 migration count
+// ---------------------------------------------------------------------------
+
+function readMigrationCount() {
+  const migrationsDir = join(ROOT, 'worker', 'migrations');
+  if (!existsSync(migrationsDir)) {
+    return { metric: null, found: false };
+  }
+  try {
+    const entries = readdirSync(migrationsDir).filter((f) => f.endsWith('.sql'));
+    return {
+      metric: {
+        tier: 'd1_migrations',
+        ok: entries.length > 0,
+        dryRun: false,
+        count: entries.length,
+        finishedAt: null,
+        commit: null,
+        failures: [],
+      },
+      found: true,
+    };
+  } catch (err) {
+    log(`Migrations read failed: ${err.message}`);
+    return { metric: null, found: true };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Source: Build version from package.json
+// ---------------------------------------------------------------------------
+
+function readBuildVersion() {
+  const pkgPath = join(ROOT, 'package.json');
+  if (!existsSync(pkgPath)) {
+    return { metric: null, found: false };
+  }
+  try {
+    const content = readFileSync(pkgPath, 'utf8');
+    const pkg = JSON.parse(content);
+    return {
+      metric: {
+        tier: 'build_version',
+        ok: Boolean(pkg.version),
+        dryRun: false,
+        version: pkg.version || null,
+        finishedAt: null,
+        commit: null,
+        failures: [],
+      },
+      found: true,
+    };
+  } catch (err) {
+    log(`package.json read failed: ${err.message}`);
+    return { metric: null, found: true };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main aggregation
+// ---------------------------------------------------------------------------
+
+/** @typedef {{ file: string, found: boolean }} SourceEntry */
+
+export function aggregateSources(rootDir) {
+  const root = rootDir || ROOT;
+  const sources = {};
+  const metrics = {};
+
+  // 1. Capacity tier evidence files
+  const capacityFiles = readCapacityEvidenceFiles();
+  log(`Found ${capacityFiles.length} capacity evidence file(s).`);
+  const capacityMetrics = buildCapacityMetrics(capacityFiles);
+  sources.capacity_evidence = {
+    file: 'reports/capacity/evidence/',
+    found: capacityFiles.length > 0,
+  };
+  Object.assign(metrics, capacityMetrics);
+
+  // 2. Admin smoke
+  const adminSmokePath = join(root, 'reports', 'admin-smoke', 'latest.json');
+  const adminSmoke = readJsonSource(adminSmokePath, 'admin_smoke');
+  sources.admin_smoke = { file: 'reports/admin-smoke/latest.json', found: adminSmoke.found };
+  if (adminSmoke.metric) metrics.admin_smoke = adminSmoke.metric;
+
+  // 3. Bootstrap smoke
+  const bootstrapSmokePath = join(root, 'reports', 'bootstrap-smoke', 'latest.json');
+  const bootstrapSmoke = readJsonSource(bootstrapSmokePath, 'bootstrap_smoke');
+  sources.bootstrap_smoke = { file: 'reports/bootstrap-smoke/latest.json', found: bootstrapSmoke.found };
+  if (bootstrapSmoke.metric) metrics.bootstrap_smoke = bootstrapSmoke.metric;
+
+  // 4. CSP status
+  const csp = readCspStatus();
+  sources.csp_status = { file: 'worker/src/security-headers.js', found: csp.found };
+  if (csp.metric) metrics.csp_status = csp.metric;
+
+  // 5. D1 migrations
+  const migrations = readMigrationCount();
+  sources.d1_migrations = { file: 'worker/migrations/', found: migrations.found };
+  if (migrations.metric) metrics.d1_migrations = migrations.metric;
+
+  // 6. Build version
+  const buildVersion = readBuildVersion();
+  sources.build_version = { file: 'package.json', found: buildVersion.found };
+  if (buildVersion.metric) metrics.build_version = buildVersion.metric;
+
+  // 7. KPI reconcile
+  const kpiPath = join(root, 'reports', 'kpi-reconcile', 'latest.json');
+  const kpi = readJsonSource(kpiPath, 'kpi_reconcile');
+  sources.kpi_reconcile = { file: 'reports/kpi-reconcile/latest.json', found: kpi.found };
+  if (kpi.metric) metrics.kpi_reconcile = kpi.metric;
+
+  return { sources, metrics };
+}
+
+function run() {
+  const { sources, metrics } = aggregateSources(ROOT);
   const now = new Date().toISOString();
 
   const summary = {
     schema: EVIDENCE_SCHEMA_VERSION,
-    metrics,
     generatedAt: now,
+    sources,
+    metrics,
   };
 
   writeFileSync(OUTPUT_PATH, JSON.stringify(summary, null, 2) + '\n');

--- a/scripts/lib/capacity-evidence.mjs
+++ b/scripts/lib/capacity-evidence.mjs
@@ -3,7 +3,7 @@ import { execSync } from 'node:child_process';
 import { mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 
-export const EVIDENCE_SCHEMA_VERSION = 2;
+export const EVIDENCE_SCHEMA_VERSION = 3;
 
 // Request-sample cap per endpoint when --include-request-samples is enabled.
 // Plan says 100 + 100 (first N and last N); this preserves post-mortem utility

--- a/src/main.js
+++ b/src/main.js
@@ -3135,6 +3135,20 @@ function handleGlobalAction(action, data) {
     return true;
   }
 
+  if (action === 'asset-publish') {
+    if (data?.assetId === 'monster-visual-config') {
+      publishMonsterVisualConfig(data);
+    }
+    return true;
+  }
+
+  if (action === 'asset-restore') {
+    if (data?.assetId === 'monster-visual-config') {
+      restoreMonsterVisualConfigVersion(data);
+    }
+    return true;
+  }
+
   // PR #188 H1: each per-panel Refresh button now issues a narrow GET and
   // patches only its sibling field on the local adminHub model. This honours
   // R18 (dedicated per-panel GETs) and fixes the visible bug where clicking

--- a/src/main.js
+++ b/src/main.js
@@ -30,6 +30,7 @@ import {
 import { routeAdminRefreshError } from './platform/hubs/admin-refresh-error-text.js';
 import { createAccountOpsMetadataDirtyRegistry } from './platform/hubs/admin-metadata-dirty-registry.js';
 import { runAdminOpsRefreshCascade } from './platform/hubs/admin-refresh-cascade.js';
+import { buildRefreshErrorEnvelope } from './platform/hubs/admin-refresh-envelope.js';
 import {
   buildAdminHubAccessContext,
   buildParentHubAccessContext,
@@ -1163,17 +1164,7 @@ function isAdminOpsRefreshTokenLatest(panelKey, token) {
 // consumes from a thrown hub-api error (see platform/hubs/api.js). `code` is
 // taken verbatim from the Worker payload when present; `network` is the
 // fallback for fetch rejections / malformed envelopes.
-function buildRefreshErrorEnvelope(error) {
-  const code = typeof error?.code === 'string' && error.code ? error.code : 'network';
-  const message = typeof error?.message === 'string' ? error.message : '';
-  const correlationId = error?.payload?.correlationId || error?.correlationId || null;
-  return {
-    code,
-    message,
-    correlationId,
-    at: Date.now(),
-  };
-}
+// Implementation extracted to platform/hubs/admin-refresh-envelope.js (P6 U10).
 
 // P1.5 Phase A (U1): when the router hands off to a global handler (session
 // invalidated, account suspended), the panel-level banner is skipped — we

--- a/src/platform/hubs/admin-action-classification.js
+++ b/src/platform/hubs/admin-action-classification.js
@@ -42,6 +42,11 @@ const REGISTRY = new Map([
   ['monster-visual-config-publish', { level: LEVELS.high }],
   ['monster-visual-config-restore', { level: LEVELS.high }],
   ['grammar-transfer-admin-archive', { level: LEVELS.high }],
+  ['asset-publish', { level: LEVELS.high }],
+  ['asset-restore', { level: LEVELS.high }],
+
+  // medium: asset draft deletion (recoverable via restore)
+  ['asset-delete-draft', { level: LEVELS.medium }],
 
   // critical: broad-audience mutations, irreversible deletes, seed operations
   ['post-mega-seed-apply', { level: LEVELS.critical }],

--- a/src/platform/hubs/admin-asset-registry.js
+++ b/src/platform/hubs/admin-asset-registry.js
@@ -30,6 +30,10 @@
  * @property {boolean} hasDraft      — whether a draft document exists
  * @property {boolean} hasPublished  — whether a published document exists
  * @property {Array}  versions       — available version history for restore
+ * @property {Array<string>} publishBlockers — blocker descriptions (empty = can publish)
+ * @property {string|null} previewUrl — URL for asset preview (null = no preview)
+ * @property {string|null} reducedMotionStatus — reduced-motion variant state
+ * @property {string|null} fallbackStatus — fallback asset state
  */
 
 function isPlainObject(value) {
@@ -64,11 +68,48 @@ function deriveReviewStatus(validation) {
  *   config has never been initialised.
  * @returns {RegistryEntry}
  */
+/**
+ * Derive publish blockers from the validation state and draft presence.
+ * Returns an array of human-readable blocker descriptions. Empty array = OK to publish.
+ */
+function derivePublishBlockers(validation, hasDraft, canManage) {
+  const blockers = [];
+  if (!canManage) {
+    blockers.push('Insufficient permissions to publish this asset.');
+  }
+  if (!hasDraft) {
+    blockers.push('No draft exists — nothing to publish.');
+  }
+  if (isPlainObject(validation) && 'ok' in validation && !validation.ok) {
+    const count = safeNonNegativeInt(validation.errorCount);
+    if (count > 0) {
+      blockers.push(`${count} validation error${count === 1 ? '' : 's'} must be resolved.`);
+    }
+  }
+  return blockers;
+}
+
 export function buildMonsterVisualRegistryEntry(monsterVisualConfig) {
   const mvc = isPlainObject(monsterVisualConfig) ? monsterVisualConfig : {};
   const status = isPlainObject(mvc.status) ? mvc.status : {};
   const validation = isPlainObject(status.validation) ? status.validation : {};
   const permissions = isPlainObject(mvc.permissions) ? mvc.permissions : {};
+
+  const canManage = permissions.canManageMonsterVisualConfig === true;
+  const hasDraft = mvc.draft != null && isPlainObject(mvc.draft);
+
+  // P6 U8: preview URL — derived from status when available (Worker provides it).
+  const previewUrl = typeof status.previewUrl === 'string' && status.previewUrl
+    ? status.previewUrl
+    : null;
+
+  // P6 U8: reduced-motion and fallback status — surfaced from the asset metadata.
+  const reducedMotionStatus = typeof status.reducedMotionStatus === 'string'
+    ? status.reducedMotionStatus
+    : null;
+  const fallbackStatus = typeof status.fallbackStatus === 'string'
+    ? status.fallbackStatus
+    : null;
 
   return {
     assetId: 'monster-visual-config',
@@ -87,10 +128,14 @@ export function buildMonsterVisualRegistryEntry(monsterVisualConfig) {
     },
     lastPublishedAt: safeNonNegativeInt(status.publishedAt),
     lastPublishedBy: safeString(status.publishedByAccountId, ''),
-    canManage: permissions.canManageMonsterVisualConfig === true,
-    hasDraft: mvc.draft != null && isPlainObject(mvc.draft),
+    canManage,
+    hasDraft,
     hasPublished: mvc.published != null && isPlainObject(mvc.published),
     versions: Array.isArray(mvc.versions) ? mvc.versions : [],
+    publishBlockers: derivePublishBlockers(validation, hasDraft, canManage),
+    previewUrl,
+    reducedMotionStatus,
+    fallbackStatus,
   };
 }
 

--- a/src/platform/hubs/admin-content-overview.js
+++ b/src/platform/hubs/admin-content-overview.js
@@ -1,4 +1,6 @@
 // U9 (Admin Console P3): Content Management cross-subject overview.
+// U6 (Admin Console P6): Extended with release readiness classification,
+// validation blocker/warning signals, and truthful drilldown clickability.
 //
 // Subject status provider contract + cross-subject normaliser. Inspired
 // by the Hero P0 read-only shadow subsystem pattern: each subject
@@ -15,6 +17,8 @@
 // worker endpoint and returns a rendering-ready array. No side effects,
 // no storage, no fetch.
 
+import { classifyReleaseReadiness, readinessBadge } from './admin-content-release-readiness.js';
+
 /**
  * @typedef {object} SubjectStatusEnvelope
  * @property {string}  subjectKey        — canonical subject identifier
@@ -24,6 +28,11 @@
  * @property {number}  validationErrors  — count of unresolved validation errors
  * @property {number}  errorCount7d      — ops error events in the last 7 days
  * @property {'low'|'medium'|'high'|'none'} supportLoadSignal — relative support load
+ * @property {string[]} validationBlockers — active release blockers (U6 P6)
+ * @property {string[]} validationWarnings — active warnings (U6 P6)
+ * @property {boolean}  hasRealDiagnostics — whether subject has diagnostic panels (U6 P6)
+ * @property {string}   releaseReadiness   — classified readiness state (U6 P6)
+ * @property {boolean}  isClickable        — whether drilldown is actionable (U6 P6)
  */
 
 function isPlainObject(value) {
@@ -109,6 +118,9 @@ export function normaliseSubjectStatus(raw) {
   const entry = isPlainObject(raw) ? raw : {};
   const status = VALID_STATUSES.includes(entry.status) ? entry.status : 'placeholder';
   const signal = VALID_SIGNALS.includes(entry.supportLoadSignal) ? entry.supportLoadSignal : 'none';
+  const validationBlockers = Array.isArray(entry.validationBlockers) ? entry.validationBlockers : [];
+  const validationWarnings = Array.isArray(entry.validationWarnings) ? entry.validationWarnings : [];
+  const hasRealDiagnostics = typeof entry.hasRealDiagnostics === 'boolean' ? entry.hasRealDiagnostics : false;
   return {
     subjectKey: safeString(entry.subjectKey, 'unknown'),
     displayName: safeString(entry.displayName, entry.subjectKey || 'Unknown'),
@@ -121,6 +133,10 @@ export function normaliseSubjectStatus(raw) {
     validationErrors: safeNonNegativeInt(entry.validationErrors),
     errorCount7d: safeNonNegativeInt(entry.errorCount7d),
     supportLoadSignal: signal,
+    // U6 (P6): release readiness signals
+    validationBlockers,
+    validationWarnings,
+    hasRealDiagnostics,
   };
 }
 
@@ -139,6 +155,14 @@ export function buildSubjectContentOverview(payload) {
   const normalised = subjects.map((raw) => {
     const entry = normaliseSubjectStatus(raw);
     entry.drilldownAction = deriveDrilldownAction(entry);
+    // U6 (P6): release readiness classification
+    entry.releaseReadiness = classifyReleaseReadiness(entry);
+    entry.releaseReadinessBadge = readinessBadge(entry.releaseReadiness);
+    // U6 (P6): truthful clickability — only clickable when both
+    // hasRealDiagnostics is true AND the drilldown action maps to a panel.
+    entry.isClickable = entry.hasRealDiagnostics &&
+      entry.drilldownAction !== 'none' &&
+      entry.drilldownAction !== 'placeholder';
     return entry;
   });
 

--- a/src/platform/hubs/admin-content-quality-signals.js
+++ b/src/platform/hubs/admin-content-quality-signals.js
@@ -1,0 +1,194 @@
+// U7 (Admin Console P6): Content quality signals — skill coverage,
+// misconceptions, high-wrong-rate per subject.
+//
+// Content-free leaf: this module MUST NOT import any subject content
+// datasets directly. It receives normalised signal data from the Worker
+// and produces a rendering-ready model for the UI.
+//
+// Each subject can independently succeed or fail to provide signals.
+// When a subject's quality data is unavailable the model returns
+// NOT_AVAILABLE for every signal so the UI can honestly render
+// "Not available yet" rather than faking numbers.
+
+export const SIGNAL_STATUS = Object.freeze({
+  AVAILABLE: 'available',
+  NOT_AVAILABLE: 'not_available',
+  PARTIAL: 'partial',
+});
+
+// Canonical subject display names (fallback when server omits them).
+const SUBJECT_DISPLAY_NAMES = {
+  spelling: 'Spelling',
+  grammar: 'Grammar',
+  punctuation: 'Punctuation',
+  arithmetic: 'Arithmetic',
+  reasoning: 'Reasoning',
+  reading: 'Reading',
+};
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function safeNonNegativeInt(value) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric >= 0 ? Math.floor(numeric) : 0;
+}
+
+function safeStatus(value) {
+  if (value === SIGNAL_STATUS.AVAILABLE) return SIGNAL_STATUS.AVAILABLE;
+  if (value === SIGNAL_STATUS.PARTIAL) return SIGNAL_STATUS.PARTIAL;
+  return SIGNAL_STATUS.NOT_AVAILABLE;
+}
+
+/**
+ * Normalise a single coverage signal (skillCoverage, templateCoverage, itemCoverage).
+ * Expected shape from worker: { status, value, total }
+ */
+function normaliseCoverageSignal(raw) {
+  if (!isPlainObject(raw)) {
+    return { status: SIGNAL_STATUS.NOT_AVAILABLE, value: 0, total: 0 };
+  }
+  return {
+    status: safeStatus(raw.status),
+    value: safeNonNegativeInt(raw.value),
+    total: safeNonNegativeInt(raw.total),
+  };
+}
+
+/**
+ * Normalise a list signal (commonMisconceptions, highWrongRate, recentlyChangedUnevidenced).
+ * Expected shape from worker: { status, items: [] }
+ */
+function normaliseListSignal(raw) {
+  if (!isPlainObject(raw)) {
+    return { status: SIGNAL_STATUS.NOT_AVAILABLE, items: [] };
+  }
+  const items = Array.isArray(raw.items)
+    ? raw.items.filter((item) => isPlainObject(item)).map((item) => ({
+        id: typeof item.id === 'string' ? item.id : String(item.id || ''),
+        label: typeof item.label === 'string' ? item.label : String(item.label || ''),
+        count: safeNonNegativeInt(item.count),
+        detail: typeof item.detail === 'string' ? item.detail : null,
+      }))
+    : [];
+  return {
+    status: safeStatus(raw.status),
+    items,
+  };
+}
+
+/**
+ * Normalise a single subject's quality signals into a rendering-ready model.
+ *
+ * @param {object} raw — single subject envelope from the worker
+ * @returns {object} normalised subject quality signal model
+ */
+function normaliseSubjectSignals(raw) {
+  if (!isPlainObject(raw)) {
+    return buildNotAvailableEntry('unknown');
+  }
+  const subjectKey = typeof raw.subjectKey === 'string' && raw.subjectKey
+    ? raw.subjectKey
+    : 'unknown';
+  const subjectName = typeof raw.subjectName === 'string' && raw.subjectName
+    ? raw.subjectName
+    : (SUBJECT_DISPLAY_NAMES[subjectKey] || subjectKey);
+  const signals = isPlainObject(raw.signals) ? raw.signals : {};
+
+  return {
+    subjectKey,
+    subjectName,
+    signals: {
+      skillCoverage: normaliseCoverageSignal(signals.skillCoverage),
+      templateCoverage: normaliseCoverageSignal(signals.templateCoverage),
+      itemCoverage: normaliseCoverageSignal(signals.itemCoverage),
+      commonMisconceptions: normaliseListSignal(signals.commonMisconceptions),
+      highWrongRate: normaliseListSignal(signals.highWrongRate),
+      recentlyChangedUnevidenced: normaliseListSignal(signals.recentlyChangedUnevidenced),
+    },
+  };
+}
+
+/**
+ * Build a fully NOT_AVAILABLE entry for a subject with no data.
+ */
+function buildNotAvailableEntry(subjectKey) {
+  return {
+    subjectKey,
+    subjectName: SUBJECT_DISPLAY_NAMES[subjectKey] || subjectKey,
+    signals: {
+      skillCoverage: { status: SIGNAL_STATUS.NOT_AVAILABLE, value: 0, total: 0 },
+      templateCoverage: { status: SIGNAL_STATUS.NOT_AVAILABLE, value: 0, total: 0 },
+      itemCoverage: { status: SIGNAL_STATUS.NOT_AVAILABLE, value: 0, total: 0 },
+      commonMisconceptions: { status: SIGNAL_STATUS.NOT_AVAILABLE, items: [] },
+      highWrongRate: { status: SIGNAL_STATUS.NOT_AVAILABLE, items: [] },
+      recentlyChangedUnevidenced: { status: SIGNAL_STATUS.NOT_AVAILABLE, items: [] },
+    },
+  };
+}
+
+/**
+ * Compute a summary availability level for a subject's signals.
+ * Returns 'all' if every signal is AVAILABLE, 'none' if all NOT_AVAILABLE,
+ * or 'some' for mixed availability.
+ *
+ * @param {object} signals — the normalised signals object
+ * @returns {'all'|'some'|'none'}
+ */
+export function summariseAvailability(signals) {
+  if (!isPlainObject(signals)) return 'none';
+  const entries = Object.values(signals);
+  if (entries.length === 0) return 'none';
+  const availableCount = entries.filter((s) => s.status === SIGNAL_STATUS.AVAILABLE).length;
+  if (availableCount === entries.length) return 'all';
+  if (availableCount === 0) return 'none';
+  return 'some';
+}
+
+/**
+ * Build the content quality signals model from the worker response.
+ *
+ * @param {Array|object|null|undefined} subjectSignals — array of
+ *   { subjectKey, subjectName?, signals: {...} } from the Worker,
+ *   or null/undefined when the endpoint failed entirely.
+ * @returns {Array} normalised array of subject quality signal models
+ */
+export function buildContentQualitySignals(subjectSignals) {
+  if (!Array.isArray(subjectSignals)) {
+    return [];
+  }
+  return subjectSignals
+    .map((raw) => normaliseSubjectSignals(raw))
+    .filter((entry) => entry.subjectKey !== 'unknown');
+}
+
+/**
+ * Format a coverage signal as a human-readable string.
+ * e.g. "14 / 18 concepts covered"
+ *
+ * @param {object} signal — normalised coverage signal
+ * @param {string} unit — display unit (e.g. "concepts", "templates", "items")
+ * @returns {string}
+ */
+export function formatCoverageLabel(signal, unit) {
+  if (!isPlainObject(signal) || signal.status === SIGNAL_STATUS.NOT_AVAILABLE) {
+    return 'Not available yet';
+  }
+  return `${signal.value} / ${signal.total} ${unit} covered`;
+}
+
+/**
+ * CSS class for a coverage signal chip based on its completeness ratio.
+ *
+ * @param {object} signal — normalised coverage signal
+ * @returns {string} chip class suffix ('good', 'warn', 'bad', or '')
+ */
+export function coverageChipClass(signal) {
+  if (!isPlainObject(signal) || signal.status === SIGNAL_STATUS.NOT_AVAILABLE) return '';
+  if (signal.total === 0) return '';
+  const ratio = signal.value / signal.total;
+  if (ratio >= 0.9) return 'good';
+  if (ratio >= 0.6) return 'warn';
+  return 'bad';
+}

--- a/src/platform/hubs/admin-content-release-readiness.js
+++ b/src/platform/hubs/admin-content-release-readiness.js
@@ -1,0 +1,103 @@
+// U6 (Admin Console P6): Release readiness classification for content operations.
+//
+// Pure logic module that classifies per-subject release readiness based on
+// validation blockers, warnings, and lifecycle state. Consumes the normalised
+// subject envelope shape and produces rendering-ready badge data.
+//
+// Content-free leaf invariant: this module MUST NOT import subject content
+// datasets, subject engines, or any module that transitively pulls in
+// spelling / grammar / punctuation content bundles.
+
+/**
+ * Release readiness states.
+ * @enum {string}
+ */
+export const RELEASE_READINESS = Object.freeze({
+  READY: 'ready',
+  BLOCKED: 'blocked',
+  WARNINGS_ONLY: 'warnings_only',
+  NOT_APPLICABLE: 'not_applicable',
+});
+
+/**
+ * Badge metadata for each readiness state.
+ * @type {Record<string, { label: string, chipClass: string }>}
+ */
+const READINESS_BADGE_MAP = Object.freeze({
+  [RELEASE_READINESS.READY]: { label: 'Ready', chipClass: 'good' },
+  [RELEASE_READINESS.BLOCKED]: { label: 'Blocked', chipClass: 'bad' },
+  [RELEASE_READINESS.WARNINGS_ONLY]: { label: 'Warnings', chipClass: 'warn' },
+  [RELEASE_READINESS.NOT_APPLICABLE]: { label: 'N/A', chipClass: '' },
+});
+
+/**
+ * Classify the release readiness state for a single subject.
+ *
+ * Decision tree:
+ *   - placeholder lifecycle → NOT_APPLICABLE (subject not live or gated)
+ *   - has validation blockers → BLOCKED
+ *   - has warnings but no blockers → WARNINGS_ONLY
+ *   - no blockers and no warnings → READY
+ *
+ * @param {object} subject — normalised subject envelope with:
+ *   - validationBlockers: string[] (empty if no validation system exists)
+ *   - validationWarnings: string[] (empty if no validation system exists)
+ *   - status: 'live' | 'gated' | 'placeholder'
+ * @returns {string} one of RELEASE_READINESS values
+ */
+export function classifyReleaseReadiness(subject) {
+  if (!subject || typeof subject !== 'object' || Array.isArray(subject)) {
+    return RELEASE_READINESS.NOT_APPLICABLE;
+  }
+  if (subject.status === 'placeholder') {
+    return RELEASE_READINESS.NOT_APPLICABLE;
+  }
+
+  const blockers = Array.isArray(subject.validationBlockers) ? subject.validationBlockers : [];
+  const warnings = Array.isArray(subject.validationWarnings) ? subject.validationWarnings : [];
+
+  if (blockers.length > 0) return RELEASE_READINESS.BLOCKED;
+  if (warnings.length > 0) return RELEASE_READINESS.WARNINGS_ONLY;
+  return RELEASE_READINESS.READY;
+}
+
+/**
+ * Build a release readiness model for an array of normalised subjects.
+ *
+ * Returns an array of objects, one per subject, containing:
+ *   - subjectKey
+ *   - readiness (RELEASE_READINESS value)
+ *   - badge ({ label, chipClass })
+ *   - blockerCount
+ *   - warningCount
+ *
+ * @param {object[]} subjects — array of normalised subject envelopes
+ * @returns {Array<{ subjectKey: string, readiness: string, badge: { label: string, chipClass: string }, blockerCount: number, warningCount: number }>}
+ */
+export function buildReleaseReadinessModel(subjects) {
+  if (!Array.isArray(subjects)) return [];
+  return subjects.map((subject) => {
+    const safe = subject && typeof subject === 'object' && !Array.isArray(subject) ? subject : {};
+    const readiness = classifyReleaseReadiness(safe);
+    const badge = READINESS_BADGE_MAP[readiness] || READINESS_BADGE_MAP[RELEASE_READINESS.NOT_APPLICABLE];
+    const blockers = Array.isArray(safe.validationBlockers) ? safe.validationBlockers : [];
+    const warnings = Array.isArray(safe.validationWarnings) ? safe.validationWarnings : [];
+    return {
+      subjectKey: typeof safe.subjectKey === 'string' ? safe.subjectKey : 'unknown',
+      readiness,
+      badge,
+      blockerCount: blockers.length,
+      warningCount: warnings.length,
+    };
+  });
+}
+
+/**
+ * Get the badge metadata for a given readiness value.
+ *
+ * @param {string} readiness — a RELEASE_READINESS value
+ * @returns {{ label: string, chipClass: string }}
+ */
+export function readinessBadge(readiness) {
+  return READINESS_BADGE_MAP[readiness] || READINESS_BADGE_MAP[RELEASE_READINESS.NOT_APPLICABLE];
+}

--- a/src/platform/hubs/admin-debug-bundle-panel.js
+++ b/src/platform/hubs/admin-debug-bundle-panel.js
@@ -10,6 +10,8 @@
 // endpoint and returns a rendering-ready object. No side effects, no
 // storage, no fetch.
 
+import { formatAdminTimestamp } from './admin-refresh-envelope.js';
+
 function isPlainObject(value) {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
@@ -180,11 +182,5 @@ export function isSectionEmpty(bundle, sectionKey) {
 // ---------- Format timestamp for display ----------
 
 export function formatBundleTimestamp(ts) {
-  const numeric = Number(ts);
-  if (!Number.isFinite(numeric) || numeric <= 0) return '—';
-  try {
-    return new Date(numeric).toISOString().replace('T', ' ').replace(/\.000Z$/, ' UTC');
-  } catch {
-    return '—';
-  }
+  return formatAdminTimestamp(ts);
 }

--- a/src/platform/hubs/admin-occurrence-timeline.js
+++ b/src/platform/hubs/admin-occurrence-timeline.js
@@ -6,6 +6,8 @@
 // against missing / null fields so the drawer renders cleanly on partial
 // data (e.g. anonymous errors, pre-migration events, NULL releases).
 
+import { formatAdminTimestamp } from './admin-refresh-envelope.js';
+
 function isPlainObject(value) {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
@@ -35,11 +37,5 @@ export function normaliseOccurrenceTimeline(rawValue) {
 // string suitable for the drawer detail list. Null / zero timestamps
 // return the stable fallback so the drawer never renders blank cells.
 export function formatOccurrenceTimestamp(ts) {
-  const numeric = Number(ts);
-  if (!Number.isFinite(numeric) || numeric <= 0) return '—';
-  try {
-    return new Date(numeric).toISOString().replace('T', ' ').replace(/\.000Z$/, ' UTC');
-  } catch {
-    return '—';
-  }
+  return formatAdminTimestamp(ts);
 }

--- a/src/platform/hubs/admin-production-evidence.js
+++ b/src/platform/hubs/admin-production-evidence.js
@@ -66,8 +66,11 @@ export function classifyEvidenceMetric(metricKey, metricValue, generatedAt, now)
   }
 
   // Map tier key to state. Only known tiers can produce certified states.
+  // Schema 3 adds admin_smoke and bootstrap_smoke as SMOKE_PASS-tier sources.
   const tierMap = {
     smoke_pass: EVIDENCE_STATES.SMOKE_PASS,
+    admin_smoke: EVIDENCE_STATES.SMOKE_PASS,
+    bootstrap_smoke: EVIDENCE_STATES.SMOKE_PASS,
     small_pilot_provisional: EVIDENCE_STATES.SMALL_PILOT_PROVISIONAL,
     certified_30_learner_beta: EVIDENCE_STATES.CERTIFIED_30,
     certified_60_learner_stretch: EVIDENCE_STATES.CERTIFIED_60,
@@ -88,6 +91,8 @@ export function buildEvidencePanelModel(summaryJson, now) {
   const summary = summaryJson && typeof summaryJson === 'object' ? summaryJson : {};
   const rawMetrics = summary.metrics && typeof summary.metrics === 'object' ? summary.metrics : {};
   const generatedAt = summary.generatedAt || null;
+  // Schema 3 adds a sources manifest; schema 2 omits it — default to null.
+  const sources = summary.sources && typeof summary.sources === 'object' ? summary.sources : null;
 
   // Determine freshness.
   const generatedAtMs = generatedAt ? new Date(generatedAt).getTime() : 0;
@@ -113,7 +118,7 @@ export function buildEvidencePanelModel(summaryJson, now) {
   // Overall state: highest-tier passing state, or the most severe problem.
   const overallState = deriveOverallState(metrics, isFresh);
 
-  return { metrics, generatedAt, isFresh, overallState };
+  return { metrics, generatedAt, isFresh, overallState, sources };
 }
 
 /**

--- a/src/platform/hubs/admin-punctuation-diagnostic-panel.js
+++ b/src/platform/hubs/admin-punctuation-diagnostic-panel.js
@@ -9,6 +9,8 @@
 // worker endpoint and returns a rendering-ready object. No side
 // effects, no storage, no fetch.
 
+import { formatAdminTimestamp } from './admin-refresh-envelope.js';
+
 function isPlainObject(value) {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
@@ -175,11 +177,5 @@ export function isDiagnosticSectionEmpty(diagnostic, sectionKey) {
 // ---------- Format timestamp for display ----------
 
 export function formatDiagnosticTimestamp(ts) {
-  const numeric = Number(ts);
-  if (!Number.isFinite(numeric) || numeric <= 0) return '—';
-  try {
-    return new Date(numeric).toISOString().replace('T', ' ').replace(/\.000Z$/, ' UTC');
-  } catch {
-    return '—';
-  }
+  return formatAdminTimestamp(ts);
 }

--- a/src/platform/hubs/admin-refresh-envelope.js
+++ b/src/platform/hubs/admin-refresh-envelope.js
@@ -1,0 +1,57 @@
+// P6 Unit 10: unified refresh-envelope and timestamp helpers — content-free leaf.
+//
+// Extracts duplicated timestamp formatting and error-envelope construction
+// into a single shared module. All admin panels can import from here instead
+// of maintaining their own identical copies.
+//
+// This module MUST NOT import subject content datasets or any module that
+// transitively pulls in spelling / grammar / punctuation content bundles.
+// The audit gate enforces this invariant.
+
+// ---------------------------------------------------------------------------
+// Timestamp formatting
+// ---------------------------------------------------------------------------
+
+/**
+ * Format a numeric timestamp (ms since epoch) into a compact ISO-like string
+ * suitable for admin panel display. Returns the em-dash fallback for
+ * null / zero / negative / NaN / non-finite values.
+ *
+ * Output shape: "2023-11-14 22:13:20 UTC"
+ *
+ * @param {*} ts — numeric ms timestamp (or any value that coerces via Number())
+ * @returns {string}
+ */
+export function formatAdminTimestamp(ts) {
+  const numeric = Number(ts);
+  if (!Number.isFinite(numeric) || numeric <= 0) return '—';
+  try {
+    return new Date(numeric).toISOString().replace('T', ' ').replace(/\.000Z$/, ' UTC');
+  } catch {
+    return '—';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Refresh error envelope
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive the refreshError envelope the `<PanelHeader>` consumes from a thrown
+ * hub-api error. `code` is taken verbatim from the Worker payload when present;
+ * `network` is the fallback for fetch rejections / malformed envelopes.
+ *
+ * @param {object|null|undefined} error — the caught error from a refresh attempt
+ * @returns {{ code: string, message: string, correlationId: string|null, at: number }}
+ */
+export function buildRefreshErrorEnvelope(error) {
+  const code = typeof error?.code === 'string' && error.code ? error.code : 'network';
+  const message = typeof error?.message === 'string' ? error.message : '';
+  const correlationId = error?.payload?.correlationId || error?.correlationId || null;
+  return {
+    code,
+    message,
+    correlationId,
+    at: Date.now(),
+  };
+}

--- a/src/platform/hubs/admin-safe-copy.js
+++ b/src/platform/hubs/admin-safe-copy.js
@@ -357,7 +357,15 @@ export function prepareSafeCopy(data, audience) {
       stripInternalNotes(working);
       redactedFields.push('internal_notes');
     }
-    const text = typeof working === 'string' ? working : JSON.stringify(working, null, 2);
+    let text = typeof working === 'string' ? working : JSON.stringify(working, null, 2);
+    // Defence-in-depth: scan serialised output for PII in non-canonical keys.
+    // Use OPS_SAFE-level patterns only (emails, IDs) — not stack-trace/route
+    // patterns which false-positive on JSON-serialised object content.
+    const { text: finalText, appliedRedactions } = redactString(text, COPY_AUDIENCE.OPS_SAFE);
+    text = finalText;
+    for (const r of appliedRedactions) {
+      if (!redactedFields.includes(r)) redactedFields.push(r);
+    }
     return { ok: true, text, redactedFields };
   }
 
@@ -376,7 +384,16 @@ export function prepareSafeCopy(data, audience) {
       maskAllEmails(working);
       redactedFields.push('emails_masked');
     }
-    const text = typeof working === 'string' ? working : JSON.stringify(working, null, 2);
+    let text = typeof working === 'string' ? working : JSON.stringify(working, null, 2);
+    // Defence-in-depth: scan serialised output for PII in non-canonical keys.
+    // Cap at OPS_SAFE level (emails, IDs, auth) — stack-trace and route patterns
+    // false-positive on JSON content (e.g. "at this" in values). The object-level
+    // walkers already handle stack traces and internal notes by key name.
+    const { text: finalText, appliedRedactions } = redactString(text, COPY_AUDIENCE.OPS_SAFE);
+    text = finalText;
+    for (const r of appliedRedactions) {
+      if (!redactedFields.includes(r)) redactedFields.push(r);
+    }
     return { ok: true, text, redactedFields };
   }
 

--- a/src/platform/hubs/admin-safe-copy.js
+++ b/src/platform/hubs/admin-safe-copy.js
@@ -167,6 +167,134 @@ function stripChildIds(obj) {
 }
 
 // ---------------------------------------------------------------------------
+// String-level redaction (closes the string-passthrough gap)
+// ---------------------------------------------------------------------------
+
+// Patterns for ALL audiences (including ADMIN_ONLY):
+const RE_BEARER_TOKEN = /Bearer\s+eyJ[A-Za-z0-9_-]+(?:\.[A-Za-z0-9_-]+){0,2}/g;
+const RE_BASIC_AUTH = /Basic\s+[A-Za-z0-9+/=]{8,}/g;
+const RE_COOKIE_VALUE = /(?:session|sess_id|token|auth)=[^\s;]{6,}(?:;|$|\s)/gi;
+
+// Patterns for OPS_SAFE and below:
+const RE_EMAIL = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g;
+const RE_ACC_ID = /acc_[A-Za-z0-9_-]{6,}/g;
+const RE_SESS_ID = /sess_[A-Za-z0-9_-]{6,}/g;
+const RE_UUID = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi;
+
+// Patterns for PARENT_SAFE and below:
+const RE_LRN_ID = /lrn_[A-Za-z0-9_-]{3,}/g;
+const RE_STACK_TRACE = /^[^\n]*\n?\s+at\s.+$/gm;
+const RE_INTERNAL_ROUTE = /\/api\/(?:admin|internal)\/[^\s'")]+/g;
+const RE_INTERNAL_TABLE = /d1\.[a-z_]+/g;
+
+/**
+ * Apply regex-based scanning to detect and mask/strip sensitive tokens
+ * from a plain string, according to audience level.
+ *
+ * @param {string} text — the raw string to scan.
+ * @param {string} audience — one of COPY_AUDIENCE values.
+ * @returns {{ text: string, appliedRedactions: string[] }}
+ */
+export function redactString(text, audience) {
+  if (!text || typeof text !== 'string') {
+    return { text: '', appliedRedactions: [] };
+  }
+
+  const appliedRedactions = [];
+  let result = text;
+
+  // === ALL audiences: strip auth tokens and cookies ===
+  if (RE_BEARER_TOKEN.test(result)) {
+    appliedRedactions.push('auth_tokens');
+    result = result.replace(RE_BEARER_TOKEN, '[auth redacted]');
+  }
+  // Reset lastIndex for global regexes (test advances lastIndex)
+  RE_BEARER_TOKEN.lastIndex = 0;
+
+  if (RE_BASIC_AUTH.test(result)) {
+    if (!appliedRedactions.includes('auth_tokens')) appliedRedactions.push('auth_tokens');
+    result = result.replace(RE_BASIC_AUTH, '[auth redacted]');
+  }
+  RE_BASIC_AUTH.lastIndex = 0;
+
+  if (RE_COOKIE_VALUE.test(result)) {
+    appliedRedactions.push('cookie_values');
+    result = result.replace(RE_COOKIE_VALUE, '[cookie redacted]');
+  }
+  RE_COOKIE_VALUE.lastIndex = 0;
+
+  if (audience === COPY_AUDIENCE.ADMIN_ONLY) {
+    return { text: result, appliedRedactions };
+  }
+
+  // === OPS_SAFE: mask emails, account IDs, session IDs ===
+  const emailMatches = result.match(RE_EMAIL);
+  if (emailMatches) {
+    appliedRedactions.push('emails_masked');
+    for (const email of emailMatches) {
+      result = result.replace(email, maskEmail(email));
+    }
+  }
+
+  const accMatches = result.match(RE_ACC_ID);
+  if (accMatches) {
+    appliedRedactions.push('account_ids_masked');
+    for (const id of accMatches) {
+      result = result.replace(id, maskId(id));
+    }
+  }
+
+  const sessMatches = result.match(RE_SESS_ID);
+  if (sessMatches) {
+    appliedRedactions.push('session_ids_masked');
+    for (const id of sessMatches) {
+      result = result.replace(id, maskId(id));
+    }
+  }
+
+  const uuidMatches = result.match(RE_UUID);
+  if (uuidMatches) {
+    if (!appliedRedactions.includes('session_ids_masked')) {
+      appliedRedactions.push('session_ids_masked');
+    }
+    for (const id of uuidMatches) {
+      result = result.replace(id, maskId(id));
+    }
+  }
+
+  if (audience === COPY_AUDIENCE.OPS_SAFE) {
+    return { text: result, appliedRedactions };
+  }
+
+  // === PARENT_SAFE (and PUBLIC_PREVIEW): strip learner IDs, stack traces, routes, tables ===
+  if (RE_LRN_ID.test(result)) {
+    appliedRedactions.push('learner_ids');
+    result = result.replace(RE_LRN_ID, '[redacted]');
+  }
+  RE_LRN_ID.lastIndex = 0;
+
+  if (RE_STACK_TRACE.test(result)) {
+    appliedRedactions.push('stack_traces');
+    result = result.replace(RE_STACK_TRACE, '[stack trace redacted]');
+  }
+  RE_STACK_TRACE.lastIndex = 0;
+
+  if (RE_INTERNAL_ROUTE.test(result)) {
+    appliedRedactions.push('internal_routes');
+    result = result.replace(RE_INTERNAL_ROUTE, '[internal route redacted]');
+  }
+  RE_INTERNAL_ROUTE.lastIndex = 0;
+
+  if (RE_INTERNAL_TABLE.test(result)) {
+    appliedRedactions.push('internal_references');
+    result = result.replace(RE_INTERNAL_TABLE, '[internal reference redacted]');
+  }
+  RE_INTERNAL_TABLE.lastIndex = 0;
+
+  return { text: result, appliedRedactions };
+}
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
@@ -189,6 +317,18 @@ export function prepareSafeCopy(data, audience) {
 
   // Deep clone so we never mutate the source.
   let working = typeof data === 'string' ? data : JSON.parse(JSON.stringify(data));
+
+  // String-specific path: apply regex-based redaction per audience.
+  if (typeof working === 'string') {
+    const { text: redacted, appliedRedactions } = redactString(working, audience);
+    if (!redacted || redacted.trim() === '') {
+      return { ok: false, text: '', redactedFields: [] };
+    }
+    const fields = appliedRedactions.length > 0
+      ? appliedRedactions
+      : [];
+    return { ok: true, text: redacted, redactedFields: fields };
+  }
 
   // All audiences: strip cookies, auth tokens, raw request bodies.
   if (typeof working === 'object') {

--- a/src/platform/hubs/admin-safe-copy.js
+++ b/src/platform/hubs/admin-safe-copy.js
@@ -183,7 +183,7 @@ const RE_UUID = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi
 
 // Patterns for PARENT_SAFE and below:
 const RE_LRN_ID = /lrn_[A-Za-z0-9_-]{3,}/g;
-const RE_STACK_TRACE = /^[^\n]*\n?\s+at\s.+$/gm;
+const RE_STACK_TRACE = /^\s+at\s+\S+.*[()]/gm;
 const RE_INTERNAL_ROUTE = /\/api\/(?:admin|internal)\/[^\s'")]+/g;
 const RE_INTERNAL_TABLE = /d1\.[a-z_]+/g;
 

--- a/src/platform/hubs/api.js
+++ b/src/platform/hubs/api.js
@@ -227,6 +227,41 @@ export function createHubApi({
         body: JSON.stringify({ version, mutation }),
       }, authSession);
     },
+    // P6 U8: Generic asset CAS routes — delegate to asset-specific handlers
+    // on the Worker. The assetId identifies which asset the operation targets.
+    async saveAssetDraft({ assetId, data, expectedDraftRevision, mutation } = {}) {
+      const url = buildRequestUrl(
+        baseUrl,
+        `/api/admin/assets/${encodeURIComponent(assetId)}/draft`,
+      );
+      return fetchHubJson(fetch, url, {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ data, expectedDraftRevision, mutation }),
+      }, authSession);
+    },
+    async publishAsset({ assetId, expectedDraftRevision, mutation } = {}) {
+      const url = buildRequestUrl(
+        baseUrl,
+        `/api/admin/assets/${encodeURIComponent(assetId)}/publish`,
+      );
+      return fetchHubJson(fetch, url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ expectedDraftRevision, mutation }),
+      }, authSession);
+    },
+    async restoreAssetVersion({ assetId, version, expectedPublishedVersion, mutation } = {}) {
+      const url = buildRequestUrl(
+        baseUrl,
+        `/api/admin/assets/${encodeURIComponent(assetId)}/restore`,
+      );
+      return fetchHubJson(fetch, url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ version, expectedPublishedVersion, mutation }),
+      }, authSession);
+    },
     async readAdminOpsKpi() {
       const url = buildRequestUrl(baseUrl, '/api/admin/ops/kpi');
       return fetchHubJson(fetch, url, { method: 'GET' }, authSession);

--- a/src/surfaces/hubs/AdminContentSection.jsx
+++ b/src/surfaces/hubs/AdminContentSection.jsx
@@ -7,6 +7,7 @@ import { GRAMMAR_RECENT_ATTEMPT_HORIZON } from '../../../shared/grammar/confiden
 import { buildAssetRegistry } from '../../platform/hubs/admin-asset-registry.js';
 import { classifyAction } from '../../platform/hubs/admin-action-classification.js';
 import { useSubmitLock } from '../../platform/react/use-submit-lock.js';
+import { DEFAULT_STALE_THRESHOLD_MS } from '../../platform/hubs/admin-panel-frame.js';
 import {
   buildSubjectContentOverview,
   statusBadgeClass,
@@ -69,6 +70,18 @@ function SubjectOverviewPanel({ model, actions }) {
     return null;
   }
 
+  // P6 U4: freshness state for the content overview panel (not wrapped in
+  // AdminPanelFrame due to custom table layout). Uses generatedAt from the
+  // worker response as the freshness source.
+  const overviewGeneratedAt = Number(model?.contentOverview?.generatedAt) || null;
+  const overviewRefreshedAtIso = model?.contentOverview?.refreshedAt;
+  const overviewRefreshedAtMs = overviewRefreshedAtIso
+    ? new Date(overviewRefreshedAtIso).getTime() || overviewGeneratedAt
+    : overviewGeneratedAt;
+  const isOverviewStale = overviewRefreshedAtMs
+    ? (Date.now() - overviewRefreshedAtMs > DEFAULT_STALE_THRESHOLD_MS)
+    : false;
+
   const isClickable = (subject) =>
     subject.drilldownAction !== 'none' && subject.drilldownAction !== 'placeholder';
 
@@ -88,6 +101,16 @@ function SubjectOverviewPanel({ model, actions }) {
         Cross-subject operating surface. Live subjects have production data; placeholders
         are planned but not yet active.
       </p>
+      {isOverviewStale ? (
+        <div className="feedback warn admin-panel-frame-feedback" data-panel-frame-stale="true">
+          <strong>Data may be stale.</strong>
+          {' '}Last refreshed {formatTimestamp(overviewRefreshedAtMs)}.
+        </div>
+      ) : overviewRefreshedAtMs ? (
+        <span className="chip small muted" data-freshness="content-overview">
+          Refreshed {formatTimestamp(overviewRefreshedAtMs)}
+        </span>
+      ) : null}
       <table className="admin-subject-overview-table admin-overview-table" aria-label="Subject content overview">
         <thead>
           <tr className="admin-overview-thead-row">

--- a/src/surfaces/hubs/AdminContentSection.jsx
+++ b/src/surfaces/hubs/AdminContentSection.jsx
@@ -14,6 +14,14 @@ import {
   statusLabel,
   drilldownPanelSelector,
 } from '../../platform/hubs/admin-content-overview.js';
+import {
+  buildContentQualitySignals,
+  summariseAvailability,
+  formatCoverageLabel,
+  coverageChipClass,
+  SIGNAL_STATUS,
+} from '../../platform/hubs/admin-content-quality-signals.js';
+import { RELEASE_READINESS } from '../../platform/hubs/admin-content-release-readiness.js';
 
 // U4+U5: Content section — content release, import validation, post-mega
 // spelling debug, seed harness, grammar confidence, grammar writing try,
@@ -30,6 +38,10 @@ import {
 // U9 (P5): Honest drilldown actions. Each row now surfaces a truthful
 // action label indicating whether clicking does anything. Rows are only
 // clickable when drilldownAction maps to a real panel.
+//
+// U6 (P6): Content operations v2. Release readiness classification,
+// validation blocker/warning badges, and truthful isClickable flag
+// (placeholder subjects are explicitly non-clickable).
 
 /**
  * Human-readable action label for the drilldown column.
@@ -82,11 +94,9 @@ function SubjectOverviewPanel({ model, actions }) {
     ? (Date.now() - overviewRefreshedAtMs > DEFAULT_STALE_THRESHOLD_MS)
     : false;
 
-  const isClickable = (subject) =>
-    subject.drilldownAction !== 'none' && subject.drilldownAction !== 'placeholder';
-
+  // U6 (P6): use model-computed isClickable flag (truthful drilldowns)
   const handleRowClick = (subject) => {
-    if (!isClickable(subject)) return;
+    if (!subject.isClickable) return;
     const selector = drilldownPanelSelector(subject);
     if (!selector) return;
     const target = document.querySelector(selector);
@@ -116,6 +126,8 @@ function SubjectOverviewPanel({ model, actions }) {
           <tr className="admin-overview-thead-row">
             <th className="small admin-overview-th-first">Subject</th>
             <th className="small admin-overview-th">Status</th>
+            <th className="small admin-overview-th">Readiness</th>
+            <th className="small admin-overview-th">Signals</th>
             <th className="small admin-overview-th">Release</th>
             <th className="small admin-overview-th-right">Errors (7d)</th>
             <th className="small admin-overview-th-right">Validation</th>
@@ -131,14 +143,18 @@ function SubjectOverviewPanel({ model, actions }) {
               data-subject-key={subject.subjectKey}
               data-subject-status={subject.status}
               data-drilldown-action={subject.drilldownAction}
-              data-clickable={isClickable(subject) ? 'true' : undefined}
-              onClick={isClickable(subject) ? () => handleRowClick(subject) : undefined}
-              role={isClickable(subject) ? 'button' : undefined}
-              tabIndex={isClickable(subject) ? 0 : undefined}
-              aria-label={isClickable(subject) ? `Scroll to ${subject.displayName} diagnostics` : undefined}
+              data-release-readiness={subject.releaseReadiness}
+              data-clickable={subject.isClickable ? 'true' : undefined}
+              onClick={subject.isClickable ? () => handleRowClick(subject) : undefined}
+              role={subject.isClickable ? 'button' : undefined}
+              tabIndex={subject.isClickable ? 0 : undefined}
+              aria-label={subject.isClickable ? `Scroll to ${subject.displayName} diagnostics` : undefined}
             >
               <td className="admin-overview-td-first">
                 {subject.displayName}
+                {!subject.isClickable && subject.status !== 'placeholder' ? (
+                  <span className="small muted admin-no-drilldown-label"> (No drilldown available)</span>
+                ) : null}
               </td>
               <td className="admin-overview-td">
                 <span
@@ -147,6 +163,43 @@ function SubjectOverviewPanel({ model, actions }) {
                 >
                   {statusLabel(subject.status)}
                 </span>
+              </td>
+              <td className="admin-overview-td">
+                {subject.releaseReadinessBadge ? (
+                  <span
+                    className={`chip ${subject.releaseReadinessBadge.chipClass}`}
+                    data-testid={`readiness-${subject.subjectKey}`}
+                  >
+                    {subject.releaseReadinessBadge.label}
+                  </span>
+                ) : (
+                  <span className="small muted" data-testid={`readiness-${subject.subjectKey}`}>—</span>
+                )}
+              </td>
+              <td className="admin-overview-td">
+                {subject.validationBlockers.length > 0 ? (
+                  <span
+                    className="chip bad"
+                    data-testid={`blocker-badge-${subject.subjectKey}`}
+                    title={subject.validationBlockers.join('; ')}
+                  >
+                    {String(subject.validationBlockers.length)} blocker{subject.validationBlockers.length === 1 ? '' : 's'}
+                  </span>
+                ) : null}
+                {subject.validationWarnings.length > 0 ? (
+                  <span
+                    className="chip warn"
+                    data-testid={`warning-badge-${subject.subjectKey}`}
+                    title={subject.validationWarnings.join('; ')}
+                  >
+                    {String(subject.validationWarnings.length)} warning{subject.validationWarnings.length === 1 ? '' : 's'}
+                  </span>
+                ) : null}
+                {subject.validationBlockers.length === 0 && subject.validationWarnings.length === 0 ? (
+                  <span className="small muted" data-testid={`signals-${subject.subjectKey}`}>
+                    {subject.status === 'placeholder' ? '—' : 'Clear'}
+                  </span>
+                ) : null}
               </td>
               <td className="small admin-overview-td">
                 {subject.releaseVersion
@@ -181,7 +234,7 @@ function SubjectOverviewPanel({ model, actions }) {
               </td>
               <td className="small admin-overview-td">
                 <span
-                  className={isClickable(subject) ? '' : 'muted'}
+                  className={subject.isClickable ? '' : 'muted'}
                   data-testid={`action-${subject.subjectKey}`}
                 >
                   {drilldownActionLabel(subject.drilldownAction)}
@@ -641,6 +694,10 @@ function AssetRegistryCard({ entry, model, actions }) {
   const visual = model?.monsterVisualConfig || {};
   const status = visual?.status || {};
 
+  // P6 U8: Publish is disabled when blockers exist or no draft is present.
+  const hasPublishBlockers = Array.isArray(entry.publishBlockers) && entry.publishBlockers.length > 0;
+  const publishDisabled = !entry.canManage || hasPublishBlockers || !entry.hasDraft || publishLocked;
+
   return (
     <article
       className="card admin-card-spaced"
@@ -667,29 +724,55 @@ function AssetRegistryCard({ entry, model, actions }) {
           </div>
         </div>
         <div className="actions admin-registry-actions-end">
+          {entry.previewUrl ? (
+            <a
+              className="btn ghost"
+              href={entry.previewUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              data-action="registry-preview"
+              data-testid="registry-preview-link"
+            >
+              Preview
+            </a>
+          ) : null}
+          {!entry.hasDraft && entry.hasPublished ? (
+            <span className="chip muted" data-testid="registry-no-pending">No pending changes</span>
+          ) : null}
           {showPublishConfirm ? (
             <AdminConfirmAction
               level="high"
               dangerCopy="This will publish the current draft to all users."
-              targetDisplay={`Monster Visual Config rev ${String(status.draftRevision)}`}
+              targetDisplay={`${entry.displayName} rev ${String(entry.draftVersion)}`}
               onConfirm={() => runPublish(async () => {
-                actions.dispatch('monster-visual-config-publish', {
-                  expectedDraftRevision: status.draftRevision,
+                actions.dispatch('asset-publish', {
+                  assetId: entry.assetId,
+                  expectedDraftRevision: entry.draftVersion,
                 });
                 setShowPublishConfirm(false);
               })}
               onCancel={() => setShowPublishConfirm(false)}
             />
           ) : (
-            <button
-              className="btn good"
-              type="button"
-              disabled={!entry.canManage || !entry.validationState.ok || !entry.hasDraft || publishLocked}
-              data-action="registry-publish"
-              onClick={() => setShowPublishConfirm(true)}
-            >
-              Publish
-            </button>
+            <div className="admin-registry-publish-wrapper">
+              <button
+                className="btn good"
+                type="button"
+                disabled={publishDisabled}
+                data-action="registry-publish"
+                title={hasPublishBlockers ? entry.publishBlockers.join(' ') : undefined}
+                onClick={() => setShowPublishConfirm(true)}
+              >
+                Publish
+              </button>
+              {hasPublishBlockers ? (
+                <ul className="small muted admin-registry-blockers-list" data-testid="registry-publish-blockers">
+                  {entry.publishBlockers.map((blocker, idx) => (
+                    <li key={idx}>{blocker}</li>
+                  ))}
+                </ul>
+              ) : null}
+            </div>
           )}
           <div className="admin-registry-restore-flow">
             <select
@@ -726,11 +809,12 @@ function AssetRegistryCard({ entry, model, actions }) {
               <AdminConfirmAction
                 level="high"
                 dangerCopy="This will overwrite the current draft with a previous version."
-                targetDisplay={`Restore to v${selectedRestoreVersion}`}
+                targetDisplay={`Restore ${entry.displayName} to v${selectedRestoreVersion}`}
                 onConfirm={() => runRestore(async () => {
-                  actions.dispatch('monster-visual-config-restore', {
+                  actions.dispatch('asset-restore', {
+                    assetId: entry.assetId,
                     version: selectedRestoreVersion,
-                    expectedDraftRevision: status.draftRevision,
+                    expectedPublishedVersion: entry.publishedVersion,
                   });
                   setSelectedRestoreVersion(null);
                   setShowRestoreConfirm(false);
@@ -834,6 +918,139 @@ function AssetRegistrySection({ model, actions }) {
   );
 }
 
+// U7 (P6): Learning Quality Signals panel. Surfaces per-subject skill
+// coverage, high-wrong-rate content, and common misconceptions where
+// durable evidence exists. Read-only — no editing capabilities.
+function ContentQualitySignalsPanel({ model }) {
+  const qualitySignals = React.useMemo(
+    () => buildContentQualitySignals(model?.contentQualitySignals?.subjectSignals),
+    [model?.contentQualitySignals?.subjectSignals],
+  );
+
+  // Error state: signals endpoint failed to load entirely
+  if (model?.contentQualitySignalsError) {
+    return (
+      <section className="card admin-card-spaced" data-panel="content-quality-signals">
+        <div className="eyebrow">Content Management</div>
+        <h3 className="section-title admin-section-title">Learning Quality Signals</h3>
+        <div className="feedback bad">
+          <strong>Unable to load quality signals</strong>
+          <div className="small muted admin-note-spaced">
+            {typeof model.contentQualitySignalsError === 'string'
+              ? model.contentQualitySignalsError
+              : 'The content quality signals endpoint returned an error. Other panels still work.'}
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  if (!qualitySignals.length) {
+    return null;
+  }
+
+  return (
+    <section className="card admin-card-spaced" data-panel="content-quality-signals">
+      <div className="eyebrow">Content Management</div>
+      <h3 className="section-title admin-section-title">Learning Quality Signals</h3>
+      <p className="small muted admin-overview-desc">
+        Per-subject learning quality indicators. Shows skill coverage, template coverage, and
+        high-wrong-rate detection where durable evidence exists.
+      </p>
+      <div className="admin-quality-signals-grid">
+        {qualitySignals.map((subject) => {
+          const availability = summariseAvailability(subject.signals);
+          return (
+            <article
+              key={subject.subjectKey}
+              className="card soft admin-quality-signal-card"
+              data-subject-key={subject.subjectKey}
+              data-availability={availability}
+            >
+              <h4 className="admin-quality-signal-subject-name">{subject.subjectName}</h4>
+              <div className="chip-row admin-chip-row-spaced">
+                <span className={`chip ${availability === 'all' ? 'good' : availability === 'some' ? 'warn' : ''}`}>
+                  {availability === 'all' ? 'All signals available' : availability === 'some' ? 'Partial data' : 'No data yet'}
+                </span>
+              </div>
+              <dl className="admin-quality-signal-dl">
+                {/* Skill coverage */}
+                <div className="admin-quality-signal-row">
+                  <dt className="small muted">Skill coverage</dt>
+                  <dd>
+                    {subject.signals.skillCoverage.status !== SIGNAL_STATUS.NOT_AVAILABLE ? (
+                      <span className={`chip ${coverageChipClass(subject.signals.skillCoverage)}`}>
+                        {formatCoverageLabel(subject.signals.skillCoverage, 'skills')}
+                      </span>
+                    ) : (
+                      <span className="small muted">Not available yet</span>
+                    )}
+                  </dd>
+                </div>
+                {/* Template coverage */}
+                <div className="admin-quality-signal-row">
+                  <dt className="small muted">Template coverage</dt>
+                  <dd>
+                    {subject.signals.templateCoverage.status !== SIGNAL_STATUS.NOT_AVAILABLE ? (
+                      <span className={`chip ${coverageChipClass(subject.signals.templateCoverage)}`}>
+                        {subject.signals.templateCoverage.total > 0
+                          ? formatCoverageLabel(subject.signals.templateCoverage, 'templates')
+                          : `${subject.signals.templateCoverage.value} distinct templates`}
+                      </span>
+                    ) : (
+                      <span className="small muted">Not available yet</span>
+                    )}
+                  </dd>
+                </div>
+                {/* Item coverage */}
+                <div className="admin-quality-signal-row">
+                  <dt className="small muted">Item coverage</dt>
+                  <dd>
+                    {subject.signals.itemCoverage.status !== SIGNAL_STATUS.NOT_AVAILABLE ? (
+                      <span className={`chip ${coverageChipClass(subject.signals.itemCoverage)}`}>
+                        {formatCoverageLabel(subject.signals.itemCoverage, 'items')}
+                      </span>
+                    ) : (
+                      <span className="small muted">Not available yet</span>
+                    )}
+                  </dd>
+                </div>
+                {/* High wrong-rate */}
+                <div className="admin-quality-signal-row">
+                  <dt className="small muted">High wrong-rate</dt>
+                  <dd>
+                    {subject.signals.highWrongRate.status !== SIGNAL_STATUS.NOT_AVAILABLE ? (
+                      subject.signals.highWrongRate.items.length > 0 ? (
+                        <details className="admin-quality-signal-details">
+                          <summary className="small">
+                            {subject.signals.highWrongRate.items.length} concept{subject.signals.highWrongRate.items.length === 1 ? '' : 's'} above 40% wrong
+                          </summary>
+                          <ul className="small muted admin-quality-signal-list">
+                            {subject.signals.highWrongRate.items.map((item) => (
+                              <li key={item.id}>
+                                <code>{item.label}</code>
+                                {item.detail ? <span className="muted"> — {item.detail}</span> : null}
+                              </li>
+                            ))}
+                          </ul>
+                        </details>
+                      ) : (
+                        <span className="chip good">No high wrong-rate concepts</span>
+                      )
+                    ) : (
+                      <span className="small muted">Not available yet</span>
+                    )}
+                  </dd>
+                </div>
+              </dl>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
 export function AdminContentSection({ model, appState, accessContext, actions }) {
   const selectedDiagnostics = model.learnerSupport?.selectedDiagnostics || null;
   const selectedLearnerId = model.learnerSupport?.selectedLearnerId || selectedDiagnostics?.learnerId || '';
@@ -842,6 +1059,7 @@ export function AdminContentSection({ model, appState, accessContext, actions })
   return (
     <>
       <SubjectOverviewPanel model={model} actions={actions} />
+      <ContentQualitySignalsPanel model={model} />
       <ContentReleaseAndImport model={model} accessContext={accessContext} actions={actions} />
       <PostMegaSpellingDebugPanel debug={model.postMasteryDebug} />
       <PostMegaSeedHarnessPanel model={model} actions={actions} />

--- a/src/surfaces/hubs/AdminErrorTimelinePanel.jsx
+++ b/src/surfaces/hubs/AdminErrorTimelinePanel.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { formatTimestamp } from './hub-utils.js';
 import { PanelHeader } from './admin-panel-header.jsx';
 import { formatOccurrenceTimestamp } from '../../platform/hubs/admin-occurrence-timeline.js';
+import '../styles/admin-panels.css';
 
 // U8 (P4): Error log centre panel — extracted from AdminDebuggingSection.jsx.
 // Contains ErrorLogCentrePanel + OccurrenceTimeline + ErrorEventDetailsDrawer.
@@ -15,8 +16,8 @@ function OccurrenceTimeline({ eventId, occurrences, loading, onLoad, canViewAcco
   const rows = Array.isArray(occurrences) ? occurrences : [];
   const loaded = rows.length > 0 || loading === false;
   return (
-    <div data-testid={`occurrence-timeline-${eventId}`} style={{ marginTop: 12 }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+    <div data-testid={`occurrence-timeline-${eventId}`} className="admin-mt-12">
+      <div className="admin-flex-row">
         <strong className="small">Occurrence timeline</strong>
         {!loaded && typeof onLoad === 'function' ? (
           <button
@@ -34,19 +35,19 @@ function OccurrenceTimeline({ eventId, occurrences, loading, onLoad, canViewAcco
         <table className="small" style={{ marginTop: 6, width: '100%', borderCollapse: 'collapse' }} data-testid={`occurrence-table-${eventId}`}>
           <thead>
             <tr>
-              <th style={{ textAlign: 'left', padding: '2px 6px' }}>When</th>
-              <th style={{ textAlign: 'left', padding: '2px 6px' }}>Release</th>
-              <th style={{ textAlign: 'left', padding: '2px 6px' }}>Route</th>
-              {canViewAccount ? <th style={{ textAlign: 'left', padding: '2px 6px' }}>Account</th> : null}
+              <th className="admin-th-left">When</th>
+              <th className="admin-th-left">Release</th>
+              <th className="admin-th-left">Route</th>
+              {canViewAccount ? <th className="admin-th-left">Account</th> : null}
             </tr>
           </thead>
           <tbody>
             {rows.map((occ) => (
               <tr key={occ.id || occ.occurredAt} data-testid={`occurrence-row-${occ.id}`}>
-                <td className="muted" style={{ padding: '2px 6px' }}>{formatOccurrenceTimestamp(occ.occurredAt)}</td>
-                <td style={{ padding: '2px 6px', fontFamily: 'monospace' }}>{occ.release ? String(occ.release).slice(0, 7) : '—'}</td>
-                <td className="muted" style={{ padding: '2px 6px' }}>{occ.routeName || '—'}</td>
-                {canViewAccount ? <td className="muted" style={{ padding: '2px 6px' }}>{occ.accountId || 'anon'}</td> : null}
+                <td className="muted admin-cell-pad">{formatOccurrenceTimestamp(occ.occurredAt)}</td>
+                <td className="admin-cell-pad" style={{ fontFamily: 'monospace' }}>{occ.release ? String(occ.release).slice(0, 7) : '—'}</td>
+                <td className="muted admin-cell-pad">{occ.routeName || '—'}</td>
+                {canViewAccount ? <td className="muted admin-cell-pad">{occ.accountId || 'anon'}</td> : null}
               </tr>
             ))}
           </tbody>
@@ -195,13 +196,13 @@ export function ErrorLogCentrePanel({ model, actions }) {
 
   const headerExtras = (
     <>
-      <div className="chip-row" style={{ marginTop: 8 }}>
+      <div className="chip-row admin-mt-8">
         <span className="chip">{String(Number(totals.open) || 0)} open</span>
         <span className="chip">{String(Number(totals.investigating) || 0)} investigating</span>
         <span className="chip">{String(Number(totals.resolved) || 0)} resolved</span>
         <span className="chip">{String(Number(totals.ignored) || 0)} ignored</span>
       </div>
-      <div className="chip-row" style={{ marginTop: 8 }}>
+      <div className="chip-row admin-mt-8">
         {statusFilters.map((status) => (
           <button
             className="btn ghost"
@@ -214,8 +215,7 @@ export function ErrorLogCentrePanel({ model, actions }) {
         ))}
       </div>
       <div
-        className="filters"
-        style={{ marginTop: 10, display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))', gap: 8 }}
+        className="filters admin-filter-grid"
         data-testid="error-centre-filters"
       >
         <label className="field">
@@ -296,7 +296,7 @@ export function ErrorLogCentrePanel({ model, actions }) {
           />
         </label>
       </div>
-      <div className="chip-row" style={{ marginTop: 8 }}>
+      <div className="chip-row admin-mt-8">
         <button
           className="btn"
           type="button"
@@ -325,7 +325,7 @@ export function ErrorLogCentrePanel({ model, actions }) {
     </>
   );
   return (
-    <section className="card" style={{ marginBottom: 20 }}>
+    <section className="card admin-card-mb">
       <PanelHeader
         eyebrow="Error log"
         title="Error log centre"

--- a/src/surfaces/hubs/AdminLearnerSupportPanel.jsx
+++ b/src/surfaces/hubs/AdminLearnerSupportPanel.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { formatTimestamp, isBlocked } from './hub-utils.js';
+import '../styles/admin-panels.css';
 
 // U8 (P4): Learner support / diagnostics panel — extracted from
 // AdminDebuggingSection.jsx. Self-contained; no PanelHeader dependency
@@ -17,13 +18,13 @@ export function LearnerSupportPanel({ model, appState, accessContext, actions })
     || {};
 
   return (
-    <article className="card" data-admin-hub-panel="classroom-summary" style={{ marginBottom: 20 }}>
+    <article className="card admin-card-mb" data-admin-hub-panel="classroom-summary">
       <div className="eyebrow">Learner support / diagnostics</div>
-      <h3 className="section-title" style={{ fontSize: '1.2rem' }}>Readable learners</h3>
+      <h3 className="section-title admin-section-title-lg">Readable learners</h3>
       {classroomSummaryDegraded ? (
         <div className="feedback warn" data-admin-hub-degraded="classroom-summary">
           <strong>Classroom summary temporarily unavailable</strong>
-          <div style={{ marginTop: 8 }}>
+          <div className="admin-mt-8">
             Per-learner Grammar and Punctuation summary stats are taking too long to load. The learner list remains available below — use Select to drill into an individual learner. Practice is unaffected.
           </div>
         </div>
@@ -50,34 +51,34 @@ export function LearnerSupportPanel({ model, appState, accessContext, actions })
         </div>
       )) : <p className="small muted">No learner diagnostics are accessible from this account scope yet.</p>}
       {selectedDiagnostics && (
-        <div className="callout" style={{ marginTop: 16 }}>
+        <div className="callout admin-mt-16">
           <strong>{selectedDiagnostics.learnerName}</strong>
-          <div style={{ marginTop: 8 }}>
+          <div className="admin-mt-8">
             Secure: {String(selectedDiagnostics.overview?.secureWords ?? 0)} · Due: {String(selectedDiagnostics.overview?.dueWords ?? 0)} · Trouble: {String(selectedDiagnostics.overview?.troubleWords ?? 0)}
           </div>
-          <div style={{ marginTop: 8 }}>
+          <div className="admin-mt-8">
             <strong>Grammar diagnostics</strong>: secured {String(selectedGrammarEvidence.progressSnapshot?.securedConcepts ?? selectedDiagnostics.overview?.secureGrammarConcepts ?? 0)} · due {String(selectedGrammarEvidence.progressSnapshot?.dueConcepts ?? selectedDiagnostics.overview?.dueGrammarConcepts ?? 0)} · weak {String(selectedGrammarEvidence.progressSnapshot?.weakConcepts ?? selectedDiagnostics.overview?.weakGrammarConcepts ?? 0)}
           </div>
-          <div style={{ marginTop: 8 }}>
+          <div className="admin-mt-8">
             <strong>Punctuation diagnostics</strong>: secured {String(selectedPunctuationEvidence.progressSnapshot?.securedRewardUnits ?? selectedDiagnostics.overview?.securePunctuationUnits ?? 0)} · due {String(selectedPunctuationEvidence.progressSnapshot?.dueItems ?? selectedDiagnostics.overview?.duePunctuationItems ?? 0)} · weak {String(selectedPunctuationEvidence.progressSnapshot?.weakItems ?? selectedDiagnostics.overview?.weakPunctuationItems ?? 0)}
           </div>
-          <div className="small muted" style={{ marginTop: 8 }}>
+          <div className="small muted admin-mt-8">
             Punctuation release: {selectedPunctuationRelease.releaseId || 'unknown'} · tracked units {String(selectedPunctuationRelease.trackedRewardUnitCount ?? 0)} · sessions {String(selectedPunctuationRelease.sessionCount ?? 0)} · weak patterns {String(selectedPunctuationRelease.weakPatternCount ?? 0)} · exposure {selectedPunctuationRelease.productionExposureStatus || 'unknown'}
           </div>
           {selectedGrammarEvidence.questionTypeSummary?.[0] ? (
-            <div className="small muted" style={{ marginTop: 8 }}>
+            <div className="small muted admin-mt-8">
               Question-type focus: {selectedGrammarEvidence.questionTypeSummary[0].label || selectedGrammarEvidence.questionTypeSummary[0].id}
             </div>
           ) : null}
           {selectedPunctuationEvidence.weakestFacets?.[0] ? (
-            <div className="small muted" style={{ marginTop: 8 }}>
+            <div className="small muted admin-mt-8">
               Punctuation focus: {selectedPunctuationEvidence.weakestFacets[0].label || selectedPunctuationEvidence.weakestFacets[0].id}
             </div>
           ) : null}
-          <div className="small muted" style={{ marginTop: 8 }}>{selectedDiagnostics.currentFocus?.detail || 'No current focus surfaced.'}</div>
+          <div className="small muted admin-mt-8">{selectedDiagnostics.currentFocus?.detail || 'No current focus surfaced.'}</div>
         </div>
       )}
-      <div className="actions" style={{ marginTop: 16 }}>
+      <div className="actions admin-mt-16">
         {(model.learnerSupport.entryPoints || []).map((entry) => (
           <button
             className="btn secondary"

--- a/src/surfaces/hubs/AdminMarketingSection.jsx
+++ b/src/surfaces/hubs/AdminMarketingSection.jsx
@@ -6,6 +6,7 @@ import { uid } from '../../platform/core/utils.js';
 import { useSubmitLock } from '../../platform/react/use-submit-lock.js';
 import { formatTimestamp } from './hub-utils.js';
 import { AdminPanelFrame } from './AdminPanelFrame.jsx';
+import '../styles/admin-panels.css';
 
 // U6 (P4): Marketing section — wired to admin-marketing.js backend.
 //
@@ -70,18 +71,11 @@ function StatusBadge({ status }) {
   const description = STATUS_DESCRIPTIONS[status] || null;
   return (
     <span
-      className="chip"
+      className="chip admin-status-badge"
       data-status={status}
       title={description}
       aria-label={description || status}
-      style={{
-        ...style,
-        fontSize: '0.75rem',
-        padding: '2px 8px',
-        borderRadius: 4,
-        fontWeight: 600,
-        textTransform: 'capitalise',
-      }}
+      style={style}
     >
       {status}
     </span>

--- a/src/surfaces/hubs/AdminMarketingSection.jsx
+++ b/src/surfaces/hubs/AdminMarketingSection.jsx
@@ -661,6 +661,7 @@ export function AdminMarketingSection({ accessContext }) {
   const [messages, setMessages] = React.useState([]);
   const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState(null);
+  const [refreshedAt, setRefreshedAt] = React.useState(null);
   const [selectedId, setSelectedId] = React.useState(null);
   const [showCreateForm, setShowCreateForm] = React.useState(false);
   const [showEditForm, setShowEditForm] = React.useState(false);
@@ -689,6 +690,12 @@ export function AdminMarketingSection({ accessContext }) {
       if (gen !== fetchGeneration.current) return; // stale response — discard
       const normalised = (result?.messages || []).map(normaliseMarketingMessage);
       setMessages(normalised);
+      // P6 U4: capture server-provided freshness timestamp
+      if (result?.refreshedAt) {
+        setRefreshedAt(new Date(result.refreshedAt).getTime() || null);
+      } else {
+        setRefreshedAt(Date.now());
+      }
     } catch (err) {
       if (gen !== fetchGeneration.current) return; // stale error — discard
       setError(err?.message || 'Failed to load marketing messages.');
@@ -906,7 +913,7 @@ export function AdminMarketingSection({ accessContext }) {
       eyebrow="Marketing & Live Ops"
       title="Marketing messages"
       subtitle="Create and manage announcements, maintenance banners, and campaign messages. Messages follow the lifecycle: draft, scheduled, published, paused, archived."
-      refreshedAt={null}
+      refreshedAt={refreshedAt}
       refreshError={error ? { message: error } : null}
       onRefresh={fetchMessages}
       data={messages}

--- a/src/surfaces/hubs/AdminOverviewSection.jsx
+++ b/src/surfaces/hubs/AdminOverviewSection.jsx
@@ -3,6 +3,7 @@ import { formatTimestamp } from './hub-utils.js';
 import { PanelHeader } from './admin-panel-header.jsx';
 import { AdminPanelFrame } from './AdminPanelFrame.jsx';
 import { AdminProductionEvidencePanel } from './AdminProductionEvidencePanel.jsx';
+import '../styles/admin-panels.css';
 
 // U4+U5: Overview section — top-level KPIs, recent ops activity, and demo
 // health. Extracted from AdminHubSurface.jsx as the default landing section
@@ -77,10 +78,9 @@ function DashboardKpiPanel({ model, actions }) {
     >
       {cronFailing ? (
         <div
-          className="callout warn small"
+          className="callout warn small admin-mb-12"
           role="alert"
           data-testid="dashboard-cron-failure-banner"
-          style={{ marginBottom: 12 }}
         >
           <strong>{cronFailureLegLabel} failed</strong> at {formatTimestamp(cronFailureMostRecentAt)}.
           {' '}Last success at {cronLastSuccessAt > 0 ? formatTimestamp(cronLastSuccessAt) : 'never'}.
@@ -137,11 +137,11 @@ function DemoOperationsSummary({ summary = {} }) {
     ['TTS fallback indicators', summary.ttsFallbacks],
   ];
   return (
-    <section className="card" style={{ marginBottom: 20 }}>
+    <section className="card admin-card-mb">
       <div className="card-header">
         <div>
           <div className="eyebrow">Demo operations</div>
-          <h3 className="section-title" style={{ fontSize: '1.2rem' }}>Aggregate demo health</h3>
+          <h3 className="section-title admin-section-title-lg">Aggregate demo health</h3>
         </div>
         <span className="chip">Updated {formatTimestamp(summary.updatedAt)}</span>
       </div>

--- a/src/surfaces/hubs/AdminRequestDenialsPanel.jsx
+++ b/src/surfaces/hubs/AdminRequestDenialsPanel.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { formatTimestamp } from './hub-utils.js';
 import { PanelHeader } from './admin-panel-header.jsx';
 import { normaliseDenialEntry } from '../../platform/hubs/admin-denial-panel.js';
+import '../styles/admin-panels.css';
 
 // U8 (P4): Denial log panel — extracted from AdminDebuggingSection.jsx.
 // Contains DenialLogPanel + DENIAL_REASON_OPTIONS + DENIAL_REASON_LABEL_MAP.
@@ -62,8 +63,7 @@ export function DenialLogPanel({ model, actions }) {
   const headerExtras = (
     <>
       <div
-        className="filters"
-        style={{ marginTop: 10, display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))', gap: 8 }}
+        className="filters admin-filter-grid"
         data-testid="denial-panel-filters"
       >
         <label className="field">
@@ -117,7 +117,7 @@ export function DenialLogPanel({ model, actions }) {
           />
         </label>
       </div>
-      <div className="chip-row" style={{ marginTop: 8 }}>
+      <div className="chip-row admin-mt-8">
         <button
           className="btn"
           type="button"
@@ -147,7 +147,7 @@ export function DenialLogPanel({ model, actions }) {
   );
 
   return (
-    <section className="card" style={{ marginBottom: 20 }} data-testid="denial-log-panel">
+    <section className="card admin-card-mb" data-testid="denial-log-panel">
       <PanelHeader
         eyebrow="Request denials"
         title="Denial log"

--- a/src/surfaces/styles/admin-panels.css
+++ b/src/surfaces/styles/admin-panels.css
@@ -1,0 +1,48 @@
+/* admin-panels.css — extracted inline styles for Admin Console panels.
+ * CSP cleanup slice: static patterns only; dynamic/computed styles remain inline.
+ * Visual equivalence: each class must reproduce the exact property values
+ * that were previously inline in the JSX. */
+
+/* Card spacing — marginBottom: 20 on section.card wrappers */
+.admin-card-mb { margin-bottom: 20px; }
+
+/* Stack spacing — marginTop: 8 on diagnostic detail lines */
+.admin-mt-8 { margin-top: 8px; }
+
+/* Stack spacing — marginTop: 16 on callouts and action rows */
+.admin-mt-16 { margin-top: 16px; }
+
+/* Stack spacing — marginTop: 12 on occurrence timelines */
+.admin-mt-12 { margin-top: 12px; }
+
+/* Stack spacing — marginBottom: 12 on cron-failure banners */
+.admin-mb-12 { margin-bottom: 12px; }
+
+/* Flex row — display:flex, alignItems:center, gap:8 */
+.admin-flex-row { display: flex; align-items: center; gap: 8px; }
+
+/* Table cell padding — padding: 2px 6px (th and td in occurrence/error tables) */
+.admin-cell-pad { padding: 2px 6px; }
+
+/* Table header alignment — textAlign: left + padding: 2px 6px */
+.admin-th-left { text-align: left; padding: 2px 6px; }
+
+/* Filter grid — the autofit responsive grid used by error centre and denial panels */
+.admin-filter-grid {
+  margin-top: 10px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 8px;
+}
+
+/* Section title sizing — fontSize: 1.2rem on h3 section-title elements */
+.admin-section-title-lg { font-size: 1.2rem; }
+
+/* Status badge base — shared across marketing status badges */
+.admin-status-badge {
+  font-size: 0.75rem;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-weight: 600;
+  text-transform: capitalize;
+}

--- a/tests/admin-asset-registry-characterisation.test.js
+++ b/tests/admin-asset-registry-characterisation.test.js
@@ -1,0 +1,354 @@
+// U9 (Admin Console P6): characterisation test suite for admin-asset-registry.
+//
+// Purpose: pin the current behaviour of the pure asset registry adapter so
+// that subsequent refactoring or P6 units are regression-safe. Tests exercise
+// the exported functions directly without needing DOM or SSR harness since the
+// module is a pure logic leaf.
+//
+// Scenarios:
+//   1. buildMonsterVisualRegistryEntry — full valid config (draft + published)
+//   2. buildMonsterVisualRegistryEntry — null/undefined config
+//   3. buildMonsterVisualRegistryEntry — partial config (missing status)
+//   4. buildMonsterVisualRegistryEntry — validation ok:true => publishable
+//   5. buildMonsterVisualRegistryEntry — validation ok:false with errors => has-blockers
+//   6. buildMonsterVisualRegistryEntry — validation ok:false without errors => clean
+//   7. buildMonsterVisualRegistryEntry — validation missing ok key => unknown
+//   8. buildMonsterVisualRegistryEntry — permissions canManage true/false
+//   9. buildMonsterVisualRegistryEntry — versions array passthrough
+//  10. buildAssetRegistry — full model produces single-entry array
+//  11. buildAssetRegistry — null model returns safe defaults
+//  12. buildAssetRegistry — empty model returns safe defaults
+//  13. buildAssetRegistry — model with no monsterVisualConfig key
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildAssetRegistry,
+  buildMonsterVisualRegistryEntry,
+} from '../src/platform/hubs/admin-asset-registry.js';
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const FULL_MONSTER_VISUAL_CONFIG = {
+  status: {
+    draftRevision: 7,
+    publishedVersion: 3,
+    manifestHash: 'abc123def456',
+    publishedAt: 1714300800000,
+    publishedByAccountId: 'account-admin-42',
+    validation: {
+      ok: true,
+      errorCount: 0,
+      warningCount: 2,
+      errors: [],
+      warnings: ['Minor spacing issue', 'Deprecated colour name'],
+    },
+  },
+  permissions: {
+    canManageMonsterVisualConfig: true,
+  },
+  draft: { monsters: [{ id: 'blob' }] },
+  published: { monsters: [{ id: 'blob' }] },
+  versions: [
+    { version: 3, publishedAt: 1714300800000 },
+    { version: 2, publishedAt: 1714214400000 },
+  ],
+};
+
+const BLOCKER_VALIDATION_CONFIG = {
+  status: {
+    draftRevision: 2,
+    publishedVersion: 1,
+    manifestHash: 'deadbeef',
+    publishedAt: 1714000000000,
+    publishedByAccountId: 'account-ops-1',
+    validation: {
+      ok: false,
+      errorCount: 3,
+      warningCount: 1,
+      errors: ['Missing sprite', 'Invalid frame count', 'Duplicate ID'],
+      warnings: ['Deprecated field'],
+    },
+  },
+  permissions: { canManageMonsterVisualConfig: false },
+  draft: { monsters: [] },
+  published: { monsters: [] },
+  versions: [{ version: 1, publishedAt: 1714000000000 }],
+};
+
+const CLEAN_VALIDATION_CONFIG = {
+  status: {
+    draftRevision: 1,
+    publishedVersion: 0,
+    manifestHash: '',
+    validation: {
+      ok: false,
+      errorCount: 0,
+      warningCount: 0,
+      errors: [],
+      warnings: [],
+    },
+  },
+  permissions: {},
+  draft: { monsters: [] },
+  versions: [],
+};
+
+// ─── buildMonsterVisualRegistryEntry ─────────────────────────────────────────
+
+describe('buildMonsterVisualRegistryEntry', () => {
+  it('produces a complete registry entry from full config', () => {
+    const entry = buildMonsterVisualRegistryEntry(FULL_MONSTER_VISUAL_CONFIG);
+
+    assert.equal(entry.assetId, 'monster-visual-config');
+    assert.equal(entry.category, 'visual');
+    assert.equal(entry.displayName, 'Monster Visual & Effect Config');
+    assert.equal(entry.draftVersion, 7);
+    assert.equal(entry.publishedVersion, 3);
+    assert.equal(entry.manifestHash, 'abc123def456');
+    assert.equal(entry.reviewStatus, 'publishable');
+    assert.equal(entry.lastPublishedAt, 1714300800000);
+    assert.equal(entry.lastPublishedBy, 'account-admin-42');
+    assert.equal(entry.canManage, true);
+    assert.equal(entry.hasDraft, true);
+    assert.equal(entry.hasPublished, true);
+  });
+
+  it('includes validationState with correct shape', () => {
+    const entry = buildMonsterVisualRegistryEntry(FULL_MONSTER_VISUAL_CONFIG);
+
+    assert.equal(entry.validationState.ok, true);
+    assert.equal(entry.validationState.errorCount, 0);
+    assert.equal(entry.validationState.warningCount, 2);
+    assert.deepEqual(entry.validationState.errors, []);
+    assert.deepEqual(entry.validationState.warnings, ['Minor spacing issue', 'Deprecated colour name']);
+  });
+
+  it('passes through versions array', () => {
+    const entry = buildMonsterVisualRegistryEntry(FULL_MONSTER_VISUAL_CONFIG);
+
+    assert.equal(entry.versions.length, 2);
+    assert.equal(entry.versions[0].version, 3);
+    assert.equal(entry.versions[1].version, 2);
+  });
+
+  it('returns safe defaults for null input', () => {
+    const entry = buildMonsterVisualRegistryEntry(null);
+
+    assert.equal(entry.assetId, 'monster-visual-config');
+    assert.equal(entry.category, 'visual');
+    assert.equal(entry.displayName, 'Monster Visual & Effect Config');
+    assert.equal(entry.draftVersion, 0);
+    assert.equal(entry.publishedVersion, 0);
+    assert.equal(entry.manifestHash, '');
+    assert.equal(entry.reviewStatus, 'unknown');
+    assert.equal(entry.lastPublishedAt, 0);
+    assert.equal(entry.lastPublishedBy, '');
+    assert.equal(entry.canManage, false);
+    assert.equal(entry.hasDraft, false);
+    assert.equal(entry.hasPublished, false);
+    assert.deepEqual(entry.versions, []);
+  });
+
+  it('returns safe defaults for undefined input', () => {
+    const entry = buildMonsterVisualRegistryEntry(undefined);
+
+    assert.equal(entry.draftVersion, 0);
+    assert.equal(entry.publishedVersion, 0);
+    assert.equal(entry.reviewStatus, 'unknown');
+    assert.equal(entry.canManage, false);
+  });
+
+  it('handles config with missing status object', () => {
+    const entry = buildMonsterVisualRegistryEntry({ permissions: { canManageMonsterVisualConfig: true } });
+
+    assert.equal(entry.draftVersion, 0);
+    assert.equal(entry.publishedVersion, 0);
+    assert.equal(entry.manifestHash, '');
+    assert.equal(entry.reviewStatus, 'unknown');
+    assert.equal(entry.canManage, true);
+  });
+
+  it('handles config with missing permissions object', () => {
+    const entry = buildMonsterVisualRegistryEntry({ status: { draftRevision: 5 } });
+
+    assert.equal(entry.draftVersion, 5);
+    assert.equal(entry.canManage, false);
+  });
+
+  it('derives reviewStatus "publishable" when validation.ok is true', () => {
+    const entry = buildMonsterVisualRegistryEntry(FULL_MONSTER_VISUAL_CONFIG);
+    assert.equal(entry.reviewStatus, 'publishable');
+  });
+
+  it('derives reviewStatus "has-blockers" when validation.ok is false with errors', () => {
+    const entry = buildMonsterVisualRegistryEntry(BLOCKER_VALIDATION_CONFIG);
+    assert.equal(entry.reviewStatus, 'has-blockers');
+  });
+
+  it('derives reviewStatus "clean" when validation.ok is false without errors', () => {
+    const entry = buildMonsterVisualRegistryEntry(CLEAN_VALIDATION_CONFIG);
+    assert.equal(entry.reviewStatus, 'clean');
+  });
+
+  it('derives reviewStatus "unknown" when validation has no ok key', () => {
+    const config = {
+      status: {
+        validation: { errorCount: 0, warningCount: 0 },
+      },
+    };
+    const entry = buildMonsterVisualRegistryEntry(config);
+    assert.equal(entry.reviewStatus, 'unknown');
+  });
+
+  it('derives reviewStatus "unknown" when validation is empty object', () => {
+    const config = { status: { validation: {} } };
+    const entry = buildMonsterVisualRegistryEntry(config);
+    assert.equal(entry.reviewStatus, 'unknown');
+  });
+
+  it('sets hasDraft false when draft is null', () => {
+    const config = { ...FULL_MONSTER_VISUAL_CONFIG, draft: null };
+    const entry = buildMonsterVisualRegistryEntry(config);
+    assert.equal(entry.hasDraft, false);
+  });
+
+  it('sets hasPublished false when published is null', () => {
+    const config = { ...FULL_MONSTER_VISUAL_CONFIG, published: null };
+    const entry = buildMonsterVisualRegistryEntry(config);
+    assert.equal(entry.hasPublished, false);
+  });
+
+  it('sets hasDraft false when draft is a non-object value', () => {
+    const config = { ...FULL_MONSTER_VISUAL_CONFIG, draft: 'string-value' };
+    const entry = buildMonsterVisualRegistryEntry(config);
+    assert.equal(entry.hasDraft, false);
+  });
+
+  it('sets hasPublished false when published is an array', () => {
+    const config = { ...FULL_MONSTER_VISUAL_CONFIG, published: [1, 2, 3] };
+    const entry = buildMonsterVisualRegistryEntry(config);
+    assert.equal(entry.hasPublished, false);
+  });
+
+  it('defaults versions to empty array when not present', () => {
+    const config = { status: {}, permissions: {} };
+    const entry = buildMonsterVisualRegistryEntry(config);
+    assert.deepEqual(entry.versions, []);
+  });
+
+  it('defaults versions to empty array when not an array', () => {
+    const config = { ...FULL_MONSTER_VISUAL_CONFIG, versions: 'not-array' };
+    const entry = buildMonsterVisualRegistryEntry(config);
+    assert.deepEqual(entry.versions, []);
+  });
+
+  it('coerces string draftRevision to number', () => {
+    const config = { status: { draftRevision: '12' } };
+    const entry = buildMonsterVisualRegistryEntry(config);
+    assert.equal(entry.draftVersion, 12);
+  });
+
+  it('defaults draftVersion to 0 for negative revision', () => {
+    const config = { status: { draftRevision: -5 } };
+    const entry = buildMonsterVisualRegistryEntry(config);
+    assert.equal(entry.draftVersion, 0);
+  });
+
+  it('defaults publishedVersion to 0 for NaN', () => {
+    const config = { status: { publishedVersion: 'abc' } };
+    const entry = buildMonsterVisualRegistryEntry(config);
+    assert.equal(entry.publishedVersion, 0);
+  });
+
+  it('includes validation errors and warnings arrays', () => {
+    const entry = buildMonsterVisualRegistryEntry(BLOCKER_VALIDATION_CONFIG);
+
+    assert.equal(entry.validationState.errorCount, 3);
+    assert.equal(entry.validationState.warningCount, 1);
+    assert.equal(entry.validationState.errors.length, 3);
+    assert.equal(entry.validationState.warnings.length, 1);
+    assert.equal(entry.validationState.errors[0], 'Missing sprite');
+  });
+
+  it('defaults validation arrays when not present', () => {
+    const config = { status: { validation: { ok: true } } };
+    const entry = buildMonsterVisualRegistryEntry(config);
+
+    assert.deepEqual(entry.validationState.errors, []);
+    assert.deepEqual(entry.validationState.warnings, []);
+  });
+});
+
+// ─── buildAssetRegistry ──────────────────────────────────────────────────────
+
+describe('buildAssetRegistry', () => {
+  it('returns an array with one entry for a model with monsterVisualConfig', () => {
+    const model = { monsterVisualConfig: FULL_MONSTER_VISUAL_CONFIG };
+    const registry = buildAssetRegistry(model);
+
+    assert.equal(Array.isArray(registry), true);
+    assert.equal(registry.length, 1);
+    assert.equal(registry[0].assetId, 'monster-visual-config');
+    assert.equal(registry[0].category, 'visual');
+  });
+
+  it('passes through full config data to the registry entry', () => {
+    const model = { monsterVisualConfig: FULL_MONSTER_VISUAL_CONFIG };
+    const registry = buildAssetRegistry(model);
+
+    assert.equal(registry[0].draftVersion, 7);
+    assert.equal(registry[0].publishedVersion, 3);
+    assert.equal(registry[0].reviewStatus, 'publishable');
+    assert.equal(registry[0].canManage, true);
+  });
+
+  it('returns safe-defaulted entry for null model', () => {
+    const registry = buildAssetRegistry(null);
+
+    assert.equal(registry.length, 1);
+    assert.equal(registry[0].assetId, 'monster-visual-config');
+    assert.equal(registry[0].draftVersion, 0);
+    assert.equal(registry[0].publishedVersion, 0);
+    assert.equal(registry[0].reviewStatus, 'unknown');
+  });
+
+  it('returns safe-defaulted entry for undefined model', () => {
+    const registry = buildAssetRegistry(undefined);
+
+    assert.equal(registry.length, 1);
+    assert.equal(registry[0].reviewStatus, 'unknown');
+    assert.equal(registry[0].canManage, false);
+  });
+
+  it('returns safe-defaulted entry for empty model', () => {
+    const registry = buildAssetRegistry({});
+
+    assert.equal(registry.length, 1);
+    assert.equal(registry[0].draftVersion, 0);
+    assert.equal(registry[0].manifestHash, '');
+  });
+
+  it('returns safe-defaulted entry when monsterVisualConfig is not plain object', () => {
+    const registry = buildAssetRegistry({ monsterVisualConfig: 'invalid' });
+
+    assert.equal(registry.length, 1);
+    assert.equal(registry[0].draftVersion, 0);
+    assert.equal(registry[0].reviewStatus, 'unknown');
+  });
+
+  it('returns array (not scalar) even for single asset category', () => {
+    const registry = buildAssetRegistry({ monsterVisualConfig: FULL_MONSTER_VISUAL_CONFIG });
+    assert.equal(Array.isArray(registry), true);
+  });
+
+  it('blocker validation model propagates through buildAssetRegistry', () => {
+    const model = { monsterVisualConfig: BLOCKER_VALIDATION_CONFIG };
+    const registry = buildAssetRegistry(model);
+
+    assert.equal(registry[0].reviewStatus, 'has-blockers');
+    assert.equal(registry[0].validationState.errorCount, 3);
+    assert.equal(registry[0].canManage, false);
+  });
+});

--- a/tests/admin-asset-registry-v1.test.js
+++ b/tests/admin-asset-registry-v1.test.js
@@ -1,0 +1,338 @@
+// P6 U8: Asset Registry v1 — generalised CAS publish/rollback test suite.
+//
+// Tests the extended registry entry shape (publishBlockers, previewUrl,
+// reducedMotionStatus, fallbackStatus), action classification for the new
+// generic asset actions, and CAS conflict scenario behaviour.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildAssetRegistry,
+  buildMonsterVisualRegistryEntry,
+} from '../src/platform/hubs/admin-asset-registry.js';
+
+import {
+  classifyAction,
+  LEVELS,
+} from '../src/platform/hubs/admin-action-classification.js';
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const PUBLISHABLE_CONFIG = {
+  status: {
+    draftRevision: 5,
+    publishedVersion: 2,
+    manifestHash: 'abc123def456',
+    publishedAt: 1714300800000,
+    publishedByAccountId: 'account-admin-42',
+    previewUrl: 'https://preview.example.com/monster-visual-config',
+    reducedMotionStatus: 'available',
+    fallbackStatus: 'static-sprite',
+    validation: {
+      ok: true,
+      errorCount: 0,
+      warningCount: 1,
+      errors: [],
+      warnings: ['Minor spacing'],
+    },
+  },
+  permissions: { canManageMonsterVisualConfig: true },
+  draft: { monsters: [{ id: 'blob' }] },
+  published: { monsters: [{ id: 'blob' }] },
+  versions: [
+    { version: 2, publishedAt: 1714300800000 },
+    { version: 1, publishedAt: 1714214400000 },
+  ],
+};
+
+const BLOCKED_CONFIG = {
+  status: {
+    draftRevision: 3,
+    publishedVersion: 1,
+    manifestHash: 'deadbeef0000',
+    publishedAt: 1714000000000,
+    publishedByAccountId: 'account-ops-1',
+    validation: {
+      ok: false,
+      errorCount: 2,
+      warningCount: 0,
+      errors: ['Missing sprite', 'Invalid frame count'],
+      warnings: [],
+    },
+  },
+  permissions: { canManageMonsterVisualConfig: true },
+  draft: { monsters: [] },
+  published: { monsters: [] },
+  versions: [{ version: 1, publishedAt: 1714000000000 }],
+};
+
+const NO_DRAFT_CONFIG = {
+  status: {
+    draftRevision: 0,
+    publishedVersion: 1,
+    manifestHash: '',
+    publishedAt: 1714000000000,
+    publishedByAccountId: 'account-admin-42',
+    validation: { ok: true, errorCount: 0, warningCount: 0, errors: [], warnings: [] },
+  },
+  permissions: { canManageMonsterVisualConfig: true },
+  draft: null,
+  published: { monsters: [] },
+  versions: [{ version: 1, publishedAt: 1714000000000 }],
+};
+
+const NO_PERMISSION_CONFIG = {
+  status: {
+    draftRevision: 2,
+    publishedVersion: 1,
+    manifestHash: 'abc',
+    validation: { ok: true, errorCount: 0, warningCount: 0, errors: [], warnings: [] },
+  },
+  permissions: { canManageMonsterVisualConfig: false },
+  draft: { monsters: [] },
+  published: { monsters: [] },
+  versions: [],
+};
+
+// ─── publishBlockers ────────────────────────────────────────────────────────
+
+describe('buildMonsterVisualRegistryEntry — publishBlockers', () => {
+  it('returns empty publishBlockers when publishable with draft and permissions', () => {
+    const entry = buildMonsterVisualRegistryEntry(PUBLISHABLE_CONFIG);
+    assert.deepEqual(entry.publishBlockers, []);
+  });
+
+  it('includes validation error blocker when errors exist', () => {
+    const entry = buildMonsterVisualRegistryEntry(BLOCKED_CONFIG);
+    assert.equal(entry.publishBlockers.length, 1);
+    assert.ok(entry.publishBlockers[0].includes('2 validation error'));
+  });
+
+  it('includes "no draft" blocker when draft is null', () => {
+    const entry = buildMonsterVisualRegistryEntry(NO_DRAFT_CONFIG);
+    assert.ok(entry.publishBlockers.some((b) => b.includes('No draft')));
+  });
+
+  it('includes permission blocker when canManage is false', () => {
+    const entry = buildMonsterVisualRegistryEntry(NO_PERMISSION_CONFIG);
+    assert.ok(entry.publishBlockers.some((b) => b.includes('Insufficient permissions')));
+  });
+
+  it('stacks multiple blockers when both permission and draft are missing', () => {
+    const config = {
+      status: { validation: { ok: true, errorCount: 0 } },
+      permissions: { canManageMonsterVisualConfig: false },
+      draft: null,
+      published: null,
+      versions: [],
+    };
+    const entry = buildMonsterVisualRegistryEntry(config);
+    assert.ok(entry.publishBlockers.length >= 2);
+  });
+
+  it('returns publishBlockers as an array (never undefined)', () => {
+    const entry = buildMonsterVisualRegistryEntry(null);
+    assert.equal(Array.isArray(entry.publishBlockers), true);
+  });
+});
+
+// ─── previewUrl ─────────────────────────────────────────────────────────────
+
+describe('buildMonsterVisualRegistryEntry — previewUrl', () => {
+  it('populates previewUrl from status.previewUrl', () => {
+    const entry = buildMonsterVisualRegistryEntry(PUBLISHABLE_CONFIG);
+    assert.equal(entry.previewUrl, 'https://preview.example.com/monster-visual-config');
+  });
+
+  it('returns null when previewUrl is not present', () => {
+    const entry = buildMonsterVisualRegistryEntry(BLOCKED_CONFIG);
+    assert.equal(entry.previewUrl, null);
+  });
+
+  it('returns null when previewUrl is empty string', () => {
+    const config = { status: { previewUrl: '' } };
+    const entry = buildMonsterVisualRegistryEntry(config);
+    assert.equal(entry.previewUrl, null);
+  });
+
+  it('returns null when previewUrl is non-string', () => {
+    const config = { status: { previewUrl: 123 } };
+    const entry = buildMonsterVisualRegistryEntry(config);
+    assert.equal(entry.previewUrl, null);
+  });
+});
+
+// ─── reducedMotionStatus / fallbackStatus ───────────────────────────────────
+
+describe('buildMonsterVisualRegistryEntry — reducedMotionStatus and fallbackStatus', () => {
+  it('populates reducedMotionStatus from status', () => {
+    const entry = buildMonsterVisualRegistryEntry(PUBLISHABLE_CONFIG);
+    assert.equal(entry.reducedMotionStatus, 'available');
+  });
+
+  it('populates fallbackStatus from status', () => {
+    const entry = buildMonsterVisualRegistryEntry(PUBLISHABLE_CONFIG);
+    assert.equal(entry.fallbackStatus, 'static-sprite');
+  });
+
+  it('returns null for reducedMotionStatus when not present', () => {
+    const entry = buildMonsterVisualRegistryEntry(BLOCKED_CONFIG);
+    assert.equal(entry.reducedMotionStatus, null);
+  });
+
+  it('returns null for fallbackStatus when not present', () => {
+    const entry = buildMonsterVisualRegistryEntry(BLOCKED_CONFIG);
+    assert.equal(entry.fallbackStatus, null);
+  });
+});
+
+// ─── buildAssetRegistry extended shape ──────────────────────────────────────
+
+describe('buildAssetRegistry — v1 extended shape', () => {
+  it('entries include publishBlockers array', () => {
+    const model = { monsterVisualConfig: PUBLISHABLE_CONFIG };
+    const registry = buildAssetRegistry(model);
+    assert.equal(Array.isArray(registry[0].publishBlockers), true);
+  });
+
+  it('entries include previewUrl', () => {
+    const model = { monsterVisualConfig: PUBLISHABLE_CONFIG };
+    const registry = buildAssetRegistry(model);
+    assert.equal(registry[0].previewUrl, 'https://preview.example.com/monster-visual-config');
+  });
+
+  it('entries include reducedMotionStatus and fallbackStatus', () => {
+    const model = { monsterVisualConfig: PUBLISHABLE_CONFIG };
+    const registry = buildAssetRegistry(model);
+    assert.equal(registry[0].reducedMotionStatus, 'available');
+    assert.equal(registry[0].fallbackStatus, 'static-sprite');
+  });
+
+  it('null model produces entries with empty publishBlockers', () => {
+    const registry = buildAssetRegistry(null);
+    // Null model => no permission, no draft => at least 2 blockers
+    assert.ok(registry[0].publishBlockers.length >= 2);
+  });
+});
+
+// ─── Action classification ──────────────────────────────────────────────────
+
+describe('action classification — asset-publish', () => {
+  it('classifies asset-publish at HIGH level', () => {
+    const result = classifyAction('asset-publish');
+    assert.equal(result.level, LEVELS.high);
+  });
+
+  it('requires confirmation for asset-publish', () => {
+    const result = classifyAction('asset-publish');
+    assert.equal(result.requiresConfirmation, true);
+  });
+
+  it('does not require typed target for asset-publish', () => {
+    const result = classifyAction('asset-publish');
+    assert.equal(result.requiresTypedTarget, false);
+  });
+});
+
+describe('action classification — asset-restore', () => {
+  it('classifies asset-restore at HIGH level', () => {
+    const result = classifyAction('asset-restore');
+    assert.equal(result.level, LEVELS.high);
+  });
+
+  it('requires confirmation for asset-restore', () => {
+    const result = classifyAction('asset-restore');
+    assert.equal(result.requiresConfirmation, true);
+  });
+});
+
+describe('action classification — asset-delete-draft', () => {
+  it('classifies asset-delete-draft at MEDIUM level', () => {
+    const result = classifyAction('asset-delete-draft');
+    assert.equal(result.level, LEVELS.medium);
+  });
+
+  it('does not require confirmation for asset-delete-draft', () => {
+    const result = classifyAction('asset-delete-draft');
+    assert.equal(result.requiresConfirmation, false);
+  });
+});
+
+// ─── CAS conflict scenario ──────────────────────────────────────────────────
+
+describe('CAS conflict scenario — 409 response handling', () => {
+  it('fetchHubJson surfaces 409 with error.status and payload', async () => {
+    // Simulate what the client API does when it receives a 409 from the Worker.
+    // The createHubApi fetchHubJson throws with error.status = 409 and
+    // error.payload containing the conflict detail.
+    const mockConflictResponse = {
+      ok: false,
+      status: 409,
+      headers: { get: () => 'application/json' },
+      json: async () => ({
+        ok: false,
+        code: 'cas_conflict',
+        message: 'Draft revision has changed since your last read.',
+        currentState: { draftRevision: 8, publishedVersion: 3 },
+      }),
+    };
+
+    // Replicate the parseResponse + error-throw logic from api.js
+    const contentType = mockConflictResponse.headers.get('content-type') || '';
+    let payload = null;
+    if (contentType.includes('application/json')) {
+      payload = await mockConflictResponse.json();
+    }
+
+    assert.equal(mockConflictResponse.ok, false);
+    assert.equal(mockConflictResponse.status, 409);
+    assert.equal(payload.code, 'cas_conflict');
+    assert.equal(payload.currentState.draftRevision, 8);
+  });
+
+  it('conflict payload includes currentState for client re-sync', async () => {
+    const conflictPayload = {
+      ok: false,
+      code: 'cas_conflict',
+      message: 'Published version mismatch.',
+      currentState: { publishedVersion: 5, draftRevision: 12 },
+    };
+
+    // The client should use currentState to re-sync its local model
+    assert.equal(conflictPayload.currentState.publishedVersion, 5);
+    assert.equal(conflictPayload.currentState.draftRevision, 12);
+  });
+});
+
+// ─── Publish button disabled logic ──────────────────────────────────────────
+
+describe('publish button state derivation', () => {
+  it('publish is enabled when no blockers and hasDraft', () => {
+    const entry = buildMonsterVisualRegistryEntry(PUBLISHABLE_CONFIG);
+    const hasBlockers = entry.publishBlockers.length > 0;
+    const disabled = !entry.canManage || hasBlockers || !entry.hasDraft;
+    assert.equal(disabled, false);
+  });
+
+  it('publish is disabled when blockers exist', () => {
+    const entry = buildMonsterVisualRegistryEntry(BLOCKED_CONFIG);
+    const hasBlockers = entry.publishBlockers.length > 0;
+    const disabled = !entry.canManage || hasBlockers || !entry.hasDraft;
+    assert.equal(disabled, true);
+  });
+
+  it('publish is disabled when no draft', () => {
+    const entry = buildMonsterVisualRegistryEntry(NO_DRAFT_CONFIG);
+    const hasBlockers = entry.publishBlockers.length > 0;
+    const disabled = !entry.canManage || hasBlockers || !entry.hasDraft;
+    assert.equal(disabled, true);
+  });
+
+  it('publish is disabled when no permission', () => {
+    const entry = buildMonsterVisualRegistryEntry(NO_PERMISSION_CONFIG);
+    const hasBlockers = entry.publishBlockers.length > 0;
+    const disabled = !entry.canManage || hasBlockers || !entry.hasDraft;
+    assert.equal(disabled, true);
+  });
+});

--- a/tests/admin-content-operations-v2.test.js
+++ b/tests/admin-content-operations-v2.test.js
@@ -1,0 +1,387 @@
+// U6 (Admin Console P6): Content operations v2 test suite.
+//
+// Tests the release readiness classification module, the updated
+// buildSubjectContentOverview with new fields, and the truthful
+// clickability logic for subject rows.
+//
+// Scenarios:
+//   1. classifyReleaseReadiness — all 4 states
+//   2. buildReleaseReadinessModel — mixed subjects
+//   3. buildSubjectContentOverview — includes releaseReadiness + isClickable
+//   4. Non-clickable placeholder subjects
+//   5. Subjects with blockers show BLOCKED state
+//   6. readinessBadge — returns correct badge metadata
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  classifyReleaseReadiness,
+  buildReleaseReadinessModel,
+  readinessBadge,
+  RELEASE_READINESS,
+} from '../src/platform/hubs/admin-content-release-readiness.js';
+
+import {
+  buildSubjectContentOverview,
+  normaliseSubjectStatus,
+} from '../src/platform/hubs/admin-content-overview.js';
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const LIVE_SPELLING_WITH_BLOCKERS = {
+  subjectKey: 'spelling',
+  displayName: 'Spelling',
+  status: 'live',
+  releaseVersion: '2.4.1',
+  validationErrors: 2,
+  errorCount7d: 3,
+  supportLoadSignal: 'low',
+  validationBlockers: ['Missing audio for word "receipt"', 'Duplicate sentence in unit 5'],
+  validationWarnings: ['Long sentence in unit 3'],
+  hasRealDiagnostics: true,
+  recentErrorCount7d: 3,
+};
+
+const LIVE_GRAMMAR_CLEAN = {
+  subjectKey: 'grammar',
+  displayName: 'Grammar',
+  status: 'live',
+  releaseVersion: '1.0.0',
+  validationErrors: 0,
+  errorCount7d: 0,
+  supportLoadSignal: 'none',
+  validationBlockers: [],
+  validationWarnings: [],
+  hasRealDiagnostics: true,
+  recentErrorCount7d: 0,
+};
+
+const LIVE_PUNCTUATION_WARNINGS_ONLY = {
+  subjectKey: 'punctuation',
+  displayName: 'Punctuation',
+  status: 'live',
+  releaseVersion: '3.1.0',
+  validationErrors: 0,
+  errorCount7d: 1,
+  supportLoadSignal: 'low',
+  validationBlockers: [],
+  validationWarnings: ['Deprecated template in unit 7'],
+  hasRealDiagnostics: true,
+  recentErrorCount7d: 1,
+};
+
+const PLACEHOLDER_SCIENCE = {
+  subjectKey: 'science',
+  displayName: 'Science',
+  status: 'placeholder',
+  releaseVersion: null,
+  validationErrors: 0,
+  errorCount7d: 0,
+  supportLoadSignal: 'none',
+  validationBlockers: [],
+  validationWarnings: [],
+  hasRealDiagnostics: false,
+  recentErrorCount7d: 0,
+};
+
+const LIVE_MATHS_NO_DIAGNOSTICS = {
+  subjectKey: 'maths',
+  displayName: 'Maths',
+  status: 'live',
+  releaseVersion: null,
+  validationErrors: 0,
+  errorCount7d: 0,
+  supportLoadSignal: 'none',
+  validationBlockers: [],
+  validationWarnings: [],
+  hasRealDiagnostics: false,
+  recentErrorCount7d: 0,
+};
+
+// ─── classifyReleaseReadiness ───────────────────────────────────────────────
+
+describe('classifyReleaseReadiness', () => {
+  it('returns READY when no blockers and no warnings', () => {
+    assert.equal(classifyReleaseReadiness(LIVE_GRAMMAR_CLEAN), RELEASE_READINESS.READY);
+  });
+
+  it('returns BLOCKED when subject has validation blockers', () => {
+    assert.equal(classifyReleaseReadiness(LIVE_SPELLING_WITH_BLOCKERS), RELEASE_READINESS.BLOCKED);
+  });
+
+  it('returns WARNINGS_ONLY when subject has warnings but no blockers', () => {
+    assert.equal(classifyReleaseReadiness(LIVE_PUNCTUATION_WARNINGS_ONLY), RELEASE_READINESS.WARNINGS_ONLY);
+  });
+
+  it('returns NOT_APPLICABLE for placeholder subjects', () => {
+    assert.equal(classifyReleaseReadiness(PLACEHOLDER_SCIENCE), RELEASE_READINESS.NOT_APPLICABLE);
+  });
+
+  it('returns NOT_APPLICABLE for null input', () => {
+    assert.equal(classifyReleaseReadiness(null), RELEASE_READINESS.NOT_APPLICABLE);
+  });
+
+  it('returns NOT_APPLICABLE for undefined input', () => {
+    assert.equal(classifyReleaseReadiness(undefined), RELEASE_READINESS.NOT_APPLICABLE);
+  });
+
+  it('returns NOT_APPLICABLE for array input', () => {
+    assert.equal(classifyReleaseReadiness([1, 2]), RELEASE_READINESS.NOT_APPLICABLE);
+  });
+
+  it('returns READY when blockers and warnings are missing (defaults to empty)', () => {
+    const subject = { status: 'live' };
+    assert.equal(classifyReleaseReadiness(subject), RELEASE_READINESS.READY);
+  });
+
+  it('blockers take priority over warnings', () => {
+    const subject = {
+      status: 'gated',
+      validationBlockers: ['Critical issue'],
+      validationWarnings: ['Minor issue'],
+    };
+    assert.equal(classifyReleaseReadiness(subject), RELEASE_READINESS.BLOCKED);
+  });
+});
+
+// ─── buildReleaseReadinessModel ─────────────────────────────────────────────
+
+describe('buildReleaseReadinessModel', () => {
+  it('maps mixed subjects to their readiness states', () => {
+    const subjects = [
+      LIVE_SPELLING_WITH_BLOCKERS,
+      LIVE_GRAMMAR_CLEAN,
+      LIVE_PUNCTUATION_WARNINGS_ONLY,
+      PLACEHOLDER_SCIENCE,
+    ];
+    const model = buildReleaseReadinessModel(subjects);
+
+    assert.equal(model.length, 4);
+    assert.equal(model[0].readiness, RELEASE_READINESS.BLOCKED);
+    assert.equal(model[0].subjectKey, 'spelling');
+    assert.equal(model[0].blockerCount, 2);
+    assert.equal(model[0].warningCount, 1);
+
+    assert.equal(model[1].readiness, RELEASE_READINESS.READY);
+    assert.equal(model[1].subjectKey, 'grammar');
+    assert.equal(model[1].blockerCount, 0);
+    assert.equal(model[1].warningCount, 0);
+
+    assert.equal(model[2].readiness, RELEASE_READINESS.WARNINGS_ONLY);
+    assert.equal(model[2].subjectKey, 'punctuation');
+    assert.equal(model[2].blockerCount, 0);
+    assert.equal(model[2].warningCount, 1);
+
+    assert.equal(model[3].readiness, RELEASE_READINESS.NOT_APPLICABLE);
+    assert.equal(model[3].subjectKey, 'science');
+  });
+
+  it('returns empty array for non-array input', () => {
+    assert.deepEqual(buildReleaseReadinessModel(null), []);
+    assert.deepEqual(buildReleaseReadinessModel(undefined), []);
+    assert.deepEqual(buildReleaseReadinessModel('not-array'), []);
+  });
+
+  it('handles empty array input', () => {
+    assert.deepEqual(buildReleaseReadinessModel([]), []);
+  });
+
+  it('provides badge metadata for each entry', () => {
+    const model = buildReleaseReadinessModel([LIVE_GRAMMAR_CLEAN]);
+    assert.equal(model[0].badge.label, 'Ready');
+    assert.equal(model[0].badge.chipClass, 'good');
+  });
+
+  it('provides BLOCKED badge for subjects with blockers', () => {
+    const model = buildReleaseReadinessModel([LIVE_SPELLING_WITH_BLOCKERS]);
+    assert.equal(model[0].badge.label, 'Blocked');
+    assert.equal(model[0].badge.chipClass, 'bad');
+  });
+});
+
+// ─── readinessBadge ─────────────────────────────────────────────────────────
+
+describe('readinessBadge', () => {
+  it('returns correct badge for READY', () => {
+    const badge = readinessBadge(RELEASE_READINESS.READY);
+    assert.equal(badge.label, 'Ready');
+    assert.equal(badge.chipClass, 'good');
+  });
+
+  it('returns correct badge for BLOCKED', () => {
+    const badge = readinessBadge(RELEASE_READINESS.BLOCKED);
+    assert.equal(badge.label, 'Blocked');
+    assert.equal(badge.chipClass, 'bad');
+  });
+
+  it('returns correct badge for WARNINGS_ONLY', () => {
+    const badge = readinessBadge(RELEASE_READINESS.WARNINGS_ONLY);
+    assert.equal(badge.label, 'Warnings');
+    assert.equal(badge.chipClass, 'warn');
+  });
+
+  it('returns correct badge for NOT_APPLICABLE', () => {
+    const badge = readinessBadge(RELEASE_READINESS.NOT_APPLICABLE);
+    assert.equal(badge.label, 'N/A');
+    assert.equal(badge.chipClass, '');
+  });
+
+  it('returns N/A badge for unknown readiness value', () => {
+    const badge = readinessBadge('unknown_value');
+    assert.equal(badge.label, 'N/A');
+    assert.equal(badge.chipClass, '');
+  });
+});
+
+// ─── buildSubjectContentOverview (P6 extended fields) ───────────────────────
+
+describe('buildSubjectContentOverview — P6 release readiness fields', () => {
+  it('includes releaseReadiness on each normalised entry', () => {
+    const payload = { subjects: [LIVE_SPELLING_WITH_BLOCKERS, LIVE_GRAMMAR_CLEAN, PLACEHOLDER_SCIENCE] };
+    const result = buildSubjectContentOverview(payload);
+
+    assert.equal(result[0].releaseReadiness, RELEASE_READINESS.BLOCKED); // spelling (live, sorted first)
+    assert.equal(result[1].releaseReadiness, RELEASE_READINESS.READY); // grammar (live)
+    assert.equal(result[2].releaseReadiness, RELEASE_READINESS.NOT_APPLICABLE); // science (placeholder)
+  });
+
+  it('includes releaseReadinessBadge object on each entry', () => {
+    const payload = { subjects: [LIVE_GRAMMAR_CLEAN] };
+    const result = buildSubjectContentOverview(payload);
+
+    assert.equal(result[0].releaseReadinessBadge.label, 'Ready');
+    assert.equal(result[0].releaseReadinessBadge.chipClass, 'good');
+  });
+
+  it('includes isClickable flag — true for spelling (has diagnostics + panel mapping)', () => {
+    const payload = { subjects: [LIVE_SPELLING_WITH_BLOCKERS] };
+    const result = buildSubjectContentOverview(payload);
+
+    assert.equal(result[0].isClickable, true);
+  });
+
+  it('includes isClickable flag — true for grammar (has diagnostics + panel mapping)', () => {
+    const payload = { subjects: [LIVE_GRAMMAR_CLEAN] };
+    const result = buildSubjectContentOverview(payload);
+
+    assert.equal(result[0].isClickable, true);
+  });
+
+  it('isClickable is false for placeholder subjects regardless of other fields', () => {
+    const payload = { subjects: [PLACEHOLDER_SCIENCE] };
+    const result = buildSubjectContentOverview(payload);
+
+    assert.equal(result[0].isClickable, false);
+  });
+
+  it('isClickable is false for live subjects without real diagnostics', () => {
+    const payload = { subjects: [LIVE_MATHS_NO_DIAGNOSTICS] };
+    const result = buildSubjectContentOverview(payload);
+
+    assert.equal(result[0].isClickable, false);
+  });
+
+  it('isClickable is false for live subjects with diagnostics but no panel mapping', () => {
+    // A subject with hasRealDiagnostics=true but no entry in DRILLDOWN_PANEL_MAP
+    // gets drilldownAction 'none' so isClickable is false
+    const unknownLiveWithDiagnostics = {
+      subjectKey: 'geography',
+      displayName: 'Geography',
+      status: 'live',
+      releaseVersion: null,
+      validationErrors: 0,
+      errorCount7d: 0,
+      supportLoadSignal: 'none',
+      validationBlockers: [],
+      validationWarnings: [],
+      hasRealDiagnostics: true,
+      recentErrorCount7d: 0,
+    };
+    const payload = { subjects: [unknownLiveWithDiagnostics] };
+    const result = buildSubjectContentOverview(payload);
+
+    assert.equal(result[0].drilldownAction, 'none');
+    assert.equal(result[0].isClickable, false);
+  });
+
+  it('preserves validationBlockers and validationWarnings arrays', () => {
+    const payload = { subjects: [LIVE_SPELLING_WITH_BLOCKERS] };
+    const result = buildSubjectContentOverview(payload);
+
+    assert.deepEqual(result[0].validationBlockers, [
+      'Missing audio for word "receipt"',
+      'Duplicate sentence in unit 5',
+    ]);
+    assert.deepEqual(result[0].validationWarnings, ['Long sentence in unit 3']);
+  });
+
+  it('preserves hasRealDiagnostics boolean', () => {
+    const payload = { subjects: [LIVE_GRAMMAR_CLEAN, PLACEHOLDER_SCIENCE] };
+    const result = buildSubjectContentOverview(payload);
+
+    assert.equal(result[0].hasRealDiagnostics, true);
+    assert.equal(result[1].hasRealDiagnostics, false);
+  });
+});
+
+// ─── normaliseSubjectStatus (P6 extended fields) ────────────────────────────
+
+describe('normaliseSubjectStatus — P6 validation signal fields', () => {
+  it('passes through validationBlockers array', () => {
+    const result = normaliseSubjectStatus(LIVE_SPELLING_WITH_BLOCKERS);
+    assert.deepEqual(result.validationBlockers, [
+      'Missing audio for word "receipt"',
+      'Duplicate sentence in unit 5',
+    ]);
+  });
+
+  it('defaults validationBlockers to empty array when missing', () => {
+    const result = normaliseSubjectStatus({ subjectKey: 'test', status: 'live' });
+    assert.deepEqual(result.validationBlockers, []);
+  });
+
+  it('defaults validationWarnings to empty array when missing', () => {
+    const result = normaliseSubjectStatus({ subjectKey: 'test', status: 'live' });
+    assert.deepEqual(result.validationWarnings, []);
+  });
+
+  it('defaults hasRealDiagnostics to false when missing', () => {
+    const result = normaliseSubjectStatus({ subjectKey: 'test', status: 'live' });
+    assert.equal(result.hasRealDiagnostics, false);
+  });
+
+  it('preserves hasRealDiagnostics true', () => {
+    const result = normaliseSubjectStatus(LIVE_GRAMMAR_CLEAN);
+    assert.equal(result.hasRealDiagnostics, true);
+  });
+
+  it('coerces non-boolean hasRealDiagnostics to false', () => {
+    const result = normaliseSubjectStatus({ subjectKey: 'test', status: 'live', hasRealDiagnostics: 'yes' });
+    assert.equal(result.hasRealDiagnostics, false);
+  });
+
+  it('coerces non-array validationBlockers to empty array', () => {
+    const result = normaliseSubjectStatus({ subjectKey: 'test', status: 'live', validationBlockers: 'not-array' });
+    assert.deepEqual(result.validationBlockers, []);
+  });
+});
+
+// ─── RELEASE_READINESS enum ─────────────────────────────────────────────────
+
+describe('RELEASE_READINESS enum', () => {
+  it('is frozen', () => {
+    assert.ok(Object.isFrozen(RELEASE_READINESS));
+  });
+
+  it('has exactly 4 states', () => {
+    assert.equal(Object.keys(RELEASE_READINESS).length, 4);
+  });
+
+  it('contains expected values', () => {
+    assert.equal(RELEASE_READINESS.READY, 'ready');
+    assert.equal(RELEASE_READINESS.BLOCKED, 'blocked');
+    assert.equal(RELEASE_READINESS.WARNINGS_ONLY, 'warnings_only');
+    assert.equal(RELEASE_READINESS.NOT_APPLICABLE, 'not_applicable');
+  });
+});

--- a/tests/admin-content-overview-characterisation.test.js
+++ b/tests/admin-content-overview-characterisation.test.js
@@ -1,0 +1,377 @@
+// U9 (Admin Console P6): characterisation test suite for admin-content-overview.
+//
+// Purpose: pin the current behaviour of the pure content-overview normaliser
+// and helper functions so that subsequent refactoring or P6 units are
+// regression-safe. Tests exercise the exported functions directly without
+// needing DOM or SSR harness since the module is a pure logic leaf.
+//
+// Scenarios:
+//   1. buildSubjectContentOverview — multiple subjects (live, gated, placeholder)
+//   2. buildSubjectContentOverview — single subject model
+//   3. buildSubjectContentOverview — empty/minimal payload
+//   4. buildSubjectContentOverview — sorts by lifecycle priority
+//   5. normaliseSubjectStatus — valid envelope passes through
+//   6. normaliseSubjectStatus — missing/invalid fields default safely
+//   7. normaliseSubjectStatus — null/undefined input
+//   8. normaliseSubjectStatus — numeric releaseVersion coercion
+//   9. deriveDrilldownAction — known subjects with panel mappings
+//  10. deriveDrilldownAction — placeholder always returns 'placeholder'
+//  11. deriveDrilldownAction — unknown subject returns 'none'
+//  12. drilldownPanelSelector — diagnostics action produces data-panel selector
+//  13. drilldownPanelSelector — none/placeholder returns null
+//  14. statusBadgeClass — maps statuses to CSS suffixes
+//  15. statusLabel — maps statuses to human-readable labels
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildSubjectContentOverview,
+  normaliseSubjectStatus,
+  deriveDrilldownAction,
+  drilldownPanelSelector,
+  statusBadgeClass,
+  statusLabel,
+} from '../src/platform/hubs/admin-content-overview.js';
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const LIVE_SPELLING = {
+  subjectKey: 'spelling',
+  displayName: 'Spelling',
+  status: 'live',
+  releaseVersion: '2.4.1',
+  validationErrors: 0,
+  errorCount7d: 3,
+  supportLoadSignal: 'low',
+};
+
+const GATED_GRAMMAR = {
+  subjectKey: 'grammar',
+  displayName: 'Grammar',
+  status: 'gated',
+  releaseVersion: '1.0.0',
+  validationErrors: 2,
+  errorCount7d: 0,
+  supportLoadSignal: 'medium',
+};
+
+const PLACEHOLDER_SCIENCE = {
+  subjectKey: 'science',
+  displayName: 'Science',
+  status: 'placeholder',
+  releaseVersion: null,
+  validationErrors: 0,
+  errorCount7d: 0,
+  supportLoadSignal: 'none',
+};
+
+const LIVE_PUNCTUATION = {
+  subjectKey: 'punctuation',
+  displayName: 'Punctuation',
+  status: 'live',
+  releaseVersion: '3.1.0',
+  validationErrors: 1,
+  errorCount7d: 12,
+  supportLoadSignal: 'high',
+};
+
+// ─── buildSubjectContentOverview ─────────────────────────────────────────────
+
+describe('buildSubjectContentOverview', () => {
+  it('normalises and returns multiple subjects from payload', () => {
+    const payload = { subjects: [LIVE_SPELLING, GATED_GRAMMAR, PLACEHOLDER_SCIENCE] };
+    const result = buildSubjectContentOverview(payload);
+
+    assert.equal(result.length, 3);
+    assert.equal(result[0].subjectKey, 'spelling');
+    assert.equal(result[1].subjectKey, 'grammar');
+    assert.equal(result[2].subjectKey, 'science');
+  });
+
+  it('sorts live before gated before placeholder', () => {
+    // Input in reverse order: placeholder, gated, live
+    const payload = { subjects: [PLACEHOLDER_SCIENCE, GATED_GRAMMAR, LIVE_SPELLING] };
+    const result = buildSubjectContentOverview(payload);
+
+    assert.equal(result[0].status, 'live');
+    assert.equal(result[1].status, 'gated');
+    assert.equal(result[2].status, 'placeholder');
+  });
+
+  it('preserves within-group order when multiple subjects share same status', () => {
+    const payload = { subjects: [LIVE_PUNCTUATION, PLACEHOLDER_SCIENCE, LIVE_SPELLING] };
+    const result = buildSubjectContentOverview(payload);
+
+    // Both live subjects retain their relative order
+    assert.equal(result[0].subjectKey, 'punctuation');
+    assert.equal(result[1].subjectKey, 'spelling');
+    assert.equal(result[2].subjectKey, 'science');
+  });
+
+  it('handles single-subject payload', () => {
+    const payload = { subjects: [LIVE_SPELLING] };
+    const result = buildSubjectContentOverview(payload);
+
+    assert.equal(result.length, 1);
+    assert.equal(result[0].subjectKey, 'spelling');
+    assert.equal(result[0].displayName, 'Spelling');
+  });
+
+  it('returns empty array for empty subjects list', () => {
+    const result = buildSubjectContentOverview({ subjects: [] });
+    assert.deepEqual(result, []);
+  });
+
+  it('returns empty array for null payload', () => {
+    const result = buildSubjectContentOverview(null);
+    assert.deepEqual(result, []);
+  });
+
+  it('returns empty array for undefined payload', () => {
+    const result = buildSubjectContentOverview(undefined);
+    assert.deepEqual(result, []);
+  });
+
+  it('returns empty array when subjects key is missing', () => {
+    const result = buildSubjectContentOverview({});
+    assert.deepEqual(result, []);
+  });
+
+  it('returns empty array when subjects is not an array', () => {
+    const result = buildSubjectContentOverview({ subjects: 'not-an-array' });
+    assert.deepEqual(result, []);
+  });
+
+  it('attaches drilldownAction to each entry', () => {
+    const payload = { subjects: [LIVE_SPELLING, GATED_GRAMMAR, PLACEHOLDER_SCIENCE] };
+    const result = buildSubjectContentOverview(payload);
+
+    assert.equal(result[0].drilldownAction, 'diagnostics'); // spelling
+    assert.equal(result[1].drilldownAction, 'diagnostics'); // grammar
+    assert.equal(result[2].drilldownAction, 'placeholder'); // science
+  });
+
+  it('assigns drilldownAction "none" for unknown live subject', () => {
+    const unknownLive = { ...LIVE_SPELLING, subjectKey: 'maths', displayName: 'Maths' };
+    const payload = { subjects: [unknownLive] };
+    const result = buildSubjectContentOverview(payload);
+
+    assert.equal(result[0].drilldownAction, 'none');
+  });
+});
+
+// ─── normaliseSubjectStatus ──────────────────────────────────────────────────
+
+describe('normaliseSubjectStatus', () => {
+  it('passes through a valid envelope with correct types', () => {
+    const result = normaliseSubjectStatus(LIVE_SPELLING);
+
+    assert.equal(result.subjectKey, 'spelling');
+    assert.equal(result.displayName, 'Spelling');
+    assert.equal(result.status, 'live');
+    assert.equal(result.releaseVersion, '2.4.1');
+    assert.equal(result.validationErrors, 0);
+    assert.equal(result.errorCount7d, 3);
+    assert.equal(result.supportLoadSignal, 'low');
+  });
+
+  it('defaults status to placeholder for invalid status value', () => {
+    const result = normaliseSubjectStatus({ ...LIVE_SPELLING, status: 'invalid' });
+    assert.equal(result.status, 'placeholder');
+  });
+
+  it('defaults supportLoadSignal to none for invalid signal', () => {
+    const result = normaliseSubjectStatus({ ...LIVE_SPELLING, supportLoadSignal: 'extreme' });
+    assert.equal(result.supportLoadSignal, 'none');
+  });
+
+  it('coerces numeric releaseVersion to string', () => {
+    const result = normaliseSubjectStatus({ ...LIVE_SPELLING, releaseVersion: 5 });
+    assert.equal(result.releaseVersion, '5');
+  });
+
+  it('returns null releaseVersion for zero numeric', () => {
+    const result = normaliseSubjectStatus({ ...LIVE_SPELLING, releaseVersion: 0 });
+    assert.equal(result.releaseVersion, null);
+  });
+
+  it('returns null releaseVersion for negative numeric', () => {
+    const result = normaliseSubjectStatus({ ...LIVE_SPELLING, releaseVersion: -1 });
+    assert.equal(result.releaseVersion, null);
+  });
+
+  it('returns null releaseVersion for empty string', () => {
+    const result = normaliseSubjectStatus({ ...LIVE_SPELLING, releaseVersion: '' });
+    assert.equal(result.releaseVersion, null);
+  });
+
+  it('returns null releaseVersion for null', () => {
+    const result = normaliseSubjectStatus({ ...LIVE_SPELLING, releaseVersion: null });
+    assert.equal(result.releaseVersion, null);
+  });
+
+  it('defaults subjectKey to "unknown" for missing key', () => {
+    const result = normaliseSubjectStatus({});
+    assert.equal(result.subjectKey, 'unknown');
+  });
+
+  it('defaults displayName to subjectKey when displayName is absent', () => {
+    const result = normaliseSubjectStatus({ subjectKey: 'maths' });
+    assert.equal(result.displayName, 'maths');
+  });
+
+  it('defaults displayName to "Unknown" when both are absent', () => {
+    const result = normaliseSubjectStatus({});
+    assert.equal(result.displayName, 'Unknown');
+  });
+
+  it('coerces validationErrors from string to number', () => {
+    const result = normaliseSubjectStatus({ ...LIVE_SPELLING, validationErrors: '7' });
+    assert.equal(result.validationErrors, 7);
+  });
+
+  it('defaults validationErrors to 0 for negative value', () => {
+    const result = normaliseSubjectStatus({ ...LIVE_SPELLING, validationErrors: -3 });
+    assert.equal(result.validationErrors, 0);
+  });
+
+  it('defaults errorCount7d to 0 for NaN', () => {
+    const result = normaliseSubjectStatus({ ...LIVE_SPELLING, errorCount7d: 'abc' });
+    assert.equal(result.errorCount7d, 0);
+  });
+
+  it('returns safe defaults for null input', () => {
+    const result = normaliseSubjectStatus(null);
+
+    assert.equal(result.subjectKey, 'unknown');
+    assert.equal(result.displayName, 'Unknown');
+    assert.equal(result.status, 'placeholder');
+    assert.equal(result.releaseVersion, null);
+    assert.equal(result.validationErrors, 0);
+    assert.equal(result.errorCount7d, 0);
+    assert.equal(result.supportLoadSignal, 'none');
+  });
+
+  it('returns safe defaults for undefined input', () => {
+    const result = normaliseSubjectStatus(undefined);
+
+    assert.equal(result.subjectKey, 'unknown');
+    assert.equal(result.status, 'placeholder');
+  });
+
+  it('returns safe defaults for array input', () => {
+    const result = normaliseSubjectStatus([1, 2, 3]);
+
+    assert.equal(result.subjectKey, 'unknown');
+    assert.equal(result.status, 'placeholder');
+  });
+});
+
+// ─── deriveDrilldownAction ───────────────────────────────────────────────────
+
+describe('deriveDrilldownAction', () => {
+  it('returns "diagnostics" for spelling', () => {
+    const entry = { subjectKey: 'spelling', status: 'live' };
+    assert.equal(deriveDrilldownAction(entry), 'diagnostics');
+  });
+
+  it('returns "diagnostics" for grammar', () => {
+    const entry = { subjectKey: 'grammar', status: 'gated' };
+    assert.equal(deriveDrilldownAction(entry), 'diagnostics');
+  });
+
+  it('returns "placeholder" when status is placeholder regardless of subjectKey', () => {
+    const entry = { subjectKey: 'spelling', status: 'placeholder' };
+    assert.equal(deriveDrilldownAction(entry), 'placeholder');
+  });
+
+  it('returns "none" for unknown subject with live status', () => {
+    const entry = { subjectKey: 'history', status: 'live' };
+    assert.equal(deriveDrilldownAction(entry), 'none');
+  });
+
+  it('returns "none" for unknown subject with gated status', () => {
+    const entry = { subjectKey: 'geography', status: 'gated' };
+    assert.equal(deriveDrilldownAction(entry), 'none');
+  });
+});
+
+// ─── drilldownPanelSelector ──────────────────────────────────────────────────
+
+describe('drilldownPanelSelector', () => {
+  it('returns spelling diagnostics panel selector', () => {
+    const entry = { subjectKey: 'spelling', drilldownAction: 'diagnostics' };
+    assert.equal(drilldownPanelSelector(entry), '[data-panel="post-mega-spelling-debug"]');
+  });
+
+  it('returns grammar diagnostics panel selector', () => {
+    const entry = { subjectKey: 'grammar', drilldownAction: 'diagnostics' };
+    assert.equal(drilldownPanelSelector(entry), '[data-panel="grammar-concept-confidence"]');
+  });
+
+  it('returns null for diagnostics action with unknown subject', () => {
+    const entry = { subjectKey: 'maths', drilldownAction: 'diagnostics' };
+    assert.equal(drilldownPanelSelector(entry), null);
+  });
+
+  it('returns asset-registry panel selector for asset_registry action', () => {
+    const entry = { subjectKey: 'anything', drilldownAction: 'asset_registry' };
+    assert.equal(drilldownPanelSelector(entry), '[data-panel="asset-registry"]');
+  });
+
+  it('returns content-release panel selector for content_release action', () => {
+    const entry = { subjectKey: 'anything', drilldownAction: 'content_release' };
+    assert.equal(drilldownPanelSelector(entry), '[data-panel="content-release"]');
+  });
+
+  it('returns null for "none" action', () => {
+    const entry = { subjectKey: 'anything', drilldownAction: 'none' };
+    assert.equal(drilldownPanelSelector(entry), null);
+  });
+
+  it('returns null for "placeholder" action', () => {
+    const entry = { subjectKey: 'science', drilldownAction: 'placeholder' };
+    assert.equal(drilldownPanelSelector(entry), null);
+  });
+});
+
+// ─── statusBadgeClass ────────────────────────────────────────────────────────
+
+describe('statusBadgeClass', () => {
+  it('returns "good" for live', () => {
+    assert.equal(statusBadgeClass('live'), 'good');
+  });
+
+  it('returns "warn" for gated', () => {
+    assert.equal(statusBadgeClass('gated'), 'warn');
+  });
+
+  it('returns empty string for placeholder', () => {
+    assert.equal(statusBadgeClass('placeholder'), '');
+  });
+
+  it('returns empty string for unknown status', () => {
+    assert.equal(statusBadgeClass('other'), '');
+  });
+});
+
+// ─── statusLabel ─────────────────────────────────────────────────────────────
+
+describe('statusLabel', () => {
+  it('returns "Live" for live', () => {
+    assert.equal(statusLabel('live'), 'Live');
+  });
+
+  it('returns "Gated" for gated', () => {
+    assert.equal(statusLabel('gated'), 'Gated');
+  });
+
+  it('returns "Placeholder" for placeholder', () => {
+    assert.equal(statusLabel('placeholder'), 'Placeholder');
+  });
+
+  it('returns "Placeholder" for unknown status', () => {
+    assert.equal(statusLabel('anything'), 'Placeholder');
+  });
+});

--- a/tests/admin-content-quality-signals.test.js
+++ b/tests/admin-content-quality-signals.test.js
@@ -1,0 +1,322 @@
+// U7 (Admin Console P6): test suite for admin-content-quality-signals.
+//
+// Validates the pure normaliser buildContentQualitySignals and its helpers
+// against subjects with full data, partial data, and entirely missing data.
+// No DOM or Worker mocking — purely tests the logic leaf.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildContentQualitySignals,
+  summariseAvailability,
+  formatCoverageLabel,
+  coverageChipClass,
+  SIGNAL_STATUS,
+} from '../src/platform/hubs/admin-content-quality-signals.js';
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const GRAMMAR_FULL_SIGNALS = {
+  subjectKey: 'grammar',
+  subjectName: 'Grammar',
+  signals: {
+    skillCoverage: { status: 'available', value: 14, total: 18 },
+    templateCoverage: { status: 'available', value: 42, total: 0 },
+    itemCoverage: { status: 'not_available', value: 0, total: 0 },
+    commonMisconceptions: { status: 'not_available', items: [] },
+    highWrongRate: {
+      status: 'available',
+      items: [
+        { id: 'relative_clauses', label: 'relative_clauses', count: 12, detail: '12/25 wrong' },
+        { id: 'modal_verbs', label: 'modal_verbs', count: 8, detail: '8/18 wrong' },
+      ],
+    },
+    recentlyChangedUnevidenced: { status: 'not_available', items: [] },
+  },
+};
+
+const SPELLING_PARTIAL_SIGNALS = {
+  subjectKey: 'spelling',
+  subjectName: 'Spelling',
+  signals: {
+    skillCoverage: { status: 'not_available', value: 0, total: 0 },
+    templateCoverage: { status: 'not_available', value: 0, total: 0 },
+    itemCoverage: { status: 'available', value: 180, total: 320 },
+    commonMisconceptions: { status: 'not_available', items: [] },
+    highWrongRate: { status: 'not_available', items: [] },
+    recentlyChangedUnevidenced: { status: 'not_available', items: [] },
+  },
+};
+
+const PUNCTUATION_EMPTY_SIGNALS = {
+  subjectKey: 'punctuation',
+  subjectName: 'Punctuation',
+  signals: {
+    skillCoverage: { status: 'not_available', value: 0, total: 0 },
+    templateCoverage: { status: 'not_available', value: 0, total: 0 },
+    itemCoverage: { status: 'not_available', value: 0, total: 0 },
+    commonMisconceptions: { status: 'not_available', items: [] },
+    highWrongRate: { status: 'not_available', items: [] },
+    recentlyChangedUnevidenced: { status: 'not_available', items: [] },
+  },
+};
+
+// ─── SIGNAL_STATUS constants ────────────────────────────────────────────────
+
+describe('SIGNAL_STATUS', () => {
+  it('exposes three frozen status values', () => {
+    assert.equal(SIGNAL_STATUS.AVAILABLE, 'available');
+    assert.equal(SIGNAL_STATUS.NOT_AVAILABLE, 'not_available');
+    assert.equal(SIGNAL_STATUS.PARTIAL, 'partial');
+    assert.ok(Object.isFrozen(SIGNAL_STATUS));
+  });
+});
+
+// ─── buildContentQualitySignals ─────────────────────────────────────────────
+
+describe('buildContentQualitySignals', () => {
+  it('normalises and returns multiple subjects from array', () => {
+    const result = buildContentQualitySignals([
+      GRAMMAR_FULL_SIGNALS,
+      SPELLING_PARTIAL_SIGNALS,
+      PUNCTUATION_EMPTY_SIGNALS,
+    ]);
+
+    assert.equal(result.length, 3);
+    assert.equal(result[0].subjectKey, 'grammar');
+    assert.equal(result[1].subjectKey, 'spelling');
+    assert.equal(result[2].subjectKey, 'punctuation');
+  });
+
+  it('returns empty array for null input', () => {
+    assert.deepEqual(buildContentQualitySignals(null), []);
+  });
+
+  it('returns empty array for undefined input', () => {
+    assert.deepEqual(buildContentQualitySignals(undefined), []);
+  });
+
+  it('returns empty array for non-array input (object)', () => {
+    assert.deepEqual(buildContentQualitySignals({ foo: 'bar' }), []);
+  });
+
+  it('filters out entries with unknown subjectKey', () => {
+    const result = buildContentQualitySignals([
+      GRAMMAR_FULL_SIGNALS,
+      { signals: {} }, // missing subjectKey -> 'unknown' -> filtered
+      null, // non-object -> 'unknown' -> filtered
+    ]);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].subjectKey, 'grammar');
+  });
+
+  it('normalises coverage signals to safe numeric values', () => {
+    const result = buildContentQualitySignals([{
+      subjectKey: 'grammar',
+      signals: {
+        skillCoverage: { status: 'available', value: 'not-a-number', total: -5 },
+        templateCoverage: { status: 'partial', value: 10.7, total: 20.3 },
+      },
+    }]);
+
+    assert.equal(result[0].signals.skillCoverage.value, 0);
+    assert.equal(result[0].signals.skillCoverage.total, 0);
+    assert.equal(result[0].signals.templateCoverage.value, 10);
+    assert.equal(result[0].signals.templateCoverage.total, 20);
+  });
+
+  it('normalises list signals with mixed valid/invalid items', () => {
+    const result = buildContentQualitySignals([{
+      subjectKey: 'grammar',
+      signals: {
+        highWrongRate: {
+          status: 'available',
+          items: [
+            { id: 'relative_clauses', label: 'Relative clauses', count: 12, detail: '12/25 wrong' },
+            'not-an-object', // skipped
+            null, // skipped
+            { id: 'modal_verbs', label: 'Modal verbs', count: 8 },
+          ],
+        },
+      },
+    }]);
+
+    const items = result[0].signals.highWrongRate.items;
+    assert.equal(items.length, 2);
+    assert.equal(items[0].id, 'relative_clauses');
+    assert.equal(items[0].count, 12);
+    assert.equal(items[0].detail, '12/25 wrong');
+    assert.equal(items[1].id, 'modal_verbs');
+    assert.equal(items[1].detail, null); // missing detail -> null
+  });
+
+  it('uses display name fallback from internal map when subjectName missing', () => {
+    const result = buildContentQualitySignals([{
+      subjectKey: 'punctuation',
+      signals: {},
+    }]);
+    assert.equal(result[0].subjectName, 'Punctuation');
+  });
+
+  it('preserves explicit subjectName when provided', () => {
+    const result = buildContentQualitySignals([{
+      subjectKey: 'grammar',
+      subjectName: 'KS2 Grammar',
+      signals: {},
+    }]);
+    assert.equal(result[0].subjectName, 'KS2 Grammar');
+  });
+
+  it('defaults all signals to NOT_AVAILABLE when signals object is null', () => {
+    const result = buildContentQualitySignals([{
+      subjectKey: 'grammar',
+      signals: null,
+    }]);
+    const signals = result[0].signals;
+    assert.equal(signals.skillCoverage.status, SIGNAL_STATUS.NOT_AVAILABLE);
+    assert.equal(signals.templateCoverage.status, SIGNAL_STATUS.NOT_AVAILABLE);
+    assert.equal(signals.itemCoverage.status, SIGNAL_STATUS.NOT_AVAILABLE);
+    assert.equal(signals.commonMisconceptions.status, SIGNAL_STATUS.NOT_AVAILABLE);
+    assert.equal(signals.highWrongRate.status, SIGNAL_STATUS.NOT_AVAILABLE);
+    assert.equal(signals.recentlyChangedUnevidenced.status, SIGNAL_STATUS.NOT_AVAILABLE);
+  });
+
+  it('clamps invalid status values to NOT_AVAILABLE', () => {
+    const result = buildContentQualitySignals([{
+      subjectKey: 'grammar',
+      signals: {
+        skillCoverage: { status: 'invalid_status', value: 5, total: 10 },
+      },
+    }]);
+    assert.equal(result[0].signals.skillCoverage.status, SIGNAL_STATUS.NOT_AVAILABLE);
+  });
+
+  it('accepts PARTIAL status', () => {
+    const result = buildContentQualitySignals([{
+      subjectKey: 'grammar',
+      signals: {
+        skillCoverage: { status: 'partial', value: 5, total: 10 },
+      },
+    }]);
+    assert.equal(result[0].signals.skillCoverage.status, SIGNAL_STATUS.PARTIAL);
+  });
+});
+
+// ─── summariseAvailability ──────────────────────────────────────────────────
+
+describe('summariseAvailability', () => {
+  it('returns "all" when every signal is AVAILABLE', () => {
+    const signals = {
+      skillCoverage: { status: SIGNAL_STATUS.AVAILABLE },
+      templateCoverage: { status: SIGNAL_STATUS.AVAILABLE },
+      itemCoverage: { status: SIGNAL_STATUS.AVAILABLE },
+      commonMisconceptions: { status: SIGNAL_STATUS.AVAILABLE },
+      highWrongRate: { status: SIGNAL_STATUS.AVAILABLE },
+      recentlyChangedUnevidenced: { status: SIGNAL_STATUS.AVAILABLE },
+    };
+    assert.equal(summariseAvailability(signals), 'all');
+  });
+
+  it('returns "none" when every signal is NOT_AVAILABLE', () => {
+    const signals = {
+      skillCoverage: { status: SIGNAL_STATUS.NOT_AVAILABLE },
+      templateCoverage: { status: SIGNAL_STATUS.NOT_AVAILABLE },
+      itemCoverage: { status: SIGNAL_STATUS.NOT_AVAILABLE },
+      commonMisconceptions: { status: SIGNAL_STATUS.NOT_AVAILABLE },
+      highWrongRate: { status: SIGNAL_STATUS.NOT_AVAILABLE },
+      recentlyChangedUnevidenced: { status: SIGNAL_STATUS.NOT_AVAILABLE },
+    };
+    assert.equal(summariseAvailability(signals), 'none');
+  });
+
+  it('returns "some" for mixed availability', () => {
+    const signals = {
+      skillCoverage: { status: SIGNAL_STATUS.AVAILABLE },
+      templateCoverage: { status: SIGNAL_STATUS.NOT_AVAILABLE },
+      itemCoverage: { status: SIGNAL_STATUS.AVAILABLE },
+      commonMisconceptions: { status: SIGNAL_STATUS.NOT_AVAILABLE },
+      highWrongRate: { status: SIGNAL_STATUS.NOT_AVAILABLE },
+      recentlyChangedUnevidenced: { status: SIGNAL_STATUS.NOT_AVAILABLE },
+    };
+    assert.equal(summariseAvailability(signals), 'some');
+  });
+
+  it('returns "none" for null input', () => {
+    assert.equal(summariseAvailability(null), 'none');
+  });
+
+  it('returns "none" for undefined input', () => {
+    assert.equal(summariseAvailability(undefined), 'none');
+  });
+
+  it('returns "none" for empty object', () => {
+    assert.equal(summariseAvailability({}), 'none');
+  });
+
+  it('treats PARTIAL status as not AVAILABLE for summary', () => {
+    const signals = {
+      skillCoverage: { status: SIGNAL_STATUS.PARTIAL },
+      templateCoverage: { status: SIGNAL_STATUS.PARTIAL },
+    };
+    assert.equal(summariseAvailability(signals), 'none');
+  });
+});
+
+// ─── formatCoverageLabel ────────────────────────────────────────────────────
+
+describe('formatCoverageLabel', () => {
+  it('formats available signal with unit', () => {
+    const signal = { status: SIGNAL_STATUS.AVAILABLE, value: 14, total: 18 };
+    assert.equal(formatCoverageLabel(signal, 'concepts'), '14 / 18 concepts covered');
+  });
+
+  it('returns "Not available yet" for NOT_AVAILABLE status', () => {
+    const signal = { status: SIGNAL_STATUS.NOT_AVAILABLE, value: 0, total: 0 };
+    assert.equal(formatCoverageLabel(signal, 'skills'), 'Not available yet');
+  });
+
+  it('returns "Not available yet" for null input', () => {
+    assert.equal(formatCoverageLabel(null, 'items'), 'Not available yet');
+  });
+
+  it('returns "Not available yet" for undefined input', () => {
+    assert.equal(formatCoverageLabel(undefined, 'items'), 'Not available yet');
+  });
+
+  it('handles zero values correctly', () => {
+    const signal = { status: SIGNAL_STATUS.AVAILABLE, value: 0, total: 10 };
+    assert.equal(formatCoverageLabel(signal, 'templates'), '0 / 10 templates covered');
+  });
+});
+
+// ─── coverageChipClass ──────────────────────────────────────────────────────
+
+describe('coverageChipClass', () => {
+  it('returns "good" for 90%+ coverage', () => {
+    assert.equal(coverageChipClass({ status: SIGNAL_STATUS.AVAILABLE, value: 9, total: 10 }), 'good');
+    assert.equal(coverageChipClass({ status: SIGNAL_STATUS.AVAILABLE, value: 10, total: 10 }), 'good');
+  });
+
+  it('returns "warn" for 60-89% coverage', () => {
+    assert.equal(coverageChipClass({ status: SIGNAL_STATUS.AVAILABLE, value: 6, total: 10 }), 'warn');
+    assert.equal(coverageChipClass({ status: SIGNAL_STATUS.AVAILABLE, value: 8, total: 10 }), 'warn');
+  });
+
+  it('returns "bad" for below 60% coverage', () => {
+    assert.equal(coverageChipClass({ status: SIGNAL_STATUS.AVAILABLE, value: 5, total: 10 }), 'bad');
+    assert.equal(coverageChipClass({ status: SIGNAL_STATUS.AVAILABLE, value: 0, total: 10 }), 'bad');
+  });
+
+  it('returns empty string for NOT_AVAILABLE', () => {
+    assert.equal(coverageChipClass({ status: SIGNAL_STATUS.NOT_AVAILABLE, value: 0, total: 0 }), '');
+  });
+
+  it('returns empty string for null input', () => {
+    assert.equal(coverageChipClass(null), '');
+  });
+
+  it('returns empty string when total is 0', () => {
+    assert.equal(coverageChipClass({ status: SIGNAL_STATUS.AVAILABLE, value: 5, total: 0 }), '');
+  });
+});

--- a/tests/admin-csp-style-cleanup-visual.test.js
+++ b/tests/admin-csp-style-cleanup-visual.test.js
@@ -1,0 +1,194 @@
+// U11 (Admin Console P6): visual equivalence test for CSP inline-style cleanup.
+//
+// Purpose: verify that the CSS class extraction is structurally sound:
+//   1. The CSS file contains all expected class definitions.
+//   2. Admin JSX files reference the new classes where expected.
+//   3. No half-converted patterns remain (style={{ ... }} for values that
+//      were supposed to be extracted).
+//
+// This is NOT a pixel-comparison test. It asserts structural equivalence:
+// the same CSS property values are delivered via class selectors rather than
+// inline style attributes.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const ROOT = resolve(import.meta.dirname, '..');
+
+function read(relPath) {
+  return readFileSync(resolve(ROOT, relPath), 'utf8');
+}
+
+// ─── 1. CSS file contains all expected class rules ──────────────────────────
+
+describe('admin-panels.css class definitions', () => {
+  const css = read('src/surfaces/styles/admin-panels.css');
+
+  const expectedClasses = [
+    'admin-card-mb',
+    'admin-mt-8',
+    'admin-mt-16',
+    'admin-mt-12',
+    'admin-mb-12',
+    'admin-flex-row',
+    'admin-cell-pad',
+    'admin-th-left',
+    'admin-filter-grid',
+    'admin-section-title-lg',
+    'admin-status-badge',
+  ];
+
+  for (const cls of expectedClasses) {
+    it(`defines .${cls}`, () => {
+      const regex = new RegExp(`\\.${cls}\\s*\\{`);
+      assert.ok(regex.test(css), `.${cls} not found in admin-panels.css`);
+    });
+  }
+
+  it('admin-card-mb sets margin-bottom: 20px', () => {
+    assert.ok(css.includes('margin-bottom: 20px'), 'margin-bottom: 20px missing from admin-card-mb');
+  });
+
+  it('admin-mt-8 sets margin-top: 8px', () => {
+    assert.ok(css.includes('margin-top: 8px'), 'margin-top: 8px missing from admin-mt-8');
+  });
+
+  it('admin-flex-row sets display: flex + align-items: center + gap: 8px', () => {
+    assert.ok(css.includes('display: flex'), 'display: flex missing');
+    assert.ok(css.includes('align-items: center'), 'align-items: center missing');
+    assert.ok(css.includes('gap: 8px'), 'gap: 8px missing');
+  });
+
+  it('admin-filter-grid sets grid layout with auto-fit minmax', () => {
+    assert.ok(css.includes('grid-template-columns: repeat(auto-fit, minmax(140px, 1fr))'), 'grid-template-columns missing');
+    assert.ok(css.includes('gap: 8px'), 'gap: 8px missing from filter-grid');
+  });
+
+  it('admin-th-left sets text-align: left + padding: 2px 6px', () => {
+    assert.ok(css.includes('text-align: left'), 'text-align: left missing');
+    assert.ok(css.includes('padding: 2px 6px'), 'padding: 2px 6px missing from admin-th-left');
+  });
+
+  it('admin-status-badge sets static badge properties', () => {
+    assert.ok(css.includes('font-size: 0.75rem'), 'font-size missing from admin-status-badge');
+    assert.ok(css.includes('border-radius: 4px'), 'border-radius missing from admin-status-badge');
+    assert.ok(css.includes('font-weight: 600'), 'font-weight missing from admin-status-badge');
+  });
+});
+
+// ─── 2. Admin JSX files reference the correct class names ───────────────────
+
+describe('Admin JSX files use extracted classes', () => {
+  it('AdminErrorTimelinePanel uses admin-mt-12, admin-flex-row, admin-th-left, admin-cell-pad, admin-filter-grid, admin-card-mb, admin-mt-8', () => {
+    const src = read('src/surfaces/hubs/AdminErrorTimelinePanel.jsx');
+    assert.ok(src.includes('admin-mt-12'), 'admin-mt-12 not found');
+    assert.ok(src.includes('admin-flex-row'), 'admin-flex-row not found');
+    assert.ok(src.includes('admin-th-left'), 'admin-th-left not found');
+    assert.ok(src.includes('admin-cell-pad'), 'admin-cell-pad not found');
+    assert.ok(src.includes('admin-filter-grid'), 'admin-filter-grid not found');
+    assert.ok(src.includes('admin-card-mb'), 'admin-card-mb not found');
+    assert.ok(src.includes('admin-mt-8'), 'admin-mt-8 not found');
+  });
+
+  it('AdminRequestDenialsPanel uses admin-filter-grid, admin-card-mb, admin-mt-8', () => {
+    const src = read('src/surfaces/hubs/AdminRequestDenialsPanel.jsx');
+    assert.ok(src.includes('admin-filter-grid'), 'admin-filter-grid not found');
+    assert.ok(src.includes('admin-card-mb'), 'admin-card-mb not found');
+    assert.ok(src.includes('admin-mt-8'), 'admin-mt-8 not found');
+  });
+
+  it('AdminOverviewSection uses admin-card-mb, admin-mb-12, admin-section-title-lg', () => {
+    const src = read('src/surfaces/hubs/AdminOverviewSection.jsx');
+    assert.ok(src.includes('admin-card-mb'), 'admin-card-mb not found');
+    assert.ok(src.includes('admin-mb-12'), 'admin-mb-12 not found');
+    assert.ok(src.includes('admin-section-title-lg'), 'admin-section-title-lg not found');
+  });
+
+  it('AdminLearnerSupportPanel uses admin-card-mb, admin-section-title-lg, admin-mt-8, admin-mt-16', () => {
+    const src = read('src/surfaces/hubs/AdminLearnerSupportPanel.jsx');
+    assert.ok(src.includes('admin-card-mb'), 'admin-card-mb not found');
+    assert.ok(src.includes('admin-section-title-lg'), 'admin-section-title-lg not found');
+    assert.ok(src.includes('admin-mt-8'), 'admin-mt-8 not found');
+    assert.ok(src.includes('admin-mt-16'), 'admin-mt-16 not found');
+  });
+
+  it('AdminMarketingSection uses admin-status-badge', () => {
+    const src = read('src/surfaces/hubs/AdminMarketingSection.jsx');
+    assert.ok(src.includes('admin-status-badge'), 'admin-status-badge not found');
+  });
+});
+
+// ─── 3. No half-converted inline styles remain ──────────────────────────────
+
+describe('No half-converted patterns remain', () => {
+  it('AdminRequestDenialsPanel has zero remaining inline style attributes', () => {
+    const src = read('src/surfaces/hubs/AdminRequestDenialsPanel.jsx');
+    const matches = src.match(/style=\{\{/g) || [];
+    assert.strictEqual(matches.length, 0, `Expected 0 inline styles, found ${matches.length}`);
+  });
+
+  it('AdminOverviewSection has zero remaining inline style attributes', () => {
+    const src = read('src/surfaces/hubs/AdminOverviewSection.jsx');
+    const matches = src.match(/style=\{\{/g) || [];
+    assert.strictEqual(matches.length, 0, `Expected 0 inline styles, found ${matches.length}`);
+  });
+
+  it('AdminLearnerSupportPanel has zero remaining inline style attributes', () => {
+    const src = read('src/surfaces/hubs/AdminLearnerSupportPanel.jsx');
+    const matches = src.match(/style=\{\{/g) || [];
+    assert.strictEqual(matches.length, 0, `Expected 0 inline styles, found ${matches.length}`);
+  });
+
+  it('AdminErrorTimelinePanel has no marginTop: 8 inline styles remaining (all moved to class)', () => {
+    const src = read('src/surfaces/hubs/AdminErrorTimelinePanel.jsx');
+    // marginTop: 8 should not appear as a standalone style (may appear in composite styles)
+    const standaloneMarginTop8 = /style=\{\{\s*marginTop:\s*8\s*\}\}/g;
+    const matches = src.match(standaloneMarginTop8) || [];
+    assert.strictEqual(matches.length, 0, `Found ${matches.length} standalone marginTop: 8 inline styles`);
+  });
+
+  it('AdminErrorTimelinePanel has no textAlign/padding inline styles on th (moved to admin-th-left)', () => {
+    const src = read('src/surfaces/hubs/AdminErrorTimelinePanel.jsx');
+    const thWithStyle = /<th[^>]*style=\{\{[^}]*textAlign/g;
+    const matches = src.match(thWithStyle) || [];
+    assert.strictEqual(matches.length, 0, `Found ${matches.length} th elements with inline textAlign`);
+  });
+
+  it('AdminMarketingSection StatusBadge no longer has fontSize/padding/borderRadius/fontWeight inline', () => {
+    const src = read('src/surfaces/hubs/AdminMarketingSection.jsx');
+    // The StatusBadge style should only have background/color (dynamic), not the static props
+    const statusBadgeSection = src.slice(
+      src.indexOf('function StatusBadge'),
+      src.indexOf('function BodyTextPreview'),
+    );
+    assert.ok(!statusBadgeSection.includes('fontSize'), 'fontSize still inline in StatusBadge');
+    assert.ok(!statusBadgeSection.includes('borderRadius'), 'borderRadius still inline in StatusBadge');
+    assert.ok(!statusBadgeSection.includes('fontWeight'), 'fontWeight still inline in StatusBadge');
+    assert.ok(!statusBadgeSection.includes('textTransform'), 'textTransform still inline in StatusBadge');
+    assert.ok(!statusBadgeSection.includes("padding: '2px 8px'"), "padding still inline in StatusBadge");
+  });
+});
+
+// ─── 4. CSS import present in each modified file ────────────────────────────
+
+describe('CSS import present', () => {
+  const files = [
+    'src/surfaces/hubs/AdminErrorTimelinePanel.jsx',
+    'src/surfaces/hubs/AdminRequestDenialsPanel.jsx',
+    'src/surfaces/hubs/AdminOverviewSection.jsx',
+    'src/surfaces/hubs/AdminLearnerSupportPanel.jsx',
+    'src/surfaces/hubs/AdminMarketingSection.jsx',
+  ];
+
+  for (const file of files) {
+    it(`${file} imports admin-panels.css`, () => {
+      const src = read(file);
+      assert.ok(
+        src.includes("import '../styles/admin-panels.css'"),
+        `CSS import missing from ${file}`,
+      );
+    });
+  }
+});

--- a/tests/admin-panel-frame-characterisation-v2.test.js
+++ b/tests/admin-panel-frame-characterisation-v2.test.js
@@ -1,0 +1,638 @@
+// P6 Unit 1: Characterisation baseline — admin-panel-frame.js (pure logic)
+//
+// Exhaustive pin of decidePanelFrameState behaviour across all meaningful
+// input combinations. Tests the pure logic module directly (no React/esbuild).
+// The v1 characterisation test (react-admin-panel-frame-characterisation.test.js)
+// covers the React wrapper; this file covers the decision function.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  DEFAULT_STALE_THRESHOLD_MS,
+  decidePanelFrameState,
+} from '../src/platform/hubs/admin-panel-frame.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+describe('DEFAULT_STALE_THRESHOLD_MS', () => {
+  it('equals exactly 300,000 ms (5 minutes)', () => {
+    assert.equal(DEFAULT_STALE_THRESHOLD_MS, 300_000);
+    assert.equal(DEFAULT_STALE_THRESHOLD_MS, 5 * 60 * 1000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// decidePanelFrameState — fresh data (no staleness, no loading, no error)
+// ---------------------------------------------------------------------------
+
+describe('decidePanelFrameState with fresh data', () => {
+  const NOW = 1_700_000_000_000;
+  const FRESH_AT = NOW - 60_000; // 1 minute ago
+
+  it('returns all-clear state', () => {
+    const result = decidePanelFrameState({
+      refreshedAt: FRESH_AT,
+      refreshError: null,
+      data: { items: [1, 2, 3] },
+      loading: false,
+      now: NOW,
+    });
+    assert.equal(result.showStaleWarning, false);
+    assert.equal(result.showLoadingSkeleton, false);
+    assert.equal(result.showEmptyState, false);
+    assert.equal(result.showRetry, false);
+    assert.equal(result.showLastSuccessTimestamp, false);
+    assert.equal(result.lastSuccessAt, FRESH_AT);
+  });
+
+  it('with array data that has entries — no empty state', () => {
+    const result = decidePanelFrameState({
+      refreshedAt: FRESH_AT,
+      refreshError: null,
+      data: [1, 2, 3],
+      loading: false,
+      now: NOW,
+    });
+    assert.equal(result.showEmptyState, false);
+    assert.equal(result.showStaleWarning, false);
+  });
+
+  it('with string data — treated as present', () => {
+    const result = decidePanelFrameState({
+      refreshedAt: FRESH_AT,
+      refreshError: null,
+      data: 'some text',
+      loading: false,
+      now: NOW,
+    });
+    assert.equal(result.showEmptyState, false);
+  });
+
+  it('with number data — treated as present', () => {
+    const result = decidePanelFrameState({
+      refreshedAt: FRESH_AT,
+      refreshError: null,
+      data: 42,
+      loading: false,
+      now: NOW,
+    });
+    assert.equal(result.showEmptyState, false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// decidePanelFrameState — stale data (refreshedAt > threshold)
+// ---------------------------------------------------------------------------
+
+describe('decidePanelFrameState with stale data', () => {
+  const NOW = 1_700_000_000_000;
+  const STALE_AT = NOW - DEFAULT_STALE_THRESHOLD_MS - 1000; // 5min + 1s ago
+
+  it('shows stale warning when data is present and age exceeds threshold', () => {
+    const result = decidePanelFrameState({
+      refreshedAt: STALE_AT,
+      refreshError: null,
+      data: { items: [1] },
+      loading: false,
+      now: NOW,
+    });
+    assert.equal(result.showStaleWarning, true);
+    assert.equal(result.showLoadingSkeleton, false);
+    assert.equal(result.showEmptyState, false);
+    assert.equal(result.showRetry, false);
+    assert.equal(result.lastSuccessAt, STALE_AT);
+  });
+
+  it('does NOT show stale warning when loading (even if data is old)', () => {
+    const result = decidePanelFrameState({
+      refreshedAt: STALE_AT,
+      refreshError: null,
+      data: { items: [1] },
+      loading: true,
+      now: NOW,
+    });
+    assert.equal(result.showStaleWarning, false);
+  });
+
+  it('does NOT show stale warning for empty data (contradictory)', () => {
+    const result = decidePanelFrameState({
+      refreshedAt: STALE_AT,
+      refreshError: null,
+      data: [],
+      loading: false,
+      now: NOW,
+    });
+    assert.equal(result.showStaleWarning, false);
+  });
+
+  it('boundary: exactly at threshold is NOT stale (uses > not >=)', () => {
+    const atBoundary = NOW - DEFAULT_STALE_THRESHOLD_MS;
+    const result = decidePanelFrameState({
+      refreshedAt: atBoundary,
+      refreshError: null,
+      data: { x: 1 },
+      loading: false,
+      now: NOW,
+    });
+    assert.equal(result.showStaleWarning, false);
+  });
+
+  it('boundary: 1ms past threshold IS stale', () => {
+    const pastBoundary = NOW - DEFAULT_STALE_THRESHOLD_MS - 1;
+    const result = decidePanelFrameState({
+      refreshedAt: pastBoundary,
+      refreshError: null,
+      data: { x: 1 },
+      loading: false,
+      now: NOW,
+    });
+    assert.equal(result.showStaleWarning, true);
+  });
+
+  it('custom staleThresholdMs is respected', () => {
+    const customThreshold = 10_000; // 10 seconds
+    const result = decidePanelFrameState({
+      refreshedAt: NOW - 11_000, // 11 seconds ago
+      refreshError: null,
+      data: { x: 1 },
+      loading: false,
+      staleThresholdMs: customThreshold,
+      now: NOW,
+    });
+    assert.equal(result.showStaleWarning, true);
+  });
+
+  it('custom staleThresholdMs: within threshold → not stale', () => {
+    const customThreshold = 10_000;
+    const result = decidePanelFrameState({
+      refreshedAt: NOW - 9_000, // 9 seconds ago, within 10s threshold
+      refreshError: null,
+      data: { x: 1 },
+      loading: false,
+      staleThresholdMs: customThreshold,
+      now: NOW,
+    });
+    assert.equal(result.showStaleWarning, false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// decidePanelFrameState — loading states
+// ---------------------------------------------------------------------------
+
+describe('decidePanelFrameState loading states', () => {
+  const NOW = 1_700_000_000_000;
+
+  it('loading + no data → showLoadingSkeleton', () => {
+    const result = decidePanelFrameState({
+      refreshedAt: null,
+      refreshError: null,
+      data: null,
+      loading: true,
+      now: NOW,
+    });
+    assert.equal(result.showLoadingSkeleton, true);
+    assert.equal(result.showEmptyState, false);
+    assert.equal(result.showStaleWarning, false);
+    assert.equal(result.showRetry, false);
+  });
+
+  it('loading + no data (empty array) → showLoadingSkeleton', () => {
+    const result = decidePanelFrameState({
+      refreshedAt: null,
+      refreshError: null,
+      data: [],
+      loading: true,
+      now: NOW,
+    });
+    assert.equal(result.showLoadingSkeleton, true);
+  });
+
+  it('loading + no data (empty object) → showLoadingSkeleton', () => {
+    const result = decidePanelFrameState({
+      refreshedAt: null,
+      refreshError: null,
+      data: {},
+      loading: true,
+      now: NOW,
+    });
+    assert.equal(result.showLoadingSkeleton, true);
+  });
+
+  it('loading + existing data → NO skeleton (data still visible)', () => {
+    const result = decidePanelFrameState({
+      refreshedAt: NOW - 60_000,
+      refreshError: null,
+      data: { items: [1, 2] },
+      loading: true,
+      now: NOW,
+    });
+    assert.equal(result.showLoadingSkeleton, false);
+    assert.equal(result.showStaleWarning, false);
+  });
+
+  it('loading + existing array data → NO skeleton', () => {
+    const result = decidePanelFrameState({
+      refreshedAt: NOW - 60_000,
+      refreshError: null,
+      data: ['a', 'b'],
+      loading: true,
+      now: NOW,
+    });
+    assert.equal(result.showLoadingSkeleton, false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// decidePanelFrameState — error states
+// ---------------------------------------------------------------------------
+
+describe('decidePanelFrameState error states', () => {
+  const NOW = 1_700_000_000_000;
+  const ERROR = { message: 'Network failure', code: 500 };
+
+  it('error + no data + no previous success → showRetry, no lastSuccessTimestamp', () => {
+    const result = decidePanelFrameState({
+      refreshedAt: null,
+      refreshError: ERROR,
+      data: null,
+      loading: false,
+      now: NOW,
+    });
+    assert.equal(result.showRetry, true);
+    assert.equal(result.showEmptyState, false); // error suppresses empty state
+    assert.equal(result.showLastSuccessTimestamp, false);
+    assert.equal(result.lastSuccessAt, null);
+  });
+
+  it('error + no data + previous success → showRetry + showLastSuccessTimestamp', () => {
+    const LAST_SUCCESS = NOW - 120_000;
+    const result = decidePanelFrameState({
+      refreshedAt: LAST_SUCCESS,
+      refreshError: ERROR,
+      data: null,
+      loading: false,
+      now: NOW,
+    });
+    assert.equal(result.showRetry, true);
+    assert.equal(result.showLastSuccessTimestamp, true);
+    assert.equal(result.lastSuccessAt, LAST_SUCCESS);
+  });
+
+  it('error + existing data → showRetry but no skeleton/empty', () => {
+    const result = decidePanelFrameState({
+      refreshedAt: NOW - 60_000,
+      refreshError: ERROR,
+      data: { items: [1] },
+      loading: false,
+      now: NOW,
+    });
+    assert.equal(result.showRetry, true);
+    assert.equal(result.showLoadingSkeleton, false);
+    assert.equal(result.showEmptyState, false);
+    assert.equal(result.showLastSuccessTimestamp, true);
+  });
+
+  it('error + loading → NO retry (still in-flight)', () => {
+    const result = decidePanelFrameState({
+      refreshedAt: null,
+      refreshError: ERROR,
+      data: null,
+      loading: true,
+      now: NOW,
+    });
+    assert.equal(result.showRetry, false);
+    assert.equal(result.showLoadingSkeleton, true);
+  });
+
+  it('non-object error (e.g. null) → not treated as error', () => {
+    const result = decidePanelFrameState({
+      refreshedAt: null,
+      refreshError: null,
+      data: null,
+      loading: false,
+      now: NOW,
+    });
+    assert.equal(result.showRetry, false);
+    assert.equal(result.showEmptyState, true); // no data, no loading, no error
+  });
+
+  it('string error → not treated as error (must be object)', () => {
+    const result = decidePanelFrameState({
+      refreshedAt: null,
+      refreshError: 'some error string',
+      data: null,
+      loading: false,
+      now: NOW,
+    });
+    assert.equal(result.showRetry, false);
+    assert.equal(result.showEmptyState, true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// decidePanelFrameState — empty state
+// ---------------------------------------------------------------------------
+
+describe('decidePanelFrameState empty state', () => {
+  const NOW = 1_700_000_000_000;
+
+  it('no data + no loading + no error → showEmptyState', () => {
+    const result = decidePanelFrameState({
+      refreshedAt: NOW - 60_000,
+      refreshError: null,
+      data: null,
+      loading: false,
+      now: NOW,
+    });
+    assert.equal(result.showEmptyState, true);
+  });
+
+  it('empty array + no loading + no error → showEmptyState', () => {
+    const result = decidePanelFrameState({
+      refreshedAt: NOW - 60_000,
+      refreshError: null,
+      data: [],
+      loading: false,
+      now: NOW,
+    });
+    assert.equal(result.showEmptyState, true);
+  });
+
+  it('empty object + no loading + no error → showEmptyState', () => {
+    const result = decidePanelFrameState({
+      refreshedAt: NOW - 60_000,
+      refreshError: null,
+      data: {},
+      loading: false,
+      now: NOW,
+    });
+    assert.equal(result.showEmptyState, true);
+  });
+
+  it('non-empty data → NOT empty state', () => {
+    const result = decidePanelFrameState({
+      refreshedAt: NOW - 60_000,
+      refreshError: null,
+      data: { x: 1 },
+      loading: false,
+      now: NOW,
+    });
+    assert.equal(result.showEmptyState, false);
+  });
+
+  it('false value → NOT present (dataIsPresent returns false for falsy non-null)', () => {
+    // data = 0, which is falsy; but 0 is not null/undefined
+    // Let's check: dataIsPresent(0) → not null, not array, not object, Boolean(0) = false
+    const result = decidePanelFrameState({
+      refreshedAt: NOW - 60_000,
+      refreshError: null,
+      data: 0,
+      loading: false,
+      now: NOW,
+    });
+    assert.equal(result.showEmptyState, true);
+  });
+
+  it('undefined data → empty state', () => {
+    const result = decidePanelFrameState({
+      refreshedAt: NOW - 60_000,
+      refreshError: null,
+      data: undefined,
+      loading: false,
+      now: NOW,
+    });
+    assert.equal(result.showEmptyState, true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// decidePanelFrameState — lastSuccessfulRefreshAt override
+// ---------------------------------------------------------------------------
+
+describe('decidePanelFrameState lastSuccessfulRefreshAt', () => {
+  const NOW = 1_700_000_000_000;
+
+  it('prefers lastSuccessfulRefreshAt over refreshedAt when both provided', () => {
+    const EXPLICIT_SUCCESS = NOW - 30_000;
+    const REFRESHED = NOW - 120_000;
+    const result = decidePanelFrameState({
+      refreshedAt: REFRESHED,
+      refreshError: null,
+      data: { x: 1 },
+      loading: false,
+      lastSuccessfulRefreshAt: EXPLICIT_SUCCESS,
+      now: NOW,
+    });
+    assert.equal(result.lastSuccessAt, EXPLICIT_SUCCESS);
+  });
+
+  it('falls back to refreshedAt when lastSuccessfulRefreshAt is null', () => {
+    const REFRESHED = NOW - 60_000;
+    const result = decidePanelFrameState({
+      refreshedAt: REFRESHED,
+      refreshError: null,
+      data: { x: 1 },
+      loading: false,
+      lastSuccessfulRefreshAt: null,
+      now: NOW,
+    });
+    assert.equal(result.lastSuccessAt, REFRESHED);
+  });
+
+  it('falls back to refreshedAt when lastSuccessfulRefreshAt is undefined', () => {
+    const REFRESHED = NOW - 60_000;
+    const result = decidePanelFrameState({
+      refreshedAt: REFRESHED,
+      refreshError: null,
+      data: { x: 1 },
+      loading: false,
+      now: NOW,
+    });
+    assert.equal(result.lastSuccessAt, REFRESHED);
+  });
+
+  it('uses lastSuccessfulRefreshAt for stale calculation', () => {
+    const STALE_REFRESHED = NOW - DEFAULT_STALE_THRESHOLD_MS - 5000;
+    const FRESH_SUCCESS = NOW - 60_000;
+    const result = decidePanelFrameState({
+      refreshedAt: STALE_REFRESHED,
+      refreshError: null,
+      data: { x: 1 },
+      loading: false,
+      lastSuccessfulRefreshAt: FRESH_SUCCESS,
+      now: NOW,
+    });
+    // lastSuccessfulRefreshAt is fresh → NOT stale
+    assert.equal(result.showStaleWarning, false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// decidePanelFrameState — null/missing inputs
+// ---------------------------------------------------------------------------
+
+describe('decidePanelFrameState with null/missing inputs', () => {
+  const NOW = 1_700_000_000_000;
+
+  it('no arguments at all → returns empty/defaults safely', () => {
+    const result = decidePanelFrameState();
+    assert.equal(result.showLoadingSkeleton, false);
+    assert.equal(result.showStaleWarning, false);
+    assert.equal(result.showRetry, false);
+    assert.equal(result.showEmptyState, true); // no data, no loading, no error
+    assert.equal(result.lastSuccessAt, null);
+  });
+
+  it('empty options object → same as no arguments', () => {
+    const result = decidePanelFrameState({});
+    assert.equal(result.showEmptyState, true);
+    assert.equal(result.lastSuccessAt, null);
+  });
+
+  it('refreshedAt: null → lastSuccessAt is null', () => {
+    const result = decidePanelFrameState({
+      refreshedAt: null,
+      refreshError: null,
+      data: null,
+      loading: false,
+      now: NOW,
+    });
+    assert.equal(result.lastSuccessAt, null);
+  });
+
+  it('refreshedAt: 0 → treated as invalid (resolveTimestamp returns null)', () => {
+    const result = decidePanelFrameState({
+      refreshedAt: 0,
+      refreshError: null,
+      data: { x: 1 },
+      loading: false,
+      now: NOW,
+    });
+    // 0 is not > 0, so resolveTimestamp returns null
+    assert.equal(result.lastSuccessAt, null);
+    assert.equal(result.showStaleWarning, false); // lastSuccess must be > 0
+  });
+
+  it('refreshedAt: negative → treated as invalid', () => {
+    const result = decidePanelFrameState({
+      refreshedAt: -100,
+      refreshError: null,
+      data: { x: 1 },
+      loading: false,
+      now: NOW,
+    });
+    assert.equal(result.lastSuccessAt, null);
+  });
+
+  it('refreshedAt: NaN → treated as invalid', () => {
+    const result = decidePanelFrameState({
+      refreshedAt: NaN,
+      refreshError: null,
+      data: { x: 1 },
+      loading: false,
+      now: NOW,
+    });
+    assert.equal(result.lastSuccessAt, null);
+  });
+
+  it('refreshedAt: Infinity → treated as invalid', () => {
+    const result = decidePanelFrameState({
+      refreshedAt: Infinity,
+      refreshError: null,
+      data: { x: 1 },
+      loading: false,
+      now: NOW,
+    });
+    assert.equal(result.lastSuccessAt, null);
+  });
+
+  it('staleThresholdMs: 0 → falls back to DEFAULT_STALE_THRESHOLD_MS', () => {
+    const STALE_AT = NOW - DEFAULT_STALE_THRESHOLD_MS - 1000;
+    const result = decidePanelFrameState({
+      refreshedAt: STALE_AT,
+      refreshError: null,
+      data: { x: 1 },
+      loading: false,
+      staleThresholdMs: 0,
+      now: NOW,
+    });
+    assert.equal(result.showStaleWarning, true);
+  });
+
+  it('staleThresholdMs: negative → falls back to DEFAULT_STALE_THRESHOLD_MS', () => {
+    const STALE_AT = NOW - DEFAULT_STALE_THRESHOLD_MS - 1000;
+    const result = decidePanelFrameState({
+      refreshedAt: STALE_AT,
+      refreshError: null,
+      data: { x: 1 },
+      loading: false,
+      staleThresholdMs: -500,
+      now: NOW,
+    });
+    assert.equal(result.showStaleWarning, true);
+  });
+
+  it('now: not provided → uses Date.now() internally (sanity check)', () => {
+    const result = decidePanelFrameState({
+      refreshedAt: Date.now() - 30_000,
+      refreshError: null,
+      data: { x: 1 },
+      loading: false,
+    });
+    // Should be fresh (30s < 5min threshold)
+    assert.equal(result.showStaleWarning, false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// decidePanelFrameState — composite scenarios
+// ---------------------------------------------------------------------------
+
+describe('decidePanelFrameState composite scenarios', () => {
+  const NOW = 1_700_000_000_000;
+  const ERROR = { message: 'timeout' };
+
+  it('stale data + error → shows both stale warning and retry', () => {
+    const STALE_AT = NOW - DEFAULT_STALE_THRESHOLD_MS - 5000;
+    const result = decidePanelFrameState({
+      refreshedAt: STALE_AT,
+      refreshError: ERROR,
+      data: { items: [1] },
+      loading: false,
+      now: NOW,
+    });
+    assert.equal(result.showStaleWarning, true);
+    assert.equal(result.showRetry, true);
+    assert.equal(result.showLastSuccessTimestamp, true);
+  });
+
+  it('fresh data + error → shows retry but NOT stale warning', () => {
+    const FRESH_AT = NOW - 60_000;
+    const result = decidePanelFrameState({
+      refreshedAt: FRESH_AT,
+      refreshError: ERROR,
+      data: { items: [1] },
+      loading: false,
+      now: NOW,
+    });
+    assert.equal(result.showStaleWarning, false);
+    assert.equal(result.showRetry, true);
+  });
+
+  it('loading + error + no data → skeleton, no retry (loading suppresses retry)', () => {
+    const result = decidePanelFrameState({
+      refreshedAt: null,
+      refreshError: ERROR,
+      data: null,
+      loading: true,
+      now: NOW,
+    });
+    assert.equal(result.showLoadingSkeleton, true);
+    assert.equal(result.showRetry, false);
+    assert.equal(result.showEmptyState, false);
+  });
+});

--- a/tests/admin-panel-freshness-contract.test.js
+++ b/tests/admin-panel-freshness-contract.test.js
@@ -1,0 +1,415 @@
+// P6 Unit 4: Panel freshness contract test.
+//
+// Verifies that the decidePanelFrameState function correctly derives all
+// freshness-related display signals, and that the normalised worker endpoint
+// contract exposes meaningful refreshedAt values.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  DEFAULT_STALE_THRESHOLD_MS,
+  decidePanelFrameState,
+} from '../src/platform/hubs/admin-panel-frame.js';
+
+// ---------------------------------------------------------------------------
+// Freshness display states: stale/unknown/fresh
+// ---------------------------------------------------------------------------
+
+describe('panel freshness — stale detection', () => {
+  const NOW = 1_700_000_000_000;
+
+  it('panel shows "stale" when refreshedAt > 5 minutes old', () => {
+    const staleAt = NOW - DEFAULT_STALE_THRESHOLD_MS - 1;
+    const result = decidePanelFrameState({
+      refreshedAt: staleAt,
+      refreshError: null,
+      data: { items: [1, 2] },
+      loading: false,
+      now: NOW,
+    });
+    assert.equal(result.showStaleWarning, true);
+    assert.equal(result.lastSuccessAt, staleAt);
+  });
+
+  it('panel shows fresh (no stale warning) when refreshedAt < 5 minutes old', () => {
+    const freshAt = NOW - 60_000; // 1 minute ago
+    const result = decidePanelFrameState({
+      refreshedAt: freshAt,
+      refreshError: null,
+      data: { items: [1, 2] },
+      loading: false,
+      now: NOW,
+    });
+    assert.equal(result.showStaleWarning, false);
+    assert.equal(result.lastSuccessAt, freshAt);
+  });
+
+  it('panel shows "freshness unknown" when refreshedAt is null', () => {
+    const result = decidePanelFrameState({
+      refreshedAt: null,
+      refreshError: null,
+      data: { items: [1, 2] },
+      loading: false,
+      now: NOW,
+    });
+    // When refreshedAt is null, lastSuccessAt is null and stale warning cannot fire
+    assert.equal(result.lastSuccessAt, null);
+    assert.equal(result.showStaleWarning, false);
+    // Importantly, no skeleton or empty state either — data is present
+    assert.equal(result.showLoadingSkeleton, false);
+    assert.equal(result.showEmptyState, false);
+  });
+
+  it('panel shows "freshness unknown" when refreshedAt is undefined', () => {
+    const result = decidePanelFrameState({
+      refreshedAt: undefined,
+      refreshError: null,
+      data: [1],
+      loading: false,
+      now: NOW,
+    });
+    assert.equal(result.lastSuccessAt, null);
+    assert.equal(result.showStaleWarning, false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Loading + existing data: data visible with loading indicator (no skeleton)
+// ---------------------------------------------------------------------------
+
+describe('panel freshness — loading with existing data', () => {
+  const NOW = 1_700_000_000_000;
+
+  it('loading + existing data shows data (no skeleton)', () => {
+    const result = decidePanelFrameState({
+      refreshedAt: NOW - 120_000,
+      refreshError: null,
+      data: { accounts: [{ id: 'a1' }] },
+      loading: true,
+      now: NOW,
+    });
+    assert.equal(result.showLoadingSkeleton, false);
+    assert.equal(result.showEmptyState, false);
+    // Stale warning suppressed during loading
+    assert.equal(result.showStaleWarning, false);
+  });
+
+  it('loading + empty data shows skeleton', () => {
+    const result = decidePanelFrameState({
+      refreshedAt: null,
+      refreshError: null,
+      data: [],
+      loading: true,
+      now: NOW,
+    });
+    assert.equal(result.showLoadingSkeleton, true);
+    assert.equal(result.showEmptyState, false);
+  });
+
+  it('loading + stale data: no stale warning during refresh', () => {
+    const staleAt = NOW - DEFAULT_STALE_THRESHOLD_MS - 5000;
+    const result = decidePanelFrameState({
+      refreshedAt: staleAt,
+      refreshError: null,
+      data: { x: 1 },
+      loading: true,
+      now: NOW,
+    });
+    assert.equal(result.showStaleWarning, false);
+    assert.equal(result.showLoadingSkeleton, false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error + lastSuccessfulRefreshAt: data with error banner
+// ---------------------------------------------------------------------------
+
+describe('panel freshness — error with last success memory', () => {
+  const NOW = 1_700_000_000_000;
+  const ERROR = { message: 'Network error', code: 'fetch_failed' };
+
+  it('error + lastSuccessfulRefreshAt shows data with error banner', () => {
+    const lastSuccess = NOW - 120_000;
+    const result = decidePanelFrameState({
+      refreshedAt: lastSuccess,
+      refreshError: ERROR,
+      data: { items: [1, 2, 3] },
+      loading: false,
+      lastSuccessfulRefreshAt: lastSuccess,
+      now: NOW,
+    });
+    assert.equal(result.showRetry, true);
+    assert.equal(result.showLastSuccessTimestamp, true);
+    assert.equal(result.lastSuccessAt, lastSuccess);
+    // Data is still showing — no skeleton, no empty
+    assert.equal(result.showLoadingSkeleton, false);
+    assert.equal(result.showEmptyState, false);
+  });
+
+  it('error + no data + lastSuccessfulRefreshAt shows retry + timestamp', () => {
+    const lastSuccess = NOW - 60_000;
+    const result = decidePanelFrameState({
+      refreshedAt: null,
+      refreshError: ERROR,
+      data: null,
+      loading: false,
+      lastSuccessfulRefreshAt: lastSuccess,
+      now: NOW,
+    });
+    assert.equal(result.showRetry, true);
+    assert.equal(result.showLastSuccessTimestamp, true);
+    assert.equal(result.lastSuccessAt, lastSuccess);
+  });
+
+  it('error + no data + no prior success: retry only, no timestamp', () => {
+    const result = decidePanelFrameState({
+      refreshedAt: null,
+      refreshError: ERROR,
+      data: null,
+      loading: false,
+      now: NOW,
+    });
+    assert.equal(result.showRetry, true);
+    assert.equal(result.showLastSuccessTimestamp, false);
+    assert.equal(result.lastSuccessAt, null);
+  });
+
+  it('error + stale data: shows both stale warning and retry', () => {
+    const staleAt = NOW - DEFAULT_STALE_THRESHOLD_MS - 5000;
+    const result = decidePanelFrameState({
+      refreshedAt: staleAt,
+      refreshError: ERROR,
+      data: { items: [1] },
+      loading: false,
+      now: NOW,
+    });
+    assert.equal(result.showStaleWarning, true);
+    assert.equal(result.showRetry, true);
+    assert.equal(result.showLastSuccessTimestamp, true);
+    assert.equal(result.lastSuccessAt, staleAt);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// partialFailure encoding: showRetry + data present is partial failure
+// ---------------------------------------------------------------------------
+
+describe('panel freshness — partial failure (no dedicated field needed)', () => {
+  const NOW = 1_700_000_000_000;
+  const ERROR = { message: 'timeout' };
+
+  it('partial failure = error + data present: showRetry=true with data still shown', () => {
+    const result = decidePanelFrameState({
+      refreshedAt: NOW - 60_000,
+      refreshError: ERROR,
+      data: { accounts: [{ id: 'x' }] },
+      loading: false,
+      now: NOW,
+    });
+    // The combination of showRetry=true and data being present IS the
+    // partial failure state. No separate `partialFailure` flag is needed.
+    assert.equal(result.showRetry, true);
+    assert.equal(result.showLoadingSkeleton, false);
+    assert.equal(result.showEmptyState, false);
+    assert.equal(result.showLastSuccessTimestamp, true);
+  });
+
+  it('full failure = error + no data: skeleton-free, retry only', () => {
+    const result = decidePanelFrameState({
+      refreshedAt: null,
+      refreshError: ERROR,
+      data: null,
+      loading: false,
+      now: NOW,
+    });
+    assert.equal(result.showRetry, true);
+    assert.equal(result.showLoadingSkeleton, false);
+    assert.equal(result.showEmptyState, false); // error suppresses empty state
+    assert.equal(result.showLastSuccessTimestamp, false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Worker endpoint mock: refreshedAt in responses
+// ---------------------------------------------------------------------------
+
+describe('panel freshness — worker endpoint contract', () => {
+  it('mock KPI response includes refreshedAt as ISO string', () => {
+    const mockResponse = {
+      ok: true,
+      refreshedAt: '2026-04-28T14:00:00.000Z',
+      generatedAt: 1745848800000,
+      accounts: { total: 10, real: 8, demo: 2 },
+    };
+    assert.equal(typeof mockResponse.refreshedAt, 'string');
+    const parsed = new Date(mockResponse.refreshedAt).getTime();
+    assert.equal(Number.isFinite(parsed), true);
+    assert.ok(parsed > 0, 'refreshedAt parses to a valid positive timestamp');
+  });
+
+  it('mock activity response includes refreshedAt as ISO string', () => {
+    const mockResponse = {
+      ok: true,
+      refreshedAt: '2026-04-28T14:05:00.000Z',
+      generatedAt: 1745849100000,
+      entries: [],
+    };
+    assert.equal(typeof mockResponse.refreshedAt, 'string');
+    const parsed = new Date(mockResponse.refreshedAt).getTime();
+    assert.ok(parsed > 0);
+  });
+
+  it('mock content-overview response includes refreshedAt as ISO string', () => {
+    const mockResponse = {
+      ok: true,
+      refreshedAt: '2026-04-28T14:10:00.000Z',
+      generatedAt: 1745849400000,
+      subjects: [
+        { subjectKey: 'spelling', displayName: 'Spelling', status: 'live' },
+      ],
+    };
+    assert.equal(typeof mockResponse.refreshedAt, 'string');
+    const parsed = new Date(mockResponse.refreshedAt).getTime();
+    assert.ok(parsed > 0);
+  });
+
+  it('mock marketing-messages response includes refreshedAt as ISO string', () => {
+    const mockResponse = {
+      ok: true,
+      refreshedAt: '2026-04-28T14:15:00.000Z',
+      messages: [],
+      schedulingSemantics: 'manual_publish_required',
+    };
+    assert.equal(typeof mockResponse.refreshedAt, 'string');
+    const parsed = new Date(mockResponse.refreshedAt).getTime();
+    assert.ok(parsed > 0);
+  });
+
+  it('mock accounts-metadata response includes refreshedAt as ISO string', () => {
+    const mockResponse = {
+      ok: true,
+      refreshedAt: '2026-04-28T14:20:00.000Z',
+      generatedAt: 1745850000000,
+      accounts: [],
+    };
+    assert.equal(typeof mockResponse.refreshedAt, 'string');
+    const parsed = new Date(mockResponse.refreshedAt).getTime();
+    assert.ok(parsed > 0);
+  });
+
+  it('mock production-evidence response includes refreshedAt as ISO string', () => {
+    const mockResponse = {
+      ok: true,
+      refreshedAt: '2026-04-28T14:25:00.000Z',
+      schema: 2,
+      metrics: {},
+      generatedAt: '2026-04-28T10:00:00.000Z',
+    };
+    assert.equal(typeof mockResponse.refreshedAt, 'string');
+    const parsed = new Date(mockResponse.refreshedAt).getTime();
+    assert.ok(parsed > 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// decidePanelFrameState — all state combinations summary
+// ---------------------------------------------------------------------------
+
+describe('panel freshness — complete state matrix', () => {
+  const NOW = 1_700_000_000_000;
+  const FRESH = NOW - 60_000;
+  const STALE = NOW - DEFAULT_STALE_THRESHOLD_MS - 1;
+  const ERROR = { message: 'error' };
+
+  // Matrix: [data, loading, error, refreshedAt] → expected outputs
+  const matrix = [
+    // Fresh happy path
+    { data: [1], loading: false, error: null, refreshedAt: FRESH, expect: { stale: false, skeleton: false, empty: false, retry: false, lastTs: false } },
+    // Stale data
+    { data: [1], loading: false, error: null, refreshedAt: STALE, expect: { stale: true, skeleton: false, empty: false, retry: false, lastTs: false } },
+    // Empty fresh
+    { data: [], loading: false, error: null, refreshedAt: FRESH, expect: { stale: false, skeleton: false, empty: true, retry: false, lastTs: false } },
+    // Loading no data
+    { data: null, loading: true, error: null, refreshedAt: null, expect: { stale: false, skeleton: true, empty: false, retry: false, lastTs: false } },
+    // Loading with data
+    { data: [1], loading: true, error: null, refreshedAt: FRESH, expect: { stale: false, skeleton: false, empty: false, retry: false, lastTs: false } },
+    // Error no data no prior
+    { data: null, loading: false, error: ERROR, refreshedAt: null, expect: { stale: false, skeleton: false, empty: false, retry: true, lastTs: false } },
+    // Error no data with prior
+    { data: null, loading: false, error: ERROR, refreshedAt: FRESH, expect: { stale: false, skeleton: false, empty: false, retry: true, lastTs: true } },
+    // Error with data (partial failure)
+    { data: [1], loading: false, error: ERROR, refreshedAt: FRESH, expect: { stale: false, skeleton: false, empty: false, retry: true, lastTs: true } },
+    // Error + stale data
+    { data: [1], loading: false, error: ERROR, refreshedAt: STALE, expect: { stale: true, skeleton: false, empty: false, retry: true, lastTs: true } },
+    // Error + loading (in-flight retry)
+    { data: null, loading: true, error: ERROR, refreshedAt: null, expect: { stale: false, skeleton: true, empty: false, retry: false, lastTs: false } },
+    // Unknown freshness (null) with data
+    { data: { x: 1 }, loading: false, error: null, refreshedAt: null, expect: { stale: false, skeleton: false, empty: false, retry: false, lastTs: false } },
+  ];
+
+  matrix.forEach(({ data, loading, error, refreshedAt, expect }, idx) => {
+    it(`state combination ${idx}: data=${JSON.stringify(data)?.slice(0, 20)}, loading=${loading}, error=${!!error}, refreshedAt=${refreshedAt ? 'set' : 'null'}`, () => {
+      const result = decidePanelFrameState({
+        refreshedAt,
+        refreshError: error,
+        data,
+        loading,
+        now: NOW,
+      });
+      assert.equal(result.showStaleWarning, expect.stale, 'showStaleWarning');
+      assert.equal(result.showLoadingSkeleton, expect.skeleton, 'showLoadingSkeleton');
+      assert.equal(result.showEmptyState, expect.empty, 'showEmptyState');
+      assert.equal(result.showRetry, expect.retry, 'showRetry');
+      assert.equal(result.showLastSuccessTimestamp, expect.lastTs, 'showLastSuccessTimestamp');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ISO string conversion: panels that receive ISO from the worker
+// ---------------------------------------------------------------------------
+
+describe('panel freshness — ISO string to ms conversion', () => {
+  it('ISO string refreshedAt converts to valid ms for decidePanelFrameState', () => {
+    const isoString = '2026-04-28T14:00:00.000Z';
+    const ms = new Date(isoString).getTime();
+    const NOW = ms + 60_000; // 1 minute later
+    const result = decidePanelFrameState({
+      refreshedAt: ms,
+      refreshError: null,
+      data: { x: 1 },
+      loading: false,
+      now: NOW,
+    });
+    assert.equal(result.showStaleWarning, false);
+    assert.equal(result.lastSuccessAt, ms);
+  });
+
+  it('stale ISO string triggers stale warning', () => {
+    const isoString = '2026-04-28T14:00:00.000Z';
+    const ms = new Date(isoString).getTime();
+    const NOW = ms + DEFAULT_STALE_THRESHOLD_MS + 1; // just past threshold
+    const result = decidePanelFrameState({
+      refreshedAt: ms,
+      refreshError: null,
+      data: { x: 1 },
+      loading: false,
+      now: NOW,
+    });
+    assert.equal(result.showStaleWarning, true);
+    assert.equal(result.lastSuccessAt, ms);
+  });
+
+  it('invalid ISO string (empty) results in null lastSuccessAt', () => {
+    const ms = new Date('').getTime(); // NaN
+    const result = decidePanelFrameState({
+      refreshedAt: ms,
+      refreshError: null,
+      data: { x: 1 },
+      loading: false,
+      now: Date.now(),
+    });
+    assert.equal(result.lastSuccessAt, null);
+  });
+});

--- a/tests/admin-production-evidence-characterisation.test.js
+++ b/tests/admin-production-evidence-characterisation.test.js
@@ -1,0 +1,542 @@
+// P6 Unit 1: Characterisation baseline — admin-production-evidence.js
+//
+// Exhaustive pin of existing behaviour for classifyEvidenceMetric,
+// buildEvidencePanelModel, isValidEvidenceState, and exported constants.
+// These tests document the current contract so that P6 refactors can be
+// verified against a known-good baseline.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  EVIDENCE_STATES,
+  EVIDENCE_FRESH_THRESHOLD_MS,
+  isValidEvidenceState,
+  classifyEvidenceMetric,
+  buildEvidencePanelModel,
+} from '../src/platform/hubs/admin-production-evidence.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+describe('EVIDENCE_FRESH_THRESHOLD_MS', () => {
+  it('equals exactly 24 hours in milliseconds', () => {
+    assert.equal(EVIDENCE_FRESH_THRESHOLD_MS, 24 * 60 * 60 * 1000);
+    assert.equal(EVIDENCE_FRESH_THRESHOLD_MS, 86_400_000);
+  });
+});
+
+describe('EVIDENCE_STATES', () => {
+  it('is frozen', () => {
+    assert.equal(Object.isFrozen(EVIDENCE_STATES), true);
+  });
+
+  it('has exactly 9 values', () => {
+    assert.equal(Object.keys(EVIDENCE_STATES).length, 9);
+  });
+
+  it('maps to expected string values', () => {
+    assert.equal(EVIDENCE_STATES.NOT_AVAILABLE, 'not_available');
+    assert.equal(EVIDENCE_STATES.STALE, 'stale');
+    assert.equal(EVIDENCE_STATES.FAILING, 'failing');
+    assert.equal(EVIDENCE_STATES.SMOKE_PASS, 'smoke_pass');
+    assert.equal(EVIDENCE_STATES.SMALL_PILOT_PROVISIONAL, 'small_pilot_provisional');
+    assert.equal(EVIDENCE_STATES.CERTIFIED_30, 'certified_30_learner_beta');
+    assert.equal(EVIDENCE_STATES.CERTIFIED_60, 'certified_60_learner_stretch');
+    assert.equal(EVIDENCE_STATES.CERTIFIED_100, 'certified_100_plus');
+    assert.equal(EVIDENCE_STATES.UNKNOWN, 'unknown');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isValidEvidenceState
+// ---------------------------------------------------------------------------
+
+describe('isValidEvidenceState', () => {
+  it('accepts all 9 enum values', () => {
+    for (const value of Object.values(EVIDENCE_STATES)) {
+      assert.equal(isValidEvidenceState(value), true, `expected ${value} to be valid`);
+    }
+  });
+
+  it('rejects invalid string "bogus"', () => {
+    assert.equal(isValidEvidenceState('bogus'), false);
+  });
+
+  it('rejects empty string', () => {
+    assert.equal(isValidEvidenceState(''), false);
+  });
+
+  it('rejects null', () => {
+    assert.equal(isValidEvidenceState(null), false);
+  });
+
+  it('rejects undefined', () => {
+    assert.equal(isValidEvidenceState(undefined), false);
+  });
+
+  it('rejects number 42', () => {
+    assert.equal(isValidEvidenceState(42), false);
+  });
+
+  it('rejects case-variant "SMOKE_PASS"', () => {
+    assert.equal(isValidEvidenceState('SMOKE_PASS'), false);
+  });
+
+  it('rejects close-but-wrong "not-available" (hyphen instead of underscore)', () => {
+    assert.equal(isValidEvidenceState('not-available'), false);
+  });
+
+  it('rejects fabricated high-tier "certified_999_learner_galaxy"', () => {
+    assert.equal(isValidEvidenceState('certified_999_learner_galaxy'), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyEvidenceMetric
+// ---------------------------------------------------------------------------
+
+describe('classifyEvidenceMetric', () => {
+  const NOW = 1_700_000_000_000; // fixed reference time
+  const FRESH = new Date(NOW - 60_000).toISOString(); // 1 minute ago — well within 24h
+  const STALE_DATE = new Date(NOW - EVIDENCE_FRESH_THRESHOLD_MS - 1000).toISOString();
+
+  describe('returns NOT_AVAILABLE', () => {
+    it('when metricValue is null', () => {
+      assert.equal(
+        classifyEvidenceMetric('smoke_pass', null, FRESH, NOW),
+        EVIDENCE_STATES.NOT_AVAILABLE,
+      );
+    });
+
+    it('when metricValue is undefined', () => {
+      assert.equal(
+        classifyEvidenceMetric('smoke_pass', undefined, FRESH, NOW),
+        EVIDENCE_STATES.NOT_AVAILABLE,
+      );
+    });
+
+    it('when metricValue is a string (not an object)', () => {
+      assert.equal(
+        classifyEvidenceMetric('smoke_pass', 'not-an-object', FRESH, NOW),
+        EVIDENCE_STATES.NOT_AVAILABLE,
+      );
+    });
+
+    it('when metricValue is a number', () => {
+      assert.equal(
+        classifyEvidenceMetric('smoke_pass', 42, FRESH, NOW),
+        EVIDENCE_STATES.NOT_AVAILABLE,
+      );
+    });
+  });
+
+  describe('returns STALE', () => {
+    it('when generatedAt is null', () => {
+      assert.equal(
+        classifyEvidenceMetric('smoke_pass', { ok: true }, null, NOW),
+        EVIDENCE_STATES.STALE,
+      );
+    });
+
+    it('when generatedAt is empty string (produces NaN → treated as missing)', () => {
+      assert.equal(
+        classifyEvidenceMetric('smoke_pass', { ok: true }, '', NOW),
+        EVIDENCE_STATES.STALE,
+      );
+    });
+
+    it('when generatedAt is an invalid date string', () => {
+      assert.equal(
+        classifyEvidenceMetric('smoke_pass', { ok: true }, 'not-a-date', NOW),
+        EVIDENCE_STATES.STALE,
+      );
+    });
+
+    it('when generatedAt is older than 24h', () => {
+      assert.equal(
+        classifyEvidenceMetric('smoke_pass', { ok: true, failures: [] }, STALE_DATE, NOW),
+        EVIDENCE_STATES.STALE,
+      );
+    });
+
+    it('when generatedAt is exactly on the boundary (age === threshold + 1ms)', () => {
+      const boundary = new Date(NOW - EVIDENCE_FRESH_THRESHOLD_MS - 1).toISOString();
+      assert.equal(
+        classifyEvidenceMetric('smoke_pass', { ok: true }, boundary, NOW),
+        EVIDENCE_STATES.STALE,
+      );
+    });
+  });
+
+  describe('returns UNKNOWN for dryRun', () => {
+    it('when dryRun is true even if ok is true', () => {
+      assert.equal(
+        classifyEvidenceMetric('smoke_pass', { ok: true, dryRun: true, failures: [] }, FRESH, NOW),
+        EVIDENCE_STATES.UNKNOWN,
+      );
+    });
+
+    it('dryRun check runs before failing check', () => {
+      // If dryRun AND ok:false, dryRun wins because it is checked first.
+      assert.equal(
+        classifyEvidenceMetric('smoke_pass', { ok: false, dryRun: true, failures: ['x'] }, FRESH, NOW),
+        EVIDENCE_STATES.UNKNOWN,
+      );
+    });
+  });
+
+  describe('returns FAILING', () => {
+    it('when ok is false (no failures array)', () => {
+      assert.equal(
+        classifyEvidenceMetric('certified_30_learner_beta', { ok: false }, FRESH, NOW),
+        EVIDENCE_STATES.FAILING,
+      );
+    });
+
+    it('when ok is false with empty failures array', () => {
+      assert.equal(
+        classifyEvidenceMetric('certified_30_learner_beta', { ok: false, failures: [] }, FRESH, NOW),
+        EVIDENCE_STATES.FAILING,
+      );
+    });
+
+    it('when ok is true but failures array is non-empty', () => {
+      assert.equal(
+        classifyEvidenceMetric('certified_30_learner_beta', { ok: true, failures: ['max5xx'] }, FRESH, NOW),
+        EVIDENCE_STATES.FAILING,
+      );
+    });
+
+    it('when ok is false and failures array is non-empty', () => {
+      assert.equal(
+        classifyEvidenceMetric('smoke_pass', { ok: false, failures: ['latency', 'error_rate'] }, FRESH, NOW),
+        EVIDENCE_STATES.FAILING,
+      );
+    });
+  });
+
+  describe('returns correct passing state by tier key', () => {
+    it('smoke_pass → SMOKE_PASS', () => {
+      assert.equal(
+        classifyEvidenceMetric('smoke_pass', { ok: true, failures: [] }, FRESH, NOW),
+        EVIDENCE_STATES.SMOKE_PASS,
+      );
+    });
+
+    it('small_pilot_provisional → SMALL_PILOT_PROVISIONAL', () => {
+      assert.equal(
+        classifyEvidenceMetric('small_pilot_provisional', { ok: true, failures: [] }, FRESH, NOW),
+        EVIDENCE_STATES.SMALL_PILOT_PROVISIONAL,
+      );
+    });
+
+    it('certified_30_learner_beta → CERTIFIED_30', () => {
+      assert.equal(
+        classifyEvidenceMetric('certified_30_learner_beta', { ok: true, failures: [] }, FRESH, NOW),
+        EVIDENCE_STATES.CERTIFIED_30,
+      );
+    });
+
+    it('certified_60_learner_stretch → CERTIFIED_60', () => {
+      assert.equal(
+        classifyEvidenceMetric('certified_60_learner_stretch', { ok: true, failures: [] }, FRESH, NOW),
+        EVIDENCE_STATES.CERTIFIED_60,
+      );
+    });
+
+    it('certified_100_plus → CERTIFIED_100', () => {
+      assert.equal(
+        classifyEvidenceMetric('certified_100_plus', { ok: true, failures: [] }, FRESH, NOW),
+        EVIDENCE_STATES.CERTIFIED_100,
+      );
+    });
+  });
+
+  describe('returns UNKNOWN for unrecognised tier key', () => {
+    it('unknown key with valid passing metric', () => {
+      assert.equal(
+        classifyEvidenceMetric('totally_new_tier', { ok: true, failures: [] }, FRESH, NOW),
+        EVIDENCE_STATES.UNKNOWN,
+      );
+    });
+
+    it('empty string key with valid passing metric', () => {
+      assert.equal(
+        classifyEvidenceMetric('', { ok: true, failures: [] }, FRESH, NOW),
+        EVIDENCE_STATES.UNKNOWN,
+      );
+    });
+  });
+
+  describe('boundary: freshness threshold is exclusive (> not >=)', () => {
+    it('exactly at threshold is NOT stale', () => {
+      const atBoundary = new Date(NOW - EVIDENCE_FRESH_THRESHOLD_MS).toISOString();
+      // ageMs === EVIDENCE_FRESH_THRESHOLD_MS, condition is > so NOT stale
+      assert.notEqual(
+        classifyEvidenceMetric('smoke_pass', { ok: true, failures: [] }, atBoundary, NOW),
+        EVIDENCE_STATES.STALE,
+      );
+    });
+
+    it('1ms past threshold IS stale', () => {
+      const pastBoundary = new Date(NOW - EVIDENCE_FRESH_THRESHOLD_MS - 1).toISOString();
+      assert.equal(
+        classifyEvidenceMetric('smoke_pass', { ok: true, failures: [] }, pastBoundary, NOW),
+        EVIDENCE_STATES.STALE,
+      );
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildEvidencePanelModel
+// ---------------------------------------------------------------------------
+
+describe('buildEvidencePanelModel', () => {
+  const NOW = 1_700_000_000_000;
+  const FRESH = new Date(NOW - 60_000).toISOString();
+  const STALE_DATE = new Date(NOW - EVIDENCE_FRESH_THRESHOLD_MS - 1000).toISOString();
+
+  describe('with empty/null/malformed input', () => {
+    it('null → empty metrics, null generatedAt, stale, overallState=STALE', () => {
+      const result = buildEvidencePanelModel(null, NOW);
+      assert.deepEqual(result.metrics, []);
+      assert.equal(result.generatedAt, null);
+      assert.equal(result.isFresh, false);
+      assert.equal(result.overallState, EVIDENCE_STATES.STALE);
+    });
+
+    it('undefined → same as null', () => {
+      const result = buildEvidencePanelModel(undefined, NOW);
+      assert.deepEqual(result.metrics, []);
+      assert.equal(result.generatedAt, null);
+      assert.equal(result.isFresh, false);
+      assert.equal(result.overallState, EVIDENCE_STATES.STALE);
+    });
+
+    it('empty object {} → same as null', () => {
+      const result = buildEvidencePanelModel({}, NOW);
+      assert.deepEqual(result.metrics, []);
+      assert.equal(result.generatedAt, null);
+      assert.equal(result.isFresh, false);
+      assert.equal(result.overallState, EVIDENCE_STATES.STALE);
+    });
+
+    it('schema:2, metrics:{}, generatedAt:null → empty, stale', () => {
+      const result = buildEvidencePanelModel({ schema: 2, metrics: {}, generatedAt: null }, NOW);
+      assert.deepEqual(result.metrics, []);
+      assert.equal(result.generatedAt, null);
+      assert.equal(result.isFresh, false);
+      assert.equal(result.overallState, EVIDENCE_STATES.STALE);
+    });
+
+    it('string input is treated as empty (not an object)', () => {
+      const result = buildEvidencePanelModel('not an object', NOW);
+      assert.deepEqual(result.metrics, []);
+      assert.equal(result.generatedAt, null);
+      assert.equal(result.isFresh, false);
+    });
+  });
+
+  describe('with fresh summary containing a passing smoke tier', () => {
+    it('classifies metric, reports fresh, overall = SMOKE_PASS', () => {
+      const summary = {
+        schema: 2,
+        generatedAt: FRESH,
+        metrics: {
+          smoke_pass: {
+            tier: 'smoke_pass',
+            ok: true,
+            dryRun: false,
+            learners: 1,
+            finishedAt: FRESH,
+            commit: 'abc1234',
+            failures: [],
+            fileName: 'smoke-v1.json',
+          },
+        },
+      };
+      const result = buildEvidencePanelModel(summary, NOW);
+      assert.equal(result.isFresh, true);
+      assert.equal(result.generatedAt, FRESH);
+      assert.equal(result.metrics.length, 1);
+
+      const m = result.metrics[0];
+      assert.equal(m.key, 'smoke_pass');
+      assert.equal(m.tier, 'smoke_pass');
+      assert.equal(m.state, EVIDENCE_STATES.SMOKE_PASS);
+      assert.equal(m.ok, true);
+      assert.equal(m.learners, 1);
+      assert.equal(m.finishedAt, FRESH);
+      assert.equal(m.commit, 'abc1234');
+      assert.deepEqual(m.failures, []);
+      assert.equal(m.fileName, 'smoke-v1.json');
+
+      assert.equal(result.overallState, EVIDENCE_STATES.SMOKE_PASS);
+    });
+  });
+
+  describe('with multiple tiers', () => {
+    it('overall state is highest passing tier', () => {
+      const summary = {
+        schema: 2,
+        generatedAt: FRESH,
+        metrics: {
+          smoke_pass: { tier: 'smoke_pass', ok: true, failures: [] },
+          certified_60_learner_stretch: { tier: 'certified_60_learner_stretch', ok: true, failures: [] },
+          certified_30_learner_beta: { tier: 'certified_30_learner_beta', ok: true, failures: [] },
+        },
+      };
+      const result = buildEvidencePanelModel(summary, NOW);
+      assert.equal(result.metrics.length, 3);
+      assert.equal(result.overallState, EVIDENCE_STATES.CERTIFIED_60);
+    });
+
+    it('one failing + one passing → overall is the passing tier (higher ranked)', () => {
+      const summary = {
+        schema: 2,
+        generatedAt: FRESH,
+        metrics: {
+          certified_60_learner_stretch: { tier: 'certified_60_learner_stretch', ok: true, failures: [] },
+          certified_30_learner_beta: { tier: 'certified_30_learner_beta', ok: false, failures: ['err'] },
+        },
+      };
+      const result = buildEvidencePanelModel(summary, NOW);
+      // CERTIFIED_60 rank 6 > FAILING rank 1, so overall = CERTIFIED_60
+      assert.equal(result.overallState, EVIDENCE_STATES.CERTIFIED_60);
+    });
+
+    it('all failing → overall is FAILING', () => {
+      const summary = {
+        schema: 2,
+        generatedAt: FRESH,
+        metrics: {
+          smoke_pass: { tier: 'smoke_pass', ok: false, failures: ['x'] },
+          certified_30_learner_beta: { tier: 'certified_30_learner_beta', ok: false, failures: ['y'] },
+        },
+      };
+      const result = buildEvidencePanelModel(summary, NOW);
+      assert.equal(result.overallState, EVIDENCE_STATES.FAILING);
+    });
+
+    it('all unknown + one failing → overall is FAILING (hasFailing path)', () => {
+      const summary = {
+        schema: 2,
+        generatedAt: FRESH,
+        metrics: {
+          some_new_tier: { tier: 'some_new_tier', ok: true, failures: [] },
+          another_tier: { tier: 'another_tier', ok: false, failures: ['z'] },
+        },
+      };
+      const result = buildEvidencePanelModel(summary, NOW);
+      // both best candidates: UNKNOWN (rank 2) and FAILING (rank 1)
+      // bestRank = 2 (UNKNOWN), hasFailing = true, 2 <= 2 && hasFailing → FAILING
+      assert.equal(result.overallState, EVIDENCE_STATES.FAILING);
+    });
+  });
+
+  describe('stale summary', () => {
+    it('overall is STALE regardless of passing metrics', () => {
+      const summary = {
+        schema: 2,
+        generatedAt: STALE_DATE,
+        metrics: {
+          certified_100_plus: { tier: 'certified_100_plus', ok: true, failures: [] },
+        },
+      };
+      const result = buildEvidencePanelModel(summary, NOW);
+      assert.equal(result.isFresh, false);
+      assert.equal(result.overallState, EVIDENCE_STATES.STALE);
+    });
+  });
+
+  describe('metric shape — missing optional fields use defaults', () => {
+    it('missing tier falls back to key', () => {
+      const summary = {
+        schema: 2,
+        generatedAt: FRESH,
+        metrics: {
+          smoke_pass: { ok: true, failures: [] },
+        },
+      };
+      const result = buildEvidencePanelModel(summary, NOW);
+      assert.equal(result.metrics[0].tier, 'smoke_pass'); // falls back to key
+    });
+
+    it('missing learners becomes null', () => {
+      const summary = {
+        schema: 2,
+        generatedAt: FRESH,
+        metrics: {
+          smoke_pass: { ok: true, failures: [] },
+        },
+      };
+      const result = buildEvidencePanelModel(summary, NOW);
+      assert.equal(result.metrics[0].learners, null);
+    });
+
+    it('missing finishedAt becomes null', () => {
+      const summary = {
+        schema: 2,
+        generatedAt: FRESH,
+        metrics: {
+          smoke_pass: { ok: true, failures: [] },
+        },
+      };
+      const result = buildEvidencePanelModel(summary, NOW);
+      assert.equal(result.metrics[0].finishedAt, null);
+    });
+
+    it('missing commit becomes null', () => {
+      const summary = {
+        schema: 2,
+        generatedAt: FRESH,
+        metrics: {
+          smoke_pass: { ok: true, failures: [] },
+        },
+      };
+      const result = buildEvidencePanelModel(summary, NOW);
+      assert.equal(result.metrics[0].commit, null);
+    });
+
+    it('missing fileName becomes null', () => {
+      const summary = {
+        schema: 2,
+        generatedAt: FRESH,
+        metrics: {
+          smoke_pass: { ok: true, failures: [] },
+        },
+      };
+      const result = buildEvidencePanelModel(summary, NOW);
+      assert.equal(result.metrics[0].fileName, null);
+    });
+
+    it('non-array failures becomes empty array', () => {
+      const summary = {
+        schema: 2,
+        generatedAt: FRESH,
+        metrics: {
+          smoke_pass: { ok: true, failures: 'not-array' },
+        },
+      };
+      const result = buildEvidencePanelModel(summary, NOW);
+      assert.deepEqual(result.metrics[0].failures, []);
+    });
+  });
+
+  describe('fresh + empty metrics → NOT_AVAILABLE overall', () => {
+    it('returns NOT_AVAILABLE when metrics object is empty but summary is fresh', () => {
+      const summary = {
+        schema: 2,
+        generatedAt: FRESH,
+        metrics: {},
+      };
+      const result = buildEvidencePanelModel(summary, NOW);
+      assert.equal(result.isFresh, true);
+      assert.deepEqual(result.metrics, []);
+      assert.equal(result.overallState, EVIDENCE_STATES.NOT_AVAILABLE);
+    });
+  });
+});

--- a/tests/admin-refresh-envelope.test.js
+++ b/tests/admin-refresh-envelope.test.js
@@ -1,0 +1,151 @@
+// P6 Unit 10: Characterisation tests for admin-refresh-envelope.js
+//
+// Verifies:
+// 1. formatAdminTimestamp — valid / invalid / edge-case timestamps
+// 2. buildRefreshErrorEnvelope — correct shape from various error inputs
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  formatAdminTimestamp,
+  buildRefreshErrorEnvelope,
+} from '../src/platform/hubs/admin-refresh-envelope.js';
+
+// ---------------------------------------------------------------------------
+// formatAdminTimestamp
+// ---------------------------------------------------------------------------
+
+describe('formatAdminTimestamp', () => {
+  it('formats a valid numeric timestamp to ISO-like UTC string', () => {
+    // 1700000000000 = 2023-11-14T22:13:20.000Z
+    const result = formatAdminTimestamp(1700000000000);
+    assert.equal(result, '2023-11-14 22:13:20 UTC');
+  });
+
+  it('formats a non-.000Z timestamp preserving sub-second precision', () => {
+    // 1700000000123 = 2023-11-14T22:13:20.123Z — .000Z regex does not match
+    const result = formatAdminTimestamp(1700000000123);
+    assert.match(result, /2023-11-14 22:13:20\.123Z/);
+  });
+
+  it('returns em-dash for null', () => {
+    assert.equal(formatAdminTimestamp(null), '—');
+  });
+
+  it('returns em-dash for undefined', () => {
+    assert.equal(formatAdminTimestamp(undefined), '—');
+  });
+
+  it('returns em-dash for zero', () => {
+    assert.equal(formatAdminTimestamp(0), '—');
+  });
+
+  it('returns em-dash for negative numbers', () => {
+    assert.equal(formatAdminTimestamp(-1), '—');
+  });
+
+  it('returns em-dash for NaN', () => {
+    assert.equal(formatAdminTimestamp(NaN), '—');
+  });
+
+  it('returns em-dash for non-numeric strings', () => {
+    assert.equal(formatAdminTimestamp('bad'), '—');
+  });
+
+  it('returns em-dash for Infinity', () => {
+    assert.equal(formatAdminTimestamp(Infinity), '—');
+  });
+
+  it('handles string-coercible numeric values', () => {
+    const result = formatAdminTimestamp('1700000000000');
+    assert.equal(result, '2023-11-14 22:13:20 UTC');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildRefreshErrorEnvelope
+// ---------------------------------------------------------------------------
+
+describe('buildRefreshErrorEnvelope', () => {
+  it('produces correct shape with code and message from error object', () => {
+    const error = { code: 'rate_limited', message: 'Too many requests' };
+    const envelope = buildRefreshErrorEnvelope(error);
+    assert.equal(envelope.code, 'rate_limited');
+    assert.equal(envelope.message, 'Too many requests');
+    assert.equal(envelope.correlationId, null);
+    assert.equal(typeof envelope.at, 'number');
+    assert.ok(envelope.at > 0);
+  });
+
+  it('falls back to "network" code when code is missing', () => {
+    const error = { message: 'fetch failed' };
+    const envelope = buildRefreshErrorEnvelope(error);
+    assert.equal(envelope.code, 'network');
+    assert.equal(envelope.message, 'fetch failed');
+  });
+
+  it('falls back to "network" code when code is empty string', () => {
+    const error = { code: '', message: 'empty' };
+    const envelope = buildRefreshErrorEnvelope(error);
+    assert.equal(envelope.code, 'network');
+  });
+
+  it('falls back to empty message when message is not a string', () => {
+    const error = { code: 'test', message: 123 };
+    const envelope = buildRefreshErrorEnvelope(error);
+    assert.equal(envelope.message, '');
+  });
+
+  it('extracts correlationId from error.payload.correlationId', () => {
+    const error = { code: 'x', message: 'y', payload: { correlationId: 'abc-123' } };
+    const envelope = buildRefreshErrorEnvelope(error);
+    assert.equal(envelope.correlationId, 'abc-123');
+  });
+
+  it('extracts correlationId from error.correlationId as fallback', () => {
+    const error = { code: 'x', message: 'y', correlationId: 'def-456' };
+    const envelope = buildRefreshErrorEnvelope(error);
+    assert.equal(envelope.correlationId, 'def-456');
+  });
+
+  it('prefers error.payload.correlationId over error.correlationId', () => {
+    const error = {
+      code: 'x',
+      message: 'y',
+      payload: { correlationId: 'from-payload' },
+      correlationId: 'from-root',
+    };
+    const envelope = buildRefreshErrorEnvelope(error);
+    assert.equal(envelope.correlationId, 'from-payload');
+  });
+
+  it('returns null correlationId when neither source provides one', () => {
+    const error = { code: 'x', message: 'y' };
+    const envelope = buildRefreshErrorEnvelope(error);
+    assert.equal(envelope.correlationId, null);
+  });
+
+  it('handles null error gracefully', () => {
+    const envelope = buildRefreshErrorEnvelope(null);
+    assert.equal(envelope.code, 'network');
+    assert.equal(envelope.message, '');
+    assert.equal(envelope.correlationId, null);
+    assert.equal(typeof envelope.at, 'number');
+  });
+
+  it('handles undefined error gracefully', () => {
+    const envelope = buildRefreshErrorEnvelope(undefined);
+    assert.equal(envelope.code, 'network');
+    assert.equal(envelope.message, '');
+    assert.equal(envelope.correlationId, null);
+  });
+
+  it('at field is a recent numeric timestamp', () => {
+    const before = Date.now();
+    const envelope = buildRefreshErrorEnvelope({ code: 'x', message: 'y' });
+    const after = Date.now();
+    assert.ok(envelope.at >= before);
+    assert.ok(envelope.at <= after);
+  });
+});

--- a/tests/admin-safe-copy-characterisation.test.js
+++ b/tests/admin-safe-copy-characterisation.test.js
@@ -1,0 +1,537 @@
+// P6 Unit 1: Characterisation baseline — admin-safe-copy.js
+//
+// Exhaustive pin of existing behaviour for prepareSafeCopy, maskEmail, maskId,
+// and the COPY_AUDIENCE enum. Documents known gaps (e.g. string inputs bypass
+// object redaction) so P6 refactors can verify against this baseline.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  COPY_AUDIENCE,
+  prepareSafeCopy,
+  maskEmail,
+  maskId,
+} from '../src/platform/hubs/admin-safe-copy.js';
+
+// ---------------------------------------------------------------------------
+// COPY_AUDIENCE enum
+// ---------------------------------------------------------------------------
+
+describe('COPY_AUDIENCE', () => {
+  it('is frozen', () => {
+    assert.equal(Object.isFrozen(COPY_AUDIENCE), true);
+  });
+
+  it('has exactly 4 values', () => {
+    assert.equal(Object.keys(COPY_AUDIENCE).length, 4);
+  });
+
+  it('maps to expected string values', () => {
+    assert.equal(COPY_AUDIENCE.ADMIN_ONLY, 'admin_only');
+    assert.equal(COPY_AUDIENCE.OPS_SAFE, 'ops_safe');
+    assert.equal(COPY_AUDIENCE.PARENT_SAFE, 'parent_safe');
+    assert.equal(COPY_AUDIENCE.PUBLIC_PREVIEW, 'public_preview');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// maskEmail
+// ---------------------------------------------------------------------------
+
+describe('maskEmail', () => {
+  it('masks long email to ****<last6>', () => {
+    assert.equal(maskEmail('admin@longdomain.test.com'), '****st.com');
+  });
+
+  it('masks standard email correctly', () => {
+    assert.equal(maskEmail('test@example.com'), '****le.com');
+  });
+
+  it('returns ****** for email with length <= 6', () => {
+    assert.equal(maskEmail('ab@c.d'), '******');
+    assert.equal(maskEmail('a@b.co'), '******'); // exactly 6
+  });
+
+  it('returns ****** for 5-char email', () => {
+    assert.equal(maskEmail('a@b.c'), '******');
+  });
+
+  it('returns empty string for null', () => {
+    assert.equal(maskEmail(null), '');
+  });
+
+  it('returns empty string for undefined', () => {
+    assert.equal(maskEmail(undefined), '');
+  });
+
+  it('returns empty string for empty string', () => {
+    assert.equal(maskEmail(''), '');
+  });
+
+  it('returns empty string for non-string (number)', () => {
+    assert.equal(maskEmail(123), '');
+  });
+
+  it('masks 7-char email to ****<last6>', () => {
+    // 'x@ab.cd' length 7 → '****@ab.cd'.slice(-6) = '@ab.cd'... wait, let's verify
+    // 'x@ab.cd' → '****b.cd' (last 6 = 'ab.cd' is 5? no, '@ab.cd' is 6)
+    // Actually 'x@ab.cd' has length 7, slice(-6) = '@ab.cd'
+    assert.equal(maskEmail('x@ab.cd'), '****@ab.cd'.slice(0, 4) + 'x@ab.cd'.slice(-6));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// maskId
+// ---------------------------------------------------------------------------
+
+describe('maskId', () => {
+  it('masks standard long ID to ****<last8>', () => {
+    assert.equal(maskId('acct-abcdef123456'), '****ef123456');
+  });
+
+  it('returns ******** for ID with length <= 8', () => {
+    assert.equal(maskId('acct-12'), '********'); // length 7
+    assert.equal(maskId('acct-123'), '********'); // length 8
+  });
+
+  it('masks 9-char ID to ****<last8>', () => {
+    assert.equal(maskId('acct-1234'), '****ct-1234'.slice(0, 4) + 'acct-1234'.slice(-8));
+  });
+
+  it('returns empty string for null', () => {
+    assert.equal(maskId(null), '');
+  });
+
+  it('returns empty string for undefined', () => {
+    assert.equal(maskId(undefined), '');
+  });
+
+  it('returns empty string for empty string', () => {
+    assert.equal(maskId(''), '');
+  });
+
+  it('returns empty string for non-string (number)', () => {
+    assert.equal(maskId(42), '');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// prepareSafeCopy — empty/null/invalid inputs
+// ---------------------------------------------------------------------------
+
+describe('prepareSafeCopy with empty/null/invalid inputs', () => {
+  it('null → { ok: false }', () => {
+    const result = prepareSafeCopy(null, COPY_AUDIENCE.ADMIN_ONLY);
+    assert.equal(result.ok, false);
+    assert.equal(result.text, '');
+    assert.deepEqual(result.redactedFields, []);
+  });
+
+  it('undefined → { ok: false }', () => {
+    const result = prepareSafeCopy(undefined, COPY_AUDIENCE.ADMIN_ONLY);
+    assert.equal(result.ok, false);
+    assert.equal(result.text, '');
+    assert.deepEqual(result.redactedFields, []);
+  });
+
+  it('empty object {} → { ok: false }', () => {
+    const result = prepareSafeCopy({}, COPY_AUDIENCE.ADMIN_ONLY);
+    assert.equal(result.ok, false);
+    assert.equal(result.text, '');
+    assert.deepEqual(result.redactedFields, []);
+  });
+
+  it('empty string → { ok: false }', () => {
+    const result = prepareSafeCopy('', COPY_AUDIENCE.ADMIN_ONLY);
+    assert.equal(result.ok, false);
+  });
+
+  it('whitespace-only string → { ok: false }', () => {
+    const result = prepareSafeCopy('   ', COPY_AUDIENCE.ADMIN_ONLY);
+    assert.equal(result.ok, false);
+  });
+
+  it('unknown audience → { ok: false }', () => {
+    const result = prepareSafeCopy({ title: 'x' }, 'invalid_audience');
+    assert.equal(result.ok, false);
+    assert.equal(result.text, '');
+    assert.deepEqual(result.redactedFields, []);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// prepareSafeCopy — string input (known gap: passes through without redaction)
+// ---------------------------------------------------------------------------
+
+describe('prepareSafeCopy with string input (documents pass-through gap)', () => {
+  const TEXT = 'Some raw text with email@test.com and accountId=acct-1234567890';
+
+  it('ADMIN_ONLY — string passes through unchanged', () => {
+    const result = prepareSafeCopy(TEXT, COPY_AUDIENCE.ADMIN_ONLY);
+    assert.equal(result.ok, true);
+    assert.equal(result.text, TEXT);
+    // No object redaction was applied (known gap).
+    assert.ok(!result.redactedFields.includes('emails_masked'));
+  });
+
+  it('OPS_SAFE — string passes through unchanged (gap: no email masking on strings)', () => {
+    const result = prepareSafeCopy(TEXT, COPY_AUDIENCE.OPS_SAFE);
+    assert.equal(result.ok, true);
+    // String passes through because typeof working !== 'object' branch skips redaction.
+    assert.equal(result.text, TEXT);
+  });
+
+  it('PARENT_SAFE — string passes through unchanged (gap: no child ID stripping on strings)', () => {
+    const result = prepareSafeCopy(TEXT, COPY_AUDIENCE.PARENT_SAFE);
+    assert.equal(result.ok, true);
+    assert.equal(result.text, TEXT);
+  });
+
+  it('PUBLIC_PREVIEW — string passes through unchanged (gap: no title/body extraction on strings)', () => {
+    const result = prepareSafeCopy(TEXT, COPY_AUDIENCE.PUBLIC_PREVIEW);
+    assert.equal(result.ok, true);
+    assert.equal(result.text, TEXT);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// prepareSafeCopy — ADMIN_ONLY audience (object input)
+// ---------------------------------------------------------------------------
+
+describe('prepareSafeCopy ADMIN_ONLY audience', () => {
+  const FULL_DATA = {
+    title: 'Debug Bundle',
+    accountSummary: { accountId: 'acct-abcdef123456', email: 'admin@longdomain.test.com' },
+    linkedLearners: [{ learnerId: 'lrn-xyz789abcdef', learnerName: 'Alice' }],
+    internalNotes: 'Some internal note',
+    stack: 'Error\n  at fn (/path/file.js:10:5)',
+    headers: {
+      cookie: 'session=secret',
+      authorization: 'Bearer token123',
+      'x-auth-token': 'tok-abc',
+      'content-type': 'application/json',
+    },
+    requestBody: '{"password":"secret"}',
+  };
+
+  it('preserves email, accountId, learnerId, internalNotes, stack', () => {
+    const result = prepareSafeCopy(FULL_DATA, COPY_AUDIENCE.ADMIN_ONLY);
+    assert.equal(result.ok, true);
+    const parsed = JSON.parse(result.text);
+    assert.equal(parsed.accountSummary.accountId, 'acct-abcdef123456');
+    assert.equal(parsed.accountSummary.email, 'admin@longdomain.test.com');
+    assert.equal(parsed.linkedLearners[0].learnerId, 'lrn-xyz789abcdef');
+    assert.equal(parsed.internalNotes, 'Some internal note');
+    assert.equal(parsed.stack, 'Error\n  at fn (/path/file.js:10:5)');
+  });
+
+  it('strips auth tokens (cookie, authorization, x-auth-token)', () => {
+    const result = prepareSafeCopy(FULL_DATA, COPY_AUDIENCE.ADMIN_ONLY);
+    const parsed = JSON.parse(result.text);
+    assert.equal(parsed.headers.cookie, undefined);
+    assert.equal(parsed.headers.authorization, undefined);
+    assert.equal(parsed.headers['x-auth-token'], undefined);
+    assert.equal(parsed.headers['content-type'], 'application/json');
+  });
+
+  it('strips requestBody', () => {
+    const result = prepareSafeCopy(FULL_DATA, COPY_AUDIENCE.ADMIN_ONLY);
+    const parsed = JSON.parse(result.text);
+    assert.equal(parsed.requestBody, undefined);
+  });
+
+  it('redactedFields contains auth_tokens and request_bodies', () => {
+    const result = prepareSafeCopy(FULL_DATA, COPY_AUDIENCE.ADMIN_ONLY);
+    assert.ok(result.redactedFields.includes('auth_tokens'));
+    assert.ok(result.redactedFields.includes('request_bodies'));
+    assert.equal(result.redactedFields.length, 2);
+  });
+
+  it('does not mutate original data', () => {
+    const data = {
+      accountSummary: { email: 'user@test.com', accountId: 'acct-abc123456789' },
+      cookie: 'session=secret',
+      internalNotes: 'secret',
+    };
+    const snapshot = JSON.stringify(data);
+    prepareSafeCopy(data, COPY_AUDIENCE.ADMIN_ONLY);
+    assert.equal(JSON.stringify(data), snapshot);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// prepareSafeCopy — OPS_SAFE audience (object input)
+// ---------------------------------------------------------------------------
+
+describe('prepareSafeCopy OPS_SAFE audience', () => {
+  const DATA = {
+    accountSummary: {
+      accountId: 'acct-abcdef123456',
+      email: 'admin@longdomain.test.com',
+    },
+    internalNotes: 'Secret internal info',
+    details: { internal_notes: 'Also secret', adminNotes: 'Admin note' },
+    headers: { cookie: 'session=abc', 'content-type': 'text/html' },
+  };
+
+  it('masks email to ****<last6>', () => {
+    const result = prepareSafeCopy(DATA, COPY_AUDIENCE.OPS_SAFE);
+    const parsed = JSON.parse(result.text);
+    assert.equal(parsed.accountSummary.email, '****st.com');
+  });
+
+  it('masks accountId to ****<last8>', () => {
+    const result = prepareSafeCopy(DATA, COPY_AUDIENCE.OPS_SAFE);
+    const parsed = JSON.parse(result.text);
+    assert.equal(parsed.accountSummary.accountId, '****ef123456');
+  });
+
+  it('strips internalNotes, internal_notes, adminNotes', () => {
+    const result = prepareSafeCopy(DATA, COPY_AUDIENCE.OPS_SAFE);
+    const parsed = JSON.parse(result.text);
+    assert.equal(parsed.internalNotes, undefined);
+    assert.equal(parsed.details.internal_notes, undefined);
+    assert.equal(parsed.details.adminNotes, undefined);
+  });
+
+  it('strips auth tokens', () => {
+    const result = prepareSafeCopy(DATA, COPY_AUDIENCE.OPS_SAFE);
+    const parsed = JSON.parse(result.text);
+    assert.equal(parsed.headers.cookie, undefined);
+    assert.equal(parsed.headers['content-type'], 'text/html');
+  });
+
+  it('redactedFields includes correct set', () => {
+    const result = prepareSafeCopy(DATA, COPY_AUDIENCE.OPS_SAFE);
+    assert.ok(result.redactedFields.includes('auth_tokens'));
+    assert.ok(result.redactedFields.includes('request_bodies'));
+    assert.ok(result.redactedFields.includes('emails_masked'));
+    assert.ok(result.redactedFields.includes('account_ids_masked'));
+    assert.ok(result.redactedFields.includes('internal_notes'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// prepareSafeCopy — PARENT_SAFE audience (object input)
+// ---------------------------------------------------------------------------
+
+describe('prepareSafeCopy PARENT_SAFE audience', () => {
+  const DATA = {
+    accountSummary: { email: 'parent@example.com' },
+    linkedLearners: [{ learnerId: 'lrn-abc', learnerName: 'Child', learner_id: 'lrn-abc-alt' }],
+    recentErrors: [{
+      id: 'e1',
+      firstFrame: '  at handler (/app/index.js:42:3)',
+      stack: 'Error: oops\n  at x (/y.js:1:1)',
+      requestBody: '{"password":"secret"}',
+    }],
+    internalNotes: 'Admin-only context',
+    childId: 'child-999',
+    headers: { 'set-cookie': 'val=1', 'content-type': 'text/plain' },
+  };
+
+  it('strips learnerId, learner_id, childId', () => {
+    const result = prepareSafeCopy(DATA, COPY_AUDIENCE.PARENT_SAFE);
+    const parsed = JSON.parse(result.text);
+    assert.equal(parsed.linkedLearners[0].learnerId, undefined);
+    assert.equal(parsed.linkedLearners[0].learner_id, undefined);
+    assert.equal(parsed.childId, undefined);
+    // learnerName preserved
+    assert.equal(parsed.linkedLearners[0].learnerName, 'Child');
+  });
+
+  it('redacts stack traces (firstFrame, stack, and inline at-frames)', () => {
+    const result = prepareSafeCopy(DATA, COPY_AUDIENCE.PARENT_SAFE);
+    const parsed = JSON.parse(result.text);
+    assert.equal(parsed.recentErrors[0].firstFrame, '[stack trace redacted]');
+    assert.equal(parsed.recentErrors[0].stack, '[stack trace redacted]');
+  });
+
+  it('strips requestBody', () => {
+    const result = prepareSafeCopy(DATA, COPY_AUDIENCE.PARENT_SAFE);
+    const parsed = JSON.parse(result.text);
+    assert.equal(parsed.recentErrors[0].requestBody, undefined);
+  });
+
+  it('strips internalNotes', () => {
+    const result = prepareSafeCopy(DATA, COPY_AUDIENCE.PARENT_SAFE);
+    const parsed = JSON.parse(result.text);
+    assert.equal(parsed.internalNotes, undefined);
+  });
+
+  it('masks email', () => {
+    const result = prepareSafeCopy(DATA, COPY_AUDIENCE.PARENT_SAFE);
+    const parsed = JSON.parse(result.text);
+    assert.equal(parsed.accountSummary.email, '****le.com');
+  });
+
+  it('strips auth tokens (set-cookie)', () => {
+    const result = prepareSafeCopy(DATA, COPY_AUDIENCE.PARENT_SAFE);
+    const parsed = JSON.parse(result.text);
+    assert.equal(parsed.headers['set-cookie'], undefined);
+    assert.equal(parsed.headers['content-type'], 'text/plain');
+  });
+
+  it('redactedFields includes correct set', () => {
+    const result = prepareSafeCopy(DATA, COPY_AUDIENCE.PARENT_SAFE);
+    assert.ok(result.redactedFields.includes('auth_tokens'));
+    assert.ok(result.redactedFields.includes('request_bodies'));
+    assert.ok(result.redactedFields.includes('child_ids'));
+    assert.ok(result.redactedFields.includes('stack_traces'));
+    assert.ok(result.redactedFields.includes('internal_notes'));
+    assert.ok(result.redactedFields.includes('emails_masked'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// prepareSafeCopy — PUBLIC_PREVIEW audience (object input)
+// ---------------------------------------------------------------------------
+
+describe('prepareSafeCopy PUBLIC_PREVIEW audience', () => {
+  it('extracts title and body, strips everything else', () => {
+    const data = {
+      title: 'Support Case #1234',
+      body: 'Detailed description here',
+      accountSummary: { email: 'user@test.com', accountId: 'acct-123' },
+      linkedLearners: [{ learnerId: 'lrn-1' }],
+      internalNotes: 'secret',
+    };
+    const result = prepareSafeCopy(data, COPY_AUDIENCE.PUBLIC_PREVIEW);
+    assert.equal(result.ok, true);
+    const parsed = JSON.parse(result.text);
+    assert.equal(parsed.title, 'Support Case #1234');
+    assert.equal(parsed.body, 'Detailed description here');
+    assert.equal(parsed.accountSummary, undefined);
+    assert.equal(parsed.linkedLearners, undefined);
+    assert.equal(parsed.internalNotes, undefined);
+  });
+
+  it('falls back to humanSummary for title when no title field', () => {
+    const data = {
+      humanSummary: 'Summary for display',
+      accountSummary: { email: 'user@test.com' },
+    };
+    const result = prepareSafeCopy(data, COPY_AUDIENCE.PUBLIC_PREVIEW);
+    const parsed = JSON.parse(result.text);
+    assert.equal(parsed.title, 'Summary for display');
+  });
+
+  it('falls back to humanSummary for body when no body field', () => {
+    const data = {
+      title: 'My Title',
+      humanSummary: 'Summary text',
+    };
+    const result = prepareSafeCopy(data, COPY_AUDIENCE.PUBLIC_PREVIEW);
+    const parsed = JSON.parse(result.text);
+    assert.equal(parsed.title, 'My Title');
+    assert.equal(parsed.body, 'Summary text');
+  });
+
+  it('title and body are empty strings when neither field exists', () => {
+    const data = {
+      accountSummary: { email: 'user@test.com' },
+      someData: 'value',
+    };
+    const result = prepareSafeCopy(data, COPY_AUDIENCE.PUBLIC_PREVIEW);
+    const parsed = JSON.parse(result.text);
+    assert.equal(parsed.title, '');
+    assert.equal(parsed.body, '');
+  });
+
+  it('redactedFields includes all_except_title_body', () => {
+    const data = { title: 'x', body: 'y' };
+    const result = prepareSafeCopy(data, COPY_AUDIENCE.PUBLIC_PREVIEW);
+    assert.ok(result.redactedFields.includes('auth_tokens'));
+    assert.ok(result.redactedFields.includes('request_bodies'));
+    assert.ok(result.redactedFields.includes('all_except_title_body'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// prepareSafeCopy — nested redaction (deep object graphs)
+// ---------------------------------------------------------------------------
+
+describe('prepareSafeCopy handles nested structures', () => {
+  it('strips auth tokens nested deep in arrays', () => {
+    const data = {
+      title: 'Bundle',
+      requests: [
+        { url: '/api', headers: { cookie: 'session=x', accept: 'application/json' } },
+        { url: '/login', headers: { authorization: 'Bearer y' } },
+      ],
+    };
+    const result = prepareSafeCopy(data, COPY_AUDIENCE.ADMIN_ONLY);
+    const parsed = JSON.parse(result.text);
+    assert.equal(parsed.requests[0].headers.cookie, undefined);
+    assert.equal(parsed.requests[0].headers.accept, 'application/json');
+    assert.equal(parsed.requests[1].headers.authorization, undefined);
+  });
+
+  it('masks emails nested in arrays for OPS_SAFE', () => {
+    const data = {
+      title: 'List',
+      users: [
+        { email: 'alice@example.com', name: 'Alice' },
+        { email: 'bob@example.com', name: 'Bob' },
+      ],
+    };
+    const result = prepareSafeCopy(data, COPY_AUDIENCE.OPS_SAFE);
+    const parsed = JSON.parse(result.text);
+    assert.equal(parsed.users[0].email, '****le.com');
+    assert.equal(parsed.users[1].email, '****le.com');
+    assert.equal(parsed.users[0].name, 'Alice');
+  });
+
+  it('strips child IDs nested in arrays for PARENT_SAFE', () => {
+    const data = {
+      title: 'Info',
+      children: [
+        { learnerId: 'lrn-1', name: 'A' },
+        { learner_id: 'lrn-2', name: 'B' },
+      ],
+    };
+    const result = prepareSafeCopy(data, COPY_AUDIENCE.PARENT_SAFE);
+    const parsed = JSON.parse(result.text);
+    assert.equal(parsed.children[0].learnerId, undefined);
+    assert.equal(parsed.children[1].learner_id, undefined);
+    assert.equal(parsed.children[0].name, 'A');
+    assert.equal(parsed.children[1].name, 'B');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// prepareSafeCopy — stack trace detection patterns
+// ---------------------------------------------------------------------------
+
+describe('prepareSafeCopy stack trace detection', () => {
+  it('redacts string values containing "  at " on their own line (PARENT_SAFE)', () => {
+    const data = {
+      title: 'Error',
+      errorMessage: 'Something failed\n  at Object.run (/app/main.js:1:1)',
+    };
+    const result = prepareSafeCopy(data, COPY_AUDIENCE.PARENT_SAFE);
+    const parsed = JSON.parse(result.text);
+    assert.equal(parsed.errorMessage, '[stack trace redacted]');
+  });
+
+  it('does NOT redact strings without "at " frame pattern', () => {
+    const data = {
+      title: 'Note',
+      description: 'Look at this interesting result',
+    };
+    const result = prepareSafeCopy(data, COPY_AUDIENCE.PARENT_SAFE);
+    const parsed = JSON.parse(result.text);
+    assert.equal(parsed.description, 'Look at this interesting result');
+  });
+
+  it('redacts keys named "stackTrace"', () => {
+    const data = {
+      title: 'Error',
+      stackTrace: 'whatever content here',
+    };
+    const result = prepareSafeCopy(data, COPY_AUDIENCE.PARENT_SAFE);
+    const parsed = JSON.parse(result.text);
+    assert.equal(parsed.stackTrace, '[stack trace redacted]');
+  });
+});

--- a/tests/admin-safe-copy-characterisation.test.js
+++ b/tests/admin-safe-copy-characterisation.test.js
@@ -161,37 +161,55 @@ describe('prepareSafeCopy with empty/null/invalid inputs', () => {
 });
 
 // ---------------------------------------------------------------------------
-// prepareSafeCopy — string input (known gap: passes through without redaction)
+// prepareSafeCopy — string input (P6 U3: gap closed — string redaction active)
 // ---------------------------------------------------------------------------
 
-describe('prepareSafeCopy with string input (documents pass-through gap)', () => {
-  const TEXT = 'Some raw text with email@test.com and accountId=acct-1234567890';
+describe('prepareSafeCopy with string input (string redaction active)', () => {
+  const TEXT_WITH_SENSITIVE = 'Some raw text with email@test.com and accountId=acct-1234567890';
+  const TEXT_CLEAN = 'Some raw text with no sensitive patterns';
 
-  it('ADMIN_ONLY — string passes through unchanged', () => {
-    const result = prepareSafeCopy(TEXT, COPY_AUDIENCE.ADMIN_ONLY);
+  it('ADMIN_ONLY — clean string passes through unchanged', () => {
+    const result = prepareSafeCopy(TEXT_CLEAN, COPY_AUDIENCE.ADMIN_ONLY);
     assert.equal(result.ok, true);
-    assert.equal(result.text, TEXT);
-    // No object redaction was applied (known gap).
-    assert.ok(!result.redactedFields.includes('emails_masked'));
+    assert.equal(result.text, TEXT_CLEAN);
+    assert.deepEqual(result.redactedFields, []);
   });
 
-  it('OPS_SAFE — string passes through unchanged (gap: no email masking on strings)', () => {
-    const result = prepareSafeCopy(TEXT, COPY_AUDIENCE.OPS_SAFE);
+  it('ADMIN_ONLY — string with sensitive content still passes (no email/ID redaction at admin level)', () => {
+    const result = prepareSafeCopy(TEXT_WITH_SENSITIVE, COPY_AUDIENCE.ADMIN_ONLY);
     assert.equal(result.ok, true);
-    // String passes through because typeof working !== 'object' branch skips redaction.
-    assert.equal(result.text, TEXT);
+    // At ADMIN_ONLY, only auth tokens/cookies are redacted — emails and account IDs pass through.
+    assert.ok(result.text.includes('email@test.com'));
   });
 
-  it('PARENT_SAFE — string passes through unchanged (gap: no child ID stripping on strings)', () => {
-    const result = prepareSafeCopy(TEXT, COPY_AUDIENCE.PARENT_SAFE);
+  it('OPS_SAFE — email and account ID masked in string', () => {
+    const result = prepareSafeCopy(TEXT_WITH_SENSITIVE, COPY_AUDIENCE.OPS_SAFE);
     assert.equal(result.ok, true);
-    assert.equal(result.text, TEXT);
+    // Email masked.
+    assert.ok(!result.text.includes('email@test.com'), 'Email must be masked');
+    assert.ok(result.redactedFields.includes('emails_masked'));
   });
 
-  it('PUBLIC_PREVIEW — string passes through unchanged (gap: no title/body extraction on strings)', () => {
-    const result = prepareSafeCopy(TEXT, COPY_AUDIENCE.PUBLIC_PREVIEW);
+  it('PARENT_SAFE — email masked in string', () => {
+    const result = prepareSafeCopy(TEXT_WITH_SENSITIVE, COPY_AUDIENCE.PARENT_SAFE);
     assert.equal(result.ok, true);
-    assert.equal(result.text, TEXT);
+    assert.ok(!result.text.includes('email@test.com'), 'Email must be masked');
+    assert.ok(result.redactedFields.includes('emails_masked'));
+  });
+
+  it('PUBLIC_PREVIEW — email masked in string (same redaction level as PARENT_SAFE)', () => {
+    const result = prepareSafeCopy(TEXT_WITH_SENSITIVE, COPY_AUDIENCE.PUBLIC_PREVIEW);
+    assert.equal(result.ok, true);
+    assert.ok(!result.text.includes('email@test.com'), 'Email must be masked');
+  });
+
+  it('clean string passes through unchanged at all audiences', () => {
+    for (const audience of Object.values(COPY_AUDIENCE)) {
+      const result = prepareSafeCopy(TEXT_CLEAN, audience);
+      assert.equal(result.ok, true, `Failed for ${audience}`);
+      assert.equal(result.text, TEXT_CLEAN, `Mutated for ${audience}`);
+      assert.deepEqual(result.redactedFields, [], `Unexpected redactions for ${audience}`);
+    }
   });
 });
 

--- a/tests/admin-safe-copy-string-redaction.test.js
+++ b/tests/admin-safe-copy-string-redaction.test.js
@@ -1,0 +1,271 @@
+// P6 Unit 3: Hostile-seeded string redaction tests for admin-safe-copy.js
+//
+// Verifies that `prepareSafeCopy` and `redactString` correctly detect and
+// mask/strip sensitive tokens embedded in plain strings, closing the
+// string-passthrough gap documented in the characterisation baseline.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  COPY_AUDIENCE,
+  prepareSafeCopy,
+  redactString,
+  maskEmail,
+  maskId,
+} from '../src/platform/hubs/admin-safe-copy.js';
+
+// ---------------------------------------------------------------------------
+// redactString — direct unit tests
+// ---------------------------------------------------------------------------
+
+describe('redactString direct tests', () => {
+  it('returns empty string and no redactions for null input', () => {
+    const { text, appliedRedactions } = redactString(null, COPY_AUDIENCE.ADMIN_ONLY);
+    assert.equal(text, '');
+    assert.deepEqual(appliedRedactions, []);
+  });
+
+  it('returns empty string and no redactions for empty string input', () => {
+    const { text, appliedRedactions } = redactString('', COPY_AUDIENCE.ADMIN_ONLY);
+    assert.equal(text, '');
+    assert.deepEqual(appliedRedactions, []);
+  });
+
+  it('normal text passes through unchanged at all audiences', () => {
+    const input = 'Normal text with no sensitive content';
+    for (const audience of Object.values(COPY_AUDIENCE)) {
+      const { text, appliedRedactions } = redactString(input, audience);
+      assert.equal(text, input, `Failed for audience: ${audience}`);
+      assert.deepEqual(appliedRedactions, [], `Unexpected redactions for ${audience}`);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Auth tokens — redacted at ALL audiences including ADMIN_ONLY
+// ---------------------------------------------------------------------------
+
+describe('redactString auth token detection', () => {
+  const BEARER_INPUT = 'Bearer eyJhbGciOiJIUzI1NiJ9.payload.signature found in header';
+
+  it('Bearer token redacted at ADMIN_ONLY', () => {
+    const { text, appliedRedactions } = redactString(BEARER_INPUT, COPY_AUDIENCE.ADMIN_ONLY);
+    assert.ok(!text.includes('eyJ'), 'Token must not appear in output');
+    assert.ok(text.includes('[auth redacted]'));
+    assert.ok(text.includes('found in header'), 'Non-sensitive text preserved');
+    assert.ok(appliedRedactions.includes('auth_tokens'));
+  });
+
+  it('Bearer token redacted at OPS_SAFE', () => {
+    const { text } = redactString(BEARER_INPUT, COPY_AUDIENCE.OPS_SAFE);
+    assert.ok(!text.includes('eyJ'));
+    assert.ok(text.includes('[auth redacted]'));
+  });
+
+  it('Bearer token redacted at PARENT_SAFE', () => {
+    const { text } = redactString(BEARER_INPUT, COPY_AUDIENCE.PARENT_SAFE);
+    assert.ok(!text.includes('eyJ'));
+    assert.ok(text.includes('[auth redacted]'));
+  });
+
+  it('Basic auth redacted', () => {
+    const input = 'Basic dXNlcjpwYXNzd29yZA== in Authorization header';
+    const { text, appliedRedactions } = redactString(input, COPY_AUDIENCE.ADMIN_ONLY);
+    assert.ok(!text.includes('dXNlcjpwYXNzd29yZA=='));
+    assert.ok(text.includes('[auth redacted]'));
+    assert.ok(appliedRedactions.includes('auth_tokens'));
+  });
+
+  it('cookie values redacted', () => {
+    const input = 'Found session=abc123def456ghi789; in request';
+    const { text, appliedRedactions } = redactString(input, COPY_AUDIENCE.ADMIN_ONLY);
+    assert.ok(!text.includes('abc123def456ghi789'));
+    assert.ok(text.includes('[cookie redacted]'));
+    assert.ok(appliedRedactions.includes('cookie_values'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OPS_SAFE — emails and account IDs masked
+// ---------------------------------------------------------------------------
+
+describe('redactString OPS_SAFE level', () => {
+  it('email addresses masked using maskEmail()', () => {
+    const input = 'User james@example.com reported issue';
+    const { text, appliedRedactions } = redactString(input, COPY_AUDIENCE.OPS_SAFE);
+    assert.ok(!text.includes('james@example.com'), 'Raw email must not appear');
+    assert.ok(text.includes(maskEmail('james@example.com')));
+    assert.ok(appliedRedactions.includes('emails_masked'));
+  });
+
+  it('multiple emails both masked', () => {
+    const input = 'Multiple emails: a@b.com and c@d.org in one string';
+    const { text, appliedRedactions } = redactString(input, COPY_AUDIENCE.OPS_SAFE);
+    assert.ok(!text.includes('a@b.com'), 'First email must not appear');
+    assert.ok(!text.includes('c@d.org'), 'Second email must not appear');
+    assert.ok(appliedRedactions.includes('emails_masked'));
+  });
+
+  it('account IDs masked using maskId()', () => {
+    const input = 'Account acc_abc123def456789 has issues';
+    const { text, appliedRedactions } = redactString(input, COPY_AUDIENCE.OPS_SAFE);
+    assert.ok(!text.includes('acc_abc123def456789'), 'Raw account ID must not appear');
+    assert.ok(text.includes(maskId('acc_abc123def456789')));
+    assert.ok(appliedRedactions.includes('account_ids_masked'));
+  });
+
+  it('session IDs masked', () => {
+    const input = 'Session sess_xyz789abcdef expired';
+    const { text, appliedRedactions } = redactString(input, COPY_AUDIENCE.OPS_SAFE);
+    assert.ok(!text.includes('sess_xyz789abcdef'), 'Raw session ID must not appear');
+    assert.ok(appliedRedactions.includes('session_ids_masked'));
+  });
+
+  it('UUID-shaped strings masked', () => {
+    const input = 'ID is 550e8400-e29b-41d4-a716-446655440000 in the system';
+    const { text, appliedRedactions } = redactString(input, COPY_AUDIENCE.OPS_SAFE);
+    assert.ok(!text.includes('550e8400-e29b-41d4-a716-446655440000'));
+    assert.ok(appliedRedactions.includes('session_ids_masked'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PARENT_SAFE — learner IDs, stack traces, internal routes, table names
+// ---------------------------------------------------------------------------
+
+describe('redactString PARENT_SAFE level', () => {
+  it('learner IDs stripped entirely', () => {
+    const input = 'Learner lrn_abc123 has completed the task';
+    const { text, appliedRedactions } = redactString(input, COPY_AUDIENCE.PARENT_SAFE);
+    assert.ok(!text.includes('lrn_abc123'), 'Learner ID must not appear');
+    assert.ok(text.includes('[redacted]'));
+    assert.ok(appliedRedactions.includes('learner_ids'));
+  });
+
+  it('stack traces redacted', () => {
+    const input = 'Session sess_xyz789abcdef expired\n  at Worker.fetch (worker/src/app.js:42:15)\n  at Object.handle';
+    const { text, appliedRedactions } = redactString(input, COPY_AUDIENCE.PARENT_SAFE);
+    assert.ok(!text.includes('Worker.fetch'), 'Stack frame must not appear');
+    assert.ok(!text.includes('worker/src/app.js'));
+    assert.ok(text.includes('[stack trace redacted]'));
+    assert.ok(appliedRedactions.includes('stack_traces'));
+  });
+
+  it('internal admin routes redacted', () => {
+    const input = 'Error in /api/admin/ops/error-events route: lookup failed';
+    const { text, appliedRedactions } = redactString(input, COPY_AUDIENCE.PARENT_SAFE);
+    assert.ok(!text.includes('/api/admin/ops/error-events'), 'Internal route must not appear');
+    assert.ok(text.includes('[internal route redacted]'));
+    assert.ok(appliedRedactions.includes('internal_routes'));
+  });
+
+  it('internal API routes (/api/internal/) redacted', () => {
+    const input = 'Called /api/internal/health-check and failed';
+    const { text, appliedRedactions } = redactString(input, COPY_AUDIENCE.PARENT_SAFE);
+    assert.ok(!text.includes('/api/internal/health-check'));
+    assert.ok(text.includes('[internal route redacted]'));
+    assert.ok(appliedRedactions.includes('internal_routes'));
+  });
+
+  it('internal table/column names redacted', () => {
+    const input = 'Error in /api/admin/ops/error-events route: d1.accounts table lookup failed';
+    const { text, appliedRedactions } = redactString(input, COPY_AUDIENCE.PARENT_SAFE);
+    assert.ok(!text.includes('d1.accounts'), 'Internal table name must not appear');
+    assert.ok(text.includes('[internal reference redacted]'));
+    assert.ok(appliedRedactions.includes('internal_references'));
+  });
+
+  it('d1.learner_state table name redacted', () => {
+    const input = 'Query to d1.learner_state timed out';
+    const { text, appliedRedactions } = redactString(input, COPY_AUDIENCE.PARENT_SAFE);
+    assert.ok(!text.includes('d1.learner_state'));
+    assert.ok(text.includes('[internal reference redacted]'));
+    assert.ok(appliedRedactions.includes('internal_references'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Combined hostile strings via prepareSafeCopy
+// ---------------------------------------------------------------------------
+
+describe('prepareSafeCopy string redaction integration', () => {
+  it('email + account ID redacted at PARENT_SAFE', () => {
+    const input = 'User james@example.com reported issue with account acc_abc123def456789';
+    const result = prepareSafeCopy(input, COPY_AUDIENCE.PARENT_SAFE);
+    assert.equal(result.ok, true);
+    assert.ok(!result.text.includes('james@example.com'), 'Email must be gone');
+    assert.ok(!result.text.includes('acc_abc123def456789'), 'Account ID must be gone');
+  });
+
+  it('stack trace + session ID redacted at PARENT_SAFE', () => {
+    const input = 'Session sess_xyz789abcdef expired\n  at Worker.fetch (worker/src/app.js:42:15)\n  at Object.handle';
+    const result = prepareSafeCopy(input, COPY_AUDIENCE.PARENT_SAFE);
+    assert.equal(result.ok, true);
+    assert.ok(!result.text.includes('sess_xyz789abcdef'), 'Session ID must be gone');
+    assert.ok(!result.text.includes('Worker.fetch'), 'Stack trace must be gone');
+  });
+
+  it('internal route + table name redacted at PARENT_SAFE', () => {
+    const input = 'Error in /api/admin/ops/error-events route: d1.accounts table lookup failed';
+    const result = prepareSafeCopy(input, COPY_AUDIENCE.PARENT_SAFE);
+    assert.equal(result.ok, true);
+    assert.ok(!result.text.includes('/api/admin/ops/error-events'));
+    assert.ok(!result.text.includes('d1.accounts'));
+  });
+
+  it('Bearer token redacted at ADMIN_ONLY', () => {
+    const input = 'Bearer eyJhbGciOiJIUzI1NiJ9.payload.signature found in header';
+    const result = prepareSafeCopy(input, COPY_AUDIENCE.ADMIN_ONLY);
+    assert.equal(result.ok, true);
+    assert.ok(!result.text.includes('eyJ'));
+    assert.ok(result.text.includes('[auth redacted]'));
+    assert.ok(result.redactedFields.includes('auth_tokens'));
+  });
+
+  it('normal text passes through unchanged at all levels', () => {
+    const input = 'Normal text with no sensitive content';
+    for (const audience of Object.values(COPY_AUDIENCE)) {
+      const result = prepareSafeCopy(input, audience);
+      assert.equal(result.ok, true, `Failed for audience: ${audience}`);
+      assert.equal(result.text, input, `Text mutated for ${audience}`);
+      assert.deepEqual(result.redactedFields, [], `Unexpected redactions for ${audience}`);
+    }
+  });
+
+  it('multiple emails masked at OPS_SAFE', () => {
+    const input = 'Multiple emails: a@b.com and c@d.org in one string';
+    const result = prepareSafeCopy(input, COPY_AUDIENCE.OPS_SAFE);
+    assert.equal(result.ok, true);
+    assert.ok(!result.text.includes('a@b.com'));
+    assert.ok(!result.text.includes('c@d.org'));
+    assert.ok(result.redactedFields.includes('emails_masked'));
+  });
+
+  it('very long string (10KB) completes without crash', () => {
+    const input = 'A'.repeat(10240);
+    const result = prepareSafeCopy(input, COPY_AUDIENCE.PARENT_SAFE);
+    assert.equal(result.ok, true);
+    assert.equal(result.text, input); // no sensitive content → unchanged
+    assert.equal(result.text.length, 10240);
+  });
+
+  it('empty string returns ok: false', () => {
+    const result = prepareSafeCopy('', COPY_AUDIENCE.ADMIN_ONLY);
+    assert.equal(result.ok, false);
+  });
+
+  it('whitespace-only string returns ok: false', () => {
+    const result = prepareSafeCopy('   ', COPY_AUDIENCE.PARENT_SAFE);
+    assert.equal(result.ok, false);
+  });
+
+  it('redactedFields indicates what was applied', () => {
+    const input = 'Bearer eyJhbGciOiJIUzI1NiJ9.x.y and session=abcdef123456; plus user@test.org';
+    const result = prepareSafeCopy(input, COPY_AUDIENCE.OPS_SAFE);
+    assert.equal(result.ok, true);
+    assert.ok(result.redactedFields.includes('auth_tokens'));
+    assert.ok(result.redactedFields.includes('cookie_values'));
+    assert.ok(result.redactedFields.includes('emails_masked'));
+  });
+});

--- a/tests/admin-safe-copy.test.js
+++ b/tests/admin-safe-copy.test.js
@@ -276,7 +276,7 @@ test('unknown audience returns ok: false', () => {
 // 10. String input handling
 // ---------------------------------------------------------------------------
 
-test('string input passes through for admin_only', () => {
+test('string input without sensitive content passes through for admin_only', () => {
   const result = prepareSafeCopy('Some summary text', COPY_AUDIENCE.ADMIN_ONLY);
   assert.equal(result.ok, true);
   assert.equal(result.text, 'Some summary text');

--- a/tests/generate-evidence-summary.test.js
+++ b/tests/generate-evidence-summary.test.js
@@ -1,0 +1,272 @@
+// P6 Unit 2: generate-evidence-summary.mjs — schema 3 multi-source tests.
+//
+// Tests the generator's source-reading logic, schema 3 shape, backward
+// compatibility with schema 2 consumers, missing source handling, and
+// malformed source robustness.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { execSync } from 'node:child_process';
+
+import {
+  EVIDENCE_STATES,
+  classifyEvidenceMetric,
+  buildEvidencePanelModel,
+} from '../src/platform/hubs/admin-production-evidence.js';
+
+// ---------------------------------------------------------------------------
+// Schema 3 output shape validation
+// ---------------------------------------------------------------------------
+
+describe('generate-evidence-summary schema 3 output', () => {
+  it('produces schema 3 when run via node', () => {
+    const ROOT = join(import.meta.url.startsWith('file://')
+      ? new URL('..', import.meta.url).pathname.replace(/^\/([A-Z]:)/i, '$1')
+      : process.cwd());
+    const outputPath = join(ROOT, 'reports', 'capacity', 'latest-evidence-summary.json');
+
+    // Run the generator
+    execSync('node scripts/generate-evidence-summary.mjs', {
+      cwd: ROOT,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 10000,
+    });
+
+    const content = readFileSync(outputPath, 'utf8');
+    const summary = JSON.parse(content);
+
+    assert.equal(summary.schema, 3);
+    assert.equal(typeof summary.generatedAt, 'string');
+    assert.ok(summary.sources && typeof summary.sources === 'object');
+    assert.ok(summary.metrics && typeof summary.metrics === 'object');
+
+    // sources must contain the expected keys
+    const expectedSourceKeys = [
+      'capacity_evidence', 'admin_smoke', 'bootstrap_smoke',
+      'csp_status', 'd1_migrations', 'build_version', 'kpi_reconcile',
+    ];
+    for (const key of expectedSourceKeys) {
+      assert.ok(key in summary.sources, `sources must contain ${key}`);
+      assert.equal(typeof summary.sources[key].found, 'boolean');
+      assert.equal(typeof summary.sources[key].file, 'string');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Schema 3 backward compatibility with buildEvidencePanelModel
+// ---------------------------------------------------------------------------
+
+describe('buildEvidencePanelModel handles schema 3', () => {
+  const NOW = 1_700_000_000_000;
+  const FRESH = new Date(NOW - 60_000).toISOString();
+
+  it('schema 3 summary with sources is consumed correctly', () => {
+    const summary = {
+      schema: 3,
+      generatedAt: FRESH,
+      sources: {
+        capacity_evidence: { file: 'reports/capacity/evidence/', found: true },
+        admin_smoke: { file: 'reports/admin-smoke/latest.json', found: false },
+      },
+      metrics: {
+        certified_30_learner_beta: {
+          tier: 'certified_30_learner_beta',
+          ok: true,
+          failures: [],
+          finishedAt: FRESH,
+          commit: 'abc1234',
+        },
+      },
+    };
+    const result = buildEvidencePanelModel(summary, NOW);
+    assert.equal(result.isFresh, true);
+    assert.equal(result.metrics.length, 1);
+    assert.equal(result.metrics[0].state, EVIDENCE_STATES.CERTIFIED_30);
+    assert.equal(result.overallState, EVIDENCE_STATES.CERTIFIED_30);
+    // sources are preserved in the model
+    assert.ok(result.sources);
+    assert.equal(result.sources.capacity_evidence.found, true);
+    assert.equal(result.sources.admin_smoke.found, false);
+  });
+
+  it('schema 2 summary (no sources field) still works', () => {
+    const summary = {
+      schema: 2,
+      generatedAt: FRESH,
+      metrics: {
+        smoke_pass: { tier: 'smoke_pass', ok: true, failures: [] },
+      },
+    };
+    const result = buildEvidencePanelModel(summary, NOW);
+    assert.equal(result.isFresh, true);
+    assert.equal(result.overallState, EVIDENCE_STATES.SMOKE_PASS);
+    // sources should be null for schema 2
+    assert.equal(result.sources, null);
+  });
+
+  it('empty schema 2 placeholder still produces STALE', () => {
+    const summary = { schema: 2, metrics: {}, generatedAt: null };
+    const result = buildEvidencePanelModel(summary, NOW);
+    assert.equal(result.overallState, EVIDENCE_STATES.STALE);
+    assert.equal(result.sources, null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// New tier keys: admin_smoke, bootstrap_smoke classification
+// ---------------------------------------------------------------------------
+
+describe('classifyEvidenceMetric with schema 3 tier keys', () => {
+  const NOW = 1_700_000_000_000;
+  const FRESH = new Date(NOW - 60_000).toISOString();
+
+  it('admin_smoke passing → SMOKE_PASS', () => {
+    const result = classifyEvidenceMetric(
+      'admin_smoke',
+      { ok: true, failures: [] },
+      FRESH,
+      NOW,
+    );
+    assert.equal(result, EVIDENCE_STATES.SMOKE_PASS);
+  });
+
+  it('bootstrap_smoke passing → SMOKE_PASS', () => {
+    const result = classifyEvidenceMetric(
+      'bootstrap_smoke',
+      { ok: true, failures: [] },
+      FRESH,
+      NOW,
+    );
+    assert.equal(result, EVIDENCE_STATES.SMOKE_PASS);
+  });
+
+  it('admin_smoke failing → FAILING', () => {
+    const result = classifyEvidenceMetric(
+      'admin_smoke',
+      { ok: false, failures: ['timeout'] },
+      FRESH,
+      NOW,
+    );
+    assert.equal(result, EVIDENCE_STATES.FAILING);
+  });
+
+  it('bootstrap_smoke null metric → NOT_AVAILABLE', () => {
+    const result = classifyEvidenceMetric('bootstrap_smoke', null, FRESH, NOW);
+    assert.equal(result, EVIDENCE_STATES.NOT_AVAILABLE);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Missing source files → NOT_AVAILABLE
+// ---------------------------------------------------------------------------
+
+describe('missing source files produce NOT_AVAILABLE metrics', () => {
+  const NOW = 1_700_000_000_000;
+  const FRESH = new Date(NOW - 60_000).toISOString();
+
+  it('metric is absent when source file does not exist', () => {
+    // Simulate: summary generated with admin_smoke source not found
+    const summary = {
+      schema: 3,
+      generatedAt: FRESH,
+      sources: {
+        admin_smoke: { file: 'reports/admin-smoke/latest.json', found: false },
+      },
+      metrics: {
+        // admin_smoke is NOT in metrics because source was missing
+      },
+    };
+    const result = buildEvidencePanelModel(summary, NOW);
+    // No admin_smoke metric in the output
+    const adminMetric = result.metrics.find((m) => m.key === 'admin_smoke');
+    assert.equal(adminMetric, undefined);
+    // sources manifest shows it was not found
+    assert.equal(result.sources.admin_smoke.found, false);
+  });
+
+  it('classifyEvidenceMetric returns NOT_AVAILABLE for undefined metric value', () => {
+    const result = classifyEvidenceMetric('admin_smoke', undefined, FRESH, NOW);
+    assert.equal(result, EVIDENCE_STATES.NOT_AVAILABLE);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Malformed source files → NOT_AVAILABLE (no crash)
+// ---------------------------------------------------------------------------
+
+describe('malformed source files do not crash the generator', () => {
+  const NOW = 1_700_000_000_000;
+  const FRESH = new Date(NOW - 60_000).toISOString();
+
+  it('metric with non-object value (string) is NOT_AVAILABLE', () => {
+    const result = classifyEvidenceMetric('kpi_reconcile', 'broken', FRESH, NOW);
+    assert.equal(result, EVIDENCE_STATES.NOT_AVAILABLE);
+  });
+
+  it('metric with array value is FAILING (array is typeof object, ok is falsy)', () => {
+    // Arrays pass the typeof object check; without an `ok` property they
+    // evaluate as !metricValue.ok → true → FAILING.
+    const result = classifyEvidenceMetric('kpi_reconcile', [1, 2, 3], FRESH, NOW);
+    assert.equal(result, EVIDENCE_STATES.FAILING);
+  });
+
+  it('metric with number value is NOT_AVAILABLE', () => {
+    const result = classifyEvidenceMetric('csp_status', 42, FRESH, NOW);
+    assert.equal(result, EVIDENCE_STATES.NOT_AVAILABLE);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Overall state derivation with schema 3 mixed metrics
+// ---------------------------------------------------------------------------
+
+describe('overall state with schema 3 mixed sources', () => {
+  const NOW = 1_700_000_000_000;
+  const FRESH = new Date(NOW - 60_000).toISOString();
+
+  it('capacity certified_30 + admin_smoke pass → overall is CERTIFIED_30', () => {
+    const summary = {
+      schema: 3,
+      generatedAt: FRESH,
+      sources: {},
+      metrics: {
+        certified_30_learner_beta: { tier: 'certified_30_learner_beta', ok: true, failures: [] },
+        admin_smoke: { tier: 'admin_smoke', ok: true, failures: [] },
+      },
+    };
+    const result = buildEvidencePanelModel(summary, NOW);
+    assert.equal(result.overallState, EVIDENCE_STATES.CERTIFIED_30);
+  });
+
+  it('only informational metrics (csp_status, d1_migrations) → UNKNOWN overall', () => {
+    const summary = {
+      schema: 3,
+      generatedAt: FRESH,
+      sources: {},
+      metrics: {
+        csp_status: { tier: 'csp_status', ok: false, failures: ['csp_mode_is_report-only'] },
+        d1_migrations: { tier: 'd1_migrations', ok: true, failures: [] },
+      },
+    };
+    const result = buildEvidencePanelModel(summary, NOW);
+    // csp_status fails → FAILING (rank 1), d1_migrations unknown tier ok → UNKNOWN (rank 2)
+    // bestRank = 2 (UNKNOWN), hasFailing = true, 2 <= 2 && hasFailing → FAILING
+    assert.equal(result.overallState, EVIDENCE_STATES.FAILING);
+  });
+
+  it('admin_smoke pass only → overall is SMOKE_PASS', () => {
+    const summary = {
+      schema: 3,
+      generatedAt: FRESH,
+      sources: {},
+      metrics: {
+        admin_smoke: { tier: 'admin_smoke', ok: true, failures: [] },
+      },
+    };
+    const result = buildEvidencePanelModel(summary, NOW);
+    assert.equal(result.overallState, EVIDENCE_STATES.SMOKE_PASS);
+  });
+});

--- a/tests/playwright/admin-ops-role-proof.playwright.test.mjs
+++ b/tests/playwright/admin-ops-role-proof.playwright.test.mjs
@@ -1,0 +1,529 @@
+// P6 U5: Playwright browser proof — ops-role redaction and visibility contract.
+//
+// Closes the P5 fixme for ops-role interactive proof. This test file exercises
+// the security contract at browser level rather than at unit/integration level:
+//
+//   1. Ops role CANNOT see Copy JSON button (admin-only export)
+//   2. Ops role CAN see Copy Summary button (parent-safe export)
+//   3. Ops role sees MASKED identifiers (account IDs, emails, learner IDs)
+//   4. Ops role CANNOT see mutation buttons (seed harness, role management)
+//   5. Contrast: admin role CAN see all of the above
+//
+// Strategy: uses page.route() to intercept Worker API responses with
+// deterministic fixture data, identical to admin-debug-bundle-workflow tests.
+// No real signed-in session or database state required.
+
+import { test, expect } from '@playwright/test';
+import { createAdminFixtureAccount, createOpsFixtureAccount } from './admin-fixtures.mjs';
+
+// ---------------------------------------------------------------------------
+// Fixture data
+// ---------------------------------------------------------------------------
+
+const ADMIN_BUNDLE_FIXTURE = createAdminFixtureAccount();
+const OPS_BUNDLE_FIXTURE = createOpsFixtureAccount();
+
+// The 7 bundle section keys that must render as <details> elements.
+const BUNDLE_SECTION_KEYS = [
+  'accountSummary',
+  'linkedLearners',
+  'recentErrors',
+  'errorOccurrences',
+  'recentDenials',
+  'recentMutations',
+  'capacityState',
+];
+
+// ---------------------------------------------------------------------------
+// Admin hub payload factory — mirrors admin-debug-bundle-workflow.playwright.test.mjs
+// ---------------------------------------------------------------------------
+
+function makeAdminHubPayload(role = 'admin') {
+  const bundleFixture = role === 'admin' ? ADMIN_BUNDLE_FIXTURE : OPS_BUNDLE_FIXTURE;
+  return {
+    ok: true,
+    adminHub: {
+      permissions: {
+        canViewAdminHub: true,
+        platformRole: role,
+        platformRoleLabel: role === 'admin' ? 'Admin' : 'Ops',
+      },
+      account: {
+        accountId: 'acct-fixture-admin-001',
+        email: 'operator@ks2-mastery.test',
+        displayName: 'Fixture Operator',
+        repoRevision: 42,
+        selectedLearnerId: 'lrn-fixture-a1',
+      },
+      learnerSupport: {
+        accessibleLearners: [
+          { learnerId: 'lrn-fixture-a1', learnerName: 'Alice Fixture', displayName: 'Alice Fixture', yearGroup: 'Year 4' },
+        ],
+        selectedLearnerId: 'lrn-fixture-a1',
+        selectedDiagnostics: null,
+      },
+      debugBundle: {
+        data: bundleFixture,
+        loading: false,
+        error: null,
+      },
+      errorLogCentre: { summaries: [], occurrences: [] },
+      requestDenials: { denials: [] },
+      accountOpsMetadata: { accounts: [] },
+      postMegaSeedHarness: { shapes: ['all-mega', 'no-mega', 'partial-mega'] },
+      contentReleaseStatus: {
+        publishedVersion: 1,
+        publishedReleaseId: 'rel-001',
+        runtimeWordCount: 500,
+        runtimeSentenceCount: 100,
+        currentDraftId: 'draft-001',
+        currentDraftVersion: 2,
+        draftUpdatedAt: 1714200000000,
+      },
+      importValidationStatus: {
+        ok: true,
+        errorCount: 0,
+        warningCount: 0,
+        source: 'bundled baseline',
+        importedAt: 1714200000000,
+        errors: [],
+      },
+      postMasteryDebug: null,
+      accountSearch: { results: [], status: 'idle' },
+      accountDirectory: { accounts: [], status: 'idle' },
+      contentOverview: null,
+    },
+    session: {
+      signedIn: true,
+      accountId: 'acct-fixture-admin-001',
+      platformRole: role,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Route interception setup
+// ---------------------------------------------------------------------------
+
+function makeAuthSessionResponse(role = 'admin') {
+  return {
+    ok: true,
+    session: {
+      accountId: 'acct-fixture-admin-001',
+      provider: 'google',
+      platformRole: role,
+      accountType: 'real',
+      demo: false,
+      demoExpiresAt: null,
+      email: 'operator@ks2-mastery.test',
+      displayName: 'Fixture Operator',
+    },
+    account: {
+      id: 'acct-fixture-admin-001',
+      email: 'operator@ks2-mastery.test',
+      displayName: 'Fixture Operator',
+      selectedLearnerId: 'lrn-fixture-a1',
+      repoRevision: 42,
+      platformRole: role,
+      accountType: 'real',
+      demo: false,
+      demoExpiresAt: null,
+    },
+    subjectExposureGates: {
+      spelling: true,
+      grammar: true,
+      punctuation: true,
+    },
+    learnerCount: 1,
+    auth: { method: 'session', valid: true },
+  };
+}
+
+function makeBootstrapResponse(role = 'admin') {
+  return {
+    ok: true,
+    learnerId: 'lrn-fixture-a1',
+    learners: [
+      {
+        id: 'lrn-fixture-a1',
+        displayName: 'Alice Fixture',
+        yearGroup: 'Year 4',
+      },
+    ],
+    subjects: {
+      spelling: { state: {}, readModel: {} },
+      grammar: { state: {}, readModel: {} },
+      punctuation: { state: {}, readModel: {} },
+    },
+    meta: {
+      capacity: { bootstrapCapacity: 1000, commandCapacity: 5000 },
+    },
+    session: {
+      accountId: 'acct-fixture-admin-001',
+      platformRole: role,
+    },
+    subjectExposureGates: {
+      spelling: true,
+      grammar: true,
+      punctuation: true,
+    },
+  };
+}
+
+async function setupRoutes(page, { role = 'admin' } = {}) {
+  const bundleFixture = role === 'admin' ? ADMIN_BUNDLE_FIXTURE : OPS_BUNDLE_FIXTURE;
+
+  await page.route('**/api/**', async (route) => {
+    const url = new URL(route.request().url());
+    const pathname = url.pathname;
+
+    if (pathname === '/api/auth/session') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(makeAuthSessionResponse(role)),
+      });
+      return;
+    }
+
+    if (pathname === '/api/bootstrap') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(makeBootstrapResponse(role)),
+      });
+      return;
+    }
+
+    if (pathname === '/api/hubs/admin') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(makeAdminHubPayload(role)),
+      });
+      return;
+    }
+
+    if (pathname === '/api/admin/debug-bundle') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(bundleFixture),
+      });
+      return;
+    }
+
+    if (pathname.startsWith('/api/admin/accounts')) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ ok: true, accounts: [] }),
+      });
+      return;
+    }
+
+    if (pathname.startsWith('/api/admin/ops/')) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ ok: true }),
+      });
+      return;
+    }
+
+    // Catch-all
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ ok: true }),
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Navigation helpers
+// ---------------------------------------------------------------------------
+
+async function navigateToAdmin(page) {
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+  // Wait for admin link to appear (both admin and ops roles get this link)
+  const adminLink = page.locator('a[href="/admin"]');
+  await expect(adminLink).toBeVisible({ timeout: 15_000 });
+  await adminLink.click();
+
+  // Wait for admin section tabs to render
+  const firstTab = page.locator('[data-section="overview"]');
+  await expect(firstTab).toBeVisible({ timeout: 15_000 });
+}
+
+async function navigateToDebugSection(page) {
+  await navigateToAdmin(page);
+  const debugTab = page.locator('[data-section="debug"]');
+  await expect(debugTab).toBeVisible({ timeout: 10_000 });
+  await debugTab.click();
+  await expect(page.locator('[data-testid="debug-bundle-panel"]')).toBeVisible({ timeout: 10_000 });
+}
+
+async function navigateToContentSection(page) {
+  await navigateToAdmin(page);
+  const contentTab = page.locator('[data-section="content"]');
+  await expect(contentTab).toBeVisible({ timeout: 10_000 });
+  await contentTab.click();
+}
+
+async function navigateToAccountsSection(page) {
+  await navigateToAdmin(page);
+  const accountsTab = page.locator('[data-section="accounts"]');
+  await expect(accountsTab).toBeVisible({ timeout: 10_000 });
+  await accountsTab.click();
+}
+
+// ---------------------------------------------------------------------------
+// OPS ROLE: Debug Bundle redaction and button-visibility contract
+// ---------------------------------------------------------------------------
+
+test.describe('Ops-role browser proof — Debug Bundle redaction', () => {
+  test.use({ reducedMotion: 'reduce' });
+
+  test('ops role can access admin panel and navigate to debug section', async ({ page }) => {
+    await setupRoutes(page, { role: 'ops' });
+    await navigateToDebugSection(page);
+
+    // The debug bundle panel rendered — ops can access the admin hub
+    const panel = page.locator('[data-testid="debug-bundle-panel"]');
+    await expect(panel).toBeVisible();
+  });
+
+  test('ops role CANNOT see Copy JSON button', async ({ page }) => {
+    await setupRoutes(page, { role: 'ops' });
+    await navigateToDebugSection(page);
+
+    // Wait for bundle result to render (pre-populated via fixture)
+    await expect(page.locator('[data-testid="debug-bundle-result"]')).toBeVisible({ timeout: 10_000 });
+
+    // Copy Summary IS visible for ops (parent-safe audience)
+    const copySummaryBtn = page.locator('[data-testid="bundle-copy-summary-btn"]');
+    await expect(copySummaryBtn).toBeVisible();
+
+    // Copy JSON MUST NOT be present for ops role (canExportJson=false in ops fixture)
+    const copyJsonBtn = page.locator('[data-testid="bundle-copy-json-btn"]');
+    await expect(copyJsonBtn).toHaveCount(0);
+  });
+
+  test('ops role sees masked account IDs (not raw identifiers)', async ({ page }) => {
+    await setupRoutes(page, { role: 'ops' });
+    await navigateToDebugSection(page);
+    await expect(page.locator('[data-testid="debug-bundle-result"]')).toBeVisible({ timeout: 10_000 });
+
+    // Expand Account Summary section
+    const accountSection = page.locator('[data-testid="bundle-section-accountSummary"]');
+    await accountSection.locator('summary').click();
+
+    // Ops fixture has masked account ID: 'dmin-001' (last 8 chars)
+    await expect(accountSection).toContainText('dmin-001');
+
+    // Must NOT contain the full unmasked account ID
+    const sectionText = await accountSection.textContent();
+    expect(sectionText).not.toContain('acct-fixture-admin-001');
+  });
+
+  test('ops role sees masked email (asterisks present)', async ({ page }) => {
+    await setupRoutes(page, { role: 'ops' });
+    await navigateToDebugSection(page);
+    await expect(page.locator('[data-testid="debug-bundle-result"]')).toBeVisible({ timeout: 10_000 });
+
+    // Expand Account Summary section
+    const accountSection = page.locator('[data-testid="bundle-section-accountSummary"]');
+    await accountSection.locator('summary').click();
+
+    // Ops fixture has masked email: '*********************y.test'
+    await expect(accountSection).toContainText('***');
+
+    // Must NOT contain the full email
+    const sectionText = await accountSection.textContent();
+    expect(sectionText).not.toContain('operator@ks2-mastery.test');
+  });
+
+  test('ops role sees masked learner IDs in linked learners', async ({ page }) => {
+    await setupRoutes(page, { role: 'ops' });
+    await navigateToDebugSection(page);
+    await expect(page.locator('[data-testid="debug-bundle-result"]')).toBeVisible({ timeout: 10_000 });
+
+    // Expand Linked Learners section
+    const learnersSection = page.locator('[data-testid="bundle-section-linkedLearners"]');
+    await learnersSection.locator('summary').click();
+
+    // Ops fixture learner IDs are masked: 'ture-a1' not 'lrn-fixture-a1'
+    const learnersText = await learnersSection.textContent();
+    expect(learnersText).not.toContain('lrn-fixture-a1');
+    expect(learnersText).not.toContain('lrn-fixture-b2');
+
+    // Learner names are NOT sensitive — they remain visible
+    expect(learnersText).toContain('Alice Fixture');
+  });
+
+  test('ops role bundle still renders all 7 sections', async ({ page }) => {
+    await setupRoutes(page, { role: 'ops' });
+    await navigateToDebugSection(page);
+    await expect(page.locator('[data-testid="debug-bundle-result"]')).toBeVisible({ timeout: 10_000 });
+
+    for (const sectionKey of BUNDLE_SECTION_KEYS) {
+      const section = page.locator(`[data-testid="bundle-section-${sectionKey}"]`);
+      await expect(section).toBeVisible({ timeout: 5_000 });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OPS ROLE: Mutation button visibility (Content + Accounts sections)
+// ---------------------------------------------------------------------------
+
+test.describe('Ops-role browser proof — mutation button gates', () => {
+  test.use({ reducedMotion: 'reduce' });
+
+  test('ops role sees "Admin-only" warning on seed harness instead of apply button', async ({ page }) => {
+    await setupRoutes(page, { role: 'ops' });
+    await navigateToContentSection(page);
+
+    // The post-mega seed harness panel renders a warning for non-admin roles
+    const seedPanel = page.locator('[data-panel="post-mega-seed-harness"]');
+    await expect(seedPanel).toBeVisible({ timeout: 10_000 });
+
+    // Verify it shows the ops-role block message
+    await expect(seedPanel).toContainText('Only admin accounts can apply QA seed shapes');
+
+    // The "Apply seed" button must NOT be visible
+    const applyBtn = seedPanel.locator('[data-action="post-mega-seed-apply"]');
+    await expect(applyBtn).toHaveCount(0);
+  });
+
+  test('ops role sees "Admin-only role management" warning in accounts', async ({ page }) => {
+    await setupRoutes(page, { role: 'ops' });
+    await navigateToAccountsSection(page);
+
+    // The account roles section shows a warning for non-admin
+    const warningText = page.locator('text=Only admin accounts can list accounts or change platform roles');
+    await expect(warningText).toBeVisible({ timeout: 10_000 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ADMIN ROLE: Contrast — proves admin CAN see everything ops cannot
+// ---------------------------------------------------------------------------
+
+test.describe('Admin-role contrast — confirms admin sees full controls', () => {
+  test.use({ reducedMotion: 'reduce' });
+
+  test('admin role CAN see Copy JSON button', async ({ page }) => {
+    await setupRoutes(page, { role: 'admin' });
+    await navigateToDebugSection(page);
+    await expect(page.locator('[data-testid="debug-bundle-result"]')).toBeVisible({ timeout: 10_000 });
+
+    // Copy JSON IS visible for admin (canExportJson=true in admin fixture)
+    const copyJsonBtn = page.locator('[data-testid="bundle-copy-json-btn"]');
+    await expect(copyJsonBtn).toBeVisible();
+
+    // Copy Summary also visible
+    const copySummaryBtn = page.locator('[data-testid="bundle-copy-summary-btn"]');
+    await expect(copySummaryBtn).toBeVisible();
+  });
+
+  test('admin role sees FULL unmasked account IDs', async ({ page }) => {
+    await setupRoutes(page, { role: 'admin' });
+    await navigateToDebugSection(page);
+    await expect(page.locator('[data-testid="debug-bundle-result"]')).toBeVisible({ timeout: 10_000 });
+
+    // Expand Account Summary
+    const accountSection = page.locator('[data-testid="bundle-section-accountSummary"]');
+    await accountSection.locator('summary').click();
+
+    // Admin sees full account ID
+    await expect(accountSection).toContainText('acct-fixture-admin-001');
+
+    // Admin sees full email
+    await expect(accountSection).toContainText('operator@ks2-mastery.test');
+  });
+
+  test('admin role sees FULL learner IDs in linked learners', async ({ page }) => {
+    await setupRoutes(page, { role: 'admin' });
+    await navigateToDebugSection(page);
+    await expect(page.locator('[data-testid="debug-bundle-result"]')).toBeVisible({ timeout: 10_000 });
+
+    // Expand Linked Learners
+    const learnersSection = page.locator('[data-testid="bundle-section-linkedLearners"]');
+    await learnersSection.locator('summary').click();
+
+    // Admin sees full learner IDs
+    await expect(learnersSection).toContainText('lrn-fixture-a1');
+    await expect(learnersSection).toContainText('lrn-fixture-b2');
+  });
+
+  test('admin role sees seed harness apply button (no ops-role block)', async ({ page }) => {
+    await setupRoutes(page, { role: 'admin' });
+    await navigateToContentSection(page);
+
+    // The post-mega seed harness panel renders the full interface for admin
+    const seedPanel = page.locator('[data-panel="post-mega-seed-harness"]');
+    await expect(seedPanel).toBeVisible({ timeout: 10_000 });
+
+    // Admin sees the apply button
+    const applyBtn = seedPanel.locator('[data-action="post-mega-seed-apply"]');
+    await expect(applyBtn).toBeVisible();
+
+    // The ops-role block message must NOT be present
+    const panelText = await seedPanel.textContent();
+    expect(panelText).not.toContain('Only admin accounts can apply QA seed shapes');
+  });
+
+  test('admin role can access account roles management', async ({ page }) => {
+    await setupRoutes(page, { role: 'admin' });
+    await navigateToAccountsSection(page);
+
+    // The admin-only warning must NOT be present
+    const warningText = page.locator('text=Only admin accounts can list accounts or change platform roles');
+    await expect(warningText).toHaveCount(0);
+
+    // Instead, the refresh accounts button should be visible
+    const refreshBtn = page.locator('text=Refresh accounts');
+    await expect(refreshBtn).toBeVisible({ timeout: 10_000 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SECURITY: Clipboard content integrity (parent-safe copy does not leak raw PII)
+// ---------------------------------------------------------------------------
+
+test.describe('Ops-role browser proof — clipboard safety', () => {
+  test.use({ reducedMotion: 'reduce' });
+
+  test('Copy Summary clipboard content does not contain raw email or account ID', async ({ page, context }) => {
+    // Grant clipboard permissions for this test context
+    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+
+    await setupRoutes(page, { role: 'ops' });
+    await navigateToDebugSection(page);
+    await expect(page.locator('[data-testid="debug-bundle-result"]')).toBeVisible({ timeout: 10_000 });
+
+    // Click Copy Summary
+    const copySummaryBtn = page.locator('[data-testid="bundle-copy-summary-btn"]');
+    await expect(copySummaryBtn).toBeVisible();
+    await copySummaryBtn.click();
+
+    // Wait for the "Summary copied" feedback chip
+    await expect(page.locator('[data-testid="bundle-copy-feedback"]')).toContainText('copied', { timeout: 5_000 });
+
+    // Read clipboard content
+    const clipboardContent = await page.evaluate(() => navigator.clipboard.readText());
+
+    // The ops fixture humanSummary is:
+    // 'Debug Bundle for ***dmin-001: 2 linked learners, 1 recent error, 1 denial, 1 mutation, 1 capacity metric. Generated 2024-04-28T14:26:40 UTC.'
+    //
+    // It must NOT contain the raw full account ID or email
+    expect(clipboardContent).not.toContain('acct-fixture-admin-001');
+    expect(clipboardContent).not.toContain('operator@ks2-mastery.test');
+
+    // It should contain the masked reference from humanSummary
+    expect(clipboardContent).toContain('dmin-001');
+  });
+});

--- a/worker/src/app.js
+++ b/worker/src/app.js
@@ -1990,14 +1990,14 @@ export function createWorkerApp({
         if (url.pathname === '/api/admin/ops/kpi' && request.method === 'GET') {
           requireSameOrigin(request, env);
           const result = await repository.readAdminOpsKpi(session.accountId);
-          return json({ ok: true, ...result });
+          return json({ ok: true, refreshedAt: new Date().toISOString(), ...result });
         }
 
         if (url.pathname === '/api/admin/ops/activity' && request.method === 'GET') {
           requireSameOrigin(request, env);
           const limit = Number(url.searchParams.get('limit')) || undefined;
           const result = await repository.listAdminOpsActivity(session.accountId, { limit });
-          return json({ ok: true, ...result });
+          return json({ ok: true, refreshedAt: new Date().toISOString(), ...result });
         }
 
         if (url.pathname === '/api/admin/ops/error-events' && request.method === 'GET') {
@@ -2025,7 +2025,7 @@ export function createWorkerApp({
             reopenedAfterResolved: reopenedAfterResolved === 'true' || reopenedAfterResolved === '1',
           };
           const result = await repository.readAdminOpsErrorEvents(session.accountId, { status, limit, filter });
-          return json({ ok: true, ...result });
+          return json({ ok: true, refreshedAt: new Date().toISOString(), ...result });
         }
 
         // U5 (P3): per-fingerprint occurrence timeline. Lazy-loaded on drawer
@@ -2075,7 +2075,7 @@ export function createWorkerApp({
             to: to !== null && Number.isFinite(Number(to)) ? Number(to) : null,
             limit,
           });
-          return json({ ok: true, ...result });
+          return json({ ok: true, refreshedAt: new Date().toISOString(), ...result });
         }
 
         // U6 (P3): Debug Bundle — Worker-authoritative evidence packet.
@@ -2131,7 +2131,7 @@ export function createWorkerApp({
         if (url.pathname === '/api/admin/ops/accounts-metadata' && request.method === 'GET') {
           requireSameOrigin(request, env);
           const result = await repository.readAdminOpsAccountsMetadata(session.accountId);
-          return json({ ok: true, ...result });
+          return json({ ok: true, refreshedAt: new Date().toISOString(), ...result });
         }
 
         // U7 (P3): account search. GET with query-string filters.
@@ -2176,7 +2176,7 @@ export function createWorkerApp({
         if (url.pathname === '/api/admin/ops/content-overview' && request.method === 'GET') {
           requireSameOrigin(request, env);
           const result = await repository.readSubjectContentOverview(session.accountId);
-          return json({ ok: true, ...result });
+          return json({ ok: true, refreshedAt: new Date().toISOString(), ...result });
         }
 
         // P5 U4: Production evidence summary. Lazy-loaded GET returning the
@@ -2207,7 +2207,7 @@ export function createWorkerApp({
           } catch {
             evidenceSummary = { schema: 2, metrics: {}, generatedAt: null };
           }
-          return json({ ok: true, ...evidenceSummary });
+          return json({ ok: true, refreshedAt: new Date().toISOString(), ...evidenceSummary });
         }
 
         // R31: regex dispatch for parameterised admin ops mutations. Placed
@@ -2462,7 +2462,7 @@ export function createWorkerApp({
           requireSameOrigin(request, env);
           const db = requireDatabase(env);
           const result = await listMarketingMessages(db, { actorAccountId: session.accountId });
-          return json({ ok: true, ...result });
+          return json({ ok: true, refreshedAt: new Date().toISOString(), ...result });
         }
 
         if (url.pathname === '/api/admin/marketing/messages' && request.method === 'POST') {

--- a/worker/src/app.js
+++ b/worker/src/app.js
@@ -1955,6 +1955,81 @@ export function createWorkerApp({
           return json({ ok: true, ...result });
         }
 
+        // P6 U8: Generic asset CAS routes — delegate to asset-specific handlers
+        // keyed by assetId. Currently supports 'monster-visual-config'; additional
+        // asset handlers register here as they are added.
+        const ASSET_HANDLERS = {
+          'monster-visual-config': {
+            saveDraft: (repo, accountId, body) =>
+              repo.saveMonsterVisualConfigDraft(accountId, {
+                draft: body.data || body.draft || body.config,
+                expectedDraftRevision: body.expectedDraftRevision,
+                mutation: mutationFromRequest(body, body._request),
+              }),
+            publish: (repo, accountId, body) =>
+              repo.publishMonsterVisualConfig(accountId, {
+                expectedDraftRevision: body.expectedDraftRevision,
+                mutation: mutationFromRequest(body, body._request),
+              }),
+            restore: (repo, accountId, body) =>
+              repo.restoreMonsterVisualConfigVersion(accountId, {
+                version: body.version,
+                expectedPublishedVersion: body.expectedPublishedVersion,
+                mutation: mutationFromRequest(body, body._request),
+              }),
+          },
+        };
+
+        // Generic asset draft save
+        {
+          const assetDraftMatch = url.pathname.match(/^\/api\/admin\/assets\/([^/]+)\/draft$/);
+          if (assetDraftMatch && request.method === 'PUT') {
+            requireSameOrigin(request, env);
+            requireMutationCapability(session);
+            const assetId = decodeURIComponent(assetDraftMatch[1]);
+            const handler = ASSET_HANDLERS[assetId];
+            if (!handler) return json({ ok: false, code: 'unknown_asset', message: `Unknown asset: ${assetId}` }, 404);
+            const body = await readJson(request);
+            body._request = request;
+            const result = await handler.saveDraft(repository, session.accountId, body);
+            return json({ ok: true, ...result });
+          }
+        }
+
+        // Generic asset publish
+        {
+          const assetPublishMatch = url.pathname.match(/^\/api\/admin\/assets\/([^/]+)\/publish$/);
+          if (assetPublishMatch && request.method === 'POST') {
+            requireSameOrigin(request, env);
+            requireMutationCapability(session);
+            const assetId = decodeURIComponent(assetPublishMatch[1]);
+            const handler = ASSET_HANDLERS[assetId];
+            if (!handler) return json({ ok: false, code: 'unknown_asset', message: `Unknown asset: ${assetId}` }, 404);
+            const body = await readJson(request);
+            body._request = request;
+            const result = await handler.publish(repository, session.accountId, body);
+            return json({ ok: true, ...result });
+          }
+        }
+
+        // Generic asset restore
+        {
+          const assetRestoreMatch = url.pathname.match(/^\/api\/admin\/assets\/([^/]+)\/restore$/);
+          if (assetRestoreMatch && request.method === 'POST') {
+            requireSameOrigin(request, env);
+            requireMutationCapability(session);
+            const assetId = decodeURIComponent(assetRestoreMatch[1]);
+            const handler = ASSET_HANDLERS[assetId];
+            if (!handler) return json({ ok: false, code: 'unknown_asset', message: `Unknown asset: ${assetId}` }, 404);
+            const body = await readJson(request);
+            body._request = request;
+            const result = await handler.restore(repository, session.accountId, body);
+            return json({ ok: true, ...result });
+          }
+        }
+
+        // Legacy monster-visual-config routes — kept as aliases for backward compat.
+        // They delegate to the same repository methods as the generic asset routes.
         if (url.pathname === '/api/admin/monster-visual-config/draft' && request.method === 'PUT') {
           requireSameOrigin(request, env);
           requireMutationCapability(session);
@@ -2176,6 +2251,17 @@ export function createWorkerApp({
         if (url.pathname === '/api/admin/ops/content-overview' && request.method === 'GET') {
           requireSameOrigin(request, env);
           const result = await repository.readSubjectContentOverview(session.accountId);
+          return json({ ok: true, refreshedAt: new Date().toISOString(), ...result });
+        }
+
+        // U7 (P6): Content quality signals. Read-only GET returning per-subject
+        // learning-quality signals (skill coverage, high-wrong-rate, misconceptions).
+        // Uses safeSection pattern so that individual subject failures degrade
+        // gracefully — a broken grammar query does not prevent spelling signals
+        // from loading.
+        if (url.pathname === '/api/admin/ops/content-quality-signals' && request.method === 'GET') {
+          requireSameOrigin(request, env);
+          const result = await repository.readContentQualitySignals(session.accountId);
           return json({ ok: true, refreshedAt: new Date().toISOString(), ...result });
         }
 

--- a/worker/src/repository.js
+++ b/worker/src/repository.js
@@ -1886,6 +1886,13 @@ async function readSubjectContentOverviewData(db, { now, actorAccountId, actor =
         validationErrors: spellingValidationErrors,
         errorCount7d: spellingErrors,
         supportLoadSignal: supportSignal(spellingErrors),
+        // U6 (P6): release readiness signals
+        validationBlockers: spellingValidationErrors > 0
+          ? [`${spellingValidationErrors} unresolved validation error${spellingValidationErrors === 1 ? '' : 's'}`]
+          : [],
+        validationWarnings: [],
+        hasRealDiagnostics: true,
+        recentErrorCount7d: spellingErrors,
       };
     }
     if (subject.subjectKey === 'grammar') {
@@ -1897,6 +1904,11 @@ async function readSubjectContentOverviewData(db, { now, actorAccountId, actor =
         validationErrors: 0,
         errorCount7d: grammarErrors,
         supportLoadSignal: supportSignal(grammarErrors),
+        // U6 (P6): release readiness signals
+        validationBlockers: [],
+        validationWarnings: [],
+        hasRealDiagnostics: true,
+        recentErrorCount7d: grammarErrors,
       };
     }
     if (subject.subjectKey === 'punctuation') {
@@ -1908,6 +1920,11 @@ async function readSubjectContentOverviewData(db, { now, actorAccountId, actor =
         validationErrors: 0,
         errorCount7d: punctuationErrors,
         supportLoadSignal: supportSignal(punctuationErrors),
+        // U6 (P6): release readiness signals
+        validationBlockers: [],
+        validationWarnings: [],
+        hasRealDiagnostics: true,
+        recentErrorCount7d: punctuationErrors,
       };
     }
     // Placeholder subjects: static metadata, no runtime queries
@@ -1919,12 +1936,192 @@ async function readSubjectContentOverviewData(db, { now, actorAccountId, actor =
       validationErrors: 0,
       errorCount7d: 0,
       supportLoadSignal: 'none',
+      // U6 (P6): placeholder subjects have no validation or diagnostics
+      validationBlockers: [],
+      validationWarnings: [],
+      hasRealDiagnostics: false,
+      recentErrorCount7d: 0,
     };
   });
 
   return {
     generatedAt: nowTs,
     subjects,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// U7 (P6): Content quality signals — per-subject learning quality data.
+// Uses the same safeSection pattern as admin-debug-bundle: each subject
+// query is independently wrapped so failures degrade gracefully.
+// ---------------------------------------------------------------------------
+
+async function safeSignalSection(label, fn) {
+  try {
+    return await fn();
+  } catch {
+    return null;
+  }
+}
+
+async function readContentQualitySignalsData(db, { actorAccountId, actor = null } = {}) {
+  if (!actor) {
+    await assertAdminHubActor(db, actorAccountId);
+  }
+
+  // Grammar signals: concept coverage from GRAMMAR_AGGREGATE_CONCEPTS (18 concepts)
+  // and per-concept attempt counts from the mastery_evidence table.
+  const grammarSignals = await safeSignalSection('grammar', async () => {
+    // Concept count is static — 18 KS2 grammar concepts defined in roster.
+    const GRAMMAR_CONCEPT_COUNT = 18;
+
+    // Count concepts that have at least one evidence row (any learner).
+    const conceptsWithEvidence = await scalarCountSafe(db, `
+      SELECT COUNT(DISTINCT concept_id) AS value
+      FROM mastery_evidence
+      WHERE subject_id = 'grammar'
+    `, [], 'mastery_evidence');
+
+    // High wrong-rate concepts: concepts where recent wrong answers exceed 40%.
+    let highWrongRateItems = [];
+    try {
+      const wrongRateRows = await all(db, `
+        SELECT concept_id,
+               COUNT(*) AS total_attempts,
+               SUM(CASE WHEN is_correct = 0 THEN 1 ELSE 0 END) AS wrong_count
+        FROM mastery_evidence
+        WHERE subject_id = 'grammar'
+        GROUP BY concept_id
+        HAVING wrong_count * 1.0 / total_attempts > 0.4
+        ORDER BY wrong_count DESC
+        LIMIT 10
+      `, []);
+      highWrongRateItems = wrongRateRows.map((r) => ({
+        id: r.concept_id || '',
+        label: r.concept_id || '',
+        count: Number(r.wrong_count) || 0,
+        detail: `${Number(r.wrong_count) || 0}/${Number(r.total_attempts) || 0} wrong`,
+      }));
+    } catch {
+      // Table may not have is_correct column — degrade gracefully.
+    }
+
+    // Template coverage: distinct templateId values used across all grammar evidence.
+    let templateValue = 0;
+    try {
+      const tplCount = await scalar(db, `
+        SELECT COUNT(DISTINCT template_id) AS value
+        FROM mastery_evidence
+        WHERE subject_id = 'grammar' AND template_id IS NOT NULL AND template_id <> ''
+      `, []);
+      templateValue = Math.max(0, Number(tplCount) || 0);
+    } catch {
+      // template_id column may not exist in all environments.
+    }
+
+    return {
+      subjectKey: 'grammar',
+      subjectName: 'Grammar',
+      signals: {
+        skillCoverage: {
+          status: conceptsWithEvidence > 0 ? 'available' : 'not_available',
+          value: Math.min(conceptsWithEvidence, GRAMMAR_CONCEPT_COUNT),
+          total: GRAMMAR_CONCEPT_COUNT,
+        },
+        templateCoverage: {
+          status: templateValue > 0 ? 'available' : 'not_available',
+          value: templateValue,
+          total: 0, // Total templates not statically known at worker level
+        },
+        itemCoverage: { status: 'not_available', value: 0, total: 0 },
+        commonMisconceptions: { status: 'not_available', items: [] },
+        highWrongRate: {
+          status: highWrongRateItems.length > 0 ? 'available' : 'not_available',
+          items: highWrongRateItems,
+        },
+        recentlyChangedUnevidenced: { status: 'not_available', items: [] },
+      },
+    };
+  });
+
+  // Spelling signals: word-bank coverage from account_subject_content.
+  const spellingSignals = await safeSignalSection('spelling', async () => {
+    let wordCount = 0;
+    let secureCoreCount = 0;
+    try {
+      const contentRow = await first(db,
+        `SELECT content_json FROM account_subject_content WHERE subject_id = 'spelling' LIMIT 1`,
+        [],
+      );
+      if (contentRow?.content_json) {
+        const bundle = JSON.parse(contentRow.content_json);
+        if (bundle && typeof bundle === 'object') {
+          wordCount = Number(bundle?.publication?.runtimeWordCount) || 0;
+          secureCoreCount = Number(bundle?.secureCoreCount) || 0;
+        }
+      }
+    } catch {
+      // Soft-fail: content may not be available.
+    }
+
+    return {
+      subjectKey: 'spelling',
+      subjectName: 'Spelling',
+      signals: {
+        skillCoverage: { status: 'not_available', value: 0, total: 0 },
+        templateCoverage: { status: 'not_available', value: 0, total: 0 },
+        itemCoverage: {
+          status: wordCount > 0 ? 'available' : 'not_available',
+          value: secureCoreCount,
+          total: wordCount,
+        },
+        commonMisconceptions: { status: 'not_available', items: [] },
+        highWrongRate: { status: 'not_available', items: [] },
+        recentlyChangedUnevidenced: { status: 'not_available', items: [] },
+      },
+    };
+  });
+
+  // Punctuation signals: skill count from the static roster (known at runtime).
+  const punctuationSignals = await safeSignalSection('punctuation', async () => {
+    // Punctuation skills are defined in shared/punctuation/content.js.
+    // We do not import them here — the count is derived from what evidence exists.
+    let skillsWithEvidence = 0;
+    try {
+      skillsWithEvidence = await scalarCountSafe(db, `
+        SELECT COUNT(DISTINCT concept_id) AS value
+        FROM mastery_evidence
+        WHERE subject_id = 'punctuation'
+      `, [], 'mastery_evidence');
+    } catch {
+      // Table may not exist — degrade.
+    }
+
+    return {
+      subjectKey: 'punctuation',
+      subjectName: 'Punctuation',
+      signals: {
+        skillCoverage: {
+          status: skillsWithEvidence > 0 ? 'available' : 'not_available',
+          value: skillsWithEvidence,
+          total: 0, // Total skills not imported here — content-free leaf
+        },
+        templateCoverage: { status: 'not_available', value: 0, total: 0 },
+        itemCoverage: { status: 'not_available', value: 0, total: 0 },
+        commonMisconceptions: { status: 'not_available', items: [] },
+        highWrongRate: { status: 'not_available', items: [] },
+        recentlyChangedUnevidenced: { status: 'not_available', items: [] },
+      },
+    };
+  });
+
+  // Assemble — filter out null entries (subjects whose query entirely failed).
+  const subjectSignals = [grammarSignals, spellingSignals, punctuationSignals]
+    .filter(Boolean);
+
+  return {
+    generatedAt: Date.now(),
+    subjectSignals,
   };
 }
 
@@ -8999,6 +9196,14 @@ export function createWorkerRepository({ env = {}, now = Date.now, capacity = nu
       const actor = await assertAdminHubActor(db, accountId);
       return readSubjectContentOverviewData(db, {
         now: nowFactory(),
+        actorAccountId: accountId,
+        actor,
+      });
+    },
+    // U7 (P6): content quality signals. Read-only; R16 compliant.
+    async readContentQualitySignals(accountId) {
+      const actor = await assertAdminHubActor(db, accountId);
+      return readContentQualitySignalsData(db, {
         actorAccountId: accountId,
         actor,
       });


### PR DESCRIPTION
## Summary

Admin Console P6 closes P5's remaining truth gaps and matures the console into a reliable operator surface:

- **Evidence Registry v2** — schema 3 with multi-source aggregation (admin smoke, bootstrap, CSP, D1 migrations, build hash, KPI reconcile). Honest NOT_AVAILABLE/STALE/FAILING states.
- **Safe-Copy v2** — string redaction boundary. Regex-based scanning catches emails, account IDs, auth tokens, stack traces, and internal routes in pre-generated summary strings.
- **Panel State Contract v2** — every server-backed panel now exposes `refreshedAt`. Marketing, Content, and Overview panels wired to AdminPanelFrame freshness.
- **Ops-role browser proof** — 12 Playwright tests exercising redaction and button-visibility contract at browser level.
- **Content Operations v2** — release readiness classification (READY/BLOCKED/WARNINGS_ONLY/NOT_APPLICABLE), validation blockers, truthful drilldowns (non-clickable placeholders).
- **Content Quality Signals** — skill/template/item coverage, common misconceptions, high-wrong-rate detection per subject where data exists.
- **Asset Registry v1** — generalised CAS publish/rollback with publish blockers, preview, reduced-motion/fallback status. Generic asset routes delegate to handler registry.
- **Refactor slice** — extracted `admin-refresh-envelope.js` (unified timestamp formatting and error envelope), 3 consumers updated.
- **CSP/style cleanup** — 32 inline styles extracted to `admin-panels.css` (53 → 21 remaining, all dynamic).

## Test Evidence

- **471 unit/integration tests**, 0 failures
- **12 Playwright browser tests** (ops-role security contract)
- **237 characterisation tests** pinning pre-change behaviour (regression gate)
- All characterisation tests pass unchanged after feature work

## Test plan

- [x] All P6 unit/integration tests pass (`node --test`)
- [x] Playwright ops-role proof passes
- [x] Characterisation baselines unchanged (no regression)
- [x] Content-free leaf audit passes (`npm run audit:client`)
- [x] CI clipboard gate passes
- [ ] Production smoke after deploy