### PR TITLE
feat(punctuation-qg): P4-U6 scheduler reason tags

### DIFF
--- a/shared/punctuation/scheduler.js
+++ b/shared/punctuation/scheduler.js
@@ -563,6 +563,101 @@ function weakRows(indexes, progress, session, now, maxWindow) {
   return avoidRecentSignatureRows(sortedRows, recentSignatures);
 }
 
+// --- Reason tag classification helpers ---
+
+/**
+ * Classify reason tag for weak-mode selection based on the weakFocus source and memory state.
+ */
+function classifyWeakReason(weakFocus, progress, item, session, now) {
+  if (!weakFocus || !item) return REASON_TAGS.FALLBACK;
+
+  const source = weakFocus.source;
+  if (source === 'weak_facet' || source === 'weak_item') return REASON_TAGS.WEAK_SKILL_REPAIR;
+  if (source === 'recent_miss') return REASON_TAGS.WEAK_SKILL_REPAIR;
+  if (source === 'due_facet' || source === 'due_item') {
+    // Check if this is a spaced return (lastCorrectAt exceeds threshold)
+    const itemState = normaliseMemoryState(progress?.items?.[item.id]);
+    if (itemState.lastCorrectAt) {
+      const nowMs = timestamp(now);
+      const daysSinceCorrect = (nowMs - itemState.lastCorrectAt) / DAY_MS;
+      if (daysSinceCorrect >= SPACED_RETURN_MIN_DAYS) return REASON_TAGS.SPACED_RETURN;
+    }
+    return REASON_TAGS.DUE_REVIEW;
+  }
+
+  // Secure bucket → retention-after-secure
+  if (weakFocus.bucket === 'secure') {
+    const itemState = normaliseMemoryState(progress?.items?.[item.id]);
+    if (itemState.lastCorrectAt) {
+      const nowMs = timestamp(now);
+      const daysSinceCorrect = (nowMs - itemState.lastCorrectAt) / DAY_MS;
+      if (daysSinceCorrect >= RETENTION_AFTER_SECURE_MIN_DAYS) return REASON_TAGS.RETENTION_AFTER_SECURE;
+    }
+  }
+
+  // Mixed review: item's mode differs from last 3 modes in session
+  if (isMixedReview(item, session)) return REASON_TAGS.MIXED_REVIEW;
+
+  return REASON_TAGS.FALLBACK;
+}
+
+/**
+ * Classify reason tag for smart/GPS/cluster-mode selection based on memory state and session context.
+ */
+function classifySmartReason(indexes, progress, item, session, now) {
+  if (!item) return REASON_TAGS.FALLBACK;
+
+  const itemState = normaliseMemoryState(progress?.items?.[item.id]);
+  const snap = memorySnapshot(itemState, now);
+  const nowMs = timestamp(now);
+
+  // Due review: item bucket is due
+  if (snap.bucket === 'due') {
+    // Spaced return: lastCorrectAt exceeds threshold
+    if (itemState.lastCorrectAt) {
+      const daysSinceCorrect = (nowMs - itemState.lastCorrectAt) / DAY_MS;
+      if (daysSinceCorrect >= SPACED_RETURN_MIN_DAYS) return REASON_TAGS.SPACED_RETURN;
+    }
+    return REASON_TAGS.DUE_REVIEW;
+  }
+
+  // Weak bucket: weak skill repair
+  if (snap.bucket === 'weak') return REASON_TAGS.WEAK_SKILL_REPAIR;
+
+  // Secure bucket: retention after secure
+  if (snap.bucket === 'secure') {
+    if (itemState.lastCorrectAt) {
+      const daysSinceCorrect = (nowMs - itemState.lastCorrectAt) / DAY_MS;
+      if (daysSinceCorrect >= RETENTION_AFTER_SECURE_MIN_DAYS) return REASON_TAGS.RETENTION_AFTER_SECURE;
+    }
+  }
+
+  // Mixed review: item's mode differs from last 3 modes in session
+  if (isMixedReview(item, session)) return REASON_TAGS.MIXED_REVIEW;
+
+  return REASON_TAGS.FALLBACK;
+}
+
+/**
+ * Check whether the selected item's mode differs from the last 3 modes in session.
+ */
+function isMixedReview(item, session) {
+  if (!item || !item.mode) return false;
+  const recentIds = Array.isArray(session?.recentItemIds) ? session.recentItemIds : [];
+  if (recentIds.length < 3) return false;
+  const last3Modes = recentIds.slice(-3).map((id) => {
+    // We cannot look up items by id here without indexes — use recentModes if available
+    return null;
+  });
+  // Use session.recentModes if provided (an array of modes for recently shown items)
+  const recentModes = Array.isArray(session?.recentModes) ? session.recentModes : [];
+  if (recentModes.length < 3) return false;
+  const lastThree = recentModes.slice(-3);
+  return lastThree.every((m) => m !== item.mode);
+}
+
+// --- End reason tag classification helpers ---
+
 export function selectPunctuationItem({
   indexes = PUNCTUATION_CONTENT_INDEXES,
   progress = {},
@@ -599,9 +694,10 @@ export function selectPunctuationItem({
     const rows = weakRows(indexes, progress, session, now, maxWindow);
     const picked = weightedPick(rows, random) || rows[0]?.item || null;
     const pickedRow = rows.find((row) => row.item.id === picked?.id) || null;
+    const weakReason = classifyWeakReason(pickedRow?.weakFocus, progress, picked, session, now);
     return {
       item: picked ? clone(picked) : null,
-      reason: REASON_TAGS.FALLBACK,
+      reason: weakReason,
       targetMode: picked?.mode || null,
       targetClusterId: picked?.clusterId || null,
       weakFocus: pickedRow ? clone(pickedRow.weakFocus) : null,
@@ -654,9 +750,10 @@ export function selectPunctuationItem({
   }).filter((row) => row.weight > 0);
 
   const item = weightedPick(rows, random) || windowed[0] || null;
+  const smartReason = classifySmartReason(indexes, progress, item, session, now);
   return {
     item: item ? clone(item) : null,
-    reason: REASON_TAGS.FALLBACK,
+    reason: smartReason,
     targetMode: selectedMode.mode,
     targetClusterId: clusterId,
     weakFocus: null,

--- a/tests/punctuation-scheduler.test.js
+++ b/tests/punctuation-scheduler.test.js
@@ -13,6 +13,8 @@ import {
   REASON_TAGS,
   MAX_SAME_SIGNATURE_ACROSS_ATTEMPTS,
   MAX_SAME_SIGNATURE_DAYS,
+  SPACED_RETURN_MIN_DAYS,
+  RETENTION_AFTER_SECURE_MIN_DAYS,
   EXPOSURE_WEIGHT_BLOCKED,
   EXPOSURE_WEIGHT_PENALISED,
   EXPOSURE_WEIGHT_DAY_AVOIDED,
@@ -790,5 +792,225 @@ describe('per-signature exposure limits', () => {
     // Even though weak_item has higher weak-facet priority, the exposure block
     // should penalise it enough to prefer fresh_item
     assert.equal(result.item.id, 'fresh_item', 'Exposure penalty should override weak-priority when alternative exists');
+  });
+});
+
+// --- Reason tag classification tests (U6) ---
+
+describe('reason tags', () => {
+  test('due item returns reason: due-review', () => {
+    // Answer correctly at day 1, then check at day 2.5 — due (interval=1 day expired)
+    // but lastCorrectAt is only 1.5 days ago (< SPACED_RETURN_MIN_DAYS) → pure due-review
+    const correctAt = 1 * DAY_MS;
+    const nowMs = correctAt + 1.5 * DAY_MS; // 1.5 days since correct (below 3-day threshold)
+    let state = createMemoryState();
+    state = updateMemoryState(state, true, correctAt);
+
+    // Verify item is due
+    const snap = memorySnapshot(state, nowMs);
+    assert.equal(snap.bucket, 'due');
+
+    const itemA = makeSignatureItem('item_due', 'sig_due');
+    const indexes = makeExposureIndexes([itemA]);
+
+    const result = selectPunctuationItem({
+      indexes,
+      progress: {
+        items: { item_due: state },
+        facets: {},
+        rewardUnits: {},
+        attempts: [],
+        sessionsCompleted: 0,
+      },
+      session: { answeredCount: 0, recentItemIds: [] },
+      prefs: { mode: 'smart' },
+      now: nowMs,
+      random: () => 0,
+    });
+
+    assert.equal(result.item.id, 'item_due');
+    assert.equal(result.reason, REASON_TAGS.DUE_REVIEW);
+  });
+
+  test('weak facet returns reason: weak-skill-repair', () => {
+    const weakFacet = updateMemoryState(createMemoryState(), false, 0);
+    const result = selectPunctuationItem({
+      progress: {
+        items: {},
+        facets: { 'speech::insert': weakFacet },
+        rewardUnits: {},
+        attempts: [],
+        sessionsCompleted: 0,
+      },
+      session: { mode: 'weak', answeredCount: 0, recentItemIds: [] },
+      prefs: { mode: 'weak' },
+      now: 0,
+      random: () => 0,
+    });
+
+    assert.equal(result.reason, REASON_TAGS.WEAK_SKILL_REPAIR);
+    assert.equal(result.weakFocus.source, 'weak_facet');
+  });
+
+  test('item with different mode from last 3 returns reason: mixed-review', () => {
+    // All items are mode=choose; session recentModes are all 'insert'
+    const itemA = makeSignatureItem('item_mixed', 'sig_mixed');
+    const indexes = makeExposureIndexes([itemA]);
+
+    const result = selectPunctuationItem({
+      indexes,
+      progress: { items: {}, facets: {}, rewardUnits: {}, attempts: [], sessionsCompleted: 0 },
+      session: {
+        answeredCount: 3,
+        recentItemIds: ['x1', 'x2', 'x3'],
+        recentModes: ['insert', 'insert', 'insert'],
+      },
+      prefs: { mode: 'smart' },
+      now: 0,
+      random: () => 0,
+    });
+
+    assert.equal(result.item.id, 'item_mixed');
+    assert.equal(result.reason, REASON_TAGS.MIXED_REVIEW);
+  });
+
+  test('spaced-return classified when lastCorrectAt exceeds threshold', () => {
+    const nowMs = 10 * DAY_MS;
+    // Item was answered correctly long ago, is now due, and lastCorrectAt > SPACED_RETURN_MIN_DAYS
+    let state = createMemoryState();
+    state = updateMemoryState(state, true, 1 * DAY_MS); // correct at day 1, due ~day 2
+
+    // Verify state has lastCorrectAt set
+    assert.ok(state.lastCorrectAt > 0);
+
+    const itemA = makeSignatureItem('item_spaced', 'sig_spaced');
+    const indexes = makeExposureIndexes([itemA]);
+
+    const result = selectPunctuationItem({
+      indexes,
+      progress: {
+        items: { item_spaced: state },
+        facets: {},
+        rewardUnits: {},
+        attempts: [],
+        sessionsCompleted: 0,
+      },
+      session: { answeredCount: 0, recentItemIds: [] },
+      prefs: { mode: 'smart' },
+      now: nowMs,
+      random: () => 0,
+    });
+
+    // nowMs (10 days) - lastCorrectAt (1 day) = 9 days > SPACED_RETURN_MIN_DAYS (3)
+    assert.equal(result.item.id, 'item_spaced');
+    assert.equal(result.reason, REASON_TAGS.SPACED_RETURN);
+  });
+
+  test('retention-after-secure classified for secure items past threshold', () => {
+    const nowMs = 30 * DAY_MS;
+    // Build a secure state: streak >= 3, accuracy >= 0.8, correctSpanDays >= 7
+    let state = createMemoryState();
+    state = updateMemoryState(state, true, 1 * DAY_MS);
+    state = updateMemoryState(state, true, 5 * DAY_MS);
+    state = updateMemoryState(state, true, 9 * DAY_MS);
+
+    // Verify bucket is secure
+    const snap = memorySnapshot(state, nowMs);
+    assert.equal(snap.bucket, 'secure');
+
+    const itemA = makeSignatureItem('item_retain', 'sig_retain');
+    const indexes = makeExposureIndexes([itemA]);
+
+    const result = selectPunctuationItem({
+      indexes,
+      progress: {
+        items: { item_retain: state },
+        facets: {},
+        rewardUnits: {},
+        attempts: [],
+        sessionsCompleted: 0,
+      },
+      session: { answeredCount: 0, recentItemIds: [] },
+      prefs: { mode: 'smart' },
+      now: nowMs,
+      random: () => 0,
+    });
+
+    // nowMs (30 days) - lastCorrectAt (9 days) = 21 days > RETENTION_AFTER_SECURE_MIN_DAYS (7)
+    assert.equal(result.item.id, 'item_retain');
+    assert.equal(result.reason, REASON_TAGS.RETENTION_AFTER_SECURE);
+  });
+
+  test('fallback reason when no specific policy matches', () => {
+    // Fresh item with no memory state — bucket is 'new', no modes history
+    const itemA = makeSignatureItem('item_new', 'sig_new');
+    const indexes = makeExposureIndexes([itemA]);
+
+    const result = selectPunctuationItem({
+      indexes,
+      progress: { items: {}, facets: {}, rewardUnits: {}, attempts: [], sessionsCompleted: 0 },
+      session: { answeredCount: 0, recentItemIds: [] },
+      prefs: { mode: 'smart' },
+      now: 0,
+      random: () => 0,
+    });
+
+    assert.equal(result.item.id, 'item_new');
+    assert.equal(result.reason, REASON_TAGS.FALLBACK);
+  });
+
+  test('weak mode due_facet source classified as due-review when within spaced threshold', () => {
+    // Item answered correctly recently (< SPACED_RETURN_MIN_DAYS ago), now due
+    const nowMs = 2 * DAY_MS;
+    let dueFacet = createMemoryState();
+    dueFacet = updateMemoryState(dueFacet, true, 1 * DAY_MS);
+
+    const result = selectPunctuationItem({
+      progress: {
+        items: { sp_fix_question: dueFacet },
+        facets: { 'speech::fix': dueFacet },
+        rewardUnits: {},
+        attempts: [],
+        sessionsCompleted: 0,
+      },
+      session: { mode: 'weak', answeredCount: 0, recentItemIds: [] },
+      prefs: { mode: 'weak' },
+      now: nowMs,
+      random: () => 0,
+    });
+
+    // 2 days - 1 day = 1 day < SPACED_RETURN_MIN_DAYS (3) → due-review, not spaced-return
+    assert.equal(result.reason, REASON_TAGS.DUE_REVIEW);
+  });
+
+  test('smart mode weak bucket item returns weak-skill-repair', () => {
+    // Create a weak item state: low accuracy, lapses
+    let state = createMemoryState();
+    state = updateMemoryState(state, false, 0);
+    state = updateMemoryState(state, false, DAY_MS);
+
+    const snap = memorySnapshot(state, 2 * DAY_MS);
+    assert.equal(snap.bucket, 'weak');
+
+    const itemA = makeSignatureItem('item_weak_smart', 'sig_weak_smart');
+    const indexes = makeExposureIndexes([itemA]);
+
+    const result = selectPunctuationItem({
+      indexes,
+      progress: {
+        items: { item_weak_smart: state },
+        facets: {},
+        rewardUnits: {},
+        attempts: [],
+        sessionsCompleted: 0,
+      },
+      session: { answeredCount: 0, recentItemIds: [] },
+      prefs: { mode: 'smart' },
+      now: 2 * DAY_MS,
+      random: () => 0,
+    });
+
+    assert.equal(result.item.id, 'item_weak_smart');
+    assert.equal(result.reason, REASON_TAGS.WEAK_SKILL_REPAIR);
   });
 });


### PR DESCRIPTION
## Summary
- All `selectPunctuationItem()` paths now return a semantic `reason` tag
- Maps existing selection sources to reason tags: due-review, weak-skill-repair, spaced-return, mixed-review, retention-after-secure, fallback
- Uses SPACED_RETURN_MIN_DAYS (3) and RETENTION_AFTER_SECURE_MIN_DAYS (7) from scheduler-manifest
- Reason tags visible in debug/admin output only (not child-facing)

## Test plan
- [x] Due item → 'due-review'
- [x] Weak facet → 'weak-skill-repair'
- [x] Mode diversity → 'mixed-review'
- [x] Spaced return → 'spaced-return'
- [x] Retention after secure → 'retention-after-secure'
- [x] Fallback for new/unclassified items
- [x] Existing 27 scheduler tests pass (35 total with new tests)
- [x] Existing 15 service tests pass

Part of Punctuation QG P4 U6