### PR TITLE
fix(monsters): pin review learner branches

### DIFF
--- a/src/platform/game/learner-monster-branch-overrides.js
+++ b/src/platform/game/learner-monster-branch-overrides.js
@@ -1,0 +1,15 @@
+import { normaliseMonsterBranch } from './monsters.js';
+
+// These two production learners are test accounts used for visual review.
+// Pinning their monster branches keeps B1/B2 asset checks deterministic
+// across subjects, resets, and future monster unlocks.
+export const LEARNER_MONSTER_BRANCH_OVERRIDES = Object.freeze({
+  '86a6c60f-e1ef-4985-954d-95ab13349c6f': 'b1', // Nelson
+  'be3b6831-d7c3-4318-9560-02051dc67704': 'b2', // Eugenia
+});
+
+export function monsterBranchOverrideForLearner(learnerId) {
+  if (typeof learnerId !== 'string' || !learnerId) return null;
+  return normaliseMonsterBranch(LEARNER_MONSTER_BRANCH_OVERRIDES[learnerId], null);
+}
+

--- a/src/platform/game/mastery/shared.js
+++ b/src/platform/game/mastery/shared.js
@@ -4,6 +4,7 @@ import {
   MONSTERS_BY_SUBJECT,
   normaliseMonsterBranch,
 } from '../monsters.js';
+import { monsterBranchOverrideForLearner } from '../learner-monster-branch-overrides.js';
 
 export const DEFAULT_SYSTEM_ID = 'monster-codex';
 export const MONSTER_IDS = Object.freeze(Object.keys(MONSTERS));
@@ -90,13 +91,23 @@ export function normaliseMonsterIdScope(monsterIds = MONSTER_IDS) {
   return requested.filter((monsterId) => MONSTERS[monsterId]);
 }
 
