### PR TITLE
feat(hero): Hero Mode P4 — Hero Coins ledger and capped daily economy

### DIFF
--- a/shared/hero/claim-contract.js
+++ b/shared/hero/claim-contract.js
@@ -1,4 +1,4 @@
-export const FORBIDDEN_CLAIM_FIELDS = ['subjectId', 'payload', 'coins', 'reward', 'balance', 'monster', 'shop'];
+export const FORBIDDEN_CLAIM_FIELDS = ['subjectId', 'payload', 'coins', 'reward', 'balance', 'monster', 'shop', 'economy', 'amount'];
 
 export const REQUIRED_CLAIM_FIELDS = ['command', 'learnerId', 'questId', 'questFingerprint', 'taskId', 'requestId', 'expectedLearnerRevision'];
 

--- a/shared/hero/economy.js
+++ b/shared/hero/economy.js
@@ -1,0 +1,68 @@
+// ── Hero Economy — shared pure contract ──────────────────────────
+// Zero side-effects. No imports from worker/, src/, react, or node: built-ins.
+
+// ── Constants ────────────────────────────────────────────────────
+
+export const HERO_ECONOMY_VERSION = 1;
+export const HERO_DAILY_COMPLETION_COINS = 100;
+export const HERO_DAILY_BONUS_COINS_CAP = 0; // P4: no bonus economy yet
+export const HERO_LEDGER_RECENT_LIMIT = 180;
+
+export const HERO_ECONOMY_ENTRY_TYPES = Object.freeze([
+  'daily-completion-award',
+  'admin-adjustment', // reserved, not enabled in P4 child flow
+]);
+
+// ── Deterministic hashing ────────────────────────────────────────
+
+function djb2Hash(str) {
+  let hash = 5381;
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) + hash + str.charCodeAt(i)) | 0;
+  }
+  return (hash >>> 0).toString(36);
+}
+
+// ── Key derivation ───────────────────────────────────────────────
+
+export function deriveDailyAwardKey({ learnerId, dateKey, questId, questFingerprint, economyVersion }) {
+  const v = economyVersion ?? HERO_ECONOMY_VERSION;
+  return `hero-daily-coins:v${v}:${learnerId}:${dateKey}:${questId}:${questFingerprint}`;
+}
+
+export function deriveLedgerEntryId(awardKey) {
+  return `hero-ledger-${djb2Hash(awardKey)}`;
+}
+
+// ── State helpers ────────────────────────────────────────────────
+
+export function emptyEconomyState() {
+  return {
+    version: HERO_ECONOMY_VERSION,
+    balance: 0,
+    lifetimeEarned: 0,
+    lifetimeSpent: 0,
+    ledger: [],
+    lastUpdatedAt: null,
+  };
+}
+
+export function normaliseHeroEconomyState(raw) {
+  if (!raw || typeof raw !== 'object') return emptyEconomyState();
+  if (raw.version !== HERO_ECONOMY_VERSION) return emptyEconomyState();
+
+  const balance = typeof raw.balance === 'number' && Number.isFinite(raw.balance) ? raw.balance : 0;
+  const lifetimeEarned = typeof raw.lifetimeEarned === 'number' && Number.isFinite(raw.lifetimeEarned) ? raw.lifetimeEarned : 0;
+  const lifetimeSpent = typeof raw.lifetimeSpent === 'number' && Number.isFinite(raw.lifetimeSpent) ? raw.lifetimeSpent : 0;
+  const ledger = Array.isArray(raw.ledger) ? raw.ledger : [];
+  const lastUpdatedAt = raw.lastUpdatedAt || null;
+
+  return {
+    version: HERO_ECONOMY_VERSION,
+    balance,
+    lifetimeEarned,
+    lifetimeSpent,
+    ledger,
+    lastUpdatedAt,
+  };
+}

--- a/shared/hero/economy.js
+++ b/shared/hero/economy.js
@@ -47,6 +47,99 @@ export function emptyEconomyState() {
   };
 }
 
