### PR TITLE
feat(punctuation-qg): P4-U7 parity baseline snapshots for 18 legacy families

### DIFF
--- a/scripts/generate-p4-parity-baseline.js
+++ b/scripts/generate-p4-parity-baseline.js
@@ -1,0 +1,108 @@
+/**
+ * Generate P4 characterisation baseline fixture for 18 legacy (unconverted) families.
+ * Run once: node scripts/generate-p4-parity-baseline.js
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createPunctuationGeneratedItems } from '../shared/punctuation/generators.js';
+import { PUNCTUATION_CONTENT_MANIFEST } from '../shared/punctuation/content.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const P3_DSL_FAMILIES = new Set([
+  'gen_sentence_endings_insert',
+  'gen_apostrophe_contractions_fix',
+  'gen_comma_clarity_insert',
+  'gen_dash_clause_fix',
+  'gen_dash_clause_combine',
+  'gen_hyphen_insert',
+  'gen_semicolon_list_fix',
+]);
+
+const LEGACY_FAMILIES = [
+  'gen_apostrophe_possession_insert',
+  'gen_apostrophe_mix_paragraph',
+  'gen_speech_insert',
+  'gen_fronted_speech_paragraph',
+  'gen_list_commas_insert',
+  'gen_list_commas_combine',
+  'gen_fronted_adverbial_fix',
+  'gen_fronted_adverbial_combine',
+  'gen_parenthesis_fix',
+  'gen_parenthesis_combine',
+  'gen_parenthesis_speech_paragraph',
+  'gen_colon_list_insert',
+  'gen_colon_list_combine',
+  'gen_semicolon_fix',
+  'gen_semicolon_combine',
+  'gen_colon_semicolon_paragraph',
+  'gen_bullet_points_fix',
+  'gen_bullet_points_paragraph',
+];
+
+const SEED = PUNCTUATION_CONTENT_MANIFEST.releaseId;
+
+function snapshotItem(item) {
+  return {
+    id: item.id,
+    generatorFamilyId: item.generatorFamilyId,
+    variantSignature: item.variantSignature,
+    templateId: item.templateId,
+    prompt: item.prompt,
+    stem: item.stem,
+    model: item.model,
+    validatorType: item.validator?.type || null,
+    validator: item.validator || null,
+    rubric: item.rubric || null,
+    misconceptionTags: item.misconceptionTags,
+    readiness: item.readiness,
+  };
+}
+
+function generateAtDepth(perFamily) {
+  const items = createPunctuationGeneratedItems({ seed: SEED, perFamily });
+  const legacy = items.filter(
+    (i) => !P3_DSL_FAMILIES.has(i.generatorFamilyId) && LEGACY_FAMILIES.includes(i.generatorFamilyId),
+  );
+  const grouped = {};
+  for (const familyId of LEGACY_FAMILIES) {
+    grouped[familyId] = legacy
+      .filter((i) => i.generatorFamilyId === familyId)
+      .map(snapshotItem);
+  }
+  return grouped;
+}
+
+const depth4 = generateAtDepth(4);
+const depth8 = generateAtDepth(8);
+
+// Validate we have exactly 18 families at each depth
+const d4Families = Object.keys(depth4).filter((k) => depth4[k].length > 0);
+const d8Families = Object.keys(depth8).filter((k) => depth8[k].length > 0);
+
+if (d4Families.length !== 18) {
+  console.error(`ERROR: depth4 has ${d4Families.length} families, expected 18`);
+  process.exit(1);
+}
+if (d8Families.length !== 18) {
+  console.error(`ERROR: depth8 has ${d8Families.length} families, expected 18`);
+  process.exit(1);
+}
+
+const fixture = {
+  meta: {
+    generatedAt: '2026-04-29',
+    purpose: 'P4 characterisation baseline for 18 legacy families before DSL conversion',
+    familyCount: 18,
+    seed: SEED,
+  },
+  depth4,
+  depth8,
+};
+
+const outPath = path.join(__dirname, '..', 'tests', 'fixtures', 'punctuation-qg-p4-parity-baseline.json');
+fs.writeFileSync(outPath, JSON.stringify(fixture, null, 2) + '\n', 'utf8');
+console.log(`Written: ${outPath}`);
+console.log(`  depth4: ${Object.values(depth4).flat().length} items across ${d4Families.length} families`);
+console.log(`  depth8: ${Object.values(depth8).flat().length} items across ${d8Families.length} families`);

--- a/tests/fixtures/punctuation-qg-p4-parity-baseline.json
+++ b/tests/fixtures/punctuation-qg-p4-parity-baseline.json
@@ -1,0 +1,6960 @@
+{
+  "meta": {
+    "generatedAt": "2026-04-29",
+    "purpose": "P4 characterisation baseline for 18 legacy families before DSL conversion",
+    "familyCount": 18,
+    "seed": "punctuation-r4-full-14-skill-structure"
+  },
+  "depth4": {
+    "gen_apostrophe_possession_insert": [
+      {
+        "id": "gen_apostrophe_possession_insert_1gnet8j_1",
+        "generatorFamilyId": "gen_apostrophe_possession_insert",
+        "variantSignature": "puncsig_f6gya8",
+        "templateId": "gen_apostrophe_possession_insert_template_veyue5",
+        "prompt": "Add apostrophes to show possession.",
+        "stem": "The childrens sketches covered the teachers desk.",
+        "model": "The children's sketches covered the teacher's desk.",
+        "validatorType": "requiresTokens",
+        "validator": {
+          "type": "requiresTokens",
+          "tokens": [
+            "children's",
+            "teacher's"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "apostrophe.possession_missing"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_apostrophe_possession_insert_1gdf7jk_2",
+        "generatorFamilyId": "gen_apostrophe_possession_insert",
+        "variantSignature": "puncsig_17nx2qt",
+        "templateId": "gen_apostrophe_possession_insert_template_100dwn",
+        "prompt": "Add apostrophes to show possession.",
+        "stem": "The captains whistle was beside the teams coats.",
+        "model": "The captain's whistle was beside the team's coats.",
+        "validatorType": "requiresTokens",
+        "validator": {
+          "type": "requiresTokens",
+          "tokens": [
+            "captain's",
+            "team's"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "apostrophe.possession_missing"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_apostrophe_possession_insert_1h7e0mh_3",
+        "generatorFamilyId": "gen_apostrophe_possession_insert",
+        "variantSignature": "puncsig_1dsmbxy",
+        "templateId": "gen_apostrophe_possession_insert_template_16nnw5j",
+        "prompt": "Add apostrophes to show possession.",
+        "stem": "The sailors flag was near the harbours gate.",
+        "model": "The sailor's flag was near the harbour's gate.",
+        "validatorType": "requiresTokens",
+        "validator": {
+          "type": "requiresTokens",
+          "tokens": [
+            "sailor's",
+            "harbour's"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "apostrophe.possession_missing"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_apostrophe_possession_insert_1gxeexi_4",
+        "generatorFamilyId": "gen_apostrophe_possession_insert",
+        "variantSignature": "puncsig_xkduxs",
+        "templateId": "gen_apostrophe_possession_insert_template_ffg657",
+        "prompt": "Add apostrophes to show possession.",
+        "stem": "The artists brush was near the museums door.",
+        "model": "The artist's brush was near the museum's door.",
+        "validatorType": "requiresTokens",
+        "validator": {
+          "type": "requiresTokens",
+          "tokens": [
+            "artist's",
+            "museum's"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "apostrophe.possession_missing"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      }
+    ],
+    "gen_apostrophe_mix_paragraph": [
+      {
+        "id": "gen_apostrophe_mix_paragraph_10iiu3e_1",
+        "generatorFamilyId": "gen_apostrophe_mix_paragraph",
+        "variantSignature": "puncsig_14shna6",
+        "templateId": "gen_apostrophe_mix_paragraph_template_18q5fxx",
+        "prompt": "Repair the apostrophes in the short passage.",
+        "stem": "We wont move the childrens paintings. The teachers notes are ready.",
+        "model": "We won't move the children's paintings. The teachers' notes are ready.",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresApostropheForms",
+              "tokens": [
+                "won't",
+                "children's",
+                "teachers' notes"
+              ],
+              "forbidden": [
+                "wont",
+                "childrens",
+                "teachers notes"
+              ],
+              "misconceptionTags": [
+                "apostrophe.contraction_missing",
+                "apostrophe.possession_missing",
+                "apostrophe.possession_number"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "apostrophe.contraction_missing",
+          "apostrophe.possession_missing",
+          "apostrophe.possession_number"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_apostrophe_mix_paragraph_10sifsd_2",
+        "generatorFamilyId": "gen_apostrophe_mix_paragraph",
+        "variantSignature": "puncsig_aco1pd",
+        "templateId": "gen_apostrophe_mix_paragraph_template_1l5nlo5",
+        "prompt": "Repair the apostrophes in the short passage.",
+        "stem": "I cant find the mens boots. The boys jackets are drying.",
+        "model": "I can't find the men's boots. The boys' jackets are drying.",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresApostropheForms",
+              "tokens": [
+                "can't",
+                "men's",
+                "boys' jackets"
+              ],
+              "forbidden": [
+                "cant",
+                "mens",
+                "boys jackets"
+              ],
+              "misconceptionTags": [
+                "apostrophe.contraction_missing",
+                "apostrophe.possession_missing",
+                "apostrophe.possession_number"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "apostrophe.contraction_missing",
+          "apostrophe.possession_missing",
+          "apostrophe.possession_number"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_apostrophe_mix_paragraph_zyjmpg_3",
+        "generatorFamilyId": "gen_apostrophe_mix_paragraph",
+        "variantSignature": "puncsig_1d7fd2j",
+        "templateId": "gen_apostrophe_mix_paragraph_template_b84fkf",
+        "prompt": "Repair the apostrophes in the short passage.",
+        "stem": "Theyre checking the captains map. We dont know the teams plan.",
+        "model": "They're checking the captain's map. We don't know the team's plan.",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresApostropheForms",
+              "tokens": [
+                "they're",
+                "captain's",
+                "don't",
+                "team's"
+              ],
+              "forbidden": [
+                "theyre",
+                "captains",
+                "dont",
+                "teams plan"
+              ],
+              "misconceptionTags": [
+                "apostrophe.contraction_missing",
+                "apostrophe.possession_missing"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "apostrophe.contraction_missing",
+          "apostrophe.possession_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_apostrophe_mix_paragraph_108j8ef_4",
+        "generatorFamilyId": "gen_apostrophe_mix_paragraph",
+        "variantSignature": "puncsig_60dsl5",
+        "templateId": "gen_apostrophe_mix_paragraph_template_1ds8nud",
+        "prompt": "Repair the apostrophes in the short passage.",
+        "stem": "She wont borrow the girls pencil. Its on the teachers shelf.",
+        "model": "She won't borrow the girl's pencil. It's on the teacher's shelf.",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresApostropheForms",
+              "tokens": [
+                "won't",
+                "girl's",
+                "it's",
+                "teacher's"
+              ],
+              "forbidden": [
+                "wont",
+                "girls pencil",
+                "its",
+                "teachers shelf"
+              ],
+              "misconceptionTags": [
+                "apostrophe.contraction_missing",
+                "apostrophe.possession_missing"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "apostrophe.contraction_missing",
+          "apostrophe.possession_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      }
+    ],
+    "gen_speech_insert": [
+      {
+        "id": "gen_speech_insert_1s7w6o3_1",
+        "generatorFamilyId": "gen_speech_insert",
+        "variantSignature": "puncsig_9ughq9",
+        "templateId": "gen_speech_insert_template_15qxnnl",
+        "prompt": "Add the direct-speech punctuation.",
+        "stem": "Ravi said, the bell is ringing.",
+        "model": "Ravi said, \"The bell is ringing.\"",
+        "validatorType": null,
+        "validator": null,
+        "rubric": {
+          "type": "speech",
+          "reportingPosition": "before",
+          "spokenWords": "the bell is ringing",
+          "requiredTerminal": "."
+        },
+        "misconceptionTags": [
+          "speech.quote_missing",
+          "speech.reporting_comma_missing",
+          "speech.punctuation_missing"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_speech_insert_1rxwkz4_2",
+        "generatorFamilyId": "gen_speech_insert",
+        "variantSignature": "puncsig_xihz5d",
+        "templateId": "gen_speech_insert_template_1s39sn2",
+        "prompt": "Add the direct-speech punctuation.",
+        "stem": "Maya asked, can we start now?",
+        "model": "Maya asked, \"Can we start now?\"",
+        "validatorType": null,
+        "validator": null,
+        "rubric": {
+          "type": "speech",
+          "reportingPosition": "before",
+          "spokenWords": "can we start now",
+          "requiredTerminal": "?"
+        },
+        "misconceptionTags": [
+          "speech.quote_missing",
+          "speech.reporting_comma_missing",
+          "speech.punctuation_missing"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_speech_insert_1srve21_3",
+        "generatorFamilyId": "gen_speech_insert",
+        "variantSignature": "puncsig_nclq3v",
+        "templateId": "gen_speech_insert_template_1lt7eo1",
+        "prompt": "Add the direct-speech punctuation.",
+        "stem": "Tom asked, where did the map go?",
+        "model": "Tom asked, \"Where did the map go?\"",
+        "validatorType": null,
+        "validator": null,
+        "rubric": {
+          "type": "speech",
+          "reportingPosition": "before",
+          "spokenWords": "where did the map go",
+          "requiredTerminal": "?"
+        },
+        "misconceptionTags": [
+          "speech.quote_missing",
+          "speech.reporting_comma_missing",
+          "speech.punctuation_missing"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_speech_insert_1shvsd2_4",
+        "generatorFamilyId": "gen_speech_insert",
+        "variantSignature": "puncsig_rd8g70",
+        "templateId": "gen_speech_insert_template_1oh4tes",
+        "prompt": "Add the direct-speech punctuation.",
+        "stem": "Lena whispered, keep the gate closed.",
+        "model": "Lena whispered, \"Keep the gate closed.\"",
+        "validatorType": null,
+        "validator": null,
+        "rubric": {
+          "type": "speech",
+          "reportingPosition": "before",
+          "spokenWords": "keep the gate closed",
+          "requiredTerminal": "."
+        },
+        "misconceptionTags": [
+          "speech.quote_missing",
+          "speech.reporting_comma_missing",
+          "speech.punctuation_missing"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      }
+    ],
+    "gen_fronted_speech_paragraph": [
+      {
+        "id": "gen_fronted_speech_paragraph_1n8m9sv_1",
+        "generatorFamilyId": "gen_fronted_speech_paragraph",
+        "variantSignature": "puncsig_cxl2dr",
+        "templateId": "gen_fronted_speech_paragraph_template_flawdf",
+        "prompt": "Repair the punctuation in the short passage.",
+        "stem": "After rehearsal Omar said the props are packed",
+        "model": "After rehearsal, Omar said, \"The props are packed.\"",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "startsWithPhraseComma",
+              "phrase": "After rehearsal",
+              "misconceptionTags": [
+                "comma.fronted_adverbial_missing"
+              ]
+            },
+            {
+              "type": "speechWithWords",
+              "words": "the props are packed",
+              "requiredTerminal": ".",
+              "misconceptionTags": [
+                "speech.quote_missing",
+                "speech.reporting_comma_missing",
+                "speech.punctuation_missing"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.fronted_adverbial_missing",
+          "speech.quote_missing",
+          "speech.reporting_comma_missing",
+          "speech.punctuation_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_fronted_speech_paragraph_1mymo3w_2",
+        "generatorFamilyId": "gen_fronted_speech_paragraph",
+        "variantSignature": "puncsig_145vp3p",
+        "templateId": "gen_fronted_speech_paragraph_template_ey0omc",
+        "prompt": "Repair the punctuation in the short passage.",
+        "stem": "Before lunch Zara asked can we start now",
+        "model": "Before lunch, Zara asked, \"Can we start now?\"",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "startsWithPhraseComma",
+              "phrase": "Before lunch",
+              "misconceptionTags": [
+                "comma.fronted_adverbial_missing"
+              ]
+            },
+            {
+              "type": "speechWithWords",
+              "words": "can we start now",
+              "requiredTerminal": "?",
+              "misconceptionTags": [
+                "speech.quote_missing",
+                "speech.reporting_comma_missing",
+                "speech.punctuation_missing"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.fronted_adverbial_missing",
+          "speech.quote_missing",
+          "speech.reporting_comma_missing",
+          "speech.punctuation_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_fronted_speech_paragraph_1nslh6t_3",
+        "generatorFamilyId": "gen_fronted_speech_paragraph",
+        "variantSignature": "puncsig_15vl1z5",
+        "templateId": "gen_fronted_speech_paragraph_template_q48vyy",
+        "prompt": "Repair the punctuation in the short passage.",
+        "stem": "At the gate Ben asked are we late",
+        "model": "At the gate, Ben asked, \"Are we late?\"",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "startsWithPhraseComma",
+              "phrase": "At the gate",
+              "misconceptionTags": [
+                "comma.fronted_adverbial_missing"
+              ]
+            },
+            {
+              "type": "speechWithWords",
+              "words": "are we late",
+              "requiredTerminal": "?",
+              "misconceptionTags": [
+                "speech.quote_missing",
+                "speech.reporting_comma_missing",
+                "speech.punctuation_missing"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.fronted_adverbial_missing",
+          "speech.quote_missing",
+          "speech.reporting_comma_missing",
+          "speech.punctuation_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_fronted_speech_paragraph_1nilvhu_4",
+        "generatorFamilyId": "gen_fronted_speech_paragraph",
+        "variantSignature": "puncsig_w1btfv",
+        "templateId": "gen_fronted_speech_paragraph_template_1vge4by",
+        "prompt": "Repair the punctuation in the short passage.",
+        "stem": "During assembly Lina whispered please sit down",
+        "model": "During assembly, Lina whispered, \"Please sit down.\"",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "startsWithPhraseComma",
+              "phrase": "During assembly",
+              "misconceptionTags": [
+                "comma.fronted_adverbial_missing"
+              ]
+            },
+            {
+              "type": "speechWithWords",
+              "words": "please sit down",
+              "requiredTerminal": ".",
+              "misconceptionTags": [
+                "speech.quote_missing",
+                "speech.reporting_comma_missing",
+                "speech.punctuation_missing"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.fronted_adverbial_missing",
+          "speech.quote_missing",
+          "speech.reporting_comma_missing",
+          "speech.punctuation_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      }
+    ],
+    "gen_list_commas_insert": [
+      {
+        "id": "gen_list_commas_insert_1h0oxzg_1",
+        "generatorFamilyId": "gen_list_commas_insert",
+        "variantSignature": "puncsig_1dte5cx",
+        "templateId": "gen_list_commas_insert_template_1cb1q38",
+        "prompt": "Add commas to separate the list items.",
+        "stem": "We packed ropes maps and snacks.",
+        "model": "We packed ropes, maps and snacks.",
+        "validatorType": "requiresListCommas",
+        "validator": {
+          "type": "requiresListCommas",
+          "items": [
+            "ropes",
+            "maps",
+            "snacks"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.list_separator_missing",
+          "comma.unnecessary_final_comma"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_list_commas_insert_1haojof_2",
+        "generatorFamilyId": "gen_list_commas_insert",
+        "variantSignature": "puncsig_1aonvno",
+        "templateId": "gen_list_commas_insert_template_1xvy2rf",
+        "prompt": "Add commas to separate the list items.",
+        "stem": "The box held shells bells and chalk.",
+        "model": "The box held shells, bells and chalk.",
+        "validatorType": "requiresListCommas",
+        "validator": {
+          "type": "requiresListCommas",
+          "items": [
+            "shells",
+            "bells",
+            "chalk"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.list_separator_missing",
+          "comma.unnecessary_final_comma"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_list_commas_insert_1hko5de_3",
+        "generatorFamilyId": "gen_list_commas_insert",
+        "variantSignature": "puncsig_jl4vs2",
+        "templateId": "gen_list_commas_insert_template_1myck8w",
+        "prompt": "Add commas to separate the list items.",
+        "stem": "The shelf held paints brushes and paper.",
+        "model": "The shelf held paints, brushes and paper.",
+        "validatorType": "requiresListCommas",
+        "validator": {
+          "type": "requiresListCommas",
+          "items": [
+            "paints",
+            "brushes",
+            "paper"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.list_separator_missing",
+          "comma.unnecessary_final_comma"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_list_commas_insert_1hunr2d_4",
+        "generatorFamilyId": "gen_list_commas_insert",
+        "variantSignature": "puncsig_1e1g3rp",
+        "templateId": "gen_list_commas_insert_template_62b991",
+        "prompt": "Add commas to separate the list items.",
+        "stem": "We saw gulls seals and dolphins.",
+        "model": "We saw gulls, seals and dolphins.",
+        "validatorType": "requiresListCommas",
+        "validator": {
+          "type": "requiresListCommas",
+          "items": [
+            "gulls",
+            "seals",
+            "dolphins"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.list_separator_missing",
+          "comma.unnecessary_final_comma"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      }
+    ],
+    "gen_list_commas_combine": [
+      {
+        "id": "gen_list_commas_combine_peklr6_1",
+        "generatorFamilyId": "gen_list_commas_combine",
+        "variantSignature": "puncsig_4ebjlq",
+        "templateId": "gen_list_commas_combine_template_14p5ger",
+        "prompt": "Combine the notes into one correctly punctuated sentence.",
+        "stem": "The tray held\n- shells\n- feathers\n- pebbles",
+        "model": "The tray held shells, feathers and pebbles.",
+        "validatorType": "combineListSentence",
+        "validator": {
+          "type": "combineListSentence",
+          "opening": "The tray held",
+          "items": [
+            "shells",
+            "feathers",
+            "pebbles"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.list_separator_missing",
+          "comma.unnecessary_final_comma"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_list_commas_combine_pok7g5_2",
+        "generatorFamilyId": "gen_list_commas_combine",
+        "variantSignature": "puncsig_1e11bmr",
+        "templateId": "gen_list_commas_combine_template_qmva3q",
+        "prompt": "Combine the notes into one correctly punctuated sentence.",
+        "stem": "We collected\n- leaves\n- twigs\n- acorns",
+        "model": "We collected leaves, twigs and acorns.",
+        "validatorType": "combineListSentence",
+        "validator": {
+          "type": "combineListSentence",
+          "opening": "We collected",
+          "items": [
+            "leaves",
+            "twigs",
+            "acorns"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.list_separator_missing",
+          "comma.unnecessary_final_comma"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_list_commas_combine_ouled8_3",
+        "generatorFamilyId": "gen_list_commas_combine",
+        "variantSignature": "puncsig_cbesme",
+        "templateId": "gen_list_commas_combine_template_1d8dwo5",
+        "prompt": "Combine the notes into one correctly punctuated sentence.",
+        "stem": "The bag contained\n- chalk\n- string\n- tape",
+        "model": "The bag contained chalk, string and tape.",
+        "validatorType": "combineListSentence",
+        "validator": {
+          "type": "combineListSentence",
+          "opening": "The bag contained",
+          "items": [
+            "chalk",
+            "string",
+            "tape"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.list_separator_missing",
+          "comma.unnecessary_final_comma"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_list_commas_combine_p4l027_4",
+        "generatorFamilyId": "gen_list_commas_combine",
+        "variantSignature": "puncsig_08ojzv",
+        "templateId": "gen_list_commas_combine_template_14arcfx",
+        "prompt": "Combine the notes into one correctly punctuated sentence.",
+        "stem": "Our lunch included\n- apples\n- sandwiches\n- juice",
+        "model": "Our lunch included apples, sandwiches and juice.",
+        "validatorType": "combineListSentence",
+        "validator": {
+          "type": "combineListSentence",
+          "opening": "Our lunch included",
+          "items": [
+            "apples",
+            "sandwiches",
+            "juice"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.list_separator_missing",
+          "comma.unnecessary_final_comma"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      }
+    ],
+    "gen_fronted_adverbial_fix": [
+      {
+        "id": "gen_fronted_adverbial_fix_1u50vwu_1",
+        "generatorFamilyId": "gen_fronted_adverbial_fix",
+        "variantSignature": "puncsig_dq7z5w",
+        "templateId": "gen_fronted_adverbial_fix_template_1e1may2",
+        "prompt": "Correct the comma after the fronted adverbial.",
+        "stem": "After the storm the path was muddy.",
+        "model": "After the storm, the path was muddy.",
+        "validatorType": "startsWithPhraseComma",
+        "validator": {
+          "type": "startsWithPhraseComma",
+          "phrase": "After the storm"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.fronted_adverbial_missing"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_fronted_adverbial_fix_1uf0hlt_2",
+        "generatorFamilyId": "gen_fronted_adverbial_fix",
+        "variantSignature": "puncsig_823nwf",
+        "templateId": "gen_fronted_adverbial_fix_template_18k5e78",
+        "prompt": "Correct the comma after the fronted adverbial.",
+        "stem": "Before sunrise the crew checked the ropes.",
+        "model": "Before sunrise, the crew checked the ropes.",
+        "validatorType": "startsWithPhraseComma",
+        "validator": {
+          "type": "startsWithPhraseComma",
+          "phrase": "Before sunrise"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.fronted_adverbial_missing"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_fronted_adverbial_fix_1tl1oiw_3",
+        "generatorFamilyId": "gen_fronted_adverbial_fix",
+        "variantSignature": "puncsig_8l2wtt",
+        "templateId": "gen_fronted_adverbial_fix_template_1wney8c",
+        "prompt": "Correct the comma after the fronted adverbial.",
+        "stem": "During the concert the hall became silent.",
+        "model": "During the concert, the hall became silent.",
+        "validatorType": "startsWithPhraseComma",
+        "validator": {
+          "type": "startsWithPhraseComma",
+          "phrase": "During the concert"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.fronted_adverbial_missing"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_fronted_adverbial_fix_1tv1a7v_4",
+        "generatorFamilyId": "gen_fronted_adverbial_fix",
+        "variantSignature": "puncsig_atzp2i",
+        "templateId": "gen_fronted_adverbial_fix_template_da25i5",
+        "prompt": "Correct the comma after the fronted adverbial.",
+        "stem": "At the edge of the field the coach waited.",
+        "model": "At the edge of the field, the coach waited.",
+        "validatorType": "startsWithPhraseComma",
+        "validator": {
+          "type": "startsWithPhraseComma",
+          "phrase": "At the edge of the field"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.fronted_adverbial_missing"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      }
+    ],
+    "gen_fronted_adverbial_combine": [
+      {
+        "id": "gen_fronted_adverbial_combine_uadfsk_1",
+        "generatorFamilyId": "gen_fronted_adverbial_combine",
+        "variantSignature": "puncsig_1un9zhg",
+        "templateId": "gen_fronted_adverbial_combine_template_kfsxpg",
+        "prompt": "Combine the adverbial and main clause into one sentence.",
+        "stem": "Before sunrise\nThe crew checked the ropes.",
+        "model": "Before sunrise, the crew checked the ropes.",
+        "validatorType": "combineFrontedAdverbial",
+        "validator": {
+          "type": "combineFrontedAdverbial",
+          "phrase": "Before sunrise",
+          "mainClause": "the crew checked the ropes"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.fronted_adverbial_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_fronted_adverbial_combine_ukd1hj_2",
+        "generatorFamilyId": "gen_fronted_adverbial_combine",
+        "variantSignature": "puncsig_5xqw3g",
+        "templateId": "gen_fronted_adverbial_combine_template_7tnqjq",
+        "prompt": "Combine the adverbial and main clause into one sentence.",
+        "stem": "After the rehearsal\nThe cast packed away the props.",
+        "model": "After the rehearsal, the cast packed away the props.",
+        "validatorType": "combineFrontedAdverbial",
+        "validator": {
+          "type": "combineFrontedAdverbial",
+          "phrase": "After the rehearsal",
+          "mainClause": "the cast packed away the props"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.fronted_adverbial_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_fronted_adverbial_combine_uucn6i_3",
+        "generatorFamilyId": "gen_fronted_adverbial_combine",
+        "variantSignature": "puncsig_1s62czm",
+        "templateId": "gen_fronted_adverbial_combine_template_116hnmp",
+        "prompt": "Combine the adverbial and main clause into one sentence.",
+        "stem": "During the concert\nThe hall became silent.",
+        "model": "During the concert, the hall became silent.",
+        "validatorType": "combineFrontedAdverbial",
+        "validator": {
+          "type": "combineFrontedAdverbial",
+          "phrase": "During the concert",
+          "mainClause": "the hall became silent"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.fronted_adverbial_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_fronted_adverbial_combine_v4c8vh_4",
+        "generatorFamilyId": "gen_fronted_adverbial_combine",
+        "variantSignature": "puncsig_36di7r",
+        "templateId": "gen_fronted_adverbial_combine_template_1plxa4t",
+        "prompt": "Combine the adverbial and main clause into one sentence.",
+        "stem": "At the edge of the field\nThe coach waited.",
+        "model": "At the edge of the field, the coach waited.",
+        "validatorType": "combineFrontedAdverbial",
+        "validator": {
+          "type": "combineFrontedAdverbial",
+          "phrase": "At the edge of the field",
+          "mainClause": "the coach waited"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.fronted_adverbial_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      }
+    ],
+    "gen_parenthesis_fix": [
+      {
+        "id": "gen_parenthesis_fix_a2o80p_1",
+        "generatorFamilyId": "gen_parenthesis_fix",
+        "variantSignature": "puncsig_mb2d85",
+        "templateId": "gen_parenthesis_fix_template_77v44m",
+        "prompt": "Correct the parenthesis punctuation.",
+        "stem": "The tower a useful lookout stood above the bay.",
+        "model": "The tower, a useful lookout, stood above the bay.",
+        "validatorType": "requiresParentheticalPhrase",
+        "validator": {
+          "type": "requiresParentheticalPhrase",
+          "before": "The tower",
+          "phrase": "a useful lookout",
+          "after": "stood above the bay"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.parenthesis_missing",
+          "structure.parenthesis_unbalanced"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_parenthesis_fix_9sombq_2",
+        "generatorFamilyId": "gen_parenthesis_fix",
+        "variantSignature": "puncsig_1c9v5hl",
+        "templateId": "gen_parenthesis_fix_template_1afsvei",
+        "prompt": "Correct the parenthesis punctuation.",
+        "stem": "The harbour, an old fishing port was busy.",
+        "model": "The harbour, an old fishing port, was busy.",
+        "validatorType": "requiresParentheticalPhrase",
+        "validator": {
+          "type": "requiresParentheticalPhrase",
+          "before": "The harbour",
+          "phrase": "an old fishing port",
+          "after": "was busy"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.parenthesis_missing",
+          "structure.parenthesis_unbalanced"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_parenthesis_fix_9ip0mr_3",
+        "generatorFamilyId": "gen_parenthesis_fix",
+        "variantSignature": "puncsig_1hjjs2m",
+        "templateId": "gen_parenthesis_fix_template_1hxyt9u",
+        "prompt": "Correct the parenthesis punctuation.",
+        "stem": "Mr Patel our maths teacher smiled proudly.",
+        "model": "Mr Patel, our maths teacher, smiled proudly.",
+        "validatorType": "requiresParentheticalPhrase",
+        "validator": {
+          "type": "requiresParentheticalPhrase",
+          "before": "Mr Patel",
+          "phrase": "our maths teacher",
+          "after": "smiled proudly"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.parenthesis_missing",
+          "structure.parenthesis_unbalanced"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_parenthesis_fix_98pexs_4",
+        "generatorFamilyId": "gen_parenthesis_fix",
+        "variantSignature": "puncsig_673mgn",
+        "templateId": "gen_parenthesis_fix_template_11xdcus",
+        "prompt": "Correct the parenthesis punctuation.",
+        "stem": "The library a quiet room closed early.",
+        "model": "The library, a quiet room, closed early.",
+        "validatorType": "requiresParentheticalPhrase",
+        "validator": {
+          "type": "requiresParentheticalPhrase",
+          "before": "The library",
+          "phrase": "a quiet room",
+          "after": "closed early"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.parenthesis_missing",
+          "structure.parenthesis_unbalanced"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      }
+    ],
+    "gen_parenthesis_combine": [
+      {
+        "id": "gen_parenthesis_combine_t29n63_1",
+        "generatorFamilyId": "gen_parenthesis_combine",
+        "variantSignature": "puncsig_1pdrtm4",
+        "templateId": "gen_parenthesis_combine_template_q327zw",
+        "prompt": "Combine the sentence and extra detail using parenthesis.",
+        "stem": "The tower stood above the bay.\nExtra detail: a useful lookout",
+        "model": "The tower, a useful lookout, stood above the bay.",
+        "validatorType": "combineParentheticalPhrase",
+        "validator": {
+          "type": "combineParentheticalPhrase",
+          "before": "The tower",
+          "phrase": "a useful lookout",
+          "after": "stood above the bay"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.parenthesis_missing",
+          "structure.parenthesis_unbalanced"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_parenthesis_combine_ssa1h4_2",
+        "generatorFamilyId": "gen_parenthesis_combine",
+        "variantSignature": "puncsig_17xfcox",
+        "templateId": "gen_parenthesis_combine_template_zw0cs4",
+        "prompt": "Combine the sentence and extra detail using parenthesis.",
+        "stem": "The harbour was busy.\nExtra detail: an old fishing port",
+        "model": "The harbour, an old fishing port, was busy.",
+        "validatorType": "combineParentheticalPhrase",
+        "validator": {
+          "type": "combineParentheticalPhrase",
+          "before": "The harbour",
+          "phrase": "an old fishing port",
+          "after": "was busy"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.parenthesis_missing",
+          "structure.parenthesis_unbalanced"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_parenthesis_combine_tm8uk1_3",
+        "generatorFamilyId": "gen_parenthesis_combine",
+        "variantSignature": "puncsig_1199s4h",
+        "templateId": "gen_parenthesis_combine_template_xpov82",
+        "prompt": "Combine the sentence and extra detail using parenthesis.",
+        "stem": "Mr Patel smiled proudly.\nExtra detail: our maths teacher",
+        "model": "Mr Patel, our maths teacher, smiled proudly.",
+        "validatorType": "combineParentheticalPhrase",
+        "validator": {
+          "type": "combineParentheticalPhrase",
+          "before": "Mr Patel",
+          "phrase": "our maths teacher",
+          "after": "smiled proudly"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.parenthesis_missing",
+          "structure.parenthesis_unbalanced"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_parenthesis_combine_tc98v2_4",
+        "generatorFamilyId": "gen_parenthesis_combine",
+        "variantSignature": "puncsig_hz9s99",
+        "templateId": "gen_parenthesis_combine_template_zwj4d4",
+        "prompt": "Combine the sentence and extra detail using parenthesis.",
+        "stem": "The library closed early.\nExtra detail: a quiet room",
+        "model": "The library, a quiet room, closed early.",
+        "validatorType": "combineParentheticalPhrase",
+        "validator": {
+          "type": "combineParentheticalPhrase",
+          "before": "The library",
+          "phrase": "a quiet room",
+          "after": "closed early"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.parenthesis_missing",
+          "structure.parenthesis_unbalanced"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      }
+    ],
+    "gen_parenthesis_speech_paragraph": [
+      {
+        "id": "gen_parenthesis_speech_paragraph_vpwpzp_1",
+        "generatorFamilyId": "gen_parenthesis_speech_paragraph",
+        "variantSignature": "puncsig_500oc3",
+        "templateId": "gen_parenthesis_speech_paragraph_template_ghicmk",
+        "prompt": "Repair the punctuation in the short passage.",
+        "stem": "The tower a useful lookout stood above the bay. Mia asked where are the boats",
+        "model": "The tower, a useful lookout, stood above the bay. Mia asked, \"Where are the boats?\"",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresParentheticalPhrase",
+              "before": "The tower",
+              "phrase": "a useful lookout",
+              "after": "stood above the bay",
+              "misconceptionTags": [
+                "structure.parenthesis_missing",
+                "structure.parenthesis_unbalanced"
+              ]
+            },
+            {
+              "type": "speechWithWords",
+              "words": "where are the boats",
+              "requiredTerminal": "?",
+              "misconceptionTags": [
+                "speech.quote_missing",
+                "speech.reporting_comma_missing",
+                "speech.punctuation_missing"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.parenthesis_missing",
+          "structure.parenthesis_unbalanced",
+          "speech.quote_missing",
+          "speech.reporting_comma_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_parenthesis_speech_paragraph_vfx4aq_2",
+        "generatorFamilyId": "gen_parenthesis_speech_paragraph",
+        "variantSignature": "puncsig_1odmcb7",
+        "templateId": "gen_parenthesis_speech_paragraph_template_188l1dz",
+        "prompt": "Repair the punctuation in the short passage.",
+        "stem": "The harbour an old fishing port was busy. Ravi said the bell is ringing",
+        "model": "The harbour, an old fishing port, was busy. Ravi said, \"The bell is ringing.\"",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresParentheticalPhrase",
+              "before": "The harbour",
+              "phrase": "an old fishing port",
+              "after": "was busy",
+              "misconceptionTags": [
+                "structure.parenthesis_missing",
+                "structure.parenthesis_unbalanced"
+              ]
+            },
+            {
+              "type": "speechWithWords",
+              "words": "the bell is ringing",
+              "requiredTerminal": ".",
+              "misconceptionTags": [
+                "speech.quote_missing",
+                "speech.reporting_comma_missing",
+                "speech.punctuation_missing"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.parenthesis_missing",
+          "structure.parenthesis_unbalanced",
+          "speech.quote_missing",
+          "speech.reporting_comma_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_parenthesis_speech_paragraph_v5xilr_3",
+        "generatorFamilyId": "gen_parenthesis_speech_paragraph",
+        "variantSignature": "puncsig_e5nb1w",
+        "templateId": "gen_parenthesis_speech_paragraph_template_l7g61c",
+        "prompt": "Repair the punctuation in the short passage.",
+        "stem": "Mr Patel our maths teacher smiled proudly. Leo asked did we win",
+        "model": "Mr Patel, our maths teacher, smiled proudly. Leo asked, \"Did we win?\"",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresParentheticalPhrase",
+              "before": "Mr Patel",
+              "phrase": "our maths teacher",
+              "after": "smiled proudly",
+              "misconceptionTags": [
+                "structure.parenthesis_missing",
+                "structure.parenthesis_unbalanced"
+              ]
+            },
+            {
+              "type": "speechWithWords",
+              "words": "did we win",
+              "requiredTerminal": "?",
+              "misconceptionTags": [
+                "speech.quote_missing",
+                "speech.reporting_comma_missing",
+                "speech.punctuation_missing"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.parenthesis_missing",
+          "structure.parenthesis_unbalanced",
+          "speech.quote_missing",
+          "speech.reporting_comma_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_parenthesis_speech_paragraph_uvxwws_4",
+        "generatorFamilyId": "gen_parenthesis_speech_paragraph",
+        "variantSignature": "puncsig_paw9dv",
+        "templateId": "gen_parenthesis_speech_paragraph_template_f5rlwh",
+        "prompt": "Repair the punctuation in the short passage.",
+        "stem": "The library a quiet room closed early. Nina said we can come back tomorrow",
+        "model": "The library, a quiet room, closed early. Nina said, \"We can come back tomorrow.\"",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresParentheticalPhrase",
+              "before": "The library",
+              "phrase": "a quiet room",
+              "after": "closed early",
+              "misconceptionTags": [
+                "structure.parenthesis_missing",
+                "structure.parenthesis_unbalanced"
+              ]
+            },
+            {
+              "type": "speechWithWords",
+              "words": "we can come back tomorrow",
+              "requiredTerminal": ".",
+              "misconceptionTags": [
+                "speech.quote_missing",
+                "speech.reporting_comma_missing",
+                "speech.punctuation_missing"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.parenthesis_missing",
+          "structure.parenthesis_unbalanced",
+          "speech.quote_missing",
+          "speech.reporting_comma_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      }
+    ],
+    "gen_colon_list_insert": [
+      {
+        "id": "gen_colon_list_insert_jm8wuh_1",
+        "generatorFamilyId": "gen_colon_list_insert",
+        "variantSignature": "puncsig_khjj5x",
+        "templateId": "gen_colon_list_insert_template_1ltdd18",
+        "prompt": "Add the colon before the list.",
+        "stem": "The kit included three things a lantern, a compass and a notebook.",
+        "model": "The kit included three things: a lantern, a compass and a notebook.",
+        "validatorType": "requiresColonBeforeList",
+        "validator": {
+          "type": "requiresColonBeforeList",
+          "opening": "The kit included three things",
+          "items": [
+            "a lantern",
+            "a compass",
+            "a notebook"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.colon_missing",
+          "structure.list_separator_missing"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_colon_list_insert_jc9b5i_2",
+        "generatorFamilyId": "gen_colon_list_insert",
+        "variantSignature": "puncsig_10m4u9s",
+        "templateId": "gen_colon_list_insert_template_drw7oh",
+        "prompt": "Add the colon before the list.",
+        "stem": "We needed three tools a torch, a rope and a map.",
+        "model": "We needed three tools: a torch, a rope and a map.",
+        "validatorType": "requiresColonBeforeList",
+        "validator": {
+          "type": "requiresColonBeforeList",
+          "opening": "We needed three tools",
+          "items": [
+            "a torch",
+            "a rope",
+            "a map"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.colon_missing",
+          "structure.list_separator_missing"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_colon_list_insert_j29pgj_3",
+        "generatorFamilyId": "gen_colon_list_insert",
+        "variantSignature": "puncsig_1b6mqjs",
+        "templateId": "gen_colon_list_insert_template_1yfkdms",
+        "prompt": "Add the colon before the list.",
+        "stem": "We chose three activities swimming, cycling and climbing.",
+        "model": "We chose three activities: swimming, cycling and climbing.",
+        "validatorType": "requiresColonBeforeList",
+        "validator": {
+          "type": "requiresColonBeforeList",
+          "opening": "We chose three activities",
+          "items": [
+            "swimming",
+            "cycling",
+            "climbing"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.colon_missing",
+          "structure.list_separator_missing"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_colon_list_insert_isa3rk_4",
+        "generatorFamilyId": "gen_colon_list_insert",
+        "variantSignature": "puncsig_gnacaa",
+        "templateId": "gen_colon_list_insert_template_1ojbkvf",
+        "prompt": "Add the colon before the list.",
+        "stem": "The drawer held three supplies pens, rulers and tape.",
+        "model": "The drawer held three supplies: pens, rulers and tape.",
+        "validatorType": "requiresColonBeforeList",
+        "validator": {
+          "type": "requiresColonBeforeList",
+          "opening": "The drawer held three supplies",
+          "items": [
+            "pens",
+            "rulers",
+            "tape"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.colon_missing",
+          "structure.list_separator_missing"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      }
+    ],
+    "gen_colon_list_combine": [
+      {
+        "id": "gen_colon_list_combine_bfoeqd_1",
+        "generatorFamilyId": "gen_colon_list_combine",
+        "variantSignature": "puncsig_weots8",
+        "templateId": "gen_colon_list_combine_template_3bbxei",
+        "prompt": "Combine the opening clause and list using a colon.",
+        "stem": "The kit included three things\na lantern / a compass / a notebook",
+        "model": "The kit included three things: a lantern, a compass and a notebook.",
+        "validatorType": "combineColonList",
+        "validator": {
+          "type": "combineColonList",
+          "opening": "The kit included three things",
+          "items": [
+            "a lantern",
+            "a compass",
+            "a notebook"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.colon_missing",
+          "structure.list_separator_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_colon_list_combine_b5ot1e_2",
+        "generatorFamilyId": "gen_colon_list_combine",
+        "variantSignature": "puncsig_k5t5fh",
+        "templateId": "gen_colon_list_combine_template_lti8wz",
+        "prompt": "Combine the opening clause and list using a colon.",
+        "stem": "We needed three tools\na torch / a rope / a map",
+        "model": "We needed three tools: a torch, a rope and a map.",
+        "validatorType": "combineColonList",
+        "validator": {
+          "type": "combineColonList",
+          "opening": "We needed three tools",
+          "items": [
+            "a torch",
+            "a rope",
+            "a map"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.colon_missing",
+          "structure.list_separator_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_colon_list_combine_avp7cf_3",
+        "generatorFamilyId": "gen_colon_list_combine",
+        "variantSignature": "puncsig_ynal65",
+        "templateId": "gen_colon_list_combine_template_19wsb66",
+        "prompt": "Combine the opening clause and list using a colon.",
+        "stem": "We chose three activities\nswimming / cycling / climbing",
+        "model": "We chose three activities: swimming, cycling and climbing.",
+        "validatorType": "combineColonList",
+        "validator": {
+          "type": "combineColonList",
+          "opening": "We chose three activities",
+          "items": [
+            "swimming",
+            "cycling",
+            "climbing"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.colon_missing",
+          "structure.list_separator_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_colon_list_combine_alplng_4",
+        "generatorFamilyId": "gen_colon_list_combine",
+        "variantSignature": "puncsig_qt2pkv",
+        "templateId": "gen_colon_list_combine_template_50y9if",
+        "prompt": "Combine the opening clause and list using a colon.",
+        "stem": "The drawer held three supplies\npens / rulers / tape",
+        "model": "The drawer held three supplies: pens, rulers and tape.",
+        "validatorType": "combineColonList",
+        "validator": {
+          "type": "combineColonList",
+          "opening": "The drawer held three supplies",
+          "items": [
+            "pens",
+            "rulers",
+            "tape"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.colon_missing",
+          "structure.list_separator_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      }
+    ],
+    "gen_semicolon_fix": [
+      {
+        "id": "gen_semicolon_fix_d24gag_1",
+        "generatorFamilyId": "gen_semicolon_fix",
+        "variantSignature": "puncsig_1y3sqx4",
+        "templateId": "gen_semicolon_fix_template_ikssce",
+        "prompt": "Replace the comma splice with a semi-colon.",
+        "stem": "The lighthouse was bright, the boats still waited.",
+        "model": "The lighthouse was bright; the boats still waited.",
+        "validatorType": "requiresBoundaryBetweenClauses",
+        "validator": {
+          "type": "requiresBoundaryBetweenClauses",
+          "left": "The lighthouse was bright",
+          "right": "the boats still waited",
+          "mark": ";"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "boundary.comma_splice",
+          "boundary.semicolon_missing"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_semicolon_fix_dc41zf_2",
+        "generatorFamilyId": "gen_semicolon_fix",
+        "variantSignature": "puncsig_7av6n9",
+        "templateId": "gen_semicolon_fix_template_s0pvzh",
+        "prompt": "Replace the comma splice with a semi-colon.",
+        "stem": "The rain eased, the match could continue.",
+        "model": "The rain eased; the match could continue.",
+        "validatorType": "requiresBoundaryBetweenClauses",
+        "validator": {
+          "type": "requiresBoundaryBetweenClauses",
+          "left": "The rain eased",
+          "right": "the match could continue",
+          "mark": ";"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "boundary.comma_splice",
+          "boundary.semicolon_missing"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_semicolon_fix_dm3noe_3",
+        "generatorFamilyId": "gen_semicolon_fix",
+        "variantSignature": "puncsig_1x27sj4",
+        "templateId": "gen_semicolon_fix_template_vwch5i",
+        "prompt": "Replace the comma splice with a semi-colon.",
+        "stem": "The clock stopped, the class kept working.",
+        "model": "The clock stopped; the class kept working.",
+        "validatorType": "requiresBoundaryBetweenClauses",
+        "validator": {
+          "type": "requiresBoundaryBetweenClauses",
+          "left": "The clock stopped",
+          "right": "the class kept working",
+          "mark": ";"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "boundary.comma_splice",
+          "boundary.semicolon_missing"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_semicolon_fix_dw39dd_4",
+        "generatorFamilyId": "gen_semicolon_fix",
+        "variantSignature": "puncsig_fu4o3l",
+        "templateId": "gen_semicolon_fix_template_r1d5mx",
+        "prompt": "Replace the comma splice with a semi-colon.",
+        "stem": "The path was narrow, the hikers walked slowly.",
+        "model": "The path was narrow; the hikers walked slowly.",
+        "validatorType": "requiresBoundaryBetweenClauses",
+        "validator": {
+          "type": "requiresBoundaryBetweenClauses",
+          "left": "The path was narrow",
+          "right": "the hikers walked slowly",
+          "mark": ";"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "boundary.comma_splice",
+          "boundary.semicolon_missing"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      }
+    ],
+    "gen_semicolon_combine": [
+      {
+        "id": "gen_semicolon_combine_5y6fqi_1",
+        "generatorFamilyId": "gen_semicolon_combine",
+        "variantSignature": "puncsig_1vqj8j6",
+        "templateId": "gen_semicolon_combine_template_1c4cawx",
+        "prompt": "Combine the two related clauses into one sentence with a semi-colon.",
+        "stem": "The lighthouse was bright.\nThe boats still waited.",
+        "model": "The lighthouse was bright; the boats still waited.",
+        "validatorType": "combineBoundaryBetweenClauses",
+        "validator": {
+          "type": "combineBoundaryBetweenClauses",
+          "left": "The lighthouse was bright",
+          "right": "the boats still waited",
+          "mark": ";"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "boundary.comma_splice",
+          "boundary.semicolon_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_semicolon_combine_6861fh_2",
+        "generatorFamilyId": "gen_semicolon_combine",
+        "variantSignature": "puncsig_1n25ezp",
+        "templateId": "gen_semicolon_combine_template_1dp84xe",
+        "prompt": "Combine the two related clauses into one sentence with a semi-colon.",
+        "stem": "The rain eased.\nThe match could continue.",
+        "model": "The rain eased; the match could continue.",
+        "validatorType": "combineBoundaryBetweenClauses",
+        "validator": {
+          "type": "combineBoundaryBetweenClauses",
+          "left": "The rain eased",
+          "right": "the match could continue",
+          "mark": ";"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "boundary.comma_splice",
+          "boundary.semicolon_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_semicolon_combine_5e78ck_3",
+        "generatorFamilyId": "gen_semicolon_combine",
+        "variantSignature": "puncsig_0ts7nt",
+        "templateId": "gen_semicolon_combine_template_iorsah",
+        "prompt": "Combine the two related clauses into one sentence with a semi-colon.",
+        "stem": "The clock stopped.\nThe class kept working.",
+        "model": "The clock stopped; the class kept working.",
+        "validatorType": "combineBoundaryBetweenClauses",
+        "validator": {
+          "type": "combineBoundaryBetweenClauses",
+          "left": "The clock stopped",
+          "right": "the class kept working",
+          "mark": ";"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "boundary.comma_splice",
+          "boundary.semicolon_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_semicolon_combine_5o6u1j_4",
+        "generatorFamilyId": "gen_semicolon_combine",
+        "variantSignature": "puncsig_4jp8xz",
+        "templateId": "gen_semicolon_combine_template_b0qttm",
+        "prompt": "Combine the two related clauses into one sentence with a semi-colon.",
+        "stem": "The path was narrow.\nThe hikers walked slowly.",
+        "model": "The path was narrow; the hikers walked slowly.",
+        "validatorType": "combineBoundaryBetweenClauses",
+        "validator": {
+          "type": "combineBoundaryBetweenClauses",
+          "left": "The path was narrow",
+          "right": "the hikers walked slowly",
+          "mark": ";"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "boundary.comma_splice",
+          "boundary.semicolon_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      }
+    ],
+    "gen_colon_semicolon_paragraph": [
+      {
+        "id": "gen_colon_semicolon_paragraph_1q4bpg5_1",
+        "generatorFamilyId": "gen_colon_semicolon_paragraph",
+        "variantSignature": "puncsig_yz3x47",
+        "templateId": "gen_colon_semicolon_paragraph_template_1anvv2m",
+        "prompt": "Repair the punctuation in the short passage.",
+        "stem": "The kit held three things, a torch, a rope and a map. The rain stopped, the match continued.",
+        "model": "The kit held three things: a torch, a rope and a map. The rain stopped; the match continued.",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresColonBeforeList",
+              "opening": "The kit held three things",
+              "items": [
+                "a torch",
+                "a rope",
+                "a map"
+              ],
+              "allowTrailingText": true,
+              "misconceptionTags": [
+                "structure.colon_missing",
+                "structure.list_separator_missing"
+              ]
+            },
+            {
+              "type": "requiresBoundaryBetweenClauses",
+              "mark": ";",
+              "left": "The rain stopped",
+              "right": "the match continued",
+              "misconceptionTags": [
+                "boundary.comma_splice",
+                "boundary.semicolon_missing"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.colon_missing",
+          "structure.list_separator_missing",
+          "boundary.comma_splice",
+          "boundary.semicolon_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_colon_semicolon_paragraph_1puc3r6_2",
+        "generatorFamilyId": "gen_colon_semicolon_paragraph",
+        "variantSignature": "puncsig_1lx0h8v",
+        "templateId": "gen_colon_semicolon_paragraph_template_1mtafqy",
+        "prompt": "Repair the punctuation in the short passage.",
+        "stem": "We needed three tools, a lantern, a compass and a notebook. The tide rose, the group moved inland.",
+        "model": "We needed three tools: a lantern, a compass and a notebook. The tide rose; the group moved inland.",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresColonBeforeList",
+              "opening": "We needed three tools",
+              "items": [
+                "a lantern",
+                "a compass",
+                "a notebook"
+              ],
+              "allowTrailingText": true,
+              "misconceptionTags": [
+                "structure.colon_missing",
+                "structure.list_separator_missing"
+              ]
+            },
+            {
+              "type": "requiresBoundaryBetweenClauses",
+              "mark": ";",
+              "left": "The tide rose",
+              "right": "the group moved inland",
+              "misconceptionTags": [
+                "boundary.comma_splice",
+                "boundary.semicolon_missing"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.colon_missing",
+          "structure.list_separator_missing",
+          "boundary.comma_splice",
+          "boundary.semicolon_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_colon_semicolon_paragraph_1pkci27_3",
+        "generatorFamilyId": "gen_colon_semicolon_paragraph",
+        "variantSignature": "puncsig_1kyykb2",
+        "templateId": "gen_colon_semicolon_paragraph_template_08cn05",
+        "prompt": "Repair the punctuation in the short passage.",
+        "stem": "Our display needed three labels, rivers, mountains and coasts. The lights dimmed, the film began.",
+        "model": "Our display needed three labels: rivers, mountains and coasts. The lights dimmed; the film began.",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresColonBeforeList",
+              "opening": "Our display needed three labels",
+              "items": [
+                "rivers",
+                "mountains",
+                "coasts"
+              ],
+              "allowTrailingText": true,
+              "misconceptionTags": [
+                "structure.colon_missing",
+                "structure.list_separator_missing"
+              ]
+            },
+            {
+              "type": "requiresBoundaryBetweenClauses",
+              "mark": ";",
+              "left": "The lights dimmed",
+              "right": "the film began",
+              "misconceptionTags": [
+                "boundary.comma_splice",
+                "boundary.semicolon_missing"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.colon_missing",
+          "structure.list_separator_missing",
+          "boundary.comma_splice",
+          "boundary.semicolon_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_colon_semicolon_paragraph_1pacwd8_4",
+        "generatorFamilyId": "gen_colon_semicolon_paragraph",
+        "variantSignature": "puncsig_nfzjh8",
+        "templateId": "gen_colon_semicolon_paragraph_template_14w5vlm",
+        "prompt": "Repair the punctuation in the short passage.",
+        "stem": "The box contained three items, a scarf, a medal and a badge. The door opened, the crowd cheered.",
+        "model": "The box contained three items: a scarf, a medal and a badge. The door opened; the crowd cheered.",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresColonBeforeList",
+              "opening": "The box contained three items",
+              "items": [
+                "a scarf",
+                "a medal",
+                "a badge"
+              ],
+              "allowTrailingText": true,
+              "misconceptionTags": [
+                "structure.colon_missing",
+                "structure.list_separator_missing"
+              ]
+            },
+            {
+              "type": "requiresBoundaryBetweenClauses",
+              "mark": ";",
+              "left": "The door opened",
+              "right": "the crowd cheered",
+              "misconceptionTags": [
+                "boundary.comma_splice",
+                "boundary.semicolon_missing"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.colon_missing",
+          "structure.list_separator_missing",
+          "boundary.comma_splice",
+          "boundary.semicolon_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      }
+    ],
+    "gen_bullet_points_fix": [
+      {
+        "id": "gen_bullet_points_fix_dsvo5r_1",
+        "generatorFamilyId": "gen_bullet_points_fix",
+        "variantSignature": "puncsig_0dj4fz",
+        "templateId": "gen_bullet_points_fix_template_113xapj",
+        "prompt": "Make the bullet punctuation consistent.",
+        "stem": "Pack:\n- pencils\n- rulers.\n- glue sticks",
+        "model": "Pack:\n- pencils\n- rulers\n- glue sticks",
+        "validatorType": "requiresBulletStemAndItems",
+        "validator": {
+          "type": "requiresBulletStemAndItems",
+          "stem": "Pack",
+          "items": [
+            "pencils",
+            "rulers",
+            "glue sticks"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.bullet_punctuation_inconsistent"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_bullet_points_fix_diw2gs_2",
+        "generatorFamilyId": "gen_bullet_points_fix",
+        "variantSignature": "puncsig_8wrlau",
+        "templateId": "gen_bullet_points_fix_template_3tfe0s",
+        "prompt": "Make the bullet punctuation consistent.",
+        "stem": "Bring:\n- a coat.\n- a torch\n- a notebook.",
+        "model": "Bring:\n- a coat.\n- a torch.\n- a notebook.",
+        "validatorType": "requiresBulletStemAndItems",
+        "validator": {
+          "type": "requiresBulletStemAndItems",
+          "stem": "Bring",
+          "items": [
+            "a coat",
+            "a torch",
+            "a notebook"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.bullet_punctuation_inconsistent"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_bullet_points_fix_ecuvjp_3",
+        "generatorFamilyId": "gen_bullet_points_fix",
+        "variantSignature": "puncsig_s8slbt",
+        "templateId": "gen_bullet_points_fix_template_ddav2o",
+        "prompt": "Make the bullet punctuation consistent.",
+        "stem": "Check:\n- doors.\n- windows\n- lights.",
+        "model": "Check:\n- doors.\n- windows.\n- lights.",
+        "validatorType": "requiresBulletStemAndItems",
+        "validator": {
+          "type": "requiresBulletStemAndItems",
+          "stem": "Check",
+          "items": [
+            "doors",
+            "windows",
+            "lights"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.bullet_punctuation_inconsistent"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_bullet_points_fix_e2v9uq_4",
+        "generatorFamilyId": "gen_bullet_points_fix",
+        "variantSignature": "puncsig_1n4aanx",
+        "templateId": "gen_bullet_points_fix_template_zg5zmq",
+        "prompt": "Make the bullet punctuation consistent.",
+        "stem": "Take:\n- water\n- snacks.\n- a hat",
+        "model": "Take:\n- water\n- snacks\n- a hat",
+        "validatorType": "requiresBulletStemAndItems",
+        "validator": {
+          "type": "requiresBulletStemAndItems",
+          "stem": "Take",
+          "items": [
+            "water",
+            "snacks",
+            "a hat"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.bullet_punctuation_inconsistent"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      }
+    ],
+    "gen_bullet_points_paragraph": [
+      {
+        "id": "gen_bullet_points_paragraph_1kwm6aa_1",
+        "generatorFamilyId": "gen_bullet_points_paragraph",
+        "variantSignature": "puncsig_18sipdw",
+        "templateId": "gen_bullet_points_paragraph_template_1dozira",
+        "prompt": "Repair the bullet-list punctuation.",
+        "stem": "Pack\n- pencils\n- rulers.\n- glue sticks",
+        "model": "Pack:\n- pencils\n- rulers\n- glue sticks",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresBulletStemAndItems",
+              "stem": "Pack",
+              "items": [
+                "pencils",
+                "rulers",
+                "glue sticks"
+              ],
+              "misconceptionTags": [
+                "structure.bullet_colon_missing",
+                "structure.bullet_marker_missing",
+                "structure.bullet_punctuation_inconsistent"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.bullet_colon_missing",
+          "structure.bullet_marker_missing",
+          "structure.bullet_punctuation_inconsistent"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_bullet_points_paragraph_1l6lrz9_2",
+        "generatorFamilyId": "gen_bullet_points_paragraph",
+        "variantSignature": "puncsig_1n9pc7n",
+        "templateId": "gen_bullet_points_paragraph_template_1pn0ihi",
+        "prompt": "Repair the bullet-list punctuation.",
+        "stem": "Bring\n- a coat.\n- a torch\n- a notebook.",
+        "model": "Bring:\n- a coat\n- a torch\n- a notebook",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresBulletStemAndItems",
+              "stem": "Bring",
+              "items": [
+                "a coat",
+                "a torch",
+                "a notebook"
+              ],
+              "misconceptionTags": [
+                "structure.bullet_colon_missing",
+                "structure.bullet_marker_missing",
+                "structure.bullet_punctuation_inconsistent"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.bullet_colon_missing",
+          "structure.bullet_marker_missing",
+          "structure.bullet_punctuation_inconsistent"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_bullet_points_paragraph_1kcmywc_3",
+        "generatorFamilyId": "gen_bullet_points_paragraph",
+        "variantSignature": "puncsig_1kngi8r",
+        "templateId": "gen_bullet_points_paragraph_template_1vsy1fq",
+        "prompt": "Repair the bullet-list punctuation.",
+        "stem": "Take\n- water\n- snacks.\n- a hat",
+        "model": "Take:\n- water\n- snacks\n- a hat",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresBulletStemAndItems",
+              "stem": "Take",
+              "items": [
+                "water",
+                "snacks",
+                "a hat"
+              ],
+              "misconceptionTags": [
+                "structure.bullet_colon_missing",
+                "structure.bullet_marker_missing",
+                "structure.bullet_punctuation_inconsistent"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.bullet_colon_missing",
+          "structure.bullet_marker_missing",
+          "structure.bullet_punctuation_inconsistent"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_bullet_points_paragraph_1kmmklb_4",
+        "generatorFamilyId": "gen_bullet_points_paragraph",
+        "variantSignature": "puncsig_1soye56",
+        "templateId": "gen_bullet_points_paragraph_template_2yowe8",
+        "prompt": "Repair the bullet-list punctuation.",
+        "stem": "Check\n- doors.\n- windows\n- lights.",
+        "model": "Check:\n- doors.\n- windows.\n- lights.",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresBulletStemAndItems",
+              "stem": "Check",
+              "items": [
+                "doors",
+                "windows",
+                "lights"
+              ],
+              "misconceptionTags": [
+                "structure.bullet_colon_missing",
+                "structure.bullet_marker_missing",
+                "structure.bullet_punctuation_inconsistent"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.bullet_colon_missing",
+          "structure.bullet_marker_missing",
+          "structure.bullet_punctuation_inconsistent"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      }
+    ]
+  },
+  "depth8": {
+    "gen_apostrophe_possession_insert": [
+      {
+        "id": "gen_apostrophe_possession_insert_1gnet8j_1",
+        "generatorFamilyId": "gen_apostrophe_possession_insert",
+        "variantSignature": "puncsig_f6gya8",
+        "templateId": "gen_apostrophe_possession_insert_template_veyue5",
+        "prompt": "Add apostrophes to show possession.",
+        "stem": "The childrens sketches covered the teachers desk.",
+        "model": "The children's sketches covered the teacher's desk.",
+        "validatorType": "requiresTokens",
+        "validator": {
+          "type": "requiresTokens",
+          "tokens": [
+            "children's",
+            "teacher's"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "apostrophe.possession_missing"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_apostrophe_possession_insert_1gdf7jk_2",
+        "generatorFamilyId": "gen_apostrophe_possession_insert",
+        "variantSignature": "puncsig_17nx2qt",
+        "templateId": "gen_apostrophe_possession_insert_template_100dwn",
+        "prompt": "Add apostrophes to show possession.",
+        "stem": "The captains whistle was beside the teams coats.",
+        "model": "The captain's whistle was beside the team's coats.",
+        "validatorType": "requiresTokens",
+        "validator": {
+          "type": "requiresTokens",
+          "tokens": [
+            "captain's",
+            "team's"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "apostrophe.possession_missing"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_apostrophe_possession_insert_1h7e0mh_3",
+        "generatorFamilyId": "gen_apostrophe_possession_insert",
+        "variantSignature": "puncsig_1dsmbxy",
+        "templateId": "gen_apostrophe_possession_insert_template_16nnw5j",
+        "prompt": "Add apostrophes to show possession.",
+        "stem": "The sailors flag was near the harbours gate.",
+        "model": "The sailor's flag was near the harbour's gate.",
+        "validatorType": "requiresTokens",
+        "validator": {
+          "type": "requiresTokens",
+          "tokens": [
+            "sailor's",
+            "harbour's"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "apostrophe.possession_missing"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_apostrophe_possession_insert_1gxeexi_4",
+        "generatorFamilyId": "gen_apostrophe_possession_insert",
+        "variantSignature": "puncsig_xkduxs",
+        "templateId": "gen_apostrophe_possession_insert_template_ffg657",
+        "prompt": "Add apostrophes to show possession.",
+        "stem": "The artists brush was near the museums door.",
+        "model": "The artist's brush was near the museum's door.",
+        "validatorType": "requiresTokens",
+        "validator": {
+          "type": "requiresTokens",
+          "tokens": [
+            "artist's",
+            "museum's"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "apostrophe.possession_missing"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_apostrophe_possession_insert_1hrd80f_5",
+        "generatorFamilyId": "gen_apostrophe_possession_insert",
+        "variantSignature": "puncsig_1dsmbxy",
+        "templateId": "gen_apostrophe_possession_insert_template_16nnw5j",
+        "prompt": "Add apostrophes to show possession.",
+        "stem": "The sailors flag was near the harbours gate.",
+        "model": "The sailor's flag was near the harbour's gate.",
+        "validatorType": "requiresTokens",
+        "validator": {
+          "type": "requiresTokens",
+          "tokens": [
+            "sailor's",
+            "harbour's"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "apostrophe.possession_missing"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_apostrophe_possession_insert_1hhdmbg_6",
+        "generatorFamilyId": "gen_apostrophe_possession_insert",
+        "variantSignature": "puncsig_xkduxs",
+        "templateId": "gen_apostrophe_possession_insert_template_ffg657",
+        "prompt": "Add apostrophes to show possession.",
+        "stem": "The artists brush was near the museums door.",
+        "model": "The artist's brush was near the museum's door.",
+        "validatorType": "requiresTokens",
+        "validator": {
+          "type": "requiresTokens",
+          "tokens": [
+            "artist's",
+            "museum's"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "apostrophe.possession_missing"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_apostrophe_possession_insert_1ibcfed_7",
+        "generatorFamilyId": "gen_apostrophe_possession_insert",
+        "variantSignature": "puncsig_1dsmbxy",
+        "templateId": "gen_apostrophe_possession_insert_template_16nnw5j",
+        "prompt": "Add apostrophes to show possession.",
+        "stem": "The sailors flag was near the harbours gate.",
+        "model": "The sailor's flag was near the harbour's gate.",
+        "validatorType": "requiresTokens",
+        "validator": {
+          "type": "requiresTokens",
+          "tokens": [
+            "sailor's",
+            "harbour's"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "apostrophe.possession_missing"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_apostrophe_possession_insert_1i1ctpe_8",
+        "generatorFamilyId": "gen_apostrophe_possession_insert",
+        "variantSignature": "puncsig_xkduxs",
+        "templateId": "gen_apostrophe_possession_insert_template_ffg657",
+        "prompt": "Add apostrophes to show possession.",
+        "stem": "The artists brush was near the museums door.",
+        "model": "The artist's brush was near the museum's door.",
+        "validatorType": "requiresTokens",
+        "validator": {
+          "type": "requiresTokens",
+          "tokens": [
+            "artist's",
+            "museum's"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "apostrophe.possession_missing"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      }
+    ],
+    "gen_apostrophe_mix_paragraph": [
+      {
+        "id": "gen_apostrophe_mix_paragraph_10iiu3e_1",
+        "generatorFamilyId": "gen_apostrophe_mix_paragraph",
+        "variantSignature": "puncsig_14shna6",
+        "templateId": "gen_apostrophe_mix_paragraph_template_18q5fxx",
+        "prompt": "Repair the apostrophes in the short passage.",
+        "stem": "We wont move the childrens paintings. The teachers notes are ready.",
+        "model": "We won't move the children's paintings. The teachers' notes are ready.",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresApostropheForms",
+              "tokens": [
+                "won't",
+                "children's",
+                "teachers' notes"
+              ],
+              "forbidden": [
+                "wont",
+                "childrens",
+                "teachers notes"
+              ],
+              "misconceptionTags": [
+                "apostrophe.contraction_missing",
+                "apostrophe.possession_missing",
+                "apostrophe.possession_number"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "apostrophe.contraction_missing",
+          "apostrophe.possession_missing",
+          "apostrophe.possession_number"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_apostrophe_mix_paragraph_10sifsd_2",
+        "generatorFamilyId": "gen_apostrophe_mix_paragraph",
+        "variantSignature": "puncsig_aco1pd",
+        "templateId": "gen_apostrophe_mix_paragraph_template_1l5nlo5",
+        "prompt": "Repair the apostrophes in the short passage.",
+        "stem": "I cant find the mens boots. The boys jackets are drying.",
+        "model": "I can't find the men's boots. The boys' jackets are drying.",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresApostropheForms",
+              "tokens": [
+                "can't",
+                "men's",
+                "boys' jackets"
+              ],
+              "forbidden": [
+                "cant",
+                "mens",
+                "boys jackets"
+              ],
+              "misconceptionTags": [
+                "apostrophe.contraction_missing",
+                "apostrophe.possession_missing",
+                "apostrophe.possession_number"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "apostrophe.contraction_missing",
+          "apostrophe.possession_missing",
+          "apostrophe.possession_number"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_apostrophe_mix_paragraph_zyjmpg_3",
+        "generatorFamilyId": "gen_apostrophe_mix_paragraph",
+        "variantSignature": "puncsig_1d7fd2j",
+        "templateId": "gen_apostrophe_mix_paragraph_template_b84fkf",
+        "prompt": "Repair the apostrophes in the short passage.",
+        "stem": "Theyre checking the captains map. We dont know the teams plan.",
+        "model": "They're checking the captain's map. We don't know the team's plan.",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresApostropheForms",
+              "tokens": [
+                "they're",
+                "captain's",
+                "don't",
+                "team's"
+              ],
+              "forbidden": [
+                "theyre",
+                "captains",
+                "dont",
+                "teams plan"
+              ],
+              "misconceptionTags": [
+                "apostrophe.contraction_missing",
+                "apostrophe.possession_missing"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "apostrophe.contraction_missing",
+          "apostrophe.possession_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_apostrophe_mix_paragraph_108j8ef_4",
+        "generatorFamilyId": "gen_apostrophe_mix_paragraph",
+        "variantSignature": "puncsig_60dsl5",
+        "templateId": "gen_apostrophe_mix_paragraph_template_1ds8nud",
+        "prompt": "Repair the apostrophes in the short passage.",
+        "stem": "She wont borrow the girls pencil. Its on the teachers shelf.",
+        "model": "She won't borrow the girl's pencil. It's on the teacher's shelf.",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresApostropheForms",
+              "tokens": [
+                "won't",
+                "girl's",
+                "it's",
+                "teacher's"
+              ],
+              "forbidden": [
+                "wont",
+                "girls pencil",
+                "its",
+                "teachers shelf"
+              ],
+              "misconceptionTags": [
+                "apostrophe.contraction_missing",
+                "apostrophe.possession_missing"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "apostrophe.contraction_missing",
+          "apostrophe.possession_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_apostrophe_mix_paragraph_zekfbi_5",
+        "generatorFamilyId": "gen_apostrophe_mix_paragraph",
+        "variantSignature": "puncsig_1d7fd2j",
+        "templateId": "gen_apostrophe_mix_paragraph_template_b84fkf",
+        "prompt": "Repair the apostrophes in the short passage.",
+        "stem": "Theyre checking the captains map. We dont know the teams plan.",
+        "model": "They're checking the captain's map. We don't know the team's plan.",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresApostropheForms",
+              "tokens": [
+                "they're",
+                "captain's",
+                "don't",
+                "team's"
+              ],
+              "forbidden": [
+                "theyre",
+                "captains",
+                "dont",
+                "teams plan"
+              ],
+              "misconceptionTags": [
+                "apostrophe.contraction_missing",
+                "apostrophe.possession_missing"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "apostrophe.contraction_missing",
+          "apostrophe.possession_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_apostrophe_mix_paragraph_zok10h_6",
+        "generatorFamilyId": "gen_apostrophe_mix_paragraph",
+        "variantSignature": "puncsig_60dsl5",
+        "templateId": "gen_apostrophe_mix_paragraph_template_1ds8nud",
+        "prompt": "Repair the apostrophes in the short passage.",
+        "stem": "She wont borrow the girls pencil. Its on the teachers shelf.",
+        "model": "She won't borrow the girl's pencil. It's on the teacher's shelf.",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresApostropheForms",
+              "tokens": [
+                "won't",
+                "girl's",
+                "it's",
+                "teacher's"
+              ],
+              "forbidden": [
+                "wont",
+                "girls pencil",
+                "its",
+                "teachers shelf"
+              ],
+              "misconceptionTags": [
+                "apostrophe.contraction_missing",
+                "apostrophe.possession_missing"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "apostrophe.contraction_missing",
+          "apostrophe.possession_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_apostrophe_mix_paragraph_yul7xk_7",
+        "generatorFamilyId": "gen_apostrophe_mix_paragraph",
+        "variantSignature": "puncsig_1d7fd2j",
+        "templateId": "gen_apostrophe_mix_paragraph_template_b84fkf",
+        "prompt": "Repair the apostrophes in the short passage.",
+        "stem": "Theyre checking the captains map. We dont know the teams plan.",
+        "model": "They're checking the captain's map. We don't know the team's plan.",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresApostropheForms",
+              "tokens": [
+                "they're",
+                "captain's",
+                "don't",
+                "team's"
+              ],
+              "forbidden": [
+                "theyre",
+                "captains",
+                "dont",
+                "teams plan"
+              ],
+              "misconceptionTags": [
+                "apostrophe.contraction_missing",
+                "apostrophe.possession_missing"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "apostrophe.contraction_missing",
+          "apostrophe.possession_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_apostrophe_mix_paragraph_z4ktmj_8",
+        "generatorFamilyId": "gen_apostrophe_mix_paragraph",
+        "variantSignature": "puncsig_60dsl5",
+        "templateId": "gen_apostrophe_mix_paragraph_template_1ds8nud",
+        "prompt": "Repair the apostrophes in the short passage.",
+        "stem": "She wont borrow the girls pencil. Its on the teachers shelf.",
+        "model": "She won't borrow the girl's pencil. It's on the teacher's shelf.",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresApostropheForms",
+              "tokens": [
+                "won't",
+                "girl's",
+                "it's",
+                "teacher's"
+              ],
+              "forbidden": [
+                "wont",
+                "girls pencil",
+                "its",
+                "teachers shelf"
+              ],
+              "misconceptionTags": [
+                "apostrophe.contraction_missing",
+                "apostrophe.possession_missing"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "apostrophe.contraction_missing",
+          "apostrophe.possession_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      }
+    ],
+    "gen_speech_insert": [
+      {
+        "id": "gen_speech_insert_1s7w6o3_1",
+        "generatorFamilyId": "gen_speech_insert",
+        "variantSignature": "puncsig_9ughq9",
+        "templateId": "gen_speech_insert_template_15qxnnl",
+        "prompt": "Add the direct-speech punctuation.",
+        "stem": "Ravi said, the bell is ringing.",
+        "model": "Ravi said, \"The bell is ringing.\"",
+        "validatorType": null,
+        "validator": null,
+        "rubric": {
+          "type": "speech",
+          "reportingPosition": "before",
+          "spokenWords": "the bell is ringing",
+          "requiredTerminal": "."
+        },
+        "misconceptionTags": [
+          "speech.quote_missing",
+          "speech.reporting_comma_missing",
+          "speech.punctuation_missing"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_speech_insert_1rxwkz4_2",
+        "generatorFamilyId": "gen_speech_insert",
+        "variantSignature": "puncsig_xihz5d",
+        "templateId": "gen_speech_insert_template_1s39sn2",
+        "prompt": "Add the direct-speech punctuation.",
+        "stem": "Maya asked, can we start now?",
+        "model": "Maya asked, \"Can we start now?\"",
+        "validatorType": null,
+        "validator": null,
+        "rubric": {
+          "type": "speech",
+          "reportingPosition": "before",
+          "spokenWords": "can we start now",
+          "requiredTerminal": "?"
+        },
+        "misconceptionTags": [
+          "speech.quote_missing",
+          "speech.reporting_comma_missing",
+          "speech.punctuation_missing"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_speech_insert_1srve21_3",
+        "generatorFamilyId": "gen_speech_insert",
+        "variantSignature": "puncsig_nclq3v",
+        "templateId": "gen_speech_insert_template_1lt7eo1",
+        "prompt": "Add the direct-speech punctuation.",
+        "stem": "Tom asked, where did the map go?",
+        "model": "Tom asked, \"Where did the map go?\"",
+        "validatorType": null,
+        "validator": null,
+        "rubric": {
+          "type": "speech",
+          "reportingPosition": "before",
+          "spokenWords": "where did the map go",
+          "requiredTerminal": "?"
+        },
+        "misconceptionTags": [
+          "speech.quote_missing",
+          "speech.reporting_comma_missing",
+          "speech.punctuation_missing"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_speech_insert_1shvsd2_4",
+        "generatorFamilyId": "gen_speech_insert",
+        "variantSignature": "puncsig_rd8g70",
+        "templateId": "gen_speech_insert_template_1oh4tes",
+        "prompt": "Add the direct-speech punctuation.",
+        "stem": "Lena whispered, keep the gate closed.",
+        "model": "Lena whispered, \"Keep the gate closed.\"",
+        "validatorType": null,
+        "validator": null,
+        "rubric": {
+          "type": "speech",
+          "reportingPosition": "before",
+          "spokenWords": "keep the gate closed",
+          "requiredTerminal": "."
+        },
+        "misconceptionTags": [
+          "speech.quote_missing",
+          "speech.reporting_comma_missing",
+          "speech.punctuation_missing"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_speech_insert_1tbulfz_5",
+        "generatorFamilyId": "gen_speech_insert",
+        "variantSignature": "puncsig_nclq3v",
+        "templateId": "gen_speech_insert_template_1lt7eo1",
+        "prompt": "Add the direct-speech punctuation.",
+        "stem": "Tom asked, where did the map go?",
+        "model": "Tom asked, \"Where did the map go?\"",
+        "validatorType": null,
+        "validator": null,
+        "rubric": {
+          "type": "speech",
+          "reportingPosition": "before",
+          "spokenWords": "where did the map go",
+          "requiredTerminal": "?"
+        },
+        "misconceptionTags": [
+          "speech.quote_missing",
+          "speech.reporting_comma_missing",
+          "speech.punctuation_missing"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_speech_insert_1t1uzr0_6",
+        "generatorFamilyId": "gen_speech_insert",
+        "variantSignature": "puncsig_rd8g70",
+        "templateId": "gen_speech_insert_template_1oh4tes",
+        "prompt": "Add the direct-speech punctuation.",
+        "stem": "Lena whispered, keep the gate closed.",
+        "model": "Lena whispered, \"Keep the gate closed.\"",
+        "validatorType": null,
+        "validator": null,
+        "rubric": {
+          "type": "speech",
+          "reportingPosition": "before",
+          "spokenWords": "keep the gate closed",
+          "requiredTerminal": "."
+        },
+        "misconceptionTags": [
+          "speech.quote_missing",
+          "speech.reporting_comma_missing",
+          "speech.punctuation_missing"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_speech_insert_1tvtstx_7",
+        "generatorFamilyId": "gen_speech_insert",
+        "variantSignature": "puncsig_nclq3v",
+        "templateId": "gen_speech_insert_template_1lt7eo1",
+        "prompt": "Add the direct-speech punctuation.",
+        "stem": "Tom asked, where did the map go?",
+        "model": "Tom asked, \"Where did the map go?\"",
+        "validatorType": null,
+        "validator": null,
+        "rubric": {
+          "type": "speech",
+          "reportingPosition": "before",
+          "spokenWords": "where did the map go",
+          "requiredTerminal": "?"
+        },
+        "misconceptionTags": [
+          "speech.quote_missing",
+          "speech.reporting_comma_missing",
+          "speech.punctuation_missing"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_speech_insert_1tlu74y_8",
+        "generatorFamilyId": "gen_speech_insert",
+        "variantSignature": "puncsig_rd8g70",
+        "templateId": "gen_speech_insert_template_1oh4tes",
+        "prompt": "Add the direct-speech punctuation.",
+        "stem": "Lena whispered, keep the gate closed.",
+        "model": "Lena whispered, \"Keep the gate closed.\"",
+        "validatorType": null,
+        "validator": null,
+        "rubric": {
+          "type": "speech",
+          "reportingPosition": "before",
+          "spokenWords": "keep the gate closed",
+          "requiredTerminal": "."
+        },
+        "misconceptionTags": [
+          "speech.quote_missing",
+          "speech.reporting_comma_missing",
+          "speech.punctuation_missing"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      }
+    ],
+    "gen_fronted_speech_paragraph": [
+      {
+        "id": "gen_fronted_speech_paragraph_1n8m9sv_1",
+        "generatorFamilyId": "gen_fronted_speech_paragraph",
+        "variantSignature": "puncsig_cxl2dr",
+        "templateId": "gen_fronted_speech_paragraph_template_flawdf",
+        "prompt": "Repair the punctuation in the short passage.",
+        "stem": "After rehearsal Omar said the props are packed",
+        "model": "After rehearsal, Omar said, \"The props are packed.\"",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "startsWithPhraseComma",
+              "phrase": "After rehearsal",
+              "misconceptionTags": [
+                "comma.fronted_adverbial_missing"
+              ]
+            },
+            {
+              "type": "speechWithWords",
+              "words": "the props are packed",
+              "requiredTerminal": ".",
+              "misconceptionTags": [
+                "speech.quote_missing",
+                "speech.reporting_comma_missing",
+                "speech.punctuation_missing"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.fronted_adverbial_missing",
+          "speech.quote_missing",
+          "speech.reporting_comma_missing",
+          "speech.punctuation_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_fronted_speech_paragraph_1mymo3w_2",
+        "generatorFamilyId": "gen_fronted_speech_paragraph",
+        "variantSignature": "puncsig_145vp3p",
+        "templateId": "gen_fronted_speech_paragraph_template_ey0omc",
+        "prompt": "Repair the punctuation in the short passage.",
+        "stem": "Before lunch Zara asked can we start now",
+        "model": "Before lunch, Zara asked, \"Can we start now?\"",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "startsWithPhraseComma",
+              "phrase": "Before lunch",
+              "misconceptionTags": [
+                "comma.fronted_adverbial_missing"
+              ]
+            },
+            {
+              "type": "speechWithWords",
+              "words": "can we start now",
+              "requiredTerminal": "?",
+              "misconceptionTags": [
+                "speech.quote_missing",
+                "speech.reporting_comma_missing",
+                "speech.punctuation_missing"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.fronted_adverbial_missing",
+          "speech.quote_missing",
+          "speech.reporting_comma_missing",
+          "speech.punctuation_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_fronted_speech_paragraph_1nslh6t_3",
+        "generatorFamilyId": "gen_fronted_speech_paragraph",
+        "variantSignature": "puncsig_15vl1z5",
+        "templateId": "gen_fronted_speech_paragraph_template_q48vyy",
+        "prompt": "Repair the punctuation in the short passage.",
+        "stem": "At the gate Ben asked are we late",
+        "model": "At the gate, Ben asked, \"Are we late?\"",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "startsWithPhraseComma",
+              "phrase": "At the gate",
+              "misconceptionTags": [
+                "comma.fronted_adverbial_missing"
+              ]
+            },
+            {
+              "type": "speechWithWords",
+              "words": "are we late",
+              "requiredTerminal": "?",
+              "misconceptionTags": [
+                "speech.quote_missing",
+                "speech.reporting_comma_missing",
+                "speech.punctuation_missing"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.fronted_adverbial_missing",
+          "speech.quote_missing",
+          "speech.reporting_comma_missing",
+          "speech.punctuation_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_fronted_speech_paragraph_1nilvhu_4",
+        "generatorFamilyId": "gen_fronted_speech_paragraph",
+        "variantSignature": "puncsig_w1btfv",
+        "templateId": "gen_fronted_speech_paragraph_template_1vge4by",
+        "prompt": "Repair the punctuation in the short passage.",
+        "stem": "During assembly Lina whispered please sit down",
+        "model": "During assembly, Lina whispered, \"Please sit down.\"",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "startsWithPhraseComma",
+              "phrase": "During assembly",
+              "misconceptionTags": [
+                "comma.fronted_adverbial_missing"
+              ]
+            },
+            {
+              "type": "speechWithWords",
+              "words": "please sit down",
+              "requiredTerminal": ".",
+              "misconceptionTags": [
+                "speech.quote_missing",
+                "speech.reporting_comma_missing",
+                "speech.punctuation_missing"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.fronted_adverbial_missing",
+          "speech.quote_missing",
+          "speech.reporting_comma_missing",
+          "speech.punctuation_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_fronted_speech_paragraph_1m4nv0z_5",
+        "generatorFamilyId": "gen_fronted_speech_paragraph",
+        "variantSignature": "puncsig_15vl1z5",
+        "templateId": "gen_fronted_speech_paragraph_template_q48vyy",
+        "prompt": "Repair the punctuation in the short passage.",
+        "stem": "At the gate Ben asked are we late",
+        "model": "At the gate, Ben asked, \"Are we late?\"",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "startsWithPhraseComma",
+              "phrase": "At the gate",
+              "misconceptionTags": [
+                "comma.fronted_adverbial_missing"
+              ]
+            },
+            {
+              "type": "speechWithWords",
+              "words": "are we late",
+              "requiredTerminal": "?",
+              "misconceptionTags": [
+                "speech.quote_missing",
+                "speech.reporting_comma_missing",
+                "speech.punctuation_missing"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.fronted_adverbial_missing",
+          "speech.quote_missing",
+          "speech.reporting_comma_missing",
+          "speech.punctuation_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_fronted_speech_paragraph_1luo9c0_6",
+        "generatorFamilyId": "gen_fronted_speech_paragraph",
+        "variantSignature": "puncsig_w1btfv",
+        "templateId": "gen_fronted_speech_paragraph_template_1vge4by",
+        "prompt": "Repair the punctuation in the short passage.",
+        "stem": "During assembly Lina whispered please sit down",
+        "model": "During assembly, Lina whispered, \"Please sit down.\"",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "startsWithPhraseComma",
+              "phrase": "During assembly",
+              "misconceptionTags": [
+                "comma.fronted_adverbial_missing"
+              ]
+            },
+            {
+              "type": "speechWithWords",
+              "words": "please sit down",
+              "requiredTerminal": ".",
+              "misconceptionTags": [
+                "speech.quote_missing",
+                "speech.reporting_comma_missing",
+                "speech.punctuation_missing"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.fronted_adverbial_missing",
+          "speech.quote_missing",
+          "speech.reporting_comma_missing",
+          "speech.punctuation_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_fronted_speech_paragraph_1mon2ex_7",
+        "generatorFamilyId": "gen_fronted_speech_paragraph",
+        "variantSignature": "puncsig_15vl1z5",
+        "templateId": "gen_fronted_speech_paragraph_template_q48vyy",
+        "prompt": "Repair the punctuation in the short passage.",
+        "stem": "At the gate Ben asked are we late",
+        "model": "At the gate, Ben asked, \"Are we late?\"",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "startsWithPhraseComma",
+              "phrase": "At the gate",
+              "misconceptionTags": [
+                "comma.fronted_adverbial_missing"
+              ]
+            },
+            {
+              "type": "speechWithWords",
+              "words": "are we late",
+              "requiredTerminal": "?",
+              "misconceptionTags": [
+                "speech.quote_missing",
+                "speech.reporting_comma_missing",
+                "speech.punctuation_missing"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.fronted_adverbial_missing",
+          "speech.quote_missing",
+          "speech.reporting_comma_missing",
+          "speech.punctuation_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_fronted_speech_paragraph_1mengpy_8",
+        "generatorFamilyId": "gen_fronted_speech_paragraph",
+        "variantSignature": "puncsig_w1btfv",
+        "templateId": "gen_fronted_speech_paragraph_template_1vge4by",
+        "prompt": "Repair the punctuation in the short passage.",
+        "stem": "During assembly Lina whispered please sit down",
+        "model": "During assembly, Lina whispered, \"Please sit down.\"",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "startsWithPhraseComma",
+              "phrase": "During assembly",
+              "misconceptionTags": [
+                "comma.fronted_adverbial_missing"
+              ]
+            },
+            {
+              "type": "speechWithWords",
+              "words": "please sit down",
+              "requiredTerminal": ".",
+              "misconceptionTags": [
+                "speech.quote_missing",
+                "speech.reporting_comma_missing",
+                "speech.punctuation_missing"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.fronted_adverbial_missing",
+          "speech.quote_missing",
+          "speech.reporting_comma_missing",
+          "speech.punctuation_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      }
+    ],
+    "gen_list_commas_insert": [
+      {
+        "id": "gen_list_commas_insert_1h0oxzg_1",
+        "generatorFamilyId": "gen_list_commas_insert",
+        "variantSignature": "puncsig_1dte5cx",
+        "templateId": "gen_list_commas_insert_template_1cb1q38",
+        "prompt": "Add commas to separate the list items.",
+        "stem": "We packed ropes maps and snacks.",
+        "model": "We packed ropes, maps and snacks.",
+        "validatorType": "requiresListCommas",
+        "validator": {
+          "type": "requiresListCommas",
+          "items": [
+            "ropes",
+            "maps",
+            "snacks"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.list_separator_missing",
+          "comma.unnecessary_final_comma"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_list_commas_insert_1haojof_2",
+        "generatorFamilyId": "gen_list_commas_insert",
+        "variantSignature": "puncsig_1aonvno",
+        "templateId": "gen_list_commas_insert_template_1xvy2rf",
+        "prompt": "Add commas to separate the list items.",
+        "stem": "The box held shells bells and chalk.",
+        "model": "The box held shells, bells and chalk.",
+        "validatorType": "requiresListCommas",
+        "validator": {
+          "type": "requiresListCommas",
+          "items": [
+            "shells",
+            "bells",
+            "chalk"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.list_separator_missing",
+          "comma.unnecessary_final_comma"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_list_commas_insert_1hko5de_3",
+        "generatorFamilyId": "gen_list_commas_insert",
+        "variantSignature": "puncsig_jl4vs2",
+        "templateId": "gen_list_commas_insert_template_1myck8w",
+        "prompt": "Add commas to separate the list items.",
+        "stem": "The shelf held paints brushes and paper.",
+        "model": "The shelf held paints, brushes and paper.",
+        "validatorType": "requiresListCommas",
+        "validator": {
+          "type": "requiresListCommas",
+          "items": [
+            "paints",
+            "brushes",
+            "paper"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.list_separator_missing",
+          "comma.unnecessary_final_comma"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_list_commas_insert_1hunr2d_4",
+        "generatorFamilyId": "gen_list_commas_insert",
+        "variantSignature": "puncsig_1e1g3rp",
+        "templateId": "gen_list_commas_insert_template_62b991",
+        "prompt": "Add commas to separate the list items.",
+        "stem": "We saw gulls seals and dolphins.",
+        "model": "We saw gulls, seals and dolphins.",
+        "validatorType": "requiresListCommas",
+        "validator": {
+          "type": "requiresListCommas",
+          "items": [
+            "gulls",
+            "seals",
+            "dolphins"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.list_separator_missing",
+          "comma.unnecessary_final_comma"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_list_commas_insert_1fwqj7k_5",
+        "generatorFamilyId": "gen_list_commas_insert",
+        "variantSignature": "puncsig_jl4vs2",
+        "templateId": "gen_list_commas_insert_template_1myck8w",
+        "prompt": "Add commas to separate the list items.",
+        "stem": "The shelf held paints brushes and paper.",
+        "model": "The shelf held paints, brushes and paper.",
+        "validatorType": "requiresListCommas",
+        "validator": {
+          "type": "requiresListCommas",
+          "items": [
+            "paints",
+            "brushes",
+            "paper"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.list_separator_missing",
+          "comma.unnecessary_final_comma"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_list_commas_insert_1g6q4wj_6",
+        "generatorFamilyId": "gen_list_commas_insert",
+        "variantSignature": "puncsig_1e1g3rp",
+        "templateId": "gen_list_commas_insert_template_62b991",
+        "prompt": "Add commas to separate the list items.",
+        "stem": "We saw gulls seals and dolphins.",
+        "model": "We saw gulls, seals and dolphins.",
+        "validatorType": "requiresListCommas",
+        "validator": {
+          "type": "requiresListCommas",
+          "items": [
+            "gulls",
+            "seals",
+            "dolphins"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.list_separator_missing",
+          "comma.unnecessary_final_comma"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_list_commas_insert_1ggpqli_7",
+        "generatorFamilyId": "gen_list_commas_insert",
+        "variantSignature": "puncsig_jl4vs2",
+        "templateId": "gen_list_commas_insert_template_1myck8w",
+        "prompt": "Add commas to separate the list items.",
+        "stem": "The shelf held paints brushes and paper.",
+        "model": "The shelf held paints, brushes and paper.",
+        "validatorType": "requiresListCommas",
+        "validator": {
+          "type": "requiresListCommas",
+          "items": [
+            "paints",
+            "brushes",
+            "paper"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.list_separator_missing",
+          "comma.unnecessary_final_comma"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_list_commas_insert_1gqpcah_8",
+        "generatorFamilyId": "gen_list_commas_insert",
+        "variantSignature": "puncsig_1e1g3rp",
+        "templateId": "gen_list_commas_insert_template_62b991",
+        "prompt": "Add commas to separate the list items.",
+        "stem": "We saw gulls seals and dolphins.",
+        "model": "We saw gulls, seals and dolphins.",
+        "validatorType": "requiresListCommas",
+        "validator": {
+          "type": "requiresListCommas",
+          "items": [
+            "gulls",
+            "seals",
+            "dolphins"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.list_separator_missing",
+          "comma.unnecessary_final_comma"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      }
+    ],
+    "gen_list_commas_combine": [
+      {
+        "id": "gen_list_commas_combine_peklr6_1",
+        "generatorFamilyId": "gen_list_commas_combine",
+        "variantSignature": "puncsig_4ebjlq",
+        "templateId": "gen_list_commas_combine_template_14p5ger",
+        "prompt": "Combine the notes into one correctly punctuated sentence.",
+        "stem": "The tray held\n- shells\n- feathers\n- pebbles",
+        "model": "The tray held shells, feathers and pebbles.",
+        "validatorType": "combineListSentence",
+        "validator": {
+          "type": "combineListSentence",
+          "opening": "The tray held",
+          "items": [
+            "shells",
+            "feathers",
+            "pebbles"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.list_separator_missing",
+          "comma.unnecessary_final_comma"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_list_commas_combine_pok7g5_2",
+        "generatorFamilyId": "gen_list_commas_combine",
+        "variantSignature": "puncsig_1e11bmr",
+        "templateId": "gen_list_commas_combine_template_qmva3q",
+        "prompt": "Combine the notes into one correctly punctuated sentence.",
+        "stem": "We collected\n- leaves\n- twigs\n- acorns",
+        "model": "We collected leaves, twigs and acorns.",
+        "validatorType": "combineListSentence",
+        "validator": {
+          "type": "combineListSentence",
+          "opening": "We collected",
+          "items": [
+            "leaves",
+            "twigs",
+            "acorns"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.list_separator_missing",
+          "comma.unnecessary_final_comma"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_list_commas_combine_ouled8_3",
+        "generatorFamilyId": "gen_list_commas_combine",
+        "variantSignature": "puncsig_cbesme",
+        "templateId": "gen_list_commas_combine_template_1d8dwo5",
+        "prompt": "Combine the notes into one correctly punctuated sentence.",
+        "stem": "The bag contained\n- chalk\n- string\n- tape",
+        "model": "The bag contained chalk, string and tape.",
+        "validatorType": "combineListSentence",
+        "validator": {
+          "type": "combineListSentence",
+          "opening": "The bag contained",
+          "items": [
+            "chalk",
+            "string",
+            "tape"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.list_separator_missing",
+          "comma.unnecessary_final_comma"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_list_commas_combine_p4l027_4",
+        "generatorFamilyId": "gen_list_commas_combine",
+        "variantSignature": "puncsig_08ojzv",
+        "templateId": "gen_list_commas_combine_template_14arcfx",
+        "prompt": "Combine the notes into one correctly punctuated sentence.",
+        "stem": "Our lunch included\n- apples\n- sandwiches\n- juice",
+        "model": "Our lunch included apples, sandwiches and juice.",
+        "validatorType": "combineListSentence",
+        "validator": {
+          "type": "combineListSentence",
+          "opening": "Our lunch included",
+          "items": [
+            "apples",
+            "sandwiches",
+            "juice"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.list_separator_missing",
+          "comma.unnecessary_final_comma"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_list_commas_combine_oam6za_5",
+        "generatorFamilyId": "gen_list_commas_combine",
+        "variantSignature": "puncsig_cbesme",
+        "templateId": "gen_list_commas_combine_template_1d8dwo5",
+        "prompt": "Combine the notes into one correctly punctuated sentence.",
+        "stem": "The bag contained\n- chalk\n- string\n- tape",
+        "model": "The bag contained chalk, string and tape.",
+        "validatorType": "combineListSentence",
+        "validator": {
+          "type": "combineListSentence",
+          "opening": "The bag contained",
+          "items": [
+            "chalk",
+            "string",
+            "tape"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.list_separator_missing",
+          "comma.unnecessary_final_comma"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_list_commas_combine_oklso9_6",
+        "generatorFamilyId": "gen_list_commas_combine",
+        "variantSignature": "puncsig_08ojzv",
+        "templateId": "gen_list_commas_combine_template_14arcfx",
+        "prompt": "Combine the notes into one correctly punctuated sentence.",
+        "stem": "Our lunch included\n- apples\n- sandwiches\n- juice",
+        "model": "Our lunch included apples, sandwiches and juice.",
+        "validatorType": "combineListSentence",
+        "validator": {
+          "type": "combineListSentence",
+          "opening": "Our lunch included",
+          "items": [
+            "apples",
+            "sandwiches",
+            "juice"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.list_separator_missing",
+          "comma.unnecessary_final_comma"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_list_commas_combine_nqmzlc_7",
+        "generatorFamilyId": "gen_list_commas_combine",
+        "variantSignature": "puncsig_cbesme",
+        "templateId": "gen_list_commas_combine_template_1d8dwo5",
+        "prompt": "Combine the notes into one correctly punctuated sentence.",
+        "stem": "The bag contained\n- chalk\n- string\n- tape",
+        "model": "The bag contained chalk, string and tape.",
+        "validatorType": "combineListSentence",
+        "validator": {
+          "type": "combineListSentence",
+          "opening": "The bag contained",
+          "items": [
+            "chalk",
+            "string",
+            "tape"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.list_separator_missing",
+          "comma.unnecessary_final_comma"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_list_commas_combine_o0mlab_8",
+        "generatorFamilyId": "gen_list_commas_combine",
+        "variantSignature": "puncsig_08ojzv",
+        "templateId": "gen_list_commas_combine_template_14arcfx",
+        "prompt": "Combine the notes into one correctly punctuated sentence.",
+        "stem": "Our lunch included\n- apples\n- sandwiches\n- juice",
+        "model": "Our lunch included apples, sandwiches and juice.",
+        "validatorType": "combineListSentence",
+        "validator": {
+          "type": "combineListSentence",
+          "opening": "Our lunch included",
+          "items": [
+            "apples",
+            "sandwiches",
+            "juice"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.list_separator_missing",
+          "comma.unnecessary_final_comma"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      }
+    ],
+    "gen_fronted_adverbial_fix": [
+      {
+        "id": "gen_fronted_adverbial_fix_1u50vwu_1",
+        "generatorFamilyId": "gen_fronted_adverbial_fix",
+        "variantSignature": "puncsig_dq7z5w",
+        "templateId": "gen_fronted_adverbial_fix_template_1e1may2",
+        "prompt": "Correct the comma after the fronted adverbial.",
+        "stem": "After the storm the path was muddy.",
+        "model": "After the storm, the path was muddy.",
+        "validatorType": "startsWithPhraseComma",
+        "validator": {
+          "type": "startsWithPhraseComma",
+          "phrase": "After the storm"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.fronted_adverbial_missing"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_fronted_adverbial_fix_1uf0hlt_2",
+        "generatorFamilyId": "gen_fronted_adverbial_fix",
+        "variantSignature": "puncsig_823nwf",
+        "templateId": "gen_fronted_adverbial_fix_template_18k5e78",
+        "prompt": "Correct the comma after the fronted adverbial.",
+        "stem": "Before sunrise the crew checked the ropes.",
+        "model": "Before sunrise, the crew checked the ropes.",
+        "validatorType": "startsWithPhraseComma",
+        "validator": {
+          "type": "startsWithPhraseComma",
+          "phrase": "Before sunrise"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.fronted_adverbial_missing"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_fronted_adverbial_fix_1tl1oiw_3",
+        "generatorFamilyId": "gen_fronted_adverbial_fix",
+        "variantSignature": "puncsig_8l2wtt",
+        "templateId": "gen_fronted_adverbial_fix_template_1wney8c",
+        "prompt": "Correct the comma after the fronted adverbial.",
+        "stem": "During the concert the hall became silent.",
+        "model": "During the concert, the hall became silent.",
+        "validatorType": "startsWithPhraseComma",
+        "validator": {
+          "type": "startsWithPhraseComma",
+          "phrase": "During the concert"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.fronted_adverbial_missing"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_fronted_adverbial_fix_1tv1a7v_4",
+        "generatorFamilyId": "gen_fronted_adverbial_fix",
+        "variantSignature": "puncsig_atzp2i",
+        "templateId": "gen_fronted_adverbial_fix_template_da25i5",
+        "prompt": "Correct the comma after the fronted adverbial.",
+        "stem": "At the edge of the field the coach waited.",
+        "model": "At the edge of the field, the coach waited.",
+        "validatorType": "startsWithPhraseComma",
+        "validator": {
+          "type": "startsWithPhraseComma",
+          "phrase": "At the edge of the field"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.fronted_adverbial_missing"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_fronted_adverbial_fix_1v8zaoq_5",
+        "generatorFamilyId": "gen_fronted_adverbial_fix",
+        "variantSignature": "puncsig_8l2wtt",
+        "templateId": "gen_fronted_adverbial_fix_template_1wney8c",
+        "prompt": "Correct the comma after the fronted adverbial.",
+        "stem": "During the concert the hall became silent.",
+        "model": "During the concert, the hall became silent.",
+        "validatorType": "startsWithPhraseComma",
+        "validator": {
+          "type": "startsWithPhraseComma",
+          "phrase": "During the concert"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.fronted_adverbial_missing"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_fronted_adverbial_fix_1viywdp_6",
+        "generatorFamilyId": "gen_fronted_adverbial_fix",
+        "variantSignature": "puncsig_atzp2i",
+        "templateId": "gen_fronted_adverbial_fix_template_da25i5",
+        "prompt": "Correct the comma after the fronted adverbial.",
+        "stem": "At the edge of the field the coach waited.",
+        "model": "At the edge of the field, the coach waited.",
+        "validatorType": "startsWithPhraseComma",
+        "validator": {
+          "type": "startsWithPhraseComma",
+          "phrase": "At the edge of the field"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.fronted_adverbial_missing"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_fronted_adverbial_fix_1up03as_7",
+        "generatorFamilyId": "gen_fronted_adverbial_fix",
+        "variantSignature": "puncsig_8l2wtt",
+        "templateId": "gen_fronted_adverbial_fix_template_1wney8c",
+        "prompt": "Correct the comma after the fronted adverbial.",
+        "stem": "During the concert the hall became silent.",
+        "model": "During the concert, the hall became silent.",
+        "validatorType": "startsWithPhraseComma",
+        "validator": {
+          "type": "startsWithPhraseComma",
+          "phrase": "During the concert"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.fronted_adverbial_missing"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_fronted_adverbial_fix_1uyzozr_8",
+        "generatorFamilyId": "gen_fronted_adverbial_fix",
+        "variantSignature": "puncsig_atzp2i",
+        "templateId": "gen_fronted_adverbial_fix_template_da25i5",
+        "prompt": "Correct the comma after the fronted adverbial.",
+        "stem": "At the edge of the field the coach waited.",
+        "model": "At the edge of the field, the coach waited.",
+        "validatorType": "startsWithPhraseComma",
+        "validator": {
+          "type": "startsWithPhraseComma",
+          "phrase": "At the edge of the field"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.fronted_adverbial_missing"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      }
+    ],
+    "gen_fronted_adverbial_combine": [
+      {
+        "id": "gen_fronted_adverbial_combine_uadfsk_1",
+        "generatorFamilyId": "gen_fronted_adverbial_combine",
+        "variantSignature": "puncsig_1un9zhg",
+        "templateId": "gen_fronted_adverbial_combine_template_kfsxpg",
+        "prompt": "Combine the adverbial and main clause into one sentence.",
+        "stem": "Before sunrise\nThe crew checked the ropes.",
+        "model": "Before sunrise, the crew checked the ropes.",
+        "validatorType": "combineFrontedAdverbial",
+        "validator": {
+          "type": "combineFrontedAdverbial",
+          "phrase": "Before sunrise",
+          "mainClause": "the crew checked the ropes"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.fronted_adverbial_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_fronted_adverbial_combine_ukd1hj_2",
+        "generatorFamilyId": "gen_fronted_adverbial_combine",
+        "variantSignature": "puncsig_5xqw3g",
+        "templateId": "gen_fronted_adverbial_combine_template_7tnqjq",
+        "prompt": "Combine the adverbial and main clause into one sentence.",
+        "stem": "After the rehearsal\nThe cast packed away the props.",
+        "model": "After the rehearsal, the cast packed away the props.",
+        "validatorType": "combineFrontedAdverbial",
+        "validator": {
+          "type": "combineFrontedAdverbial",
+          "phrase": "After the rehearsal",
+          "mainClause": "the cast packed away the props"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.fronted_adverbial_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_fronted_adverbial_combine_uucn6i_3",
+        "generatorFamilyId": "gen_fronted_adverbial_combine",
+        "variantSignature": "puncsig_1s62czm",
+        "templateId": "gen_fronted_adverbial_combine_template_116hnmp",
+        "prompt": "Combine the adverbial and main clause into one sentence.",
+        "stem": "During the concert\nThe hall became silent.",
+        "model": "During the concert, the hall became silent.",
+        "validatorType": "combineFrontedAdverbial",
+        "validator": {
+          "type": "combineFrontedAdverbial",
+          "phrase": "During the concert",
+          "mainClause": "the hall became silent"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.fronted_adverbial_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_fronted_adverbial_combine_v4c8vh_4",
+        "generatorFamilyId": "gen_fronted_adverbial_combine",
+        "variantSignature": "puncsig_36di7r",
+        "templateId": "gen_fronted_adverbial_combine_template_1plxa4t",
+        "prompt": "Combine the adverbial and main clause into one sentence.",
+        "stem": "At the edge of the field\nThe coach waited.",
+        "model": "At the edge of the field, the coach waited.",
+        "validatorType": "combineFrontedAdverbial",
+        "validator": {
+          "type": "combineFrontedAdverbial",
+          "phrase": "At the edge of the field",
+          "mainClause": "the coach waited"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.fronted_adverbial_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_fronted_adverbial_combine_t6f10o_5",
+        "generatorFamilyId": "gen_fronted_adverbial_combine",
+        "variantSignature": "puncsig_1s62czm",
+        "templateId": "gen_fronted_adverbial_combine_template_116hnmp",
+        "prompt": "Combine the adverbial and main clause into one sentence.",
+        "stem": "During the concert\nThe hall became silent.",
+        "model": "During the concert, the hall became silent.",
+        "validatorType": "combineFrontedAdverbial",
+        "validator": {
+          "type": "combineFrontedAdverbial",
+          "phrase": "During the concert",
+          "mainClause": "the hall became silent"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.fronted_adverbial_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_fronted_adverbial_combine_tgempn_6",
+        "generatorFamilyId": "gen_fronted_adverbial_combine",
+        "variantSignature": "puncsig_36di7r",
+        "templateId": "gen_fronted_adverbial_combine_template_1plxa4t",
+        "prompt": "Combine the adverbial and main clause into one sentence.",
+        "stem": "At the edge of the field\nThe coach waited.",
+        "model": "At the edge of the field, the coach waited.",
+        "validatorType": "combineFrontedAdverbial",
+        "validator": {
+          "type": "combineFrontedAdverbial",
+          "phrase": "At the edge of the field",
+          "mainClause": "the coach waited"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.fronted_adverbial_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_fronted_adverbial_combine_tqe8em_7",
+        "generatorFamilyId": "gen_fronted_adverbial_combine",
+        "variantSignature": "puncsig_1s62czm",
+        "templateId": "gen_fronted_adverbial_combine_template_116hnmp",
+        "prompt": "Combine the adverbial and main clause into one sentence.",
+        "stem": "During the concert\nThe hall became silent.",
+        "model": "During the concert, the hall became silent.",
+        "validatorType": "combineFrontedAdverbial",
+        "validator": {
+          "type": "combineFrontedAdverbial",
+          "phrase": "During the concert",
+          "mainClause": "the hall became silent"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.fronted_adverbial_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_fronted_adverbial_combine_u0du3l_8",
+        "generatorFamilyId": "gen_fronted_adverbial_combine",
+        "variantSignature": "puncsig_36di7r",
+        "templateId": "gen_fronted_adverbial_combine_template_1plxa4t",
+        "prompt": "Combine the adverbial and main clause into one sentence.",
+        "stem": "At the edge of the field\nThe coach waited.",
+        "model": "At the edge of the field, the coach waited.",
+        "validatorType": "combineFrontedAdverbial",
+        "validator": {
+          "type": "combineFrontedAdverbial",
+          "phrase": "At the edge of the field",
+          "mainClause": "the coach waited"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "comma.fronted_adverbial_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      }
+    ],
+    "gen_parenthesis_fix": [
+      {
+        "id": "gen_parenthesis_fix_a2o80p_1",
+        "generatorFamilyId": "gen_parenthesis_fix",
+        "variantSignature": "puncsig_mb2d85",
+        "templateId": "gen_parenthesis_fix_template_77v44m",
+        "prompt": "Correct the parenthesis punctuation.",
+        "stem": "The tower a useful lookout stood above the bay.",
+        "model": "The tower, a useful lookout, stood above the bay.",
+        "validatorType": "requiresParentheticalPhrase",
+        "validator": {
+          "type": "requiresParentheticalPhrase",
+          "before": "The tower",
+          "phrase": "a useful lookout",
+          "after": "stood above the bay"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.parenthesis_missing",
+          "structure.parenthesis_unbalanced"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_parenthesis_fix_9sombq_2",
+        "generatorFamilyId": "gen_parenthesis_fix",
+        "variantSignature": "puncsig_1c9v5hl",
+        "templateId": "gen_parenthesis_fix_template_1afsvei",
+        "prompt": "Correct the parenthesis punctuation.",
+        "stem": "The harbour, an old fishing port was busy.",
+        "model": "The harbour, an old fishing port, was busy.",
+        "validatorType": "requiresParentheticalPhrase",
+        "validator": {
+          "type": "requiresParentheticalPhrase",
+          "before": "The harbour",
+          "phrase": "an old fishing port",
+          "after": "was busy"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.parenthesis_missing",
+          "structure.parenthesis_unbalanced"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_parenthesis_fix_9ip0mr_3",
+        "generatorFamilyId": "gen_parenthesis_fix",
+        "variantSignature": "puncsig_1hjjs2m",
+        "templateId": "gen_parenthesis_fix_template_1hxyt9u",
+        "prompt": "Correct the parenthesis punctuation.",
+        "stem": "Mr Patel our maths teacher smiled proudly.",
+        "model": "Mr Patel, our maths teacher, smiled proudly.",
+        "validatorType": "requiresParentheticalPhrase",
+        "validator": {
+          "type": "requiresParentheticalPhrase",
+          "before": "Mr Patel",
+          "phrase": "our maths teacher",
+          "after": "smiled proudly"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.parenthesis_missing",
+          "structure.parenthesis_unbalanced"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_parenthesis_fix_98pexs_4",
+        "generatorFamilyId": "gen_parenthesis_fix",
+        "variantSignature": "puncsig_673mgn",
+        "templateId": "gen_parenthesis_fix_template_11xdcus",
+        "prompt": "Correct the parenthesis punctuation.",
+        "stem": "The library a quiet room closed early.",
+        "model": "The library, a quiet room, closed early.",
+        "validatorType": "requiresParentheticalPhrase",
+        "validator": {
+          "type": "requiresParentheticalPhrase",
+          "before": "The library",
+          "phrase": "a quiet room",
+          "after": "closed early"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.parenthesis_missing",
+          "structure.parenthesis_unbalanced"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_parenthesis_fix_b6mmsl_5",
+        "generatorFamilyId": "gen_parenthesis_fix",
+        "variantSignature": "puncsig_1hjjs2m",
+        "templateId": "gen_parenthesis_fix_template_1hxyt9u",
+        "prompt": "Correct the parenthesis punctuation.",
+        "stem": "Mr Patel our maths teacher smiled proudly.",
+        "model": "Mr Patel, our maths teacher, smiled proudly.",
+        "validatorType": "requiresParentheticalPhrase",
+        "validator": {
+          "type": "requiresParentheticalPhrase",
+          "before": "Mr Patel",
+          "phrase": "our maths teacher",
+          "after": "smiled proudly"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.parenthesis_missing",
+          "structure.parenthesis_unbalanced"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_parenthesis_fix_awn13m_6",
+        "generatorFamilyId": "gen_parenthesis_fix",
+        "variantSignature": "puncsig_673mgn",
+        "templateId": "gen_parenthesis_fix_template_11xdcus",
+        "prompt": "Correct the parenthesis punctuation.",
+        "stem": "The library a quiet room closed early.",
+        "model": "The library, a quiet room, closed early.",
+        "validatorType": "requiresParentheticalPhrase",
+        "validator": {
+          "type": "requiresParentheticalPhrase",
+          "before": "The library",
+          "phrase": "a quiet room",
+          "after": "closed early"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.parenthesis_missing",
+          "structure.parenthesis_unbalanced"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_parenthesis_fix_amnfen_7",
+        "generatorFamilyId": "gen_parenthesis_fix",
+        "variantSignature": "puncsig_1hjjs2m",
+        "templateId": "gen_parenthesis_fix_template_1hxyt9u",
+        "prompt": "Correct the parenthesis punctuation.",
+        "stem": "Mr Patel our maths teacher smiled proudly.",
+        "model": "Mr Patel, our maths teacher, smiled proudly.",
+        "validatorType": "requiresParentheticalPhrase",
+        "validator": {
+          "type": "requiresParentheticalPhrase",
+          "before": "Mr Patel",
+          "phrase": "our maths teacher",
+          "after": "smiled proudly"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.parenthesis_missing",
+          "structure.parenthesis_unbalanced"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_parenthesis_fix_acntpo_8",
+        "generatorFamilyId": "gen_parenthesis_fix",
+        "variantSignature": "puncsig_673mgn",
+        "templateId": "gen_parenthesis_fix_template_11xdcus",
+        "prompt": "Correct the parenthesis punctuation.",
+        "stem": "The library a quiet room closed early.",
+        "model": "The library, a quiet room, closed early.",
+        "validatorType": "requiresParentheticalPhrase",
+        "validator": {
+          "type": "requiresParentheticalPhrase",
+          "before": "The library",
+          "phrase": "a quiet room",
+          "after": "closed early"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.parenthesis_missing",
+          "structure.parenthesis_unbalanced"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      }
+    ],
+    "gen_parenthesis_combine": [
+      {
+        "id": "gen_parenthesis_combine_t29n63_1",
+        "generatorFamilyId": "gen_parenthesis_combine",
+        "variantSignature": "puncsig_1pdrtm4",
+        "templateId": "gen_parenthesis_combine_template_q327zw",
+        "prompt": "Combine the sentence and extra detail using parenthesis.",
+        "stem": "The tower stood above the bay.\nExtra detail: a useful lookout",
+        "model": "The tower, a useful lookout, stood above the bay.",
+        "validatorType": "combineParentheticalPhrase",
+        "validator": {
+          "type": "combineParentheticalPhrase",
+          "before": "The tower",
+          "phrase": "a useful lookout",
+          "after": "stood above the bay"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.parenthesis_missing",
+          "structure.parenthesis_unbalanced"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_parenthesis_combine_ssa1h4_2",
+        "generatorFamilyId": "gen_parenthesis_combine",
+        "variantSignature": "puncsig_17xfcox",
+        "templateId": "gen_parenthesis_combine_template_zw0cs4",
+        "prompt": "Combine the sentence and extra detail using parenthesis.",
+        "stem": "The harbour was busy.\nExtra detail: an old fishing port",
+        "model": "The harbour, an old fishing port, was busy.",
+        "validatorType": "combineParentheticalPhrase",
+        "validator": {
+          "type": "combineParentheticalPhrase",
+          "before": "The harbour",
+          "phrase": "an old fishing port",
+          "after": "was busy"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.parenthesis_missing",
+          "structure.parenthesis_unbalanced"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_parenthesis_combine_tm8uk1_3",
+        "generatorFamilyId": "gen_parenthesis_combine",
+        "variantSignature": "puncsig_1199s4h",
+        "templateId": "gen_parenthesis_combine_template_xpov82",
+        "prompt": "Combine the sentence and extra detail using parenthesis.",
+        "stem": "Mr Patel smiled proudly.\nExtra detail: our maths teacher",
+        "model": "Mr Patel, our maths teacher, smiled proudly.",
+        "validatorType": "combineParentheticalPhrase",
+        "validator": {
+          "type": "combineParentheticalPhrase",
+          "before": "Mr Patel",
+          "phrase": "our maths teacher",
+          "after": "smiled proudly"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.parenthesis_missing",
+          "structure.parenthesis_unbalanced"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_parenthesis_combine_tc98v2_4",
+        "generatorFamilyId": "gen_parenthesis_combine",
+        "variantSignature": "puncsig_hz9s99",
+        "templateId": "gen_parenthesis_combine_template_zwj4d4",
+        "prompt": "Combine the sentence and extra detail using parenthesis.",
+        "stem": "The library closed early.\nExtra detail: a quiet room",
+        "model": "The library, a quiet room, closed early.",
+        "validatorType": "combineParentheticalPhrase",
+        "validator": {
+          "type": "combineParentheticalPhrase",
+          "before": "The library",
+          "phrase": "a quiet room",
+          "after": "closed early"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.parenthesis_missing",
+          "structure.parenthesis_unbalanced"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_parenthesis_combine_u681xz_5",
+        "generatorFamilyId": "gen_parenthesis_combine",
+        "variantSignature": "puncsig_1199s4h",
+        "templateId": "gen_parenthesis_combine_template_xpov82",
+        "prompt": "Combine the sentence and extra detail using parenthesis.",
+        "stem": "Mr Patel smiled proudly.\nExtra detail: our maths teacher",
+        "model": "Mr Patel, our maths teacher, smiled proudly.",
+        "validatorType": "combineParentheticalPhrase",
+        "validator": {
+          "type": "combineParentheticalPhrase",
+          "before": "Mr Patel",
+          "phrase": "our maths teacher",
+          "after": "smiled proudly"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.parenthesis_missing",
+          "structure.parenthesis_unbalanced"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_parenthesis_combine_tw8g90_6",
+        "generatorFamilyId": "gen_parenthesis_combine",
+        "variantSignature": "puncsig_hz9s99",
+        "templateId": "gen_parenthesis_combine_template_zwj4d4",
+        "prompt": "Combine the sentence and extra detail using parenthesis.",
+        "stem": "The library closed early.\nExtra detail: a quiet room",
+        "model": "The library, a quiet room, closed early.",
+        "validatorType": "combineParentheticalPhrase",
+        "validator": {
+          "type": "combineParentheticalPhrase",
+          "before": "The library",
+          "phrase": "a quiet room",
+          "after": "closed early"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.parenthesis_missing",
+          "structure.parenthesis_unbalanced"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_parenthesis_combine_uq79bx_7",
+        "generatorFamilyId": "gen_parenthesis_combine",
+        "variantSignature": "puncsig_1199s4h",
+        "templateId": "gen_parenthesis_combine_template_xpov82",
+        "prompt": "Combine the sentence and extra detail using parenthesis.",
+        "stem": "Mr Patel smiled proudly.\nExtra detail: our maths teacher",
+        "model": "Mr Patel, our maths teacher, smiled proudly.",
+        "validatorType": "combineParentheticalPhrase",
+        "validator": {
+          "type": "combineParentheticalPhrase",
+          "before": "Mr Patel",
+          "phrase": "our maths teacher",
+          "after": "smiled proudly"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.parenthesis_missing",
+          "structure.parenthesis_unbalanced"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_parenthesis_combine_ug7nmy_8",
+        "generatorFamilyId": "gen_parenthesis_combine",
+        "variantSignature": "puncsig_hz9s99",
+        "templateId": "gen_parenthesis_combine_template_zwj4d4",
+        "prompt": "Combine the sentence and extra detail using parenthesis.",
+        "stem": "The library closed early.\nExtra detail: a quiet room",
+        "model": "The library, a quiet room, closed early.",
+        "validatorType": "combineParentheticalPhrase",
+        "validator": {
+          "type": "combineParentheticalPhrase",
+          "before": "The library",
+          "phrase": "a quiet room",
+          "after": "closed early"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.parenthesis_missing",
+          "structure.parenthesis_unbalanced"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      }
+    ],
+    "gen_parenthesis_speech_paragraph": [
+      {
+        "id": "gen_parenthesis_speech_paragraph_vpwpzp_1",
+        "generatorFamilyId": "gen_parenthesis_speech_paragraph",
+        "variantSignature": "puncsig_500oc3",
+        "templateId": "gen_parenthesis_speech_paragraph_template_ghicmk",
+        "prompt": "Repair the punctuation in the short passage.",
+        "stem": "The tower a useful lookout stood above the bay. Mia asked where are the boats",
+        "model": "The tower, a useful lookout, stood above the bay. Mia asked, \"Where are the boats?\"",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresParentheticalPhrase",
+              "before": "The tower",
+              "phrase": "a useful lookout",
+              "after": "stood above the bay",
+              "misconceptionTags": [
+                "structure.parenthesis_missing",
+                "structure.parenthesis_unbalanced"
+              ]
+            },
+            {
+              "type": "speechWithWords",
+              "words": "where are the boats",
+              "requiredTerminal": "?",
+              "misconceptionTags": [
+                "speech.quote_missing",
+                "speech.reporting_comma_missing",
+                "speech.punctuation_missing"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.parenthesis_missing",
+          "structure.parenthesis_unbalanced",
+          "speech.quote_missing",
+          "speech.reporting_comma_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_parenthesis_speech_paragraph_vfx4aq_2",
+        "generatorFamilyId": "gen_parenthesis_speech_paragraph",
+        "variantSignature": "puncsig_1odmcb7",
+        "templateId": "gen_parenthesis_speech_paragraph_template_188l1dz",
+        "prompt": "Repair the punctuation in the short passage.",
+        "stem": "The harbour an old fishing port was busy. Ravi said the bell is ringing",
+        "model": "The harbour, an old fishing port, was busy. Ravi said, \"The bell is ringing.\"",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresParentheticalPhrase",
+              "before": "The harbour",
+              "phrase": "an old fishing port",
+              "after": "was busy",
+              "misconceptionTags": [
+                "structure.parenthesis_missing",
+                "structure.parenthesis_unbalanced"
+              ]
+            },
+            {
+              "type": "speechWithWords",
+              "words": "the bell is ringing",
+              "requiredTerminal": ".",
+              "misconceptionTags": [
+                "speech.quote_missing",
+                "speech.reporting_comma_missing",
+                "speech.punctuation_missing"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.parenthesis_missing",
+          "structure.parenthesis_unbalanced",
+          "speech.quote_missing",
+          "speech.reporting_comma_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_parenthesis_speech_paragraph_v5xilr_3",
+        "generatorFamilyId": "gen_parenthesis_speech_paragraph",
+        "variantSignature": "puncsig_e5nb1w",
+        "templateId": "gen_parenthesis_speech_paragraph_template_l7g61c",
+        "prompt": "Repair the punctuation in the short passage.",
+        "stem": "Mr Patel our maths teacher smiled proudly. Leo asked did we win",
+        "model": "Mr Patel, our maths teacher, smiled proudly. Leo asked, \"Did we win?\"",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresParentheticalPhrase",
+              "before": "Mr Patel",
+              "phrase": "our maths teacher",
+              "after": "smiled proudly",
+              "misconceptionTags": [
+                "structure.parenthesis_missing",
+                "structure.parenthesis_unbalanced"
+              ]
+            },
+            {
+              "type": "speechWithWords",
+              "words": "did we win",
+              "requiredTerminal": "?",
+              "misconceptionTags": [
+                "speech.quote_missing",
+                "speech.reporting_comma_missing",
+                "speech.punctuation_missing"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.parenthesis_missing",
+          "structure.parenthesis_unbalanced",
+          "speech.quote_missing",
+          "speech.reporting_comma_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_parenthesis_speech_paragraph_uvxwws_4",
+        "generatorFamilyId": "gen_parenthesis_speech_paragraph",
+        "variantSignature": "puncsig_paw9dv",
+        "templateId": "gen_parenthesis_speech_paragraph_template_f5rlwh",
+        "prompt": "Repair the punctuation in the short passage.",
+        "stem": "The library a quiet room closed early. Nina said we can come back tomorrow",
+        "model": "The library, a quiet room, closed early. Nina said, \"We can come back tomorrow.\"",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresParentheticalPhrase",
+              "before": "The library",
+              "phrase": "a quiet room",
+              "after": "closed early",
+              "misconceptionTags": [
+                "structure.parenthesis_missing",
+                "structure.parenthesis_unbalanced"
+              ]
+            },
+            {
+              "type": "speechWithWords",
+              "words": "we can come back tomorrow",
+              "requiredTerminal": ".",
+              "misconceptionTags": [
+                "speech.quote_missing",
+                "speech.reporting_comma_missing",
+                "speech.punctuation_missing"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.parenthesis_missing",
+          "structure.parenthesis_unbalanced",
+          "speech.quote_missing",
+          "speech.reporting_comma_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_parenthesis_speech_paragraph_ulyb7t_5",
+        "generatorFamilyId": "gen_parenthesis_speech_paragraph",
+        "variantSignature": "puncsig_e5nb1w",
+        "templateId": "gen_parenthesis_speech_paragraph_template_l7g61c",
+        "prompt": "Repair the punctuation in the short passage.",
+        "stem": "Mr Patel our maths teacher smiled proudly. Leo asked did we win",
+        "model": "Mr Patel, our maths teacher, smiled proudly. Leo asked, \"Did we win?\"",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresParentheticalPhrase",
+              "before": "Mr Patel",
+              "phrase": "our maths teacher",
+              "after": "smiled proudly",
+              "misconceptionTags": [
+                "structure.parenthesis_missing",
+                "structure.parenthesis_unbalanced"
+              ]
+            },
+            {
+              "type": "speechWithWords",
+              "words": "did we win",
+              "requiredTerminal": "?",
+              "misconceptionTags": [
+                "speech.quote_missing",
+                "speech.reporting_comma_missing",
+                "speech.punctuation_missing"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.parenthesis_missing",
+          "structure.parenthesis_unbalanced",
+          "speech.quote_missing",
+          "speech.reporting_comma_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_parenthesis_speech_paragraph_ubypiu_6",
+        "generatorFamilyId": "gen_parenthesis_speech_paragraph",
+        "variantSignature": "puncsig_paw9dv",
+        "templateId": "gen_parenthesis_speech_paragraph_template_f5rlwh",
+        "prompt": "Repair the punctuation in the short passage.",
+        "stem": "The library a quiet room closed early. Nina said we can come back tomorrow",
+        "model": "The library, a quiet room, closed early. Nina said, \"We can come back tomorrow.\"",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresParentheticalPhrase",
+              "before": "The library",
+              "phrase": "a quiet room",
+              "after": "closed early",
+              "misconceptionTags": [
+                "structure.parenthesis_missing",
+                "structure.parenthesis_unbalanced"
+              ]
+            },
+            {
+              "type": "speechWithWords",
+              "words": "we can come back tomorrow",
+              "requiredTerminal": ".",
+              "misconceptionTags": [
+                "speech.quote_missing",
+                "speech.reporting_comma_missing",
+                "speech.punctuation_missing"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.parenthesis_missing",
+          "structure.parenthesis_unbalanced",
+          "speech.quote_missing",
+          "speech.reporting_comma_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_parenthesis_speech_paragraph_u1z3tv_7",
+        "generatorFamilyId": "gen_parenthesis_speech_paragraph",
+        "variantSignature": "puncsig_e5nb1w",
+        "templateId": "gen_parenthesis_speech_paragraph_template_l7g61c",
+        "prompt": "Repair the punctuation in the short passage.",
+        "stem": "Mr Patel our maths teacher smiled proudly. Leo asked did we win",
+        "model": "Mr Patel, our maths teacher, smiled proudly. Leo asked, \"Did we win?\"",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresParentheticalPhrase",
+              "before": "Mr Patel",
+              "phrase": "our maths teacher",
+              "after": "smiled proudly",
+              "misconceptionTags": [
+                "structure.parenthesis_missing",
+                "structure.parenthesis_unbalanced"
+              ]
+            },
+            {
+              "type": "speechWithWords",
+              "words": "did we win",
+              "requiredTerminal": "?",
+              "misconceptionTags": [
+                "speech.quote_missing",
+                "speech.reporting_comma_missing",
+                "speech.punctuation_missing"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.parenthesis_missing",
+          "structure.parenthesis_unbalanced",
+          "speech.quote_missing",
+          "speech.reporting_comma_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_parenthesis_speech_paragraph_trzi4w_8",
+        "generatorFamilyId": "gen_parenthesis_speech_paragraph",
+        "variantSignature": "puncsig_paw9dv",
+        "templateId": "gen_parenthesis_speech_paragraph_template_f5rlwh",
+        "prompt": "Repair the punctuation in the short passage.",
+        "stem": "The library a quiet room closed early. Nina said we can come back tomorrow",
+        "model": "The library, a quiet room, closed early. Nina said, \"We can come back tomorrow.\"",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresParentheticalPhrase",
+              "before": "The library",
+              "phrase": "a quiet room",
+              "after": "closed early",
+              "misconceptionTags": [
+                "structure.parenthesis_missing",
+                "structure.parenthesis_unbalanced"
+              ]
+            },
+            {
+              "type": "speechWithWords",
+              "words": "we can come back tomorrow",
+              "requiredTerminal": ".",
+              "misconceptionTags": [
+                "speech.quote_missing",
+                "speech.reporting_comma_missing",
+                "speech.punctuation_missing"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.parenthesis_missing",
+          "structure.parenthesis_unbalanced",
+          "speech.quote_missing",
+          "speech.reporting_comma_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      }
+    ],
+    "gen_colon_list_insert": [
+      {
+        "id": "gen_colon_list_insert_jm8wuh_1",
+        "generatorFamilyId": "gen_colon_list_insert",
+        "variantSignature": "puncsig_khjj5x",
+        "templateId": "gen_colon_list_insert_template_1ltdd18",
+        "prompt": "Add the colon before the list.",
+        "stem": "The kit included three things a lantern, a compass and a notebook.",
+        "model": "The kit included three things: a lantern, a compass and a notebook.",
+        "validatorType": "requiresColonBeforeList",
+        "validator": {
+          "type": "requiresColonBeforeList",
+          "opening": "The kit included three things",
+          "items": [
+            "a lantern",
+            "a compass",
+            "a notebook"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.colon_missing",
+          "structure.list_separator_missing"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_colon_list_insert_jc9b5i_2",
+        "generatorFamilyId": "gen_colon_list_insert",
+        "variantSignature": "puncsig_10m4u9s",
+        "templateId": "gen_colon_list_insert_template_drw7oh",
+        "prompt": "Add the colon before the list.",
+        "stem": "We needed three tools a torch, a rope and a map.",
+        "model": "We needed three tools: a torch, a rope and a map.",
+        "validatorType": "requiresColonBeforeList",
+        "validator": {
+          "type": "requiresColonBeforeList",
+          "opening": "We needed three tools",
+          "items": [
+            "a torch",
+            "a rope",
+            "a map"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.colon_missing",
+          "structure.list_separator_missing"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_colon_list_insert_j29pgj_3",
+        "generatorFamilyId": "gen_colon_list_insert",
+        "variantSignature": "puncsig_1b6mqjs",
+        "templateId": "gen_colon_list_insert_template_1yfkdms",
+        "prompt": "Add the colon before the list.",
+        "stem": "We chose three activities swimming, cycling and climbing.",
+        "model": "We chose three activities: swimming, cycling and climbing.",
+        "validatorType": "requiresColonBeforeList",
+        "validator": {
+          "type": "requiresColonBeforeList",
+          "opening": "We chose three activities",
+          "items": [
+            "swimming",
+            "cycling",
+            "climbing"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.colon_missing",
+          "structure.list_separator_missing"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_colon_list_insert_isa3rk_4",
+        "generatorFamilyId": "gen_colon_list_insert",
+        "variantSignature": "puncsig_gnacaa",
+        "templateId": "gen_colon_list_insert_template_1ojbkvf",
+        "prompt": "Add the colon before the list.",
+        "stem": "The drawer held three supplies pens, rulers and tape.",
+        "model": "The drawer held three supplies: pens, rulers and tape.",
+        "validatorType": "requiresColonBeforeList",
+        "validator": {
+          "type": "requiresColonBeforeList",
+          "opening": "The drawer held three supplies",
+          "items": [
+            "pens",
+            "rulers",
+            "tape"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.colon_missing",
+          "structure.list_separator_missing"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_colon_list_insert_kq7bmd_5",
+        "generatorFamilyId": "gen_colon_list_insert",
+        "variantSignature": "puncsig_1b6mqjs",
+        "templateId": "gen_colon_list_insert_template_1yfkdms",
+        "prompt": "Add the colon before the list.",
+        "stem": "We chose three activities swimming, cycling and climbing.",
+        "model": "We chose three activities: swimming, cycling and climbing.",
+        "validatorType": "requiresColonBeforeList",
+        "validator": {
+          "type": "requiresColonBeforeList",
+          "opening": "We chose three activities",
+          "items": [
+            "swimming",
+            "cycling",
+            "climbing"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.colon_missing",
+          "structure.list_separator_missing"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_colon_list_insert_kg7pxe_6",
+        "generatorFamilyId": "gen_colon_list_insert",
+        "variantSignature": "puncsig_gnacaa",
+        "templateId": "gen_colon_list_insert_template_1ojbkvf",
+        "prompt": "Add the colon before the list.",
+        "stem": "The drawer held three supplies pens, rulers and tape.",
+        "model": "The drawer held three supplies: pens, rulers and tape.",
+        "validatorType": "requiresColonBeforeList",
+        "validator": {
+          "type": "requiresColonBeforeList",
+          "opening": "The drawer held three supplies",
+          "items": [
+            "pens",
+            "rulers",
+            "tape"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.colon_missing",
+          "structure.list_separator_missing"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_colon_list_insert_k6848f_7",
+        "generatorFamilyId": "gen_colon_list_insert",
+        "variantSignature": "puncsig_1b6mqjs",
+        "templateId": "gen_colon_list_insert_template_1yfkdms",
+        "prompt": "Add the colon before the list.",
+        "stem": "We chose three activities swimming, cycling and climbing.",
+        "model": "We chose three activities: swimming, cycling and climbing.",
+        "validatorType": "requiresColonBeforeList",
+        "validator": {
+          "type": "requiresColonBeforeList",
+          "opening": "We chose three activities",
+          "items": [
+            "swimming",
+            "cycling",
+            "climbing"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.colon_missing",
+          "structure.list_separator_missing"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_colon_list_insert_jw8ijg_8",
+        "generatorFamilyId": "gen_colon_list_insert",
+        "variantSignature": "puncsig_gnacaa",
+        "templateId": "gen_colon_list_insert_template_1ojbkvf",
+        "prompt": "Add the colon before the list.",
+        "stem": "The drawer held three supplies pens, rulers and tape.",
+        "model": "The drawer held three supplies: pens, rulers and tape.",
+        "validatorType": "requiresColonBeforeList",
+        "validator": {
+          "type": "requiresColonBeforeList",
+          "opening": "The drawer held three supplies",
+          "items": [
+            "pens",
+            "rulers",
+            "tape"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.colon_missing",
+          "structure.list_separator_missing"
+        ],
+        "readiness": [
+          "insertion",
+          "misconception",
+          "negative_test"
+        ]
+      }
+    ],
+    "gen_colon_list_combine": [
+      {
+        "id": "gen_colon_list_combine_bfoeqd_1",
+        "generatorFamilyId": "gen_colon_list_combine",
+        "variantSignature": "puncsig_weots8",
+        "templateId": "gen_colon_list_combine_template_3bbxei",
+        "prompt": "Combine the opening clause and list using a colon.",
+        "stem": "The kit included three things\na lantern / a compass / a notebook",
+        "model": "The kit included three things: a lantern, a compass and a notebook.",
+        "validatorType": "combineColonList",
+        "validator": {
+          "type": "combineColonList",
+          "opening": "The kit included three things",
+          "items": [
+            "a lantern",
+            "a compass",
+            "a notebook"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.colon_missing",
+          "structure.list_separator_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_colon_list_combine_b5ot1e_2",
+        "generatorFamilyId": "gen_colon_list_combine",
+        "variantSignature": "puncsig_k5t5fh",
+        "templateId": "gen_colon_list_combine_template_lti8wz",
+        "prompt": "Combine the opening clause and list using a colon.",
+        "stem": "We needed three tools\na torch / a rope / a map",
+        "model": "We needed three tools: a torch, a rope and a map.",
+        "validatorType": "combineColonList",
+        "validator": {
+          "type": "combineColonList",
+          "opening": "We needed three tools",
+          "items": [
+            "a torch",
+            "a rope",
+            "a map"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.colon_missing",
+          "structure.list_separator_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_colon_list_combine_avp7cf_3",
+        "generatorFamilyId": "gen_colon_list_combine",
+        "variantSignature": "puncsig_ynal65",
+        "templateId": "gen_colon_list_combine_template_19wsb66",
+        "prompt": "Combine the opening clause and list using a colon.",
+        "stem": "We chose three activities\nswimming / cycling / climbing",
+        "model": "We chose three activities: swimming, cycling and climbing.",
+        "validatorType": "combineColonList",
+        "validator": {
+          "type": "combineColonList",
+          "opening": "We chose three activities",
+          "items": [
+            "swimming",
+            "cycling",
+            "climbing"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.colon_missing",
+          "structure.list_separator_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_colon_list_combine_alplng_4",
+        "generatorFamilyId": "gen_colon_list_combine",
+        "variantSignature": "puncsig_qt2pkv",
+        "templateId": "gen_colon_list_combine_template_50y9if",
+        "prompt": "Combine the opening clause and list using a colon.",
+        "stem": "The drawer held three supplies\npens / rulers / tape",
+        "model": "The drawer held three supplies: pens, rulers and tape.",
+        "validatorType": "combineColonList",
+        "validator": {
+          "type": "combineColonList",
+          "opening": "The drawer held three supplies",
+          "items": [
+            "pens",
+            "rulers",
+            "tape"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.colon_missing",
+          "structure.list_separator_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_colon_list_combine_abpzyh_5",
+        "generatorFamilyId": "gen_colon_list_combine",
+        "variantSignature": "puncsig_ynal65",
+        "templateId": "gen_colon_list_combine_template_19wsb66",
+        "prompt": "Combine the opening clause and list using a colon.",
+        "stem": "We chose three activities\nswimming / cycling / climbing",
+        "model": "We chose three activities: swimming, cycling and climbing.",
+        "validatorType": "combineColonList",
+        "validator": {
+          "type": "combineColonList",
+          "opening": "We chose three activities",
+          "items": [
+            "swimming",
+            "cycling",
+            "climbing"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.colon_missing",
+          "structure.list_separator_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_colon_list_combine_a1qe9i_6",
+        "generatorFamilyId": "gen_colon_list_combine",
+        "variantSignature": "puncsig_qt2pkv",
+        "templateId": "gen_colon_list_combine_template_50y9if",
+        "prompt": "Combine the opening clause and list using a colon.",
+        "stem": "The drawer held three supplies\npens / rulers / tape",
+        "model": "The drawer held three supplies: pens, rulers and tape.",
+        "validatorType": "combineColonList",
+        "validator": {
+          "type": "combineColonList",
+          "opening": "The drawer held three supplies",
+          "items": [
+            "pens",
+            "rulers",
+            "tape"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.colon_missing",
+          "structure.list_separator_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_colon_list_combine_9rqskj_7",
+        "generatorFamilyId": "gen_colon_list_combine",
+        "variantSignature": "puncsig_ynal65",
+        "templateId": "gen_colon_list_combine_template_19wsb66",
+        "prompt": "Combine the opening clause and list using a colon.",
+        "stem": "We chose three activities\nswimming / cycling / climbing",
+        "model": "We chose three activities: swimming, cycling and climbing.",
+        "validatorType": "combineColonList",
+        "validator": {
+          "type": "combineColonList",
+          "opening": "We chose three activities",
+          "items": [
+            "swimming",
+            "cycling",
+            "climbing"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.colon_missing",
+          "structure.list_separator_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_colon_list_combine_9hr6vk_8",
+        "generatorFamilyId": "gen_colon_list_combine",
+        "variantSignature": "puncsig_qt2pkv",
+        "templateId": "gen_colon_list_combine_template_50y9if",
+        "prompt": "Combine the opening clause and list using a colon.",
+        "stem": "The drawer held three supplies\npens / rulers / tape",
+        "model": "The drawer held three supplies: pens, rulers and tape.",
+        "validatorType": "combineColonList",
+        "validator": {
+          "type": "combineColonList",
+          "opening": "The drawer held three supplies",
+          "items": [
+            "pens",
+            "rulers",
+            "tape"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.colon_missing",
+          "structure.list_separator_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      }
+    ],
+    "gen_semicolon_fix": [
+      {
+        "id": "gen_semicolon_fix_d24gag_1",
+        "generatorFamilyId": "gen_semicolon_fix",
+        "variantSignature": "puncsig_1y3sqx4",
+        "templateId": "gen_semicolon_fix_template_ikssce",
+        "prompt": "Replace the comma splice with a semi-colon.",
+        "stem": "The lighthouse was bright, the boats still waited.",
+        "model": "The lighthouse was bright; the boats still waited.",
+        "validatorType": "requiresBoundaryBetweenClauses",
+        "validator": {
+          "type": "requiresBoundaryBetweenClauses",
+          "left": "The lighthouse was bright",
+          "right": "the boats still waited",
+          "mark": ";"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "boundary.comma_splice",
+          "boundary.semicolon_missing"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_semicolon_fix_dc41zf_2",
+        "generatorFamilyId": "gen_semicolon_fix",
+        "variantSignature": "puncsig_7av6n9",
+        "templateId": "gen_semicolon_fix_template_s0pvzh",
+        "prompt": "Replace the comma splice with a semi-colon.",
+        "stem": "The rain eased, the match could continue.",
+        "model": "The rain eased; the match could continue.",
+        "validatorType": "requiresBoundaryBetweenClauses",
+        "validator": {
+          "type": "requiresBoundaryBetweenClauses",
+          "left": "The rain eased",
+          "right": "the match could continue",
+          "mark": ";"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "boundary.comma_splice",
+          "boundary.semicolon_missing"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_semicolon_fix_dm3noe_3",
+        "generatorFamilyId": "gen_semicolon_fix",
+        "variantSignature": "puncsig_1x27sj4",
+        "templateId": "gen_semicolon_fix_template_vwch5i",
+        "prompt": "Replace the comma splice with a semi-colon.",
+        "stem": "The clock stopped, the class kept working.",
+        "model": "The clock stopped; the class kept working.",
+        "validatorType": "requiresBoundaryBetweenClauses",
+        "validator": {
+          "type": "requiresBoundaryBetweenClauses",
+          "left": "The clock stopped",
+          "right": "the class kept working",
+          "mark": ";"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "boundary.comma_splice",
+          "boundary.semicolon_missing"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_semicolon_fix_dw39dd_4",
+        "generatorFamilyId": "gen_semicolon_fix",
+        "variantSignature": "puncsig_fu4o3l",
+        "templateId": "gen_semicolon_fix_template_r1d5mx",
+        "prompt": "Replace the comma splice with a semi-colon.",
+        "stem": "The path was narrow, the hikers walked slowly.",
+        "model": "The path was narrow; the hikers walked slowly.",
+        "validatorType": "requiresBoundaryBetweenClauses",
+        "validator": {
+          "type": "requiresBoundaryBetweenClauses",
+          "left": "The path was narrow",
+          "right": "the hikers walked slowly",
+          "mark": ";"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "boundary.comma_splice",
+          "boundary.semicolon_missing"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_semicolon_fix_e62v2c_5",
+        "generatorFamilyId": "gen_semicolon_fix",
+        "variantSignature": "puncsig_1x27sj4",
+        "templateId": "gen_semicolon_fix_template_vwch5i",
+        "prompt": "Replace the comma splice with a semi-colon.",
+        "stem": "The clock stopped, the class kept working.",
+        "model": "The clock stopped; the class kept working.",
+        "validatorType": "requiresBoundaryBetweenClauses",
+        "validator": {
+          "type": "requiresBoundaryBetweenClauses",
+          "left": "The clock stopped",
+          "right": "the class kept working",
+          "mark": ";"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "boundary.comma_splice",
+          "boundary.semicolon_missing"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_semicolon_fix_eg2grb_6",
+        "generatorFamilyId": "gen_semicolon_fix",
+        "variantSignature": "puncsig_fu4o3l",
+        "templateId": "gen_semicolon_fix_template_r1d5mx",
+        "prompt": "Replace the comma splice with a semi-colon.",
+        "stem": "The path was narrow, the hikers walked slowly.",
+        "model": "The path was narrow; the hikers walked slowly.",
+        "validatorType": "requiresBoundaryBetweenClauses",
+        "validator": {
+          "type": "requiresBoundaryBetweenClauses",
+          "left": "The path was narrow",
+          "right": "the hikers walked slowly",
+          "mark": ";"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "boundary.comma_splice",
+          "boundary.semicolon_missing"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_semicolon_fix_eq22ga_7",
+        "generatorFamilyId": "gen_semicolon_fix",
+        "variantSignature": "puncsig_1x27sj4",
+        "templateId": "gen_semicolon_fix_template_vwch5i",
+        "prompt": "Replace the comma splice with a semi-colon.",
+        "stem": "The clock stopped, the class kept working.",
+        "model": "The clock stopped; the class kept working.",
+        "validatorType": "requiresBoundaryBetweenClauses",
+        "validator": {
+          "type": "requiresBoundaryBetweenClauses",
+          "left": "The clock stopped",
+          "right": "the class kept working",
+          "mark": ";"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "boundary.comma_splice",
+          "boundary.semicolon_missing"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_semicolon_fix_f01o59_8",
+        "generatorFamilyId": "gen_semicolon_fix",
+        "variantSignature": "puncsig_fu4o3l",
+        "templateId": "gen_semicolon_fix_template_r1d5mx",
+        "prompt": "Replace the comma splice with a semi-colon.",
+        "stem": "The path was narrow, the hikers walked slowly.",
+        "model": "The path was narrow; the hikers walked slowly.",
+        "validatorType": "requiresBoundaryBetweenClauses",
+        "validator": {
+          "type": "requiresBoundaryBetweenClauses",
+          "left": "The path was narrow",
+          "right": "the hikers walked slowly",
+          "mark": ";"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "boundary.comma_splice",
+          "boundary.semicolon_missing"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      }
+    ],
+    "gen_semicolon_combine": [
+      {
+        "id": "gen_semicolon_combine_5y6fqi_1",
+        "generatorFamilyId": "gen_semicolon_combine",
+        "variantSignature": "puncsig_1vqj8j6",
+        "templateId": "gen_semicolon_combine_template_1c4cawx",
+        "prompt": "Combine the two related clauses into one sentence with a semi-colon.",
+        "stem": "The lighthouse was bright.\nThe boats still waited.",
+        "model": "The lighthouse was bright; the boats still waited.",
+        "validatorType": "combineBoundaryBetweenClauses",
+        "validator": {
+          "type": "combineBoundaryBetweenClauses",
+          "left": "The lighthouse was bright",
+          "right": "the boats still waited",
+          "mark": ";"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "boundary.comma_splice",
+          "boundary.semicolon_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_semicolon_combine_6861fh_2",
+        "generatorFamilyId": "gen_semicolon_combine",
+        "variantSignature": "puncsig_1n25ezp",
+        "templateId": "gen_semicolon_combine_template_1dp84xe",
+        "prompt": "Combine the two related clauses into one sentence with a semi-colon.",
+        "stem": "The rain eased.\nThe match could continue.",
+        "model": "The rain eased; the match could continue.",
+        "validatorType": "combineBoundaryBetweenClauses",
+        "validator": {
+          "type": "combineBoundaryBetweenClauses",
+          "left": "The rain eased",
+          "right": "the match could continue",
+          "mark": ";"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "boundary.comma_splice",
+          "boundary.semicolon_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_semicolon_combine_5e78ck_3",
+        "generatorFamilyId": "gen_semicolon_combine",
+        "variantSignature": "puncsig_0ts7nt",
+        "templateId": "gen_semicolon_combine_template_iorsah",
+        "prompt": "Combine the two related clauses into one sentence with a semi-colon.",
+        "stem": "The clock stopped.\nThe class kept working.",
+        "model": "The clock stopped; the class kept working.",
+        "validatorType": "combineBoundaryBetweenClauses",
+        "validator": {
+          "type": "combineBoundaryBetweenClauses",
+          "left": "The clock stopped",
+          "right": "the class kept working",
+          "mark": ";"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "boundary.comma_splice",
+          "boundary.semicolon_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_semicolon_combine_5o6u1j_4",
+        "generatorFamilyId": "gen_semicolon_combine",
+        "variantSignature": "puncsig_4jp8xz",
+        "templateId": "gen_semicolon_combine_template_b0qttm",
+        "prompt": "Combine the two related clauses into one sentence with a semi-colon.",
+        "stem": "The path was narrow.\nThe hikers walked slowly.",
+        "model": "The path was narrow; the hikers walked slowly.",
+        "validatorType": "combineBoundaryBetweenClauses",
+        "validator": {
+          "type": "combineBoundaryBetweenClauses",
+          "left": "The path was narrow",
+          "right": "the hikers walked slowly",
+          "mark": ";"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "boundary.comma_splice",
+          "boundary.semicolon_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_semicolon_combine_4u80ym_5",
+        "generatorFamilyId": "gen_semicolon_combine",
+        "variantSignature": "puncsig_0ts7nt",
+        "templateId": "gen_semicolon_combine_template_iorsah",
+        "prompt": "Combine the two related clauses into one sentence with a semi-colon.",
+        "stem": "The clock stopped.\nThe class kept working.",
+        "model": "The clock stopped; the class kept working.",
+        "validatorType": "combineBoundaryBetweenClauses",
+        "validator": {
+          "type": "combineBoundaryBetweenClauses",
+          "left": "The clock stopped",
+          "right": "the class kept working",
+          "mark": ";"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "boundary.comma_splice",
+          "boundary.semicolon_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_semicolon_combine_547mnl_6",
+        "generatorFamilyId": "gen_semicolon_combine",
+        "variantSignature": "puncsig_4jp8xz",
+        "templateId": "gen_semicolon_combine_template_b0qttm",
+        "prompt": "Combine the two related clauses into one sentence with a semi-colon.",
+        "stem": "The path was narrow.\nThe hikers walked slowly.",
+        "model": "The path was narrow; the hikers walked slowly.",
+        "validatorType": "combineBoundaryBetweenClauses",
+        "validator": {
+          "type": "combineBoundaryBetweenClauses",
+          "left": "The path was narrow",
+          "right": "the hikers walked slowly",
+          "mark": ";"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "boundary.comma_splice",
+          "boundary.semicolon_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_semicolon_combine_4a8tko_7",
+        "generatorFamilyId": "gen_semicolon_combine",
+        "variantSignature": "puncsig_0ts7nt",
+        "templateId": "gen_semicolon_combine_template_iorsah",
+        "prompt": "Combine the two related clauses into one sentence with a semi-colon.",
+        "stem": "The clock stopped.\nThe class kept working.",
+        "model": "The clock stopped; the class kept working.",
+        "validatorType": "combineBoundaryBetweenClauses",
+        "validator": {
+          "type": "combineBoundaryBetweenClauses",
+          "left": "The clock stopped",
+          "right": "the class kept working",
+          "mark": ";"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "boundary.comma_splice",
+          "boundary.semicolon_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_semicolon_combine_4k8f9n_8",
+        "generatorFamilyId": "gen_semicolon_combine",
+        "variantSignature": "puncsig_4jp8xz",
+        "templateId": "gen_semicolon_combine_template_b0qttm",
+        "prompt": "Combine the two related clauses into one sentence with a semi-colon.",
+        "stem": "The path was narrow.\nThe hikers walked slowly.",
+        "model": "The path was narrow; the hikers walked slowly.",
+        "validatorType": "combineBoundaryBetweenClauses",
+        "validator": {
+          "type": "combineBoundaryBetweenClauses",
+          "left": "The path was narrow",
+          "right": "the hikers walked slowly",
+          "mark": ";"
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "boundary.comma_splice",
+          "boundary.semicolon_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      }
+    ],
+    "gen_colon_semicolon_paragraph": [
+      {
+        "id": "gen_colon_semicolon_paragraph_1q4bpg5_1",
+        "generatorFamilyId": "gen_colon_semicolon_paragraph",
+        "variantSignature": "puncsig_yz3x47",
+        "templateId": "gen_colon_semicolon_paragraph_template_1anvv2m",
+        "prompt": "Repair the punctuation in the short passage.",
+        "stem": "The kit held three things, a torch, a rope and a map. The rain stopped, the match continued.",
+        "model": "The kit held three things: a torch, a rope and a map. The rain stopped; the match continued.",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresColonBeforeList",
+              "opening": "The kit held three things",
+              "items": [
+                "a torch",
+                "a rope",
+                "a map"
+              ],
+              "allowTrailingText": true,
+              "misconceptionTags": [
+                "structure.colon_missing",
+                "structure.list_separator_missing"
+              ]
+            },
+            {
+              "type": "requiresBoundaryBetweenClauses",
+              "mark": ";",
+              "left": "The rain stopped",
+              "right": "the match continued",
+              "misconceptionTags": [
+                "boundary.comma_splice",
+                "boundary.semicolon_missing"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.colon_missing",
+          "structure.list_separator_missing",
+          "boundary.comma_splice",
+          "boundary.semicolon_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_colon_semicolon_paragraph_1puc3r6_2",
+        "generatorFamilyId": "gen_colon_semicolon_paragraph",
+        "variantSignature": "puncsig_1lx0h8v",
+        "templateId": "gen_colon_semicolon_paragraph_template_1mtafqy",
+        "prompt": "Repair the punctuation in the short passage.",
+        "stem": "We needed three tools, a lantern, a compass and a notebook. The tide rose, the group moved inland.",
+        "model": "We needed three tools: a lantern, a compass and a notebook. The tide rose; the group moved inland.",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresColonBeforeList",
+              "opening": "We needed three tools",
+              "items": [
+                "a lantern",
+                "a compass",
+                "a notebook"
+              ],
+              "allowTrailingText": true,
+              "misconceptionTags": [
+                "structure.colon_missing",
+                "structure.list_separator_missing"
+              ]
+            },
+            {
+              "type": "requiresBoundaryBetweenClauses",
+              "mark": ";",
+              "left": "The tide rose",
+              "right": "the group moved inland",
+              "misconceptionTags": [
+                "boundary.comma_splice",
+                "boundary.semicolon_missing"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.colon_missing",
+          "structure.list_separator_missing",
+          "boundary.comma_splice",
+          "boundary.semicolon_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_colon_semicolon_paragraph_1pkci27_3",
+        "generatorFamilyId": "gen_colon_semicolon_paragraph",
+        "variantSignature": "puncsig_1kyykb2",
+        "templateId": "gen_colon_semicolon_paragraph_template_08cn05",
+        "prompt": "Repair the punctuation in the short passage.",
+        "stem": "Our display needed three labels, rivers, mountains and coasts. The lights dimmed, the film began.",
+        "model": "Our display needed three labels: rivers, mountains and coasts. The lights dimmed; the film began.",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresColonBeforeList",
+              "opening": "Our display needed three labels",
+              "items": [
+                "rivers",
+                "mountains",
+                "coasts"
+              ],
+              "allowTrailingText": true,
+              "misconceptionTags": [
+                "structure.colon_missing",
+                "structure.list_separator_missing"
+              ]
+            },
+            {
+              "type": "requiresBoundaryBetweenClauses",
+              "mark": ";",
+              "left": "The lights dimmed",
+              "right": "the film began",
+              "misconceptionTags": [
+                "boundary.comma_splice",
+                "boundary.semicolon_missing"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.colon_missing",
+          "structure.list_separator_missing",
+          "boundary.comma_splice",
+          "boundary.semicolon_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_colon_semicolon_paragraph_1pacwd8_4",
+        "generatorFamilyId": "gen_colon_semicolon_paragraph",
+        "variantSignature": "puncsig_nfzjh8",
+        "templateId": "gen_colon_semicolon_paragraph_template_14w5vlm",
+        "prompt": "Repair the punctuation in the short passage.",
+        "stem": "The box contained three items, a scarf, a medal and a badge. The door opened, the crowd cheered.",
+        "model": "The box contained three items: a scarf, a medal and a badge. The door opened; the crowd cheered.",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresColonBeforeList",
+              "opening": "The box contained three items",
+              "items": [
+                "a scarf",
+                "a medal",
+                "a badge"
+              ],
+              "allowTrailingText": true,
+              "misconceptionTags": [
+                "structure.colon_missing",
+                "structure.list_separator_missing"
+              ]
+            },
+            {
+              "type": "requiresBoundaryBetweenClauses",
+              "mark": ";",
+              "left": "The door opened",
+              "right": "the crowd cheered",
+              "misconceptionTags": [
+                "boundary.comma_splice",
+                "boundary.semicolon_missing"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.colon_missing",
+          "structure.list_separator_missing",
+          "boundary.comma_splice",
+          "boundary.semicolon_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_colon_semicolon_paragraph_1p0dao9_5",
+        "generatorFamilyId": "gen_colon_semicolon_paragraph",
+        "variantSignature": "puncsig_1kyykb2",
+        "templateId": "gen_colon_semicolon_paragraph_template_08cn05",
+        "prompt": "Repair the punctuation in the short passage.",
+        "stem": "Our display needed three labels, rivers, mountains and coasts. The lights dimmed, the film began.",
+        "model": "Our display needed three labels: rivers, mountains and coasts. The lights dimmed; the film began.",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresColonBeforeList",
+              "opening": "Our display needed three labels",
+              "items": [
+                "rivers",
+                "mountains",
+                "coasts"
+              ],
+              "allowTrailingText": true,
+              "misconceptionTags": [
+                "structure.colon_missing",
+                "structure.list_separator_missing"
+              ]
+            },
+            {
+              "type": "requiresBoundaryBetweenClauses",
+              "mark": ";",
+              "left": "The lights dimmed",
+              "right": "the film began",
+              "misconceptionTags": [
+                "boundary.comma_splice",
+                "boundary.semicolon_missing"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.colon_missing",
+          "structure.list_separator_missing",
+          "boundary.comma_splice",
+          "boundary.semicolon_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_colon_semicolon_paragraph_1oqdoza_6",
+        "generatorFamilyId": "gen_colon_semicolon_paragraph",
+        "variantSignature": "puncsig_nfzjh8",
+        "templateId": "gen_colon_semicolon_paragraph_template_14w5vlm",
+        "prompt": "Repair the punctuation in the short passage.",
+        "stem": "The box contained three items, a scarf, a medal and a badge. The door opened, the crowd cheered.",
+        "model": "The box contained three items: a scarf, a medal and a badge. The door opened; the crowd cheered.",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresColonBeforeList",
+              "opening": "The box contained three items",
+              "items": [
+                "a scarf",
+                "a medal",
+                "a badge"
+              ],
+              "allowTrailingText": true,
+              "misconceptionTags": [
+                "structure.colon_missing",
+                "structure.list_separator_missing"
+              ]
+            },
+            {
+              "type": "requiresBoundaryBetweenClauses",
+              "mark": ";",
+              "left": "The door opened",
+              "right": "the crowd cheered",
+              "misconceptionTags": [
+                "boundary.comma_splice",
+                "boundary.semicolon_missing"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.colon_missing",
+          "structure.list_separator_missing",
+          "boundary.comma_splice",
+          "boundary.semicolon_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_colon_semicolon_paragraph_1oge3ab_7",
+        "generatorFamilyId": "gen_colon_semicolon_paragraph",
+        "variantSignature": "puncsig_1kyykb2",
+        "templateId": "gen_colon_semicolon_paragraph_template_08cn05",
+        "prompt": "Repair the punctuation in the short passage.",
+        "stem": "Our display needed three labels, rivers, mountains and coasts. The lights dimmed, the film began.",
+        "model": "Our display needed three labels: rivers, mountains and coasts. The lights dimmed; the film began.",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresColonBeforeList",
+              "opening": "Our display needed three labels",
+              "items": [
+                "rivers",
+                "mountains",
+                "coasts"
+              ],
+              "allowTrailingText": true,
+              "misconceptionTags": [
+                "structure.colon_missing",
+                "structure.list_separator_missing"
+              ]
+            },
+            {
+              "type": "requiresBoundaryBetweenClauses",
+              "mark": ";",
+              "left": "The lights dimmed",
+              "right": "the film began",
+              "misconceptionTags": [
+                "boundary.comma_splice",
+                "boundary.semicolon_missing"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.colon_missing",
+          "structure.list_separator_missing",
+          "boundary.comma_splice",
+          "boundary.semicolon_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_colon_semicolon_paragraph_1o6ehlc_8",
+        "generatorFamilyId": "gen_colon_semicolon_paragraph",
+        "variantSignature": "puncsig_nfzjh8",
+        "templateId": "gen_colon_semicolon_paragraph_template_14w5vlm",
+        "prompt": "Repair the punctuation in the short passage.",
+        "stem": "The box contained three items, a scarf, a medal and a badge. The door opened, the crowd cheered.",
+        "model": "The box contained three items: a scarf, a medal and a badge. The door opened; the crowd cheered.",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresColonBeforeList",
+              "opening": "The box contained three items",
+              "items": [
+                "a scarf",
+                "a medal",
+                "a badge"
+              ],
+              "allowTrailingText": true,
+              "misconceptionTags": [
+                "structure.colon_missing",
+                "structure.list_separator_missing"
+              ]
+            },
+            {
+              "type": "requiresBoundaryBetweenClauses",
+              "mark": ";",
+              "left": "The door opened",
+              "right": "the crowd cheered",
+              "misconceptionTags": [
+                "boundary.comma_splice",
+                "boundary.semicolon_missing"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.colon_missing",
+          "structure.list_separator_missing",
+          "boundary.comma_splice",
+          "boundary.semicolon_missing"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      }
+    ],
+    "gen_bullet_points_fix": [
+      {
+        "id": "gen_bullet_points_fix_dsvo5r_1",
+        "generatorFamilyId": "gen_bullet_points_fix",
+        "variantSignature": "puncsig_0dj4fz",
+        "templateId": "gen_bullet_points_fix_template_113xapj",
+        "prompt": "Make the bullet punctuation consistent.",
+        "stem": "Pack:\n- pencils\n- rulers.\n- glue sticks",
+        "model": "Pack:\n- pencils\n- rulers\n- glue sticks",
+        "validatorType": "requiresBulletStemAndItems",
+        "validator": {
+          "type": "requiresBulletStemAndItems",
+          "stem": "Pack",
+          "items": [
+            "pencils",
+            "rulers",
+            "glue sticks"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.bullet_punctuation_inconsistent"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_bullet_points_fix_diw2gs_2",
+        "generatorFamilyId": "gen_bullet_points_fix",
+        "variantSignature": "puncsig_8wrlau",
+        "templateId": "gen_bullet_points_fix_template_3tfe0s",
+        "prompt": "Make the bullet punctuation consistent.",
+        "stem": "Bring:\n- a coat.\n- a torch\n- a notebook.",
+        "model": "Bring:\n- a coat.\n- a torch.\n- a notebook.",
+        "validatorType": "requiresBulletStemAndItems",
+        "validator": {
+          "type": "requiresBulletStemAndItems",
+          "stem": "Bring",
+          "items": [
+            "a coat",
+            "a torch",
+            "a notebook"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.bullet_punctuation_inconsistent"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_bullet_points_fix_ecuvjp_3",
+        "generatorFamilyId": "gen_bullet_points_fix",
+        "variantSignature": "puncsig_s8slbt",
+        "templateId": "gen_bullet_points_fix_template_ddav2o",
+        "prompt": "Make the bullet punctuation consistent.",
+        "stem": "Check:\n- doors.\n- windows\n- lights.",
+        "model": "Check:\n- doors.\n- windows.\n- lights.",
+        "validatorType": "requiresBulletStemAndItems",
+        "validator": {
+          "type": "requiresBulletStemAndItems",
+          "stem": "Check",
+          "items": [
+            "doors",
+            "windows",
+            "lights"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.bullet_punctuation_inconsistent"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_bullet_points_fix_e2v9uq_4",
+        "generatorFamilyId": "gen_bullet_points_fix",
+        "variantSignature": "puncsig_1n4aanx",
+        "templateId": "gen_bullet_points_fix_template_zg5zmq",
+        "prompt": "Make the bullet punctuation consistent.",
+        "stem": "Take:\n- water\n- snacks.\n- a hat",
+        "model": "Take:\n- water\n- snacks\n- a hat",
+        "validatorType": "requiresBulletStemAndItems",
+        "validator": {
+          "type": "requiresBulletStemAndItems",
+          "stem": "Take",
+          "items": [
+            "water",
+            "snacks",
+            "a hat"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.bullet_punctuation_inconsistent"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_bullet_points_fix_cox9dv_5",
+        "generatorFamilyId": "gen_bullet_points_fix",
+        "variantSignature": "puncsig_s8slbt",
+        "templateId": "gen_bullet_points_fix_template_ddav2o",
+        "prompt": "Make the bullet punctuation consistent.",
+        "stem": "Check:\n- doors.\n- windows\n- lights.",
+        "model": "Check:\n- doors.\n- windows.\n- lights.",
+        "validatorType": "requiresBulletStemAndItems",
+        "validator": {
+          "type": "requiresBulletStemAndItems",
+          "stem": "Check",
+          "items": [
+            "doors",
+            "windows",
+            "lights"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.bullet_punctuation_inconsistent"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_bullet_points_fix_cexnow_6",
+        "generatorFamilyId": "gen_bullet_points_fix",
+        "variantSignature": "puncsig_1n4aanx",
+        "templateId": "gen_bullet_points_fix_template_zg5zmq",
+        "prompt": "Make the bullet punctuation consistent.",
+        "stem": "Take:\n- water\n- snacks.\n- a hat",
+        "model": "Take:\n- water\n- snacks\n- a hat",
+        "validatorType": "requiresBulletStemAndItems",
+        "validator": {
+          "type": "requiresBulletStemAndItems",
+          "stem": "Take",
+          "items": [
+            "water",
+            "snacks",
+            "a hat"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.bullet_punctuation_inconsistent"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_bullet_points_fix_d8wgrt_7",
+        "generatorFamilyId": "gen_bullet_points_fix",
+        "variantSignature": "puncsig_s8slbt",
+        "templateId": "gen_bullet_points_fix_template_ddav2o",
+        "prompt": "Make the bullet punctuation consistent.",
+        "stem": "Check:\n- doors.\n- windows\n- lights.",
+        "model": "Check:\n- doors.\n- windows.\n- lights.",
+        "validatorType": "requiresBulletStemAndItems",
+        "validator": {
+          "type": "requiresBulletStemAndItems",
+          "stem": "Check",
+          "items": [
+            "doors",
+            "windows",
+            "lights"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.bullet_punctuation_inconsistent"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_bullet_points_fix_cywv2u_8",
+        "generatorFamilyId": "gen_bullet_points_fix",
+        "variantSignature": "puncsig_1n4aanx",
+        "templateId": "gen_bullet_points_fix_template_zg5zmq",
+        "prompt": "Make the bullet punctuation consistent.",
+        "stem": "Take:\n- water\n- snacks.\n- a hat",
+        "model": "Take:\n- water\n- snacks\n- a hat",
+        "validatorType": "requiresBulletStemAndItems",
+        "validator": {
+          "type": "requiresBulletStemAndItems",
+          "stem": "Take",
+          "items": [
+            "water",
+            "snacks",
+            "a hat"
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.bullet_punctuation_inconsistent"
+        ],
+        "readiness": [
+          "proofreading",
+          "misconception",
+          "negative_test"
+        ]
+      }
+    ],
+    "gen_bullet_points_paragraph": [
+      {
+        "id": "gen_bullet_points_paragraph_1kwm6aa_1",
+        "generatorFamilyId": "gen_bullet_points_paragraph",
+        "variantSignature": "puncsig_18sipdw",
+        "templateId": "gen_bullet_points_paragraph_template_1dozira",
+        "prompt": "Repair the bullet-list punctuation.",
+        "stem": "Pack\n- pencils\n- rulers.\n- glue sticks",
+        "model": "Pack:\n- pencils\n- rulers\n- glue sticks",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresBulletStemAndItems",
+              "stem": "Pack",
+              "items": [
+                "pencils",
+                "rulers",
+                "glue sticks"
+              ],
+              "misconceptionTags": [
+                "structure.bullet_colon_missing",
+                "structure.bullet_marker_missing",
+                "structure.bullet_punctuation_inconsistent"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.bullet_colon_missing",
+          "structure.bullet_marker_missing",
+          "structure.bullet_punctuation_inconsistent"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_bullet_points_paragraph_1l6lrz9_2",
+        "generatorFamilyId": "gen_bullet_points_paragraph",
+        "variantSignature": "puncsig_1n9pc7n",
+        "templateId": "gen_bullet_points_paragraph_template_1pn0ihi",
+        "prompt": "Repair the bullet-list punctuation.",
+        "stem": "Bring\n- a coat.\n- a torch\n- a notebook.",
+        "model": "Bring:\n- a coat\n- a torch\n- a notebook",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresBulletStemAndItems",
+              "stem": "Bring",
+              "items": [
+                "a coat",
+                "a torch",
+                "a notebook"
+              ],
+              "misconceptionTags": [
+                "structure.bullet_colon_missing",
+                "structure.bullet_marker_missing",
+                "structure.bullet_punctuation_inconsistent"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.bullet_colon_missing",
+          "structure.bullet_marker_missing",
+          "structure.bullet_punctuation_inconsistent"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_bullet_points_paragraph_1kcmywc_3",
+        "generatorFamilyId": "gen_bullet_points_paragraph",
+        "variantSignature": "puncsig_1kngi8r",
+        "templateId": "gen_bullet_points_paragraph_template_1vsy1fq",
+        "prompt": "Repair the bullet-list punctuation.",
+        "stem": "Take\n- water\n- snacks.\n- a hat",
+        "model": "Take:\n- water\n- snacks\n- a hat",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresBulletStemAndItems",
+              "stem": "Take",
+              "items": [
+                "water",
+                "snacks",
+                "a hat"
+              ],
+              "misconceptionTags": [
+                "structure.bullet_colon_missing",
+                "structure.bullet_marker_missing",
+                "structure.bullet_punctuation_inconsistent"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.bullet_colon_missing",
+          "structure.bullet_marker_missing",
+          "structure.bullet_punctuation_inconsistent"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_bullet_points_paragraph_1kmmklb_4",
+        "generatorFamilyId": "gen_bullet_points_paragraph",
+        "variantSignature": "puncsig_1soye56",
+        "templateId": "gen_bullet_points_paragraph_template_2yowe8",
+        "prompt": "Repair the bullet-list punctuation.",
+        "stem": "Check\n- doors.\n- windows\n- lights.",
+        "model": "Check:\n- doors.\n- windows.\n- lights.",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresBulletStemAndItems",
+              "stem": "Check",
+              "items": [
+                "doors",
+                "windows",
+                "lights"
+              ],
+              "misconceptionTags": [
+                "structure.bullet_colon_missing",
+                "structure.bullet_marker_missing",
+                "structure.bullet_punctuation_inconsistent"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.bullet_colon_missing",
+          "structure.bullet_marker_missing",
+          "structure.bullet_punctuation_inconsistent"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_bullet_points_paragraph_1jsnrie_5",
+        "generatorFamilyId": "gen_bullet_points_paragraph",
+        "variantSignature": "puncsig_1kngi8r",
+        "templateId": "gen_bullet_points_paragraph_template_1vsy1fq",
+        "prompt": "Repair the bullet-list punctuation.",
+        "stem": "Take\n- water\n- snacks.\n- a hat",
+        "model": "Take:\n- water\n- snacks\n- a hat",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresBulletStemAndItems",
+              "stem": "Take",
+              "items": [
+                "water",
+                "snacks",
+                "a hat"
+              ],
+              "misconceptionTags": [
+                "structure.bullet_colon_missing",
+                "structure.bullet_marker_missing",
+                "structure.bullet_punctuation_inconsistent"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.bullet_colon_missing",
+          "structure.bullet_marker_missing",
+          "structure.bullet_punctuation_inconsistent"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_bullet_points_paragraph_1k2nd7d_6",
+        "generatorFamilyId": "gen_bullet_points_paragraph",
+        "variantSignature": "puncsig_1soye56",
+        "templateId": "gen_bullet_points_paragraph_template_2yowe8",
+        "prompt": "Repair the bullet-list punctuation.",
+        "stem": "Check\n- doors.\n- windows\n- lights.",
+        "model": "Check:\n- doors.\n- windows.\n- lights.",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresBulletStemAndItems",
+              "stem": "Check",
+              "items": [
+                "doors",
+                "windows",
+                "lights"
+              ],
+              "misconceptionTags": [
+                "structure.bullet_colon_missing",
+                "structure.bullet_marker_missing",
+                "structure.bullet_punctuation_inconsistent"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.bullet_colon_missing",
+          "structure.bullet_marker_missing",
+          "structure.bullet_punctuation_inconsistent"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_bullet_points_paragraph_1j8ok4g_7",
+        "generatorFamilyId": "gen_bullet_points_paragraph",
+        "variantSignature": "puncsig_1kngi8r",
+        "templateId": "gen_bullet_points_paragraph_template_1vsy1fq",
+        "prompt": "Repair the bullet-list punctuation.",
+        "stem": "Take\n- water\n- snacks.\n- a hat",
+        "model": "Take:\n- water\n- snacks\n- a hat",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresBulletStemAndItems",
+              "stem": "Take",
+              "items": [
+                "water",
+                "snacks",
+                "a hat"
+              ],
+              "misconceptionTags": [
+                "structure.bullet_colon_missing",
+                "structure.bullet_marker_missing",
+                "structure.bullet_punctuation_inconsistent"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.bullet_colon_missing",
+          "structure.bullet_marker_missing",
+          "structure.bullet_punctuation_inconsistent"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      },
+      {
+        "id": "gen_bullet_points_paragraph_1jio5tf_8",
+        "generatorFamilyId": "gen_bullet_points_paragraph",
+        "variantSignature": "puncsig_1soye56",
+        "templateId": "gen_bullet_points_paragraph_template_2yowe8",
+        "prompt": "Repair the bullet-list punctuation.",
+        "stem": "Check\n- doors.\n- windows\n- lights.",
+        "model": "Check:\n- doors.\n- windows.\n- lights.",
+        "validatorType": "paragraphRepair",
+        "validator": {
+          "type": "paragraphRepair",
+          "checks": [
+            {
+              "type": "requiresBulletStemAndItems",
+              "stem": "Check",
+              "items": [
+                "doors",
+                "windows",
+                "lights"
+              ],
+              "misconceptionTags": [
+                "structure.bullet_colon_missing",
+                "structure.bullet_marker_missing",
+                "structure.bullet_punctuation_inconsistent"
+              ]
+            }
+          ]
+        },
+        "rubric": null,
+        "misconceptionTags": [
+          "structure.bullet_colon_missing",
+          "structure.bullet_marker_missing",
+          "structure.bullet_punctuation_inconsistent"
+        ],
+        "readiness": [
+          "constrained_transfer",
+          "misconception",
+          "negative_test"
+        ]
+      }
+    ]
+  }
+}

--- a/tests/punctuation-dsl-conversion-parity.test.js
+++ b/tests/punctuation-dsl-conversion-parity.test.js
@@ -20,6 +20,9 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const BASELINE = JSON.parse(
   fs.readFileSync(path.join(__dirname, 'fixtures/punctuation-qg-p3-parity-baseline.json'), 'utf8'),
 );
+const P4_BASELINE = JSON.parse(
+  fs.readFileSync(path.join(__dirname, 'fixtures/punctuation-qg-p4-parity-baseline.json'), 'utf8'),
+);
 
 const PRIORITY_FAMILIES = [
   'gen_sentence_endings_insert',
@@ -29,6 +32,27 @@ const PRIORITY_FAMILIES = [
   'gen_dash_clause_combine',
   'gen_hyphen_insert',
   'gen_semicolon_list_fix',
+];
+
+const P4_LEGACY_FAMILIES = [
+  'gen_apostrophe_possession_insert',
+  'gen_apostrophe_mix_paragraph',
+  'gen_speech_insert',
+  'gen_fronted_speech_paragraph',
+  'gen_list_commas_insert',
+  'gen_list_commas_combine',
+  'gen_fronted_adverbial_fix',
+  'gen_fronted_adverbial_combine',
+  'gen_parenthesis_fix',
+  'gen_parenthesis_combine',
+  'gen_parenthesis_speech_paragraph',
+  'gen_colon_list_insert',
+  'gen_colon_list_combine',
+  'gen_semicolon_fix',
+  'gen_semicolon_combine',
+  'gen_colon_semicolon_paragraph',
+  'gen_bullet_points_fix',
+  'gen_bullet_points_paragraph',
 ];
 
 // ─── Parity: perFamily = 4 ───────────────────────────────────────────────────
@@ -184,5 +208,111 @@ test('content audit logic passes for DSL-converted families at perFamily=4', () 
   for (const item of generatedItems) {
     const result = markPunctuationAnswer({ item, answer: { typed: item.model } });
     assert.equal(result.correct, true, `Audit marking failed for ${item.id}`);
+  }
+});
+
+// ─── P4 Legacy Family Characterisation Baseline ──────────────────────────────
+
+test('P4 fixture covers exactly 18 legacy families and no P3-converted families', () => {
+  assert.equal(P4_BASELINE.meta.familyCount, 18);
+
+  const fixtureDepth4Families = Object.keys(P4_BASELINE.depth4);
+  const fixtureDepth8Families = Object.keys(P4_BASELINE.depth8);
+
+  assert.equal(fixtureDepth4Families.length, 18);
+  assert.equal(fixtureDepth8Families.length, 18);
+
+  // No overlap with P3-converted families
+  for (const familyId of PRIORITY_FAMILIES) {
+    assert.equal(
+      fixtureDepth4Families.includes(familyId), false,
+      `P3-converted family ${familyId} found in P4 fixture depth4`,
+    );
+    assert.equal(
+      fixtureDepth8Families.includes(familyId), false,
+      `P3-converted family ${familyId} found in P4 fixture depth8`,
+    );
+  }
+
+  // All 18 legacy families present
+  for (const familyId of P4_LEGACY_FAMILIES) {
+    assert.ok(
+      fixtureDepth4Families.includes(familyId),
+      `Missing legacy family ${familyId} in P4 fixture depth4`,
+    );
+    assert.ok(
+      fixtureDepth8Families.includes(familyId),
+      `Missing legacy family ${familyId} in P4 fixture depth8`,
+    );
+  }
+});
+
+test('depth 4 output matches P4 baseline for all 18 legacy families', () => {
+  const items = createPunctuationGeneratedItems({
+    seed: P4_BASELINE.meta.seed,
+    perFamily: 4,
+  });
+
+  for (const familyId of P4_LEGACY_FAMILIES) {
+    const familyItems = items
+      .filter((i) => i.generatorFamilyId === familyId)
+      .map((i) => ({
+        id: i.id,
+        generatorFamilyId: i.generatorFamilyId,
+        variantSignature: i.variantSignature,
+        templateId: i.templateId,
+        prompt: i.prompt,
+        stem: i.stem,
+        model: i.model,
+        validatorType: i.validator?.type || null,
+        validator: i.validator || null,
+        rubric: i.rubric || null,
+        misconceptionTags: i.misconceptionTags,
+        readiness: i.readiness,
+      }));
+
+    const expected = P4_BASELINE.depth4[familyId];
+    assert.equal(familyItems.length, expected.length,
+      `${familyId}: expected ${expected.length} items at depth 4, got ${familyItems.length}`);
+
+    for (let idx = 0; idx < familyItems.length; idx += 1) {
+      assert.deepEqual(familyItems[idx], expected[idx],
+        `${familyId} depth4 mismatch at index ${idx}`);
+    }
+  }
+});
+
+test('depth 8 output matches P4 baseline for all 18 legacy families', () => {
+  const items = createPunctuationGeneratedItems({
+    seed: P4_BASELINE.meta.seed,
+    perFamily: 8,
+  });
+
+  for (const familyId of P4_LEGACY_FAMILIES) {
+    const familyItems = items
+      .filter((i) => i.generatorFamilyId === familyId)
+      .map((i) => ({
+        id: i.id,
+        generatorFamilyId: i.generatorFamilyId,
+        variantSignature: i.variantSignature,
+        templateId: i.templateId,
+        prompt: i.prompt,
+        stem: i.stem,
+        model: i.model,
+        validatorType: i.validator?.type || null,
+        validator: i.validator || null,
+        rubric: i.rubric || null,
+        misconceptionTags: i.misconceptionTags,
+        readiness: i.readiness,
+      }));
+
+    const expected = P4_BASELINE.depth8[familyId];
+    assert.equal(familyItems.length, expected.length,
+      `${familyId}: expected ${expected.length} items at depth 8, got ${familyItems.length}`);
+
+    for (let idx = 0; idx < familyItems.length; idx += 1) {
+      assert.deepEqual(familyItems[idx], expected[idx],
+        `${familyId} depth8 mismatch at index ${idx}`);
+    }
   }
 });


### PR DESCRIPTION
## Summary
- Generates characterisation snapshots at depth 4 and depth 8 for all 18 unconverted generator families
- Commits frozen fixture at `tests/fixtures/punctuation-qg-p4-parity-baseline.json`
- Adds parity test asserting exact match (the regression gate for DSL conversion)
- No generator code modified — pure snapshot of current behaviour

## Test plan
- [x] Fixture covers exactly 18 families (no P3-converted families included)
- [x] Parity test passes at depth 4 (production)
- [x] Parity test passes at depth 8 (capacity)
- [x] Existing P3 parity tests still pass (all 9 tests green)

Part of Punctuation QG P4 (plan: docs/plans/2026-04-29-004-feat-punctuation-qg-p4-evidence-scheduler-dsl-coverage-plan.md)