-export function withMonsterBranches(rawState, { random = Math.random, monsterIds = MONSTER_IDS } = {}) {
+export function withMonsterBranches(rawState, { random = Math.random, monsterIds = MONSTER_IDS, learnerId = '' } = {}) {
   const state = isPlainObject(rawState) ? { ...rawState } : {};
   let changed = false;
+  const branchOverride = monsterBranchOverrideForLearner(learnerId);
 
   for (const monsterId of normaliseMonsterIdScope(monsterIds)) {
     const current = isPlainObject(state[monsterId]) ? state[monsterId] : {};
     const branch = normaliseMonsterBranch(current.branch, null);
+    if (branchOverride) {
+      if (branch === branchOverride) continue;
+      state[monsterId] = {
+        ...current,
+        branch: branchOverride,
+      };
+      changed = true;
+      continue;
+    }
     if (branch) continue;
     state[monsterId] = {
       ...current,
@@ -118,8 +129,9 @@ export function saveMonsterState(learnerId, state, gameStateRepository) {
 
 export function ensureMonsterBranches(learnerId, gameStateRepository, options = {}) {
   const before = loadMonsterState(learnerId, gameStateRepository);
-  if (!gameStateRepository) return withMonsterBranches(before, { ...options, random: () => 0 }).state;
-  const { state, changed } = withMonsterBranches(before, options);
+  const branchOptions = { ...options, learnerId };
+  if (!gameStateRepository) return withMonsterBranches(before, { ...branchOptions, random: () => 0 }).state;
+  const { state, changed } = withMonsterBranches(before, branchOptions);
   return changed ? saveMonsterState(learnerId, state, gameStateRepository) : state;
 }
 

--- a/src/platform/game/mastery/spelling.js
+++ b/src/platform/game/mastery/spelling.js
@@ -12,9 +12,11 @@ import {
   loadMonsterState,
   masteredCount,
   masteredList,
+  MONSTER_IDS,
   saveMonsterState,
   SPELLING_MONSTER_IDS,
   DIRECT_SPELLING_MONSTER_IDS,
+  withMonsterBranches,
 } from './shared.js';
 import { derivePhaeton, PHAETON_SOURCE_MONSTER_IDS } from './phaeton.js';
 import { activePunctuationMonsterSummaryFromState } from './punctuation.js';
@@ -165,6 +167,13 @@ export function monsterSummaryFromSpellingAnalytics(analytics, {
     branchState = persistBranches
       ? ensureMonsterBranches(learnerId, gameStateRepository, { random, monsterIds: SPELLING_MONSTER_IDS })
       : loadMonsterState(learnerId, gameStateRepository);
+    if (!persistBranches) {
+      branchState = withMonsterBranches(branchState, {
+        learnerId,
+        random: () => 0,
+        monsterIds: MONSTER_IDS,
+      }).state;
+    }
   }
 
   if (!analyticsHasWordRows(analytics) && hasMonsterMasteryProgress(branchState)) {

--- a/src/subjects/spelling/module.js
+++ b/src/subjects/spelling/module.js
@@ -1,5 +1,6 @@
 import { monsterSummaryFromSpellingAnalytics } from '../../platform/game/monster-system.js';
 import { dropSessionEphemeralFields } from '../../platform/core/subject-contract.js';
+import { monsterBranchOverrideForLearner } from '../../platform/game/learner-monster-branch-overrides.js';
 import { createInitialSpellingState, isMegaSafeMode, isPostMasteryMode } from './service-contract.js';
 import {
   WORD_BANK_FILTER_IDS,
@@ -175,8 +176,9 @@ export const spellingModule = {
         ?? postMastery?.allWordsMega,
       );
       if (postMega) {
+        const branchOverride = monsterBranchOverrideForLearner(learner.id);
         const monsterState = repositories?.gameState?.read?.(learner.id, 'monster-codex');
-        const rawBranch = String(monsterState?.phaeton?.branch || '').trim();
+        const rawBranch = branchOverride || String(monsterState?.phaeton?.branch || '').trim();
         postMegaBranch = rawBranch === 'b2' ? 'b2' : 'b1';
       }
     }

--- a/tests/learner-monster-branch-overrides.test.js
+++ b/tests/learner-monster-branch-overrides.test.js
@@ -1,0 +1,142 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  monsterBranchOverrideForLearner,
+} from '../src/platform/game/learner-monster-branch-overrides.js';
+import {
+  ensureMonsterBranches,
+} from '../src/platform/game/mastery/shared.js';
+import {
+  monsterSummaryFromSpellingAnalytics,
+} from '../src/platform/game/mastery/spelling.js';
+import {
+  publicGameStateRowToRecord,
+  publicMonsterCodexStateFromSpellingProgress,
+} from '../worker/src/row-transforms.js';
+
+const NELSON_ID = '86a6c60f-e1ef-4985-954d-95ab13349c6f';
+const EUGENIA_ID = 'be3b6831-d7c3-4318-9560-02051dc67704';
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function makeGameStateRepository(initialState = {}) {
+  let state = clone(initialState);
+  let writes = 0;
+  return {
+    read() {
+      return clone(state);
+    },
+    write(_learnerId, _systemId, nextState) {
+      writes += 1;
+      state = clone(nextState);
+      return clone(state);
+    },
+    writes() {
+      return writes;
+    },
+  };
+}
+
+test('known review learners have pinned monster branches', () => {
+  assert.equal(monsterBranchOverrideForLearner(NELSON_ID), 'b1');
+  assert.equal(monsterBranchOverrideForLearner(EUGENIA_ID), 'b2');
+  assert.equal(monsterBranchOverrideForLearner('learner-a'), null);
+});
+
+test('ensureMonsterBranches rewrites mismatched branches for pinned learners', () => {
+  const repository = makeGameStateRepository({
+    inklet: { branch: 'b2', caught: true },
+    glimmerbug: { branch: 'b2' },
+  });
+
+  const state = ensureMonsterBranches(NELSON_ID, repository, {
+    random: () => 0.75,
+    monsterIds: ['inklet', 'glimmerbug', 'phaeton'],
+  });
+
+  assert.equal(state.inklet.branch, 'b1');
+  assert.equal(state.glimmerbug.branch, 'b1');
+  assert.equal(state.phaeton.branch, 'b1');
+  assert.equal(repository.writes(), 1);
+});
+
+test('unrecognised learners keep existing branch behaviour', () => {
+  const repository = makeGameStateRepository({
+    inklet: { branch: 'b1', caught: true },
+  });
+
+  const state = ensureMonsterBranches('learner-a', repository, {
+    random: () => 0.75,
+    monsterIds: ['inklet', 'glimmerbug'],
+  });
+
+  assert.equal(state.inklet.branch, 'b1');
+  assert.equal(state.glimmerbug.branch, 'b2');
+});
+
+test('public monster-codex bootstrap redacts stored branch to learner pin', () => {
+  const state = publicGameStateRowToRecord({
+    learner_id: EUGENIA_ID,
+    system_id: 'monster-codex',
+    state_json: JSON.stringify({
+      inklet: { mastered: ['possess'], caught: true, branch: 'b1' },
+      pealark: { branch: 'b1', starHighWater: 2 },
+    }),
+  });
+
+  assert.equal(state.inklet.branch, 'b2');
+  assert.equal(state.pealark.branch, 'b2');
+  assert.equal(state.inklet.masteredCount, 1);
+  assert.equal(state.pealark.starHighWater, 2);
+});
+
+test('derived spelling codex state uses learner pin when no stored branch exists', () => {
+  const derived = publicMonsterCodexStateFromSpellingProgress(
+    {
+      possess: { stage: 4 },
+      necessary: { stage: 4 },
+      mollusc: { stage: 4 },
+    },
+    {
+      words: [
+        { slug: 'possess', year: '3-4' },
+        { slug: 'necessary', year: '5-6' },
+        { slug: 'mollusc', spellingPool: 'extra', yearBand: 'extra' },
+      ],
+    },
+    {},
+    { learnerId: EUGENIA_ID },
+  );
+
+  assert.equal(derived.state.inklet.branch, 'b2');
+  assert.equal(derived.state.glimmerbug.branch, 'b2');
+  assert.equal(derived.state.phaeton.branch, 'b2');
+  assert.equal(derived.state.vellhorn.branch, 'b2');
+});
+
+test('read-only spelling analytics projections still apply learner pins', () => {
+  const repository = makeGameStateRepository({});
+  const summary = monsterSummaryFromSpellingAnalytics(
+    { wordGroups: [] },
+    {
+      learnerId: EUGENIA_ID,
+      gameStateRepository: repository,
+      persistBranches: false,
+    },
+  );
+
+  const spellingBranches = Object.fromEntries(
+    summary
+      .filter((entry) => entry.subjectId === 'spelling')
+      .map((entry) => [entry.monster.id, entry.progress.branch]),
+  );
+
+  assert.equal(spellingBranches.inklet, 'b2');
+  assert.equal(spellingBranches.glimmerbug, 'b2');
+  assert.equal(spellingBranches.phaeton, 'b2');
+  assert.equal(spellingBranches.vellhorn, 'b2');
+  assert.equal(repository.writes(), 0);
+});

--- a/worker/src/repository.js
+++ b/worker/src/repository.js
@@ -376,8 +376,8 @@ async function mergePublicSpellingCodexState(db, accountId, subjectRows, gameSta
     const progress = spellingProgressFromSubjectRow(row);
     if (!progress) continue;
     const key = gameStateKey(row.learner_id, PUBLIC_MONSTER_CODEX_SYSTEM_ID);
-    const existingState = publicMonsterCodexState(gameState[key] || {});
-    const derived = publicMonsterCodexStateFromSpellingProgress(progress, snapshot, existingState);
+    const existingState = publicMonsterCodexState(gameState[key] || {}, { learnerId: row.learner_id });
+    const derived = publicMonsterCodexStateFromSpellingProgress(progress, snapshot, existingState, { learnerId: row.learner_id });
     if (!derived) continue;
     if (derived.knownWordCount > 0 || !publicMonsterCodexHasMastery(existingState)) {
       gameState[key] = derived.state;

--- a/worker/src/row-transforms.js
+++ b/worker/src/row-transforms.js
@@ -21,6 +21,7 @@ import {
   normalisePunctuationSummary,
 } from '../../src/subjects/punctuation/service-contract.js';
 import { MONSTERS_BY_SUBJECT } from '../../src/platform/game/monsters.js';
+import { monsterBranchOverrideForLearner } from '../../src/platform/game/learner-monster-branch-overrides.js';
 import { monsterIdForSpellingWord } from '../../src/platform/game/monster-system.js';
 import {
   asTs,
@@ -153,7 +154,7 @@ function safePublicNonNegativeInt(value, { max = null } = {}) {
   return max == null ? clamped : Math.min(max, clamped);
 }
 
-export function publicMonsterCodexEntry(entry) {
+export function publicMonsterCodexEntry(entry, branchOverride = null) {
   if (!isPlainObject(entry)) return null;
   const masteredCount = Number(entry.masteredCount);
   const mastered = Array.isArray(entry.mastered)
@@ -165,7 +166,8 @@ export function publicMonsterCodexEntry(entry) {
     masteredCount: mastered,
     caught: Boolean(entry.caught) || mastered > 0,
   };
-  if (PUBLIC_MONSTER_BRANCHES.has(entry.branch)) output.branch = entry.branch;
+  if (PUBLIC_MONSTER_BRANCHES.has(branchOverride)) output.branch = branchOverride;
+  else if (PUBLIC_MONSTER_BRANCHES.has(entry.branch)) output.branch = entry.branch;
   const starHighWater = safePublicNonNegativeInt(entry.starHighWater);
   if (starHighWater != null) output.starHighWater = starHighWater;
   const starModelVersion = safePublicNonNegativeInt(entry.starModelVersion);
@@ -175,11 +177,12 @@ export function publicMonsterCodexEntry(entry) {
   return output;
 }
 
-export function publicMonsterCodexState(rawState) {
+export function publicMonsterCodexState(rawState, { learnerId = '' } = {}) {
   const state = isPlainObject(rawState) ? rawState : {};
   const output = {};
+  const branchOverride = monsterBranchOverrideForLearner(learnerId);
   for (const monsterId of PUBLIC_MONSTER_IDS) {
-    const entry = publicMonsterCodexEntry(state[monsterId]);
+    const entry = publicMonsterCodexEntry(state[monsterId], branchOverride);
     if (entry) output[monsterId] = entry;
   }
   return output;
@@ -187,7 +190,7 @@ export function publicMonsterCodexState(rawState) {
 
 export function publicGameStateRowToRecord(row) {
   if (row.system_id !== PUBLIC_MONSTER_CODEX_SYSTEM_ID) return null;
-  return publicMonsterCodexState(gameStateRowToRecord(row));
+  return publicMonsterCodexState(gameStateRowToRecord(row), { learnerId: row.learner_id });
 }
 
 // ─── Spelling progress / codex derivation ───────────────────────────────────
@@ -202,8 +205,14 @@ export function spellingProgressFromSubjectRow(row) {
   return isPlainObject(data?.progress) ? data.progress : null;
 }
 
-export function publicMonsterCodexStateFromSpellingProgress(progress, snapshot, existingState = {}) {
+export function publicMonsterCodexStateFromSpellingProgress(progress, snapshot, existingState = {}, { learnerId = '' } = {}) {
   if (!isPlainObject(progress)) return null;
+  const branchOverride = monsterBranchOverrideForLearner(learnerId);
+  const branchForOutput = (existing) => (
+    PUBLIC_MONSTER_BRANCHES.has(branchOverride)
+      ? { branch: branchOverride }
+      : (PUBLIC_MONSTER_BRANCHES.has(existing.branch) ? { branch: existing.branch } : {})
+  );
   const counts = Object.fromEntries(PUBLIC_DIRECT_SPELLING_MONSTER_IDS.map((monsterId) => [monsterId, 0]));
   const words = Array.isArray(snapshot?.words) ? snapshot.words : [];
   let knownWordCount = 0;
@@ -222,7 +231,7 @@ export function publicMonsterCodexStateFromSpellingProgress(progress, snapshot, 
     nextState[monsterId] = {
       masteredCount: counts[monsterId],
       caught: counts[monsterId] > 0,
-      ...(PUBLIC_MONSTER_BRANCHES.has(existing.branch) ? { branch: existing.branch } : {}),
+      ...branchForOutput(existing),
     };
   }
 
@@ -231,11 +240,11 @@ export function publicMonsterCodexStateFromSpellingProgress(progress, snapshot, 
   nextState.phaeton = {
     masteredCount: phaetonCount,
     caught: phaetonCount >= 3,
-    ...(PUBLIC_MONSTER_BRANCHES.has(existingPhaeton.branch) ? { branch: existingPhaeton.branch } : {}),
+    ...branchForOutput(existingPhaeton),
   };
 
   return {
-    state: publicMonsterCodexState(nextState),
+    state: publicMonsterCodexState(nextState, { learnerId }),
     knownWordCount,
   };
 }


### PR DESCRIPTION
## Summary
- Pin Nelson (`86a6c60f-e1ef-4985-954d-95ab13349c6f`) to monster branch `b1` and Eugenia (`be3b6831-d7c3-4318-9560-02051dc67704`) to `b2`.
- Apply the pin in persistent write paths (`ensureMonsterBranches`), public bootstrap redaction, derived Spelling codex state, read-only Home/Spelling projections, and the Spelling post-Mega dashboard branch.
- Leave all other learners on the existing automatic branch assignment path.

## Production data backfill
- Applied a remote D1 backfill to `child_game_state` / `monster-codex` for Nelson and Eugenia.
- Verified sample branches after the backfill:
  - Nelson: `inklet`, `glimmerbug`, `pealark`, `curlune`, `bracehart`, `concordium` all `b1`.
  - Eugenia: same sample set all `b2`.

## Verification
- `node --test tests/learner-monster-branch-overrides.test.js tests/monster-system.test.js tests/worker-auth.test.js` ✅ 32 pass
- `npm run check` ✅ bundle `220400 / 221000` gzip
- `git diff --check` ✅

## Full suite note
- `npm test` was attempted before the final rebase/targeted verification. It surfaced 11 failures in unrelated capacity evidence schema, Grammar content audit doc drift, Hero no-write scan over generated `src/bundles`, and Admin subject drilldown expectations. Those failures are outside this branch's touched files and the relevant targeted suites pass.