+// ── Award logic ─────────────────────────────────────────────────
+
+export function canAwardDailyCompletionCoins(heroState, economyEnabled) {
+  if (economyEnabled !== true) {
+    return { canAward: false, reason: 'economy_disabled' };
+  }
+  if (heroState.daily === null || heroState.daily === undefined) {
+    return { canAward: false, reason: 'daily_null' };
+  }
+  if (heroState.daily.status !== 'completed') {
+    return { canAward: false, reason: 'daily_not_completed' };
+  }
+  if (heroState.daily.economy && heroState.daily.economy.dailyAwardLedgerEntryId) {
+    return { canAward: false, reason: 'already_awarded' };
+  }
+  // Check ledger for duplicate idempotency key
+  const { dateKey, questId, questFingerprint } = heroState.daily;
+  const learnerId = heroState.economy && heroState.economy.ledger && heroState.economy.ledger.length > 0
+    ? heroState.economy.ledger[0].learnerId
+    : null;
+  if (learnerId) {
+    const awardKey = deriveDailyAwardKey({ learnerId, dateKey, questId, questFingerprint, economyVersion: HERO_ECONOMY_VERSION });
+    const existing = heroState.economy.ledger.find(e => e.idempotencyKey === awardKey);
+    if (existing) {
+      return { canAward: false, reason: 'ledger_duplicate' };
+    }
+  }
+  return { canAward: true, reason: 'eligible' };
+}
+
+export function applyDailyCompletionCoinAward(heroState, { learnerId, nowTs, dailyCompletionCoins }) {
+  const { dateKey, questId, questFingerprint } = heroState.daily;
+  const awardKey = deriveDailyAwardKey({ learnerId, dateKey, questId, questFingerprint, economyVersion: HERO_ECONOMY_VERSION });
+  const entryId = deriveLedgerEntryId(awardKey);
+
+  // Idempotency check — if ledger already contains this key, return early
+  const existingEntry = heroState.economy.ledger.find(e => e.idempotencyKey === awardKey);
+  if (existingEntry) {
+    return { state: heroState, awarded: false, alreadyAwarded: true, amount: 0, ledgerEntryId: existingEntry.entryId };
+  }
+
+  const balanceAfter = heroState.economy.balance + dailyCompletionCoins;
+
+  const ledgerEntry = {
+    entryId,
+    idempotencyKey: awardKey,
+    type: 'daily-completion-award',
+    amount: dailyCompletionCoins,
+    balanceAfter,
+    learnerId,
+    dateKey,
+    questId,
+    questFingerprint,
+    source: {
+      kind: 'hero-daily-completion',
+      dailyCompletedAt: heroState.daily.completedAt,
+      completedTaskIds: heroState.daily.completedTaskIds || [],
+      effortCompleted: heroState.daily.effortCompleted || 0,
+      effortPlanned: heroState.daily.effortPlanned || 0,
+    },
+    createdAt: nowTs,
+    createdBy: 'system',
+  };
+
+  const updatedLedger = [...heroState.economy.ledger, ledgerEntry].slice(-HERO_LEDGER_RECENT_LIMIT);
+
+  const updatedState = {
+    ...heroState,
+    economy: {
+      ...heroState.economy,
+      balance: balanceAfter,
+      lifetimeEarned: heroState.economy.lifetimeEarned + dailyCompletionCoins,
+      ledger: updatedLedger,
+      lastUpdatedAt: nowTs,
+    },
+    daily: {
+      ...heroState.daily,
+      economy: {
+        dailyAwardStatus: 'awarded',
+        dailyAwardCoinsAvailable: dailyCompletionCoins,
+        dailyAwardCoinsAwarded: dailyCompletionCoins,
+        dailyAwardLedgerEntryId: entryId,
+        dailyAwardedAt: nowTs,
+        dailyAwardReason: 'daily-completion',
+      },
+    },
+  };
+
+  return { state: updatedState, awarded: true, alreadyAwarded: false, amount: dailyCompletionCoins, ledgerEntryId: entryId, balanceAfter };
+}
+
+// ── State helpers ────────────────────────────────────────────────
+
 export function normaliseHeroEconomyState(raw) {
   if (!raw || typeof raw !== 'object') return emptyEconomyState();
   if (raw.version !== HERO_ECONOMY_VERSION) return emptyEconomyState();

--- a/shared/hero/economy.js
+++ b/shared/hero/economy.js
@@ -64,11 +64,8 @@ export function canAwardDailyCompletionCoins(heroState, economyEnabled) {
   }
   // Check ledger for duplicate idempotency key
   const { dateKey, questId, questFingerprint } = heroState.daily;
-  const learnerId = heroState.economy && heroState.economy.ledger && heroState.economy.ledger.length > 0
-    ? heroState.economy.ledger[0].learnerId
-    : null;
-  if (learnerId) {
-    const awardKey = deriveDailyAwardKey({ learnerId, dateKey, questId, questFingerprint, economyVersion: HERO_ECONOMY_VERSION });
+  if (heroState.economy && Array.isArray(heroState.economy.ledger) && heroState.economy.ledger.length > 0) {
+    const awardKey = deriveDailyAwardKey({ learnerId: heroState.economy.ledger[0].learnerId || '', dateKey, questId, questFingerprint, economyVersion: HERO_ECONOMY_VERSION });
     const existing = heroState.economy.ledger.find(e => e.idempotencyKey === awardKey);
     if (existing) {
       return { canAward: false, reason: 'ledger_duplicate' };
@@ -152,7 +149,7 @@ export function selectChildSafeEconomyReadModel(heroState, dateKey, questId) {
   if (todayMatch) {
     if (daily.economy?.dailyAwardStatus === 'awarded') awardStatus = 'awarded';
     else if (daily.status === 'completed') awardStatus = 'available';
-    else awardStatus = 'available';
+    else awardStatus = 'in-progress';
   }
 
   const safeNum = (v) => (typeof v === 'number' && Number.isFinite(v)) ? v : 0;

--- a/shared/hero/economy.js
+++ b/shared/hero/economy.js
@@ -140,6 +140,55 @@ export function applyDailyCompletionCoinAward(heroState, { learnerId, nowTs, dai
 
 // ── State helpers ────────────────────────────────────────────────
 
+// ── Child-safe read model projection ───────────────────────────
+
+export function selectChildSafeEconomyReadModel(heroState, dateKey, questId) {
+  const economy = heroState?.economy;
+  if (!economy) return null;
+  const daily = heroState?.daily;
+  const todayMatch = daily?.dateKey === dateKey;
+
+  let awardStatus = 'not-eligible';
+  if (todayMatch) {
+    if (daily.economy?.dailyAwardStatus === 'awarded') awardStatus = 'awarded';
+    else if (daily.status === 'completed') awardStatus = 'available';
+    else awardStatus = 'available';
+  }
+
+  const safeNum = (v) => (typeof v === 'number' && Number.isFinite(v)) ? v : 0;
+
+  return {
+    enabled: true,
+    version: HERO_ECONOMY_VERSION,
+    balance: safeNum(economy.balance),
+    lifetimeEarned: safeNum(economy.lifetimeEarned),
+    lifetimeSpent: safeNum(economy.lifetimeSpent),
+    today: {
+      dateKey,
+      questId,
+      awardStatus,
+      coinsAvailable: HERO_DAILY_COMPLETION_COINS,
+      coinsAwarded: todayMatch ? safeNum(daily.economy?.dailyAwardCoinsAwarded) : 0,
+      ledgerEntryId: todayMatch ? (daily.economy?.dailyAwardLedgerEntryId || null) : null,
+      awardedAt: todayMatch ? (daily.economy?.dailyAwardedAt || null) : null,
+    },
+    recentLedger: buildChildSafeLedgerEntries(economy.ledger),
+  };
+}
+
+function buildChildSafeLedgerEntries(ledger) {
+  if (!Array.isArray(ledger)) return [];
+  return ledger.slice(-10).map(entry => ({
+    entryId: entry.entryId,
+    type: entry.type,
+    amount: entry.amount,
+    dateKey: entry.dateKey,
+    createdAt: entry.createdAt,
+  }));
+}
+
+// ── State helpers ────────────────────────────────────────────────
+
 export function normaliseHeroEconomyState(raw) {
   if (!raw || typeof raw !== 'object') return emptyEconomyState();
   if (raw.version !== HERO_ECONOMY_VERSION) return emptyEconomyState();

--- a/shared/hero/hero-copy.js
+++ b/shared/hero/hero-copy.js
@@ -51,6 +51,18 @@ export const HERO_PROGRESS_COPY = Object.freeze({
 });
 
 /**
+ * P4 economy copy — shown in HeroQuestCard when daily Coins are awarded.
+ * Calm, non-pressurising. No shop/deal/streak/loot language.
+ */
+export const HERO_ECONOMY_COPY = Object.freeze({
+  coinsAdded: 'Hero Coins added.',
+  coinsAddedDetail: 'You completed today\'s Hero Quest.',
+  balanceLabel: 'Hero Coins',
+  savedForCamp: 'Hero Coins saved for Hero Camp.',
+  dailyAvailable: 'Complete today\'s Hero Quest to add 100 Hero Coins.',
+});
+
+/**
  * Child-facing labels by intent.  Explains *why* this task was chosen
  * in age-appropriate language.
  */

--- a/shared/hero/hero-copy.js
+++ b/shared/hero/hero-copy.js
@@ -3,36 +3,57 @@
 // All child-visible text for Hero Quest surfaces lives here.
 // Pure module — ZERO Worker, React, D1, or framework imports.
 //
-// The HERO_FORBIDDEN_VOCABULARY list is the canonical source of truth for
-// economy/pressure vocabulary scanning in boundary tests.
+// The HERO_FORBIDDEN_PRESSURE_VOCABULARY list is the canonical source of truth
+// for pressure/gambling vocabulary scanning in boundary tests.
 
 /**
- * Forbidden economy/pressure vocabulary.  No Hero-facing surface may
- * contain any of these tokens (case-insensitive).
+ * P4: Pressure/gambling vocabulary — ALWAYS forbidden in ALL Hero surfaces.
+ * These terms create urgency, gambling mechanics, or shop pressure.
  */
-export const HERO_FORBIDDEN_VOCABULARY = Object.freeze([
-  'coin',
+export const HERO_FORBIDDEN_PRESSURE_VOCABULARY = Object.freeze([
   'shop',
   'deal',
   'loot',
-  'streak',
-  'claim',
-  'reward',
-  'treasure',
-  'buy',
+  'jackpot',
   'limited time',
   'daily deal',
   "don't miss out",
-  'earn',
-  'claim your reward',
-  'earn coins',
+  'streak reward',
   'grind',
+  'buy now',
+  'spend now',
   'you missed out',
   'unlock now',
-  'spend now',
-  'jackpot',
-  'streak reward',
+  'treasure',
+  'claim your reward',
+  'earn coins',
 ]);
+
+/**
+ * P4: Economy vocabulary allowed ONLY in economy-scoped files.
+ * These terms must NOT appear in subject surfaces, HeroTaskBanner,
+ * scheduler explanations, or non-economy Hero copy.
+ */
+export const HERO_ECONOMY_ALLOWED_VOCABULARY = Object.freeze([
+  'coin',
+  'balance',
+  'Hero Coins',
+]);
+
+/**
+ * Files where economy vocabulary is permitted.
+ */
+export const HERO_ECONOMY_ALLOWED_FILES = Object.freeze([
+  'shared/hero/economy.js',
+  'shared/hero/hero-copy.js',
+  'shared/hero/claim-contract.js',
+  'src/platform/hero/hero-ui-model.js',
+  'src/surfaces/home/HeroQuestCard.jsx',
+  'worker/src/hero/read-model.js',
+]);
+
+// Backward compat — tests importing this get the pressure-only list
+export const HERO_FORBIDDEN_VOCABULARY = HERO_FORBIDDEN_PRESSURE_VOCABULARY;
 
 /**
  * P3 progress copy — shown in HeroQuestCard and HeroTaskBanner for

--- a/shared/hero/progress-state.js
+++ b/shared/hero/progress-state.js
@@ -1,4 +1,6 @@
-export const HERO_PROGRESS_VERSION = 1;
+import { emptyEconomyState, normaliseHeroEconomyState } from './economy.js';
+
+export const HERO_PROGRESS_VERSION = 2;
 export const MAX_RECENT_CLAIMS_AGE_DAYS = 7;
 
 function emptyDailyState() {
@@ -10,17 +12,34 @@ export function emptyProgressState() {
     version: HERO_PROGRESS_VERSION,
     daily: null,
     recentClaims: [],
+    economy: emptyEconomyState(),
   };
 }
 
 export function normaliseHeroProgressState(raw) {
   if (!raw || typeof raw !== 'object') return emptyProgressState();
-  if (raw.version !== HERO_PROGRESS_VERSION) return emptyProgressState();
-  return {
-    version: HERO_PROGRESS_VERSION,
-    daily: normaliseDailyState(raw.daily),
-    recentClaims: Array.isArray(raw.recentClaims) ? raw.recentClaims : [],
-  };
+
+  if (raw.version === 1) {
+    // v1 → v2 upgrade: preserve daily + recentClaims, add empty economy
+    return {
+      version: HERO_PROGRESS_VERSION,
+      daily: normaliseDailyState(raw.daily),
+      recentClaims: Array.isArray(raw.recentClaims) ? raw.recentClaims : [],
+      economy: emptyEconomyState(),
+    };
+  }
+
+  if (raw.version === HERO_PROGRESS_VERSION) {
+    return {
+      version: HERO_PROGRESS_VERSION,
+      daily: normaliseDailyState(raw.daily),
+      recentClaims: Array.isArray(raw.recentClaims) ? raw.recentClaims : [],
+      economy: normaliseHeroEconomyState(raw.economy),
+    };
+  }
+
+  // Unknown or missing version — return empty v2 state
+  return emptyProgressState();
 }
 
 function normaliseDailyState(daily) {

--- a/shared/hero/progress-state.js
+++ b/shared/hero/progress-state.js
@@ -63,6 +63,8 @@ function normaliseDailyState(daily) {
     firstStartedAt: daily.firstStartedAt || null,
     completedAt: daily.completedAt || null,
     lastUpdatedAt: daily.lastUpdatedAt || Date.now(),
+    // P4: Economy sub-block preserved from applyDailyCompletionCoinAward
+    economy: daily.economy && typeof daily.economy === 'object' ? daily.economy : null,
   };
 }
 

--- a/src/platform/hero/hero-ui-model.js
+++ b/src/platform/hero/hero-ui-model.js
@@ -49,6 +49,15 @@ export function buildHeroHomeModel(heroUi) {
   const effortCompleted = progress?.effortCompleted || 0;
   const completedTaskIds = progress?.completedTaskIds || [];
 
+  // P4 U6: Economy fields from read model v5
+  const coinsEnabled = readModel?.coinsEnabled === true;
+  const economyBlock = readModel?.economy || null;
+  const coinBalance = coinsEnabled ? (economyBlock?.balance || 0) : 0;
+  const coinsAwardedToday = coinsEnabled ? (economyBlock?.today?.coinsAwarded || 0) : 0;
+  const dailyAwardStatus = economyBlock?.today?.awardStatus || 'not-eligible';
+  const showCoinsAwarded = coinsEnabled && dailyAwardStatus === 'awarded' && coinsAwardedToday > 0;
+  const showCoinBalance = coinsEnabled;
+
   return {
     status,
     enabled,
@@ -70,5 +79,12 @@ export function buildHeroHomeModel(heroUi) {
     dailyStatus,
     effortCompleted,
     completedTaskIds,
+    // P4 U6: economy
+    coinsEnabled,
+    coinBalance,
+    coinsAwardedToday,
+    dailyAwardStatus,
+    showCoinsAwarded,
+    showCoinBalance,
   };
 }

--- a/src/surfaces/home/HeroQuestCard.jsx
+++ b/src/surfaces/home/HeroQuestCard.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   HERO_CTA_TEXT,
   HERO_PROGRESS_COPY,
+  HERO_ECONOMY_COPY,
   HERO_SUBJECT_LABELS,
   HERO_UI_REASON_LABELS,
 } from '../../../shared/hero/hero-copy.js';
@@ -26,7 +27,7 @@ export function HeroQuestCard({ hero, actions }) {
   const isLaunching = hero.status === 'launching';
   const hasError = Boolean(hero.error);
 
-  // (p3-a) Daily complete — highest priority P3 display (no CTA, no pressure)
+  // (p3-a) Daily complete — with optional economy acknowledgement
   if (hero.dailyStatus === 'completed') {
     return (
       <div className="hero-quest-card hero-quest-card--complete" data-hero-card>
@@ -34,9 +35,21 @@ export function HeroQuestCard({ hero, actions }) {
         <p className="hero-quest-card__daily-complete" aria-live="polite">
           {HERO_PROGRESS_COPY.dailyComplete}
         </p>
-        <p className="hero-quest-card__daily-complete-detail">
-          {HERO_PROGRESS_COPY.dailyCompleteDetail}
-        </p>
+        {hero.showCoinsAwarded && (
+          <div className="hero-quest-card__economy" aria-live="polite">
+            <p className="hero-quest-card__coins-added">
+              {hero.coinsAwardedToday} {HERO_ECONOMY_COPY.coinsAdded}
+            </p>
+            <p className="hero-quest-card__coin-balance">
+              Balance: {hero.coinBalance} {HERO_ECONOMY_COPY.balanceLabel}.
+            </p>
+          </div>
+        )}
+        {!hero.showCoinsAwarded && (
+          <p className="hero-quest-card__daily-complete-detail">
+            {HERO_PROGRESS_COPY.dailyCompleteDetail}
+          </p>
+        )}
       </div>
     );
   }

--- a/tests/hero-copy-contract.test.js
+++ b/tests/hero-copy-contract.test.js
@@ -3,6 +3,9 @@ import assert from 'node:assert/strict';
 
 import {
   HERO_FORBIDDEN_VOCABULARY,
+  HERO_FORBIDDEN_PRESSURE_VOCABULARY,
+  HERO_ECONOMY_ALLOWED_VOCABULARY,
+  HERO_ECONOMY_ALLOWED_FILES,
   HERO_INTENT_LABELS,
   HERO_SUBJECT_LABELS,
   HERO_INTENT_REASONS,
@@ -31,8 +34,8 @@ test('HERO_FORBIDDEN_VOCABULARY is frozen', () => {
   assert.ok(Object.isFrozen(HERO_FORBIDDEN_VOCABULARY));
 });
 
-test('HERO_FORBIDDEN_VOCABULARY contains expected tokens', () => {
-  const expected = ['coin', 'shop', 'deal', 'loot', 'streak', 'claim', 'reward', 'treasure', 'buy', 'earn'];
+test('HERO_FORBIDDEN_VOCABULARY contains expected pressure tokens', () => {
+  const expected = ['shop', 'deal', 'loot', 'treasure', 'jackpot', 'grind'];
   for (const token of expected) {
     assert.ok(
       HERO_FORBIDDEN_VOCABULARY.includes(token),
@@ -41,10 +44,31 @@ test('HERO_FORBIDDEN_VOCABULARY contains expected tokens', () => {
   }
 });
 
-test('HERO_FORBIDDEN_VOCABULARY contains multi-word tokens', () => {
+test('HERO_FORBIDDEN_VOCABULARY aliases HERO_FORBIDDEN_PRESSURE_VOCABULARY', () => {
+  assert.equal(HERO_FORBIDDEN_VOCABULARY, HERO_FORBIDDEN_PRESSURE_VOCABULARY);
+});
+
+test('HERO_ECONOMY_ALLOWED_VOCABULARY contains economy tokens', () => {
+  const expected = ['coin', 'balance', 'Hero Coins'];
+  for (const token of expected) {
+    assert.ok(
+      HERO_ECONOMY_ALLOWED_VOCABULARY.includes(token),
+      `HERO_ECONOMY_ALLOWED_VOCABULARY must include "${token}"`,
+    );
+  }
+});
+
+test('HERO_ECONOMY_ALLOWED_FILES is frozen and non-empty', () => {
+  assert.ok(Object.isFrozen(HERO_ECONOMY_ALLOWED_FILES));
+  assert.ok(HERO_ECONOMY_ALLOWED_FILES.length > 0);
+});
+
+test('HERO_FORBIDDEN_VOCABULARY contains multi-word pressure tokens', () => {
   assert.ok(HERO_FORBIDDEN_VOCABULARY.includes('limited time'));
   assert.ok(HERO_FORBIDDEN_VOCABULARY.includes('daily deal'));
   assert.ok(HERO_FORBIDDEN_VOCABULARY.includes("don't miss out"));
+  assert.ok(HERO_FORBIDDEN_VOCABULARY.includes('claim your reward'));
+  assert.ok(HERO_FORBIDDEN_VOCABULARY.includes('earn coins'));
 });
 
 // ── Zero economy vocabulary in all exported copy ───────────────────────

--- a/tests/hero-economy-award.test.js
+++ b/tests/hero-economy-award.test.js
@@ -1,0 +1,348 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  HERO_ECONOMY_VERSION,
+  HERO_DAILY_COMPLETION_COINS,
+  HERO_LEDGER_RECENT_LIMIT,
+  deriveDailyAwardKey,
+  deriveLedgerEntryId,
+  emptyEconomyState,
+  canAwardDailyCompletionCoins,
+  applyDailyCompletionCoinAward,
+} from '../shared/hero/economy.js';
+
+// ── Test fixtures ───────────────────────────────────────────────
+
+function makeCompletedDaily(overrides = {}) {
+  return {
+    dateKey: '2026-04-29',
+    questId: 'quest-abc',
+    questFingerprint: 'fp-xyz',
+    timezone: 'Europe/London',
+    status: 'completed',
+    effortTarget: 18,
+    effortPlanned: 18,
+    effortCompleted: 18,
+    taskOrder: ['t1', 't2', 't3'],
+    completedTaskIds: ['t1', 't2', 't3'],
+    tasks: {
+      t1: { taskId: 't1', status: 'completed', effortTarget: 6 },
+      t2: { taskId: 't2', status: 'completed', effortTarget: 6 },
+      t3: { taskId: 't3', status: 'completed', effortTarget: 6 },
+    },
+    generatedAt: 1000,
+    firstStartedAt: 1001,
+    completedAt: 5000,
+    lastUpdatedAt: 5000,
+    ...overrides,
+  };
+}
+
+function makeHeroState(overrides = {}) {
+  return {
+    version: 2,
+    daily: makeCompletedDaily(),
+    recentClaims: [],
+    economy: emptyEconomyState(),
+    ...overrides,
+  };
+}
+
+// ── canAwardDailyCompletionCoins ────────────────────────────────
+
+test('canAward: economy disabled returns economy_disabled', () => {
+  const state = makeHeroState();
+  const result = canAwardDailyCompletionCoins(state, false);
+  assert.equal(result.canAward, false);
+  assert.equal(result.reason, 'economy_disabled');
+});
+
+test('canAward: economy disabled (undefined) returns economy_disabled', () => {
+  const state = makeHeroState();
+  const result = canAwardDailyCompletionCoins(state, undefined);
+  assert.equal(result.canAward, false);
+  assert.equal(result.reason, 'economy_disabled');
+});
+
+test('canAward: daily is null returns daily_null', () => {
+  const state = makeHeroState({ daily: null });
+  const result = canAwardDailyCompletionCoins(state, true);
+  assert.equal(result.canAward, false);
+  assert.equal(result.reason, 'daily_null');
+});
+
+test('canAward: daily not completed (status=active) returns daily_not_completed', () => {
+  const state = makeHeroState({ daily: makeCompletedDaily({ status: 'active' }) });
+  const result = canAwardDailyCompletionCoins(state, true);
+  assert.equal(result.canAward, false);
+  assert.equal(result.reason, 'daily_not_completed');
+});
+
+test('canAward: already awarded (dailyAwardLedgerEntryId set) returns already_awarded', () => {
+  const daily = makeCompletedDaily();
+  daily.economy = { dailyAwardLedgerEntryId: 'hero-ledger-abc123' };
+  const state = makeHeroState({ daily });
+  const result = canAwardDailyCompletionCoins(state, true);
+  assert.equal(result.canAward, false);
+  assert.equal(result.reason, 'already_awarded');
+});
+
+test('canAward: ledger contains matching idempotency key returns ledger_duplicate', () => {
+  const learnerId = 'learner-1';
+  const daily = makeCompletedDaily();
+  const awardKey = deriveDailyAwardKey({
+    learnerId,
+    dateKey: daily.dateKey,
+    questId: daily.questId,
+    questFingerprint: daily.questFingerprint,
+    economyVersion: HERO_ECONOMY_VERSION,
+  });
+  const state = makeHeroState({
+    daily,
+    economy: {
+      ...emptyEconomyState(),
+      ledger: [{ entryId: 'hero-ledger-existing', idempotencyKey: awardKey, learnerId }],
+    },
+  });
+  const result = canAwardDailyCompletionCoins(state, true);
+  assert.equal(result.canAward, false);
+  assert.equal(result.reason, 'ledger_duplicate');
+});
+
+test('canAward: eligible daily completed + no prior award returns eligible', () => {
+  const state = makeHeroState();
+  const result = canAwardDailyCompletionCoins(state, true);
+  assert.equal(result.canAward, true);
+  assert.equal(result.reason, 'eligible');
+});
+
+// ── applyDailyCompletionCoinAward — happy path ──────────────────
+
+test('happy path: award applied, balance incremented, ledger entry appended', () => {
+  const state = makeHeroState();
+  const nowTs = 6000;
+  const result = applyDailyCompletionCoinAward(state, {
+    learnerId: 'learner-1',
+    nowTs,
+    dailyCompletionCoins: HERO_DAILY_COMPLETION_COINS,
+  });
+
+  assert.equal(result.awarded, true);
+  assert.equal(result.alreadyAwarded, false);
+  assert.equal(result.amount, 100);
+  assert.equal(result.state.economy.balance, 100);
+  assert.equal(result.state.economy.lifetimeEarned, 100);
+  assert.equal(result.state.economy.ledger.length, 1);
+  assert.equal(result.state.economy.lastUpdatedAt, nowTs);
+});
+
+test('happy path: correct return shape', () => {
+  const state = makeHeroState();
+  const result = applyDailyCompletionCoinAward(state, {
+    learnerId: 'learner-1',
+    nowTs: 6000,
+    dailyCompletionCoins: 100,
+  });
+
+  assert.equal(typeof result.state, 'object');
+  assert.equal(result.awarded, true);
+  assert.equal(result.amount, 100);
+  assert.ok(result.ledgerEntryId.startsWith('hero-ledger-'));
+  assert.equal(result.balanceAfter, 100);
+  assert.equal(result.alreadyAwarded, false);
+});
+
+test('happy path: daily.economy marker set correctly', () => {
+  const state = makeHeroState();
+  const nowTs = 7000;
+  const result = applyDailyCompletionCoinAward(state, {
+    learnerId: 'learner-1',
+    nowTs,
+    dailyCompletionCoins: 100,
+  });
+
+  const dailyEcon = result.state.daily.economy;
+  assert.equal(dailyEcon.dailyAwardStatus, 'awarded');
+  assert.equal(dailyEcon.dailyAwardCoinsAvailable, 100);
+  assert.equal(dailyEcon.dailyAwardCoinsAwarded, 100);
+  assert.ok(dailyEcon.dailyAwardLedgerEntryId.startsWith('hero-ledger-'));
+  assert.equal(dailyEcon.dailyAwardedAt, nowTs);
+  assert.equal(dailyEcon.dailyAwardReason, 'daily-completion');
+});
+
+test('happy path: ledger entry has correct source shape', () => {
+  const state = makeHeroState();
+  const result = applyDailyCompletionCoinAward(state, {
+    learnerId: 'learner-1',
+    nowTs: 8000,
+    dailyCompletionCoins: 100,
+  });
+
+  const entry = result.state.economy.ledger[0];
+  assert.equal(entry.type, 'daily-completion-award');
+  assert.equal(entry.amount, 100);
+  assert.equal(entry.balanceAfter, 100);
+  assert.equal(entry.learnerId, 'learner-1');
+  assert.equal(entry.dateKey, '2026-04-29');
+  assert.equal(entry.questId, 'quest-abc');
+  assert.equal(entry.questFingerprint, 'fp-xyz');
+  assert.equal(entry.source.kind, 'hero-daily-completion');
+  assert.equal(entry.source.dailyCompletedAt, 5000);
+  assert.deepEqual(entry.source.completedTaskIds, ['t1', 't2', 't3']);
+  assert.equal(entry.source.effortCompleted, 18);
+  assert.equal(entry.source.effortPlanned, 18);
+  assert.equal(entry.createdAt, 8000);
+  assert.equal(entry.createdBy, 'system');
+});
+
+// ── applyDailyCompletionCoinAward — idempotency ─────────────────
+
+test('idempotency: ledger contains matching key but daily marker missing returns alreadyAwarded', () => {
+  const learnerId = 'learner-1';
+  const daily = makeCompletedDaily();
+  const awardKey = deriveDailyAwardKey({
+    learnerId,
+    dateKey: daily.dateKey,
+    questId: daily.questId,
+    questFingerprint: daily.questFingerprint,
+    economyVersion: HERO_ECONOMY_VERSION,
+  });
+  const existingEntryId = deriveLedgerEntryId(awardKey);
+  const state = makeHeroState({
+    daily, // no economy marker on daily
+    economy: {
+      ...emptyEconomyState(),
+      balance: 100,
+      lifetimeEarned: 100,
+      ledger: [{ entryId: existingEntryId, idempotencyKey: awardKey, learnerId, amount: 100 }],
+    },
+  });
+
+  const result = applyDailyCompletionCoinAward(state, {
+    learnerId,
+    nowTs: 9000,
+    dailyCompletionCoins: 100,
+  });
+
+  assert.equal(result.awarded, false);
+  assert.equal(result.alreadyAwarded, true);
+  assert.equal(result.amount, 0);
+  assert.equal(result.ledgerEntryId, existingEntryId);
+  // Balance unchanged
+  assert.equal(result.state.economy.balance, 100);
+  assert.equal(result.state, state); // same reference, no mutation
+});
+
+test('idempotency: calling applyDailyCompletionCoinAward twice with same state produces same result', () => {
+  const state = makeHeroState();
+  const params = { learnerId: 'learner-1', nowTs: 10000, dailyCompletionCoins: 100 };
+  const result1 = applyDailyCompletionCoinAward(state, params);
+  const result2 = applyDailyCompletionCoinAward(state, params);
+
+  assert.equal(result1.awarded, true);
+  assert.equal(result2.awarded, true);
+  assert.equal(result1.ledgerEntryId, result2.ledgerEntryId);
+  assert.equal(result1.amount, result2.amount);
+  assert.equal(result1.balanceAfter, result2.balanceAfter);
+  // Both produce structurally equal state
+  assert.deepEqual(result1.state.economy, result2.state.economy);
+});
+
+// ── Deterministic entry IDs ─────────────────────────────────────
+
+test('derived entry IDs are deterministic across multiple calls with same inputs', () => {
+  const params = {
+    learnerId: 'learner-1',
+    dateKey: '2026-04-29',
+    questId: 'quest-abc',
+    questFingerprint: 'fp-xyz',
+    economyVersion: HERO_ECONOMY_VERSION,
+  };
+  const key1 = deriveDailyAwardKey(params);
+  const key2 = deriveDailyAwardKey(params);
+  assert.equal(key1, key2);
+  assert.equal(deriveLedgerEntryId(key1), deriveLedgerEntryId(key2));
+
+  // Via applyDailyCompletionCoinAward
+  const state = makeHeroState();
+  const r1 = applyDailyCompletionCoinAward(state, { learnerId: 'learner-1', nowTs: 11000, dailyCompletionCoins: 100 });
+  const r2 = applyDailyCompletionCoinAward(state, { learnerId: 'learner-1', nowTs: 11000, dailyCompletionCoins: 100 });
+  assert.equal(r1.ledgerEntryId, r2.ledgerEntryId);
+});
+
+// ── Balance from previous non-zero balance ──────────────────────
+
+test('balance increments correctly from previous non-zero balance (200 -> 300)', () => {
+  const state = makeHeroState({
+    economy: {
+      ...emptyEconomyState(),
+      balance: 200,
+      lifetimeEarned: 200,
+    },
+  });
+  const result = applyDailyCompletionCoinAward(state, {
+    learnerId: 'learner-1',
+    nowTs: 12000,
+    dailyCompletionCoins: 100,
+  });
+
+  assert.equal(result.state.economy.balance, 300);
+  assert.equal(result.state.economy.lifetimeEarned, 300);
+  assert.equal(result.balanceAfter, 300);
+  assert.equal(result.state.economy.ledger[0].balanceAfter, 300);
+});
+
+// ── Ledger trimming ─────────────────────────────────────────────
+
+test('ledger at HERO_LEDGER_RECENT_LIMIT (180) trims oldest entry after new append', () => {
+  // Fill ledger to exactly 180 entries
+  const fullLedger = Array.from({ length: HERO_LEDGER_RECENT_LIMIT }, (_, i) => ({
+    entryId: `entry-${i}`,
+    idempotencyKey: `key-${i}`,
+    learnerId: 'learner-1',
+    amount: 100,
+  }));
+  const state = makeHeroState({
+    economy: {
+      ...emptyEconomyState(),
+      balance: 18000,
+      lifetimeEarned: 18000,
+      ledger: fullLedger,
+    },
+  });
+
+  const result = applyDailyCompletionCoinAward(state, {
+    learnerId: 'learner-1',
+    nowTs: 13000,
+    dailyCompletionCoins: 100,
+  });
+
+  // Ledger still at 180 (trimmed)
+  assert.equal(result.state.economy.ledger.length, HERO_LEDGER_RECENT_LIMIT);
+  // Oldest entry (entry-0) is gone
+  assert.equal(result.state.economy.ledger.find(e => e.entryId === 'entry-0'), undefined);
+  // Newest entry is present
+  const newestEntry = result.state.economy.ledger[result.state.economy.ledger.length - 1];
+  assert.equal(newestEntry.type, 'daily-completion-award');
+  assert.equal(newestEntry.entryId, result.ledgerEntryId);
+});
+
+// ── Immutability ────────────────────────────────────────────────
+
+test('applyDailyCompletionCoinAward does not mutate original state', () => {
+  const state = makeHeroState();
+  const originalBalance = state.economy.balance;
+  const originalLedgerLength = state.economy.ledger.length;
+
+  applyDailyCompletionCoinAward(state, {
+    learnerId: 'learner-1',
+    nowTs: 14000,
+    dailyCompletionCoins: 100,
+  });
+
+  // Original state unchanged
+  assert.equal(state.economy.balance, originalBalance);
+  assert.equal(state.economy.ledger.length, originalLedgerLength);
+  assert.equal(state.daily.economy, undefined);
+});

--- a/tests/hero-economy-contract.test.js
+++ b/tests/hero-economy-contract.test.js
@@ -1,0 +1,171 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import {
+  HERO_ECONOMY_VERSION,
+  HERO_DAILY_COMPLETION_COINS,
+  HERO_DAILY_BONUS_COINS_CAP,
+  HERO_LEDGER_RECENT_LIMIT,
+  HERO_ECONOMY_ENTRY_TYPES,
+  deriveDailyAwardKey,
+  deriveLedgerEntryId,
+  emptyEconomyState,
+  normaliseHeroEconomyState,
+} from '../shared/hero/economy.js';
+
+// ── deriveDailyAwardKey ──────────────────────────────────────────
+
+test('deriveDailyAwardKey produces stable key for same inputs (deterministic)', () => {
+  const params = {
+    learnerId: 'learner-1',
+    dateKey: '2026-04-29',
+    questId: 'quest-abc',
+    questFingerprint: 'fp-xyz',
+    economyVersion: 1,
+  };
+  const key1 = deriveDailyAwardKey(params);
+  const key2 = deriveDailyAwardKey(params);
+  assert.equal(key1, key2);
+  assert.equal(key1, 'hero-daily-coins:v1:learner-1:2026-04-29:quest-abc:fp-xyz');
+});
+
+test('deriveDailyAwardKey produces different keys for different inputs', () => {
+  const base = {
+    learnerId: 'learner-1',
+    dateKey: '2026-04-29',
+    questId: 'quest-abc',
+    questFingerprint: 'fp-xyz',
+    economyVersion: 1,
+  };
+  const altered = { ...base, learnerId: 'learner-2' };
+  assert.notEqual(deriveDailyAwardKey(base), deriveDailyAwardKey(altered));
+
+  const alteredDate = { ...base, dateKey: '2026-04-30' };
+  assert.notEqual(deriveDailyAwardKey(base), deriveDailyAwardKey(alteredDate));
+
+  const alteredQuest = { ...base, questId: 'quest-def' };
+  assert.notEqual(deriveDailyAwardKey(base), deriveDailyAwardKey(alteredQuest));
+});
+
+// ── deriveLedgerEntryId ──────────────────────────────────────────
+
+test('deriveLedgerEntryId produces hero-ledger- prefixed deterministic ID', () => {
+  const key = 'hero-daily-coins:v1:learner-1:2026-04-29:quest-abc:fp-xyz';
+  const id = deriveLedgerEntryId(key);
+  assert.ok(id.startsWith('hero-ledger-'));
+  assert.ok(id.length > 'hero-ledger-'.length);
+});
+
+test('same inputs across calls produce identical keys and IDs', () => {
+  const params = {
+    learnerId: 'learner-1',
+    dateKey: '2026-04-29',
+    questId: 'quest-abc',
+    questFingerprint: 'fp-xyz',
+    economyVersion: 1,
+  };
+  const key1 = deriveDailyAwardKey(params);
+  const key2 = deriveDailyAwardKey(params);
+  assert.equal(key1, key2);
+  assert.equal(deriveLedgerEntryId(key1), deriveLedgerEntryId(key2));
+});
+
+// ── emptyEconomyState ────────────────────────────────────────────
+
+test('emptyEconomyState() returns correct shape', () => {
+  const state = emptyEconomyState();
+  assert.equal(state.version, 1);
+  assert.equal(state.balance, 0);
+  assert.equal(state.lifetimeEarned, 0);
+  assert.equal(state.lifetimeSpent, 0);
+  assert.deepEqual(state.ledger, []);
+  assert.equal(state.lastUpdatedAt, null);
+});
+
+// ── normaliseHeroEconomyState ────────────────────────────────────
+
+test('normaliseHeroEconomyState(null) returns empty state', () => {
+  const state = normaliseHeroEconomyState(null);
+  assert.deepEqual(state, emptyEconomyState());
+});
+
+test('normaliseHeroEconomyState(undefined) returns empty state', () => {
+  const state = normaliseHeroEconomyState(undefined);
+  assert.deepEqual(state, emptyEconomyState());
+});
+
+test('normaliseHeroEconomyState({ version: 1, balance: "abc" }) normalises safely', () => {
+  const state = normaliseHeroEconomyState({ version: 1, balance: 'abc' });
+  assert.equal(state.version, 1);
+  assert.equal(state.balance, 0); // coerced from invalid string
+  assert.equal(state.lifetimeEarned, 0);
+  assert.equal(state.lifetimeSpent, 0);
+  assert.deepEqual(state.ledger, []);
+});
+
+test('normaliseHeroEconomyState with valid data returns normalised copy', () => {
+  const input = {
+    version: 1,
+    balance: 300,
+    lifetimeEarned: 500,
+    lifetimeSpent: 200,
+    ledger: [{ id: 'entry-1', amount: 100 }],
+    lastUpdatedAt: '2026-04-29T10:00:00Z',
+  };
+  const state = normaliseHeroEconomyState(input);
+  assert.equal(state.version, 1);
+  assert.equal(state.balance, 300);
+  assert.equal(state.lifetimeEarned, 500);
+  assert.equal(state.lifetimeSpent, 200);
+  assert.deepEqual(state.ledger, [{ id: 'entry-1', amount: 100 }]);
+  assert.equal(state.lastUpdatedAt, '2026-04-29T10:00:00Z');
+  // Verify it is a copy, not the same reference
+  assert.notEqual(state, input);
+});
+
+test('ledger entries in state are preserved through normalisation', () => {
+  const ledger = [
+    { id: 'e1', type: 'daily-completion-award', amount: 100 },
+    { id: 'e2', type: 'daily-completion-award', amount: 100 },
+  ];
+  const input = { version: 1, balance: 200, lifetimeEarned: 200, lifetimeSpent: 0, ledger, lastUpdatedAt: null };
+  const state = normaliseHeroEconomyState(input);
+  assert.equal(state.ledger.length, 2);
+  assert.deepEqual(state.ledger, ledger);
+});
+
+// ── Structural assertions ────────────────────────────────────────
+
+test('no Math.random() in module source', () => {
+  const src = readFileSync(resolve(import.meta.dirname, '..', 'shared', 'hero', 'economy.js'), 'utf8');
+  assert.equal(src.includes('Math.random'), false, 'Module must not use Math.random()');
+});
+
+test('no Date.now() in module source', () => {
+  const src = readFileSync(resolve(import.meta.dirname, '..', 'shared', 'hero', 'economy.js'), 'utf8');
+  assert.equal(src.includes('Date.now'), false, 'Module must not use Date.now()');
+});
+
+test('no Worker/React/D1/browser imports in module source', () => {
+  const src = readFileSync(resolve(import.meta.dirname, '..', 'shared', 'hero', 'economy.js'), 'utf8');
+  const forbidden = ['worker/', 'react', 'node:', '../worker'];
+  for (const token of forbidden) {
+    const importPattern = new RegExp(`import\\s.*from\\s+['"].*${token.replace('/', '\\/')}`, 'm');
+    assert.equal(importPattern.test(src), false, `Module must not import from '${token}'`);
+  }
+});
+
+test('HERO_ECONOMY_ENTRY_TYPES is frozen', () => {
+  assert.ok(Object.isFrozen(HERO_ECONOMY_ENTRY_TYPES));
+});
+
+// ── Constants sanity ─────────────────────────────────────────────
+
+test('constants have expected values', () => {
+  assert.equal(HERO_ECONOMY_VERSION, 1);
+  assert.equal(HERO_DAILY_COMPLETION_COINS, 100);
+  assert.equal(HERO_DAILY_BONUS_COINS_CAP, 0);
+  assert.equal(HERO_LEDGER_RECENT_LIMIT, 180);
+});

--- a/tests/hero-p3-boundary.test.js
+++ b/tests/hero-p3-boundary.test.js
@@ -18,7 +18,13 @@ import { fileURLToPath } from 'node:url';
 
 import { createApiPlatformRepositories } from '../src/platform/core/repositories/index.js';
 import { createWorkerRepositoryServer } from './helpers/worker-server.js';
-import { HERO_FORBIDDEN_VOCABULARY, HERO_PROGRESS_COPY } from '../shared/hero/hero-copy.js';
+import {
+  HERO_FORBIDDEN_VOCABULARY,
+  HERO_FORBIDDEN_PRESSURE_VOCABULARY,
+  HERO_ECONOMY_ALLOWED_VOCABULARY,
+  HERO_ECONOMY_ALLOWED_FILES,
+  HERO_PROGRESS_COPY,
+} from '../shared/hero/hero-copy.js';
 
 // ── Helpers ──────────────────────────────────────────────────────────
 

--- a/tests/hero-p4-economy-e2e.test.js
+++ b/tests/hero-p4-economy-e2e.test.js
@@ -1,0 +1,564 @@
+// Hero Mode P4 U8 — Economy end-to-end safety tests through the Worker handler.
+//
+// Tests the full Worker claim-task handler for abuse/safety scenarios:
+// 1. Full daily completion flow: start 3 tasks, claim 3 tasks, final claim awards coins
+// 2. Replay of final claim (same requestId) returns same response with coins data
+// 3. Different requestId after completion returns already-completed with correct coinBalance
+// 4. Economy disabled → full flow works with zero coins, P3 responses preserved
+// 5. Cross-learner: claim with different learnerId session context → rejected
+// 6. Missing heroContext in practice session + economy on → rejected
+// 7. Economy state NOT written when economy flag is off
+// 8. After coins awarded, reading hero read-model returns correct balance
+// 9. Stale revision on claim → 409 stale_write, no coins awarded
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createApiPlatformRepositories } from '../src/platform/core/repositories/index.js';
+import { createWorkerRepositoryServer } from './helpers/worker-server.js';
+import { HERO_DAILY_COMPLETION_COINS } from '../shared/hero/economy.js';
+
+const HERO_COMMAND_URL = 'https://repo.test/api/hero/command';
+const HERO_READ_MODEL_URL = 'https://repo.test/api/hero/read-model';
+
+// ── Server factories ───────────────────────────────────────────────────
+
+function createEconomyServer() {
+  return createWorkerRepositoryServer({
+    env: {
+      HERO_MODE_SHADOW_ENABLED: 'true',
+      HERO_MODE_LAUNCH_ENABLED: 'true',
+      HERO_MODE_CHILD_UI_ENABLED: 'true',
+      HERO_MODE_PROGRESS_ENABLED: 'true',
+      HERO_MODE_ECONOMY_ENABLED: 'true',
+      PUNCTUATION_SUBJECT_ENABLED: 'true',
+    },
+  });
+}
+
+function createEconomyDisabledServer() {
+  return createWorkerRepositoryServer({
+    env: {
+      HERO_MODE_SHADOW_ENABLED: 'true',
+      HERO_MODE_LAUNCH_ENABLED: 'true',
+      HERO_MODE_CHILD_UI_ENABLED: 'true',
+      HERO_MODE_PROGRESS_ENABLED: 'true',
+      HERO_MODE_ECONOMY_ENABLED: 'false',
+      PUNCTUATION_SUBJECT_ENABLED: 'true',
+    },
+  });
+}
+
+// ── Fixture seeding ────────────────────────────────────────────────────
+
+const HERO_SPELLING_DATA = {
+  stats: {
+    core: { total: 50, secure: 30, due: 10, fresh: 5, trouble: 5, attempts: 200, correct: 160, accuracy: 0.8 },
+    all: { total: 50, secure: 30, due: 10, fresh: 5, trouble: 5, attempts: 200, correct: 160, accuracy: 0.8 },
+  },
+};
+
+const HERO_PUNCTUATION_DATA = {
+  availability: { status: 'ready' },
+  stats: { total: 20, secure: 8, due: 5, fresh: 3, weak: 2, attempts: 100, correct: 75, accuracy: 75 },
+};
+
+async function seedLearnerWithSubjectState(server, accountId, learnerId) {
+  const repos = createApiPlatformRepositories({
+    baseUrl: 'https://repo.test',
+    fetch: server.fetch.bind(server),
+    authSession: server.authSessionFor(accountId),
+  });
+  await repos.hydrate();
+  repos.learners.write({
+    byId: {
+      [learnerId]: {
+        id: learnerId,
+        name: 'Economy E2E Safety Learner',
+        yearGroup: 'Y5',
+        goal: 'sats',
+        dailyMinutes: 15,
+        avatarColor: '#3E6FA8',
+        createdAt: 1,
+      },
+    },
+    allIds: [learnerId],
+    selectedId: learnerId,
+  });
+  await repos.flush();
+
+  const now = Date.now();
+  server.DB.db.prepare(`
+    INSERT INTO child_subject_state (learner_id, subject_id, ui_json, data_json, updated_at, updated_by_account_id)
+    VALUES (?, 'spelling', '{}', ?, ?, ?)
+  `).run(learnerId, JSON.stringify(HERO_SPELLING_DATA), now, accountId);
+
+  server.DB.db.prepare(`
+    INSERT INTO child_subject_state (learner_id, subject_id, ui_json, data_json, updated_at, updated_by_account_id)
+    VALUES (?, 'punctuation', '{}', ?, ?, ?)
+  `).run(learnerId, JSON.stringify(HERO_PUNCTUATION_DATA), now, accountId);
+
+  return repos;
+}
+
+// ── Shared helpers ─────────────────────────────────────────────────────
+
+async function getReadModel(server, learnerId = 'learner-a') {
+  const response = await server.fetch(`${HERO_READ_MODEL_URL}?learnerId=${learnerId}`);
+  const payload = await response.json();
+  assert.equal(response.status, 200, `Read model returned ${response.status}: ${JSON.stringify(payload)}`);
+  assert.ok(payload.hero, 'Read model must contain hero block');
+  return payload;
+}
+
+function findFirstLaunchableTask(heroPayload) {
+  const quest = heroPayload.hero.dailyQuest;
+  if (!quest || !quest.tasks) return null;
+  const task = quest.tasks.find((t) => t.launchStatus === 'launchable');
+  if (!task) return null;
+  return {
+    questId: quest.questId,
+    questFingerprint: heroPayload.hero.questFingerprint,
+    taskId: task.taskId,
+    subjectId: task.subjectId,
+    task,
+  };
+}
+
+function getLearnerRevision(server, accountId = 'adult-a') {
+  const row = server.DB.db.prepare(
+    `SELECT lp.state_revision FROM learner_profiles lp
+     JOIN account_learner_memberships alm ON alm.learner_id = lp.id
+     WHERE alm.account_id = ?`,
+  ).get(accountId);
+  return row?.state_revision ?? 0;
+}
+
+async function postHeroCommand(server, body, accountId = 'adult-a') {
+  return server.fetchAs(accountId, HERO_COMMAND_URL, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function getHeroProgressRow(server, learnerId) {
+  const row = server.DB.db.prepare(
+    `SELECT state_json, updated_at FROM child_game_state
+     WHERE learner_id = ? AND system_id = 'hero-mode'`,
+  ).get(learnerId);
+  if (!row) return null;
+  return JSON.parse(row.state_json);
+}
+
+/**
+ * Launches and claims ALL tasks in the quest to trigger daily completion.
+ * Returns the final claim payload and all tasks.
+ */
+async function claimAllTasks(server, learnerId, accountId) {
+  const readModelPayload = await getReadModel(server, learnerId);
+  const quest = readModelPayload.hero.dailyQuest;
+  const fingerprint = readModelPayload.hero.questFingerprint;
+  const allTasks = quest.tasks.filter(t => t.launchStatus === 'launchable');
+  if (allTasks.length < 1) throw new Error('Fixture must produce at least 1 launchable task');
+
+  const nowTs = Date.now();
+  let lastClaimPayload = null;
+  let lastRequestId = null;
+
+  for (let i = 0; i < allTasks.length; i++) {
+    const task = allTasks[i];
+    const rev = getLearnerRevision(server, accountId);
+
+    // Launch
+    await postHeroCommand(server, {
+      command: 'start-task',
+      learnerId,
+      questId: quest.questId,
+      questFingerprint: fingerprint,
+      taskId: task.taskId,
+      requestId: `e2e-safety-launch-${i}-${Date.now()}`,
+      expectedLearnerRevision: rev,
+    }, accountId);
+
+    // Seed practice session with heroContext
+    const sessionId = `ps-e2e-safety-${i}-${Date.now().toString(36)}`;
+    const summaryJson = JSON.stringify({
+      heroContext: {
+        source: 'hero-mode',
+        questId: quest.questId,
+        questFingerprint: fingerprint,
+        taskId: task.taskId,
+        intent: task.intent || 'due-review',
+        launcher: task.launcher || 'smart-practice',
+      },
+      status: 'completed',
+    });
+    server.DB.db.prepare(`
+      INSERT INTO practice_sessions (id, learner_id, subject_id, session_kind, status, session_state_json, summary_json, created_at, updated_at)
+      VALUES (?, ?, ?, 'smart-practice', 'completed', '{}', ?, ?, ?)
+    `).run(sessionId, learnerId, task.subjectId, summaryJson, nowTs + i, nowTs + i);
+
+    // Claim
+    const claimRev = getLearnerRevision(server, accountId);
+    lastRequestId = `e2e-safety-claim-${i}-${Date.now()}`;
+    const claimResp = await postHeroCommand(server, {
+      command: 'claim-task',
+      learnerId,
+      questId: quest.questId,
+      questFingerprint: fingerprint,
+      taskId: task.taskId,
+      requestId: lastRequestId,
+      expectedLearnerRevision: claimRev,
+    }, accountId);
+    lastClaimPayload = await claimResp.json();
+    assert.equal(claimResp.status, 200, `Claim ${i} must succeed: ${JSON.stringify(lastClaimPayload)}`);
+  }
+
+  return { lastClaimPayload, lastRequestId, allTasks, quest, fingerprint };
+}
+
+// ── 1. Full daily completion flow awards coins ───────────────────────────
+
+test('U8 E2E: full daily completion flow — all tasks claimed → coins awarded', async () => {
+  const server = createEconomyServer();
+  await seedLearnerWithSubjectState(server, 'adult-a', 'learner-a');
+
+  const { lastClaimPayload } = await claimAllTasks(server, 'learner-a', 'adult-a');
+
+  assert.equal(lastClaimPayload.heroClaim.dailyStatus, 'completed');
+  assert.equal(lastClaimPayload.heroClaim.coinsEnabled, true);
+  assert.equal(lastClaimPayload.heroClaim.coinsAwarded, HERO_DAILY_COMPLETION_COINS);
+  assert.ok(lastClaimPayload.heroClaim.coinBalance >= HERO_DAILY_COMPLETION_COINS);
+  assert.equal(lastClaimPayload.heroClaim.dailyCoinsAlreadyAwarded, false);
+
+  server.close();
+});
+
+// ── 2. Replay of final claim (same task, new requestId) → already-completed with coins data ──
+
+test('U8 E2E: replay after completion → already-completed with coinBalance preserved', async () => {
+  const server = createEconomyServer();
+  await seedLearnerWithSubjectState(server, 'adult-a', 'learner-a');
+
+  const { quest, fingerprint, allTasks } = await claimAllTasks(server, 'learner-a', 'adult-a');
+
+  // Replay the final task with a NEW requestId
+  const lastTask = allTasks[allTasks.length - 1];
+  const revision = getLearnerRevision(server);
+  const response = await postHeroCommand(server, {
+    command: 'claim-task',
+    learnerId: 'learner-a',
+    questId: quest.questId,
+    questFingerprint: fingerprint,
+    taskId: lastTask.taskId,
+    requestId: `e2e-replay-${Date.now()}`,
+    expectedLearnerRevision: revision,
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 200, `Replay must succeed: ${JSON.stringify(payload)}`);
+  assert.equal(payload.ok, true);
+  assert.equal(payload.heroClaim.status, 'already-completed');
+  assert.equal(payload.heroClaim.coinsEnabled, true);
+  assert.equal(payload.heroClaim.coinBalance, HERO_DAILY_COMPLETION_COINS);
+  assert.equal(payload.heroClaim.dailyCoinsAlreadyAwarded, true);
+  // Coins must NOT be re-awarded on replay
+  assert.equal(payload.heroClaim.coinsAwarded, 0);
+
+  server.close();
+});
+
+// ── 3. Different requestId after completion → already-completed with correct coinBalance ──
+
+test('U8 E2E: different requestId after full completion → already-completed, balance correct', async () => {
+  const server = createEconomyServer();
+  await seedLearnerWithSubjectState(server, 'adult-a', 'learner-a');
+
+  const { quest, fingerprint, allTasks } = await claimAllTasks(server, 'learner-a', 'adult-a');
+
+  // Attempt to claim any task with a completely different requestId
+  const firstTask = allTasks[0];
+  const revision = getLearnerRevision(server);
+  const response = await postHeroCommand(server, {
+    command: 'claim-task',
+    learnerId: 'learner-a',
+    questId: quest.questId,
+    questFingerprint: fingerprint,
+    taskId: firstTask.taskId,
+    requestId: `e2e-post-complete-diff-${Date.now()}`,
+    expectedLearnerRevision: revision,
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 200, `Expected 200: ${JSON.stringify(payload)}`);
+  assert.equal(payload.heroClaim.status, 'already-completed');
+  assert.equal(payload.heroClaim.coinBalance, HERO_DAILY_COMPLETION_COINS);
+  assert.equal(payload.heroClaim.dailyCoinsAlreadyAwarded, true);
+
+  server.close();
+});
+
+// ── 4. Economy disabled → full flow works with zero coins, P3 responses preserved ──
+
+test('U8 E2E: economy disabled → full flow succeeds with coinsEnabled=false, zero coins', async () => {
+  const server = createEconomyDisabledServer();
+  await seedLearnerWithSubjectState(server, 'adult-a', 'learner-a');
+
+  const { lastClaimPayload } = await claimAllTasks(server, 'learner-a', 'adult-a');
+
+  assert.equal(lastClaimPayload.heroClaim.dailyStatus, 'completed');
+  assert.equal(lastClaimPayload.heroClaim.coinsEnabled, false);
+  assert.equal(lastClaimPayload.heroClaim.coinsAwarded, 0);
+  assert.equal(lastClaimPayload.heroClaim.coinBalance, 0);
+  // P3 fields must still be present
+  assert.equal(lastClaimPayload.heroClaim.heroStatePersistenceEnabled, true);
+  assert.equal(typeof lastClaimPayload.heroClaim.effortCompleted, 'number');
+  assert.equal(typeof lastClaimPayload.heroClaim.effortPlanned, 'number');
+
+  server.close();
+});
+
+// ── 5. Cross-learner: claim for task with no matching practice session → rejected ──
+
+test('U8 E2E: cross-learner isolation — mismatched heroContext → rejected (no_evidence)', async () => {
+  const server = createEconomyServer();
+  await seedLearnerWithSubjectState(server, 'adult-a', 'learner-a');
+
+  // Get read model and launch a task
+  const readModelPayload = await getReadModel(server, 'learner-a');
+  const launchable = findFirstLaunchableTask(readModelPayload);
+  if (!launchable) { server.close(); return; }
+
+  const rev = getLearnerRevision(server);
+  await postHeroCommand(server, {
+    command: 'start-task',
+    learnerId: 'learner-a',
+    questId: launchable.questId,
+    questFingerprint: launchable.questFingerprint,
+    taskId: launchable.taskId,
+    requestId: `e2e-cross-launch-${Date.now()}`,
+    expectedLearnerRevision: rev,
+  });
+
+  // Seed a practice session for learner-a but with WRONG heroContext
+  // (simulates a cross-learner attack where the attacker's session data
+  // references a different quest/task — the evidence query filters by
+  // matching heroContext, so this session won't satisfy the claim.)
+  const sessionId = `ps-cross-attack-${Date.now().toString(36)}`;
+  const nowTs = Date.now();
+  const summaryJson = JSON.stringify({
+    heroContext: {
+      source: 'hero-mode',
+      questId: 'different-quest-id-attacker',
+      questFingerprint: 'different-fp-attacker',
+      taskId: 'different-task-id-attacker',
+      intent: 'due-review',
+      launcher: 'smart-practice',
+    },
+    status: 'completed',
+  });
+  server.DB.db.prepare(`
+    INSERT INTO practice_sessions (id, learner_id, subject_id, session_kind, status, session_state_json, summary_json, created_at, updated_at)
+    VALUES (?, ?, ?, 'smart-practice', 'completed', '{}', ?, ?, ?)
+  `).run(sessionId, 'learner-a', launchable.subjectId, summaryJson, nowTs, nowTs);
+
+  // Clear any heroContext from subject state so fallback cannot match
+  server.DB.db.prepare(`
+    UPDATE child_subject_state SET ui_json = '{}' WHERE learner_id = ?
+  `).run('learner-a');
+
+  // Claim as learner-a — no matching heroContext evidence for this quest/task
+  const claimRev = getLearnerRevision(server);
+  const response = await postHeroCommand(server, {
+    command: 'claim-task',
+    learnerId: 'learner-a',
+    questId: launchable.questId,
+    questFingerprint: launchable.questFingerprint,
+    taskId: launchable.taskId,
+    requestId: `e2e-cross-claim-${Date.now()}`,
+    expectedLearnerRevision: claimRev,
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 400, `Expected 400 for cross-learner: ${JSON.stringify(payload)}`);
+  assert.equal(payload.error.code, 'hero_claim_no_evidence');
+
+  server.close();
+});
+
+// ── 6. Missing heroContext in practice session + economy on → rejected ──
+
+test('U8 E2E: missing heroContext in practice session → rejected with no_evidence', async () => {
+  const server = createEconomyServer();
+  await seedLearnerWithSubjectState(server, 'adult-a', 'learner-a');
+
+  // Launch a task
+  const readModelPayload = await getReadModel(server, 'learner-a');
+  const launchable = findFirstLaunchableTask(readModelPayload);
+  if (!launchable) { server.close(); return; }
+
+  const rev = getLearnerRevision(server);
+  await postHeroCommand(server, {
+    command: 'start-task',
+    learnerId: 'learner-a',
+    questId: launchable.questId,
+    questFingerprint: launchable.questFingerprint,
+    taskId: launchable.taskId,
+    requestId: `e2e-noctx-launch-${Date.now()}`,
+    expectedLearnerRevision: rev,
+  });
+
+  // Seed a practice session WITHOUT heroContext
+  const sessionId = `ps-no-ctx-${Date.now().toString(36)}`;
+  const nowTs = Date.now();
+  const summaryJson = JSON.stringify({
+    status: 'completed',
+    score: 8,
+    total: 10,
+    // NOTE: heroContext deliberately omitted
+  });
+  server.DB.db.prepare(`
+    INSERT INTO practice_sessions (id, learner_id, subject_id, session_kind, status, session_state_json, summary_json, created_at, updated_at)
+    VALUES (?, ?, ?, 'smart-practice', 'completed', '{}', ?, ?, ?)
+  `).run(sessionId, 'learner-a', launchable.subjectId, summaryJson, nowTs, nowTs);
+
+  // Clear subject ui_json heroContext fallback
+  server.DB.db.prepare(`
+    UPDATE child_subject_state SET ui_json = '{}' WHERE learner_id = ?
+  `).run('learner-a');
+
+  // Attempt to claim — no valid heroContext evidence exists
+  const claimRev = getLearnerRevision(server);
+  const response = await postHeroCommand(server, {
+    command: 'claim-task',
+    learnerId: 'learner-a',
+    questId: launchable.questId,
+    questFingerprint: launchable.questFingerprint,
+    taskId: launchable.taskId,
+    requestId: `e2e-noctx-claim-${Date.now()}`,
+    expectedLearnerRevision: claimRev,
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 400, `Expected 400 for missing heroContext: ${JSON.stringify(payload)}`);
+  assert.equal(payload.error.code, 'hero_claim_no_evidence');
+
+  server.close();
+});
+
+// ── 7. Economy state NOT written when economy flag is off ────────────────
+
+test('U8 E2E: economy disabled → no economy block changes in persisted state', async () => {
+  const server = createEconomyDisabledServer();
+  await seedLearnerWithSubjectState(server, 'adult-a', 'learner-a');
+
+  await claimAllTasks(server, 'learner-a', 'adult-a');
+
+  const progress = getHeroProgressRow(server, 'learner-a');
+  assert.ok(progress, 'Hero progress row must exist');
+  // Economy balance must remain at 0 when disabled
+  assert.equal(progress.economy.balance, 0, 'Balance must be 0 when economy disabled');
+  assert.equal(progress.economy.lifetimeEarned, 0, 'lifetimeEarned must be 0 when economy disabled');
+  assert.equal(progress.economy.ledger.length, 0, 'Ledger must be empty when economy disabled');
+  // daily.economy sub-block must not have an award
+  if (progress.daily.economy) {
+    assert.notEqual(progress.daily.economy.dailyAwardStatus, 'awarded',
+      'daily economy must not show awarded when flag is off');
+  }
+
+  server.close();
+});
+
+// ── 8. After coins awarded, reading hero read-model returns correct balance ──
+
+test('U8 E2E: after coins awarded, read-model shows correct economy balance', async () => {
+  const server = createEconomyServer();
+  await seedLearnerWithSubjectState(server, 'adult-a', 'learner-a');
+
+  await claimAllTasks(server, 'learner-a', 'adult-a');
+
+  // Read the hero read-model
+  const readModel = await getReadModel(server, 'learner-a');
+  const economy = readModel.hero.economy;
+
+  assert.ok(economy, 'Read model must contain economy block');
+  assert.equal(economy.enabled, true);
+  assert.equal(economy.balance, HERO_DAILY_COMPLETION_COINS);
+  assert.equal(economy.lifetimeEarned, HERO_DAILY_COMPLETION_COINS);
+  assert.ok(economy.today, 'Economy must include today block');
+  assert.equal(economy.today.awardStatus, 'awarded');
+  assert.equal(economy.today.coinsAwarded, HERO_DAILY_COMPLETION_COINS);
+  assert.ok(economy.today.ledgerEntryId, 'Must include ledgerEntryId in today block');
+
+  server.close();
+});
+
+// ── 9. Stale revision on claim → 409 stale_write, no coins awarded ──
+
+test('U8 E2E: stale expectedLearnerRevision → 409 stale_write, economy unchanged', async () => {
+  const server = createEconomyServer();
+  await seedLearnerWithSubjectState(server, 'adult-a', 'learner-a');
+
+  // Launch a task to set up progress
+  const readModelPayload = await getReadModel(server, 'learner-a');
+  const launchable = findFirstLaunchableTask(readModelPayload);
+  if (!launchable) { server.close(); return; }
+
+  const rev = getLearnerRevision(server);
+  await postHeroCommand(server, {
+    command: 'start-task',
+    learnerId: 'learner-a',
+    questId: launchable.questId,
+    questFingerprint: launchable.questFingerprint,
+    taskId: launchable.taskId,
+    requestId: `e2e-stale-launch-${Date.now()}`,
+    expectedLearnerRevision: rev,
+  });
+
+  // Seed a valid practice session
+  const sessionId = `ps-stale-${Date.now().toString(36)}`;
+  const nowTs = Date.now();
+  const summaryJson = JSON.stringify({
+    heroContext: {
+      source: 'hero-mode',
+      questId: launchable.questId,
+      questFingerprint: launchable.questFingerprint,
+      taskId: launchable.taskId,
+      intent: launchable.task.intent || 'due-review',
+      launcher: launchable.task.launcher || 'smart-practice',
+    },
+    status: 'completed',
+  });
+  server.DB.db.prepare(`
+    INSERT INTO practice_sessions (id, learner_id, subject_id, session_kind, status, session_state_json, summary_json, created_at, updated_at)
+    VALUES (?, ?, ?, 'smart-practice', 'completed', '{}', ?, ?, ?)
+  `).run(sessionId, 'learner-a', launchable.subjectId, summaryJson, nowTs, nowTs);
+
+  // Use a STALE revision (current - 1 would be stale since launch bumped it)
+  const currentRevision = getLearnerRevision(server);
+  const staleRevision = currentRevision - 1;
+
+  const response = await postHeroCommand(server, {
+    command: 'claim-task',
+    learnerId: 'learner-a',
+    questId: launchable.questId,
+    questFingerprint: launchable.questFingerprint,
+    taskId: launchable.taskId,
+    requestId: `e2e-stale-claim-${Date.now()}`,
+    expectedLearnerRevision: staleRevision,
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 409, `Expected 409: ${JSON.stringify(payload)}`);
+  assert.equal(payload.code, 'stale_write');
+
+  // Verify economy is untouched (no coins awarded through stale claim)
+  const progress = getHeroProgressRow(server, 'learner-a');
+  if (progress && progress.economy) {
+    assert.equal(progress.economy.balance, 0, 'Balance must remain 0 after stale write rejection');
+    assert.equal(progress.economy.ledger.length, 0, 'Ledger must remain empty after stale write rejection');
+  }
+
+  server.close();
+});

--- a/tests/hero-p4-economy-mutation.test.js
+++ b/tests/hero-p4-economy-mutation.test.js
@@ -1,0 +1,555 @@
+// Hero Mode P4 U4 — Economy integration into claim-task mutation.
+//
+// Tests exercise the Worker claim-task handler with HERO_MODE_ECONOMY_ENABLED
+// enabled/disabled and verify coin awards, structured logs, event_log entries,
+// and flag hierarchy enforcement.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createApiPlatformRepositories } from '../src/platform/core/repositories/index.js';
+import { createWorkerRepositoryServer } from './helpers/worker-server.js';
+import { HERO_DAILY_COMPLETION_COINS } from '../shared/hero/economy.js';
+
+const HERO_COMMAND_URL = 'https://repo.test/api/hero/command';
+const HERO_READ_MODEL_URL = 'https://repo.test/api/hero/read-model';
+
+// ── Server factories ───────────────────────────────────────────────────
+
+function createEconomyServer() {
+  return createWorkerRepositoryServer({
+    env: {
+      HERO_MODE_SHADOW_ENABLED: 'true',
+      HERO_MODE_LAUNCH_ENABLED: 'true',
+      HERO_MODE_CHILD_UI_ENABLED: 'true',
+      HERO_MODE_PROGRESS_ENABLED: 'true',
+      HERO_MODE_ECONOMY_ENABLED: 'true',
+      PUNCTUATION_SUBJECT_ENABLED: 'true',
+    },
+  });
+}
+
+function createEconomyDisabledServer() {
+  return createWorkerRepositoryServer({
+    env: {
+      HERO_MODE_SHADOW_ENABLED: 'true',
+      HERO_MODE_LAUNCH_ENABLED: 'true',
+      HERO_MODE_CHILD_UI_ENABLED: 'true',
+      HERO_MODE_PROGRESS_ENABLED: 'true',
+      HERO_MODE_ECONOMY_ENABLED: 'false',
+      PUNCTUATION_SUBJECT_ENABLED: 'true',
+    },
+  });
+}
+
+function createEconomyWithoutProgressServer() {
+  return createWorkerRepositoryServer({
+    env: {
+      HERO_MODE_SHADOW_ENABLED: 'true',
+      HERO_MODE_LAUNCH_ENABLED: 'true',
+      HERO_MODE_CHILD_UI_ENABLED: 'true',
+      HERO_MODE_PROGRESS_ENABLED: 'false',
+      HERO_MODE_ECONOMY_ENABLED: 'true',
+      PUNCTUATION_SUBJECT_ENABLED: 'true',
+    },
+  });
+}
+
+// ── Fixture seeding ────────────────────────────────────────────────────
+
+const HERO_SPELLING_DATA = {
+  stats: {
+    core: { total: 50, secure: 30, due: 10, fresh: 5, trouble: 5, attempts: 200, correct: 160, accuracy: 0.8 },
+    all: { total: 50, secure: 30, due: 10, fresh: 5, trouble: 5, attempts: 200, correct: 160, accuracy: 0.8 },
+  },
+};
+
+const HERO_PUNCTUATION_DATA = {
+  availability: { status: 'ready' },
+  stats: { total: 20, secure: 8, due: 5, fresh: 3, weak: 2, attempts: 100, correct: 75, accuracy: 75 },
+};
+
+async function seedLearnerWithSubjectState(server, accountId, learnerId) {
+  const repos = createApiPlatformRepositories({
+    baseUrl: 'https://repo.test',
+    fetch: server.fetch.bind(server),
+    authSession: server.authSessionFor(accountId),
+  });
+  await repos.hydrate();
+  repos.learners.write({
+    byId: {
+      [learnerId]: {
+        id: learnerId,
+        name: 'Economy Test Learner',
+        yearGroup: 'Y5',
+        goal: 'sats',
+        dailyMinutes: 15,
+        avatarColor: '#3E6FA8',
+        createdAt: 1,
+      },
+    },
+    allIds: [learnerId],
+    selectedId: learnerId,
+  });
+  await repos.flush();
+
+  const now = Date.now();
+  server.DB.db.prepare(`
+    INSERT INTO child_subject_state (learner_id, subject_id, ui_json, data_json, updated_at, updated_by_account_id)
+    VALUES (?, 'spelling', '{}', ?, ?, ?)
+  `).run(learnerId, JSON.stringify(HERO_SPELLING_DATA), now, accountId);
+
+  server.DB.db.prepare(`
+    INSERT INTO child_subject_state (learner_id, subject_id, ui_json, data_json, updated_at, updated_by_account_id)
+    VALUES (?, 'punctuation', '{}', ?, ?, ?)
+  `).run(learnerId, JSON.stringify(HERO_PUNCTUATION_DATA), now, accountId);
+
+  return repos;
+}
+
+// ── Shared helpers ─────────────────────────────────────────────────────
+
+async function getReadModel(server, learnerId = 'learner-a') {
+  const response = await server.fetch(`${HERO_READ_MODEL_URL}?learnerId=${learnerId}`);
+  const payload = await response.json();
+  assert.equal(response.status, 200, `Read model returned ${response.status}: ${JSON.stringify(payload)}`);
+  assert.ok(payload.hero, 'Read model must contain hero block');
+  return payload;
+}
+
+function findFirstLaunchableTask(heroPayload) {
+  const quest = heroPayload.hero.dailyQuest;
+  if (!quest || !quest.tasks) return null;
+  const task = quest.tasks.find((t) => t.launchStatus === 'launchable');
+  if (!task) return null;
+  return {
+    questId: quest.questId,
+    questFingerprint: heroPayload.hero.questFingerprint,
+    taskId: task.taskId,
+    subjectId: task.subjectId,
+    task,
+  };
+}
+
+function getLearnerRevision(server, accountId = 'adult-a') {
+  const row = server.DB.db.prepare(
+    `SELECT lp.state_revision FROM learner_profiles lp
+     JOIN account_learner_memberships alm ON alm.learner_id = lp.id
+     WHERE alm.account_id = ?`,
+  ).get(accountId);
+  return row?.state_revision ?? 0;
+}
+
+async function postHeroCommand(server, body, accountId = 'adult-a') {
+  return server.fetchAs(accountId, HERO_COMMAND_URL, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function getHeroProgressRow(server, learnerId) {
+  const row = server.DB.db.prepare(
+    `SELECT state_json, updated_at FROM child_game_state
+     WHERE learner_id = ? AND system_id = 'hero-mode'`,
+  ).get(learnerId);
+  if (!row) return null;
+  return JSON.parse(row.state_json);
+}
+
+function getHeroEvents(server) {
+  return server.DB.db.prepare(
+    `SELECT id, learner_id, event_type, event_json, created_at FROM event_log WHERE event_type LIKE 'hero.%' ORDER BY created_at`,
+  ).all();
+}
+
+/**
+ * Seeds hero progress state and a completed practice session with heroContext.
+ * Returns the task metadata needed for making a claim.
+ */
+async function seedClaimableState(server, learnerId, accountId) {
+  const readModelPayload = await getReadModel(server, learnerId);
+  const launchable = findFirstLaunchableTask(readModelPayload);
+  if (!launchable) throw new Error('No launchable task found in fixture');
+
+  const revision = getLearnerRevision(server, accountId);
+  const launchResp = await postHeroCommand(server, {
+    command: 'start-task',
+    learnerId,
+    questId: launchable.questId,
+    questFingerprint: launchable.questFingerprint,
+    taskId: launchable.taskId,
+    requestId: `econ-seed-launch-${Date.now()}`,
+    expectedLearnerRevision: revision,
+  }, accountId);
+  const launchPayload = await launchResp.json();
+  assert.equal(launchResp.status, 200, `Seed launch must succeed: ${JSON.stringify(launchPayload)}`);
+
+  // Seed a completed practice session with heroContext
+  const sessionId = `ps-econ-${Date.now().toString(36)}`;
+  const nowTs = Date.now();
+  const summaryJson = JSON.stringify({
+    heroContext: {
+      source: 'hero-mode',
+      questId: launchable.questId,
+      questFingerprint: launchable.questFingerprint,
+      taskId: launchable.taskId,
+      intent: launchable.task.intent || 'due-review',
+      launcher: launchable.task.launcher || 'smart-practice',
+    },
+    status: 'completed',
+    score: 8,
+    total: 10,
+  });
+
+  server.DB.db.prepare(`
+    INSERT INTO practice_sessions (id, learner_id, subject_id, session_kind, status, session_state_json, summary_json, created_at, updated_at)
+    VALUES (?, ?, ?, 'smart-practice', 'completed', '{}', ?, ?, ?)
+  `).run(sessionId, learnerId, launchable.subjectId, summaryJson, nowTs, nowTs);
+
+  return {
+    questId: launchable.questId,
+    questFingerprint: launchable.questFingerprint,
+    taskId: launchable.taskId,
+    subjectId: launchable.subjectId,
+    practiceSessionId: sessionId,
+    task: launchable.task,
+  };
+}
+
+/**
+ * Launches and claims ALL tasks in the quest to trigger daily completion.
+ * Returns the final claim payload and all tasks.
+ */
+async function claimAllTasks(server, learnerId, accountId) {
+  const readModelPayload = await getReadModel(server, learnerId);
+  const quest = readModelPayload.hero.dailyQuest;
+  const fingerprint = readModelPayload.hero.questFingerprint;
+  const allTasks = quest.tasks.filter(t => t.launchStatus === 'launchable');
+  if (allTasks.length < 1) throw new Error('Fixture must produce at least 1 launchable task');
+
+  const nowTs = Date.now();
+  let lastClaimPayload = null;
+
+  for (let i = 0; i < allTasks.length; i++) {
+    const task = allTasks[i];
+    const rev = getLearnerRevision(server, accountId);
+
+    // Launch
+    await postHeroCommand(server, {
+      command: 'start-task',
+      learnerId,
+      questId: quest.questId,
+      questFingerprint: fingerprint,
+      taskId: task.taskId,
+      requestId: `econ-all-launch-${i}-${Date.now()}`,
+      expectedLearnerRevision: rev,
+    }, accountId);
+
+    // Seed practice session
+    const sessionId = `ps-econ-all-${i}-${Date.now().toString(36)}`;
+    const summaryJson = JSON.stringify({
+      heroContext: {
+        source: 'hero-mode',
+        questId: quest.questId,
+        questFingerprint: fingerprint,
+        taskId: task.taskId,
+        intent: task.intent || 'due-review',
+        launcher: task.launcher || 'smart-practice',
+      },
+      status: 'completed',
+    });
+    server.DB.db.prepare(`
+      INSERT INTO practice_sessions (id, learner_id, subject_id, session_kind, status, session_state_json, summary_json, created_at, updated_at)
+      VALUES (?, ?, ?, 'smart-practice', 'completed', '{}', ?, ?, ?)
+    `).run(sessionId, learnerId, task.subjectId, summaryJson, nowTs + i, nowTs + i);
+
+    // Claim
+    const claimRev = getLearnerRevision(server, accountId);
+    const claimResp = await postHeroCommand(server, {
+      command: 'claim-task',
+      learnerId,
+      questId: quest.questId,
+      questFingerprint: fingerprint,
+      taskId: task.taskId,
+      requestId: `econ-all-claim-${i}-${Date.now()}`,
+      expectedLearnerRevision: claimRev,
+    }, accountId);
+    lastClaimPayload = await claimResp.json();
+    assert.equal(claimResp.status, 200, `Claim ${i} must succeed: ${JSON.stringify(lastClaimPayload)}`);
+  }
+
+  return { lastClaimPayload, allTasks, quest, fingerprint };
+}
+
+// ── 1. Final task claim completes daily quest → +100 Coins awarded ─────
+
+test('P4 U4: final task claim with economy enabled → coins awarded', async () => {
+  const server = createEconomyServer();
+  await seedLearnerWithSubjectState(server, 'adult-a', 'learner-a');
+
+  const { lastClaimPayload } = await claimAllTasks(server, 'learner-a', 'adult-a');
+
+  // The final claim must show daily completed
+  assert.equal(lastClaimPayload.heroClaim.dailyStatus, 'completed');
+  assert.equal(lastClaimPayload.heroClaim.coinsEnabled, true);
+  assert.equal(lastClaimPayload.heroClaim.coinsAwarded, HERO_DAILY_COMPLETION_COINS);
+  assert.ok(lastClaimPayload.heroClaim.coinBalance >= HERO_DAILY_COMPLETION_COINS);
+  assert.equal(lastClaimPayload.heroClaim.dailyCoinsAlreadyAwarded, false);
+
+  // Verify state persisted correctly
+  const progress = getHeroProgressRow(server, 'learner-a');
+  assert.equal(progress.economy.balance, HERO_DAILY_COMPLETION_COINS);
+  assert.equal(progress.economy.lifetimeEarned, HERO_DAILY_COMPLETION_COINS);
+  assert.ok(progress.economy.ledger.length > 0);
+  assert.equal(progress.economy.ledger[0].type, 'daily-completion-award');
+  assert.equal(progress.economy.ledger[0].amount, HERO_DAILY_COMPLETION_COINS);
+
+  // Verify daily economy block
+  assert.equal(progress.daily.economy.dailyAwardStatus, 'awarded');
+  assert.equal(progress.daily.economy.dailyAwardCoinsAwarded, HERO_DAILY_COMPLETION_COINS);
+  assert.ok(progress.daily.economy.dailyAwardLedgerEntryId);
+
+  // Verify hero.coins.awarded event in event_log
+  const events = getHeroEvents(server);
+  const coinsEvent = events.find(e => e.event_type === 'hero.coins.awarded');
+  assert.ok(coinsEvent, 'hero.coins.awarded event must exist in event_log');
+  const coinsData = JSON.parse(coinsEvent.event_json);
+  assert.equal(coinsData.amount, HERO_DAILY_COMPLETION_COINS);
+  assert.ok(coinsData.ledgerEntryId);
+  assert.equal(coinsData.balanceAfter, HERO_DAILY_COMPLETION_COINS);
+
+  server.close();
+});
+
+// ── 2. Non-final task claim (daily still active) → 0 coins ─────────────
+
+test('P4 U4: non-final task claim with economy enabled → 0 coins awarded', async () => {
+  const server = createEconomyServer();
+  await seedLearnerWithSubjectState(server, 'adult-a', 'learner-a');
+  const claimable = await seedClaimableState(server, 'learner-a', 'adult-a');
+
+  // Get read model to check task count
+  const readModel = await getReadModel(server, 'learner-a');
+  const quest = readModel.hero.dailyQuest;
+  const taskCount = quest.tasks.filter(t => t.launchStatus === 'launchable' || t.launchStatus === 'started').length;
+
+  // If there's only 1 task, this claim would complete the daily — skip the test
+  if (taskCount <= 1) {
+    server.close();
+    return;
+  }
+
+  const revision = getLearnerRevision(server);
+  const response = await postHeroCommand(server, {
+    command: 'claim-task',
+    learnerId: 'learner-a',
+    questId: claimable.questId,
+    questFingerprint: claimable.questFingerprint,
+    taskId: claimable.taskId,
+    requestId: `econ-nonfinal-${Date.now()}`,
+    expectedLearnerRevision: revision,
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 200, `Expected 200, got ${response.status}: ${JSON.stringify(payload)}`);
+  assert.equal(payload.heroClaim.status, 'claimed');
+  assert.equal(payload.heroClaim.coinsEnabled, true);
+  assert.equal(payload.heroClaim.coinsAwarded, 0);
+  assert.equal(payload.heroClaim.coinBalance, 0);
+  assert.equal(payload.heroClaim.dailyCoinsAlreadyAwarded, false);
+  assert.notEqual(payload.heroClaim.dailyStatus, 'completed');
+
+  server.close();
+});
+
+// ── 3. Economy disabled → claim succeeds, P3 behaviour preserved ───────
+
+test('P4 U4: economy disabled → claim succeeds with coinsEnabled=false', async () => {
+  const server = createEconomyDisabledServer();
+  await seedLearnerWithSubjectState(server, 'adult-a', 'learner-a');
+  const claimable = await seedClaimableState(server, 'learner-a', 'adult-a');
+
+  const revision = getLearnerRevision(server);
+  const response = await postHeroCommand(server, {
+    command: 'claim-task',
+    learnerId: 'learner-a',
+    questId: claimable.questId,
+    questFingerprint: claimable.questFingerprint,
+    taskId: claimable.taskId,
+    requestId: `econ-disabled-${Date.now()}`,
+    expectedLearnerRevision: revision,
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 200, `Expected 200, got ${response.status}: ${JSON.stringify(payload)}`);
+  assert.equal(payload.heroClaim.status, 'claimed');
+  assert.equal(payload.heroClaim.coinsEnabled, false);
+  assert.equal(payload.heroClaim.coinsAwarded, 0);
+  assert.equal(payload.heroClaim.coinBalance, 0);
+  assert.equal(payload.heroClaim.dailyCoinsAlreadyAwarded, false);
+  assert.equal(payload.heroClaim.heroStatePersistenceEnabled, true);
+
+  // Verify no economy event in event_log
+  const events = getHeroEvents(server);
+  const coinsEvent = events.find(e => e.event_type === 'hero.coins.awarded');
+  assert.equal(coinsEvent, undefined, 'No hero.coins.awarded event when economy disabled');
+
+  server.close();
+});
+
+// ── 4. Same requestId replay → replayed response includes same coins data ─
+
+test('P4 U4: same requestId replay after coin award → idempotent coins data', async () => {
+  const server = createEconomyServer();
+  await seedLearnerWithSubjectState(server, 'adult-a', 'learner-a');
+
+  const { lastClaimPayload, quest, fingerprint, allTasks } = await claimAllTasks(server, 'learner-a', 'adult-a');
+
+  // The final claim awarded coins
+  assert.equal(lastClaimPayload.heroClaim.coinsAwarded, HERO_DAILY_COMPLETION_COINS);
+
+  // Now replay: claim same task again with same questId/taskId
+  // The task is already completed, so resolver returns already-completed
+  const lastTask = allTasks[allTasks.length - 1];
+  const revision = getLearnerRevision(server);
+  const response = await postHeroCommand(server, {
+    command: 'claim-task',
+    learnerId: 'learner-a',
+    questId: quest.questId,
+    questFingerprint: fingerprint,
+    taskId: lastTask.taskId,
+    requestId: `econ-replay-different-${Date.now()}`,
+    expectedLearnerRevision: revision,
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 200, `Replay must succeed: ${JSON.stringify(payload)}`);
+  assert.equal(payload.ok, true);
+
+  // Should be already-completed path with coins data
+  assert.equal(payload.heroClaim.status, 'already-completed');
+  assert.equal(payload.heroClaim.coinsEnabled, true);
+  assert.equal(payload.heroClaim.coinsAwarded, 0);
+  assert.equal(payload.heroClaim.coinBalance, HERO_DAILY_COMPLETION_COINS);
+  assert.equal(payload.heroClaim.dailyCoinsAlreadyAwarded, true);
+
+  server.close();
+});
+
+// ── 5. Different request after completion → already-completed + dailyCoinsAlreadyAwarded ─
+
+test('P4 U4: different request after daily completion → already-completed with dailyCoinsAlreadyAwarded=true', async () => {
+  const server = createEconomyServer();
+  await seedLearnerWithSubjectState(server, 'adult-a', 'learner-a');
+
+  const { quest, fingerprint, allTasks } = await claimAllTasks(server, 'learner-a', 'adult-a');
+
+  // Try claiming any already-completed task with a new requestId
+  const lastTask = allTasks[allTasks.length - 1];
+  const revision = getLearnerRevision(server);
+  const response = await postHeroCommand(server, {
+    command: 'claim-task',
+    learnerId: 'learner-a',
+    questId: quest.questId,
+    questFingerprint: fingerprint,
+    taskId: lastTask.taskId,
+    requestId: `econ-post-complete-${Date.now()}`,
+    expectedLearnerRevision: revision,
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 200, `Expected 200: ${JSON.stringify(payload)}`);
+  assert.equal(payload.heroClaim.status, 'already-completed');
+  assert.equal(payload.heroClaim.coinsEnabled, true);
+  assert.equal(payload.heroClaim.dailyCoinsAlreadyAwarded, true);
+  assert.equal(payload.heroClaim.coinBalance, HERO_DAILY_COMPLETION_COINS);
+
+  server.close();
+});
+
+// ── 6. Economy enabled + progress disabled → 409 hero_economy_misconfigured ─
+
+test('P4 U4: economy enabled + progress disabled → 409 hero_economy_misconfigured', async () => {
+  const server = createEconomyWithoutProgressServer();
+  await seedLearnerWithSubjectState(server, 'adult-a', 'learner-a');
+
+  const revision = getLearnerRevision(server);
+  const response = await postHeroCommand(server, {
+    command: 'claim-task',
+    learnerId: 'learner-a',
+    questId: 'any-quest',
+    questFingerprint: 'any-fp',
+    taskId: 'any-task',
+    requestId: `econ-misconfig-${Date.now()}`,
+    expectedLearnerRevision: revision,
+  });
+  const payload = await response.json();
+
+  assert.equal(response.status, 409, `Expected 409, got ${response.status}: ${JSON.stringify(payload)}`);
+  assert.equal(payload.error.code, 'hero_economy_misconfigured');
+
+  server.close();
+});
+
+// ── 7. Event-log write failure → does NOT duplicate award ─────────────
+
+test('P4 U4: event_log write is non-fatal and does not affect award', async () => {
+  const server = createEconomyServer();
+  await seedLearnerWithSubjectState(server, 'adult-a', 'learner-a');
+
+  const { lastClaimPayload } = await claimAllTasks(server, 'learner-a', 'adult-a');
+
+  // Coins were awarded in the mutation
+  assert.equal(lastClaimPayload.heroClaim.coinsAwarded, HERO_DAILY_COMPLETION_COINS);
+
+  // Verify the economy award is in the persisted state (regardless of event_log)
+  const progress = getHeroProgressRow(server, 'learner-a');
+  assert.equal(progress.economy.balance, HERO_DAILY_COMPLETION_COINS);
+  assert.equal(progress.economy.ledger.length, 1);
+
+  // The award event uses ON CONFLICT(id) DO NOTHING — inserting again is safe
+  const events = getHeroEvents(server);
+  const coinsEvents = events.filter(e => e.event_type === 'hero.coins.awarded');
+  assert.equal(coinsEvents.length, 1, 'Only one coins event exists (idempotent by ON CONFLICT)');
+
+  server.close();
+});
+
+// ── 8. Structured log emitted for hero_daily_coins_awarded ─────────────
+
+test('P4 U4: structured log hero_daily_coins_awarded emitted on successful award', async () => {
+  const server = createEconomyServer();
+  await seedLearnerWithSubjectState(server, 'adult-a', 'learner-a');
+
+  // Capture console.log output
+  const logs = [];
+  const originalLog = console.log;
+  console.log = (...args) => {
+    logs.push(args.join(' '));
+  };
+
+  try {
+    await claimAllTasks(server, 'learner-a', 'adult-a');
+  } finally {
+    console.log = originalLog;
+  }
+
+  // Find the hero_daily_coins_awarded log entry
+  const coinsLog = logs.find(l => {
+    try {
+      const parsed = JSON.parse(l);
+      return parsed.event === 'hero_daily_coins_awarded';
+    } catch { return false; }
+  });
+  assert.ok(coinsLog, 'hero_daily_coins_awarded structured log must be emitted');
+
+  const parsed = JSON.parse(coinsLog);
+  assert.equal(parsed.event, 'hero_daily_coins_awarded');
+  assert.equal(parsed.learnerId, 'learner-a');
+  assert.equal(parsed.amount, HERO_DAILY_COMPLETION_COINS);
+  assert.ok(parsed.balanceAfter >= HERO_DAILY_COMPLETION_COINS);
+  assert.ok(parsed.ledgerEntryId);
+
+  server.close();
+});

--- a/tests/hero-p4-economy-safety.test.js
+++ b/tests/hero-p4-economy-safety.test.js
@@ -1,0 +1,334 @@
+// Hero Mode P4 U8 — Economy abuse and idempotency safety tests.
+//
+// Pure-logic layer tests covering:
+// 1. Deterministic ledger entry ID derivation
+// 2. Double-award prevention (applyDailyCompletionCoinAward idempotency)
+// 3. Sequential award attempts on same state
+// 4. FORBIDDEN_CLAIM_FIELDS completeness
+// 5. Forbidden field rejection via validateClaimRequest
+// 6. Forged questFingerprint produces different idempotency key
+// 7. No negative amounts in daily-completion-award
+// 8. Empty ledger + completed daily → canAward: true (not vacuously false)
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  canAwardDailyCompletionCoins,
+  applyDailyCompletionCoinAward,
+  HERO_DAILY_COMPLETION_COINS,
+  deriveDailyAwardKey,
+  deriveLedgerEntryId,
+  emptyEconomyState,
+} from '../shared/hero/economy.js';
+import { emptyProgressState, applyClaimToProgress } from '../shared/hero/progress-state.js';
+import { validateClaimRequest, FORBIDDEN_CLAIM_FIELDS } from '../shared/hero/claim-contract.js';
+
+// ── Fixture builders ────────────────────────────────────────────────────
+
+function buildCompletedDailyState(overrides = {}) {
+  return {
+    dateKey: '2026-04-29',
+    questId: 'quest-safety-1',
+    questFingerprint: 'hero-qf-abc123def456',
+    status: 'completed',
+    completedTaskIds: ['task-a', 'task-b', 'task-c'],
+    completedAt: Date.now(),
+    effortCompleted: 3,
+    effortPlanned: 3,
+    economy: null,
+    ...overrides,
+  };
+}
+
+function buildHeroStateWithCompletedDaily(overrides = {}) {
+  return {
+    daily: buildCompletedDailyState(overrides.daily),
+    economy: overrides.economy ?? emptyEconomyState(),
+  };
+}
+
+function buildValidClaimBody(overrides = {}) {
+  return {
+    command: 'claim-task',
+    learnerId: 'learner-safety-1',
+    questId: 'quest-safety-1',
+    questFingerprint: 'hero-qf-abc123def456',
+    taskId: 'task-a',
+    requestId: 'req-safety-1',
+    expectedLearnerRevision: 5,
+    ...overrides,
+  };
+}
+
+// ── 1. Same final claim-task produces same ledger entry ID (deterministic) ──
+
+test('U8 Safety: same inputs produce identical ledger entry ID (deterministic)', () => {
+  const params = {
+    learnerId: 'learner-det-1',
+    dateKey: '2026-04-29',
+    questId: 'quest-det-1',
+    questFingerprint: 'hero-qf-000111222333',
+    economyVersion: 1,
+  };
+
+  const key1 = deriveDailyAwardKey(params);
+  const key2 = deriveDailyAwardKey(params);
+  assert.equal(key1, key2, 'Same params must produce same award key');
+
+  const id1 = deriveLedgerEntryId(key1);
+  const id2 = deriveLedgerEntryId(key2);
+  assert.equal(id1, id2, 'Same award key must produce same ledger entry ID');
+  assert.ok(id1.startsWith('hero-ledger-'), 'Ledger entry ID must start with hero-ledger-');
+});
+
+// ── 2. applyDailyCompletionCoinAward on already-awarded state → { awarded: false } ──
+
+test('U8 Safety: applyDailyCompletionCoinAward on already-awarded state returns awarded=false', () => {
+  const heroState = buildHeroStateWithCompletedDaily();
+  const nowTs = Date.now();
+
+  // First award succeeds
+  const first = applyDailyCompletionCoinAward(heroState, {
+    learnerId: 'learner-dup-1',
+    nowTs,
+    dailyCompletionCoins: HERO_DAILY_COMPLETION_COINS,
+  });
+  assert.equal(first.awarded, true);
+  assert.equal(first.amount, HERO_DAILY_COMPLETION_COINS);
+
+  // Second award on updated state returns awarded=false
+  const second = applyDailyCompletionCoinAward(first.state, {
+    learnerId: 'learner-dup-1',
+    nowTs: nowTs + 1000,
+    dailyCompletionCoins: HERO_DAILY_COMPLETION_COINS,
+  });
+  assert.equal(second.awarded, false);
+  assert.equal(second.alreadyAwarded, true);
+  assert.equal(second.amount, 0);
+});
+
+// ── 3. Two sequential award attempts on same state → first awards, second returns alreadyAwarded ──
+
+test('U8 Safety: two sequential awards — first succeeds, second blocked by ledger idempotency', () => {
+  const heroState = buildHeroStateWithCompletedDaily();
+  const nowTs = Date.now();
+
+  const first = applyDailyCompletionCoinAward(heroState, {
+    learnerId: 'learner-seq-1',
+    nowTs,
+    dailyCompletionCoins: HERO_DAILY_COMPLETION_COINS,
+  });
+  assert.equal(first.awarded, true);
+  assert.equal(first.state.economy.balance, HERO_DAILY_COMPLETION_COINS);
+  assert.equal(first.state.economy.ledger.length, 1);
+
+  const second = applyDailyCompletionCoinAward(first.state, {
+    learnerId: 'learner-seq-1',
+    nowTs: nowTs + 500,
+    dailyCompletionCoins: HERO_DAILY_COMPLETION_COINS,
+  });
+  assert.equal(second.awarded, false);
+  assert.equal(second.alreadyAwarded, true);
+  // Balance must NOT double
+  assert.equal(first.state.economy.balance, HERO_DAILY_COMPLETION_COINS);
+});
+
+// ── 4. FORBIDDEN_CLAIM_FIELDS includes economy-related field names ──
+
+test('U8 Safety: FORBIDDEN_CLAIM_FIELDS includes coins, balance, reward, economy, amount, monster, shop', () => {
+  const required = ['coins', 'balance', 'reward', 'economy', 'amount', 'monster', 'shop'];
+  for (const field of required) {
+    assert.ok(
+      FORBIDDEN_CLAIM_FIELDS.includes(field),
+      `FORBIDDEN_CLAIM_FIELDS must include '${field}'`,
+    );
+  }
+});
+
+// ── 5. Client sending ANY forbidden field gets rejected by validateClaimRequest ──
+
+test('U8 Safety: validateClaimRequest rejects each forbidden field individually', () => {
+  for (const field of FORBIDDEN_CLAIM_FIELDS) {
+    const body = buildValidClaimBody({ [field]: 'injected-value' });
+    const result = validateClaimRequest(body);
+    assert.equal(result.valid, false, `Body with '${field}' must be invalid`);
+    const relevantError = result.errors.find(e => e.includes(field));
+    assert.ok(relevantError, `Error message must mention '${field}'`);
+  }
+});
+
+// ── 6. Forged questFingerprint produces different idempotency key ──
+
+test('U8 Safety: forged questFingerprint produces different idempotency key — will not collide', () => {
+  const legitimate = deriveDailyAwardKey({
+    learnerId: 'learner-forge-1',
+    dateKey: '2026-04-29',
+    questId: 'quest-forge-1',
+    questFingerprint: 'hero-qf-real123456',
+    economyVersion: 1,
+  });
+  const forged = deriveDailyAwardKey({
+    learnerId: 'learner-forge-1',
+    dateKey: '2026-04-29',
+    questId: 'quest-forge-1',
+    questFingerprint: 'hero-qf-forged99999',
+    economyVersion: 1,
+  });
+
+  assert.notEqual(legitimate, forged, 'Different fingerprints must produce different award keys');
+  assert.notEqual(
+    deriveLedgerEntryId(legitimate),
+    deriveLedgerEntryId(forged),
+    'Different award keys must produce different ledger entry IDs',
+  );
+});
+
+// ── 7. Balance can ONLY increase through award (no negative amount) ──
+
+test('U8 Safety: daily-completion-award always uses positive HERO_DAILY_COMPLETION_COINS', () => {
+  assert.ok(HERO_DAILY_COMPLETION_COINS > 0, 'HERO_DAILY_COMPLETION_COINS must be positive');
+
+  const heroState = buildHeroStateWithCompletedDaily();
+  const result = applyDailyCompletionCoinAward(heroState, {
+    learnerId: 'learner-pos-1',
+    nowTs: Date.now(),
+    dailyCompletionCoins: HERO_DAILY_COMPLETION_COINS,
+  });
+
+  assert.equal(result.awarded, true);
+  assert.equal(result.amount, HERO_DAILY_COMPLETION_COINS);
+  assert.ok(result.state.economy.balance > 0, 'Balance must be positive after award');
+  assert.ok(result.state.economy.lifetimeEarned > 0, 'lifetimeEarned must be positive after award');
+
+  // Verify the ledger entry itself has positive amount
+  const entry = result.state.economy.ledger[0];
+  assert.ok(entry.amount > 0, 'Ledger entry amount must be positive');
+  assert.equal(entry.type, 'daily-completion-award');
+});
+
+// ── 8. Empty ledger + completed daily → canAward: true (not vacuously false) ──
+
+test('U8 Safety: canAwardDailyCompletionCoins with completed daily + empty ledger → canAward: true', () => {
+  const heroState = buildHeroStateWithCompletedDaily();
+  // Confirm the economy ledger is empty
+  assert.equal(heroState.economy.ledger.length, 0);
+  // Confirm daily is completed
+  assert.equal(heroState.daily.status, 'completed');
+  // Confirm no economy sub-block on daily
+  assert.equal(heroState.daily.economy, null);
+
+  const result = canAwardDailyCompletionCoins(heroState, true);
+  assert.equal(result.canAward, true, 'Empty ledger with completed daily must be eligible');
+  assert.equal(result.reason, 'eligible');
+});
+
+// ── 9. canAwardDailyCompletionCoins with economy disabled → canAward: false ──
+
+test('U8 Safety: canAwardDailyCompletionCoins with economy disabled → canAward: false', () => {
+  const heroState = buildHeroStateWithCompletedDaily();
+  const result = canAwardDailyCompletionCoins(heroState, false);
+  assert.equal(result.canAward, false);
+  assert.equal(result.reason, 'economy_disabled');
+});
+
+// ── 10. canAwardDailyCompletionCoins with daily null → canAward: false ──
+
+test('U8 Safety: canAwardDailyCompletionCoins with daily null → canAward: false', () => {
+  const heroState = { daily: null, economy: emptyEconomyState() };
+  const result = canAwardDailyCompletionCoins(heroState, true);
+  assert.equal(result.canAward, false);
+  assert.equal(result.reason, 'daily_null');
+});
+
+// ── 11. canAwardDailyCompletionCoins with daily active (not completed) → canAward: false ──
+
+test('U8 Safety: canAwardDailyCompletionCoins with daily active → canAward: false', () => {
+  const heroState = buildHeroStateWithCompletedDaily({ daily: { status: 'active' } });
+  const result = canAwardDailyCompletionCoins(heroState, true);
+  assert.equal(result.canAward, false);
+  assert.equal(result.reason, 'daily_not_completed');
+});
+
+// ── 12. canAwardDailyCompletionCoins with already-awarded daily.economy → canAward: false ──
+
+test('U8 Safety: canAwardDailyCompletionCoins with dailyAwardLedgerEntryId set → already_awarded', () => {
+  const heroState = buildHeroStateWithCompletedDaily({
+    daily: {
+      economy: {
+        dailyAwardStatus: 'awarded',
+        dailyAwardLedgerEntryId: 'hero-ledger-existing',
+      },
+    },
+  });
+  const result = canAwardDailyCompletionCoins(heroState, true);
+  assert.equal(result.canAward, false);
+  assert.equal(result.reason, 'already_awarded');
+});
+
+// ── 13. validateClaimRequest rejects missing required fields ──
+
+test('U8 Safety: validateClaimRequest rejects missing required fields', () => {
+  const result = validateClaimRequest({});
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.length > 0);
+});
+
+// ── 14. validateClaimRequest rejects wrong command ──
+
+test('U8 Safety: validateClaimRequest rejects wrong command', () => {
+  const body = buildValidClaimBody({ command: 'forge-coins' });
+  const result = validateClaimRequest(body);
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some(e => e.includes('command')));
+});
+
+// ── 15. validateClaimRequest accepts valid body ──
+
+test('U8 Safety: validateClaimRequest accepts valid claim body', () => {
+  const body = buildValidClaimBody();
+  const result = validateClaimRequest(body);
+  assert.equal(result.valid, true);
+  assert.equal(result.errors.length, 0);
+});
+
+// ── 16. applyClaimToProgress is no-op for already-completed task (no double-count) ──
+
+test('U8 Safety: applyClaimToProgress does not double-count already-completed tasks', () => {
+  const state = emptyProgressState();
+  const dailyState = {
+    ...state,
+    daily: {
+      dateKey: '2026-04-29',
+      questId: 'quest-dc-1',
+      questFingerprint: 'hero-qf-dc1',
+      status: 'active',
+      effortTarget: 3,
+      effortPlanned: 3,
+      effortCompleted: 0,
+      taskOrder: ['task-x'],
+      completedTaskIds: [],
+      tasks: {
+        'task-x': {
+          taskId: 'task-x',
+          questId: 'quest-dc-1',
+          subjectId: 'spelling',
+          effortTarget: 1,
+          status: 'started',
+          completedAt: null,
+        },
+      },
+      completedAt: null,
+      lastUpdatedAt: Date.now(),
+    },
+  };
+
+  const nowTs = Date.now();
+  const claimed = applyClaimToProgress(dailyState, { taskId: 'task-x', requestId: 'r1' }, nowTs);
+  assert.equal(claimed.daily.tasks['task-x'].status, 'completed');
+  assert.equal(claimed.daily.effortCompleted, 1);
+
+  // Second apply with same taskId — no double-count
+  const duplicated = applyClaimToProgress(claimed, { taskId: 'task-x', requestId: 'r2' }, nowTs + 1000);
+  assert.equal(duplicated.daily.effortCompleted, 1, 'Effort must not double-count');
+  assert.equal(duplicated.daily.completedTaskIds.length, 1, 'completedTaskIds must not duplicate');
+});

--- a/tests/hero-p4-economy-telemetry.test.js
+++ b/tests/hero-p4-economy-telemetry.test.js
@@ -1,0 +1,556 @@
+// Hero Mode P4 U9 — Economy telemetry and event mirror tests.
+//
+// Verifies structured log emission and event_log entries for all economy
+// event types: awarded, disabled, blocked, duplicate_prevented, and
+// already_awarded (on the already-completed early-return path).
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createApiPlatformRepositories } from '../src/platform/core/repositories/index.js';
+import { createWorkerRepositoryServer } from './helpers/worker-server.js';
+import { HERO_DAILY_COMPLETION_COINS } from '../shared/hero/economy.js';
+
+const HERO_COMMAND_URL = 'https://repo.test/api/hero/command';
+const HERO_READ_MODEL_URL = 'https://repo.test/api/hero/read-model';
+
+// ── Server factories ───────────────────────────────────────────────────
+
+function createEconomyServer() {
+  return createWorkerRepositoryServer({
+    env: {
+      HERO_MODE_SHADOW_ENABLED: 'true',
+      HERO_MODE_LAUNCH_ENABLED: 'true',
+      HERO_MODE_CHILD_UI_ENABLED: 'true',
+      HERO_MODE_PROGRESS_ENABLED: 'true',
+      HERO_MODE_ECONOMY_ENABLED: 'true',
+      PUNCTUATION_SUBJECT_ENABLED: 'true',
+    },
+  });
+}
+
+function createEconomyDisabledServer() {
+  return createWorkerRepositoryServer({
+    env: {
+      HERO_MODE_SHADOW_ENABLED: 'true',
+      HERO_MODE_LAUNCH_ENABLED: 'true',
+      HERO_MODE_CHILD_UI_ENABLED: 'true',
+      HERO_MODE_PROGRESS_ENABLED: 'true',
+      HERO_MODE_ECONOMY_ENABLED: 'false',
+      PUNCTUATION_SUBJECT_ENABLED: 'true',
+    },
+  });
+}
+
+// ── Fixture seeding ────────────────────────────────────────────────────
+
+const HERO_SPELLING_DATA = {
+  stats: {
+    core: { total: 50, secure: 30, due: 10, fresh: 5, trouble: 5, attempts: 200, correct: 160, accuracy: 0.8 },
+    all: { total: 50, secure: 30, due: 10, fresh: 5, trouble: 5, attempts: 200, correct: 160, accuracy: 0.8 },
+  },
+};
+
+const HERO_PUNCTUATION_DATA = {
+  availability: { status: 'ready' },
+  stats: { total: 20, secure: 8, due: 5, fresh: 3, weak: 2, attempts: 100, correct: 75, accuracy: 75 },
+};
+
+async function seedLearnerWithSubjectState(server, accountId, learnerId) {
+  const repos = createApiPlatformRepositories({
+    baseUrl: 'https://repo.test',
+    fetch: server.fetch.bind(server),
+    authSession: server.authSessionFor(accountId),
+  });
+  await repos.hydrate();
+  repos.learners.write({
+    byId: {
+      [learnerId]: {
+        id: learnerId,
+        name: 'Telemetry Test Learner',
+        yearGroup: 'Y5',
+        goal: 'sats',
+        dailyMinutes: 15,
+        avatarColor: '#3E6FA8',
+        createdAt: 1,
+      },
+    },
+    allIds: [learnerId],
+    selectedId: learnerId,
+  });
+  await repos.flush();
+
+  const now = Date.now();
+  server.DB.db.prepare(`
+    INSERT INTO child_subject_state (learner_id, subject_id, ui_json, data_json, updated_at, updated_by_account_id)
+    VALUES (?, 'spelling', '{}', ?, ?, ?)
+  `).run(learnerId, JSON.stringify(HERO_SPELLING_DATA), now, accountId);
+
+  server.DB.db.prepare(`
+    INSERT INTO child_subject_state (learner_id, subject_id, ui_json, data_json, updated_at, updated_by_account_id)
+    VALUES (?, 'punctuation', '{}', ?, ?, ?)
+  `).run(learnerId, JSON.stringify(HERO_PUNCTUATION_DATA), now, accountId);
+
+  return repos;
+}
+
+// ── Shared helpers ─────────────────────────────────────────────────────
+
+async function getReadModel(server, learnerId = 'learner-a') {
+  const response = await server.fetch(`${HERO_READ_MODEL_URL}?learnerId=${learnerId}`);
+  const payload = await response.json();
+  assert.equal(response.status, 200, `Read model returned ${response.status}: ${JSON.stringify(payload)}`);
+  assert.ok(payload.hero, 'Read model must contain hero block');
+  return payload;
+}
+
+function findFirstLaunchableTask(heroPayload) {
+  const quest = heroPayload.hero.dailyQuest;
+  if (!quest || !quest.tasks) return null;
+  const task = quest.tasks.find((t) => t.launchStatus === 'launchable');
+  if (!task) return null;
+  return {
+    questId: quest.questId,
+    questFingerprint: heroPayload.hero.questFingerprint,
+    taskId: task.taskId,
+    subjectId: task.subjectId,
+    task,
+  };
+}
+
+function getLearnerRevision(server, accountId = 'adult-a') {
+  const row = server.DB.db.prepare(
+    `SELECT lp.state_revision FROM learner_profiles lp
+     JOIN account_learner_memberships alm ON alm.learner_id = lp.id
+     WHERE alm.account_id = ?`,
+  ).get(accountId);
+  return row?.state_revision ?? 0;
+}
+
+async function postHeroCommand(server, body, accountId = 'adult-a') {
+  return server.fetchAs(accountId, HERO_COMMAND_URL, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function getHeroEvents(server) {
+  return server.DB.db.prepare(
+    `SELECT id, learner_id, event_type, event_json, created_at FROM event_log WHERE event_type LIKE 'hero.%' ORDER BY created_at`,
+  ).all();
+}
+
+/**
+ * Seeds hero progress state and a completed practice session with heroContext.
+ * Returns the task metadata needed for making a claim.
+ */
+async function seedClaimableState(server, learnerId, accountId) {
+  const readModelPayload = await getReadModel(server, learnerId);
+  const launchable = findFirstLaunchableTask(readModelPayload);
+  if (!launchable) throw new Error('No launchable task found in fixture');
+
+  const revision = getLearnerRevision(server, accountId);
+  const launchResp = await postHeroCommand(server, {
+    command: 'start-task',
+    learnerId,
+    questId: launchable.questId,
+    questFingerprint: launchable.questFingerprint,
+    taskId: launchable.taskId,
+    requestId: `telem-seed-launch-${Date.now()}`,
+    expectedLearnerRevision: revision,
+  }, accountId);
+  const launchPayload = await launchResp.json();
+  assert.equal(launchResp.status, 200, `Seed launch must succeed: ${JSON.stringify(launchPayload)}`);
+
+  // Seed a completed practice session with heroContext
+  const sessionId = `ps-telem-${Date.now().toString(36)}`;
+  const nowTs = Date.now();
+  const summaryJson = JSON.stringify({
+    heroContext: {
+      source: 'hero-mode',
+      questId: launchable.questId,
+      questFingerprint: launchable.questFingerprint,
+      taskId: launchable.taskId,
+      intent: launchable.task.intent || 'due-review',
+      launcher: launchable.task.launcher || 'smart-practice',
+    },
+    status: 'completed',
+    score: 8,
+    total: 10,
+  });
+
+  server.DB.db.prepare(`
+    INSERT INTO practice_sessions (id, learner_id, subject_id, session_kind, status, session_state_json, summary_json, created_at, updated_at)
+    VALUES (?, ?, ?, 'smart-practice', 'completed', '{}', ?, ?, ?)
+  `).run(sessionId, learnerId, launchable.subjectId, summaryJson, nowTs, nowTs);
+
+  return {
+    questId: launchable.questId,
+    questFingerprint: launchable.questFingerprint,
+    taskId: launchable.taskId,
+    subjectId: launchable.subjectId,
+    practiceSessionId: sessionId,
+    task: launchable.task,
+  };
+}
+
+/**
+ * Launches and claims ALL tasks in the quest to trigger daily completion.
+ * Returns the final claim payload and all tasks.
+ */
+async function claimAllTasks(server, learnerId, accountId) {
+  const readModelPayload = await getReadModel(server, learnerId);
+  const quest = readModelPayload.hero.dailyQuest;
+  const fingerprint = readModelPayload.hero.questFingerprint;
+  const allTasks = quest.tasks.filter(t => t.launchStatus === 'launchable');
+  if (allTasks.length < 1) throw new Error('Fixture must produce at least 1 launchable task');
+
+  const nowTs = Date.now();
+  let lastClaimPayload = null;
+
+  for (let i = 0; i < allTasks.length; i++) {
+    const task = allTasks[i];
+    const rev = getLearnerRevision(server, accountId);
+
+    // Launch
+    await postHeroCommand(server, {
+      command: 'start-task',
+      learnerId,
+      questId: quest.questId,
+      questFingerprint: fingerprint,
+      taskId: task.taskId,
+      requestId: `telem-all-launch-${i}-${Date.now()}`,
+      expectedLearnerRevision: rev,
+    }, accountId);
+
+    // Seed practice session
+    const sessionId = `ps-telem-all-${i}-${Date.now().toString(36)}`;
+    const summaryJson = JSON.stringify({
+      heroContext: {
+        source: 'hero-mode',
+        questId: quest.questId,
+        questFingerprint: fingerprint,
+        taskId: task.taskId,
+        intent: task.intent || 'due-review',
+        launcher: task.launcher || 'smart-practice',
+      },
+      status: 'completed',
+    });
+    server.DB.db.prepare(`
+      INSERT INTO practice_sessions (id, learner_id, subject_id, session_kind, status, session_state_json, summary_json, created_at, updated_at)
+      VALUES (?, ?, ?, 'smart-practice', 'completed', '{}', ?, ?, ?)
+    `).run(sessionId, learnerId, task.subjectId, summaryJson, nowTs + i, nowTs + i);
+
+    // Claim
+    const claimRev = getLearnerRevision(server, accountId);
+    const claimResp = await postHeroCommand(server, {
+      command: 'claim-task',
+      learnerId,
+      questId: quest.questId,
+      questFingerprint: fingerprint,
+      taskId: task.taskId,
+      requestId: `telem-all-claim-${i}-${Date.now()}`,
+      expectedLearnerRevision: claimRev,
+    }, accountId);
+    lastClaimPayload = await claimResp.json();
+    assert.equal(claimResp.status, 200, `Claim ${i} must succeed: ${JSON.stringify(lastClaimPayload)}`);
+  }
+
+  return { lastClaimPayload, allTasks, quest, fingerprint };
+}
+
+// ── Helper: capture structured logs during a callback ──────────────────
+
+function captureStructuredLogs(fn) {
+  const logs = [];
+  const originalLog = console.log;
+  console.log = (...args) => {
+    logs.push(args.join(' '));
+  };
+  const restore = () => { console.log = originalLog; };
+  return fn().then((result) => {
+    restore();
+    return { result, logs };
+  }).catch((err) => {
+    restore();
+    throw err;
+  });
+}
+
+function findLogEvent(logs, eventName) {
+  for (const l of logs) {
+    try {
+      const parsed = JSON.parse(l);
+      if (parsed.event === eventName) return parsed;
+    } catch { /* skip non-JSON */ }
+  }
+  return null;
+}
+
+function findAllLogEvents(logs, eventName) {
+  const results = [];
+  for (const l of logs) {
+    try {
+      const parsed = JSON.parse(l);
+      if (parsed.event === eventName) results.push(parsed);
+    } catch { /* skip non-JSON */ }
+  }
+  return results;
+}
+
+// ── 1. Successful award emits hero_daily_coins_awarded with full fields ───
+
+test('U9: hero_daily_coins_awarded log contains learnerId, questId, amount, balanceAfter, ledgerEntryId', async () => {
+  const server = createEconomyServer();
+  await seedLearnerWithSubjectState(server, 'adult-a', 'learner-a');
+
+  const { logs } = await captureStructuredLogs(async () => {
+    await claimAllTasks(server, 'learner-a', 'adult-a');
+  });
+
+  const awarded = findLogEvent(logs, 'hero_daily_coins_awarded');
+  assert.ok(awarded, 'hero_daily_coins_awarded log must be emitted');
+  assert.equal(awarded.learnerId, 'learner-a');
+  assert.ok(awarded.questId, 'questId must be populated');
+  assert.equal(awarded.amount, HERO_DAILY_COMPLETION_COINS);
+  assert.ok(awarded.balanceAfter >= HERO_DAILY_COMPLETION_COINS);
+  assert.ok(awarded.ledgerEntryId, 'ledgerEntryId must be present');
+  assert.ok(awarded.ledgerEntryId.startsWith('hero-ledger-'), 'ledgerEntryId must start with hero-ledger-');
+
+  server.close();
+});
+
+// ── 2. Event mirror row uses deterministic ID (hero-evt-<ledgerEntryId>) ──
+
+test('U9: event_log entry for hero.coins.awarded uses deterministic ID hero-evt-<ledgerEntryId>', async () => {
+  const server = createEconomyServer();
+  await seedLearnerWithSubjectState(server, 'adult-a', 'learner-a');
+  await claimAllTasks(server, 'learner-a', 'adult-a');
+
+  const events = getHeroEvents(server);
+  const coinsEvent = events.find(e => e.event_type === 'hero.coins.awarded');
+  assert.ok(coinsEvent, 'hero.coins.awarded event must exist');
+
+  // The ID must be hero-evt-<ledgerEntryId>
+  const eventData = JSON.parse(coinsEvent.event_json);
+  assert.ok(eventData.ledgerEntryId, 'event must contain ledgerEntryId');
+  assert.equal(coinsEvent.id, `hero-evt-${eventData.ledgerEntryId}`);
+
+  // Verify full event data
+  assert.equal(eventData.amount, HERO_DAILY_COMPLETION_COINS);
+  assert.ok(eventData.balanceAfter >= HERO_DAILY_COMPLETION_COINS);
+  assert.ok(eventData.dateKey, 'dateKey must be present');
+  assert.ok(eventData.questId, 'questId must be present');
+
+  server.close();
+});
+
+// ── 3. Duplicate event insert (ON CONFLICT DO NOTHING) → no error ─────
+
+test('U9: duplicate event_log insert with same deterministic ID produces no error', async () => {
+  const server = createEconomyServer();
+  await seedLearnerWithSubjectState(server, 'adult-a', 'learner-a');
+  await claimAllTasks(server, 'learner-a', 'adult-a');
+
+  const events = getHeroEvents(server);
+  const coinsEvent = events.find(e => e.event_type === 'hero.coins.awarded');
+  assert.ok(coinsEvent, 'hero.coins.awarded event must exist');
+
+  // Manually attempt to insert the same event ID again — must not throw
+  const duplicateInsert = () => server.DB.db.prepare(`
+    INSERT INTO event_log (id, learner_id, subject_id, system_id, event_type, event_json, created_at, actor_account_id)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(id) DO NOTHING
+  `).run(
+    coinsEvent.id,
+    coinsEvent.learner_id,
+    null,
+    'hero-mode',
+    'hero.coins.awarded',
+    coinsEvent.event_json,
+    Date.now(),
+    'adult-a',
+  );
+  assert.doesNotThrow(duplicateInsert, 'ON CONFLICT DO NOTHING must not throw');
+
+  // Verify still only one row
+  const eventsAfter = getHeroEvents(server);
+  const coinsEventsAfter = eventsAfter.filter(e => e.event_type === 'hero.coins.awarded');
+  assert.equal(coinsEventsAfter.length, 1, 'Only one coins event must exist after duplicate insert');
+
+  server.close();
+});
+
+// ── 4. Already-awarded emits hero_task_claim_already_completed with coins flag ──
+
+test('U9: already-awarded path emits hero_task_claim_already_completed with hero_daily_coins_already_awarded', async () => {
+  const server = createEconomyServer();
+  await seedLearnerWithSubjectState(server, 'adult-a', 'learner-a');
+
+  const { quest, fingerprint, allTasks } = await claimAllTasks(server, 'learner-a', 'adult-a');
+
+  // Now re-claim the last task — triggers already-completed path
+  const lastTask = allTasks[allTasks.length - 1];
+  const revision = getLearnerRevision(server);
+
+  const { logs } = await captureStructuredLogs(async () => {
+    await postHeroCommand(server, {
+      command: 'claim-task',
+      learnerId: 'learner-a',
+      questId: quest.questId,
+      questFingerprint: fingerprint,
+      taskId: lastTask.taskId,
+      requestId: `telem-already-${Date.now()}`,
+      expectedLearnerRevision: revision,
+    });
+  });
+
+  const alreadyLog = findLogEvent(logs, 'hero_task_claim_already_completed');
+  assert.ok(alreadyLog, 'hero_task_claim_already_completed log must be emitted');
+  assert.equal(alreadyLog.learnerId, 'learner-a');
+  assert.equal(alreadyLog.hero_daily_coins_already_awarded, true);
+
+  server.close();
+});
+
+// ── 5. Economy disabled emits hero_daily_coins_disabled log ─────────────
+
+test('U9: economy disabled emits hero_daily_coins_disabled on claim-task', async () => {
+  const server = createEconomyDisabledServer();
+  await seedLearnerWithSubjectState(server, 'adult-a', 'learner-a');
+  const claimable = await seedClaimableState(server, 'learner-a', 'adult-a');
+
+  const revision = getLearnerRevision(server);
+  const { logs } = await captureStructuredLogs(async () => {
+    await postHeroCommand(server, {
+      command: 'claim-task',
+      learnerId: 'learner-a',
+      questId: claimable.questId,
+      questFingerprint: claimable.questFingerprint,
+      taskId: claimable.taskId,
+      requestId: `telem-disabled-${Date.now()}`,
+      expectedLearnerRevision: revision,
+    });
+  });
+
+  const disabledLog = findLogEvent(logs, 'hero_daily_coins_disabled');
+  assert.ok(disabledLog, 'hero_daily_coins_disabled log must be emitted');
+  assert.equal(disabledLog.learnerId, 'learner-a');
+  assert.equal(disabledLog.questId, claimable.questId);
+  assert.equal(disabledLog.taskId, claimable.taskId);
+
+  server.close();
+});
+
+// ── 6. Non-final claim with economy enabled emits hero_daily_coins_blocked ──
+
+test('U9: non-final claim emits hero_daily_coins_blocked with reason daily_not_completed', async () => {
+  const server = createEconomyServer();
+  await seedLearnerWithSubjectState(server, 'adult-a', 'learner-a');
+  const claimable = await seedClaimableState(server, 'learner-a', 'adult-a');
+
+  // Check that there is more than 1 launchable task
+  const readModel = await getReadModel(server, 'learner-a');
+  const quest = readModel.hero.dailyQuest;
+  const remaining = quest.tasks.filter(t => t.launchStatus === 'launchable' || t.launchStatus === 'started').length;
+
+  // If only 1 task, this claim completes the daily — skip (covered by test 1)
+  if (remaining <= 1) {
+    server.close();
+    return;
+  }
+
+  const revision = getLearnerRevision(server);
+  const { logs } = await captureStructuredLogs(async () => {
+    await postHeroCommand(server, {
+      command: 'claim-task',
+      learnerId: 'learner-a',
+      questId: claimable.questId,
+      questFingerprint: claimable.questFingerprint,
+      taskId: claimable.taskId,
+      requestId: `telem-blocked-${Date.now()}`,
+      expectedLearnerRevision: revision,
+    });
+  });
+
+  const blockedLog = findLogEvent(logs, 'hero_daily_coins_blocked');
+  assert.ok(blockedLog, 'hero_daily_coins_blocked log must be emitted for non-final claim');
+  assert.equal(blockedLog.learnerId, 'learner-a');
+  assert.equal(blockedLog.questId, claimable.questId);
+  assert.equal(blockedLog.taskId, claimable.taskId);
+  assert.equal(blockedLog.reason, 'daily_not_completed');
+
+  server.close();
+});
+
+// ── 7. hero_daily_coins_awarded is emitted exactly once per daily completion ──
+
+test('U9: hero_daily_coins_awarded emitted exactly once across all task claims', async () => {
+  const server = createEconomyServer();
+  await seedLearnerWithSubjectState(server, 'adult-a', 'learner-a');
+
+  const { logs } = await captureStructuredLogs(async () => {
+    await claimAllTasks(server, 'learner-a', 'adult-a');
+  });
+
+  const awardedLogs = findAllLogEvents(logs, 'hero_daily_coins_awarded');
+  assert.equal(awardedLogs.length, 1, 'hero_daily_coins_awarded must fire exactly once');
+
+  server.close();
+});
+
+// ── 8. hero_task_claim_succeeded always emitted on successful claim ────
+
+test('U9: hero_task_claim_succeeded emitted for each successful claim', async () => {
+  const server = createEconomyServer();
+  await seedLearnerWithSubjectState(server, 'adult-a', 'learner-a');
+
+  const { logs } = await captureStructuredLogs(async () => {
+    await claimAllTasks(server, 'learner-a', 'adult-a');
+  });
+
+  const succeedLogs = findAllLogEvents(logs, 'hero_task_claim_succeeded');
+  assert.ok(succeedLogs.length >= 1, 'At least one hero_task_claim_succeeded log must be emitted');
+
+  // Each must contain the required fields
+  for (const log of succeedLogs) {
+    assert.equal(log.learnerId, 'learner-a');
+    assert.ok(log.questId, 'questId must be populated');
+    assert.ok(log.taskId, 'taskId must be populated');
+    assert.ok(log.subjectId, 'subjectId must be populated');
+    assert.ok(log.dailyStatus, 'dailyStatus must be populated');
+  }
+
+  // The final claim's dailyStatus must be 'completed'
+  const lastSucceed = succeedLogs[succeedLogs.length - 1];
+  assert.equal(lastSucceed.dailyStatus, 'completed');
+
+  server.close();
+});
+
+// ── 9. Event mirror rows include both hero.task.completed and hero.daily.completed ──
+
+test('U9: event_log contains hero.task.completed and hero.daily.completed after full daily', async () => {
+  const server = createEconomyServer();
+  await seedLearnerWithSubjectState(server, 'adult-a', 'learner-a');
+  await claimAllTasks(server, 'learner-a', 'adult-a');
+
+  const events = getHeroEvents(server);
+
+  const taskEvents = events.filter(e => e.event_type === 'hero.task.completed');
+  assert.ok(taskEvents.length >= 1, 'At least one hero.task.completed event must exist');
+
+  const dailyEvent = events.find(e => e.event_type === 'hero.daily.completed');
+  assert.ok(dailyEvent, 'hero.daily.completed event must exist');
+
+  const dailyData = JSON.parse(dailyEvent.event_json);
+  assert.ok(dailyData.data.questId, 'questId in daily event');
+  assert.ok(dailyData.data.dateKey, 'dateKey in daily event');
+
+  // Coins event must also exist
+  const coinsEvent = events.find(e => e.event_type === 'hero.coins.awarded');
+  assert.ok(coinsEvent, 'hero.coins.awarded event must exist');
+
+  server.close();
+});

--- a/tests/hero-p4-economy-ui.test.js
+++ b/tests/hero-p4-economy-ui.test.js
@@ -1,0 +1,296 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { buildHeroHomeModel } from '../src/platform/hero/hero-ui-model.js';
+import { HERO_ECONOMY_COPY, HERO_FORBIDDEN_VOCABULARY } from '../shared/hero/hero-copy.js';
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+/** V5 read model with economy block enabled. */
+function v5ReadModel({
+  coinsEnabled = true,
+  balance = 500,
+  coinsAwarded = 100,
+  awardStatus = 'awarded',
+  dailyStatus = 'completed',
+} = {}) {
+  return {
+    version: 5,
+    childVisible: true,
+    coinsEnabled,
+    ui: { enabled: true, surface: 'dashboard', reason: 'enabled', copyVersion: 'hero-p2-copy-v1' },
+    dailyQuest: { questId: 'quest-001', effortPlanned: 6, tasks: [] },
+    activeHeroSession: null,
+    eligibleSubjects: ['spelling', 'grammar'],
+    progress: { status: dailyStatus, effortCompleted: 6, completedTaskIds: ['t1'] },
+    claim: { enabled: false },
+    economy: {
+      balance,
+      today: { coinsAwarded, awardStatus },
+    },
+  };
+}
+
+/** V4 read model (no economy block). */
+function v4ReadModel() {
+  return {
+    version: 4,
+    childVisible: true,
+    ui: { enabled: true, surface: 'dashboard', reason: 'enabled', copyVersion: 'hero-p2-copy-v1' },
+    dailyQuest: { questId: 'quest-001', effortPlanned: 6, tasks: [] },
+    activeHeroSession: null,
+    eligibleSubjects: ['spelling', 'grammar'],
+    progress: { status: 'completed', effortCompleted: 6, completedTaskIds: ['t1'] },
+    claim: { enabled: false },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// buildHeroHomeModel — economy field derivation
+// ---------------------------------------------------------------------------
+
+describe('buildHeroHomeModel — economy fields (P4 U6)', () => {
+  it('v5 read model with economy enabled returns correct economy fields', () => {
+    const heroUi = { status: 'ready', readModel: v5ReadModel() };
+    const result = buildHeroHomeModel(heroUi);
+
+    assert.equal(result.coinsEnabled, true);
+    assert.equal(result.coinBalance, 500);
+    assert.equal(result.coinsAwardedToday, 100);
+    assert.equal(result.dailyAwardStatus, 'awarded');
+    assert.equal(result.showCoinsAwarded, true);
+    assert.equal(result.showCoinBalance, true);
+  });
+
+  it('v4 read model (no economy block) returns coinsEnabled: false', () => {
+    const heroUi = { status: 'ready', readModel: v4ReadModel() };
+    const result = buildHeroHomeModel(heroUi);
+
+    assert.equal(result.coinsEnabled, false);
+    assert.equal(result.coinBalance, 0);
+    assert.equal(result.coinsAwardedToday, 0);
+    assert.equal(result.dailyAwardStatus, 'not-eligible');
+    assert.equal(result.showCoinsAwarded, false);
+    assert.equal(result.showCoinBalance, false);
+  });
+
+  it('daily complete + economy on → showCoinsAwarded: true, correct balance', () => {
+    const heroUi = {
+      status: 'ready',
+      readModel: v5ReadModel({ balance: 700, coinsAwarded: 100, awardStatus: 'awarded' }),
+    };
+    const result = buildHeroHomeModel(heroUi);
+
+    assert.equal(result.dailyStatus, 'completed');
+    assert.equal(result.showCoinsAwarded, true);
+    assert.equal(result.coinBalance, 700);
+    assert.equal(result.coinsAwardedToday, 100);
+  });
+
+  it('daily complete + economy off → showCoinsAwarded: false', () => {
+    const heroUi = {
+      status: 'ready',
+      readModel: v5ReadModel({ coinsEnabled: false }),
+    };
+    const result = buildHeroHomeModel(heroUi);
+
+    assert.equal(result.dailyStatus, 'completed');
+    assert.equal(result.showCoinsAwarded, false);
+    assert.equal(result.coinsEnabled, false);
+    assert.equal(result.coinBalance, 0);
+  });
+
+  it('economy on but award not yet issued (status=available) → showCoinsAwarded: false', () => {
+    const heroUi = {
+      status: 'ready',
+      readModel: v5ReadModel({ awardStatus: 'available', coinsAwarded: 0 }),
+    };
+    const result = buildHeroHomeModel(heroUi);
+
+    assert.equal(result.coinsEnabled, true);
+    assert.equal(result.dailyAwardStatus, 'available');
+    assert.equal(result.showCoinsAwarded, false);
+  });
+
+  it('zero balance displays correctly (first day, coinsAwardedToday=100, coinBalance=100)', () => {
+    const heroUi = {
+      status: 'ready',
+      readModel: v5ReadModel({ balance: 100, coinsAwarded: 100, awardStatus: 'awarded' }),
+    };
+    const result = buildHeroHomeModel(heroUi);
+
+    assert.equal(result.coinBalance, 100);
+    assert.equal(result.coinsAwardedToday, 100);
+    assert.equal(result.showCoinsAwarded, true);
+  });
+
+  it('coinsEnabled true but economy block missing → safe defaults', () => {
+    const rm = v5ReadModel();
+    delete rm.economy;
+    const heroUi = { status: 'ready', readModel: rm };
+    const result = buildHeroHomeModel(heroUi);
+
+    assert.equal(result.coinsEnabled, true);
+    assert.equal(result.coinBalance, 0);
+    assert.equal(result.coinsAwardedToday, 0);
+    assert.equal(result.dailyAwardStatus, 'not-eligible');
+    assert.equal(result.showCoinsAwarded, false);
+  });
+
+  it('economy block present but coinsEnabled false → fields are zeroed', () => {
+    const rm = v5ReadModel({ coinsEnabled: false });
+    // Still has economy block in the read model
+    rm.economy = { balance: 999, today: { coinsAwarded: 100, awardStatus: 'awarded' } };
+    const heroUi = { status: 'ready', readModel: rm };
+    const result = buildHeroHomeModel(heroUi);
+
+    assert.equal(result.coinsEnabled, false);
+    assert.equal(result.coinBalance, 0);
+    assert.equal(result.coinsAwardedToday, 0);
+    assert.equal(result.showCoinsAwarded, false);
+    assert.equal(result.showCoinBalance, false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HeroQuestCard — economy rendering (structural assertions via source scan)
+// ---------------------------------------------------------------------------
+
+describe('HeroQuestCard — economy rendering (P4 U6)', () => {
+  const cardSource = readFileSync(
+    resolve(import.meta.dirname, '..', 'src', 'surfaces', 'home', 'HeroQuestCard.jsx'),
+    'utf8',
+  );
+
+  it('HeroQuestCard imports HERO_ECONOMY_COPY', () => {
+    assert.ok(
+      cardSource.includes('HERO_ECONOMY_COPY'),
+      'HeroQuestCard must import HERO_ECONOMY_COPY',
+    );
+  });
+
+  it('HeroQuestCard renders economy block when showCoinsAwarded is true', () => {
+    assert.ok(
+      cardSource.includes('hero.showCoinsAwarded'),
+      'HeroQuestCard must branch on hero.showCoinsAwarded',
+    );
+    assert.ok(
+      cardSource.includes('hero-quest-card__economy'),
+      'HeroQuestCard must have an economy container class',
+    );
+    assert.ok(
+      cardSource.includes('hero-quest-card__coins-added'),
+      'HeroQuestCard must render coins-added element',
+    );
+    assert.ok(
+      cardSource.includes('hero-quest-card__coin-balance'),
+      'HeroQuestCard must render coin-balance element',
+    );
+  });
+
+  it('HeroQuestCard renders P3 dailyCompleteDetail when economy is off', () => {
+    assert.ok(
+      cardSource.includes('!hero.showCoinsAwarded'),
+      'HeroQuestCard must handle showCoinsAwarded=false with P3 copy',
+    );
+    assert.ok(
+      cardSource.includes('HERO_PROGRESS_COPY.dailyCompleteDetail'),
+      'HeroQuestCard must show dailyCompleteDetail when economy is off',
+    );
+  });
+
+  it('HeroQuestCard uses coinsAwardedToday and coinBalance from hero model', () => {
+    assert.ok(
+      cardSource.includes('hero.coinsAwardedToday'),
+      'HeroQuestCard must display coinsAwardedToday',
+    );
+    assert.ok(
+      cardSource.includes('hero.coinBalance'),
+      'HeroQuestCard must display coinBalance',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HeroTaskBanner — MUST remain economy-free
+// ---------------------------------------------------------------------------
+
+describe('HeroTaskBanner — no economy vocabulary (P4 U6)', () => {
+  const bannerSourceRaw = readFileSync(
+    resolve(import.meta.dirname, '..', 'src', 'surfaces', 'subject', 'HeroTaskBanner.jsx'),
+    'utf8',
+  );
+
+  // Strip block comments (/** ... */) and line comments (// ...) to scan
+  // only executable code and string literals — JSDoc may reference economy
+  // terms when documenting what the banner does NOT render.
+  const bannerSource = bannerSourceRaw
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/.*$/gm, '');
+
+  it('HeroTaskBanner does not import HERO_ECONOMY_COPY', () => {
+    assert.ok(
+      !bannerSource.includes('HERO_ECONOMY_COPY'),
+      'HeroTaskBanner must NOT import economy copy',
+    );
+  });
+
+  it('HeroTaskBanner contains no economy-related class names', () => {
+    const economyPatterns = ['economy', 'coin', 'balance', 'award'];
+    for (const pattern of economyPatterns) {
+      assert.ok(
+        !bannerSource.toLowerCase().includes(pattern),
+        `HeroTaskBanner must not contain "${pattern}"`,
+      );
+    }
+  });
+
+  it('HeroTaskBanner source passes forbidden vocabulary scan', () => {
+    const lower = bannerSource.toLowerCase();
+    for (const token of HERO_FORBIDDEN_VOCABULARY) {
+      const tokenLower = token.toLowerCase();
+      const found = tokenLower.includes(' ')
+        ? lower.includes(tokenLower)
+        : new RegExp(`\\b${tokenLower}\\b`).test(lower);
+      assert.ok(
+        !found,
+        `HeroTaskBanner contains forbidden economy token "${token}"`,
+      );
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HERO_ECONOMY_COPY — structural assertions
+// ---------------------------------------------------------------------------
+
+describe('HERO_ECONOMY_COPY — structure (P4 U6)', () => {
+  it('is frozen', () => {
+    assert.ok(Object.isFrozen(HERO_ECONOMY_COPY));
+  });
+
+  it('has all required keys', () => {
+    const requiredKeys = ['coinsAdded', 'coinsAddedDetail', 'balanceLabel', 'savedForCamp', 'dailyAvailable'];
+    for (const key of requiredKeys) {
+      assert.ok(key in HERO_ECONOMY_COPY, `Missing key: ${key}`);
+      assert.equal(typeof HERO_ECONOMY_COPY[key], 'string');
+      assert.ok(HERO_ECONOMY_COPY[key].length > 0, `${key} must be non-empty`);
+    }
+  });
+
+  it('uses calm, non-pressurising language (no shop/deal/streak/loot)', () => {
+    const pressureTokens = ['shop', 'deal', 'streak', 'loot', 'grind', 'jackpot', 'limited time'];
+    for (const [key, text] of Object.entries(HERO_ECONOMY_COPY)) {
+      const lower = text.toLowerCase();
+      for (const token of pressureTokens) {
+        assert.ok(
+          !lower.includes(token),
+          `HERO_ECONOMY_COPY['${key}'] must not contain pressure token "${token}"`,
+        );
+      }
+    }
+  });
+});

--- a/tests/hero-p4-read-model.test.js
+++ b/tests/hero-p4-read-model.test.js
@@ -263,7 +263,7 @@ test('today.awardStatus = available before daily coin award', () => {
 
   const model = buildV5({ heroProgressState: progressState });
 
-  assert.equal(model.economy.today.awardStatus, 'available');
+  assert.equal(model.economy.today.awardStatus, 'in-progress');
   assert.equal(model.economy.today.coinsAwarded, 0);
   assert.equal(model.economy.today.ledgerEntryId, null);
   assert.equal(model.economy.today.awardedAt, null);

--- a/tests/hero-p4-read-model.test.js
+++ b/tests/hero-p4-read-model.test.js
@@ -1,0 +1,491 @@
+// Hero Mode P4 U5 — Read model v5 with child-safe economy fields.
+//
+// Tests verify that the read model correctly evolves to v5 when economy
+// is enabled, exposes child-safe economy fields, handles edge cases
+// gracefully, and preserves v4 behaviour when economy is disabled.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildHeroShadowReadModel } from '../worker/src/hero/read-model.js';
+import { normaliseHeroProgressState, emptyProgressState } from '../shared/hero/progress-state.js';
+import { HERO_DAILY_COMPLETION_COINS, HERO_ECONOMY_VERSION } from '../shared/hero/economy.js';
+
+// ── Fixture helpers ───────────────────────────────────────────────────
+
+const BASE_ENV = {
+  HERO_MODE_SHADOW_ENABLED: 'true',
+  HERO_MODE_LAUNCH_ENABLED: 'true',
+  HERO_MODE_CHILD_UI_ENABLED: 'true',
+};
+
+const PROGRESS_ENV = {
+  ...BASE_ENV,
+  HERO_MODE_PROGRESS_ENABLED: 'true',
+};
+
+const ECONOMY_ENV = {
+  ...PROGRESS_ENV,
+  HERO_MODE_ECONOMY_ENABLED: 'true',
+};
+
+const SPELLING_DATA = {
+  stats: {
+    core: { total: 50, secure: 30, due: 10, fresh: 5, trouble: 5, attempts: 200, correct: 160, accuracy: 0.8 },
+    all: { total: 50, secure: 30, due: 10, fresh: 5, trouble: 5, attempts: 200, correct: 160, accuracy: 0.8 },
+  },
+};
+
+const PUNCTUATION_DATA = {
+  availability: { status: 'ready' },
+  stats: { total: 20, secure: 8, due: 5, fresh: 3, weak: 2, attempts: 100, correct: 75, accuracy: 75 },
+};
+
+function makeSubjectReadModels() {
+  return {
+    spelling: { data: SPELLING_DATA, ui: {} },
+    punctuation: { data: PUNCTUATION_DATA, ui: {} },
+  };
+}
+
+function buildV4(overrides = {}) {
+  return buildHeroShadowReadModel({
+    learnerId: 'learner-1',
+    accountId: 'account-1',
+    subjectReadModels: makeSubjectReadModels(),
+    now: Date.now(),
+    env: PROGRESS_ENV,
+    progressEnabled: true,
+    economyEnabled: false,
+    heroProgressState: null,
+    recentCompletedSessions: [],
+    ...overrides,
+  });
+}
+
+function buildV5(overrides = {}) {
+  return buildHeroShadowReadModel({
+    learnerId: 'learner-1',
+    accountId: 'account-1',
+    subjectReadModels: makeSubjectReadModels(),
+    now: Date.now(),
+    env: ECONOMY_ENV,
+    progressEnabled: true,
+    economyEnabled: true,
+    heroProgressState: null,
+    recentCompletedSessions: [],
+    ...overrides,
+  });
+}
+
+function buildProgressState(model, overrides = {}) {
+  const daily = model.dailyQuest;
+  const tasks = {};
+  const taskOrder = [];
+  for (const task of daily.tasks) {
+    taskOrder.push(task.taskId);
+    tasks[task.taskId] = {
+      taskId: task.taskId,
+      questId: daily.questId,
+      questFingerprint: model.questFingerprint,
+      dateKey: model.dateKey,
+      subjectId: task.subjectId,
+      intent: task.intent,
+      launcher: task.launcher,
+      effortTarget: task.effortTarget || 0,
+      status: 'planned',
+      launchRequestId: null,
+      claimRequestId: null,
+      startedAt: null,
+      completedAt: null,
+      subjectPracticeSessionId: null,
+      evidence: null,
+      ...((overrides.taskOverrides || {})[task.taskId] || {}),
+    };
+  }
+  return normaliseHeroProgressState({
+    version: 1,
+    daily: {
+      dateKey: model.dateKey,
+      timezone: model.timezone,
+      questId: daily.questId,
+      questFingerprint: model.questFingerprint,
+      schedulerVersion: model.schedulerVersion,
+      status: overrides.dailyStatus || 'active',
+      effortTarget: daily.effortTarget,
+      effortPlanned: daily.effortPlanned,
+      effortCompleted: overrides.effortCompleted || 0,
+      taskOrder,
+      completedTaskIds: overrides.completedTaskIds || [],
+      tasks,
+      generatedAt: Date.now() - 10000,
+      firstStartedAt: overrides.firstStartedAt || null,
+      completedAt: overrides.completedAt || null,
+      lastUpdatedAt: Date.now(),
+    },
+    recentClaims: [],
+  });
+}
+
+// ── V5 shape: economy enabled ─────────────────────────────────────────
+
+test('economy enabled → version 5, economy block present with correct balance', () => {
+  const model = buildV5();
+
+  assert.equal(model.version, 5);
+  assert.equal(model.coinsEnabled, true);
+  assert.ok(model.economy, 'economy block must be present');
+  assert.equal(model.economy.enabled, true);
+  assert.equal(model.economy.version, HERO_ECONOMY_VERSION);
+  assert.equal(model.economy.balance, 0);
+  assert.equal(model.economy.lifetimeEarned, 0);
+  assert.equal(model.economy.lifetimeSpent, 0);
+});
+
+test('economy enabled with balance → economy.balance reflects persisted state', () => {
+  const baseModel = buildV5();
+  const progressState = buildProgressState(baseModel, {
+    dailyStatus: 'completed',
+    completedAt: Date.now() - 5000,
+  });
+
+  // Add economy state to progress
+  progressState.economy = {
+    version: 1,
+    balance: 300,
+    lifetimeEarned: 500,
+    lifetimeSpent: 200,
+    ledger: [
+      { entryId: 'e1', type: 'daily-completion-award', amount: 100, dateKey: '2026-04-27', createdAt: Date.now() - 172800000 },
+      { entryId: 'e2', type: 'daily-completion-award', amount: 100, dateKey: '2026-04-28', createdAt: Date.now() - 86400000 },
+      { entryId: 'e3', type: 'daily-completion-award', amount: 100, dateKey: '2026-04-29', createdAt: Date.now() - 1000 },
+    ],
+    lastUpdatedAt: Date.now() - 1000,
+  };
+
+  const model = buildV5({ heroProgressState: progressState });
+
+  assert.equal(model.economy.balance, 300);
+  assert.equal(model.economy.lifetimeEarned, 500);
+  assert.equal(model.economy.lifetimeSpent, 200);
+  assert.equal(model.economy.recentLedger.length, 3);
+});
+
+// ── V4 shape: economy disabled ────────────────────────────────────────
+
+test('economy disabled → version 4, coinsEnabled: false, no economy block', () => {
+  const model = buildV4();
+
+  assert.equal(model.version, 4);
+  assert.equal(model.coinsEnabled, false);
+  assert.equal('economy' in model, false, 'No economy block in v4');
+});
+
+test('economy disabled still returns all v4 fields', () => {
+  const model = buildV4();
+
+  assert.equal(model.mode, 'progress');
+  assert.ok(model.progress);
+  assert.ok(model.claim);
+  assert.ok(model.launch);
+  assert.equal(model.writesEnabled, true);
+});
+
+// ── today.awardStatus scenarios ───────────────────────────────────────
+
+test('today.awardStatus = awarded after daily completion with coins', () => {
+  const baseModel = buildV5();
+  const tasks = baseModel.dailyQuest.tasks;
+  const taskOverrides = {};
+  const completedIds = [];
+
+  for (const task of tasks) {
+    taskOverrides[task.taskId] = {
+      status: 'completed',
+      completedAt: Date.now() - 5000,
+      claimRequestId: `claim-${task.taskId}`,
+    };
+    completedIds.push(task.taskId);
+  }
+
+  const progressState = buildProgressState(baseModel, {
+    taskOverrides,
+    completedTaskIds: completedIds,
+    dailyStatus: 'completed',
+    completedAt: Date.now() - 1000,
+  });
+
+  // Add economy with awarded status
+  progressState.economy = {
+    version: 1,
+    balance: 100,
+    lifetimeEarned: 100,
+    lifetimeSpent: 0,
+    ledger: [
+      { entryId: 'award-1', type: 'daily-completion-award', amount: 100, dateKey: baseModel.dateKey, createdAt: Date.now() - 500 },
+    ],
+    lastUpdatedAt: Date.now() - 500,
+  };
+
+  // Mark daily economy as awarded
+  progressState.daily.economy = {
+    dailyAwardStatus: 'awarded',
+    dailyAwardCoinsAvailable: HERO_DAILY_COMPLETION_COINS,
+    dailyAwardCoinsAwarded: HERO_DAILY_COMPLETION_COINS,
+    dailyAwardLedgerEntryId: 'award-1',
+    dailyAwardedAt: Date.now() - 500,
+    dailyAwardReason: 'daily-completion',
+  };
+
+  const model = buildV5({ heroProgressState: progressState });
+
+  assert.equal(model.economy.today.awardStatus, 'awarded');
+  assert.equal(model.economy.today.coinsAwarded, HERO_DAILY_COMPLETION_COINS);
+  assert.equal(model.economy.today.ledgerEntryId, 'award-1');
+  assert.ok(model.economy.today.awardedAt > 0);
+});
+
+test('today.awardStatus = available before daily coin award', () => {
+  const baseModel = buildV5();
+  const progressState = buildProgressState(baseModel, {
+    dailyStatus: 'active',
+  });
+
+  // Add economy state (no daily award yet)
+  progressState.economy = {
+    version: 1,
+    balance: 0,
+    lifetimeEarned: 0,
+    lifetimeSpent: 0,
+    ledger: [],
+    lastUpdatedAt: null,
+  };
+
+  const model = buildV5({ heroProgressState: progressState });
+
+  assert.equal(model.economy.today.awardStatus, 'available');
+  assert.equal(model.economy.today.coinsAwarded, 0);
+  assert.equal(model.economy.today.ledgerEntryId, null);
+  assert.equal(model.economy.today.awardedAt, null);
+});
+
+test('today.awardStatus = not-eligible when no daily state', () => {
+  const model = buildV5({ heroProgressState: null });
+
+  assert.equal(model.economy.today.awardStatus, 'not-eligible');
+});
+
+// ── Economy state persists but hidden when flag off ────────────────────
+
+test('economy state persists internally but hidden when flag off', () => {
+  const baseModel = buildV4();
+  const progressState = buildProgressState(baseModel);
+
+  // Learner has earned coins previously but flag is now off
+  progressState.economy = {
+    version: 1,
+    balance: 500,
+    lifetimeEarned: 500,
+    lifetimeSpent: 0,
+    ledger: [
+      { entryId: 'e1', type: 'daily-completion-award', amount: 100, dateKey: '2026-04-25', createdAt: Date.now() - 400000 },
+    ],
+    lastUpdatedAt: Date.now() - 400000,
+  };
+
+  const model = buildV4({ heroProgressState: progressState });
+
+  assert.equal(model.version, 4);
+  assert.equal(model.coinsEnabled, false);
+  assert.equal('economy' in model, false, 'Economy block hidden when flag off');
+});
+
+// ── Malformed economy state ───────────────────────────────────────────
+
+test('malformed economy state does not crash read-model assembly', () => {
+  const baseModel = buildV5();
+  const progressState = buildProgressState(baseModel);
+
+  // Malformed economy: wrong types everywhere
+  progressState.economy = {
+    version: 'not-a-number',
+    balance: 'invalid',
+    lifetimeEarned: null,
+    lifetimeSpent: undefined,
+    ledger: 'not-an-array',
+    lastUpdatedAt: {},
+  };
+
+  // Must not throw
+  const model = buildV5({ heroProgressState: progressState });
+  assert.equal(model.version, 5);
+  assert.ok(model.economy);
+  // Graceful defaults from selectChildSafeEconomyReadModel's || guards
+  assert.equal(model.economy.balance, 0);
+  assert.equal(model.economy.lifetimeEarned, 0);
+  assert.equal(model.economy.lifetimeSpent, 0);
+  assert.deepEqual(model.economy.recentLedger, []);
+});
+
+test('null heroProgressState with economy enabled → safe default economy block', () => {
+  const model = buildV5({ heroProgressState: null });
+
+  assert.equal(model.version, 5);
+  assert.equal(model.coinsEnabled, true);
+  assert.ok(model.economy);
+  assert.equal(model.economy.balance, 0);
+  assert.equal(model.economy.lifetimeEarned, 0);
+  assert.equal(model.economy.lifetimeSpent, 0);
+  assert.deepEqual(model.economy.recentLedger, []);
+  assert.equal(model.economy.today.awardStatus, 'not-eligible');
+});
+
+// ── Child-safe ledger filtering ───────────────────────────────────────
+
+test('child-safe ledger excludes source details (only entryId, type, amount, dateKey, createdAt)', () => {
+  const baseModel = buildV5();
+  const progressState = buildProgressState(baseModel);
+
+  progressState.economy = {
+    version: 1,
+    balance: 100,
+    lifetimeEarned: 100,
+    lifetimeSpent: 0,
+    ledger: [{
+      entryId: 'ledger-1',
+      idempotencyKey: 'hero-daily-coins:v1:learner-1:2026-04-29:quest-1:fp-1',
+      type: 'daily-completion-award',
+      amount: 100,
+      balanceAfter: 100,
+      learnerId: 'learner-1',
+      dateKey: '2026-04-29',
+      questId: 'quest-1',
+      questFingerprint: 'fp-1',
+      source: {
+        kind: 'hero-daily-completion',
+        dailyCompletedAt: Date.now() - 5000,
+        completedTaskIds: ['t1', 't2'],
+        effortCompleted: 12,
+        effortPlanned: 12,
+      },
+      createdAt: Date.now() - 1000,
+      createdBy: 'system',
+    }],
+    lastUpdatedAt: Date.now() - 1000,
+  };
+
+  const model = buildV5({ heroProgressState: progressState });
+  const entry = model.economy.recentLedger[0];
+
+  assert.ok(entry, 'Should have one ledger entry');
+  // Allowed fields
+  assert.equal(entry.entryId, 'ledger-1');
+  assert.equal(entry.type, 'daily-completion-award');
+  assert.equal(entry.amount, 100);
+  assert.equal(entry.dateKey, '2026-04-29');
+  assert.ok(entry.createdAt > 0);
+
+  // Disallowed fields must NOT be present
+  assert.equal('idempotencyKey' in entry, false, 'idempotencyKey must be excluded');
+  assert.equal('balanceAfter' in entry, false, 'balanceAfter must be excluded');
+  assert.equal('learnerId' in entry, false, 'learnerId must be excluded');
+  assert.equal('questId' in entry, false, 'questId must be excluded');
+  assert.equal('questFingerprint' in entry, false, 'questFingerprint must be excluded');
+  assert.equal('source' in entry, false, 'source details must be excluded');
+  assert.equal('createdBy' in entry, false, 'createdBy must be excluded');
+});
+
+test('child-safe ledger capped at 10 entries for display', () => {
+  const baseModel = buildV5();
+  const progressState = buildProgressState(baseModel);
+
+  const ledger = [];
+  for (let i = 0; i < 20; i++) {
+    ledger.push({
+      entryId: `entry-${i}`,
+      type: 'daily-completion-award',
+      amount: 100,
+      dateKey: `2026-04-${String(10 + i).padStart(2, '0')}`,
+      createdAt: Date.now() - (20 - i) * 86400000,
+      // Extra fields that should be stripped
+      idempotencyKey: `key-${i}`,
+      source: { kind: 'hero-daily-completion' },
+    });
+  }
+
+  progressState.economy = {
+    version: 1,
+    balance: 2000,
+    lifetimeEarned: 2000,
+    lifetimeSpent: 0,
+    ledger,
+    lastUpdatedAt: Date.now(),
+  };
+
+  const model = buildV5({ heroProgressState: progressState });
+
+  assert.equal(model.economy.recentLedger.length, 10, 'Max 10 entries');
+  // Should be the last 10 entries (most recent)
+  assert.equal(model.economy.recentLedger[0].entryId, 'entry-10');
+  assert.equal(model.economy.recentLedger[9].entryId, 'entry-19');
+});
+
+// ── V5 retains all v4 structural fields ───────────────────────────────
+
+test('v5 retains all v4 structural fields', () => {
+  const model = buildV5();
+
+  assert.equal(model.mode, 'progress');
+  assert.equal(model.writesEnabled, true);
+  assert.ok(model.dateKey);
+  assert.ok(model.timezone);
+  assert.ok(model.schedulerVersion);
+  assert.ok(model.questFingerprint);
+  assert.ok(Array.isArray(model.eligibleSubjects));
+  assert.ok(Array.isArray(model.lockedSubjects));
+  assert.ok(model.dailyQuest);
+  assert.ok(model.progress);
+  assert.ok(model.launch);
+  assert.ok(model.claim);
+  assert.ok(model.ui);
+  assert.ok('activeHeroSession' in model);
+  assert.ok('pendingCompletedHeroSession' in model);
+  assert.ok('debug' in model);
+});
+
+// ── Economy today block shape ─────────────────────────────────────────
+
+test('economy today block has correct shape', () => {
+  const model = buildV5();
+  const today = model.economy.today;
+
+  assert.ok('dateKey' in today);
+  assert.ok('questId' in today);
+  assert.ok('awardStatus' in today);
+  assert.ok('coinsAvailable' in today);
+  assert.ok('coinsAwarded' in today);
+  assert.ok('ledgerEntryId' in today);
+  assert.ok('awardedAt' in today);
+  assert.equal(today.coinsAvailable, HERO_DAILY_COMPLETION_COINS);
+  assert.equal(today.dateKey, model.dateKey);
+  assert.equal(today.questId, model.dailyQuest.questId);
+});
+
+// ── Flag hierarchy: economy requires progress ─────────────────────────
+
+test('economy enabled but progress disabled → v3 without economy', () => {
+  const model = buildHeroShadowReadModel({
+    learnerId: 'learner-1',
+    accountId: 'account-1',
+    subjectReadModels: makeSubjectReadModels(),
+    now: Date.now(),
+    env: { ...BASE_ENV, HERO_MODE_PROGRESS_ENABLED: 'false', HERO_MODE_ECONOMY_ENABLED: 'true' },
+    progressEnabled: false,
+    economyEnabled: false, // route layer enforces: progressFlagEnabled && economyFlagEnabled
+    heroProgressState: null,
+    recentCompletedSessions: [],
+  });
+
+  assert.equal(model.version, 3);
+  assert.equal('economy' in model, false);
+});

--- a/tests/hero-p4-trust-anchor.test.js
+++ b/tests/hero-p4-trust-anchor.test.js
@@ -1,0 +1,265 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  resolveHeroClaimCommand,
+} from '../worker/src/hero/claim.js';
+import { validateClaimRequest } from '../shared/hero/claim-contract.js';
+
+// ── Test fixtures ────────────────────────────────────────────────────
+
+function makeValidBody(overrides = {}) {
+  return {
+    command: 'claim-task',
+    learnerId: 'learner-1',
+    questId: 'quest-abc',
+    questFingerprint: 'fp-xyz',
+    taskId: 'task-spelling-1',
+    requestId: 'req-001',
+    expectedLearnerRevision: 3,
+    ...overrides,
+  };
+}
+
+function makeProgressState(overrides = {}) {
+  const dateKey = overrides.dateKey || '2026-04-28';
+  return {
+    version: 1,
+    daily: {
+      dateKey,
+      timezone: 'Europe/London',
+      questId: 'quest-abc',
+      questFingerprint: 'fp-xyz',
+      status: 'active',
+      effortTarget: 18,
+      effortPlanned: 18,
+      effortCompleted: 0,
+      taskOrder: ['task-spelling-1'],
+      completedTaskIds: [],
+      tasks: {
+        'task-spelling-1': {
+          taskId: 'task-spelling-1',
+          questId: 'quest-abc',
+          questFingerprint: 'fp-xyz',
+          dateKey,
+          subjectId: 'spelling',
+          intent: 'due-review',
+          launcher: 'smart-practice',
+          effortTarget: 6,
+          status: 'started',
+          launchRequestId: 'launch-001',
+          claimRequestId: null,
+          startedAt: Date.now(),
+          completedAt: null,
+          subjectPracticeSessionId: null,
+          evidence: null,
+        },
+      },
+      generatedAt: Date.now(),
+      firstStartedAt: Date.now(),
+      completedAt: null,
+      lastUpdatedAt: Date.now(),
+      ...overrides,
+    },
+    recentClaims: [],
+  };
+}
+
+function makeCompletedRowWithHeroContext() {
+  return {
+    id: 'session-123',
+    learner_id: 'learner-1',
+    subject_id: 'spelling',
+    status: 'completed',
+    summary_json: JSON.stringify({
+      heroContext: {
+        source: 'hero-mode',
+        questId: 'quest-abc',
+        taskId: 'task-spelling-1',
+        questFingerprint: 'fp-xyz',
+        launchRequestId: 'launch-001',
+      },
+    }),
+  };
+}
+
+function makeCompletedRowWithoutHeroContext() {
+  return {
+    id: 'session-no-ctx',
+    learner_id: 'learner-1',
+    subject_id: 'spelling',
+    status: 'completed',
+    summary_json: JSON.stringify({ totalCorrect: 8, totalQuestions: 10 }),
+  };
+}
+
+const TODAY_MID_TS = Date.UTC(2026, 3, 28, 14, 0, 0);
+
+// ── P4 Trust Anchor: Economy enabled + valid heroContext → success ───
+
+test('P4: claim with valid heroContext succeeds when economy enabled', () => {
+  const result = resolveHeroClaimCommand({
+    body: makeValidBody(),
+    heroProgressState: makeProgressState(),
+    practiceSessionRows: [makeCompletedRowWithHeroContext()],
+    subjectUiStates: {},
+    nowTs: TODAY_MID_TS,
+    economyEnabled: true,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.status, 'claimed');
+  assert.equal(result.practiceSessionId, 'session-123');
+  assert.equal(result.evidence.source, 'practice-session');
+});
+
+// ── P4 Trust Anchor: Economy enabled + missing heroContext → rejected ─
+
+test('P4: claim with missing heroContext rejected when economy enabled (targeted session)', () => {
+  const result = resolveHeroClaimCommand({
+    body: makeValidBody({ practiceSessionId: 'session-no-ctx' }),
+    heroProgressState: makeProgressState(),
+    practiceSessionRows: [makeCompletedRowWithoutHeroContext()],
+    subjectUiStates: {},
+    nowTs: TODAY_MID_TS,
+    economyEnabled: true,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, 'hero_claim_missing_hero_context');
+  assert.equal(result.reason, 'Economy requires heroContext evidence');
+});
+
+test('P4: claim with missing heroContext in for-loop path returns no evidence (economy on)', () => {
+  // When no practiceSessionId is in body, the for-loop skips non-heroContext rows
+  const result = resolveHeroClaimCommand({
+    body: makeValidBody(),
+    heroProgressState: makeProgressState(),
+    practiceSessionRows: [makeCompletedRowWithoutHeroContext()],
+    subjectUiStates: {},
+    nowTs: TODAY_MID_TS,
+    economyEnabled: true,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, 'hero_claim_no_evidence');
+});
+
+// ── P3 compat: Economy disabled + valid heroContext → success ────────
+
+test('P3 compat: claim with valid heroContext succeeds when economy disabled', () => {
+  const result = resolveHeroClaimCommand({
+    body: makeValidBody(),
+    heroProgressState: makeProgressState(),
+    practiceSessionRows: [makeCompletedRowWithHeroContext()],
+    subjectUiStates: {},
+    nowTs: TODAY_MID_TS,
+    economyEnabled: false,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.status, 'claimed');
+});
+
+// ── P3 compat: Economy disabled + missing heroContext → still accepted ─
+// (practiceSessionId must be in body to hit validatePracticeSession path)
+
+test('P3 compat: claim with missing heroContext still succeeds when economy disabled', () => {
+  const result = resolveHeroClaimCommand({
+    body: makeValidBody({ practiceSessionId: 'session-no-ctx' }),
+    heroProgressState: makeProgressState(),
+    practiceSessionRows: [makeCompletedRowWithoutHeroContext()],
+    subjectUiStates: {},
+    nowTs: TODAY_MID_TS,
+    economyEnabled: false,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.status, 'claimed');
+  assert.equal(result.practiceSessionId, 'session-no-ctx');
+});
+
+// ── P3 compat: Economy unset (undefined) + missing heroContext → still accepted ─
+
+test('P3 compat: claim with missing heroContext still succeeds when economyEnabled is undefined (default)', () => {
+  const result = resolveHeroClaimCommand({
+    body: makeValidBody({ practiceSessionId: 'session-no-ctx' }),
+    heroProgressState: makeProgressState(),
+    practiceSessionRows: [makeCompletedRowWithoutHeroContext()],
+    subjectUiStates: {},
+    nowTs: TODAY_MID_TS,
+    // economyEnabled not passed — defaults to undefined (falsy)
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.status, 'claimed');
+});
+
+// ── Forbidden fields: economy and amount rejected at validation ──────
+
+test('P4: client sends economy field → rejected with hero_claim_forbidden_fields', () => {
+  const body = makeValidBody({ economy: { coins: 50 } });
+
+  const result = resolveHeroClaimCommand({
+    body,
+    heroProgressState: makeProgressState(),
+    practiceSessionRows: [],
+    subjectUiStates: {},
+    nowTs: TODAY_MID_TS,
+    economyEnabled: true,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, 'hero_claim_forbidden_fields');
+  assert.ok(result.reason.includes('economy'));
+});
+
+test('P4: client sends amount field → rejected with hero_claim_forbidden_fields', () => {
+  const body = makeValidBody({ amount: 100 });
+
+  const result = resolveHeroClaimCommand({
+    body,
+    heroProgressState: makeProgressState(),
+    practiceSessionRows: [],
+    subjectUiStates: {},
+    nowTs: TODAY_MID_TS,
+    economyEnabled: true,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, 'hero_claim_forbidden_fields');
+  assert.ok(result.reason.includes('amount'));
+});
+
+// ── Forbidden fields: economy and amount via validateClaimRequest directly ─
+
+test('P4: validateClaimRequest rejects economy field', () => {
+  const body = makeValidBody({ economy: true });
+  const result = validateClaimRequest(body);
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some(e => e.includes('economy')));
+});
+
+test('P4: validateClaimRequest rejects amount field', () => {
+  const body = makeValidBody({ amount: 999 });
+  const result = validateClaimRequest(body);
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some(e => e.includes('amount')));
+});
+
+// ── Economy enabled + practiceSessionId targets session without heroContext ─
+
+test('P4: targeted practiceSessionId without heroContext rejected when economy enabled', () => {
+  const row = makeCompletedRowWithoutHeroContext();
+  const result = resolveHeroClaimCommand({
+    body: makeValidBody({ practiceSessionId: 'session-no-ctx' }),
+    heroProgressState: makeProgressState(),
+    practiceSessionRows: [row],
+    subjectUiStates: {},
+    nowTs: TODAY_MID_TS,
+    economyEnabled: true,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, 'hero_claim_missing_hero_context');
+});

--- a/tests/hero-p4-vocabulary-boundary.test.js
+++ b/tests/hero-p4-vocabulary-boundary.test.js
@@ -1,0 +1,299 @@
+// Hero Mode P4 U7 — Vocabulary boundary tests.
+//
+// Proves the P4 economy vocabulary scope split:
+// - Pressure/gambling terms remain forbidden EVERYWHERE.
+// - Economy terms ('coin', 'balance', etc.) are permitted ONLY in economy-scoped files.
+// - Subject surfaces, HeroTaskBanner, and worker scheduler remain economy-free.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  HERO_FORBIDDEN_PRESSURE_VOCABULARY,
+  HERO_ECONOMY_ALLOWED_VOCABULARY,
+  HERO_ECONOMY_ALLOWED_FILES,
+} from '../shared/hero/hero-copy.js';
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+function collectJsFiles(dir) {
+  const results = [];
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return results;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...collectJsFiles(full));
+    } else if (entry.isFile() && (entry.name.endsWith('.js') || entry.name.endsWith('.jsx'))) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+function stripComments(source) {
+  return source
+    .replace(/\/\/.*$/gm, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+/**
+ * Strip vocabulary/boundary definition arrays so that tokens inside
+ * defining array literals do not trigger their own scan.
+ * Covers: HERO_FORBIDDEN_*, HERO_ECONOMY_*, FORBIDDEN_CLAIM_FIELDS, etc.
+ */
+function stripVocabDefinitions(source) {
+  // Strip exported const arrays that define vocabulary or forbidden-field lists
+  return source
+    .replace(
+      /export\s+const\s+(?:HERO_(?:FORBIDDEN_PRESSURE_VOCABULARY|ECONOMY_ALLOWED_VOCABULARY|FORBIDDEN_VOCABULARY|ECONOMY_ALLOWED_FILES)|FORBIDDEN_CLAIM_FIELDS)\s*=\s*(?:Object\.freeze\()?\[[\s\S]*?\]\)?;/g,
+      '',
+    );
+}
+
+function relPath(filePath) {
+  return path.relative(REPO_ROOT, filePath).replace(/\\/g, '/');
+}
+
+// ── Directories scanned ──────────────────────────────────────────────
+
+const HERO_SOURCE_DIRS = [
+  path.join(REPO_ROOT, 'shared', 'hero'),
+  path.join(REPO_ROOT, 'worker', 'src', 'hero'),
+  path.join(REPO_ROOT, 'src', 'platform', 'hero'),
+];
+
+const HERO_SURFACE_FILES = [
+  path.join(REPO_ROOT, 'src', 'surfaces', 'home', 'HeroQuestCard.jsx'),
+  path.join(REPO_ROOT, 'src', 'surfaces', 'subject', 'HeroTaskBanner.jsx'),
+];
+
+const ECONOMY_FREE_WORKER_FILES = [
+  path.join(REPO_ROOT, 'worker', 'src', 'hero', 'launch.js'),
+  // read-model.js is economy-allowed since P4 added the economy block
+];
+
+const SUBJECT_DIR = path.join(REPO_ROOT, 'src', 'subjects');
+
+// Collect all Hero source files
+const ALL_HERO_FILES = [
+  ...HERO_SOURCE_DIRS.flatMap((dir) => collectJsFiles(dir)),
+  ...HERO_SURFACE_FILES.filter((f) => fs.existsSync(f)),
+];
+
+// Resolve economy-allowed files to absolute paths
+const ECONOMY_ALLOWED_ABSOLUTE = HERO_ECONOMY_ALLOWED_FILES.map(
+  (rel) => path.join(REPO_ROOT, rel.replace(/\//g, path.sep)),
+);
+
+function isEconomyAllowed(filePath) {
+  const rel = relPath(filePath);
+  return HERO_ECONOMY_ALLOWED_FILES.includes(rel);
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// Test 1: Pressure vocabulary forbidden in ALL Hero source files
+// ══════════════════════════════════════════════════════════════════════
+
+test('P4 Vocabulary: pressure/gambling terms are absent from ALL Hero source files', () => {
+  assert.ok(ALL_HERO_FILES.length > 0, 'Expected Hero source files to scan');
+  assert.ok(HERO_FORBIDDEN_PRESSURE_VOCABULARY.length > 0, 'Pressure vocabulary must be non-empty');
+
+  const patterns = HERO_FORBIDDEN_PRESSURE_VOCABULARY.map((token) => ({
+    token,
+    regex: new RegExp(
+      token.includes(' ')
+        ? token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+        : `\\b${token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`,
+      'i',
+    ),
+  }));
+
+  for (const filePath of ALL_HERO_FILES) {
+    const rel = relPath(filePath);
+    const raw = fs.readFileSync(filePath, 'utf8');
+    const code = stripVocabDefinitions(stripComments(raw));
+
+    for (const { token, regex } of patterns) {
+      assert.ok(
+        !regex.test(code),
+        `${rel} contains pressure vocabulary "${token}" — pressure terms are ALWAYS forbidden`,
+      );
+    }
+  }
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// Test 2: Economy vocabulary present in economy-allowed files (sanity)
+// ══════════════════════════════════════════════════════════════════════
+
+test('P4 Vocabulary: economy terms appear in at least one economy-allowed file', () => {
+  // 'coin' must appear in at least one allowed file (hero-copy.js has HERO_ECONOMY_COPY)
+  const coinRegex = /\bcoin\b/i;
+  let found = false;
+  for (const absPath of ECONOMY_ALLOWED_ABSOLUTE) {
+    if (!fs.existsSync(absPath)) continue;
+    const code = stripComments(fs.readFileSync(absPath, 'utf8'));
+    if (coinRegex.test(code)) {
+      found = true;
+      break;
+    }
+  }
+  assert.ok(found, 'Economy term "coin" must appear in at least one economy-allowed file');
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// Test 3: Economy vocabulary NOT in HeroTaskBanner
+// ══════════════════════════════════════════════════════════════════════
+
+test('P4 Vocabulary: economy terms do NOT appear in HeroTaskBanner', () => {
+  const bannerPath = path.join(REPO_ROOT, 'src', 'surfaces', 'subject', 'HeroTaskBanner.jsx');
+  if (!fs.existsSync(bannerPath)) return; // skip if file does not exist yet
+
+  const raw = fs.readFileSync(bannerPath, 'utf8');
+  const code = stripVocabDefinitions(stripComments(raw));
+
+  for (const token of HERO_ECONOMY_ALLOWED_VOCABULARY) {
+    const regex = new RegExp(
+      token.includes(' ')
+        ? token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+        : `\\b${token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`,
+      'i',
+    );
+    assert.ok(
+      !regex.test(code),
+      `HeroTaskBanner.jsx contains economy vocabulary "${token}" — economy terms must not leak into subject banner`,
+    );
+  }
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// Test 4: Economy vocabulary NOT in any subject engine file
+// ══════════════════════════════════════════════════════════════════════
+
+test('P4 Vocabulary: economy terms do NOT appear in src/subjects/ (excluding content data)', () => {
+  const subjectFiles = collectJsFiles(SUBJECT_DIR).filter((f) => {
+    const rel = relPath(f);
+    // Exclude raw content/data files — they contain curriculum sentences, not Hero UI
+    return !rel.includes('/data/') && !rel.includes('/content/');
+  });
+  if (subjectFiles.length === 0) return; // skip if no subject files
+
+  const patterns = HERO_ECONOMY_ALLOWED_VOCABULARY.map((token) => ({
+    token,
+    regex: new RegExp(
+      token.includes(' ')
+        ? token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+        : `\\b${token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`,
+      'i',
+    ),
+  }));
+
+  for (const filePath of subjectFiles) {
+    const rel = relPath(filePath);
+    const code = stripComments(fs.readFileSync(filePath, 'utf8'));
+
+    for (const { token, regex } of patterns) {
+      assert.ok(
+        !regex.test(code),
+        `${rel} contains economy vocabulary "${token}" — economy terms must not appear in subject engine files`,
+      );
+    }
+  }
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// Test 5: Economy vocabulary NOT in economy-free worker files
+// ══════════════════════════════════════════════════════════════════════
+
+test('P4 Vocabulary: economy terms do NOT appear in worker/src/hero/launch.js', () => {
+  const patterns = HERO_ECONOMY_ALLOWED_VOCABULARY.map((token) => ({
+    token,
+    regex: new RegExp(
+      token.includes(' ')
+        ? token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+        : `\\b${token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`,
+      'i',
+    ),
+  }));
+
+  for (const filePath of ECONOMY_FREE_WORKER_FILES) {
+    if (!fs.existsSync(filePath)) continue;
+    const rel = relPath(filePath);
+    const code = stripVocabDefinitions(stripComments(fs.readFileSync(filePath, 'utf8')));
+
+    for (const { token, regex } of patterns) {
+      assert.ok(
+        !regex.test(code),
+        `${rel} contains economy vocabulary "${token}" — launch must be economy-free`,
+      );
+    }
+  }
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// Test 6: 'claim your reward' is still in pressure list
+// ══════════════════════════════════════════════════════════════════════
+
+test('P4 Vocabulary: "claim your reward" remains in pressure-forbidden list', () => {
+  assert.ok(
+    HERO_FORBIDDEN_PRESSURE_VOCABULARY.includes('claim your reward'),
+    '"claim your reward" must remain forbidden as pressure vocabulary',
+  );
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// Test 7: HERO_ECONOMY_ALLOWED_FILES all exist on disk
+// ══════════════════════════════════════════════════════════════════════
+
+test('P4 Vocabulary: every file in HERO_ECONOMY_ALLOWED_FILES exists', () => {
+  for (const relFile of HERO_ECONOMY_ALLOWED_FILES) {
+    const absPath = path.join(REPO_ROOT, relFile.replace(/\//g, path.sep));
+    assert.ok(
+      fs.existsSync(absPath),
+      `HERO_ECONOMY_ALLOWED_FILES references "${relFile}" but it does not exist`,
+    );
+  }
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// Test 8: Economy vocabulary in non-allowed Hero files is forbidden
+// ══════════════════════════════════════════════════════════════════════
+
+test('P4 Vocabulary: economy terms do NOT appear in Hero files outside HERO_ECONOMY_ALLOWED_FILES', () => {
+  const nonAllowedFiles = ALL_HERO_FILES.filter((f) => !isEconomyAllowed(f));
+  assert.ok(nonAllowedFiles.length > 0, 'Expected non-allowed Hero files to scan');
+
+  const patterns = HERO_ECONOMY_ALLOWED_VOCABULARY.map((token) => ({
+    token,
+    regex: new RegExp(
+      token.includes(' ')
+        ? token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+        : `\\b${token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`,
+      'i',
+    ),
+  }));
+
+  for (const filePath of nonAllowedFiles) {
+    const rel = relPath(filePath);
+    const raw = fs.readFileSync(filePath, 'utf8');
+    const code = stripVocabDefinitions(stripComments(raw));
+
+    for (const { token, regex } of patterns) {
+      assert.ok(
+        !regex.test(code),
+        `${rel} contains economy vocabulary "${token}" — economy terms only permitted in HERO_ECONOMY_ALLOWED_FILES`,
+      );
+    }
+  }
+});

--- a/tests/hero-progress-mutation-safety.test.js
+++ b/tests/hero-progress-mutation-safety.test.js
@@ -114,7 +114,7 @@ test('readHeroProgressState with no existing row returns normalised empty state'
   // We verify the contract of normaliseHeroProgressState(null).
   const expected = normaliseHeroProgressState(null);
   assert.deepEqual(expected, emptyProgressState());
-  assert.equal(expected.version, 1);
+  assert.equal(expected.version, 2);
   assert.equal(expected.daily, null);
   assert.deepEqual(expected.recentClaims, []);
 
@@ -163,7 +163,7 @@ test('readHeroProgressState with valid existing row returns parsed state', async
   assert.ok(row, 'hero-mode row must exist after direct insert');
   const parsed = JSON.parse(row.state_json);
   const normalised = normaliseHeroProgressState(parsed);
-  assert.equal(normalised.version, 1);
+  assert.equal(normalised.version, 2);
   assert.equal(normalised.daily.questId, 'quest-abc');
   assert.equal(normalised.daily.status, 'active');
   assert.equal(normalised.daily.effortCompleted, 1);
@@ -576,7 +576,7 @@ test('batch atomicity: after hero mutation, child_game_state + mutation_receipts
   const gameRow = getHeroGameStateRow(server);
   assert.ok(gameRow, 'child_game_state must contain hero-mode row after mutation');
   const stateAfter = JSON.parse(gameRow.state_json);
-  assert.equal(stateAfter.version, 1);
+  assert.equal(stateAfter.version, 2);
 
   // 2. mutation_receipts row exists with kind='hero_command.claim-task'
   const receipt = getMutationReceipt(server, 'adult-a', 'hero-atomicity-1');
@@ -676,7 +676,7 @@ test('normaliseHeroProgressState with wrong version returns empty progress', () 
 test('normaliseHeroProgressState with valid minimal state returns normalised', () => {
   const input = { version: 1, daily: null, recentClaims: [] };
   const result = normaliseHeroProgressState(input);
-  assert.equal(result.version, 1);
+  assert.equal(result.version, 2);
   assert.equal(result.daily, null);
   assert.deepEqual(result.recentClaims, []);
 });

--- a/tests/hero-progress-state.test.js
+++ b/tests/hero-progress-state.test.js
@@ -12,23 +12,29 @@ import {
   markTaskStarted,
 } from '../shared/hero/progress-state.js';
 
+import { HERO_ECONOMY_VERSION, emptyEconomyState } from '../shared/hero/economy.js';
+
 // ── normaliseHeroProgressState ────────────────────────────────────
 
-test('normaliseHeroProgressState with null returns empty state with version 1', () => {
+test('normaliseHeroProgressState with null returns empty v2 state', () => {
   const result = normaliseHeroProgressState(null);
-  assert.equal(result.version, HERO_PROGRESS_VERSION);
+  assert.equal(result.version, 2);
   assert.equal(result.daily, null);
   assert.deepEqual(result.recentClaims, []);
+  assert.equal(result.economy.version, HERO_ECONOMY_VERSION);
+  assert.equal(result.economy.balance, 0);
+  assert.deepEqual(result.economy.ledger, []);
 });
 
-test('normaliseHeroProgressState with undefined returns empty state', () => {
+test('normaliseHeroProgressState with undefined returns empty v2 state', () => {
   const result = normaliseHeroProgressState(undefined);
-  assert.equal(result.version, 1);
+  assert.equal(result.version, 2);
   assert.equal(result.daily, null);
   assert.deepEqual(result.recentClaims, []);
+  assert.equal(result.economy.version, HERO_ECONOMY_VERSION);
 });
 
-test('normaliseHeroProgressState with valid state returns normalised structure', () => {
+test('normaliseHeroProgressState v1 state migrates to v2 preserving daily and recentClaims', () => {
   const input = {
     version: 1,
     daily: {
@@ -53,25 +59,146 @@ test('normaliseHeroProgressState with valid state returns normalised structure',
     recentClaims: [{ claimId: 'c1', createdAt: 999 }],
   };
   const result = normaliseHeroProgressState(input);
-  assert.equal(result.version, 1);
+  assert.equal(result.version, 2);
   assert.equal(result.daily.dateKey, '2026-04-28');
   assert.equal(result.daily.questId, 'quest-abc');
   assert.equal(result.daily.tasks.t1.status, 'completed');
   assert.equal(result.daily.tasks.t2.status, 'planned');
   assert.deepEqual(result.recentClaims, [{ claimId: 'c1', createdAt: 999 }]);
+  // Economy must be empty (v1 had no economy)
+  assert.equal(result.economy.version, HERO_ECONOMY_VERSION);
+  assert.equal(result.economy.balance, 0);
+  assert.equal(result.economy.lifetimeEarned, 0);
+  assert.equal(result.economy.lifetimeSpent, 0);
+  assert.deepEqual(result.economy.ledger, []);
+  assert.equal(result.economy.lastUpdatedAt, null);
 });
 
-test('normaliseHeroProgressState with wrong version returns empty state', () => {
+test('normaliseHeroProgressState v2 state with existing economy normalises correctly', () => {
+  const input = {
+    version: 2,
+    daily: {
+      dateKey: '2026-04-29',
+      questId: 'quest-xyz',
+      timezone: 'Europe/London',
+      status: 'completed',
+      effortTarget: 18,
+      effortPlanned: 18,
+      effortCompleted: 18,
+      taskOrder: ['t1'],
+      completedTaskIds: ['t1'],
+      tasks: {
+        t1: { taskId: 't1', status: 'completed', effortTarget: 18 },
+      },
+      generatedAt: 5000,
+      firstStartedAt: 5001,
+      completedAt: 5500,
+      lastUpdatedAt: 5500,
+    },
+    recentClaims: [{ claimId: 'c2', createdAt: 5500 }],
+    economy: {
+      version: HERO_ECONOMY_VERSION,
+      balance: 100,
+      lifetimeEarned: 200,
+      lifetimeSpent: 100,
+      ledger: [{ id: 'entry-1', type: 'daily-completion-award', coins: 100 }],
+      lastUpdatedAt: 5500,
+    },
+  };
+  const result = normaliseHeroProgressState(input);
+  assert.equal(result.version, 2);
+  assert.equal(result.daily.questId, 'quest-xyz');
+  assert.equal(result.economy.balance, 100);
+  assert.equal(result.economy.lifetimeEarned, 200);
+  assert.equal(result.economy.lifetimeSpent, 100);
+  assert.equal(result.economy.ledger.length, 1);
+  assert.equal(result.economy.lastUpdatedAt, 5500);
+});
+
+test('normaliseHeroProgressState with malformed version (99) returns empty v2 state', () => {
   const result = normaliseHeroProgressState({ version: 99, daily: null, recentClaims: [] });
-  assert.equal(result.version, 1);
+  assert.equal(result.version, 2);
   assert.equal(result.daily, null);
+  assert.equal(result.economy.version, HERO_ECONOMY_VERSION);
+  assert.equal(result.economy.balance, 0);
+});
+
+test('normaliseHeroProgressState with missing version returns empty v2 state', () => {
+  const result = normaliseHeroProgressState({ daily: null, recentClaims: [] });
+  assert.equal(result.version, 2);
+  assert.equal(result.daily, null);
+  assert.equal(result.economy.version, HERO_ECONOMY_VERSION);
+});
+
+test('normaliseHeroProgressState with version as string returns empty v2 state', () => {
+  const result = normaliseHeroProgressState({ version: '2', daily: null, recentClaims: [] });
+  assert.equal(result.version, 2);
+  assert.equal(result.daily, null);
+  assert.equal(result.economy.version, HERO_ECONOMY_VERSION);
+});
+
+test('normaliseHeroProgressState v2 with partially corrupt economy normalises safely', () => {
+  const input = {
+    version: 2,
+    daily: {
+      dateKey: '2026-04-29',
+      questId: 'quest-keep',
+      timezone: 'Europe/London',
+      status: 'active',
+      effortTarget: 12,
+      effortPlanned: 12,
+      effortCompleted: 0,
+      taskOrder: ['t1'],
+      completedTaskIds: [],
+      tasks: {
+        t1: { taskId: 't1', status: 'planned', effortTarget: 12 },
+      },
+      generatedAt: 7000,
+      firstStartedAt: null,
+      completedAt: null,
+      lastUpdatedAt: 7000,
+    },
+    recentClaims: [{ claimId: 'c3', createdAt: 7000 }],
+    economy: {
+      version: HERO_ECONOMY_VERSION,
+      balance: 'corrupted', // not a number
+      lifetimeEarned: Infinity, // not finite
+      lifetimeSpent: -1, // not tested as corrupt, just negative
+      ledger: 'not-an-array', // corrupt
+      lastUpdatedAt: null,
+    },
+  };
+  const result = normaliseHeroProgressState(input);
+  // Daily progress MUST survive
+  assert.equal(result.daily.questId, 'quest-keep');
+  assert.equal(result.daily.tasks.t1.status, 'planned');
+  assert.deepEqual(result.recentClaims, [{ claimId: 'c3', createdAt: 7000 }]);
+  // Economy normalises to safe defaults
+  assert.equal(result.economy.version, HERO_ECONOMY_VERSION);
+  assert.equal(result.economy.balance, 0); // 'corrupted' → 0
+  assert.equal(result.economy.lifetimeEarned, 0); // Infinity → 0
+  assert.deepEqual(result.economy.ledger, []); // 'not-an-array' → []
+});
+
+test('normaliseHeroProgressState v2 with null economy gets empty economy', () => {
+  const input = {
+    version: 2,
+    daily: null,
+    recentClaims: [],
+    economy: null,
+  };
+  const result = normaliseHeroProgressState(input);
+  assert.equal(result.version, 2);
+  assert.equal(result.economy.version, HERO_ECONOMY_VERSION);
+  assert.equal(result.economy.balance, 0);
 });
 
 test('normaliseHeroProgressState with malformed daily repairs safely', () => {
   const result = normaliseHeroProgressState({
-    version: 1,
+    version: 2,
     daily: { dateKey: '2026-04-28', questId: 'q1', status: 'garbage', effortTarget: 'abc' },
     recentClaims: 'not-an-array',
+    economy: emptyEconomyState(),
   });
   assert.equal(result.daily.status, 'active'); // unknown status defaults to 'active'
   assert.equal(result.daily.effortTarget, 0); // NaN coerces to 0
@@ -80,9 +207,10 @@ test('normaliseHeroProgressState with malformed daily repairs safely', () => {
 
 test('normaliseHeroProgressState with daily missing dateKey returns null daily', () => {
   const result = normaliseHeroProgressState({
-    version: 1,
+    version: 2,
     daily: { questId: 'q1' }, // no dateKey
     recentClaims: [],
+    economy: emptyEconomyState(),
   });
   assert.equal(result.daily, null);
 });
@@ -131,7 +259,7 @@ test('initialiseDailyProgress from quest with 3 tasks produces correct shape', (
 
 test('applyClaimToProgress increments effortCompleted and adds to completedTaskIds', () => {
   const state = {
-    version: 1,
+    version: 2,
     daily: {
       dateKey: '2026-04-28',
       questId: 'q1',
@@ -147,6 +275,7 @@ test('applyClaimToProgress increments effortCompleted and adds to completedTaskI
       },
     },
     recentClaims: [],
+    economy: emptyEconomyState(),
   };
   const claimResult = { taskId: 't1', requestId: 'req-1', practiceSessionId: 'sess-1', evidence: { score: 5 } };
   const nowTs = 2000;
@@ -164,7 +293,7 @@ test('applyClaimToProgress increments effortCompleted and adds to completedTaskI
 
 test('applyClaimToProgress for already-completed task returns unchanged (no double-count)', () => {
   const state = {
-    version: 1,
+    version: 2,
     daily: {
       dateKey: '2026-04-28',
       questId: 'q1',
@@ -180,6 +309,7 @@ test('applyClaimToProgress for already-completed task returns unchanged (no doub
       },
     },
     recentClaims: [],
+    economy: emptyEconomyState(),
   };
   const claimResult = { taskId: 't1', requestId: 'req-2' };
   const result = applyClaimToProgress(state, claimResult, 3000);
@@ -190,7 +320,7 @@ test('applyClaimToProgress for already-completed task returns unchanged (no doub
 
 test('applyClaimToProgress when all tasks complete sets daily.status=completed', () => {
   const state = {
-    version: 1,
+    version: 2,
     daily: {
       dateKey: '2026-04-28',
       questId: 'q1',
@@ -206,6 +336,7 @@ test('applyClaimToProgress when all tasks complete sets daily.status=completed',
       },
     },
     recentClaims: [],
+    economy: emptyEconomyState(),
   };
   const claimResult = { taskId: 't2', requestId: 'req-3', practiceSessionId: 'sess-2' };
   const nowTs = 4000;
@@ -229,12 +360,13 @@ test('pruneRecentClaims removes old claims and keeps recent ones', () => {
   const oldTs = nowTs - (MAX_RECENT_CLAIMS_AGE_DAYS + 1) * 24 * 60 * 60 * 1000;
   const recentTs = nowTs - 1000;
   const state = {
-    version: 1,
+    version: 2,
     daily: null,
     recentClaims: [
       { claimId: 'old', createdAt: oldTs },
       { claimId: 'recent', createdAt: recentTs },
     ],
+    economy: emptyEconomyState(),
   };
   const result = pruneRecentClaims(state, nowTs);
   assert.equal(result.recentClaims.length, 1);
@@ -244,16 +376,17 @@ test('pruneRecentClaims removes old claims and keeps recent ones', () => {
 test('pruneRecentClaims returns same reference when nothing to prune', () => {
   const nowTs = Date.now();
   const state = {
-    version: 1,
+    version: 2,
     daily: null,
     recentClaims: [{ claimId: 'fresh', createdAt: nowTs - 1000 }],
+    economy: emptyEconomyState(),
   };
   const result = pruneRecentClaims(state, nowTs);
   assert.equal(result, state);
 });
 
 test('pruneRecentClaims with empty recentClaims returns same reference', () => {
-  const state = { version: 1, daily: null, recentClaims: [] };
+  const state = { version: 2, daily: null, recentClaims: [], economy: emptyEconomyState() };
   const result = pruneRecentClaims(state, Date.now());
   assert.equal(result, state);
 });
@@ -262,7 +395,7 @@ test('pruneRecentClaims with empty recentClaims returns same reference', () => {
 
 test('markTaskStarted sets status=started and startedAt', () => {
   const state = {
-    version: 1,
+    version: 2,
     daily: {
       dateKey: '2026-04-28',
       questId: 'q1',
@@ -273,6 +406,7 @@ test('markTaskStarted sets status=started and startedAt', () => {
       },
     },
     recentClaims: [],
+    economy: emptyEconomyState(),
   };
   const nowTs = 2000;
   const result = markTaskStarted(state, 't1', 'launch-req-1', nowTs);
@@ -286,7 +420,7 @@ test('markTaskStarted sets status=started and startedAt', () => {
 
 test('markTaskStarted does not regress a completed task', () => {
   const state = {
-    version: 1,
+    version: 2,
     daily: {
       dateKey: '2026-04-28',
       questId: 'q1',
@@ -297,6 +431,7 @@ test('markTaskStarted does not regress a completed task', () => {
       },
     },
     recentClaims: [],
+    economy: emptyEconomyState(),
   };
   const result = markTaskStarted(state, 't1', 'launch-req-2', 3000);
   assert.equal(result, state); // unchanged
@@ -304,7 +439,7 @@ test('markTaskStarted does not regress a completed task', () => {
 
 test('markTaskStarted preserves existing firstStartedAt', () => {
   const state = {
-    version: 1,
+    version: 2,
     daily: {
       dateKey: '2026-04-28',
       questId: 'q1',
@@ -315,6 +450,7 @@ test('markTaskStarted preserves existing firstStartedAt', () => {
       },
     },
     recentClaims: [],
+    economy: emptyEconomyState(),
   };
   const result = markTaskStarted(state, 't1', 'lr-1', 2000);
   assert.equal(result.daily.firstStartedAt, 500); // not overwritten
@@ -322,30 +458,22 @@ test('markTaskStarted preserves existing firstStartedAt', () => {
 
 // ── emptyProgressState ────────────────────────────────────────────
 
-test('emptyProgressState returns correct default shape', () => {
+test('emptyProgressState returns correct v2 shape with economy', () => {
   const result = emptyProgressState();
   assert.equal(result.version, HERO_PROGRESS_VERSION);
+  assert.equal(result.version, 2);
   assert.equal(result.daily, null);
   assert.deepEqual(result.recentClaims, []);
+  assert.equal(result.economy.version, HERO_ECONOMY_VERSION);
+  assert.equal(result.economy.balance, 0);
+  assert.equal(result.economy.lifetimeEarned, 0);
+  assert.equal(result.economy.lifetimeSpent, 0);
+  assert.deepEqual(result.economy.ledger, []);
+  assert.equal(result.economy.lastUpdatedAt, null);
 });
 
-// ── No economy vocabulary ─────────────────────────────────────────
+// ── HERO_PROGRESS_VERSION is 2 ───────────────────────────────────
 
-test('progress-state exports contain no economy vocabulary', () => {
-  const exportNames = [
-    'HERO_PROGRESS_VERSION',
-    'MAX_RECENT_CLAIMS_AGE_DAYS',
-    'emptyProgressState',
-    'normaliseHeroProgressState',
-    'initialiseDailyProgress',
-    'applyClaimToProgress',
-    'pruneRecentClaims',
-    'markTaskStarted',
-  ];
-  const forbidden = ['coins', 'reward', 'xp', 'balance', 'shop', 'monster'];
-  for (const name of exportNames) {
-    for (const word of forbidden) {
-      assert.ok(!name.toLowerCase().includes(word), `${name} must not contain "${word}"`);
-    }
-  }
+test('HERO_PROGRESS_VERSION is 2', () => {
+  assert.equal(HERO_PROGRESS_VERSION, 2);
 });

--- a/worker/src/app.js
+++ b/worker/src/app.js
@@ -1571,9 +1571,9 @@ export function createWorkerApp({
               updatedState = { ...updatedState, recentClaims: [...(updatedState.recentClaims || []), claimRecord] };
 
               // P4: Check if daily just completed and award coins
-              let economyResult = { awarded: false, alreadyAwarded: false, amount: 0, ledgerEntryId: null, balanceAfter: 0 };
+              let economyResult = { awarded: false, alreadyAwarded: false, amount: 0, ledgerEntryId: null, balanceAfter: 0, blockedReason: null };
               if (economyEnabled) {
-                const { canAward } = canAwardDailyCompletionCoins(updatedState, economyEnabled);
+                const { canAward, reason } = canAwardDailyCompletionCoins(updatedState, economyEnabled);
                 if (canAward) {
                   economyResult = applyDailyCompletionCoinAward(updatedState, {
                     learnerId: heroLearnerId,
@@ -1581,6 +1581,8 @@ export function createWorkerApp({
                     dailyCompletionCoins: HERO_DAILY_COMPLETION_COINS,
                   });
                   updatedState = economyResult.state;
+                } else {
+                  economyResult.blockedReason = reason;
                 }
               }
 
@@ -1666,6 +1668,15 @@ export function createWorkerApp({
                   balanceAfter: mutationResult.economyResult.balanceAfter,
                   ledgerEntryId: mutationResult.economyResult.ledgerEntryId,
                 }));
+              } else if (mutationResult.economyResult?.alreadyAwarded) {
+                // eslint-disable-next-line no-console
+                console.log(JSON.stringify({
+                  event: 'hero_daily_coins_duplicate_prevented',
+                  learnerId: heroLearnerId,
+                  questId: body.questId || '',
+                  taskId: body.taskId || '',
+                  ledgerEntryId: mutationResult.economyResult.ledgerEntryId || '',
+                }));
               } else if (!economyEnabled) {
                 // eslint-disable-next-line no-console
                 console.log(JSON.stringify({
@@ -1673,6 +1684,15 @@ export function createWorkerApp({
                   learnerId: heroLearnerId,
                   questId: body.questId || '',
                   taskId: body.taskId || '',
+                }));
+              } else if (economyEnabled && mutationResult.economyResult?.blockedReason) {
+                // eslint-disable-next-line no-console
+                console.log(JSON.stringify({
+                  event: 'hero_daily_coins_blocked',
+                  learnerId: heroLearnerId,
+                  questId: body.questId || '',
+                  taskId: body.taskId || '',
+                  reason: mutationResult.economyResult.blockedReason,
                 }));
               }
             } catch { /* best-effort */ }

--- a/worker/src/app.js
+++ b/worker/src/app.js
@@ -1486,6 +1486,7 @@ export function createWorkerApp({
               practiceSessionRows,
               subjectUiStates,
               nowTs,
+              economyEnabled: envFlagEnabled(env.HERO_MODE_ECONOMY_ENABLED),
             });
 
             // Handle rejection

--- a/worker/src/app.js
+++ b/worker/src/app.js
@@ -54,6 +54,7 @@ import {
   pruneRecentClaims,
 } from '../../shared/hero/progress-state.js';
 import { buildClaimRecord } from '../../shared/hero/claim-contract.js';
+import { canAwardDailyCompletionCoins, applyDailyCompletionCoinAward, HERO_DAILY_COMPLETION_COINS } from '../../shared/hero/economy.js';
 import { logRequestDenial } from './admin-denial-logger.js';
 import {
   DENIAL_RATE_LIMIT_EXCEEDED,
@@ -1429,6 +1430,11 @@ export function createWorkerApp({
 
           // P3 U6: claim-task command — full mutation with evidence, CAS, events.
           if (body?.command === 'claim-task') {
+            const economyEnabled = envFlagEnabled(env.HERO_MODE_ECONOMY_ENABLED);
+            // P4: Flag hierarchy: economy requires progress
+            if (economyEnabled && !envFlagEnabled(env.HERO_MODE_PROGRESS_ENABLED)) {
+              return json({ ok: false, error: { code: 'hero_economy_misconfigured', message: 'Economy requires progress to be enabled' } }, 409);
+            }
             if (!envFlagEnabled(env.HERO_MODE_PROGRESS_ENABLED)) {
               try {
                 // eslint-disable-next-line no-console
@@ -1507,6 +1513,7 @@ export function createWorkerApp({
 
             // Handle already-completed (safe duplicate)
             if (claimResult.status === 'already-completed') {
+              const dailyCoinsAlreadyAwarded = economyEnabled && Boolean(heroProgressState.daily?.economy?.dailyAwardLedgerEntryId);
               try {
                 // eslint-disable-next-line no-console
                 console.log(JSON.stringify({
@@ -1514,11 +1521,22 @@ export function createWorkerApp({
                   learnerId: heroLearnerId,
                   questId: body.questId || '',
                   taskId: body.taskId || '',
+                  ...(economyEnabled ? { hero_daily_coins_already_awarded: dailyCoinsAlreadyAwarded } : {}),
                 }));
               } catch { /* best-effort */ }
               return json({
                 ok: true,
-                heroClaim: { version: 1, status: 'already-completed', learnerId: heroLearnerId, taskId: claimResult.taskId, questId: claimResult.questId },
+                heroClaim: {
+                  version: 1,
+                  status: 'already-completed',
+                  learnerId: heroLearnerId,
+                  taskId: claimResult.taskId,
+                  questId: claimResult.questId,
+                  coinsEnabled: economyEnabled,
+                  coinsAwarded: 0,
+                  coinBalance: economyEnabled ? (heroProgressState.economy?.balance || 0) : 0,
+                  dailyCoinsAlreadyAwarded,
+                },
               });
             }
 
@@ -1552,7 +1570,21 @@ export function createWorkerApp({
               });
               updatedState = { ...updatedState, recentClaims: [...(updatedState.recentClaims || []), claimRecord] };
 
-              return { state: updatedState, claimResult };
+              // P4: Check if daily just completed and award coins
+              let economyResult = { awarded: false, alreadyAwarded: false, amount: 0, ledgerEntryId: null, balanceAfter: 0 };
+              if (economyEnabled) {
+                const { canAward } = canAwardDailyCompletionCoins(updatedState, economyEnabled);
+                if (canAward) {
+                  economyResult = applyDailyCompletionCoinAward(updatedState, {
+                    learnerId: heroLearnerId,
+                    nowTs,
+                    dailyCompletionCoins: HERO_DAILY_COMPLETION_COINS,
+                  });
+                  updatedState = economyResult.state;
+                }
+              }
+
+              return { state: updatedState, claimResult, economyResult };
             });
 
             // Build event_log entries (fire-and-forget, non-fatal)
@@ -1598,7 +1630,52 @@ export function createWorkerApp({
               console.error('[hero] claim event_log write failed:', err.message);
             }
 
-            // Build response
+            // P4: Economy event_log entry (fire-and-forget, non-fatal)
+            if (mutationResult.economyResult?.awarded) {
+              const ledgerEntryId = mutationResult.economyResult.ledgerEntryId;
+              try {
+                await run(db, `
+                  INSERT INTO event_log (id, learner_id, subject_id, system_id, event_type, event_json, created_at, actor_account_id)
+                  VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                  ON CONFLICT(id) DO NOTHING
+                `, [
+                  `hero-evt-${ledgerEntryId}`,
+                  heroLearnerId,
+                  null,
+                  'hero-mode',
+                  'hero.coins.awarded',
+                  JSON.stringify({ questId: body.questId, dateKey: heroProgressState.daily?.dateKey, amount: mutationResult.economyResult.amount, ledgerEntryId, balanceAfter: mutationResult.economyResult.balanceAfter }),
+                  nowTs,
+                  session.accountId,
+                ]);
+              } catch (err) {
+                // eslint-disable-next-line no-console
+                console.error('[hero] coins event_log write failed:', err.message);
+              }
+            }
+
+            // Build response — structured logs for economy
+            try {
+              if (mutationResult.economyResult?.awarded) {
+                // eslint-disable-next-line no-console
+                console.log(JSON.stringify({
+                  event: 'hero_daily_coins_awarded',
+                  learnerId: heroLearnerId,
+                  questId: body.questId || '',
+                  amount: mutationResult.economyResult.amount,
+                  balanceAfter: mutationResult.economyResult.balanceAfter,
+                  ledgerEntryId: mutationResult.economyResult.ledgerEntryId,
+                }));
+              } else if (!economyEnabled) {
+                // eslint-disable-next-line no-console
+                console.log(JSON.stringify({
+                  event: 'hero_daily_coins_disabled',
+                  learnerId: heroLearnerId,
+                  questId: body.questId || '',
+                  taskId: body.taskId || '',
+                }));
+              }
+            } catch { /* best-effort */ }
             try {
               // eslint-disable-next-line no-console
               console.log(JSON.stringify({
@@ -1627,7 +1704,10 @@ export function createWorkerApp({
                 effortCompleted: updatedDaily?.effortCompleted || 0,
                 effortPlanned: updatedDaily?.effortPlanned || 0,
                 dailyStatus: updatedDaily?.status || 'active',
-                coinsEnabled: false,
+                coinsEnabled: economyEnabled,
+                coinsAwarded: mutationResult.economyResult?.amount || 0,
+                coinBalance: mutationResult.economyResult?.balanceAfter || (mutationResult.state?.economy?.balance || 0),
+                dailyCoinsAlreadyAwarded: mutationResult.economyResult?.alreadyAwarded || false,
                 heroStatePersistenceEnabled: true,
               },
               mutation: mutationResult.mutation || null,

--- a/worker/src/hero/claim.js
+++ b/worker/src/hero/claim.js
@@ -9,7 +9,7 @@ import { HERO_CLAIM_GRACE_HOURS } from '../../../shared/hero/constants.js';
  * Pure claim resolver — receives pre-loaded data, returns a result object.
  * Does NOT perform DB reads or writes.
  */
-export function resolveHeroClaimCommand({ body, heroProgressState, practiceSessionRows, subjectUiStates, nowTs }) {
+export function resolveHeroClaimCommand({ body, heroProgressState, practiceSessionRows, subjectUiStates, nowTs, economyEnabled }) {
   // 1. Validate request body
   const validation = validateClaimRequest(body);
   if (!validation.valid) {
@@ -82,6 +82,7 @@ export function resolveHeroClaimCommand({ body, heroProgressState, practiceSessi
     practiceSessionId,
     practiceSessionRows,
     subjectUiStates,
+    economyEnabled,
   });
 
   if (!evidence.found) {
@@ -101,7 +102,7 @@ export function resolveHeroClaimCommand({ body, heroProgressState, practiceSessi
   if (!evidence.completed) {
     return {
       ok: false,
-      code: 'hero_claim_evidence_not_completed',
+      code: evidence.code || 'hero_claim_evidence_not_completed',
       reason: evidence.reason || 'Session found but not completed',
     };
   }
@@ -127,14 +128,14 @@ export function resolveHeroClaimCommand({ body, heroProgressState, practiceSessi
   };
 }
 
-export function findCompletionEvidence({ taskId, questId, questFingerprint, learnerId, subjectId, practiceSessionId, practiceSessionRows, subjectUiStates }) {
+export function findCompletionEvidence({ taskId, questId, questFingerprint, learnerId, subjectId, practiceSessionId, practiceSessionRows, subjectUiStates, economyEnabled }) {
   // Strategy 1: Check practice_sessions with heroContext in summary
   if (practiceSessionRows && practiceSessionRows.length > 0) {
     // If a specific practiceSessionId was provided, check it first
     if (practiceSessionId) {
       const specific = practiceSessionRows.find(r => r.id === practiceSessionId);
       if (specific) {
-        const result = validatePracticeSession(specific, { taskId, questId, questFingerprint, learnerId, subjectId });
+        const result = validatePracticeSession(specific, { taskId, questId, questFingerprint, learnerId, subjectId, economyEnabled });
         if (result.found) return result;
       }
     }
@@ -196,7 +197,7 @@ export function findCompletionEvidence({ taskId, questId, questFingerprint, lear
   };
 }
 
-function validatePracticeSession(row, { taskId, questId, questFingerprint, learnerId, subjectId }) {
+function validatePracticeSession(row, { taskId, questId, questFingerprint, learnerId, subjectId, economyEnabled }) {
   if (row.learner_id !== learnerId) {
     return { found: true, completed: false, learnerMismatch: true, reason: 'Session belongs to different learner' };
   }
@@ -208,6 +209,9 @@ function validatePracticeSession(row, { taskId, questId, questFingerprint, learn
   }
   const summary = safeParseJson(row.summary_json);
   if (!summary?.heroContext) {
+    if (economyEnabled) {
+      return { found: true, completed: false, code: 'hero_claim_missing_hero_context', reason: 'Economy requires heroContext evidence' };
+    }
     return { found: true, completed: true, source: 'practice-session', practiceSessionId: row.id, sessionStatus: 'completed', summaryStatus: 'completed', reason: 'Completed but no heroContext in summary (pre-P3 session)' };
   }
   if (summary.heroContext.questId !== questId || summary.heroContext.taskId !== taskId) {

--- a/worker/src/hero/read-model.js
+++ b/worker/src/hero/read-model.js
@@ -1,4 +1,4 @@
-// Hero Mode — Shadow read-model assembler (v3 / v4).
+// Hero Mode — Shadow read-model assembler (v3 / v4 / v5).
 //
 // Orchestrates providers, eligibility, and the scheduler into a complete
 // shadow response. Pure read-only path — MUST NOT mutate any state, write
@@ -9,6 +9,9 @@
 //
 // v4 adds: progress merge, per-task completionStatus, pending completed
 // session detection, progress/claim blocks, writesEnabled, and mode='progress'.
+//
+// v5 adds: child-safe economy block (balance, today award status, recent
+// ledger summary), coinsEnabled=true, behind HERO_MODE_ECONOMY_ENABLED.
 
 import {
   HERO_DEFAULT_EFFORT_TARGET,
@@ -28,6 +31,7 @@ import { determineLaunchStatus } from '../../../shared/hero/launch-status.js';
 import { deriveHeroQuestFingerprint } from '../../../shared/hero/quest-fingerprint.js';
 import { resolveChildLabel, resolveChildReason } from '../../../shared/hero/hero-copy.js';
 import { deriveTaskCompletionStatus, deriveDailyCompletionStatus } from '../../../shared/hero/completion-status.js';
+import { selectChildSafeEconomyReadModel } from '../../../shared/hero/economy.js';
 import { mapHeroEnvelopeToSubjectPayload } from './launch-adapters/index.js';
 import { runProvider } from './providers/index.js';
 
@@ -104,7 +108,7 @@ function detectPendingCompletedSession(heroProgressState, recentCompletedSession
 }
 
 /**
- * Assemble the full Hero shadow read model for a learner (v3/v4).
+ * Assemble the full Hero shadow read model for a learner (v3/v4/v5).
  *
  * @param {Object} params
  * @param {string} params.learnerId
@@ -113,10 +117,11 @@ function detectPendingCompletedSession(heroProgressState, recentCompletedSession
  *   per-subject read-model (or null when absent)
  * @param {number} params.now — epoch milliseconds
  * @param {Object} [params.env] — Worker environment bindings (optional for P0 compat)
- * @param {Object} [params.heroProgressState] — normalised hero progress state (v4)
- * @param {Array}  [params.recentCompletedSessions] — recent completed practice session rows (v4)
- * @param {boolean} [params.progressEnabled] — whether progress mode is enabled (v4)
- * @returns {Object} shadow read model v3 or v4
+ * @param {Object} [params.heroProgressState] — normalised hero progress state (v4+)
+ * @param {Array}  [params.recentCompletedSessions] — recent completed practice session rows (v4+)
+ * @param {boolean} [params.progressEnabled] — whether progress mode is enabled (v4+)
+ * @param {boolean} [params.economyEnabled] — whether economy (coins) is enabled (v5)
+ * @returns {Object} shadow read model v3, v4, or v5
  */
 export function buildHeroShadowReadModel({
   learnerId,
@@ -127,6 +132,7 @@ export function buildHeroShadowReadModel({
   heroProgressState = null,
   recentCompletedSessions = [],
   progressEnabled = false,
+  economyEnabled = false,
 } = {}) {
   const dateKey = deriveDateKey(now, HERO_DEFAULT_TIMEZONE);
   const safeEnv = env || {};
@@ -397,8 +403,8 @@ export function buildHeroShadowReadModel({
   const canClaim = mergedTasks.some(t => t.canClaim);
   const pendingClaimTaskId = pendingCompletedHeroSession?.taskId || null;
 
-  // 16. Assemble v4 response shape
-  return {
+  // 16. Assemble v4 (or v5 with economy) response shape
+  const v4Base = {
     version: 4,
     mode: 'progress',
     childVisible: childUiEnabled,
@@ -448,5 +454,37 @@ export function buildHeroShadowReadModel({
     activeHeroSession,
     pendingCompletedHeroSession,
     debug: quest.debug,
+  };
+
+  // 17. If economy enabled → evolve to v5 with child-safe economy block
+  if (!economyEnabled) return v4Base;
+
+  const economyBlock = selectChildSafeEconomyReadModel(
+    heroProgressState,
+    dateKey,
+    quest.questId,
+  );
+
+  return {
+    ...v4Base,
+    version: 5,
+    coinsEnabled: true,
+    economy: economyBlock || {
+      enabled: true,
+      version: 1,
+      balance: 0,
+      lifetimeEarned: 0,
+      lifetimeSpent: 0,
+      today: {
+        dateKey,
+        questId: quest.questId,
+        awardStatus: 'not-eligible',
+        coinsAvailable: 100,
+        coinsAwarded: 0,
+        ledgerEntryId: null,
+        awardedAt: null,
+      },
+      recentLedger: [],
+    },
   };
 }

--- a/worker/src/hero/routes.js
+++ b/worker/src/hero/routes.js
@@ -60,11 +60,12 @@ export async function handleHeroReadModel({
 
   // 4b. P3 U7: load progress bundle for the v4 read model when progress enabled.
   const progressFlagEnabled = envFlagEnabled(env.HERO_MODE_PROGRESS_ENABLED);
+  const economyFlagEnabled = envFlagEnabled(env.HERO_MODE_ECONOMY_ENABLED);
   const heroProgressData = progressFlagEnabled
     ? await repository.readHeroProgressData(learnerId)
     : { heroProgressState: null, recentCompletedSessions: [] };
 
-  // 5. Assemble the shadow read model (v3 or v4: pass accountId and env for
+  // 5. Assemble the shadow read model (v3, v4, or v5: pass accountId and env for
   //    quest fingerprint and the HERO_MODE_CHILD_UI_ENABLED gate).
   const nowTs = typeof now === 'function' ? now() : Date.now();
   const result = buildHeroShadowReadModel({
@@ -76,6 +77,7 @@ export async function handleHeroReadModel({
     heroProgressState: heroProgressData.heroProgressState,
     recentCompletedSessions: heroProgressData.recentCompletedSessions,
     progressEnabled: progressFlagEnabled,
+    economyEnabled: progressFlagEnabled && economyFlagEnabled,
   });
 
   // U10: structured observability — fire-and-forget, never blocks the response.

--- a/worker/wrangler.example.jsonc
+++ b/worker/wrangler.example.jsonc
@@ -29,7 +29,8 @@
     "PUNCTUATION_EVENTS_ENABLED": "false",
     "HERO_MODE_SHADOW_ENABLED": "false",
     "HERO_MODE_LAUNCH_ENABLED": "false",
-    "HERO_MODE_CHILD_UI_ENABLED": "false"
+    "HERO_MODE_CHILD_UI_ENABLED": "false",
+    "HERO_MODE_ECONOMY_ENABLED": "false"
   },
   "d1_databases": [
     {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -45,7 +45,8 @@
     "HERO_MODE_SHADOW_ENABLED": "false",
     "HERO_MODE_LAUNCH_ENABLED": "false",
     "HERO_MODE_CHILD_UI_ENABLED": "false",
-    "HERO_MODE_PROGRESS_ENABLED": "false"
+    "HERO_MODE_PROGRESS_ENABLED": "false",
+    "HERO_MODE_ECONOMY_ENABLED": "false"
   },
   "d1_databases": [
     {


### PR DESCRIPTION
## Summary

- Adds the first Hero reward economy: daily Hero Quest completion awards exactly +100 Hero Coins, once per day, deterministically and idempotently
- Economy is a reaction to authoritative daily completion (P3 claim-task), not a goal function for the scheduler
- All economy writes are inside the existing `runHeroCommandMutation` batch — same CAS, same receipt dedup, same atomic D1 batch
- Feature-gated behind `HERO_MODE_ECONOMY_ENABLED=false` (fifth flag in hierarchy)

## Implementation Units (10 commits)

| Unit | Description | Tests |
|------|-------------|-------|
| U0 | Trust anchor hardening — reject claims without heroContext when economy enabled | 12 |
| U1 | Shared economy contract — constants, deterministic IDs, normalisers | 15 |
| U2 | Hero state v1→v2 migration with economy block | 24 |
| U3 | Daily completion award helper — pure, idempotent | 17 |
| U4 | Worker claim-task economy integration — same batch, event mirror | 8 |
| U5 | Read model v5 — child-safe economy fields | 15 |
| U6 | Client/UI economy acknowledgement — calm copy, HeroTaskBanner economy-free | 18 |
| U7 | Vocabulary boundary split — pressure forbidden, economy scoped | 8 |
| U8 | Abuse/safety E2E tests — duplicate, two-tab, cross-learner, stale-write | 25 |
| U9 | Economy telemetry — structured logs + deterministic event mirror | 9 |

## Safety invariants

- 779 hero tests pass, 0 failures
- 893 worker tests pass, 0 regressions
- Missing heroContext cannot lead to Coins (U0 trust anchor)
- Three-layer idempotency: mutation receipt → already-completed → deterministic ledger entry ID
- Economy disabled preserves P3 behaviour exactly
- Subject mastery, Stars, scheduler, marking, feedback — all unchanged
- HeroTaskBanner remains economy-free (structural scan)
- Pressure vocabulary forbidden everywhere (U7 boundary tests)

## Test plan

- [ ] All hero tests pass (`node --test tests/hero-*.test.js` → 779 pass)
- [ ] All worker tests pass (`node --test tests/worker-*.test.js` → 893 pass)
- [ ] Economy flag defaults false in wrangler.jsonc
- [ ] With economy on: final daily claim awards +100 coins exactly once
- [ ] With economy off: claim-task behaviour identical to P3
- [ ] Read model returns v5 with economy block (economy on) or v4 (economy off)
- [ ] HeroQuestCard shows calm coins copy when awarded
- [ ] No pressure vocabulary in any Hero surface