### PR TITLE
feat(hero): Hero Mode P5 — Hero Camp and Hero Pool Monsters

### DIFF
--- a/shared/hero/economy.js
+++ b/shared/hero/economy.js
@@ -10,7 +10,20 @@ export const HERO_LEDGER_RECENT_LIMIT = 180;
 
 export const HERO_ECONOMY_ENTRY_TYPES = Object.freeze([
   'daily-completion-award',
-  'admin-adjustment', // reserved, not enabled in P4 child flow
+  'monster-invite',    // P5: negative amount (spending)
+  'monster-grow',      // P5: negative amount (spending)
+  'admin-adjustment',  // reserved, can be positive or negative
+]);
+
+/** Entry types that MUST have a positive amount (earning). */
+export const HERO_EARNING_ENTRY_TYPES = Object.freeze([
+  'daily-completion-award',
+]);
+
+/** Entry types that MUST have a negative amount (spending). */
+export const HERO_SPENDING_ENTRY_TYPES = Object.freeze([
+  'monster-invite',
+  'monster-grow',
 ]);
 
 // ── Deterministic hashing ────────────────────────────────────────
@@ -188,13 +201,38 @@ function buildChildSafeLedgerEntries(ledger) {
 
 export function normaliseHeroEconomyState(raw) {
   if (!raw || typeof raw !== 'object') return emptyEconomyState();
+  if (Array.isArray(raw)) return emptyEconomyState();
   if (raw.version !== HERO_ECONOMY_VERSION) return emptyEconomyState();
 
-  const balance = typeof raw.balance === 'number' && Number.isFinite(raw.balance) ? raw.balance : 0;
-  const lifetimeEarned = typeof raw.lifetimeEarned === 'number' && Number.isFinite(raw.lifetimeEarned) ? raw.lifetimeEarned : 0;
-  const lifetimeSpent = typeof raw.lifetimeSpent === 'number' && Number.isFinite(raw.lifetimeSpent) ? raw.lifetimeSpent : 0;
-  const ledger = Array.isArray(raw.ledger) ? raw.ledger : [];
+  const safeNonNeg = (v) => (typeof v === 'number' && Number.isFinite(v) && v >= 0) ? v : 0;
+
+  const balance = safeNonNeg(raw.balance);
+  const lifetimeEarned = safeNonNeg(raw.lifetimeEarned);
+  const lifetimeSpent = safeNonNeg(raw.lifetimeSpent);
+  const rawLedger = Array.isArray(raw.ledger) ? raw.ledger : [];
   const lastUpdatedAt = raw.lastUpdatedAt || null;
+
+  // Validate each ledger entry — drop entries that violate polarity or have
+  // known-bad scalars. Fields that are absent are NOT enforced (backward compat
+  // with P4 entries that predate the spending schema).
+  const ledger = [];
+  for (let i = 0; i < rawLedger.length; i++) {
+    const entry = rawLedger[i];
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue;
+    // type: if explicitly provided it must be recognised; undefined/absent passes
+    const t = entry.type;
+    if (t !== undefined && !HERO_ECONOMY_ENTRY_TYPES.includes(t)) continue;
+    // amount: if explicitly provided it must be finite; undefined/absent passes
+    const a = entry.amount;
+    if (a !== undefined && (typeof a !== 'number' || !Number.isFinite(a))) continue;
+    // balanceAfter: if explicitly provided as a number, must be finite >= 0
+    const ba = entry.balanceAfter;
+    if (typeof ba === 'number' && (!Number.isFinite(ba) || ba < 0)) continue;
+    // Polarity checks (only when both type and amount are present)
+    if (HERO_EARNING_ENTRY_TYPES.includes(t) && typeof a === 'number' && a <= 0) continue;
+    if (HERO_SPENDING_ENTRY_TYPES.includes(t) && typeof a === 'number' && a >= 0) continue;
+    ledger.push(entry);
+  }
 
   return {
     version: HERO_ECONOMY_VERSION,

--- a/shared/hero/hero-copy.js
+++ b/shared/hero/hero-copy.js
@@ -58,10 +58,17 @@ export const HERO_ECONOMY_ALLOWED_FILES = Object.freeze([
   'shared/hero/economy.js',
   'shared/hero/hero-copy.js',
   'shared/hero/hero-pool.js',
+  'shared/hero/monster-economy.js',
   'shared/hero/claim-contract.js',
   'src/platform/hero/hero-ui-model.js',
+  'src/platform/hero/hero-camp-model.js',
+  'src/platform/hero/hero-monster-assets.js',
   'src/surfaces/home/HeroQuestCard.jsx',
+  'src/surfaces/home/HeroCampPanel.jsx',
+  'src/surfaces/home/HeroCampMonsterCard.jsx',
+  'src/surfaces/home/HeroCampConfirmation.jsx',
   'worker/src/hero/read-model.js',
+  'worker/src/hero/camp.js',
 ]);
 
 // Backward compat — tests importing this get the pressure-only list

--- a/shared/hero/hero-copy.js
+++ b/shared/hero/hero-copy.js
@@ -18,10 +18,14 @@ export const HERO_FORBIDDEN_PRESSURE_VOCABULARY = Object.freeze([
   'limited time',
   'daily deal',
   "don't miss out",
+  "don't miss",
   'streak reward',
   'grind',
+  'buy',
   'buy now',
+  'purchase',
   'spend now',
+  'offer',
   'you missed out',
   'unlock now',
   'treasure',
@@ -38,6 +42,13 @@ export const HERO_ECONOMY_ALLOWED_VOCABULARY = Object.freeze([
   'coin',
   'balance',
   'Hero Coins',
+  'invite',
+  'monster grow',
+  'camp',
+  'hero camp',
+  'hero pool',
+  'monster invite',
+  'hero monster',
 ]);
 
 /**
@@ -46,6 +57,7 @@ export const HERO_ECONOMY_ALLOWED_VOCABULARY = Object.freeze([
 export const HERO_ECONOMY_ALLOWED_FILES = Object.freeze([
   'shared/hero/economy.js',
   'shared/hero/hero-copy.js',
+  'shared/hero/hero-pool.js',
   'shared/hero/claim-contract.js',
   'src/platform/hero/hero-ui-model.js',
   'src/surfaces/home/HeroQuestCard.jsx',

--- a/shared/hero/hero-pool.js
+++ b/shared/hero/hero-pool.js
@@ -1,0 +1,138 @@
+'use strict';
+
+// ── Hero Pool Registry — shared pure contract ─────────────────────
+// Zero side-effects. No imports from worker/, src/, react, or node: built-ins.
+
+// ── Constants ────────────────────────────────────────────────────
+
+export const HERO_MONSTER_INVITE_COST = 150;
+
+export const HERO_MONSTER_GROW_COSTS = Object.freeze({ 1: 300, 2: 600, 3: 1000, 4: 1600 });
+
+export const HERO_POOL_ROSTER_VERSION = 'hero-pool-v1';
+
+// ── Registry ─────────────────────────────────────────────────────
+
+const BRANCH_OPTIONS = Object.freeze([
+  Object.freeze({ branch: 'b1', childLabel: 'Path A' }),
+  Object.freeze({ branch: 'b2', childLabel: 'Path B' }),
+]);
+
+const MAX_STAGE = 4;
+
+const registry = Object.freeze({
+  glossbloom: Object.freeze({
+    monsterId: 'glossbloom',
+    displayName: 'Glossbloom',
+    sourceAssetMonsterId: 'glossbloom',
+    origin: 'grammar-reserve',
+    displayOrder: 1,
+    maxStage: MAX_STAGE,
+    inviteCost: HERO_MONSTER_INVITE_COST,
+    growCosts: HERO_MONSTER_GROW_COSTS,
+    branchOptions: BRANCH_OPTIONS,
+    childBlurb: 'A word-garden creature that loves clear phrases.',
+  }),
+  loomrill: Object.freeze({
+    monsterId: 'loomrill',
+    displayName: 'Loomrill',
+    sourceAssetMonsterId: 'loomrill',
+    origin: 'grammar-reserve',
+    displayOrder: 2,
+    maxStage: MAX_STAGE,
+    inviteCost: HERO_MONSTER_INVITE_COST,
+    growCosts: HERO_MONSTER_GROW_COSTS,
+    branchOptions: BRANCH_OPTIONS,
+    childBlurb: 'A thread creature that keeps ideas joined together.',
+  }),
+  mirrane: Object.freeze({
+    monsterId: 'mirrane',
+    displayName: 'Mirrane',
+    sourceAssetMonsterId: 'mirrane',
+    origin: 'grammar-reserve',
+    displayOrder: 3,
+    maxStage: MAX_STAGE,
+    inviteCost: HERO_MONSTER_INVITE_COST,
+    growCosts: HERO_MONSTER_GROW_COSTS,
+    branchOptions: BRANCH_OPTIONS,
+    childBlurb: 'A mirror creature that reflects roles and voices.',
+  }),
+  colisk: Object.freeze({
+    monsterId: 'colisk',
+    displayName: 'Colisk',
+    sourceAssetMonsterId: 'colisk',
+    origin: 'punctuation-reserve',
+    displayOrder: 4,
+    maxStage: MAX_STAGE,
+    inviteCost: HERO_MONSTER_INVITE_COST,
+    growCosts: HERO_MONSTER_GROW_COSTS,
+    branchOptions: BRANCH_OPTIONS,
+    childBlurb: 'A structure creature that builds strong lists and shapes.',
+  }),
+  hyphang: Object.freeze({
+    monsterId: 'hyphang',
+    displayName: 'Hyphang',
+    sourceAssetMonsterId: 'hyphang',
+    origin: 'punctuation-reserve',
+    displayOrder: 5,
+    maxStage: MAX_STAGE,
+    inviteCost: HERO_MONSTER_INVITE_COST,
+    growCosts: HERO_MONSTER_GROW_COSTS,
+    branchOptions: BRANCH_OPTIONS,
+    childBlurb: 'A boundary creature that links ideas carefully.',
+  }),
+  carillon: Object.freeze({
+    monsterId: 'carillon',
+    displayName: 'Carillon',
+    sourceAssetMonsterId: 'carillon',
+    origin: 'punctuation-reserve',
+    displayOrder: 6,
+    maxStage: MAX_STAGE,
+    inviteCost: HERO_MONSTER_INVITE_COST,
+    growCosts: HERO_MONSTER_GROW_COSTS,
+    branchOptions: BRANCH_OPTIONS,
+    childBlurb: 'A bell creature that gathers the Hero Camp together.',
+  }),
+});
+
+export const HERO_POOL_REGISTRY = registry;
+
+export const HERO_POOL_INITIAL_MONSTER_IDS = Object.freeze([
+  'glossbloom',
+  'loomrill',
+  'mirrane',
+  'colisk',
+  'hyphang',
+  'carillon',
+]);
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+const MONSTER_ID_SET = new Set(HERO_POOL_INITIAL_MONSTER_IDS);
+const VALID_BRANCHES = new Set(['b1', 'b2']);
+
+export function getHeroMonsterDefinition(id) {
+  return registry[id];
+}
+
+export function getInviteCost() {
+  return HERO_MONSTER_INVITE_COST;
+}
+
+export function getGrowCost(targetStage) {
+  return HERO_MONSTER_GROW_COSTS[targetStage];
+}
+
+export function isValidHeroMonsterId(id) {
+  return typeof id === 'string' && MONSTER_ID_SET.has(id);
+}
+
+export function isValidHeroMonsterBranch(branch) {
+  return typeof branch === 'string' && VALID_BRANCHES.has(branch);
+}
+
+export const isValidBranch = isValidHeroMonsterBranch;
+
+export function getMaxStage() {
+  return MAX_STAGE;
+}

--- a/shared/hero/monster-economy.js
+++ b/shared/hero/monster-economy.js
@@ -16,6 +16,9 @@ import { deriveLedgerEntryId } from './economy.js';
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
+/** Re-export for spend-side — same DJB2 hash as economy.js earning entries. */
+export const deriveSpendLedgerEntryId = deriveLedgerEntryId;
+
 function buildIdempotencyKey(prefix, learnerId, monsterId, discriminator) {
   return `${prefix}:v1:${learnerId}:${monsterId}:${discriminator}`;
 }
@@ -36,8 +39,8 @@ export function computeMonsterInviteIntent({
     return { ok: false, code: 'hero_monster_unknown', reason: `Unknown monsterId: ${monsterId}` };
   }
 
-  // Validate branch — must be provided
-  if (branch === null || branch === undefined) {
+  // Validate branch — must be provided and non-empty
+  if (branch === null || branch === undefined || branch === '') {
     return { ok: false, code: 'hero_monster_branch_required', reason: 'Branch is required for invite' };
   }
   if (!isValidHeroMonsterBranch(branch)) {
@@ -49,7 +52,7 @@ export function computeMonsterInviteIntent({
     ? heroPoolState.monsters[monsterId]
     : undefined;
   if (existingMonster && existingMonster.owned) {
-    return { ok: true, status: 'already-owned', cost: 0, coinsUsed: 0, ledgerEntryId: null };
+    return { ok: true, status: 'already-owned', cost: 0, coinsUsed: 0 };
   }
 
   // Cost and affordability
@@ -80,7 +83,7 @@ export function computeMonsterInviteIntent({
   };
 
   // Build new monster state
-  const monsterState = {
+  const newMonsterState = {
     monsterId,
     owned: true,
     stage: 0,
@@ -105,21 +108,17 @@ export function computeMonsterInviteIntent({
     createdAt: nowTs,
   };
 
+  const newLifetimeSpent = economyState.lifetimeSpent + cost;
+
   return {
     ok: true,
     status: 'invited',
-    cost,
-    coinsUsed: cost,
-    ledgerEntryId: entryId,
     intent: {
+      newBalance: balanceAfter,
+      newLifetimeSpent,
       ledgerEntry,
-      monsterState,
+      newMonsterState,
       actionRecord,
-      economyDelta: {
-        balanceDelta: -cost,
-        lifetimeSpentDelta: cost,
-        balanceAfter,
-      },
     },
   };
 }
@@ -166,7 +165,7 @@ export function computeMonsterGrowIntent({
 
   // Already at or past target
   if (currentStage >= targetStage) {
-    return { ok: true, status: 'already-stage', cost: 0, coinsUsed: 0, ledgerEntryId: null };
+    return { ok: true, status: 'already-stage', cost: 0, coinsUsed: 0 };
   }
 
   // Must be next sequential stage
@@ -202,7 +201,7 @@ export function computeMonsterGrowIntent({
   };
 
   // Build updated monster state
-  const monsterState = {
+  const newMonsterState = {
     ...existingMonster,
     stage: targetStage,
     investedCoins: (existingMonster.investedCoins || 0) + cost,
@@ -218,27 +217,23 @@ export function computeMonsterGrowIntent({
     monsterId,
     stageBefore: currentStage,
     stageAfter: targetStage,
-    branch: existingMonster.branch,
+    branch: existingMonster.branch || null,
     cost,
     ledgerEntryId: entryId,
     createdAt: nowTs,
   };
 
+  const newLifetimeSpent = economyState.lifetimeSpent + cost;
+
   return {
     ok: true,
     status: 'grown',
-    cost,
-    coinsUsed: cost,
-    ledgerEntryId: entryId,
     intent: {
+      newBalance: balanceAfter,
+      newLifetimeSpent,
       ledgerEntry,
-      monsterState,
+      newMonsterState,
       actionRecord,
-      economyDelta: {
-        balanceDelta: -cost,
-        lifetimeSpentDelta: cost,
-        balanceAfter,
-      },
     },
   };
 }

--- a/shared/hero/monster-economy.js
+++ b/shared/hero/monster-economy.js
@@ -1,0 +1,244 @@
+'use strict';
+
+// ── Monster Economy — pure spending computation ─────────────────────
+// Zero side-effects. No Worker, no D1, no React.
+// Imports ONLY from sibling shared modules.
+
+import {
+  isValidHeroMonsterId,
+  isValidHeroMonsterBranch,
+  getInviteCost,
+  getGrowCost,
+  getMaxStage,
+} from './hero-pool.js';
+
+import { deriveLedgerEntryId } from './economy.js';
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+function buildIdempotencyKey(prefix, learnerId, monsterId, discriminator) {
+  return `${prefix}:v1:${learnerId}:${monsterId}:${discriminator}`;
+}
+
+// ── computeMonsterInviteIntent ──────────────────────────────────────
+
+export function computeMonsterInviteIntent({
+  economyState,
+  heroPoolState,
+  monsterId,
+  branch,
+  learnerId,
+  rosterVersion,
+  nowTs,
+}) {
+  // Validate monsterId
+  if (!isValidHeroMonsterId(monsterId)) {
+    return { ok: false, code: 'hero_monster_unknown', reason: `Unknown monsterId: ${monsterId}` };
+  }
+
+  // Validate branch — must be provided
+  if (branch === null || branch === undefined) {
+    return { ok: false, code: 'hero_monster_branch_required', reason: 'Branch is required for invite' };
+  }
+  if (!isValidHeroMonsterBranch(branch)) {
+    return { ok: false, code: 'hero_monster_branch_invalid', reason: `Invalid branch: ${branch}` };
+  }
+
+  // Already owned check
+  const existingMonster = heroPoolState && heroPoolState.monsters
+    ? heroPoolState.monsters[monsterId]
+    : undefined;
+  if (existingMonster && existingMonster.owned) {
+    return { ok: true, status: 'already-owned', cost: 0, coinsUsed: 0, ledgerEntryId: null };
+  }
+
+  // Cost and affordability
+  const cost = getInviteCost();
+  if (economyState.balance < cost) {
+    return { ok: false, code: 'hero_insufficient_coins', reason: `Need ${cost} coins, have ${economyState.balance}` };
+  }
+
+  // Deterministic IDs
+  const idempotencyKey = buildIdempotencyKey('hero-monster-invite', learnerId, monsterId, branch);
+  const entryId = deriveLedgerEntryId(idempotencyKey);
+  const balanceAfter = economyState.balance - cost;
+
+  // Build ledger entry
+  const ledgerEntry = {
+    entryId,
+    idempotencyKey,
+    type: 'monster-invite',
+    amount: -cost,
+    balanceAfter,
+    learnerId,
+    monsterId,
+    branch,
+    stageAfter: 0,
+    source: { kind: 'hero-camp-monster-invite', rosterVersion },
+    createdAt: nowTs,
+    createdBy: 'system',
+  };
+
+  // Build new monster state
+  const monsterState = {
+    monsterId,
+    owned: true,
+    stage: 0,
+    branch,
+    investedCoins: cost,
+    invitedAt: nowTs,
+    lastGrownAt: null,
+    lastLedgerEntryId: entryId,
+  };
+
+  // Build action record
+  const actionRecord = {
+    actionId: entryId,
+    requestId: null,
+    type: 'monster-invite',
+    monsterId,
+    stageBefore: null,
+    stageAfter: 0,
+    branch,
+    cost,
+    ledgerEntryId: entryId,
+    createdAt: nowTs,
+  };
+
+  return {
+    ok: true,
+    status: 'invited',
+    cost,
+    coinsUsed: cost,
+    ledgerEntryId: entryId,
+    intent: {
+      ledgerEntry,
+      monsterState,
+      actionRecord,
+      economyDelta: {
+        balanceDelta: -cost,
+        lifetimeSpentDelta: cost,
+        balanceAfter,
+      },
+    },
+  };
+}
+
+// ── computeMonsterGrowIntent ────────────────────────────────────────
+
+export function computeMonsterGrowIntent({
+  economyState,
+  heroPoolState,
+  monsterId,
+  targetStage,
+  learnerId,
+  rosterVersion,
+  nowTs,
+}) {
+  // Validate monsterId
+  if (!isValidHeroMonsterId(monsterId)) {
+    return { ok: false, code: 'hero_monster_unknown', reason: `Unknown monsterId: ${monsterId}` };
+  }
+
+  // Check monster is owned
+  const existingMonster = heroPoolState && heroPoolState.monsters
+    ? heroPoolState.monsters[monsterId]
+    : undefined;
+  if (!existingMonster || !existingMonster.owned) {
+    return { ok: false, code: 'hero_monster_not_owned', reason: `Monster '${monsterId}' is not owned` };
+  }
+
+  // Validate targetStage is a number 1-4
+  const maxStage = getMaxStage();
+  if (typeof targetStage !== 'number' || !Number.isInteger(targetStage) || targetStage < 1 || targetStage > maxStage) {
+    if (typeof targetStage === 'number' && targetStage > maxStage) {
+      return { ok: false, code: 'hero_monster_max_stage', reason: `Target stage ${targetStage} exceeds max ${maxStage}` };
+    }
+    return { ok: false, code: 'hero_monster_stage_invalid', reason: `Target stage must be 1-${maxStage}` };
+  }
+
+  // Check if target exceeds max
+  if (targetStage > maxStage) {
+    return { ok: false, code: 'hero_monster_max_stage', reason: `Target stage ${targetStage} exceeds max ${maxStage}` };
+  }
+
+  const currentStage = existingMonster.stage;
+
+  // Already at or past target
+  if (currentStage >= targetStage) {
+    return { ok: true, status: 'already-stage', cost: 0, coinsUsed: 0, ledgerEntryId: null };
+  }
+
+  // Must be next sequential stage
+  if (targetStage !== currentStage + 1) {
+    return { ok: false, code: 'hero_monster_stage_not_next', reason: `Must grow to stage ${currentStage + 1}, not ${targetStage}` };
+  }
+
+  // Cost and affordability
+  const cost = getGrowCost(targetStage);
+  if (economyState.balance < cost) {
+    return { ok: false, code: 'hero_insufficient_coins', reason: `Need ${cost} coins, have ${economyState.balance}` };
+  }
+
+  // Deterministic IDs
+  const idempotencyKey = buildIdempotencyKey('hero-monster-grow', learnerId, monsterId, String(targetStage));
+  const entryId = deriveLedgerEntryId(idempotencyKey);
+  const balanceAfter = economyState.balance - cost;
+
+  // Build ledger entry
+  const ledgerEntry = {
+    entryId,
+    idempotencyKey,
+    type: 'monster-grow',
+    amount: -cost,
+    balanceAfter,
+    learnerId,
+    monsterId,
+    stageBefore: currentStage,
+    stageAfter: targetStage,
+    source: { kind: 'hero-camp-monster-grow', rosterVersion },
+    createdAt: nowTs,
+    createdBy: 'system',
+  };
+
+  // Build updated monster state
+  const monsterState = {
+    ...existingMonster,
+    stage: targetStage,
+    investedCoins: (existingMonster.investedCoins || 0) + cost,
+    lastGrownAt: nowTs,
+    lastLedgerEntryId: entryId,
+  };
+
+  // Build action record
+  const actionRecord = {
+    actionId: entryId,
+    requestId: null,
+    type: 'monster-grow',
+    monsterId,
+    stageBefore: currentStage,
+    stageAfter: targetStage,
+    branch: existingMonster.branch,
+    cost,
+    ledgerEntryId: entryId,
+    createdAt: nowTs,
+  };
+
+  return {
+    ok: true,
+    status: 'grown',
+    cost,
+    coinsUsed: cost,
+    ledgerEntryId: entryId,
+    intent: {
+      ledgerEntry,
+      monsterState,
+      actionRecord,
+      economyDelta: {
+        balanceDelta: -cost,
+        lifetimeSpentDelta: cost,
+        balanceAfter,
+      },
+    },
+  };
+}

--- a/shared/hero/progress-state.js
+++ b/shared/hero/progress-state.js
@@ -60,11 +60,11 @@ export function normaliseHeroPoolState(raw) {
     }
   }
 
-  // Filter recentActions: keep only well-formed entries (objects with action+monsterId)
+  // Filter recentActions: keep only well-formed entries (objects with type+monsterId)
   let recentActions = [];
   if (Array.isArray(raw.recentActions)) {
     recentActions = raw.recentActions.filter(
-      entry => entry && typeof entry === 'object' && typeof entry.action === 'string'
+      entry => entry && typeof entry === 'object' && typeof entry.type === 'string'
     );
   }
 

--- a/shared/hero/progress-state.js
+++ b/shared/hero/progress-state.js
@@ -80,10 +80,6 @@ export function normaliseHeroPoolState(raw) {
 
 // ── Progress state ──────────────────────────────────────────────
 
-function emptyDailyState() {
-  return null;
-}
-
 export function emptyProgressState() {
   return {
     version: HERO_PROGRESS_VERSION,

--- a/shared/hero/progress-state.js
+++ b/shared/hero/progress-state.js
@@ -1,7 +1,84 @@
 import { emptyEconomyState, normaliseHeroEconomyState } from './economy.js';
+import {
+  HERO_POOL_ROSTER_VERSION as _HERO_POOL_ROSTER_VERSION,
+  isValidHeroMonsterId,
+  isValidHeroMonsterBranch,
+} from './hero-pool.js';
 
-export const HERO_PROGRESS_VERSION = 2;
+export const HERO_PROGRESS_VERSION = 3;
 export const MAX_RECENT_CLAIMS_AGE_DAYS = 7;
+
+
+// ── Hero Pool state ─────────────────────────────────────────────
+
+export const HERO_POOL_STATE_VERSION = 1;
+export const HERO_POOL_ROSTER_VERSION = _HERO_POOL_ROSTER_VERSION;
+
+export function emptyHeroPoolState() {
+  return {
+    version: HERO_POOL_STATE_VERSION,
+    rosterVersion: HERO_POOL_ROSTER_VERSION,
+    selectedMonsterId: null,
+    monsters: {},
+    recentActions: [],
+    lastUpdatedAt: null,
+  };
+}
+
+function normaliseStage(stage) {
+  if (typeof stage !== 'number') return 0;
+  if (!Number.isFinite(stage)) return 0;
+  return Math.max(0, Math.min(4, Math.floor(stage)));
+}
+
+function normaliseBranch(branch, owned) {
+  if (isValidHeroMonsterBranch(branch)) return branch;
+  // Only normalise to null — owned monsters with invalid branch also lose it
+  return null;
+}
+
+export function normaliseHeroPoolState(raw) {
+  if (!raw || typeof raw !== 'object') return emptyHeroPoolState();
+
+  const monsters = {};
+
+  if (raw.monsters && typeof raw.monsters === 'object') {
+    for (const [id, m] of Object.entries(raw.monsters)) {
+      if (!isValidHeroMonsterId(id)) continue; // drop unknown IDs
+      if (!m || typeof m !== 'object') continue;
+      const owned = m.owned === true;
+      monsters[id] = {
+        monsterId: id,
+        owned,
+        stage: normaliseStage(m.stage),
+        branch: normaliseBranch(m.branch, owned),
+        investedCoins: typeof m.investedCoins === 'number' && Number.isFinite(m.investedCoins) ? Math.max(0, m.investedCoins) : 0,
+        invitedAt: m.invitedAt || null,
+        lastGrownAt: m.lastGrownAt || null,
+        lastLedgerEntryId: typeof m.lastLedgerEntryId === 'string' ? m.lastLedgerEntryId : null,
+      };
+    }
+  }
+
+  // Filter recentActions: keep only well-formed entries (objects with action+monsterId)
+  let recentActions = [];
+  if (Array.isArray(raw.recentActions)) {
+    recentActions = raw.recentActions.filter(
+      entry => entry && typeof entry === 'object' && typeof entry.action === 'string'
+    );
+  }
+
+  return {
+    version: HERO_POOL_STATE_VERSION,
+    rosterVersion: typeof raw.rosterVersion === 'string' ? raw.rosterVersion : HERO_POOL_ROSTER_VERSION,
+    selectedMonsterId: typeof raw.selectedMonsterId === 'string' && isValidHeroMonsterId(raw.selectedMonsterId) ? raw.selectedMonsterId : null,
+    monsters,
+    recentActions,
+    lastUpdatedAt: raw.lastUpdatedAt || null,
+  };
+}
+
+// ── Progress state ──────────────────────────────────────────────
 
 function emptyDailyState() {
   return null;
@@ -13,6 +90,7 @@ export function emptyProgressState() {
     daily: null,
     recentClaims: [],
     economy: emptyEconomyState(),
+    heroPool: emptyHeroPoolState(),
   };
 }
 
@@ -20,25 +98,39 @@ export function normaliseHeroProgressState(raw) {
   if (!raw || typeof raw !== 'object') return emptyProgressState();
 
   if (raw.version === 1) {
-    // v1 → v2 upgrade: preserve daily + recentClaims, add empty economy
+    // v1 → v3 upgrade: preserve daily + recentClaims, add empty economy + empty heroPool
     return {
       version: HERO_PROGRESS_VERSION,
       daily: normaliseDailyState(raw.daily),
       recentClaims: Array.isArray(raw.recentClaims) ? raw.recentClaims : [],
       economy: emptyEconomyState(),
+      heroPool: emptyHeroPoolState(),
     };
   }
 
-  if (raw.version === HERO_PROGRESS_VERSION) {
+  if (raw.version === 2) {
+    // v2 → v3 upgrade: preserve economy, add empty heroPool
     return {
       version: HERO_PROGRESS_VERSION,
       daily: normaliseDailyState(raw.daily),
       recentClaims: Array.isArray(raw.recentClaims) ? raw.recentClaims : [],
       economy: normaliseHeroEconomyState(raw.economy),
+      heroPool: emptyHeroPoolState(),
     };
   }
 
-  // Unknown or missing version — return empty v2 state
+  if (raw.version === HERO_PROGRESS_VERSION) {
+    // v3 → v3: normalise all sub-blocks
+    return {
+      version: HERO_PROGRESS_VERSION,
+      daily: normaliseDailyState(raw.daily),
+      recentClaims: Array.isArray(raw.recentClaims) ? raw.recentClaims : [],
+      economy: normaliseHeroEconomyState(raw.economy),
+      heroPool: normaliseHeroPoolState(raw.heroPool),
+    };
+  }
+
+  // Unknown or missing version — return safe empty v3 state
   return emptyProgressState();
 }
 

--- a/src/platform/hero/hero-camp-model.js
+++ b/src/platform/hero/hero-camp-model.js
@@ -28,6 +28,7 @@ export function buildHeroCampModel(readModel) {
     recentActions: camp.recentActions || [],
     lastAction: (camp.recentActions || []).slice(-1)[0] || null,
     hasAffordableAction: monsters.some(m => m.canAffordInvite || m.canAffordGrow),
+    empty: monsters.length === 0 || monsters.every(m => !m.owned),
     insufficientBalanceMessage: 'Save more Hero Coins by completing Hero Quests.',
   };
 }
@@ -43,6 +44,7 @@ function emptyCampModel() {
     recentActions: [],
     lastAction: null,
     hasAffordableAction: false,
+    empty: true,
     insufficientBalanceMessage: null,
   };
 }

--- a/src/platform/hero/hero-camp-model.js
+++ b/src/platform/hero/hero-camp-model.js
@@ -1,0 +1,99 @@
+// Hero Camp UI model — derives view state from read model v6.
+// Client-only module. Does NOT import shared/ or worker/ code.
+
+export function buildHeroCampModel(readModel) {
+  if (!readModel) return emptyCampModel();
+
+  const camp = readModel.camp;
+  if (!camp || !camp.enabled) {
+    return emptyCampModel();
+  }
+
+  const balance = camp.balance ?? 0;
+  const monsters = (camp.monsters || []).map(m => ({
+    ...m,
+    // Add UI-derived fields
+    actionLabel: deriveActionLabel(m),
+    costLabel: deriveCostLabel(m),
+    statusLabel: deriveStatusLabel(m),
+  }));
+
+  return {
+    campEnabled: true,
+    balance,
+    balanceLabel: `${balance} Hero Coins`,
+    monsters,
+    selectedMonsterId: camp.selectedMonsterId,
+    rosterVersion: camp.rosterVersion,
+    recentActions: camp.recentActions || [],
+    lastAction: (camp.recentActions || []).slice(-1)[0] || null,
+    hasAffordableAction: monsters.some(m => m.canAffordInvite || m.canAffordGrow),
+    insufficientBalanceMessage: 'Save more Hero Coins by completing Hero Quests.',
+  };
+}
+
+function emptyCampModel() {
+  return {
+    campEnabled: false,
+    balance: 0,
+    balanceLabel: '0 Hero Coins',
+    monsters: [],
+    selectedMonsterId: null,
+    rosterVersion: null,
+    recentActions: [],
+    lastAction: null,
+    hasAffordableAction: false,
+    insufficientBalanceMessage: null,
+  };
+}
+
+function deriveActionLabel(monster) {
+  if (monster.fullyGrown) return 'Fully grown';
+  if (!monster.owned) return `Use ${monster.inviteCost} Hero Coins to invite`;
+  return `Use ${monster.nextGrowCost} Hero Coins to grow`;
+}
+
+function deriveCostLabel(monster) {
+  if (monster.fullyGrown) return null;
+  if (!monster.owned) return `${monster.inviteCost} Hero Coins`;
+  return `${monster.nextGrowCost} Hero Coins`;
+}
+
+function deriveStatusLabel(monster) {
+  if (!monster.owned) return 'Not yet invited';
+  if (monster.fullyGrown) return 'Fully grown';
+  return `Stage ${monster.stage}`;
+}
+
+// Confirmation copy builders
+export function buildInviteConfirmation(monster, balance) {
+  const balanceAfter = balance - monster.inviteCost;
+  return {
+    heading: `Use ${monster.inviteCost} Hero Coins to invite ${monster.displayName} to Hero Camp?`,
+    balanceAfter: `Your balance will be ${balanceAfter} Hero Coins.`,
+    canConfirm: balance >= monster.inviteCost,
+  };
+}
+
+export function buildGrowConfirmation(monster, balance) {
+  const balanceAfter = balance - monster.nextGrowCost;
+  return {
+    heading: `Use ${monster.nextGrowCost} Hero Coins to grow ${monster.displayName} to stage ${monster.nextStage}?`,
+    balanceAfter: `Your balance will be ${balanceAfter} Hero Coins.`,
+    canConfirm: balance >= monster.nextGrowCost,
+  };
+}
+
+// Success copy builders
+export function buildInviteSuccess(monsterName) {
+  return `${monsterName} joined your Hero Camp.`;
+}
+
+export function buildGrowSuccess(monsterName) {
+  return `${monsterName} grew stronger.`;
+}
+
+// Insufficient balance copy
+export function buildInsufficientMessage(deficit) {
+  return `You need ${deficit} more Hero Coins. Complete Hero Quests to add more Hero Coins.`;
+}

--- a/src/platform/hero/hero-client.js
+++ b/src/platform/hero/hero-client.js
@@ -342,5 +342,143 @@ export function createHeroModeClient({
     return responsePayload;
   }
 
-  return { readModel, startTask, claimTask };
+  // -----------------------------------------------------------------------
+  // unlockMonster
+  // -----------------------------------------------------------------------
+
+  async function unlockMonster({ learnerId, monsterId, branch, requestId } = {}) {
+    const cleanLearnerId = String(learnerId || '').trim();
+    if (!cleanLearnerId || !monsterId || !requestId) {
+      throw new HeroModeClientError({
+        code: 'hero_client_invalid',
+        status: 400,
+        retryable: false,
+        message: 'unlockMonster requires learnerId, monsterId, and requestId.',
+      });
+    }
+
+    const expectedLearnerRevision = typeof getLearnerRevision === 'function'
+      ? Number(getLearnerRevision(cleanLearnerId)) || 0
+      : 0;
+
+    // Body shape: Hero unlock-monster command.
+    // NEVER send cost, amount, balance, ledgerEntryId, stage, owned, payload.
+    const body = {
+      command: 'unlock-monster',
+      learnerId: cleanLearnerId,
+      monsterId,
+      branch: branch ?? null,
+      requestId,
+      expectedLearnerRevision,
+    };
+
+    let response;
+    try {
+      response = await fetchFn('/api/hero/command', {
+        method: 'POST',
+        headers: {
+          accept: 'application/json',
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify(body),
+      });
+    } catch (error) {
+      throw new HeroModeClientError({
+        code: 'network_error',
+        status: 0,
+        retryable: true,
+        message: error?.message || 'Hero unlock-monster request could not reach the server.',
+      });
+    }
+
+    const responsePayload = await parseJson(response);
+
+    if (!response.ok || responsePayload?.ok === false) {
+      const errorCode = responsePayload?.code || responsePayload?.error || 'hero_unlock_failed';
+      const heroError = new HeroModeClientError({
+        code: errorCode,
+        status: response.status,
+        payload: responsePayload,
+      });
+
+      if (errorCode === 'stale_write' && typeof onStaleWrite === 'function') {
+        onStaleWrite({ error: heroError, learnerId: cleanLearnerId });
+      }
+
+      throw heroError;
+    }
+
+    return responsePayload;
+  }
+
+  // -----------------------------------------------------------------------
+  // evolveMonster
+  // -----------------------------------------------------------------------
+
+  async function evolveMonster({ learnerId, monsterId, targetStage, requestId } = {}) {
+    const cleanLearnerId = String(learnerId || '').trim();
+    if (!cleanLearnerId || !monsterId || targetStage == null || !requestId) {
+      throw new HeroModeClientError({
+        code: 'hero_client_invalid',
+        status: 400,
+        retryable: false,
+        message: 'evolveMonster requires learnerId, monsterId, targetStage, and requestId.',
+      });
+    }
+
+    const expectedLearnerRevision = typeof getLearnerRevision === 'function'
+      ? Number(getLearnerRevision(cleanLearnerId)) || 0
+      : 0;
+
+    // Body shape: Hero evolve-monster command.
+    // NEVER send cost, amount, balance, ledgerEntryId, stage, owned, payload.
+    const body = {
+      command: 'evolve-monster',
+      learnerId: cleanLearnerId,
+      monsterId,
+      targetStage,
+      requestId,
+      expectedLearnerRevision,
+    };
+
+    let response;
+    try {
+      response = await fetchFn('/api/hero/command', {
+        method: 'POST',
+        headers: {
+          accept: 'application/json',
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify(body),
+      });
+    } catch (error) {
+      throw new HeroModeClientError({
+        code: 'network_error',
+        status: 0,
+        retryable: true,
+        message: error?.message || 'Hero evolve-monster request could not reach the server.',
+      });
+    }
+
+    const responsePayload = await parseJson(response);
+
+    if (!response.ok || responsePayload?.ok === false) {
+      const errorCode = responsePayload?.code || responsePayload?.error || 'hero_evolve_failed';
+      const heroError = new HeroModeClientError({
+        code: errorCode,
+        status: response.status,
+        payload: responsePayload,
+      });
+
+      if (errorCode === 'stale_write' && typeof onStaleWrite === 'function') {
+        onStaleWrite({ error: heroError, learnerId: cleanLearnerId });
+      }
+
+      throw heroError;
+    }
+
+    return responsePayload;
+  }
+
+  return { readModel, startTask, claimTask, unlockMonster, evolveMonster };
 }

--- a/src/platform/hero/hero-monster-assets.js
+++ b/src/platform/hero/hero-monster-assets.js
@@ -1,0 +1,49 @@
+// Hero Monster asset adapter — client-only.
+// Maps Hero Pool monster IDs to the existing platform asset structure.
+// Does NOT import from shared/ or worker/.
+//
+// Asset keys follow the convention in monster-asset-manifest.js:
+//   key = `${sourceAssetMonsterId}-${branchId}-${stage}`
+//   path = `./assets/monsters/${key}/${size}.webp`
+
+/**
+ * Get the asset source set for a Hero Pool monster.
+ * Falls back gracefully if assets are missing.
+ *
+ * @param {string} sourceAssetMonsterId — base monster id (e.g. "bracehart")
+ * @param {number} stage — evolution stage (0-based)
+ * @param {string} [branch] — branch id (e.g. "b1")
+ * @returns {{ key: string, src: string, fallback: string, srcSet: string }}
+ */
+export function getHeroMonsterAssetSrc(sourceAssetMonsterId, stage, branch) {
+  const branchPart = branch || 'b1';
+  const stageNum = Number(stage) || 0;
+  const key = `${sourceAssetMonsterId}-${branchPart}-${stageNum}`;
+  const fallbackKey = `${sourceAssetMonsterId}-${branchPart}-0`;
+
+  return {
+    key,
+    src: `./assets/monsters/${key}/640.webp`,
+    fallback: `./assets/monsters/${fallbackKey}/640.webp`,
+    srcSet: [
+      `./assets/monsters/${key}/320.webp 320w`,
+      `./assets/monsters/${key}/640.webp 640w`,
+      `./assets/monsters/${key}/1280.webp 1280w`,
+    ].join(', '),
+  };
+}
+
+/**
+ * Check if a specific stage/branch asset likely exists.
+ * In P5, we assume base assets exist; stage/branch variants may not.
+ * UI should degrade gracefully (show fallback image).
+ *
+ * @param {string} sourceAssetMonsterId
+ * @param {number} stage
+ * @param {string} [branch]
+ * @returns {boolean}
+ */
+export function hasHeroMonsterAsset(sourceAssetMonsterId, stage, branch) {
+  // Optimistic — UI handles missing images via onerror/fallback
+  return Boolean(sourceAssetMonsterId);
+}

--- a/src/surfaces/home/HeroCampConfirmation.jsx
+++ b/src/surfaces/home/HeroCampConfirmation.jsx
@@ -1,0 +1,71 @@
+import React from 'react';
+
+/**
+ * HeroCampConfirmation — calm confirmation dialog for Hero Camp actions.
+ *
+ * Shows cost, balance after, and two calm buttons (confirm / cancel).
+ * No urgency, no pressure, no countdown. Clear language for ages 7-11.
+ *
+ * Props:
+ *   visible       — boolean, whether to show the dialog
+ *   heading       — e.g. "Use 150 Hero Coins to invite Glossbloom?"
+ *   balanceAfter  — e.g. "Your balance will be 350 Hero Coins."
+ *   actionLabel   — e.g. "invite" or "grow"
+ *   onConfirm     — () => void
+ *   onCancel      — () => void
+ */
+export function HeroCampConfirmation({
+  visible,
+  heading,
+  balanceAfter,
+  actionLabel,
+  onConfirm,
+  onCancel,
+}) {
+  if (!visible) return null;
+
+  const confirmText = actionLabel
+    ? `Yes, ${actionLabel}`
+    : 'Yes';
+
+  return (
+    <div
+      className="hero-camp-confirmation"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="hero-camp-confirmation-heading"
+      data-hero-camp-confirmation
+    >
+      <div className="hero-camp-confirmation__backdrop" aria-hidden="true" />
+      <div className="hero-camp-confirmation__panel">
+        <h2
+          id="hero-camp-confirmation-heading"
+          className="hero-camp-confirmation__heading"
+        >
+          {heading}
+        </h2>
+        <p className="hero-camp-confirmation__balance-after">
+          {balanceAfter}
+        </p>
+        <div className="hero-camp-confirmation__actions">
+          <button
+            type="button"
+            className="btn primary hero-camp-confirmation__confirm"
+            onClick={onConfirm}
+            aria-label={confirmText}
+          >
+            {confirmText}
+          </button>
+          <button
+            type="button"
+            className="btn ghost hero-camp-confirmation__cancel"
+            onClick={onCancel}
+            aria-label="Not now"
+          >
+            Not now
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/surfaces/home/HeroCampMonsterCard.jsx
+++ b/src/surfaces/home/HeroCampMonsterCard.jsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { getHeroMonsterAssetSrc } from '../../platform/hero/hero-monster-assets.js';
+
+/**
+ * HeroCampMonsterCard — individual monster card within Hero Camp.
+ *
+ * Calm, playful design for ages 7-11. No shop/deal/loot language.
+ * Accessible: all buttons have aria-labels, keyboard focusable.
+ *
+ * Props:
+ *   monster      — monster view model from buildHeroCampModel
+ *   balance      — current Hero Coins balance
+ *   onInvite     — (monsterId, branch) => void
+ *   onGrow       — (monsterId, targetStage) => void
+ */
+export function HeroCampMonsterCard({ monster, balance, onInvite, onGrow }) {
+  if (!monster) return null;
+
+  const fullyGrown = monster.fullyGrown === true;
+  const owned = monster.owned === true;
+
+  // Determine CTA state
+  let ctaText = '';
+  let ctaDisabled = false;
+  let ctaAction = null;
+
+  if (fullyGrown) {
+    ctaText = 'Fully grown';
+  } else if (!owned) {
+    const cost = monster.inviteCost || 0;
+    ctaText = `Invite — ${cost} Hero Coins`;
+    ctaDisabled = balance < cost;
+    ctaAction = () => onInvite?.(monster.monsterId, monster.defaultBranch || 'b1');
+  } else {
+    const cost = monster.nextGrowCost || 0;
+    ctaText = `Grow — ${cost} Hero Coins`;
+    ctaDisabled = balance < cost;
+    ctaAction = () => onGrow?.(monster.monsterId, monster.nextStage);
+  }
+
+  // Stage indicator (dots)
+  const maxStage = monster.maxStage || 4;
+  const currentStage = monster.stage || 0;
+
+  // Monster image asset
+  const assetSrc = getHeroMonsterAssetSrc(
+    monster.sourceAssetMonsterId || monster.monsterId,
+    currentStage,
+    monster.branch,
+  );
+
+  return (
+    <div
+      className="hero-camp-monster-card"
+      data-monster-id={monster.monsterId}
+      data-owned={owned ? 'true' : 'false'}
+      data-fully-grown={fullyGrown ? 'true' : 'false'}
+    >
+      {/* Monster image */}
+      <div className="hero-camp-monster-card__image-container">
+        <img
+          className="hero-camp-monster-card__image"
+          src={assetSrc.src}
+          srcSet={assetSrc.srcSet}
+          sizes="(max-width: 480px) 160px, 240px"
+          alt={`${monster.displayName}${owned ? `, stage ${currentStage}` : ''}`}
+          loading="lazy"
+          onError={(e) => { e.currentTarget.src = assetSrc.fallback; }}
+        />
+      </div>
+
+      <div className="hero-camp-monster-card__header">
+        <h3 className="hero-camp-monster-card__name">{monster.displayName}</h3>
+        {owned && monster.branch && (
+          <span className="hero-camp-monster-card__branch" aria-label={`Path ${monster.branch === 'b1' ? 'A' : 'B'}`}>
+            {monster.branch === 'b1' ? 'Path A' : 'Path B'}
+          </span>
+        )}
+      </div>
+
+      <p className="hero-camp-monster-card__blurb">{monster.childBlurb}</p>
+
+      {owned && (
+        <div className="hero-camp-monster-card__stage" aria-label={`Stage ${currentStage} of ${maxStage}`}>
+          {Array.from({ length: maxStage }, (_, i) => (
+            <span
+              key={i}
+              className={`hero-camp-monster-card__stage-dot${i < currentStage ? ' hero-camp-monster-card__stage-dot--filled' : ''}`}
+              aria-hidden="true"
+            />
+          ))}
+          <span className="hero-camp-monster-card__stage-label">
+            {fullyGrown ? 'Fully grown' : `Stage ${currentStage}`}
+          </span>
+        </div>
+      )}
+
+      {!owned && (
+        <div className="hero-camp-monster-card__stage" aria-label="Not yet invited">
+          <span className="hero-camp-monster-card__stage-label">Not yet invited</span>
+        </div>
+      )}
+
+      <div className="hero-camp-monster-card__cta">
+        {fullyGrown ? (
+          <span className="hero-camp-monster-card__fully-grown" aria-label="Fully grown">
+            Fully grown
+          </span>
+        ) : (
+          <button
+            type="button"
+            className={`btn hero-camp-monster-card__action${ctaDisabled ? ' hero-camp-monster-card__action--disabled' : ''}`}
+            disabled={ctaDisabled}
+            onClick={ctaAction}
+            aria-label={ctaText}
+          >
+            {ctaText}
+          </button>
+        )}
+        {ctaDisabled && !fullyGrown && (
+          <p className="hero-camp-monster-card__insufficient" aria-live="polite">
+            Save more Hero Coins by completing Hero Quests.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/surfaces/home/HeroCampPanel.jsx
+++ b/src/surfaces/home/HeroCampPanel.jsx
@@ -1,0 +1,253 @@
+import React, { useState } from 'react';
+import { HeroCampMonsterCard } from './HeroCampMonsterCard.jsx';
+import { HeroCampConfirmation } from './HeroCampConfirmation.jsx';
+import {
+  buildHeroCampModel,
+  buildInviteConfirmation,
+  buildGrowConfirmation,
+  buildInviteSuccess,
+  buildGrowSuccess,
+  buildInsufficientMessage,
+} from '../../platform/hero/hero-camp-model.js';
+
+/**
+ * HeroCampPanel — calm child-led spending surface for Hero Camp.
+ *
+ * Renders as a secondary section below the Hero Quest card. Shows the
+ * Hero Coins balance (prominent but not pressure-y), a grid of monster
+ * cards, and a confirmation dialog on action. Calm, welcoming tone.
+ *
+ * States:
+ *   1. Camp disabled → null
+ *   2. Loading → non-blocking placeholder
+ *   3. Normal → shows balance + 6 monster cards
+ *   4. Confirming invite → overlay with cost and balance-after
+ *   5. Confirming grow → overlay with cost and target stage
+ *   6. Success → acknowledgement message
+ *   7. Insufficient → calm save-more message
+ *   8. Error/stale → gentle refresh prompt
+ *
+ * Props:
+ *   readModel   — the v6 Hero read model (parent passes this)
+ *   heroClient  — hero client instance { unlockMonster, evolveMonster }
+ *   learnerId   — current learner ID
+ *   onRefresh   — callback to refetch read model after action
+ */
+export function HeroCampPanel({ readModel, heroClient, learnerId, onRefresh }) {
+  const [confirmation, setConfirmation] = useState(null);
+  const [success, setSuccess] = useState(null);
+  const [error, setError] = useState(null);
+  const [busy, setBusy] = useState(false);
+
+  // Build camp model from read model
+  const campModel = readModel ? buildHeroCampModel(readModel) : null;
+
+  // State 1: Camp disabled
+  if (!campModel || !campModel.campEnabled) return null;
+
+  const balance = campModel.balance;
+  const monsters = campModel.monsters || [];
+  const allFullyGrown = monsters.length > 0 && monsters.every(m => m.fullyGrown);
+  const hasAnyOwned = monsters.some(m => m.owned);
+
+  // State 8: Error/stale — gentle refresh prompt
+  if (error) {
+    return (
+      <section className="hero-camp-panel hero-camp-panel--error" aria-label="Hero Camp" data-hero-camp-panel>
+        <h2 className="hero-camp-panel__title">Hero Camp</h2>
+        <p className="hero-camp-panel__error" aria-live="polite">
+          Something went wrong. Try refreshing.
+        </p>
+        <button
+          type="button"
+          className="btn ghost hero-camp-panel__refresh"
+          onClick={() => { setError(null); onRefresh?.(); }}
+          aria-label="Refresh Hero Camp"
+        >
+          Refresh
+        </button>
+      </section>
+    );
+  }
+
+  // State 2: Loading (busy after action)
+  if (busy) {
+    return (
+      <section className="hero-camp-panel hero-camp-panel--loading" aria-label="Hero Camp" data-hero-camp-panel>
+        <h2 className="hero-camp-panel__title">Hero Camp</h2>
+        <p className="hero-camp-panel__loading">Loading Hero Camp…</p>
+      </section>
+    );
+  }
+
+  // Handlers that open confirmation dialog
+  function handleInvite(monsterId, branch) {
+    const monster = monsters.find(m => m.monsterId === monsterId);
+    if (!monster) return;
+    if (balance < monster.inviteCost) {
+      const deficit = monster.inviteCost - balance;
+      setSuccess(null);
+      setConfirmation({ type: 'insufficient', message: buildInsufficientMessage(deficit) });
+      return;
+    }
+    const conf = buildInviteConfirmation(monster, balance);
+    setConfirmation({
+      type: 'invite',
+      monsterId,
+      branch,
+      monsterName: monster.displayName,
+      cost: monster.inviteCost,
+      heading: conf.heading,
+      balanceAfterText: conf.balanceAfter,
+    });
+  }
+
+  function handleGrow(monsterId, targetStage) {
+    const monster = monsters.find(m => m.monsterId === monsterId);
+    if (!monster) return;
+    if (balance < monster.nextGrowCost) {
+      const deficit = monster.nextGrowCost - balance;
+      setSuccess(null);
+      setConfirmation({ type: 'insufficient', message: buildInsufficientMessage(deficit) });
+      return;
+    }
+    const conf = buildGrowConfirmation(monster, balance);
+    setConfirmation({
+      type: 'grow',
+      monsterId,
+      targetStage,
+      monsterName: monster.displayName,
+      cost: monster.nextGrowCost,
+      heading: conf.heading,
+      balanceAfterText: conf.balanceAfter,
+    });
+  }
+
+  async function handleConfirm() {
+    if (!confirmation || confirmation.type === 'insufficient') return;
+    setBusy(true);
+    setConfirmation(null);
+    try {
+      const requestId = `camp-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      if (confirmation.type === 'invite') {
+        await heroClient.unlockMonster({
+          learnerId,
+          monsterId: confirmation.monsterId,
+          branch: confirmation.branch,
+          requestId,
+        });
+        setSuccess(buildInviteSuccess(confirmation.monsterName));
+      } else {
+        await heroClient.evolveMonster({
+          learnerId,
+          monsterId: confirmation.monsterId,
+          targetStage: confirmation.targetStage,
+          requestId,
+        });
+        setSuccess(buildGrowSuccess(confirmation.monsterName));
+      }
+      onRefresh?.();
+    } catch (err) {
+      setError(err?.message || 'Action failed');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function handleCancel() {
+    setConfirmation(null);
+  }
+
+  function dismissSuccess() {
+    setSuccess(null);
+  }
+
+  // Confirmation dialog props
+  const confirmationVisible = confirmation !== null && confirmation.type !== 'insufficient';
+  const confirmationHeading = confirmation?.heading || '';
+  const confirmationBalanceAfter = confirmation?.balanceAfterText || '';
+  const confirmationActionLabel = confirmation?.type === 'invite' ? 'invite' : 'grow';
+
+  return (
+    <section className="hero-camp-panel" aria-label="Hero Camp" data-hero-camp-panel>
+      <div className="hero-camp-panel__header">
+        <h2 className="hero-camp-panel__title">Hero Camp</h2>
+        <div className="hero-camp-panel__balance" aria-label={`${balance} Hero Coins`}>
+          <span className="hero-camp-panel__balance-value">{balance}</span>
+          <span className="hero-camp-panel__balance-label">Hero Coins</span>
+        </div>
+      </div>
+
+      {/* State 6: Success acknowledgement */}
+      {success && (
+        <div className="hero-camp-panel__success" aria-live="polite" data-hero-camp-success>
+          <p className="hero-camp-panel__success-message">{success}</p>
+          <button
+            type="button"
+            className="btn ghost hero-camp-panel__success-dismiss"
+            onClick={dismissSuccess}
+            aria-label="Done"
+          >
+            Done
+          </button>
+        </div>
+      )}
+
+      {/* State 7: Insufficient balance */}
+      {confirmation?.type === 'insufficient' && (
+        <div className="hero-camp-panel__insufficient" aria-live="polite" data-hero-camp-insufficient>
+          <p className="hero-camp-panel__insufficient-message">{confirmation.message}</p>
+          <p className="hero-camp-panel__insufficient-help">
+            Complete Hero Quests to add more Hero Coins.
+          </p>
+          <button
+            type="button"
+            className="btn ghost hero-camp-panel__insufficient-dismiss"
+            onClick={handleCancel}
+            aria-label="Done"
+          >
+            Done
+          </button>
+        </div>
+      )}
+
+      {/* All fully grown celebration */}
+      {allFullyGrown && (
+        <p className="hero-camp-panel__all-grown" aria-live="polite">
+          All your Hero Camp monsters are fully grown. Well done!
+        </p>
+      )}
+
+      {/* No monsters owned — invite prompt */}
+      {!allFullyGrown && !hasAnyOwned && monsters.length > 0 && (
+        <p className="hero-camp-panel__invite-prompt">
+          Choose a Hero monster to invite.
+        </p>
+      )}
+
+      {/* Monster grid */}
+      <div className="hero-camp-panel__grid" role="list">
+        {monsters.map(monster => (
+          <div key={monster.monsterId} role="listitem">
+            <HeroCampMonsterCard
+              monster={monster}
+              balance={balance}
+              onInvite={handleInvite}
+              onGrow={handleGrow}
+            />
+          </div>
+        ))}
+      </div>
+
+      {/* Confirmation dialog */}
+      <HeroCampConfirmation
+        visible={confirmationVisible}
+        heading={confirmationHeading}
+        balanceAfter={confirmationBalanceAfter}
+        actionLabel={confirmationActionLabel}
+        onConfirm={handleConfirm}
+        onCancel={handleCancel}
+      />
+    </section>
+  );
+}

--- a/src/surfaces/home/HomeSurface.jsx
+++ b/src/surfaces/home/HomeSurface.jsx
@@ -3,6 +3,7 @@ import { TopNav } from '../shell/TopNav.jsx';
 import { MonsterMeadow } from './MonsterMeadow.jsx';
 import { SubjectCard } from './SubjectCard.jsx';
 import { HeroQuestCard } from './HeroQuestCard.jsx';
+import { HeroCampPanel } from './HeroCampPanel.jsx';
 import { IconArrowRight } from './icons.jsx';
 import {
   buildMeadowMonsters,
@@ -87,7 +88,15 @@ export function HomeSurface({ model, actions, shellClassName = 'app-shell' }) {
             {companionName ? `${companionName} is ready for round ${model.roundNumber || 1}.` : 'A fresh round is waiting.'}
           </div>
           {heroActive ? (
-            <HeroQuestCard hero={hero} actions={actions} />
+            <>
+              <HeroQuestCard hero={hero} actions={actions} />
+              <HeroCampPanel
+                readModel={model.heroReadModel}
+                heroClient={model.heroClient}
+                learnerId={model.learner?.id}
+                onRefresh={actions.refreshHeroQuest}
+              />
+            </>
           ) : (
             <>
               {recommendation ? (

--- a/tests/helpers/react-render.js
+++ b/tests/helpers/react-render.js
@@ -1300,3 +1300,119 @@ export function renderAppFixture({ route = 'dashboard' } = {}) {
     console.log(html);
   `);
 }
+
+export function renderHeroCampPanelFixture({ campModel, balance = 500, loading = false } = {}) {
+  // The HeroCampPanel takes { readModel, heroClient, learnerId, onRefresh }
+  // and internally calls buildHeroCampModel(readModel). We build a readModel
+  // from the campModel fixture that will produce the expected camp model.
+  const readModel = campModel && campModel.campEnabled
+    ? { camp: { enabled: true, balance: campModel.balance ?? balance, monsters: campModel.monsters || [], selectedMonsterId: campModel.selectedMonsterId || null, rosterVersion: campModel.rosterVersion || 'hero-pool-v1', recentActions: campModel.recentActions || [] } }
+    : campModel === null ? null : { camp: { enabled: false } };
+  return renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { HeroCampPanel } from ${JSON.stringify(absoluteSpecifier('src/surfaces/home/HeroCampPanel.jsx'))};
+
+    const readModel = ${JSON.stringify(readModel)};
+    const heroClient = { unlockMonster: async () => {}, evolveMonster: async () => {} };
+    const html = renderToStaticMarkup(
+      <HeroCampPanel readModel={readModel} heroClient={heroClient} learnerId="learner-test" onRefresh={() => {}} />
+    );
+    console.log(html);
+  `);
+}
+
+export function renderHeroCampMonsterCardFixture({ monster, balance = 500 } = {}) {
+  return renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { HeroCampMonsterCard } from ${JSON.stringify(absoluteSpecifier('src/surfaces/home/HeroCampMonsterCard.jsx'))};
+
+    const monster = ${JSON.stringify(monster)};
+    const balance = ${JSON.stringify(balance)};
+    const html = renderToStaticMarkup(
+      <HeroCampMonsterCard monster={monster} balance={balance} onInvite={() => {}} onGrow={() => {}} />
+    );
+    console.log(html);
+  `);
+}
+
+export function renderHeroCampConfirmationFixture({ visible = true, heading, balanceAfter, actionLabel } = {}) {
+  return renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { HeroCampConfirmation } from ${JSON.stringify(absoluteSpecifier('src/surfaces/home/HeroCampConfirmation.jsx'))};
+
+    const html = renderToStaticMarkup(
+      <HeroCampConfirmation
+        visible={${JSON.stringify(visible)}}
+        heading={${JSON.stringify(heading)}}
+        balanceAfter={${JSON.stringify(balanceAfter)}}
+        actionLabel={${JSON.stringify(actionLabel)}}
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />
+    );
+    console.log(html);
+  `);
+}
+
+export function renderHomeSurfaceWithCampFixture({ hero = null, heroCamp = null, heroReadModel = null } = {}) {
+  // If heroCamp is provided with campEnabled, auto-build a heroReadModel
+  // that produces the expected camp model when no explicit heroReadModel given.
+  const derivedReadModel = heroReadModel || (heroCamp && heroCamp.campEnabled
+    ? { camp: { enabled: true, balance: heroCamp.balance ?? 500, monsters: heroCamp.monsters || [], selectedMonsterId: null, rosterVersion: 'hero-pool-v1', recentActions: [] } }
+    : null);
+  return renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { HomeSurface } from ${JSON.stringify(absoluteSpecifier('src/surfaces/home/HomeSurface.jsx'))};
+
+    const model = {
+      theme: 'light',
+      learner: { id: 'learner-a', name: 'Ava' },
+      learnerLabel: 'Ava',
+      learnerOptions: [{ id: 'learner-a', name: 'Ava', yearGroup: 'Y5' }],
+      signedInAs: null,
+      persistence: { mode: 'local-only', label: 'Local-only' },
+      monsterSummary: [],
+      subjects: [
+        { id: 'spelling', name: 'Spelling', blurb: 'KS2 spelling.', accent: '#3E6FA8', status: 'live', glyph: 'S', progress: 0, progressLabel: '0 words secure' },
+        { id: 'grammar', name: 'Grammar', blurb: 'KS2 grammar.', accent: '#A83E6F', status: 'live', glyph: 'G', progress: 0, progressLabel: '0 concepts' },
+        { id: 'punctuation', name: 'Punctuation', blurb: 'KS2 punctuation.', accent: '#6FA83E', status: 'live', glyph: 'P', progress: 0, progressLabel: '0 units' },
+      ],
+      dashboardStats: {
+        spelling: { pct: 0, due: 0, streak: 0, nextUp: 'Ready' },
+        grammar: { pct: 0, due: 0, streak: 0, nextUp: 'Ready' },
+        punctuation: { pct: 0, due: 0, streak: 0, nextUp: 'Ready' },
+      },
+      dueTotal: 0,
+      roundNumber: 1,
+      now: new Date('2026-04-22T12:00:00Z'),
+      permissions: { canOpenParentHub: false },
+      hero: ${JSON.stringify(hero)},
+      heroCamp: ${JSON.stringify(heroCamp)},
+      heroReadModel: ${JSON.stringify(derivedReadModel)},
+      heroClient: { unlockMonster: async () => {}, evolveMonster: async () => {} },
+    };
+    const actions = {
+      dispatch() {},
+      toggleTheme() {},
+      selectLearner() {},
+      navigateHome() {},
+      openProfileSettings() {},
+      openSubject() {},
+      openCodex() {},
+      openParentHub() {},
+      openAdminHub() {},
+      openHeroCamp() {},
+      logout() {},
+      retryPersistence() {},
+      startHeroQuestTask() {},
+      continueHeroTask() {},
+      refreshHeroQuest() {},
+    };
+    const html = renderToStaticMarkup(<HomeSurface model={model} actions={actions} />);
+    console.log(html);
+  `);
+}

--- a/tests/hero-launch-boundary.test.js
+++ b/tests/hero-launch-boundary.test.js
@@ -131,7 +131,9 @@ test('S-L4: no Hero source file contains economy vocabulary tokens', () => {
   // use them in child-facing copy. Exclude it from the token scan.
   // claim-contract.js, claim-resolver.js: P3 claim architecture — economy-
   // adjacent terms are legitimate in the server-side reward/claim boundary.
-  const EXCLUDED_BASENAMES = new Set(['hero-copy.js', 'claim-contract.js', 'claim-resolver.js']);
+  // camp.js, monster-economy.js: P5 camp architecture — uses economy terms
+  // in field-rejection guards and spending computation (legitimate use).
+  const EXCLUDED_BASENAMES = new Set(['hero-copy.js', 'claim-contract.js', 'claim-resolver.js', 'camp.js', 'monster-economy.js']);
 
   const allHeroFiles = [
     ...collectJsFiles(SHARED_HERO_DIR),

--- a/tests/hero-no-write-boundary.test.js
+++ b/tests/hero-no-write-boundary.test.js
@@ -228,9 +228,9 @@ test('S6: no P0 Hero source file contains reward/economy tokens', () => {
     /streak\s+loss/i,
   ];
 
-  // P3 files that legitimately use economy-adjacent vocabulary as part of
-  // the claim/reward architecture — excluded from this P0-era scan.
-  const S6_EXCLUDED_SUFFIXES = ['hero-copy.js', 'claim-contract.js', 'claim-resolver.js'];
+  // P3+ files that legitimately use economy-adjacent vocabulary as part of
+  // the claim/reward architecture or as field-rejection guards — excluded from this P0-era scan.
+  const S6_EXCLUDED_SUFFIXES = ['hero-copy.js', 'claim-contract.js', 'claim-resolver.js', 'camp.js', 'monster-economy.js'];
 
   for (const [rel, { code }] of HERO_SOURCES) {
     if (S6_EXCLUDED_SUFFIXES.some((suffix) => rel.endsWith(suffix))) continue;

--- a/tests/hero-p4-vocabulary-boundary.test.js
+++ b/tests/hero-p4-vocabulary-boundary.test.js
@@ -56,7 +56,7 @@ function stripVocabDefinitions(source) {
   // Strip exported const arrays that define vocabulary or forbidden-field lists
   return source
     .replace(
-      /export\s+const\s+(?:HERO_(?:FORBIDDEN_PRESSURE_VOCABULARY|ECONOMY_ALLOWED_VOCABULARY|FORBIDDEN_VOCABULARY|ECONOMY_ALLOWED_FILES)|FORBIDDEN_CLAIM_FIELDS)\s*=\s*(?:Object\.freeze\()?\[[\s\S]*?\]\)?;/g,
+      /export\s+const\s+(?:HERO_(?:FORBIDDEN_PRESSURE_VOCABULARY|ECONOMY_ALLOWED_VOCABULARY|FORBIDDEN_VOCABULARY|ECONOMY_ALLOWED_FILES)|FORBIDDEN_C(?:LAIM|AMP)_FIELDS)\s*=\s*(?:Object\.freeze\()?\[[\s\S]*?\]\)?;/g,
       '',
     );
 }

--- a/tests/hero-p5-boundaries.test.js
+++ b/tests/hero-p5-boundaries.test.js
@@ -1,0 +1,165 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { HERO_FORBIDDEN_PRESSURE_VOCABULARY } from '../shared/hero/hero-copy.js';
+
+const ROOT = join(import.meta.dirname, '..');
+
+function readFile(relPath) {
+  return readFileSync(join(ROOT, relPath), 'utf8');
+}
+
+// ── Import boundary tests ─────────────────────────────────────────────
+
+describe('Hero P5 — import boundaries', () => {
+  it('worker/src/hero/camp.js has zero imports from subjects/runtime or subjects/', () => {
+    const src = readFile('worker/src/hero/camp.js');
+    const lines = src.split('\n').filter(l => /^\s*(import|require)/.test(l));
+    const forbidden = lines.filter(l => /subjects\/runtime|subjects\//.test(l));
+    assert.equal(forbidden.length, 0, `camp.js imports from subjects/: ${forbidden.join(', ')}`);
+  });
+
+  it('shared/hero/hero-pool.js has zero imports from worker/ or src/', () => {
+    const src = readFile('shared/hero/hero-pool.js');
+    const lines = src.split('\n').filter(l => /^\s*(import|require)/.test(l));
+    const forbidden = lines.filter(l => /['"].*(?:worker\/|src\/)/.test(l));
+    assert.equal(forbidden.length, 0, `hero-pool.js imports from worker/ or src/: ${forbidden.join(', ')}`);
+  });
+
+  it('shared/hero/monster-economy.js has zero imports from worker/ or src/', () => {
+    const src = readFile('shared/hero/monster-economy.js');
+    const lines = src.split('\n').filter(l => /^\s*(import|require)/.test(l));
+    const forbidden = lines.filter(l => /['"].*(?:worker\/|src\/)/.test(l));
+    assert.equal(forbidden.length, 0, `monster-economy.js imports from worker/ or src/: ${forbidden.join(', ')}`);
+  });
+
+  it('Worker/shared Hero code does not import src/platform/game/monsters.js', () => {
+    const filesToCheck = [
+      'worker/src/hero/camp.js',
+      'shared/hero/hero-pool.js',
+      'shared/hero/monster-economy.js',
+    ];
+    for (const relPath of filesToCheck) {
+      const src = readFile(relPath);
+      assert.ok(
+        !src.includes('platform/game/monsters'),
+        `${relPath} imports from platform/game/monsters.js`
+      );
+    }
+  });
+
+  it('src/platform/hero/hero-monster-assets.js does not import from shared/ or worker/', () => {
+    const src = readFile('src/platform/hero/hero-monster-assets.js');
+    const lines = src.split('\n').filter(l => /^\s*(import|require)/.test(l));
+    const forbidden = lines.filter(l => /['"].*(?:shared\/|worker\/)/.test(l));
+    assert.equal(forbidden.length, 0, `hero-monster-assets.js imports from shared/ or worker/: ${forbidden.join(', ')}`);
+  });
+});
+
+// ── Vocabulary boundary tests ─────────────────────────────────────────
+
+describe('Hero P5 — vocabulary boundaries', () => {
+  const CAMP_FILES = [
+    'src/surfaces/home/HeroCampPanel.jsx',
+    'src/surfaces/home/HeroCampMonsterCard.jsx',
+    'src/platform/hero/hero-camp-model.js',
+    'shared/hero/hero-pool.js',
+  ];
+
+  it('Hero Camp files contain zero HERO_FORBIDDEN_PRESSURE_VOCABULARY terms in string literals', () => {
+    const violations = [];
+    for (const relPath of CAMP_FILES) {
+      const src = readFile(relPath);
+      // Strip comment lines (// and /* */ and * lines) to avoid false positives from documentation
+      const nonCommentLines = src.split('\n').filter(line => {
+        const trimmed = line.trim();
+        return !trimmed.startsWith('//') && !trimmed.startsWith('*') && !trimmed.startsWith('/*');
+      }).join('\n').toLowerCase();
+      for (const word of HERO_FORBIDDEN_PRESSURE_VOCABULARY) {
+        if (nonCommentLines.includes(word.toLowerCase())) {
+          violations.push(`${relPath} contains forbidden term: "${word}"`);
+        }
+      }
+    }
+    assert.equal(violations.length, 0, `Vocabulary violations:\n${violations.join('\n')}`);
+  });
+
+  it('Economy vocabulary (coin, balance, Hero Coins) does NOT appear in subject surfaces', () => {
+    // Quick check of a few subject surface files if they exist
+    const subjectSurfaces = [
+      'src/surfaces/subjects/grammar/GrammarMapScreen.jsx',
+      'src/surfaces/subjects/spelling/SpellingMapScreen.jsx',
+      'src/surfaces/subjects/punctuation/PunctuationMapScreen.jsx',
+    ];
+    const economyTerms = ['coin', 'balance', 'Hero Coins'];
+    const violations = [];
+    for (const relPath of subjectSurfaces) {
+      try {
+        const src = readFile(relPath).toLowerCase();
+        for (const term of economyTerms) {
+          if (src.includes(term.toLowerCase())) {
+            violations.push(`${relPath} contains economy term: "${term}"`);
+          }
+        }
+      } catch {
+        // File may not exist — that is fine, skip
+      }
+    }
+    assert.equal(violations.length, 0, `Economy vocabulary in subject surfaces:\n${violations.join('\n')}`);
+  });
+});
+
+// ── Structural boundary tests ────────────────────────────────────────
+
+describe('Hero P5 — structural boundaries', () => {
+  it('No new D1 migration files were added for P5 camp', () => {
+    // P5 camp must NOT add new migration files — it stores state in existing hero_progress JSON
+    const migrationsDir = join(ROOT, 'worker', 'migrations');
+    let files;
+    try {
+      files = readdirSync(migrationsDir).filter(f => f.endsWith('.sql'));
+    } catch {
+      // No migrations directory — that is acceptable
+      files = [];
+    }
+    // The highest known pre-P5 migration is 0013. Anything above means new tables were added.
+    const p5Migrations = files.filter(f => {
+      const match = f.match(/^(\d+)/);
+      return match && parseInt(match[1], 10) > 13;
+    });
+    assert.equal(p5Migrations.length, 0, `P5 added new migrations: ${p5Migrations.join(', ')}`);
+  });
+
+  it('camp.js does not read from event_log table (event mirror is not authority)', () => {
+    const src = readFile('worker/src/hero/camp.js');
+    assert.ok(
+      !src.includes('event_log'),
+      'camp.js references event_log — it must not read from the event mirror'
+    );
+    assert.ok(
+      !src.includes('SELECT'),
+      'camp.js contains SQL SELECT — it must not read from any table'
+    );
+  });
+});
+
+// ── State safety tests ───────────────────────────────────────────────
+
+describe('Hero P5 — state safety', () => {
+  it('camp.js does NOT write to child_subject_state', () => {
+    const src = readFile('worker/src/hero/camp.js');
+    assert.ok(
+      !src.includes('child_subject_state'),
+      'camp.js references child_subject_state — camp commands must not touch subject state'
+    );
+  });
+
+  it('camp.js does NOT write to practice_sessions', () => {
+    const src = readFile('worker/src/hero/camp.js');
+    assert.ok(
+      !src.includes('practice_sessions'),
+      'camp.js references practice_sessions — camp commands must not touch practice sessions'
+    );
+  });
+});

--- a/tests/hero-p5-boundary.test.js
+++ b/tests/hero-p5-boundary.test.js
@@ -1,0 +1,226 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const ROOT = resolve(import.meta.dirname, '..');
+
+function readSource(relativePath) {
+  return readFileSync(resolve(ROOT, relativePath), 'utf-8');
+}
+
+function extractImports(source) {
+  // Match both static import and dynamic import()
+  const staticImports = [...source.matchAll(/(?:^|\n)\s*import\s+.*?from\s+['"]([^'"]+)['"]/g)].map(m => m[1]);
+  const dynamicImports = [...source.matchAll(/import\(['"]([^'"]+)['"]\)/g)].map(m => m[1]);
+  return [...staticImports, ...dynamicImports];
+}
+
+// ── Section 1: Structural import boundary tests ─────────────────────────────
+
+test('worker/src/hero/camp.js has zero imports from subject runtime (worker/src/subjects/)', () => {
+  const source = readSource('worker/src/hero/camp.js');
+  const imports = extractImports(source);
+  const subjectImports = imports.filter(i => i.includes('subjects/') || i.includes('subjects\\'));
+  assert.deepEqual(subjectImports, [], `camp.js must NOT import from worker/src/subjects/; found: ${subjectImports.join(', ')}`);
+});
+
+test('shared/hero/hero-pool.js has zero imports from worker/ or src/', () => {
+  const source = readSource('shared/hero/hero-pool.js');
+  const imports = extractImports(source);
+  const forbidden = imports.filter(i =>
+    i.includes('worker/') || i.includes('worker\\') ||
+    i.includes('src/') || i.includes('src\\') ||
+    i.includes('../worker') || i.includes('../src'),
+  );
+  assert.deepEqual(forbidden, [], `hero-pool.js must NOT import from worker/ or src/; found: ${forbidden.join(', ')}`);
+});
+
+test('shared/hero/monster-economy.js has zero imports from worker/ or src/', () => {
+  const source = readSource('shared/hero/monster-economy.js');
+  const imports = extractImports(source);
+  const forbidden = imports.filter(i =>
+    i.includes('worker/') || i.includes('worker\\') ||
+    i.includes('src/') || i.includes('src\\') ||
+    i.includes('../worker') || i.includes('../src'),
+  );
+  assert.deepEqual(forbidden, [], `monster-economy.js must NOT import from worker/ or src/; found: ${forbidden.join(', ')}`);
+});
+
+test('worker/src/hero/camp.js does not import repository.js or D1', () => {
+  const source = readSource('worker/src/hero/camp.js');
+  const imports = extractImports(source);
+  const forbidden = imports.filter(i => i.includes('repository') || i.includes('d1') || i.includes('D1'));
+  assert.deepEqual(forbidden, [], `camp.js must NOT import repository.js or D1; found: ${forbidden.join(', ')}`);
+  // Also check for direct D1 usage patterns
+  assert.ok(!source.includes('.prepare('), 'camp.js must NOT use D1 .prepare()');
+  assert.ok(!source.includes('.batch('), 'camp.js must NOT use D1 .batch()');
+});
+
+test('src/platform/hero/hero-camp-model.js does not import from shared/hero/ or worker/', () => {
+  const source = readSource('src/platform/hero/hero-camp-model.js');
+  const imports = extractImports(source);
+  const forbidden = imports.filter(i =>
+    i.includes('shared/hero') || i.includes('shared\\hero') ||
+    i.includes('worker/') || i.includes('worker\\') ||
+    i.includes('../../../shared') || i.includes('../../../../worker'),
+  );
+  assert.deepEqual(forbidden, [], `hero-camp-model.js must NOT import from shared/hero/ or worker/; found: ${forbidden.join(', ')}`);
+});
+
+test('src/platform/hero/hero-monster-assets.js does not import from shared/ or worker/', () => {
+  const source = readSource('src/platform/hero/hero-monster-assets.js');
+  const imports = extractImports(source);
+  const forbidden = imports.filter(i =>
+    i.includes('shared/') || i.includes('shared\\') ||
+    i.includes('worker/') || i.includes('worker\\') ||
+    i.includes('../../../shared') || i.includes('../../../../worker'),
+  );
+  assert.deepEqual(forbidden, [], `hero-monster-assets.js must NOT import from shared/ or worker/; found: ${forbidden.join(', ')}`);
+});
+
+test('Worker/shared Camp code does not import src/platform/game/monsters.js', () => {
+  const campFiles = [
+    'worker/src/hero/camp.js',
+    'shared/hero/hero-pool.js',
+    'shared/hero/monster-economy.js',
+  ];
+  for (const file of campFiles) {
+    const source = readSource(file);
+    const imports = extractImports(source);
+    const forbidden = imports.filter(i => i.includes('platform/game/monsters') || i.includes('game/monsters'));
+    assert.deepEqual(forbidden, [], `${file} must NOT import src/platform/game/monsters.js; found: ${forbidden.join(', ')}`);
+  }
+});
+
+// ── Section 2: Vocabulary boundary tests — forbidden pressure words ──────────
+
+import { HERO_FORBIDDEN_PRESSURE_VOCABULARY } from '../shared/hero/hero-copy.js';
+
+const CAMP_UI_FILES = [
+  'src/surfaces/home/HeroCampPanel.jsx',
+  'src/surfaces/home/HeroCampMonsterCard.jsx',
+  'src/surfaces/home/HeroCampConfirmation.jsx',
+  'src/platform/hero/hero-camp-model.js',
+];
+
+function stripComments(source) {
+  // Remove block comments (/* ... */) and line comments (// ...)
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/[^\n]*/g, '');
+}
+
+for (const filePath of CAMP_UI_FILES) {
+  test(`${filePath} contains zero forbidden pressure vocabulary`, () => {
+    const source = readSource(filePath);
+    const stripped = stripComments(source);
+    const lower = stripped.toLowerCase();
+    const found = [];
+    for (const token of HERO_FORBIDDEN_PRESSURE_VOCABULARY) {
+      const tokenLower = token.toLowerCase();
+      // Multi-word tokens use simple includes;
+      // Single-word tokens use word-boundary regex to avoid false positives
+      const hit = tokenLower.includes(' ')
+        ? lower.includes(tokenLower)
+        : new RegExp(`\\b${tokenLower}\\b`).test(lower);
+      if (hit) found.push(token);
+    }
+    assert.deepEqual(found, [], `${filePath} contains forbidden vocabulary: ${found.join(', ')}`);
+  });
+}
+
+// ── Section 3: No subject mutation in Camp section ───────────────────────────
+
+test('Camp section of worker/src/app.js does NOT write to child_subject_state', () => {
+  const source = readSource('worker/src/app.js');
+  // Camp section is delimited by the comment marker and the subsequent section start
+  const campStart = source.indexOf("// P5 U6: Camp spending commands");
+  const campEnd = source.indexOf("// U10: outer try wraps the full resolve", campStart);
+  assert.ok(campStart > -1, 'Camp section marker not found in app.js');
+  assert.ok(campEnd > -1, 'Camp section end marker not found in app.js');
+  const campSection = source.slice(campStart, campEnd);
+  assert.ok(!campSection.includes('child_subject_state'), 'Camp section must NOT reference child_subject_state');
+});
+
+test('Camp section of worker/src/app.js does NOT write to practice_sessions', () => {
+  const source = readSource('worker/src/app.js');
+  const campStart = source.indexOf("// P5 U6: Camp spending commands");
+  const campEnd = source.indexOf("// U10: outer try wraps the full resolve", campStart);
+  const campSection = source.slice(campStart, campEnd);
+  assert.ok(!campSection.includes('practice_sessions'), 'Camp section must NOT reference practice_sessions');
+});
+
+test('Camp section of worker/src/app.js does NOT dispatch to subject runtime', () => {
+  const source = readSource('worker/src/app.js');
+  const campStart = source.indexOf("// P5 U6: Camp spending commands");
+  const campEnd = source.indexOf("// U10: outer try wraps the full resolve", campStart);
+  const campSection = source.slice(campStart, campEnd);
+  // Subject runtime dispatch patterns
+  assert.ok(!campSection.includes('subjectRuntime'), 'Camp section must NOT call subjectRuntime');
+  assert.ok(!campSection.includes('dispatchSubject'), 'Camp section must NOT call dispatchSubject');
+  assert.ok(!campSection.includes('subjectCommand'), 'Camp section must NOT reference subjectCommand');
+  assert.ok(!campSection.includes('resolveSubject'), 'Camp section must NOT call resolveSubject');
+});
+
+// ── Section 4: Schema stability ──────────────────────────────────────────────
+
+test('No new D1 migration tables for hero/camp/monster in P5', () => {
+  // Check all migration files for CREATE TABLE with hero camp or monster-pool naming
+  const migrationsDir = resolve(ROOT, 'worker/migrations');
+  const files = readdirSync(migrationsDir).filter(f => f.endsWith('.sql'));
+
+  const heroPoolTablePattern = /CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(hero_camp|hero_pool|hero_monster|camp_monster)/gi;
+  for (const file of files) {
+    const sql = readFileSync(resolve(migrationsDir, file), 'utf-8');
+    const matches = [...sql.matchAll(heroPoolTablePattern)];
+    assert.deepEqual(
+      matches.map(m => m[1]),
+      [],
+      `Migration ${file} must NOT create hero_camp/hero_pool/hero_monster tables (Camp state lives in JSON column)`,
+    );
+  }
+});
+
+test('Camp event_log entries use INSERT with ON CONFLICT DO NOTHING', () => {
+  const source = readSource('worker/src/app.js');
+  const campStart = source.indexOf("// P5 U6: Camp spending commands");
+  const campEnd = source.indexOf("// U10: outer try wraps the full resolve", campStart);
+  const campSection = source.slice(campStart, campEnd);
+
+  // Any INSERT in camp section must have ON CONFLICT DO NOTHING
+  const insertStatements = [...campSection.matchAll(/INSERT\s+INTO\s+(\w+)/gi)];
+  for (const match of insertStatements) {
+    const afterInsert = campSection.slice(match.index, match.index + 500);
+    assert.ok(
+      afterInsert.includes('ON CONFLICT') && afterInsert.includes('DO NOTHING'),
+      `INSERT INTO ${match[1]} in Camp section must use ON CONFLICT DO NOTHING (non-authoritative mirror)`,
+    );
+  }
+});
+
+// ── Section 5: Structured telemetry presence ─────────────────────────────────
+
+test('Camp handler emits hero_camp_disabled_attempt telemetry', () => {
+  const source = readSource('worker/src/app.js');
+  assert.ok(source.includes("event: 'hero_camp_disabled_attempt'"), 'hero_camp_disabled_attempt telemetry missing');
+});
+
+test('Camp handler emits hero_camp_command_rejected telemetry', () => {
+  const source = readSource('worker/src/app.js');
+  assert.ok(source.includes("event: 'hero_camp_command_rejected'"), 'hero_camp_command_rejected telemetry missing');
+});
+
+test('Camp handler emits hero_camp_command_idempotent or hero_monster_duplicate_prevented telemetry', () => {
+  const source = readSource('worker/src/app.js');
+  const hasIdempotent = source.includes("event: 'hero_camp_command_idempotent'") ||
+                        source.includes("event: 'hero_monster_duplicate_prevented'");
+  assert.ok(hasIdempotent, 'idempotent camp telemetry missing');
+});
+
+test('Camp handler emits hero_camp_command_succeeded telemetry', () => {
+  const source = readSource('worker/src/app.js');
+  assert.ok(source.includes("event: 'hero_camp_command_succeeded'"), 'hero_camp_command_succeeded telemetry missing');
+});

--- a/tests/hero-p5-camp-client.test.js
+++ b/tests/hero-p5-camp-client.test.js
@@ -1,0 +1,454 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { createHeroModeClient, HeroModeClientError } from '../src/platform/hero/hero-client.js';
+import {
+  buildHeroCampModel,
+  buildInviteConfirmation,
+  buildGrowConfirmation,
+  buildInviteSuccess,
+  buildGrowSuccess,
+  buildInsufficientMessage,
+} from '../src/platform/hero/hero-camp-model.js';
+import { getHeroMonsterAssetSrc, hasHeroMonsterAsset } from '../src/platform/hero/hero-monster-assets.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mockFetch(status, body = {}, { ok = status >= 200 && status < 300 } = {}) {
+  const calls = [];
+  async function fakeFetch(url, init) {
+    calls.push({ url, init });
+    return {
+      ok,
+      status,
+      json: async () => body,
+    };
+  }
+  fakeFetch.calls = calls;
+  return fakeFetch;
+}
+
+function defaultOpts(overrides = {}) {
+  return {
+    fetch: mockFetch(200, { ok: true }),
+    getLearnerRevision: () => 42,
+    ...overrides,
+  };
+}
+
+/** Six monsters with various affordability states. */
+function buildCampReadModel({ balance = 150 } = {}) {
+  return {
+    camp: {
+      enabled: true,
+      balance,
+      selectedMonsterId: 'mon-2',
+      rosterVersion: 3,
+      recentActions: [{ type: 'invite', monsterId: 'mon-1' }],
+      monsters: [
+        { id: 'mon-1', displayName: 'Frostclaw', owned: true, fullyGrown: false, stage: 2, inviteCost: 30, nextGrowCost: 50, nextStage: 3, canAffordInvite: false, canAffordGrow: true },
+        { id: 'mon-2', displayName: 'Emberfin', owned: true, fullyGrown: true, stage: 4, inviteCost: 30, nextGrowCost: 0, nextStage: null, canAffordInvite: false, canAffordGrow: false },
+        { id: 'mon-3', displayName: 'Thornveil', owned: false, fullyGrown: false, stage: 0, inviteCost: 40, nextGrowCost: 0, nextStage: null, canAffordInvite: true, canAffordGrow: false },
+        { id: 'mon-4', displayName: 'Glintscale', owned: false, fullyGrown: false, stage: 0, inviteCost: 200, nextGrowCost: 0, nextStage: null, canAffordInvite: false, canAffordGrow: false },
+        { id: 'mon-5', displayName: 'Duskpetal', owned: true, fullyGrown: false, stage: 1, inviteCost: 30, nextGrowCost: 60, nextStage: 2, canAffordInvite: false, canAffordGrow: true },
+        { id: 'mon-6', displayName: 'Quakeroot', owned: true, fullyGrown: false, stage: 3, inviteCost: 30, nextGrowCost: 80, nextStage: 4, canAffordInvite: false, canAffordGrow: true },
+      ],
+    },
+  };
+}
+
+// Forbidden fields that must NEVER appear in unlock/evolve payloads
+const FORBIDDEN_FIELDS = ['cost', 'amount', 'balance', 'ledgerEntryId', 'stage', 'owned', 'payload', 'subjectId'];
+
+// ---------------------------------------------------------------------------
+// unlockMonster — payload shape
+// ---------------------------------------------------------------------------
+
+describe('hero-client unlockMonster — payload shape', () => {
+  it('sends correct payload without forbidden fields', async () => {
+    const fakeFetch = mockFetch(200, { ok: true, monsterId: 'mon-1' });
+    const client = createHeroModeClient({ ...defaultOpts(), fetch: fakeFetch });
+
+    await client.unlockMonster({
+      learnerId: 'learner-1',
+      monsterId: 'mon-1',
+      branch: 'b2',
+      requestId: 'req-abc',
+    });
+
+    assert.equal(fakeFetch.calls.length, 1);
+    const { url, init } = fakeFetch.calls[0];
+    assert.equal(url, '/api/hero/command');
+    assert.equal(init.method, 'POST');
+
+    const body = JSON.parse(init.body);
+    assert.equal(body.command, 'unlock-monster');
+    assert.equal(body.learnerId, 'learner-1');
+    assert.equal(body.monsterId, 'mon-1');
+    assert.equal(body.branch, 'b2');
+    assert.equal(body.requestId, 'req-abc');
+    assert.equal(body.expectedLearnerRevision, 42);
+
+    // Forbidden fields must not be present
+    for (const field of FORBIDDEN_FIELDS) {
+      assert.ok(!(field in body), `body must not include ${field}`);
+    }
+  });
+
+  it('branch defaults to null when not provided', async () => {
+    const fakeFetch = mockFetch(200, { ok: true });
+    const client = createHeroModeClient({ ...defaultOpts(), fetch: fakeFetch });
+
+    await client.unlockMonster({ learnerId: 'l', monsterId: 'm', requestId: 'r' });
+
+    const body = JSON.parse(fakeFetch.calls[0].init.body);
+    assert.equal(body.branch, null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// evolveMonster — payload shape
+// ---------------------------------------------------------------------------
+
+describe('hero-client evolveMonster — payload shape', () => {
+  it('sends correct payload with targetStage', async () => {
+    const fakeFetch = mockFetch(200, { ok: true, monsterId: 'mon-2', stage: 3 });
+    const client = createHeroModeClient({ ...defaultOpts(), fetch: fakeFetch });
+
+    await client.evolveMonster({
+      learnerId: 'learner-2',
+      monsterId: 'mon-2',
+      targetStage: 3,
+      requestId: 'req-def',
+    });
+
+    assert.equal(fakeFetch.calls.length, 1);
+    const body = JSON.parse(fakeFetch.calls[0].init.body);
+    assert.equal(body.command, 'evolve-monster');
+    assert.equal(body.learnerId, 'learner-2');
+    assert.equal(body.monsterId, 'mon-2');
+    assert.equal(body.targetStage, 3);
+    assert.equal(body.requestId, 'req-def');
+    assert.equal(body.expectedLearnerRevision, 42);
+
+    // Forbidden fields must not be present
+    for (const field of FORBIDDEN_FIELDS) {
+      assert.ok(!(field in body), `body must not include ${field}`);
+    }
+  });
+
+  it('rejects missing targetStage', async () => {
+    const client = createHeroModeClient(defaultOpts());
+
+    const err = await client.evolveMonster({
+      learnerId: 'l',
+      monsterId: 'm',
+      requestId: 'r',
+    }).catch(e => e);
+
+    assert.ok(err instanceof HeroModeClientError);
+    assert.equal(err.code, 'hero_client_invalid');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stale-write triggers onStaleWrite callback
+// ---------------------------------------------------------------------------
+
+describe('hero-client camp commands — stale write', () => {
+  it('unlockMonster stale_write triggers onStaleWrite', async () => {
+    const fakeFetch = mockFetch(409, { ok: false, code: 'stale_write' });
+    const staleWrites = [];
+    const client = createHeroModeClient({
+      ...defaultOpts(),
+      fetch: fakeFetch,
+      onStaleWrite: (info) => staleWrites.push(info),
+    });
+
+    await client.unlockMonster({
+      learnerId: 'learner-x',
+      monsterId: 'mon-1',
+      requestId: 'r',
+    }).catch(() => {});
+
+    assert.equal(staleWrites.length, 1);
+    assert.equal(staleWrites[0].learnerId, 'learner-x');
+    assert.equal(staleWrites[0].error.code, 'stale_write');
+  });
+
+  it('evolveMonster stale_write triggers onStaleWrite', async () => {
+    const fakeFetch = mockFetch(409, { ok: false, code: 'stale_write' });
+    const staleWrites = [];
+    const client = createHeroModeClient({
+      ...defaultOpts(),
+      fetch: fakeFetch,
+      onStaleWrite: (info) => staleWrites.push(info),
+    });
+
+    await client.evolveMonster({
+      learnerId: 'learner-y',
+      monsterId: 'mon-2',
+      targetStage: 2,
+      requestId: 'r',
+    }).catch(() => {});
+
+    assert.equal(staleWrites.length, 1);
+    assert.equal(staleWrites[0].learnerId, 'learner-y');
+    assert.equal(staleWrites[0].error.code, 'stale_write');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hero_insufficient_coins — model can handle
+// ---------------------------------------------------------------------------
+
+describe('hero-client camp commands — insufficient coins', () => {
+  it('unlockMonster hero_insufficient_coins throws typed error', async () => {
+    const fakeFetch = mockFetch(402, { ok: false, code: 'hero_insufficient_coins', deficit: 30 });
+    const client = createHeroModeClient(defaultOpts({ fetch: fakeFetch }));
+
+    const err = await client.unlockMonster({
+      learnerId: 'l', monsterId: 'm', requestId: 'r',
+    }).catch(e => e);
+
+    assert.ok(err instanceof HeroModeClientError);
+    assert.equal(err.code, 'hero_insufficient_coins');
+    assert.equal(err.payload.deficit, 30);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Camp model — derives 6 monster cards with correct affordability
+// ---------------------------------------------------------------------------
+
+describe('buildHeroCampModel — monster cards', () => {
+  it('derives 6 monsters from read model with correct affordability', () => {
+    const model = buildHeroCampModel(buildCampReadModel());
+
+    assert.equal(model.monsters.length, 6);
+    assert.equal(model.campEnabled, true);
+    assert.equal(model.hasAffordableAction, true);
+  });
+
+  it('derives correct actionLabel for each state', () => {
+    const model = buildHeroCampModel(buildCampReadModel());
+    const [frostclaw, emberfin, thornveil] = model.monsters;
+
+    // owned, not fully grown → grow label
+    assert.equal(frostclaw.actionLabel, 'Use 50 Hero Coins to grow');
+    // fully grown
+    assert.equal(emberfin.actionLabel, 'Fully grown');
+    // not owned → invite label
+    assert.equal(thornveil.actionLabel, 'Use 40 Hero Coins to invite');
+  });
+
+  it('derives correct statusLabel for each state', () => {
+    const model = buildHeroCampModel(buildCampReadModel());
+    const [frostclaw, emberfin, thornveil] = model.monsters;
+
+    assert.equal(frostclaw.statusLabel, 'Stage 2');
+    assert.equal(emberfin.statusLabel, 'Fully grown');
+    assert.equal(thornveil.statusLabel, 'Not yet invited');
+  });
+
+  it('derives correct costLabel', () => {
+    const model = buildHeroCampModel(buildCampReadModel());
+    const [frostclaw, emberfin, thornveil] = model.monsters;
+
+    assert.equal(frostclaw.costLabel, '50 Hero Coins');
+    assert.equal(emberfin.costLabel, null);
+    assert.equal(thornveil.costLabel, '40 Hero Coins');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Camp model — shows balance from read model
+// ---------------------------------------------------------------------------
+
+describe('buildHeroCampModel — balance', () => {
+  it('shows balance from read model camp block', () => {
+    const model = buildHeroCampModel(buildCampReadModel({ balance: 275 }));
+
+    assert.equal(model.balance, 275);
+    assert.equal(model.balanceLabel, '275 Hero Coins');
+  });
+
+  it('defaults balance to 0 when missing', () => {
+    const readModel = { camp: { enabled: true, monsters: [] } };
+    const model = buildHeroCampModel(readModel);
+
+    assert.equal(model.balance, 0);
+    assert.equal(model.balanceLabel, '0 Hero Coins');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Camp disabled → campEnabled false, no monster cards
+// ---------------------------------------------------------------------------
+
+describe('buildHeroCampModel — disabled', () => {
+  it('returns empty model when camp is not enabled', () => {
+    const model = buildHeroCampModel({ camp: { enabled: false } });
+
+    assert.equal(model.campEnabled, false);
+    assert.equal(model.monsters.length, 0);
+    assert.equal(model.balance, 0);
+    assert.equal(model.insufficientBalanceMessage, null);
+  });
+
+  it('returns empty model when readModel is null', () => {
+    const model = buildHeroCampModel(null);
+
+    assert.equal(model.campEnabled, false);
+    assert.equal(model.monsters.length, 0);
+  });
+
+  it('returns empty model when camp block is missing', () => {
+    const model = buildHeroCampModel({});
+
+    assert.equal(model.campEnabled, false);
+    assert.equal(model.monsters.length, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Client methods never include forbidden fields in request body
+// ---------------------------------------------------------------------------
+
+describe('hero-client camp commands — forbidden fields', () => {
+  it('unlockMonster body never includes forbidden fields even if caller passes them', async () => {
+    const fakeFetch = mockFetch(200, { ok: true });
+    const client = createHeroModeClient({ ...defaultOpts(), fetch: fakeFetch });
+
+    // Attempt to sneak forbidden fields via the options object
+    await client.unlockMonster({
+      learnerId: 'l',
+      monsterId: 'm',
+      requestId: 'r',
+      cost: 99,        // should be ignored
+      amount: 100,     // should be ignored
+      balance: 500,    // should be ignored
+    });
+
+    const body = JSON.parse(fakeFetch.calls[0].init.body);
+    for (const field of FORBIDDEN_FIELDS) {
+      assert.ok(!(field in body), `body must not include ${field}`);
+    }
+  });
+
+  it('evolveMonster body never includes forbidden fields even if caller passes them', async () => {
+    const fakeFetch = mockFetch(200, { ok: true });
+    const client = createHeroModeClient({ ...defaultOpts(), fetch: fakeFetch });
+
+    await client.evolveMonster({
+      learnerId: 'l',
+      monsterId: 'm',
+      targetStage: 2,
+      requestId: 'r',
+      cost: 99,
+      ledgerEntryId: 'fake-id',
+    });
+
+    const body = JSON.parse(fakeFetch.calls[0].init.body);
+    for (const field of FORBIDDEN_FIELDS) {
+      assert.ok(!(field in body), `body must not include ${field}`);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hero-monster-assets.js does not import from shared/ or worker/
+// ---------------------------------------------------------------------------
+
+describe('hero-monster-assets — no shared/worker imports', () => {
+  it('module exports expected functions without shared/worker dependencies', async () => {
+    // The fact we imported successfully at the top of this file proves it
+    // does not depend on shared/ or worker/ code.
+    assert.equal(typeof getHeroMonsterAssetSrc, 'function');
+    assert.equal(typeof hasHeroMonsterAsset, 'function');
+  });
+
+  it('getHeroMonsterAssetSrc returns correct structure', () => {
+    const result = getHeroMonsterAssetSrc('bracehart', 2, 'b1');
+
+    assert.equal(result.key, 'bracehart-b1-2');
+    assert.equal(result.src, './assets/monsters/bracehart-b1-2/640.webp');
+    assert.equal(result.fallback, './assets/monsters/bracehart-b1-0/640.webp');
+    assert.ok(result.srcSet.includes('bracehart-b1-2/320.webp 320w'));
+    assert.ok(result.srcSet.includes('bracehart-b1-2/1280.webp 1280w'));
+  });
+
+  it('hasHeroMonsterAsset returns true for valid monsterId', () => {
+    assert.equal(hasHeroMonsterAsset('bracehart', 1, 'b1'), true);
+  });
+
+  it('hasHeroMonsterAsset returns false for empty monsterId', () => {
+    assert.equal(hasHeroMonsterAsset('', 0, 'b1'), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildInviteConfirmation — correct copy
+// ---------------------------------------------------------------------------
+
+describe('buildInviteConfirmation', () => {
+  it('produces correct confirmation when balance is sufficient', () => {
+    const monster = { displayName: 'Thornveil', inviteCost: 40 };
+    const result = buildInviteConfirmation(monster, 150);
+
+    assert.equal(result.heading, 'Use 40 Hero Coins to invite Thornveil to Hero Camp?');
+    assert.equal(result.balanceAfter, 'Your balance will be 110 Hero Coins.');
+    assert.equal(result.canConfirm, true);
+  });
+
+  it('canConfirm is false when balance is insufficient', () => {
+    const monster = { displayName: 'Glintscale', inviteCost: 200 };
+    const result = buildInviteConfirmation(monster, 50);
+
+    assert.equal(result.canConfirm, false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildGrowConfirmation — correct copy
+// ---------------------------------------------------------------------------
+
+describe('buildGrowConfirmation', () => {
+  it('produces correct confirmation when balance is sufficient', () => {
+    const monster = { displayName: 'Frostclaw', nextGrowCost: 50, nextStage: 3 };
+    const result = buildGrowConfirmation(monster, 150);
+
+    assert.equal(result.heading, 'Use 50 Hero Coins to grow Frostclaw to stage 3?');
+    assert.equal(result.balanceAfter, 'Your balance will be 100 Hero Coins.');
+    assert.equal(result.canConfirm, true);
+  });
+
+  it('canConfirm is false when balance is insufficient', () => {
+    const monster = { displayName: 'Quakeroot', nextGrowCost: 80, nextStage: 4 };
+    const result = buildGrowConfirmation(monster, 30);
+
+    assert.equal(result.canConfirm, false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Success and insufficient message builders
+// ---------------------------------------------------------------------------
+
+describe('Camp copy builders', () => {
+  it('buildInviteSuccess produces correct message', () => {
+    assert.equal(buildInviteSuccess('Thornveil'), 'Thornveil joined your Hero Camp.');
+  });
+
+  it('buildGrowSuccess produces correct message', () => {
+    assert.equal(buildGrowSuccess('Frostclaw'), 'Frostclaw grew stronger.');
+  });
+
+  it('buildInsufficientMessage produces correct message with deficit', () => {
+    assert.equal(
+      buildInsufficientMessage(30),
+      'You need 30 more Hero Coins. Complete Hero Quests to add more Hero Coins.',
+    );
+  });
+});

--- a/tests/hero-p5-camp-commands.test.js
+++ b/tests/hero-p5-camp-commands.test.js
@@ -1,0 +1,330 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import {
+  resolveHeroCampCommand,
+  FORBIDDEN_CAMP_FIELDS,
+} from '../worker/src/hero/camp.js';
+
+import {
+  HERO_MONSTER_INVITE_COST,
+  HERO_MONSTER_GROW_COSTS,
+  HERO_POOL_ROSTER_VERSION,
+} from '../shared/hero/hero-pool.js';
+
+// ── Fixtures ────────────────────────────────────────────────────────────
+
+const LEARNER = 'learner-camp-cmd-001';
+const NOW = 1714400000000;
+const MONSTER = 'glossbloom';
+const MONSTER_B = 'loomrill';
+
+function makeEconomy(balance = 1000, lifetimeSpent = 0, lifetimeEarned = 1000) {
+  return { version: 1, balance, lifetimeEarned, lifetimeSpent, ledger: [], lastUpdatedAt: NOW - 1000 };
+}
+
+function makeEmptyPool() {
+  return {
+    version: 1,
+    rosterVersion: HERO_POOL_ROSTER_VERSION,
+    selectedMonsterId: null,
+    monsters: {},
+    recentActions: [],
+    lastUpdatedAt: null,
+  };
+}
+
+function makePoolWithOwned(monsterId, stage = 0, branch = 'b1') {
+  return {
+    version: 1,
+    rosterVersion: HERO_POOL_ROSTER_VERSION,
+    selectedMonsterId: null,
+    monsters: {
+      [monsterId]: {
+        monsterId,
+        owned: true,
+        stage,
+        branch,
+        investedCoins: HERO_MONSTER_INVITE_COST,
+        invitedAt: NOW - 5000,
+        lastGrownAt: null,
+        lastLedgerEntryId: 'prev-entry',
+      },
+    },
+    recentActions: [],
+    lastUpdatedAt: NOW - 1000,
+  };
+}
+
+function makeHeroState(economyOverride, poolOverride) {
+  return {
+    version: 3,
+    economy: economyOverride || makeEconomy(),
+    heroPool: poolOverride || makeEmptyPool(),
+    daily: { dateKey: '2026-04-29', status: 'active', tasks: {}, effortCompleted: 0, effortPlanned: 3 },
+    recentClaims: [],
+  };
+}
+
+// ── Feature flag gating tests ──────────────────────────────────────────
+
+describe('P5-U6 Camp commands — route-level gating', () => {
+  describe('Feature flag checks', () => {
+    it('HERO_MODE_CAMP_ENABLED = false → returns hero_camp_disabled', () => {
+      // Simulates what the route handler does before calling resolveHeroCampCommand
+      const env = {
+        HERO_MODE_CAMP_ENABLED: 'false',
+        HERO_MODE_ECONOMY_ENABLED: 'true',
+        HERO_MODE_CHILD_UI_ENABLED: 'true',
+      };
+      const flagEnabled = (v) => ['1', 'true', 'yes', 'on'].includes(String(v || '').trim().toLowerCase());
+
+      // Gate 1
+      if (!flagEnabled(env.HERO_MODE_CAMP_ENABLED)) {
+        const response = { ok: false, error: { code: 'hero_camp_disabled', message: 'Hero Camp is not enabled' } };
+        assert.equal(response.error.code, 'hero_camp_disabled');
+        return;
+      }
+      assert.fail('Should have returned disabled');
+    });
+
+    it('HERO_MODE_CAMP_ENABLED = true + ECONOMY off → returns hero_camp_misconfigured', () => {
+      const env = {
+        HERO_MODE_CAMP_ENABLED: 'true',
+        HERO_MODE_ECONOMY_ENABLED: 'false',
+        HERO_MODE_CHILD_UI_ENABLED: 'true',
+      };
+      const flagEnabled = (v) => ['1', 'true', 'yes', 'on'].includes(String(v || '').trim().toLowerCase());
+
+      assert.ok(flagEnabled(env.HERO_MODE_CAMP_ENABLED), 'camp should be enabled');
+      assert.ok(!flagEnabled(env.HERO_MODE_ECONOMY_ENABLED), 'economy should be disabled');
+      // Gate 2 triggers
+      const response = { ok: false, error: { code: 'hero_camp_misconfigured', message: 'Hero Camp requires economy to be enabled' } };
+      assert.equal(response.error.code, 'hero_camp_misconfigured');
+    });
+
+    it('HERO_MODE_CAMP_ENABLED = true + ECONOMY on + CHILD_UI off → returns hero_camp_disabled', () => {
+      const env = {
+        HERO_MODE_CAMP_ENABLED: 'true',
+        HERO_MODE_ECONOMY_ENABLED: 'true',
+        HERO_MODE_CHILD_UI_ENABLED: 'false',
+      };
+      const flagEnabled = (v) => ['1', 'true', 'yes', 'on'].includes(String(v || '').trim().toLowerCase());
+
+      assert.ok(flagEnabled(env.HERO_MODE_CAMP_ENABLED));
+      assert.ok(flagEnabled(env.HERO_MODE_ECONOMY_ENABLED));
+      assert.ok(!flagEnabled(env.HERO_MODE_CHILD_UI_ENABLED));
+      // Gate 3 triggers
+      const response = { ok: false, error: { code: 'hero_camp_disabled', message: 'Hero Camp requires child UI to be enabled' } };
+      assert.equal(response.error.code, 'hero_camp_disabled');
+    });
+
+    it('flag values read correctly — string "true" enables, "false" disables', () => {
+      const flagEnabled = (v) => ['1', 'true', 'yes', 'on'].includes(String(v || '').trim().toLowerCase());
+      assert.ok(flagEnabled('true'));
+      assert.ok(flagEnabled('1'));
+      assert.ok(flagEnabled('yes'));
+      assert.ok(flagEnabled('on'));
+      assert.ok(!flagEnabled('false'));
+      assert.ok(!flagEnabled('0'));
+      assert.ok(!flagEnabled(''));
+      assert.ok(!flagEnabled(undefined));
+      assert.ok(!flagEnabled(null));
+    });
+  });
+
+  describe('Resolver wiring — resolveHeroCampCommand called with correct parameters', () => {
+    it('unlock-monster is dispatched to resolver and returns correct shape on success', () => {
+      const heroState = makeHeroState(makeEconomy(500), makeEmptyPool());
+      const body = { command: 'unlock-monster', monsterId: MONSTER, branch: 'b1' };
+      const result = resolveHeroCampCommand({
+        command: 'unlock-monster',
+        body,
+        heroState,
+        learnerId: LEARNER,
+        rosterVersion: HERO_POOL_ROSTER_VERSION,
+        nowTs: NOW,
+      });
+
+      assert.ok(result.ok, `Expected ok: true, got: ${JSON.stringify(result)}`);
+      assert.ok(result.intent, 'Must have intent for mutation');
+      assert.ok(result.heroCampAction);
+      assert.equal(result.heroCampAction.status, 'invited');
+      assert.equal(result.heroCampAction.learnerId, LEARNER);
+      assert.equal(result.heroCampAction.monsterId, MONSTER);
+      assert.equal(result.heroCampAction.branch, 'b1');
+      assert.equal(typeof result.heroCampAction.cost, 'number');
+      assert.equal(typeof result.heroCampAction.coinBalance, 'number');
+      assert.equal(typeof result.heroCampAction.ledgerEntryId, 'string');
+    });
+
+    it('evolve-monster is dispatched to resolver and returns correct shape on success', () => {
+      const heroState = makeHeroState(makeEconomy(500), makePoolWithOwned(MONSTER, 0, 'b1'));
+      const body = { command: 'evolve-monster', monsterId: MONSTER, targetStage: 1 };
+      const result = resolveHeroCampCommand({
+        command: 'evolve-monster',
+        body,
+        heroState,
+        learnerId: LEARNER,
+        rosterVersion: HERO_POOL_ROSTER_VERSION,
+        nowTs: NOW,
+      });
+
+      assert.ok(result.ok, `Expected ok: true, got: ${JSON.stringify(result)}`);
+      assert.ok(result.intent, 'Must have intent for mutation');
+      assert.ok(result.heroCampAction);
+      assert.equal(result.heroCampAction.status, 'grown');
+      assert.equal(result.heroCampAction.learnerId, LEARNER);
+      assert.equal(result.heroCampAction.monsterId, MONSTER);
+      assert.equal(typeof result.heroCampAction.cost, 'number');
+      assert.equal(typeof result.heroCampAction.coinBalance, 'number');
+      assert.equal(typeof result.heroCampAction.ledgerEntryId, 'string');
+    });
+
+    it('success response includes expected fields: status, cost, coinBalance, ledgerEntryId', () => {
+      const heroState = makeHeroState(makeEconomy(500), makeEmptyPool());
+      const body = { command: 'unlock-monster', monsterId: MONSTER, branch: 'b1' };
+      const result = resolveHeroCampCommand({
+        command: 'unlock-monster',
+        body,
+        heroState,
+        learnerId: LEARNER,
+        rosterVersion: HERO_POOL_ROSTER_VERSION,
+        nowTs: NOW,
+      });
+
+      assert.ok(result.ok);
+      const action = result.heroCampAction;
+      assert.ok('status' in action, 'response must include status');
+      assert.ok('cost' in action, 'response must include cost');
+      assert.ok('coinBalance' in action, 'response must include coinBalance');
+      assert.ok('ledgerEntryId' in action, 'response must include ledgerEntryId');
+      assert.ok('coinsUsed' in action, 'response must include coinsUsed');
+    });
+  });
+
+  describe('Idempotent responses — already-owned / already-stage skip mutation', () => {
+    it('already-owned returns 200 without entering mutation (no intent property)', () => {
+      const heroState = makeHeroState(makeEconomy(500), makePoolWithOwned(MONSTER, 0, 'b1'));
+      const body = { command: 'unlock-monster', monsterId: MONSTER, branch: 'b1' };
+      const result = resolveHeroCampCommand({
+        command: 'unlock-monster',
+        body,
+        heroState,
+        learnerId: LEARNER,
+        rosterVersion: HERO_POOL_ROSTER_VERSION,
+        nowTs: NOW,
+      });
+
+      assert.ok(result.ok);
+      assert.equal(result.heroCampAction.status, 'already-owned');
+      // No intent means no mutation path is entered
+      assert.equal(result.intent, undefined);
+      assert.ok(result.heroCampAction);
+      assert.equal(result.heroCampAction.cost, 0);
+      assert.equal(result.heroCampAction.coinsUsed, 0);
+    });
+
+    it('already-stage returns 200 without entering mutation (no intent property)', () => {
+      // Monster at stage 1, requesting evolve to stage 1 (already there)
+      const pool = makePoolWithOwned(MONSTER, 1, 'b1');
+      const heroState = makeHeroState(makeEconomy(500), pool);
+      const body = { command: 'evolve-monster', monsterId: MONSTER, targetStage: 1 };
+      const result = resolveHeroCampCommand({
+        command: 'evolve-monster',
+        body,
+        heroState,
+        learnerId: LEARNER,
+        rosterVersion: HERO_POOL_ROSTER_VERSION,
+        nowTs: NOW,
+      });
+
+      assert.ok(result.ok);
+      assert.equal(result.heroCampAction.status, 'already-stage');
+      // No intent means no mutation path is entered
+      assert.equal(result.intent, undefined);
+      assert.ok(result.heroCampAction);
+      assert.equal(result.heroCampAction.cost, 0);
+      assert.equal(result.heroCampAction.coinsUsed, 0);
+    });
+  });
+
+  describe('Error responses', () => {
+    it('unsupported camp command returns hero_camp_disabled', () => {
+      const heroState = makeHeroState();
+      const result = resolveHeroCampCommand({
+        command: 'fly-to-moon',
+        body: { command: 'fly-to-moon' },
+        heroState,
+        learnerId: LEARNER,
+        rosterVersion: HERO_POOL_ROSTER_VERSION,
+        nowTs: NOW,
+      });
+      assert.ok(!result.ok);
+      assert.equal(result.code, 'hero_camp_disabled');
+      assert.equal(result.httpStatus, 400);
+    });
+
+    it('insufficient coins returns hero_insufficient_coins with httpStatus 409', () => {
+      const heroState = makeHeroState(makeEconomy(0), makeEmptyPool());
+      const body = { command: 'unlock-monster', monsterId: MONSTER, branch: 'b1' };
+      const result = resolveHeroCampCommand({
+        command: 'unlock-monster',
+        body,
+        heroState,
+        learnerId: LEARNER,
+        rosterVersion: HERO_POOL_ROSTER_VERSION,
+        nowTs: NOW,
+      });
+      assert.ok(!result.ok);
+      assert.equal(result.code, 'hero_insufficient_coins');
+      assert.equal(result.httpStatus, 409);
+    });
+
+    it('forbidden client fields are rejected', () => {
+      const heroState = makeHeroState();
+      const body = { command: 'unlock-monster', monsterId: MONSTER, branch: 'b1', cost: 999 };
+      const result = resolveHeroCampCommand({
+        command: 'unlock-monster',
+        body,
+        heroState,
+        learnerId: LEARNER,
+        rosterVersion: HERO_POOL_ROSTER_VERSION,
+        nowTs: NOW,
+      });
+      assert.ok(!result.ok);
+      assert.equal(result.code, 'hero_client_field_rejected');
+    });
+  });
+});
+
+// ── Wrangler config check ──────────────────────────────────────────────
+
+describe('P5-U6 Camp — wrangler.jsonc contains HERO_MODE_CAMP_ENABLED', () => {
+  it('wrangler.jsonc has HERO_MODE_CAMP_ENABLED set to "false"', () => {
+    const raw = readFileSync(resolve(import.meta.dirname, '../wrangler.jsonc'), 'utf8');
+    assert.ok(raw.includes('"HERO_MODE_CAMP_ENABLED"'), 'Flag must exist in wrangler.jsonc');
+    assert.ok(raw.includes('"HERO_MODE_CAMP_ENABLED": "false"'), 'Flag must default to "false"');
+  });
+
+  it('worker/wrangler.example.jsonc has HERO_MODE_CAMP_ENABLED set to "false"', () => {
+    const raw = readFileSync(resolve(import.meta.dirname, '../worker/wrangler.example.jsonc'), 'utf8');
+    assert.ok(raw.includes('"HERO_MODE_CAMP_ENABLED"'), 'Flag must exist in example wrangler');
+    assert.ok(raw.includes('"HERO_MODE_CAMP_ENABLED": "false"'), 'Flag must default to "false"');
+  });
+});
+
+// ── Import path verification ───────────────────────────────────────────
+
+describe('P5-U6 Camp — import path is correct', () => {
+  it('camp.js resolver is importable and exports resolveHeroCampCommand', () => {
+    assert.equal(typeof resolveHeroCampCommand, 'function');
+  });
+
+  it('camp.js exports FORBIDDEN_CAMP_FIELDS', () => {
+    assert.ok(Array.isArray(FORBIDDEN_CAMP_FIELDS));
+    assert.ok(FORBIDDEN_CAMP_FIELDS.length > 0);
+  });
+});

--- a/tests/hero-p5-camp-commands.test.js
+++ b/tests/hero-p5-camp-commands.test.js
@@ -1,306 +1,827 @@
-import { describe, it } from 'node:test';
+// Hero Mode P5 U6 — Camp command integration tests.
+//
+// Exercises the full Worker route handler (/api/hero/command) for
+// unlock-monster and evolve-monster commands. Validates flag gating,
+// CAS mutation, receipt replay, idempotent responses, and non-regression
+// with start-task/claim-task.
+
+import test, { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
-import {
-  resolveHeroCampCommand,
-  FORBIDDEN_CAMP_FIELDS,
-} from '../worker/src/hero/camp.js';
-
+import { createApiPlatformRepositories } from '../src/platform/core/repositories/index.js';
+import { createWorkerRepositoryServer } from './helpers/worker-server.js';
 import {
   HERO_MONSTER_INVITE_COST,
   HERO_MONSTER_GROW_COSTS,
   HERO_POOL_ROSTER_VERSION,
 } from '../shared/hero/hero-pool.js';
+import { HERO_DAILY_COMPLETION_COINS } from '../shared/hero/economy.js';
+import {
+  resolveHeroCampCommand,
+  FORBIDDEN_CAMP_FIELDS,
+} from '../worker/src/hero/camp.js';
 
-// ── Fixtures ────────────────────────────────────────────────────────────
+const HERO_COMMAND_URL = 'https://repo.test/api/hero/command';
+const HERO_READ_MODEL_URL = 'https://repo.test/api/hero/read-model';
 
-const LEARNER = 'learner-camp-cmd-001';
-const NOW = 1714400000000;
-const MONSTER = 'glossbloom';
-const MONSTER_B = 'loomrill';
+// ── Server factories ────────────────────────────────────────────────────
 
-function makeEconomy(balance = 1000, lifetimeSpent = 0, lifetimeEarned = 1000) {
-  return { version: 1, balance, lifetimeEarned, lifetimeSpent, ledger: [], lastUpdatedAt: NOW - 1000 };
+function createCampServer() {
+  return createWorkerRepositoryServer({
+    env: {
+      HERO_MODE_SHADOW_ENABLED: 'true',
+      HERO_MODE_LAUNCH_ENABLED: 'true',
+      HERO_MODE_CHILD_UI_ENABLED: 'true',
+      HERO_MODE_PROGRESS_ENABLED: 'true',
+      HERO_MODE_ECONOMY_ENABLED: 'true',
+      HERO_MODE_CAMP_ENABLED: 'true',
+      PUNCTUATION_SUBJECT_ENABLED: 'true',
+    },
+  });
 }
 
-function makeEmptyPool() {
-  return {
-    version: 1,
-    rosterVersion: HERO_POOL_ROSTER_VERSION,
-    selectedMonsterId: null,
-    monsters: {},
-    recentActions: [],
-    lastUpdatedAt: null,
-  };
+function createCampDisabledServer() {
+  return createWorkerRepositoryServer({
+    env: {
+      HERO_MODE_SHADOW_ENABLED: 'true',
+      HERO_MODE_LAUNCH_ENABLED: 'true',
+      HERO_MODE_CHILD_UI_ENABLED: 'true',
+      HERO_MODE_PROGRESS_ENABLED: 'true',
+      HERO_MODE_ECONOMY_ENABLED: 'true',
+      HERO_MODE_CAMP_ENABLED: 'false',
+      PUNCTUATION_SUBJECT_ENABLED: 'true',
+    },
+  });
 }
 
-function makePoolWithOwned(monsterId, stage = 0, branch = 'b1') {
-  return {
-    version: 1,
-    rosterVersion: HERO_POOL_ROSTER_VERSION,
-    selectedMonsterId: null,
-    monsters: {
-      [monsterId]: {
-        monsterId,
-        owned: true,
-        stage,
-        branch,
-        investedCoins: HERO_MONSTER_INVITE_COST,
-        invitedAt: NOW - 5000,
-        lastGrownAt: null,
-        lastLedgerEntryId: 'prev-entry',
+function createCampWithoutEconomyServer() {
+  return createWorkerRepositoryServer({
+    env: {
+      HERO_MODE_SHADOW_ENABLED: 'true',
+      HERO_MODE_LAUNCH_ENABLED: 'true',
+      HERO_MODE_CHILD_UI_ENABLED: 'true',
+      HERO_MODE_PROGRESS_ENABLED: 'true',
+      HERO_MODE_ECONOMY_ENABLED: 'false',
+      HERO_MODE_CAMP_ENABLED: 'true',
+      PUNCTUATION_SUBJECT_ENABLED: 'true',
+    },
+  });
+}
+
+// ── Fixture seeding ─────────────────────────────────────────────────────
+
+const HERO_SPELLING_DATA = {
+  stats: {
+    core: { total: 50, secure: 30, due: 10, fresh: 5, trouble: 5, attempts: 200, correct: 160, accuracy: 0.8 },
+    all: { total: 50, secure: 30, due: 10, fresh: 5, trouble: 5, attempts: 200, correct: 160, accuracy: 0.8 },
+  },
+};
+
+const HERO_PUNCTUATION_DATA = {
+  availability: { status: 'ready' },
+  stats: { total: 20, secure: 8, due: 5, fresh: 3, weak: 2, attempts: 100, correct: 75, accuracy: 75 },
+};
+
+async function seedLearner(server, accountId, learnerId) {
+  const repos = createApiPlatformRepositories({
+    baseUrl: 'https://repo.test',
+    fetch: server.fetch.bind(server),
+    authSession: server.authSessionFor(accountId),
+  });
+  await repos.hydrate();
+  repos.learners.write({
+    byId: {
+      [learnerId]: {
+        id: learnerId,
+        name: 'Camp Test Learner',
+        yearGroup: 'Y5',
+        goal: 'sats',
+        dailyMinutes: 15,
+        avatarColor: '#3E6FA8',
+        createdAt: 1,
       },
     },
-    recentActions: [],
-    lastUpdatedAt: NOW - 1000,
-  };
+    allIds: [learnerId],
+    selectedId: learnerId,
+  });
+  await repos.flush();
+
+  const now = Date.now();
+  server.DB.db.prepare(`
+    INSERT INTO child_subject_state (learner_id, subject_id, ui_json, data_json, updated_at, updated_by_account_id)
+    VALUES (?, 'spelling', '{}', ?, ?, ?)
+  `).run(learnerId, JSON.stringify(HERO_SPELLING_DATA), now, accountId);
+
+  server.DB.db.prepare(`
+    INSERT INTO child_subject_state (learner_id, subject_id, ui_json, data_json, updated_at, updated_by_account_id)
+    VALUES (?, 'punctuation', '{}', ?, ?, ?)
+  `).run(learnerId, JSON.stringify(HERO_PUNCTUATION_DATA), now, accountId);
 }
 
-function makeHeroState(economyOverride, poolOverride) {
-  return {
-    version: 3,
-    economy: economyOverride || makeEconomy(),
-    heroPool: poolOverride || makeEmptyPool(),
-    daily: { dateKey: '2026-04-29', status: 'active', tasks: {}, effortCompleted: 0, effortPlanned: 3 },
-    recentClaims: [],
-  };
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+function getLearnerRevision(server, accountId = 'adult-a') {
+  const row = server.DB.db.prepare(
+    `SELECT lp.state_revision FROM learner_profiles lp
+     JOIN account_learner_memberships alm ON alm.learner_id = lp.id
+     WHERE alm.account_id = ?`,
+  ).get(accountId);
+  return row?.state_revision ?? 0;
 }
 
-// ── Feature flag gating tests ──────────────────────────────────────────
-
-describe('P5-U6 Camp commands — route-level gating', () => {
-  describe('Feature flag checks', () => {
-    it('HERO_MODE_CAMP_ENABLED = false → returns hero_camp_disabled', () => {
-      // Simulates what the route handler does before calling resolveHeroCampCommand
-      const env = {
-        HERO_MODE_CAMP_ENABLED: 'false',
-        HERO_MODE_ECONOMY_ENABLED: 'true',
-        HERO_MODE_CHILD_UI_ENABLED: 'true',
-      };
-      const flagEnabled = (v) => ['1', 'true', 'yes', 'on'].includes(String(v || '').trim().toLowerCase());
-
-      // Gate 1
-      if (!flagEnabled(env.HERO_MODE_CAMP_ENABLED)) {
-        const response = { ok: false, error: { code: 'hero_camp_disabled', message: 'Hero Camp is not enabled' } };
-        assert.equal(response.error.code, 'hero_camp_disabled');
-        return;
-      }
-      assert.fail('Should have returned disabled');
-    });
-
-    it('HERO_MODE_CAMP_ENABLED = true + ECONOMY off → returns hero_camp_misconfigured', () => {
-      const env = {
-        HERO_MODE_CAMP_ENABLED: 'true',
-        HERO_MODE_ECONOMY_ENABLED: 'false',
-        HERO_MODE_CHILD_UI_ENABLED: 'true',
-      };
-      const flagEnabled = (v) => ['1', 'true', 'yes', 'on'].includes(String(v || '').trim().toLowerCase());
-
-      assert.ok(flagEnabled(env.HERO_MODE_CAMP_ENABLED), 'camp should be enabled');
-      assert.ok(!flagEnabled(env.HERO_MODE_ECONOMY_ENABLED), 'economy should be disabled');
-      // Gate 2 triggers
-      const response = { ok: false, error: { code: 'hero_camp_misconfigured', message: 'Hero Camp requires economy to be enabled' } };
-      assert.equal(response.error.code, 'hero_camp_misconfigured');
-    });
-
-    it('HERO_MODE_CAMP_ENABLED = true + ECONOMY on + CHILD_UI off → returns hero_camp_disabled', () => {
-      const env = {
-        HERO_MODE_CAMP_ENABLED: 'true',
-        HERO_MODE_ECONOMY_ENABLED: 'true',
-        HERO_MODE_CHILD_UI_ENABLED: 'false',
-      };
-      const flagEnabled = (v) => ['1', 'true', 'yes', 'on'].includes(String(v || '').trim().toLowerCase());
-
-      assert.ok(flagEnabled(env.HERO_MODE_CAMP_ENABLED));
-      assert.ok(flagEnabled(env.HERO_MODE_ECONOMY_ENABLED));
-      assert.ok(!flagEnabled(env.HERO_MODE_CHILD_UI_ENABLED));
-      // Gate 3 triggers
-      const response = { ok: false, error: { code: 'hero_camp_disabled', message: 'Hero Camp requires child UI to be enabled' } };
-      assert.equal(response.error.code, 'hero_camp_disabled');
-    });
-
-    it('flag values read correctly — string "true" enables, "false" disables', () => {
-      const flagEnabled = (v) => ['1', 'true', 'yes', 'on'].includes(String(v || '').trim().toLowerCase());
-      assert.ok(flagEnabled('true'));
-      assert.ok(flagEnabled('1'));
-      assert.ok(flagEnabled('yes'));
-      assert.ok(flagEnabled('on'));
-      assert.ok(!flagEnabled('false'));
-      assert.ok(!flagEnabled('0'));
-      assert.ok(!flagEnabled(''));
-      assert.ok(!flagEnabled(undefined));
-      assert.ok(!flagEnabled(null));
-    });
+async function postHeroCommand(server, body, accountId = 'adult-a') {
+  return server.fetchAs(accountId, HERO_COMMAND_URL, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
   });
+}
 
-  describe('Resolver wiring — resolveHeroCampCommand called with correct parameters', () => {
-    it('unlock-monster is dispatched to resolver and returns correct shape on success', () => {
-      const heroState = makeHeroState(makeEconomy(500), makeEmptyPool());
-      const body = { command: 'unlock-monster', monsterId: MONSTER, branch: 'b1' };
-      const result = resolveHeroCampCommand({
-        command: 'unlock-monster',
-        body,
-        heroState,
-        learnerId: LEARNER,
-        rosterVersion: HERO_POOL_ROSTER_VERSION,
-        nowTs: NOW,
-      });
+function getHeroProgressRow(server, learnerId) {
+  const row = server.DB.db.prepare(
+    `SELECT state_json, updated_at FROM child_game_state
+     WHERE learner_id = ? AND system_id = 'hero-mode'`,
+  ).get(learnerId);
+  if (!row) return null;
+  return JSON.parse(row.state_json);
+}
 
-      assert.ok(result.ok, `Expected ok: true, got: ${JSON.stringify(result)}`);
-      assert.ok(result.intent, 'Must have intent for mutation');
-      assert.ok(result.heroCampAction);
-      assert.equal(result.heroCampAction.status, 'invited');
-      assert.equal(result.heroCampAction.learnerId, LEARNER);
-      assert.equal(result.heroCampAction.monsterId, MONSTER);
-      assert.equal(result.heroCampAction.branch, 'b1');
-      assert.equal(typeof result.heroCampAction.cost, 'number');
-      assert.equal(typeof result.heroCampAction.coinBalance, 'number');
-      assert.equal(typeof result.heroCampAction.ledgerEntryId, 'string');
-    });
+function getHeroEvents(server) {
+  return server.DB.db.prepare(
+    `SELECT id, learner_id, event_type, event_json, created_at FROM event_log WHERE event_type LIKE 'hero.%' ORDER BY created_at`,
+  ).all();
+}
 
-    it('evolve-monster is dispatched to resolver and returns correct shape on success', () => {
-      const heroState = makeHeroState(makeEconomy(500), makePoolWithOwned(MONSTER, 0, 'b1'));
-      const body = { command: 'evolve-monster', monsterId: MONSTER, targetStage: 1 };
-      const result = resolveHeroCampCommand({
-        command: 'evolve-monster',
-        body,
-        heroState,
-        learnerId: LEARNER,
-        rosterVersion: HERO_POOL_ROSTER_VERSION,
-        nowTs: NOW,
-      });
+/**
+ * Seeds hero progress state with a high coin balance by:
+ * 1. Running start-task to initialise daily progress
+ * 2. Directly writing a large balance into the economy state
+ * Returns the seeded balance.
+ */
+async function seedCoins(server, learnerId, accountId, targetBalance = 5000) {
+  // We must initialise the hero progress state so it exists in the DB.
+  // A start-task call does this.
+  const rmResp = await server.fetch(`${HERO_READ_MODEL_URL}?learnerId=${learnerId}`);
+  const rmPayload = await rmResp.json();
+  assert.equal(rmResp.status, 200, `Read model must succeed: ${JSON.stringify(rmPayload)}`);
 
-      assert.ok(result.ok, `Expected ok: true, got: ${JSON.stringify(result)}`);
-      assert.ok(result.intent, 'Must have intent for mutation');
-      assert.ok(result.heroCampAction);
-      assert.equal(result.heroCampAction.status, 'grown');
-      assert.equal(result.heroCampAction.learnerId, LEARNER);
-      assert.equal(result.heroCampAction.monsterId, MONSTER);
-      assert.equal(typeof result.heroCampAction.cost, 'number');
-      assert.equal(typeof result.heroCampAction.coinBalance, 'number');
-      assert.equal(typeof result.heroCampAction.ledgerEntryId, 'string');
-    });
+  const quest = rmPayload.hero.dailyQuest;
+  const fingerprint = rmPayload.hero.questFingerprint;
+  const allTasks = quest.tasks.filter(t => t.launchStatus === 'launchable');
+  if (allTasks.length < 1) throw new Error('Fixture must produce at least 1 launchable task');
 
-    it('success response includes expected fields: status, cost, coinBalance, ledgerEntryId', () => {
-      const heroState = makeHeroState(makeEconomy(500), makeEmptyPool());
-      const body = { command: 'unlock-monster', monsterId: MONSTER, branch: 'b1' };
-      const result = resolveHeroCampCommand({
-        command: 'unlock-monster',
-        body,
-        heroState,
-        learnerId: LEARNER,
-        rosterVersion: HERO_POOL_ROSTER_VERSION,
-        nowTs: NOW,
-      });
+  // Launch first task to initialise progress state
+  const rev = getLearnerRevision(server, accountId);
+  await postHeroCommand(server, {
+    command: 'start-task',
+    learnerId,
+    questId: quest.questId,
+    questFingerprint: fingerprint,
+    taskId: allTasks[0].taskId,
+    requestId: `camp-seed-start-${Date.now()}`,
+    expectedLearnerRevision: rev,
+  }, accountId);
 
-      assert.ok(result.ok);
-      const action = result.heroCampAction;
-      assert.ok('status' in action, 'response must include status');
-      assert.ok('cost' in action, 'response must include cost');
-      assert.ok('coinBalance' in action, 'response must include coinBalance');
-      assert.ok('ledgerEntryId' in action, 'response must include ledgerEntryId');
-      assert.ok('coinsUsed' in action, 'response must include coinsUsed');
-    });
-  });
+  // Now directly inject a high balance into the persisted state
+  const progress = getHeroProgressRow(server, learnerId);
+  if (!progress) throw new Error('Hero progress state must exist after start-task');
+  progress.economy = {
+    ...progress.economy,
+    version: 1,
+    balance: targetBalance,
+    lifetimeEarned: targetBalance,
+    lifetimeSpent: 0,
+    ledger: [{
+      entryId: 'seed-coins-entry',
+      idempotencyKey: 'seed-coins-key',
+      type: 'test-seed',
+      amount: targetBalance,
+      balanceAfter: targetBalance,
+      learnerId,
+      source: { kind: 'test-seed' },
+      createdAt: Date.now(),
+      createdBy: 'test',
+    }],
+    lastUpdatedAt: Date.now(),
+  };
+  server.DB.db.prepare(`
+    UPDATE child_game_state SET state_json = ? WHERE learner_id = ? AND system_id = 'hero-mode'
+  `).run(JSON.stringify(progress), learnerId);
 
-  describe('Idempotent responses — already-owned / already-stage skip mutation', () => {
-    it('already-owned returns 200 without entering mutation (no intent property)', () => {
-      const heroState = makeHeroState(makeEconomy(500), makePoolWithOwned(MONSTER, 0, 'b1'));
-      const body = { command: 'unlock-monster', monsterId: MONSTER, branch: 'b1' };
-      const result = resolveHeroCampCommand({
-        command: 'unlock-monster',
-        body,
-        heroState,
-        learnerId: LEARNER,
-        rosterVersion: HERO_POOL_ROSTER_VERSION,
-        nowTs: NOW,
-      });
+  return targetBalance;
+}
 
-      assert.ok(result.ok);
-      assert.equal(result.heroCampAction.status, 'already-owned');
-      // No intent means no mutation path is entered
-      assert.equal(result.intent, undefined);
-      assert.ok(result.heroCampAction);
-      assert.equal(result.heroCampAction.cost, 0);
-      assert.equal(result.heroCampAction.coinsUsed, 0);
-    });
+// ── 1. unlock-monster happy path ─────────────────────────────────────────
 
-    it('already-stage returns 200 without entering mutation (no intent property)', () => {
-      // Monster at stage 1, requesting evolve to stage 1 (already there)
-      const pool = makePoolWithOwned(MONSTER, 1, 'b1');
-      const heroState = makeHeroState(makeEconomy(500), pool);
-      const body = { command: 'evolve-monster', monsterId: MONSTER, targetStage: 1 };
-      const result = resolveHeroCampCommand({
-        command: 'evolve-monster',
-        body,
-        heroState,
-        learnerId: LEARNER,
-        rosterVersion: HERO_POOL_ROSTER_VERSION,
-        nowTs: NOW,
-      });
+test('P5-U6: unlock-monster happy path — debits coins, creates owned monster at stage 0', async () => {
+  const server = createCampServer();
+  const learnerId = 'learner-a';
+  const accountId = 'adult-a';
+  await seedLearner(server, accountId, learnerId);
 
-      assert.ok(result.ok);
-      assert.equal(result.heroCampAction.status, 'already-stage');
-      // No intent means no mutation path is entered
-      assert.equal(result.intent, undefined);
-      assert.ok(result.heroCampAction);
-      assert.equal(result.heroCampAction.cost, 0);
-      assert.equal(result.heroCampAction.coinsUsed, 0);
-    });
-  });
+  const balance = await seedCoins(server, learnerId, accountId);
+  assert.ok(balance >= HERO_MONSTER_INVITE_COST, `Need at least ${HERO_MONSTER_INVITE_COST} coins, have ${balance}`);
 
-  describe('Error responses', () => {
-    it('unsupported camp command returns hero_camp_disabled', () => {
-      const heroState = makeHeroState();
-      const result = resolveHeroCampCommand({
-        command: 'fly-to-moon',
-        body: { command: 'fly-to-moon' },
-        heroState,
-        learnerId: LEARNER,
-        rosterVersion: HERO_POOL_ROSTER_VERSION,
-        nowTs: NOW,
-      });
-      assert.ok(!result.ok);
-      assert.equal(result.code, 'hero_camp_disabled');
-      assert.equal(result.httpStatus, 400);
-    });
+  const revision = getLearnerRevision(server, accountId);
+  const requestId = `camp-unlock-${Date.now()}`;
+  const response = await postHeroCommand(server, {
+    command: 'unlock-monster',
+    learnerId,
+    monsterId: 'glossbloom',
+    branch: 'b1',
+    requestId,
+    expectedLearnerRevision: revision,
+  }, accountId);
+  const payload = await response.json();
 
-    it('insufficient coins returns hero_insufficient_coins with httpStatus 409', () => {
-      const heroState = makeHeroState(makeEconomy(0), makeEmptyPool());
-      const body = { command: 'unlock-monster', monsterId: MONSTER, branch: 'b1' };
-      const result = resolveHeroCampCommand({
-        command: 'unlock-monster',
-        body,
-        heroState,
-        learnerId: LEARNER,
-        rosterVersion: HERO_POOL_ROSTER_VERSION,
-        nowTs: NOW,
-      });
-      assert.ok(!result.ok);
-      assert.equal(result.code, 'hero_insufficient_coins');
-      assert.equal(result.httpStatus, 409);
-    });
+  assert.equal(response.status, 200, `Expected 200, got ${response.status}: ${JSON.stringify(payload)}`);
+  assert.equal(payload.ok, true);
+  assert.ok(payload.heroCampAction, 'Response must include heroCampAction');
+  assert.equal(payload.heroCampAction.status, 'invited');
+  assert.equal(payload.heroCampAction.monsterId, 'glossbloom');
+  assert.equal(payload.heroCampAction.branch, 'b1');
+  assert.equal(payload.heroCampAction.cost, HERO_MONSTER_INVITE_COST);
+  assert.equal(payload.heroCampAction.coinsUsed, HERO_MONSTER_INVITE_COST);
+  assert.equal(payload.heroCampAction.coinBalance, balance - HERO_MONSTER_INVITE_COST);
+  assert.equal(typeof payload.heroCampAction.ledgerEntryId, 'string');
+  assert.ok(payload.mutation, 'Response must include mutation metadata');
 
-    it('forbidden client fields are rejected', () => {
-      const heroState = makeHeroState();
-      const body = { command: 'unlock-monster', monsterId: MONSTER, branch: 'b1', cost: 999 };
-      const result = resolveHeroCampCommand({
-        command: 'unlock-monster',
-        body,
-        heroState,
-        learnerId: LEARNER,
-        rosterVersion: HERO_POOL_ROSTER_VERSION,
-        nowTs: NOW,
-      });
-      assert.ok(!result.ok);
-      assert.equal(result.code, 'hero_client_field_rejected');
-    });
-  });
+  // Verify persisted state
+  const progress = getHeroProgressRow(server, learnerId);
+  assert.equal(progress.economy.balance, balance - HERO_MONSTER_INVITE_COST);
+  assert.equal(progress.heroPool.monsters.glossbloom.owned, true);
+  assert.equal(progress.heroPool.monsters.glossbloom.stage, 0);
+  assert.equal(progress.heroPool.monsters.glossbloom.branch, 'b1');
+
+  // Verify event_log
+  const events = getHeroEvents(server);
+  const campEvent = events.find(e => e.event_type === 'hero.camp.monster.invited');
+  assert.ok(campEvent, 'hero.camp.monster.invited event must exist in event_log');
+
+  server.close();
 });
 
-// ── Wrangler config check ──────────────────────────────────────────────
+// ── 2. evolve-monster happy path ─────────────────────────────────────────
+
+test('P5-U6: evolve-monster happy path — debits coins, advances stage', async () => {
+  const server = createCampServer();
+  const learnerId = 'learner-a';
+  const accountId = 'adult-a';
+  await seedLearner(server, accountId, learnerId);
+
+  const balance = await seedCoins(server, learnerId, accountId);
+  assert.ok(balance >= HERO_MONSTER_INVITE_COST + HERO_MONSTER_GROW_COSTS[1],
+    `Need at least ${HERO_MONSTER_INVITE_COST + HERO_MONSTER_GROW_COSTS[1]} coins, have ${balance}`);
+
+  // First unlock a monster
+  let revision = getLearnerRevision(server, accountId);
+  const unlockResp = await postHeroCommand(server, {
+    command: 'unlock-monster',
+    learnerId,
+    monsterId: 'loomrill',
+    branch: 'b2',
+    requestId: `camp-unlock-evo-${Date.now()}`,
+    expectedLearnerRevision: revision,
+  }, accountId);
+  const unlockPayload = await unlockResp.json();
+  assert.equal(unlockResp.status, 200, `Unlock must succeed: ${JSON.stringify(unlockPayload)}`);
+  const balanceAfterUnlock = unlockPayload.heroCampAction.coinBalance;
+
+  // Now evolve it to stage 1
+  revision = getLearnerRevision(server, accountId);
+  const evolveResp = await postHeroCommand(server, {
+    command: 'evolve-monster',
+    learnerId,
+    monsterId: 'loomrill',
+    targetStage: 1,
+    requestId: `camp-evolve-${Date.now()}`,
+    expectedLearnerRevision: revision,
+  }, accountId);
+  const evolvePayload = await evolveResp.json();
+
+  assert.equal(evolveResp.status, 200, `Expected 200, got ${evolveResp.status}: ${JSON.stringify(evolvePayload)}`);
+  assert.equal(evolvePayload.ok, true);
+  assert.ok(evolvePayload.heroCampAction);
+  assert.equal(evolvePayload.heroCampAction.status, 'grown');
+  assert.equal(evolvePayload.heroCampAction.monsterId, 'loomrill');
+  assert.equal(evolvePayload.heroCampAction.stageBefore, 0);
+  assert.equal(evolvePayload.heroCampAction.stageAfter, 1);
+  assert.equal(evolvePayload.heroCampAction.cost, HERO_MONSTER_GROW_COSTS[1]);
+  assert.equal(evolvePayload.heroCampAction.coinBalance, balanceAfterUnlock - HERO_MONSTER_GROW_COSTS[1]);
+  assert.ok(evolvePayload.mutation);
+
+  // Verify persisted state
+  const progress = getHeroProgressRow(server, learnerId);
+  assert.equal(progress.heroPool.monsters.loomrill.stage, 1);
+  assert.equal(progress.economy.balance, balanceAfterUnlock - HERO_MONSTER_GROW_COSTS[1]);
+
+  // Verify event_log
+  const events = getHeroEvents(server);
+  const growEvent = events.find(e => e.event_type === 'hero.camp.monster.grown');
+  assert.ok(growEvent, 'hero.camp.monster.grown event must exist in event_log');
+
+  server.close();
+});
+
+// ── 3. Same requestId on repeat — resolver idempotency prevents double debit ──
+
+test('P5-U6: same requestId on repeat — no double debit, idempotent response', async () => {
+  const server = createCampServer();
+  const learnerId = 'learner-a';
+  const accountId = 'adult-a';
+  await seedLearner(server, accountId, learnerId);
+
+  const balance = await seedCoins(server, learnerId, accountId);
+  assert.ok(balance >= HERO_MONSTER_INVITE_COST);
+
+  const revision = getLearnerRevision(server, accountId);
+  const requestId = `camp-replay-${Date.now()}`;
+
+  // First call — successfully invites the monster
+  const resp1 = await postHeroCommand(server, {
+    command: 'unlock-monster',
+    learnerId,
+    monsterId: 'mirrane',
+    branch: 'b1',
+    requestId,
+    expectedLearnerRevision: revision,
+  }, accountId);
+  const payload1 = await resp1.json();
+  assert.equal(resp1.status, 200);
+  assert.equal(payload1.ok, true);
+  assert.equal(payload1.heroCampAction.status, 'invited');
+
+  // Same requestId on retry — state already reflects ownership so resolver
+  // returns already-owned (short-circuits before mutation path). This is the
+  // camp's built-in idempotency: the pure resolver re-reads fresh state.
+  const newRevision = getLearnerRevision(server, accountId);
+  const resp2 = await postHeroCommand(server, {
+    command: 'unlock-monster',
+    learnerId,
+    monsterId: 'mirrane',
+    branch: 'b1',
+    requestId,
+    expectedLearnerRevision: newRevision,
+  }, accountId);
+  const payload2 = await resp2.json();
+  assert.equal(resp2.status, 200, `Repeat must 200: ${JSON.stringify(payload2)}`);
+  assert.equal(payload2.ok, true);
+  assert.equal(payload2.heroCampAction.status, 'already-owned');
+  assert.equal(payload2.heroCampAction.cost, 0);
+
+  // Balance must not have been debited twice
+  const progress = getHeroProgressRow(server, learnerId);
+  assert.equal(progress.economy.balance, balance - HERO_MONSTER_INVITE_COST);
+
+  server.close();
+});
+
+// ── 4. Different requestId for already-owned → no debit ──────────────────
+
+test('P5-U6: different requestId for already-owned monster → no debit, idempotent', async () => {
+  const server = createCampServer();
+  const learnerId = 'learner-a';
+  const accountId = 'adult-a';
+  await seedLearner(server, accountId, learnerId);
+
+  const balance = await seedCoins(server, learnerId, accountId);
+  assert.ok(balance >= HERO_MONSTER_INVITE_COST);
+
+  // First unlock
+  let revision = getLearnerRevision(server, accountId);
+  const resp1 = await postHeroCommand(server, {
+    command: 'unlock-monster',
+    learnerId,
+    monsterId: 'colisk',
+    branch: 'b1',
+    requestId: `camp-first-${Date.now()}`,
+    expectedLearnerRevision: revision,
+  }, accountId);
+  assert.equal(resp1.status, 200);
+
+  // Second unlock with different requestId — should be idempotent (already-owned)
+  revision = getLearnerRevision(server, accountId);
+  const resp2 = await postHeroCommand(server, {
+    command: 'unlock-monster',
+    learnerId,
+    monsterId: 'colisk',
+    branch: 'b1',
+    requestId: `camp-second-${Date.now()}`,
+    expectedLearnerRevision: revision,
+  }, accountId);
+  const payload2 = await resp2.json();
+  assert.equal(resp2.status, 200);
+  assert.equal(payload2.ok, true);
+  assert.equal(payload2.heroCampAction.status, 'already-owned');
+  assert.equal(payload2.heroCampAction.cost, 0);
+  assert.equal(payload2.heroCampAction.coinsUsed, 0);
+
+  // Balance only debited once
+  const progress = getHeroProgressRow(server, learnerId);
+  assert.equal(progress.economy.balance, balance - HERO_MONSTER_INVITE_COST);
+
+  server.close();
+});
+
+// ── 5. Different requestId for already-stage → no debit ──────────────────
+
+test('P5-U6: different requestId for already-stage → no debit, idempotent', async () => {
+  const server = createCampServer();
+  const learnerId = 'learner-a';
+  const accountId = 'adult-a';
+  await seedLearner(server, accountId, learnerId);
+
+  const balance = await seedCoins(server, learnerId, accountId);
+  const totalCost = HERO_MONSTER_INVITE_COST + HERO_MONSTER_GROW_COSTS[1];
+  assert.ok(balance >= totalCost, `Need at least ${totalCost} coins`);
+
+  // Unlock
+  let revision = getLearnerRevision(server, accountId);
+  await postHeroCommand(server, {
+    command: 'unlock-monster',
+    learnerId,
+    monsterId: 'hyphang',
+    branch: 'b2',
+    requestId: `camp-stage-unlock-${Date.now()}`,
+    expectedLearnerRevision: revision,
+  }, accountId);
+
+  // Evolve to stage 1
+  revision = getLearnerRevision(server, accountId);
+  await postHeroCommand(server, {
+    command: 'evolve-monster',
+    learnerId,
+    monsterId: 'hyphang',
+    targetStage: 1,
+    requestId: `camp-stage-evolve-${Date.now()}`,
+    expectedLearnerRevision: revision,
+  }, accountId);
+
+  // Evolve again to stage 1 with different requestId — should be idempotent
+  revision = getLearnerRevision(server, accountId);
+  const resp = await postHeroCommand(server, {
+    command: 'evolve-monster',
+    learnerId,
+    monsterId: 'hyphang',
+    targetStage: 1,
+    requestId: `camp-stage-dup-${Date.now()}`,
+    expectedLearnerRevision: revision,
+  }, accountId);
+  const payload = await resp.json();
+  assert.equal(resp.status, 200);
+  assert.equal(payload.ok, true);
+  assert.equal(payload.heroCampAction.status, 'already-stage');
+  assert.equal(payload.heroCampAction.cost, 0);
+  assert.equal(payload.heroCampAction.coinsUsed, 0);
+
+  // Balance debited exactly invite + grow(1)
+  const progress = getHeroProgressRow(server, learnerId);
+  assert.equal(progress.economy.balance, balance - totalCost);
+
+  server.close();
+});
+
+// ── 6. Camp disabled → 409 hero_camp_disabled ────────────────────────────
+
+test('P5-U6: Camp off → 409 hero_camp_disabled', async () => {
+  const server = createCampDisabledServer();
+  const learnerId = 'learner-a';
+  const accountId = 'adult-a';
+  await seedLearner(server, accountId, learnerId);
+
+  const revision = getLearnerRevision(server, accountId);
+  const resp = await postHeroCommand(server, {
+    command: 'unlock-monster',
+    learnerId,
+    monsterId: 'glossbloom',
+    branch: 'b1',
+    requestId: `camp-off-${Date.now()}`,
+    expectedLearnerRevision: revision,
+  }, accountId);
+  const payload = await resp.json();
+
+  assert.equal(resp.status, 409);
+  assert.equal(payload.ok, false);
+  assert.equal(payload.error.code, 'hero_camp_disabled');
+
+  server.close();
+});
+
+// ── 7. Camp on + Economy off → 409 hero_camp_misconfigured ───────────────
+
+test('P5-U6: Camp on, Economy off → 409 hero_camp_misconfigured', async () => {
+  const server = createCampWithoutEconomyServer();
+  const learnerId = 'learner-a';
+  const accountId = 'adult-a';
+  await seedLearner(server, accountId, learnerId);
+
+  const revision = getLearnerRevision(server, accountId);
+  const resp = await postHeroCommand(server, {
+    command: 'unlock-monster',
+    learnerId,
+    monsterId: 'glossbloom',
+    branch: 'b1',
+    requestId: `camp-noeco-${Date.now()}`,
+    expectedLearnerRevision: revision,
+  }, accountId);
+  const payload = await resp.json();
+
+  assert.equal(resp.status, 409);
+  assert.equal(payload.ok, false);
+  assert.equal(payload.error.code, 'hero_camp_misconfigured');
+
+  server.close();
+});
+
+// ── 8. Stale revision → 409 stale_write ─────────────────────────────────
+
+test('P5-U6: stale revision → 409 stale_write', async () => {
+  const server = createCampServer();
+  const learnerId = 'learner-a';
+  const accountId = 'adult-a';
+  await seedLearner(server, accountId, learnerId);
+
+  await seedCoins(server, learnerId, accountId);
+
+  // Get the actual current revision, then use (current - 1) to force stale
+  const actualRevision = getLearnerRevision(server, accountId);
+  assert.ok(actualRevision > 0, `Revision must be > 0 after seeding, got ${actualRevision}`);
+
+  const resp = await postHeroCommand(server, {
+    command: 'unlock-monster',
+    learnerId,
+    monsterId: 'glossbloom',
+    branch: 'b1',
+    requestId: `camp-stale-${Date.now()}`,
+    expectedLearnerRevision: actualRevision - 1, // stale — one behind current
+  }, accountId);
+  const payload = await resp.json();
+
+  assert.equal(resp.status, 409);
+  assert.equal(payload.ok, false);
+  assert.ok(
+    payload.code === 'stale_write' || payload.code === 'mutation_stale_write',
+    `Expected stale_write error code, got: ${payload.code}`,
+  );
+
+  server.close();
+});
+
+// ── 9. Insufficient coins → 409 hero_insufficient_coins ─────────────────
+
+test('P5-U6: insufficient coins → hero_insufficient_coins', async () => {
+  const server = createCampServer();
+  const learnerId = 'learner-a';
+  const accountId = 'adult-a';
+  await seedLearner(server, accountId, learnerId);
+
+  // Do NOT seed coins — balance is 0
+  // But we need to have the hero progress state initialised, so do a start-task
+  const rmResp = await server.fetch(`${HERO_READ_MODEL_URL}?learnerId=${learnerId}`);
+  const rmPayload = await rmResp.json();
+  const quest = rmPayload.hero.dailyQuest;
+  const task = quest.tasks.find(t => t.launchStatus === 'launchable');
+
+  let revision = getLearnerRevision(server, accountId);
+  await postHeroCommand(server, {
+    command: 'start-task',
+    learnerId,
+    questId: quest.questId,
+    questFingerprint: rmPayload.hero.questFingerprint,
+    taskId: task.taskId,
+    requestId: `camp-nocoins-start-${Date.now()}`,
+    expectedLearnerRevision: revision,
+  }, accountId);
+
+  // Now try unlock with 0 balance
+  revision = getLearnerRevision(server, accountId);
+  const resp = await postHeroCommand(server, {
+    command: 'unlock-monster',
+    learnerId,
+    monsterId: 'glossbloom',
+    branch: 'b1',
+    requestId: `camp-nocoins-${Date.now()}`,
+    expectedLearnerRevision: revision,
+  }, accountId);
+  const payload = await resp.json();
+
+  assert.equal(resp.status, 409);
+  assert.equal(payload.ok, false);
+  assert.equal(payload.error.code, 'hero_insufficient_coins');
+
+  server.close();
+});
+
+// ── 10. Client sends `cost` field → 400 hero_client_field_rejected ───────
+
+test('P5-U6: client sends forbidden `cost` field → 400 hero_client_field_rejected', async () => {
+  const server = createCampServer();
+  const learnerId = 'learner-a';
+  const accountId = 'adult-a';
+  await seedLearner(server, accountId, learnerId);
+
+  await seedCoins(server, learnerId, accountId);
+
+  const revision = getLearnerRevision(server, accountId);
+  const resp = await postHeroCommand(server, {
+    command: 'unlock-monster',
+    learnerId,
+    monsterId: 'glossbloom',
+    branch: 'b1',
+    cost: 999, // forbidden field
+    requestId: `camp-forbidden-${Date.now()}`,
+    expectedLearnerRevision: revision,
+  }, accountId);
+  const payload = await resp.json();
+
+  assert.equal(resp.status, 400);
+  assert.equal(payload.ok, false);
+  assert.equal(payload.error.code, 'hero_client_field_rejected');
+
+  server.close();
+});
+
+// ── 11. No child_subject_state write occurs ──────────────────────────────
+
+test('P5-U6: no child_subject_state write occurs from camp commands', async () => {
+  const server = createCampServer();
+  const learnerId = 'learner-a';
+  const accountId = 'adult-a';
+  await seedLearner(server, accountId, learnerId);
+
+  await seedCoins(server, learnerId, accountId);
+
+  // Snapshot subject state before
+  const subjectStatesBefore = server.DB.db.prepare(
+    `SELECT subject_id, updated_at FROM child_subject_state WHERE learner_id = ?`,
+  ).all(learnerId);
+
+  const revision = getLearnerRevision(server, accountId);
+  await postHeroCommand(server, {
+    command: 'unlock-monster',
+    learnerId,
+    monsterId: 'carillon',
+    branch: 'b1',
+    requestId: `camp-nosubject-${Date.now()}`,
+    expectedLearnerRevision: revision,
+  }, accountId);
+
+  // Subject states must be unchanged
+  const subjectStatesAfter = server.DB.db.prepare(
+    `SELECT subject_id, updated_at FROM child_subject_state WHERE learner_id = ?`,
+  ).all(learnerId);
+  assert.deepEqual(subjectStatesAfter, subjectStatesBefore);
+
+  server.close();
+});
+
+// ── 12. No practice_sessions write occurs ────────────────────────────────
+
+test('P5-U6: no practice_sessions write occurs from camp commands', async () => {
+  const server = createCampServer();
+  const learnerId = 'learner-a';
+  const accountId = 'adult-a';
+  await seedLearner(server, accountId, learnerId);
+
+  await seedCoins(server, learnerId, accountId);
+
+  // Count practice sessions before
+  const countBefore = server.DB.db.prepare(
+    `SELECT COUNT(*) as cnt FROM practice_sessions WHERE learner_id = ?`,
+  ).get(learnerId).cnt;
+
+  const revision = getLearnerRevision(server, accountId);
+  await postHeroCommand(server, {
+    command: 'unlock-monster',
+    learnerId,
+    monsterId: 'carillon',
+    branch: 'b2',
+    requestId: `camp-nops-${Date.now()}`,
+    expectedLearnerRevision: revision,
+  }, accountId);
+
+  const countAfter = server.DB.db.prepare(
+    `SELECT COUNT(*) as cnt FROM practice_sessions WHERE learner_id = ?`,
+  ).get(learnerId).cnt;
+  assert.equal(countAfter, countBefore, 'No new practice_sessions rows from camp commands');
+
+  server.close();
+});
+
+// ── 13. Existing start-task and claim-task still work ────────────────────
+
+test('P5-U6: start-task and claim-task still work after camp wiring', async () => {
+  const server = createCampServer();
+  const learnerId = 'learner-a';
+  const accountId = 'adult-a';
+  await seedLearner(server, accountId, learnerId);
+
+  // start-task
+  const rmResp = await server.fetch(`${HERO_READ_MODEL_URL}?learnerId=${learnerId}`);
+  const rmPayload = await rmResp.json();
+  assert.equal(rmResp.status, 200);
+  const quest = rmPayload.hero.dailyQuest;
+  const task = quest.tasks.find(t => t.launchStatus === 'launchable');
+  assert.ok(task, 'Must have a launchable task');
+
+  const revision = getLearnerRevision(server, accountId);
+  const startResp = await postHeroCommand(server, {
+    command: 'start-task',
+    learnerId,
+    questId: quest.questId,
+    questFingerprint: rmPayload.hero.questFingerprint,
+    taskId: task.taskId,
+    requestId: `camp-compat-start-${Date.now()}`,
+    expectedLearnerRevision: revision,
+  }, accountId);
+  const startPayload = await startResp.json();
+  assert.equal(startResp.status, 200, `start-task must succeed: ${JSON.stringify(startPayload)}`);
+  assert.equal(startPayload.ok, true);
+
+  // claim-task
+  const nowTs = Date.now();
+  const sessionId = `ps-camp-compat-${Date.now().toString(36)}`;
+  const summaryJson = JSON.stringify({
+    heroContext: {
+      source: 'hero-mode',
+      questId: quest.questId,
+      questFingerprint: rmPayload.hero.questFingerprint,
+      taskId: task.taskId,
+      intent: task.intent || 'due-review',
+      launcher: task.launcher || 'smart-practice',
+    },
+    status: 'completed',
+  });
+  server.DB.db.prepare(`
+    INSERT INTO practice_sessions (id, learner_id, subject_id, session_kind, status, session_state_json, summary_json, created_at, updated_at)
+    VALUES (?, ?, ?, 'smart-practice', 'completed', '{}', ?, ?, ?)
+  `).run(sessionId, learnerId, task.subjectId, summaryJson, nowTs, nowTs);
+
+  const claimRev = getLearnerRevision(server, accountId);
+  const claimResp = await postHeroCommand(server, {
+    command: 'claim-task',
+    learnerId,
+    questId: quest.questId,
+    questFingerprint: rmPayload.hero.questFingerprint,
+    taskId: task.taskId,
+    requestId: `camp-compat-claim-${Date.now()}`,
+    expectedLearnerRevision: claimRev,
+  }, accountId);
+  const claimPayload = await claimResp.json();
+  assert.equal(claimResp.status, 200, `claim-task must succeed: ${JSON.stringify(claimPayload)}`);
+  assert.equal(claimPayload.ok, true);
+  assert.equal(claimPayload.heroClaim.status, 'claimed');
+
+  server.close();
+});
+
+// ── 14. Ledger is capped at 180 entries ──────────────────────────────────
+
+test('P5-U6: ledger is capped at 180 entries after mutation', async () => {
+  const server = createCampServer();
+  const learnerId = 'learner-a';
+  const accountId = 'adult-a';
+  await seedLearner(server, accountId, learnerId);
+
+  await seedCoins(server, learnerId, accountId);
+
+  // Manually inject a large ledger (179 entries) into state
+  const progress = getHeroProgressRow(server, learnerId);
+  const fakeLedger = Array.from({ length: 179 }, (_, i) => ({
+    entryId: `fake-${i}`,
+    type: 'test',
+    amount: 1,
+    balanceAfter: 100 + i,
+    createdAt: Date.now() - (179 - i) * 1000,
+  }));
+  progress.economy.ledger = fakeLedger;
+  progress.economy.balance = 1000; // Ensure enough balance
+  server.DB.db.prepare(`
+    UPDATE child_game_state SET state_json = ? WHERE learner_id = ? AND system_id = 'hero-mode'
+  `).run(JSON.stringify(progress), learnerId);
+
+  const revision = getLearnerRevision(server, accountId);
+  const resp = await postHeroCommand(server, {
+    command: 'unlock-monster',
+    learnerId,
+    monsterId: 'glossbloom',
+    branch: 'b1',
+    requestId: `camp-ledger-cap-${Date.now()}`,
+    expectedLearnerRevision: revision,
+  }, accountId);
+  const payload = await resp.json();
+  assert.equal(resp.status, 200, `Expected 200, got ${resp.status}: ${JSON.stringify(payload)}`);
+
+  // Check ledger is capped
+  const updated = getHeroProgressRow(server, learnerId);
+  assert.ok(updated.economy.ledger.length <= 180, `Ledger must be <= 180, got ${updated.economy.ledger.length}`);
+
+  server.close();
+});
+
+// ── Wrangler config check ────────────────────────────────────────────────
 
 describe('P5-U6 Camp — wrangler.jsonc contains HERO_MODE_CAMP_ENABLED', () => {
   it('wrangler.jsonc has HERO_MODE_CAMP_ENABLED set to "false"', () => {
@@ -316,7 +837,7 @@ describe('P5-U6 Camp — wrangler.jsonc contains HERO_MODE_CAMP_ENABLED', () => 
   });
 });
 
-// ── Import path verification ───────────────────────────────────────────
+// ── Import verification ──────────────────────────────────────────────────
 
 describe('P5-U6 Camp — import path is correct', () => {
   it('camp.js resolver is importable and exports resolveHeroCampCommand', () => {
@@ -326,5 +847,6 @@ describe('P5-U6 Camp — import path is correct', () => {
   it('camp.js exports FORBIDDEN_CAMP_FIELDS', () => {
     assert.ok(Array.isArray(FORBIDDEN_CAMP_FIELDS));
     assert.ok(FORBIDDEN_CAMP_FIELDS.length > 0);
+    assert.ok(FORBIDDEN_CAMP_FIELDS.includes('cost'));
   });
 });

--- a/tests/hero-p5-camp-resolver.test.js
+++ b/tests/hero-p5-camp-resolver.test.js
@@ -1,0 +1,329 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import {
+  resolveHeroCampCommand,
+  FORBIDDEN_CAMP_FIELDS,
+} from '../worker/src/hero/camp.js';
+
+import {
+  HERO_MONSTER_INVITE_COST,
+  HERO_MONSTER_GROW_COSTS,
+  HERO_POOL_ROSTER_VERSION,
+} from '../shared/hero/hero-pool.js';
+
+// ── Fixtures ────────────────────────────────────────────────────────────
+
+const LEARNER = 'learner-camp-test-001';
+const NOW = 1714400000000;
+
+function makeEconomy(balance = 1000, lifetimeSpent = 0, lifetimeEarned = 1000) {
+  return { version: 1, balance, lifetimeEarned, lifetimeSpent, ledger: [], lastUpdatedAt: NOW - 1000 };
+}
+
+function makeEmptyPool() {
+  return {
+    version: 1,
+    rosterVersion: HERO_POOL_ROSTER_VERSION,
+    selectedMonsterId: null,
+    monsters: {},
+    recentActions: [],
+    lastUpdatedAt: null,
+  };
+}
+
+function makePoolWithOwned(monsterId, stage = 0, branch = 'b1') {
+  return {
+    version: 1,
+    rosterVersion: HERO_POOL_ROSTER_VERSION,
+    selectedMonsterId: null,
+    monsters: {
+      [monsterId]: {
+        monsterId,
+        owned: true,
+        stage,
+        branch,
+        investedCoins: HERO_MONSTER_INVITE_COST,
+        invitedAt: NOW - 5000,
+        lastGrownAt: null,
+        lastLedgerEntryId: 'prev-entry',
+      },
+    },
+    recentActions: [],
+    lastUpdatedAt: NOW - 1000,
+  };
+}
+
+function makeHeroState(economyOverride, poolOverride) {
+  return {
+    economy: economyOverride || makeEconomy(),
+    heroPool: poolOverride || makeEmptyPool(),
+  };
+}
+
+// ── unlock-monster: success ─────────────────────────────────────────────
+
+describe('resolveHeroCampCommand — unlock-monster', () => {
+  it('returns ok intent with valid body', () => {
+    const result = resolveHeroCampCommand({
+      command: 'unlock-monster',
+      body: { monsterId: 'glossbloom', branch: 'b1' },
+      heroState: makeHeroState(),
+      learnerId: LEARNER,
+      nowTs: NOW,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.status, 'invited');
+    assert.equal(result.httpStatus, 200);
+    assert.ok(result.intent);
+    assert.equal(result.intent.newBalance, 1000 - HERO_MONSTER_INVITE_COST);
+    assert.equal(result.response.heroCampAction.status, 'invited');
+    assert.equal(result.response.heroCampAction.monsterId, 'glossbloom');
+    assert.equal(result.response.heroCampAction.branch, 'b1');
+  });
+
+  it('returns server-derived cost, not from client body', () => {
+    // Even if client tries to send cost=0, the resolver uses server-side cost
+    const result = resolveHeroCampCommand({
+      command: 'unlock-monster',
+      body: { monsterId: 'loomrill', branch: 'b2' },
+      heroState: makeHeroState(),
+      learnerId: LEARNER,
+      nowTs: NOW,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.response.heroCampAction.cost, HERO_MONSTER_INVITE_COST);
+    assert.equal(result.response.heroCampAction.coinsUsed, HERO_MONSTER_INVITE_COST);
+  });
+
+  it('already-owned invite returns already-owned with no debit intent', () => {
+    const pool = makePoolWithOwned('glossbloom', 2, 'b1');
+    const result = resolveHeroCampCommand({
+      command: 'unlock-monster',
+      body: { monsterId: 'glossbloom', branch: 'b1' },
+      heroState: makeHeroState(makeEconomy(), pool),
+      learnerId: LEARNER,
+      nowTs: NOW,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.status, 'already-owned');
+    assert.equal(result.httpStatus, 200);
+    assert.equal(result.intent, undefined);
+    assert.equal(result.response.heroCampAction.cost, 0);
+    assert.equal(result.response.heroCampAction.coinsUsed, 0);
+    assert.equal(result.response.heroCampAction.ledgerEntryId, null);
+  });
+
+  it('missing monsterId returns validation error', () => {
+    const result = resolveHeroCampCommand({
+      command: 'unlock-monster',
+      body: { branch: 'b1' },
+      heroState: makeHeroState(),
+      learnerId: LEARNER,
+      nowTs: NOW,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.code, 'hero_monster_unknown');
+    assert.equal(result.httpStatus, 400);
+  });
+
+  it('invalid branch returns error', () => {
+    const result = resolveHeroCampCommand({
+      command: 'unlock-monster',
+      body: { monsterId: 'glossbloom', branch: 'bad-branch' },
+      heroState: makeHeroState(),
+      learnerId: LEARNER,
+      nowTs: NOW,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.code, 'hero_monster_branch_invalid');
+    assert.equal(result.httpStatus, 400);
+  });
+
+  it('insufficient coins returns 409', () => {
+    const result = resolveHeroCampCommand({
+      command: 'unlock-monster',
+      body: { monsterId: 'glossbloom', branch: 'b1' },
+      heroState: makeHeroState(makeEconomy(10)),
+      learnerId: LEARNER,
+      nowTs: NOW,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.code, 'hero_insufficient_coins');
+    assert.equal(result.httpStatus, 409);
+  });
+});
+
+// ── evolve-monster: success ─────────────────────────────────────────────
+
+describe('resolveHeroCampCommand — evolve-monster', () => {
+  it('returns ok intent with valid body', () => {
+    const pool = makePoolWithOwned('mirrane', 0, 'b2');
+    const result = resolveHeroCampCommand({
+      command: 'evolve-monster',
+      body: { monsterId: 'mirrane', targetStage: 1 },
+      heroState: makeHeroState(makeEconomy(2000), pool),
+      learnerId: LEARNER,
+      nowTs: NOW,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.status, 'grown');
+    assert.equal(result.httpStatus, 200);
+    assert.ok(result.intent);
+    assert.equal(result.intent.newBalance, 2000 - HERO_MONSTER_GROW_COSTS[1]);
+    assert.equal(result.response.heroCampAction.status, 'grown');
+    assert.equal(result.response.heroCampAction.monsterId, 'mirrane');
+    assert.equal(result.response.heroCampAction.stageAfter, 1);
+  });
+
+  it('already-stage grow returns already-stage with no debit intent', () => {
+    const pool = makePoolWithOwned('colisk', 2, 'b1');
+    const result = resolveHeroCampCommand({
+      command: 'evolve-monster',
+      body: { monsterId: 'colisk', targetStage: 1 },
+      heroState: makeHeroState(makeEconomy(), pool),
+      learnerId: LEARNER,
+      nowTs: NOW,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.status, 'already-stage');
+    assert.equal(result.httpStatus, 200);
+    assert.equal(result.intent, undefined);
+    assert.equal(result.response.heroCampAction.cost, 0);
+    assert.equal(result.response.heroCampAction.coinsUsed, 0);
+    assert.equal(result.response.heroCampAction.ledgerEntryId, null);
+  });
+
+  it('missing monsterId returns validation error', () => {
+    const result = resolveHeroCampCommand({
+      command: 'evolve-monster',
+      body: { targetStage: 1 },
+      heroState: makeHeroState(),
+      learnerId: LEARNER,
+      nowTs: NOW,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.code, 'hero_monster_unknown');
+    assert.equal(result.httpStatus, 400);
+  });
+
+  it('insufficient coins for grow returns 409', () => {
+    const pool = makePoolWithOwned('hyphang', 0, 'b1');
+    const result = resolveHeroCampCommand({
+      command: 'evolve-monster',
+      body: { monsterId: 'hyphang', targetStage: 1 },
+      heroState: makeHeroState(makeEconomy(5), pool),
+      learnerId: LEARNER,
+      nowTs: NOW,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.code, 'hero_insufficient_coins');
+    assert.equal(result.httpStatus, 409);
+  });
+});
+
+// ── Forbidden fields ────────────────────────────────────────────────────
+
+describe('resolveHeroCampCommand — forbidden fields', () => {
+  it('forbidden field "cost" in body returns hero_client_field_rejected', () => {
+    const result = resolveHeroCampCommand({
+      command: 'unlock-monster',
+      body: { monsterId: 'glossbloom', branch: 'b1', cost: 0 },
+      heroState: makeHeroState(),
+      learnerId: LEARNER,
+      nowTs: NOW,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.code, 'hero_client_field_rejected');
+    assert.equal(result.httpStatus, 400);
+    assert.ok(result.rejectedFields.includes('cost'));
+  });
+
+  it('forbidden field "balance" in body returns hero_client_field_rejected', () => {
+    const result = resolveHeroCampCommand({
+      command: 'evolve-monster',
+      body: { monsterId: 'glossbloom', targetStage: 1, balance: 9999 },
+      heroState: makeHeroState(),
+      learnerId: LEARNER,
+      nowTs: NOW,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.code, 'hero_client_field_rejected');
+    assert.equal(result.httpStatus, 400);
+    assert.ok(result.rejectedFields.includes('balance'));
+  });
+
+  it('multiple forbidden fields are all reported', () => {
+    const result = resolveHeroCampCommand({
+      command: 'unlock-monster',
+      body: { monsterId: 'glossbloom', branch: 'b1', cost: 0, ledger: [], economy: {} },
+      heroState: makeHeroState(),
+      learnerId: LEARNER,
+      nowTs: NOW,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.code, 'hero_client_field_rejected');
+    assert.ok(result.rejectedFields.includes('cost'));
+    assert.ok(result.rejectedFields.includes('ledger'));
+    assert.ok(result.rejectedFields.includes('economy'));
+  });
+});
+
+// ── Unknown command ─────────────────────────────────────────────────────
+
+describe('resolveHeroCampCommand — unknown command', () => {
+  it('unknown command returns error', () => {
+    const result = resolveHeroCampCommand({
+      command: 'buy-hat',
+      body: {},
+      heroState: makeHeroState(),
+      learnerId: LEARNER,
+      nowTs: NOW,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.code, 'hero_command_unknown');
+    assert.equal(result.httpStatus, 400);
+  });
+});
+
+// ── Source integrity ────────────────────────────────────────────────────
+
+describe('resolveHeroCampCommand — source integrity', () => {
+  const campSource = readFileSync(
+    resolve(import.meta.dirname, '..', 'worker', 'src', 'hero', 'camp.js'),
+    'utf8'
+  );
+
+  it('has zero imports from subject runtime', () => {
+    const subjectImports = campSource.match(/from\s+['"].*subjects\//g);
+    assert.equal(subjectImports, null, 'Must not import from worker/src/subjects/');
+  });
+
+  it('does not import repository or D1', () => {
+    const repoImports = campSource.match(/from\s+['"].*repository/g);
+    const d1Imports = campSource.match(/from\s+['"].*d1/gi);
+    assert.equal(repoImports, null, 'Must not import repository');
+    assert.equal(d1Imports, null, 'Must not import D1');
+  });
+
+  it('does not call runHeroCommandMutation', () => {
+    const mutationCalls = campSource.match(/runHeroCommandMutation/g);
+    assert.equal(mutationCalls, null, 'Must not reference runHeroCommandMutation');
+  });
+});

--- a/tests/hero-p5-camp-resolver.test.js
+++ b/tests/hero-p5-camp-resolver.test.js
@@ -1,4 +1,4 @@
-import { describe, it } from 'node:test';
+import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
@@ -14,19 +14,20 @@ import {
   HERO_POOL_ROSTER_VERSION,
 } from '../shared/hero/hero-pool.js';
 
-// ── Fixtures ────────────────────────────────────────────────────────────
+// ── Fixtures ─────────────────────────────────────────────────────────
 
 const LEARNER = 'learner-camp-test-001';
 const NOW = 1714400000000;
+const ROSTER_V = HERO_POOL_ROSTER_VERSION;
 
-function makeEconomy(balance = 1000, lifetimeSpent = 0, lifetimeEarned = 1000) {
-  return { version: 1, balance, lifetimeEarned, lifetimeSpent, ledger: [], lastUpdatedAt: NOW - 1000 };
+function makeEconomy(balance = 1000) {
+  return { version: 1, balance, lifetimeEarned: balance, lifetimeSpent: 0, ledger: [], lastUpdatedAt: NOW - 1000 };
 }
 
 function makeEmptyPool() {
   return {
     version: 1,
-    rosterVersion: HERO_POOL_ROSTER_VERSION,
+    rosterVersion: ROSTER_V,
     selectedMonsterId: null,
     monsters: {},
     recentActions: [],
@@ -37,7 +38,7 @@ function makeEmptyPool() {
 function makePoolWithOwned(monsterId, stage = 0, branch = 'b1') {
   return {
     version: 1,
-    rosterVersion: HERO_POOL_ROSTER_VERSION,
+    rosterVersion: ROSTER_V,
     selectedMonsterId: null,
     monsters: {
       [monsterId]: {
@@ -56,274 +57,213 @@ function makePoolWithOwned(monsterId, stage = 0, branch = 'b1') {
   };
 }
 
-function makeHeroState(economyOverride, poolOverride) {
+function makeHeroState(balance = 1000, pool = null) {
   return {
-    economy: economyOverride || makeEconomy(),
-    heroPool: poolOverride || makeEmptyPool(),
+    version: 3,
+    daily: null,
+    recentClaims: [],
+    economy: makeEconomy(balance),
+    heroPool: pool || makeEmptyPool(),
   };
 }
 
-// ── unlock-monster: success ─────────────────────────────────────────────
-
-describe('resolveHeroCampCommand — unlock-monster', () => {
-  it('returns ok intent with valid body', () => {
-    const result = resolveHeroCampCommand({
-      command: 'unlock-monster',
-      body: { monsterId: 'glossbloom', branch: 'b1' },
-      heroState: makeHeroState(),
-      learnerId: LEARNER,
-      nowTs: NOW,
-    });
-
-    assert.equal(result.ok, true);
-    assert.equal(result.status, 'invited');
-    assert.equal(result.httpStatus, 200);
-    assert.ok(result.intent);
-    assert.equal(result.intent.newBalance, 1000 - HERO_MONSTER_INVITE_COST);
-    assert.equal(result.response.heroCampAction.status, 'invited');
-    assert.equal(result.response.heroCampAction.monsterId, 'glossbloom');
-    assert.equal(result.response.heroCampAction.branch, 'b1');
+function invoke(command, body, opts = {}) {
+  return resolveHeroCampCommand({
+    command,
+    body,
+    heroState: opts.heroState || makeHeroState(opts.balance, opts.pool),
+    learnerId: opts.learnerId || LEARNER,
+    rosterVersion: opts.rosterVersion || ROSTER_V,
+    nowTs: opts.nowTs || NOW,
   });
+}
 
-  it('returns server-derived cost, not from client body', () => {
-    // Even if client tries to send cost=0, the resolver uses server-side cost
-    const result = resolveHeroCampCommand({
-      command: 'unlock-monster',
-      body: { monsterId: 'loomrill', branch: 'b2' },
-      heroState: makeHeroState(),
-      learnerId: LEARNER,
-      nowTs: NOW,
-    });
+// ── Happy path: unlock-monster with valid body → status 'invited' ───
 
-    assert.equal(result.ok, true);
-    assert.equal(result.response.heroCampAction.cost, HERO_MONSTER_INVITE_COST);
-    assert.equal(result.response.heroCampAction.coinsUsed, HERO_MONSTER_INVITE_COST);
-  });
+test('unlock-monster: valid body returns ok intent with status invited', () => {
+  const result = invoke('unlock-monster', { monsterId: 'glossbloom', branch: 'b1' }, { balance: 500 });
 
-  it('already-owned invite returns already-owned with no debit intent', () => {
-    const pool = makePoolWithOwned('glossbloom', 2, 'b1');
-    const result = resolveHeroCampCommand({
-      command: 'unlock-monster',
-      body: { monsterId: 'glossbloom', branch: 'b1' },
-      heroState: makeHeroState(makeEconomy(), pool),
-      learnerId: LEARNER,
-      nowTs: NOW,
-    });
-
-    assert.equal(result.ok, true);
-    assert.equal(result.status, 'already-owned');
-    assert.equal(result.httpStatus, 200);
-    assert.equal(result.intent, undefined);
-    assert.equal(result.response.heroCampAction.cost, 0);
-    assert.equal(result.response.heroCampAction.coinsUsed, 0);
-    assert.equal(result.response.heroCampAction.ledgerEntryId, null);
-  });
-
-  it('missing monsterId returns validation error', () => {
-    const result = resolveHeroCampCommand({
-      command: 'unlock-monster',
-      body: { branch: 'b1' },
-      heroState: makeHeroState(),
-      learnerId: LEARNER,
-      nowTs: NOW,
-    });
-
-    assert.equal(result.ok, false);
-    assert.equal(result.code, 'hero_monster_unknown');
-    assert.equal(result.httpStatus, 400);
-  });
-
-  it('invalid branch returns error', () => {
-    const result = resolveHeroCampCommand({
-      command: 'unlock-monster',
-      body: { monsterId: 'glossbloom', branch: 'bad-branch' },
-      heroState: makeHeroState(),
-      learnerId: LEARNER,
-      nowTs: NOW,
-    });
-
-    assert.equal(result.ok, false);
-    assert.equal(result.code, 'hero_monster_branch_invalid');
-    assert.equal(result.httpStatus, 400);
-  });
-
-  it('insufficient coins returns 409', () => {
-    const result = resolveHeroCampCommand({
-      command: 'unlock-monster',
-      body: { monsterId: 'glossbloom', branch: 'b1' },
-      heroState: makeHeroState(makeEconomy(10)),
-      learnerId: LEARNER,
-      nowTs: NOW,
-    });
-
-    assert.equal(result.ok, false);
-    assert.equal(result.code, 'hero_insufficient_coins');
-    assert.equal(result.httpStatus, 409);
-  });
+  assert.equal(result.ok, true);
+  assert.equal(result.heroCampAction.status, 'invited');
+  assert.equal(result.heroCampAction.learnerId, LEARNER);
+  assert.equal(result.heroCampAction.monsterId, 'glossbloom');
+  assert.equal(result.heroCampAction.branch, 'b1');
+  assert.equal(result.heroCampAction.version, 1);
+  assert.equal(typeof result.heroCampAction.ledgerEntryId, 'string');
+  assert.equal(result.heroCampAction.coinBalance, 500 - HERO_MONSTER_INVITE_COST);
 });
 
-// ── evolve-monster: success ─────────────────────────────────────────────
+// ── Happy path: evolve-monster with valid body → status 'grown' ─────
 
-describe('resolveHeroCampCommand — evolve-monster', () => {
-  it('returns ok intent with valid body', () => {
-    const pool = makePoolWithOwned('mirrane', 0, 'b2');
-    const result = resolveHeroCampCommand({
-      command: 'evolve-monster',
-      body: { monsterId: 'mirrane', targetStage: 1 },
-      heroState: makeHeroState(makeEconomy(2000), pool),
-      learnerId: LEARNER,
-      nowTs: NOW,
-    });
+test('evolve-monster: valid body returns ok with status grown', () => {
+  const pool = makePoolWithOwned('glossbloom', 0, 'b1');
+  const result = invoke('evolve-monster', { monsterId: 'glossbloom', targetStage: 1 }, { balance: 2000, pool });
 
-    assert.equal(result.ok, true);
-    assert.equal(result.status, 'grown');
-    assert.equal(result.httpStatus, 200);
-    assert.ok(result.intent);
-    assert.equal(result.intent.newBalance, 2000 - HERO_MONSTER_GROW_COSTS[1]);
-    assert.equal(result.response.heroCampAction.status, 'grown');
-    assert.equal(result.response.heroCampAction.monsterId, 'mirrane');
-    assert.equal(result.response.heroCampAction.stageAfter, 1);
-  });
-
-  it('already-stage grow returns already-stage with no debit intent', () => {
-    const pool = makePoolWithOwned('colisk', 2, 'b1');
-    const result = resolveHeroCampCommand({
-      command: 'evolve-monster',
-      body: { monsterId: 'colisk', targetStage: 1 },
-      heroState: makeHeroState(makeEconomy(), pool),
-      learnerId: LEARNER,
-      nowTs: NOW,
-    });
-
-    assert.equal(result.ok, true);
-    assert.equal(result.status, 'already-stage');
-    assert.equal(result.httpStatus, 200);
-    assert.equal(result.intent, undefined);
-    assert.equal(result.response.heroCampAction.cost, 0);
-    assert.equal(result.response.heroCampAction.coinsUsed, 0);
-    assert.equal(result.response.heroCampAction.ledgerEntryId, null);
-  });
-
-  it('missing monsterId returns validation error', () => {
-    const result = resolveHeroCampCommand({
-      command: 'evolve-monster',
-      body: { targetStage: 1 },
-      heroState: makeHeroState(),
-      learnerId: LEARNER,
-      nowTs: NOW,
-    });
-
-    assert.equal(result.ok, false);
-    assert.equal(result.code, 'hero_monster_unknown');
-    assert.equal(result.httpStatus, 400);
-  });
-
-  it('insufficient coins for grow returns 409', () => {
-    const pool = makePoolWithOwned('hyphang', 0, 'b1');
-    const result = resolveHeroCampCommand({
-      command: 'evolve-monster',
-      body: { monsterId: 'hyphang', targetStage: 1 },
-      heroState: makeHeroState(makeEconomy(5), pool),
-      learnerId: LEARNER,
-      nowTs: NOW,
-    });
-
-    assert.equal(result.ok, false);
-    assert.equal(result.code, 'hero_insufficient_coins');
-    assert.equal(result.httpStatus, 409);
-  });
+  assert.equal(result.ok, true);
+  assert.equal(result.heroCampAction.status, 'grown');
+  assert.equal(result.heroCampAction.monsterId, 'glossbloom');
+  assert.equal(result.heroCampAction.stageBefore, 0);
+  assert.equal(result.heroCampAction.stageAfter, 1);
+  assert.equal(result.heroCampAction.coinBalance, 2000 - HERO_MONSTER_GROW_COSTS[1]);
+  assert.equal(typeof result.heroCampAction.ledgerEntryId, 'string');
 });
 
-// ── Forbidden fields ────────────────────────────────────────────────────
+// ── Happy path: resolver returns server-derived cost ─────────────────
 
-describe('resolveHeroCampCommand — forbidden fields', () => {
-  it('forbidden field "cost" in body returns hero_client_field_rejected', () => {
-    const result = resolveHeroCampCommand({
-      command: 'unlock-monster',
-      body: { monsterId: 'glossbloom', branch: 'b1', cost: 0 },
-      heroState: makeHeroState(),
-      learnerId: LEARNER,
-      nowTs: NOW,
-    });
+test('resolver returns server-derived cost, not from client', () => {
+  const result = invoke('unlock-monster', { monsterId: 'loomrill', branch: 'b2' }, { balance: 500 });
 
-    assert.equal(result.ok, false);
-    assert.equal(result.code, 'hero_client_field_rejected');
-    assert.equal(result.httpStatus, 400);
-    assert.ok(result.rejectedFields.includes('cost'));
-  });
-
-  it('forbidden field "balance" in body returns hero_client_field_rejected', () => {
-    const result = resolveHeroCampCommand({
-      command: 'evolve-monster',
-      body: { monsterId: 'glossbloom', targetStage: 1, balance: 9999 },
-      heroState: makeHeroState(),
-      learnerId: LEARNER,
-      nowTs: NOW,
-    });
-
-    assert.equal(result.ok, false);
-    assert.equal(result.code, 'hero_client_field_rejected');
-    assert.equal(result.httpStatus, 400);
-    assert.ok(result.rejectedFields.includes('balance'));
-  });
-
-  it('multiple forbidden fields are all reported', () => {
-    const result = resolveHeroCampCommand({
-      command: 'unlock-monster',
-      body: { monsterId: 'glossbloom', branch: 'b1', cost: 0, ledger: [], economy: {} },
-      heroState: makeHeroState(),
-      learnerId: LEARNER,
-      nowTs: NOW,
-    });
-
-    assert.equal(result.ok, false);
-    assert.equal(result.code, 'hero_client_field_rejected');
-    assert.ok(result.rejectedFields.includes('cost'));
-    assert.ok(result.rejectedFields.includes('ledger'));
-    assert.ok(result.rejectedFields.includes('economy'));
-  });
+  assert.equal(result.ok, true);
+  assert.equal(result.heroCampAction.cost, HERO_MONSTER_INVITE_COST);
+  assert.equal(result.heroCampAction.coinsUsed, HERO_MONSTER_INVITE_COST);
 });
 
-// ── Unknown command ─────────────────────────────────────────────────────
+// ── Edge case: already-owned invite → status 'already-owned' ────────
 
-describe('resolveHeroCampCommand — unknown command', () => {
-  it('unknown command returns error', () => {
-    const result = resolveHeroCampCommand({
-      command: 'buy-hat',
-      body: {},
-      heroState: makeHeroState(),
-      learnerId: LEARNER,
-      nowTs: NOW,
-    });
+test('unlock-monster: already-owned returns status already-owned, no ledger entry', () => {
+  const pool = makePoolWithOwned('glossbloom', 2, 'b1');
+  const result = invoke('unlock-monster', { monsterId: 'glossbloom', branch: 'b1' }, { balance: 500, pool });
 
-    assert.equal(result.ok, false);
-    assert.equal(result.code, 'hero_command_unknown');
-    assert.equal(result.httpStatus, 400);
-  });
+  assert.equal(result.ok, true);
+  assert.equal(result.heroCampAction.status, 'already-owned');
+  assert.equal(result.heroCampAction.cost, 0);
+  assert.equal(result.heroCampAction.coinsUsed, 0);
+  assert.equal(result.heroCampAction.ledgerEntryId, null);
 });
 
-// ── Source integrity ────────────────────────────────────────────────────
+// ── Edge case: already-at-stage grow → status 'already-stage' ───────
 
-describe('resolveHeroCampCommand — source integrity', () => {
-  const campSource = readFileSync(
-    resolve(import.meta.dirname, '..', 'worker', 'src', 'hero', 'camp.js'),
-    'utf8'
-  );
+test('evolve-monster: already-at-stage returns status already-stage, no ledger entry', () => {
+  const pool = makePoolWithOwned('glossbloom', 2, 'b1');
+  const result = invoke('evolve-monster', { monsterId: 'glossbloom', targetStage: 2 }, { balance: 5000, pool });
 
-  it('has zero imports from subject runtime', () => {
-    const subjectImports = campSource.match(/from\s+['"].*subjects\//g);
-    assert.equal(subjectImports, null, 'Must not import from worker/src/subjects/');
-  });
+  assert.equal(result.ok, true);
+  assert.equal(result.heroCampAction.status, 'already-stage');
+  assert.equal(result.heroCampAction.cost, 0);
+  assert.equal(result.heroCampAction.coinsUsed, 0);
+  assert.equal(result.heroCampAction.ledgerEntryId, null);
+});
 
-  it('does not import repository or D1', () => {
-    const repoImports = campSource.match(/from\s+['"].*repository/g);
-    const d1Imports = campSource.match(/from\s+['"].*d1/gi);
-    assert.equal(repoImports, null, 'Must not import repository');
-    assert.equal(d1Imports, null, 'Must not import D1');
-  });
+// ── Error: forbidden field 'cost' ───────────────────────────────────
 
-  it('does not call runHeroCommandMutation', () => {
-    const mutationCalls = campSource.match(/runHeroCommandMutation/g);
-    assert.equal(mutationCalls, null, 'Must not reference runHeroCommandMutation');
-  });
+test('forbidden field cost in body returns hero_client_field_rejected with httpStatus 400', () => {
+  const result = invoke('unlock-monster', { monsterId: 'glossbloom', branch: 'b1', cost: 50 });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, 'hero_client_field_rejected');
+  assert.equal(result.httpStatus, 400);
+});
+
+// ── Error: forbidden field 'balance' ────────────────────────────────
+
+test('forbidden field balance in body returns hero_client_field_rejected with httpStatus 400', () => {
+  const result = invoke('unlock-monster', { monsterId: 'glossbloom', branch: 'b1', balance: 999 });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, 'hero_client_field_rejected');
+  assert.equal(result.httpStatus, 400);
+});
+
+// ── Error: forbidden field 'payload' ────────────────────────────────
+
+test('forbidden field payload in body returns hero_client_field_rejected with httpStatus 400', () => {
+  const result = invoke('evolve-monster', { monsterId: 'glossbloom', targetStage: 1, payload: {} });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, 'hero_client_field_rejected');
+  assert.equal(result.httpStatus, 400);
+});
+
+// ── Error: unknown monsterId ────────────────────────────────────────
+
+test('unknown monsterId returns hero_monster_unknown', () => {
+  const result = invoke('unlock-monster', { monsterId: 'fake-dragon', branch: 'b1' }, { balance: 500 });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, 'hero_monster_unknown');
+  assert.equal(result.httpStatus, 400);
+});
+
+// ── Error: invalid branch ───────────────────────────────────────────
+
+test('invalid branch returns hero_monster_branch_invalid', () => {
+  const result = invoke('unlock-monster', { monsterId: 'glossbloom', branch: 'b99' }, { balance: 500 });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, 'hero_monster_branch_invalid');
+  assert.equal(result.httpStatus, 400);
+});
+
+// ── Error: missing branch ───────────────────────────────────────────
+
+test('missing branch returns hero_monster_branch_required', () => {
+  const result = invoke('unlock-monster', { monsterId: 'glossbloom' }, { balance: 500 });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, 'hero_monster_branch_required');
+  assert.equal(result.httpStatus, 400);
+});
+
+// ── Error: monster not owned for grow ───────────────────────────────
+
+test('evolve-monster: monster not owned returns hero_monster_not_owned', () => {
+  const result = invoke('evolve-monster', { monsterId: 'glossbloom', targetStage: 1 }, { balance: 2000 });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, 'hero_monster_not_owned');
+  assert.equal(result.httpStatus, 400);
+});
+
+// ── Error: target stage not next ────────────────────────────────────
+
+test('evolve-monster: target stage not next returns hero_monster_stage_not_next', () => {
+  const pool = makePoolWithOwned('glossbloom', 0, 'b1');
+  const result = invoke('evolve-monster', { monsterId: 'glossbloom', targetStage: 2 }, { balance: 5000, pool });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, 'hero_monster_stage_not_next');
+  assert.equal(result.httpStatus, 400);
+});
+
+// ── Error: insufficient coins ───────────────────────────────────────
+
+test('unlock-monster: insufficient coins returns hero_insufficient_coins with httpStatus 409', () => {
+  const result = invoke('unlock-monster', { monsterId: 'glossbloom', branch: 'b1' }, { balance: 10 });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, 'hero_insufficient_coins');
+  assert.equal(result.httpStatus, 409);
+});
+
+test('evolve-monster: insufficient coins returns hero_insufficient_coins with httpStatus 409', () => {
+  const pool = makePoolWithOwned('glossbloom', 0, 'b1');
+  const result = invoke('evolve-monster', { monsterId: 'glossbloom', targetStage: 1 }, { balance: 10, pool });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, 'hero_insufficient_coins');
+  assert.equal(result.httpStatus, 409);
+});
+
+// ── Boundary: zero imports from subject runtime ─────────────────────
+
+test('structural: camp.js has zero imports from subject runtime', () => {
+  const src = readFileSync(resolve(import.meta.dirname, '../worker/src/hero/camp.js'), 'utf8');
+
+  assert.equal(src.includes('from \'../subjects/'), false, 'must not import from subjects/');
+  assert.equal(src.includes('from \'../../subjects/'), false, 'must not import from subjects/');
+  assert.equal(src.includes('from \'../../../src/'), false, 'must not import from src/');
+  assert.equal(src.includes('from \'react'), false, 'must not import react');
+  assert.equal(src.includes('require(\'react'), false, 'must not require react');
+});
+
+// ── Boundary: no repository or D1 imports ───────────────────────────
+
+test('structural: camp.js does not import repository or D1', () => {
+  const src = readFileSync(resolve(import.meta.dirname, '../worker/src/hero/camp.js'), 'utf8');
+
+  assert.equal(src.includes('repository'), false, 'must not reference repository');
+  assert.equal(src.includes('D1'), false, 'must not reference D1');
+  assert.equal(src.includes('.prepare('), false, 'must not use SQL prepare');
+  assert.equal(src.includes('.bind('), false, 'must not use SQL bind');
+  assert.equal(src.includes('env.DB'), false, 'must not reference env.DB');
 });

--- a/tests/hero-p5-camp-resolver.test.js
+++ b/tests/hero-p5-camp-resolver.test.js
@@ -244,6 +244,21 @@ test('evolve-monster: insufficient coins returns hero_insufficient_coins with ht
   assert.equal(result.httpStatus, 409);
 });
 
+// ── Error: unknown command ─────────────────────────────────────────
+
+test('unknown command returns error', () => {
+  const result = resolveHeroCampCommand({
+    command: 'steal-coins',
+    body: { monsterId: 'glossbloom', branch: 'b1' },
+    heroState: makeHeroState(),
+    learnerId: LEARNER,
+    rosterVersion: ROSTER_V,
+    nowTs: NOW,
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.httpStatus, 400);
+});
+
 // ── Boundary: zero imports from subject runtime ─────────────────────
 
 test('structural: camp.js has zero imports from subject runtime', () => {

--- a/tests/hero-p5-camp-ui.test.js
+++ b/tests/hero-p5-camp-ui.test.js
@@ -1,0 +1,498 @@
+// Hero Mode P5 U9 — Hero Camp UI surface and monster card tests.
+//
+// Validates:
+//  - Camp panel visibility (enabled vs disabled)
+//  - Hero Quest remains primary action (not displaced by Camp)
+//  - Monster card rendering (invite, grow, fully grown)
+//  - Insufficient balance messaging
+//  - Confirmation dialog copy
+//  - Vocabulary boundary (no shop/deal/loot/limited-time/streak)
+//  - Keyboard accessibility (buttons are focusable with labels)
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  renderHeroCampPanelFixture,
+  renderHeroCampMonsterCardFixture,
+  renderHeroCampConfirmationFixture,
+  renderHomeSurfaceWithCampFixture,
+} from './helpers/react-render.js';
+import { HERO_FORBIDDEN_VOCABULARY } from '../shared/hero/hero-copy.js';
+import { buildHeroCampModel } from '../src/platform/hero/hero-camp-model.js';
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+function monsterDef(id, overrides = {}) {
+  return {
+    monsterId: id,
+    displayName: id.charAt(0).toUpperCase() + id.slice(1),
+    childBlurb: `A creature called ${id}.`,
+    owned: false,
+    fullyGrown: false,
+    stage: 0,
+    maxStage: 4,
+    inviteCost: 150,
+    nextGrowCost: 300,
+    nextStage: 1,
+    branch: null,
+    defaultBranch: 'b1',
+    sourceAssetMonsterId: id,
+    canAffordInvite: true,
+    canAffordGrow: false,
+    ...overrides,
+  };
+}
+
+function ownedMonster(id, stage = 1, overrides = {}) {
+  return monsterDef(id, {
+    owned: true,
+    stage,
+    branch: 'b1',
+    nextStage: stage + 1,
+    nextGrowCost: stage === 1 ? 300 : stage === 2 ? 600 : stage === 3 ? 1000 : 1600,
+    canAffordGrow: true,
+    ...overrides,
+  });
+}
+
+function fullyGrownMonster(id) {
+  return monsterDef(id, {
+    owned: true,
+    fullyGrown: true,
+    stage: 4,
+    maxStage: 4,
+    branch: 'b1',
+    nextStage: null,
+    nextGrowCost: null,
+    canAffordGrow: false,
+    canAffordInvite: false,
+  });
+}
+
+function sixMonsters(overrides = []) {
+  const ids = ['glossbloom', 'loomrill', 'mirrane', 'colisk', 'hyphang', 'carillon'];
+  return ids.map((id, i) => overrides[i] ? { ...monsterDef(id), ...overrides[i] } : monsterDef(id));
+}
+
+function campModelEnabled(monsters = sixMonsters(), balance = 500) {
+  return {
+    campEnabled: true,
+    balance,
+    balanceLabel: `${balance} Hero Coins`,
+    monsters,
+    selectedMonsterId: null,
+    rosterVersion: 'hero-pool-v1',
+    recentActions: [],
+    lastAction: null,
+    hasAffordableAction: monsters.some(m => m.canAffordInvite || m.canAffordGrow),
+    insufficientBalanceMessage: 'Save more Hero Coins by completing Hero Quests.',
+  };
+}
+
+function campModelDisabled() {
+  return { campEnabled: false, balance: 0, monsters: [] };
+}
+
+function heroModel(overrides = {}) {
+  return {
+    status: 'ready',
+    enabled: true,
+    nextTask: {
+      taskId: 'task-001',
+      subjectId: 'spelling',
+      intent: 'weak-repair',
+      launcher: 'standard-practice',
+      launchStatus: 'launchable',
+      childLabel: 'Spelling: Practise something tricky',
+      childReason: 'This will help you get better at something you find tricky.',
+    },
+    activeHeroSession: null,
+    canStart: true,
+    canContinue: false,
+    error: '',
+    effortPlanned: 18,
+    eligibleSubjects: ['spelling', 'grammar'],
+    lockedSubjects: [],
+    lastLaunch: null,
+    coinsEnabled: true,
+    coinBalance: 500,
+    dailyStatus: 'none',
+    ...overrides,
+  };
+}
+
+// Build a heroReadModel that will produce camp data through buildHeroCampModel
+function heroReadModelWithCamp(monsters = sixMonsters(), balance = 500) {
+  return {
+    camp: {
+      enabled: true,
+      balance,
+      monsters,
+      selectedMonsterId: null,
+      rosterVersion: 'hero-pool-v1',
+      recentActions: [],
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Camp panel integration on HomeSurface
+// ---------------------------------------------------------------------------
+
+describe('Hero Camp panel on HomeSurface', () => {
+  it('camp panel appears when hero is active and camp is enabled', async () => {
+    const html = await renderHomeSurfaceWithCampFixture({
+      hero: heroModel(),
+      heroCamp: { campEnabled: true },
+    });
+    assert.ok(html.includes('data-hero-camp-panel'), 'camp panel is rendered');
+    assert.ok(html.includes('Hero Camp'), 'camp title is rendered');
+  });
+
+  it('camp panel does NOT appear when camp is disabled', async () => {
+    const html = await renderHomeSurfaceWithCampFixture({
+      hero: heroModel(),
+      heroCamp: { campEnabled: false },
+    });
+    assert.ok(!html.includes('data-hero-camp-panel'), 'camp panel is not rendered');
+  });
+
+  it('camp panel does NOT appear when hero is not active', async () => {
+    const html = await renderHomeSurfaceWithCampFixture({
+      hero: { enabled: false, status: 'idle' },
+      heroCamp: { campEnabled: true },
+    });
+    assert.ok(!html.includes('data-hero-camp-panel'), 'camp panel not rendered without hero');
+  });
+
+  it('Hero Quest remains primary action — camp panel is secondary', async () => {
+    const html = await renderHomeSurfaceWithCampFixture({
+      hero: heroModel(),
+      heroCamp: { campEnabled: true },
+    });
+    const heroCardPos = html.indexOf('data-hero-card');
+    const campPanelPos = html.indexOf('data-hero-camp-panel');
+    assert.ok(heroCardPos >= 0, 'hero card is present');
+    assert.ok(campPanelPos >= 0, 'camp panel is present');
+    assert.ok(heroCardPos < campPanelPos, 'hero card appears before camp panel');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HeroCampPanel (standalone)
+// ---------------------------------------------------------------------------
+
+describe('HeroCampPanel', () => {
+  it('renders nothing when campModel is disabled', async () => {
+    const html = await renderHeroCampPanelFixture({
+      campModel: campModelDisabled(),
+      balance: 500,
+    });
+    assert.ok(!html.includes('data-hero-camp-panel'), 'panel is not rendered');
+  });
+
+  it('renders six monster cards when camp model has 6 monsters', async () => {
+    const html = await renderHeroCampPanelFixture({
+      campModel: campModelEnabled(),
+      balance: 500,
+    });
+    assert.ok(html.includes('data-hero-camp-panel'), 'panel renders');
+    // Count monster cards by data-monster-id
+    const matches = html.match(/data-monster-id/g);
+    assert.equal(matches?.length, 6, 'six monster cards rendered');
+  });
+
+  it('shows balance', async () => {
+    const html = await renderHeroCampPanelFixture({
+      campModel: campModelEnabled(sixMonsters(), 750),
+      balance: 750,
+    });
+    assert.ok(html.includes('750'), 'balance value is shown');
+    assert.ok(html.includes('Hero Coins'), 'Hero Coins label is shown');
+  });
+
+  it('shows invite prompt when no monsters are owned', async () => {
+    const html = await renderHeroCampPanelFixture({
+      campModel: campModelEnabled(),
+      balance: 500,
+    });
+    assert.ok(html.includes('Choose a Hero monster to invite.'), 'invite prompt shown');
+  });
+
+  it('shows all-grown message when every monster is fully grown', async () => {
+    const allGrown = ['glossbloom', 'loomrill', 'mirrane', 'colisk', 'hyphang', 'carillon']
+      .map(id => fullyGrownMonster(id));
+    const html = await renderHeroCampPanelFixture({
+      campModel: campModelEnabled(allGrown),
+      balance: 500,
+    });
+    assert.ok(html.includes('fully grown'), 'all-grown message shown');
+    assert.ok(html.includes('Well done'), 'celebratory message shown');
+  });
+
+  it('has section role with aria-label', async () => {
+    const html = await renderHeroCampPanelFixture({
+      campModel: campModelEnabled(),
+      balance: 500,
+    });
+    assert.ok(html.includes('aria-label="Hero Camp"'), 'section has aria-label');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HeroCampMonsterCard
+// ---------------------------------------------------------------------------
+
+describe('HeroCampMonsterCard', () => {
+  it('invite CTA shows correct cost', async () => {
+    const html = await renderHeroCampMonsterCardFixture({
+      monster: monsterDef('glossbloom', { inviteCost: 150 }),
+      balance: 500,
+    });
+    assert.ok(html.includes('Invite'), 'CTA contains Invite');
+    assert.ok(html.includes('150 Hero Coins'), 'CTA shows cost of 150');
+  });
+
+  it('grow CTA shows correct cost and target stage', async () => {
+    const html = await renderHeroCampMonsterCardFixture({
+      monster: ownedMonster('loomrill', 2, { nextGrowCost: 600, nextStage: 3 }),
+      balance: 1000,
+    });
+    assert.ok(html.includes('Grow'), 'CTA contains Grow');
+    assert.ok(html.includes('600 Hero Coins'), 'CTA shows grow cost');
+  });
+
+  it('fully grown shows "Fully grown" with no action button', async () => {
+    const html = await renderHeroCampMonsterCardFixture({
+      monster: fullyGrownMonster('mirrane'),
+      balance: 500,
+    });
+    assert.ok(html.includes('Fully grown'), 'shows Fully grown label');
+    // No Invite or Grow CTA when fully grown
+    assert.ok(!html.includes('Invite'), 'no Invite text');
+    assert.ok(!html.includes('>Grow'), 'no Grow CTA');
+  });
+
+  it('insufficient balance shows calm "Save more" copy', async () => {
+    const html = await renderHeroCampMonsterCardFixture({
+      monster: monsterDef('colisk', { inviteCost: 150 }),
+      balance: 50, // not enough
+    });
+    assert.ok(html.includes('Save more Hero Coins by completing Hero Quests'), 'insufficient message shown');
+    assert.ok(html.includes('disabled'), 'button is disabled');
+  });
+
+  it('shows monster name and blurb', async () => {
+    const html = await renderHeroCampMonsterCardFixture({
+      monster: monsterDef('hyphang', { displayName: 'Hyphang', childBlurb: 'A boundary creature.' }),
+      balance: 500,
+    });
+    assert.ok(html.includes('Hyphang'), 'monster name rendered');
+    assert.ok(html.includes('A boundary creature.'), 'blurb rendered');
+  });
+
+  it('shows branch badge when owned', async () => {
+    const html = await renderHeroCampMonsterCardFixture({
+      monster: ownedMonster('glossbloom', 1, { branch: 'b1' }),
+      balance: 500,
+    });
+    assert.ok(html.includes('Path A'), 'branch badge shown');
+  });
+
+  it('shows stage indicator when owned', async () => {
+    const html = await renderHeroCampMonsterCardFixture({
+      monster: ownedMonster('loomrill', 2),
+      balance: 500,
+    });
+    assert.ok(html.includes('Stage 2'), 'stage label shown');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HeroCampConfirmation
+// ---------------------------------------------------------------------------
+
+describe('HeroCampConfirmation', () => {
+  it('renders nothing when not visible', async () => {
+    const html = await renderHeroCampConfirmationFixture({
+      visible: false,
+      heading: 'Use 150 Hero Coins to invite Glossbloom?',
+      balanceAfter: 'Your balance will be 350 Hero Coins.',
+      actionLabel: 'invite',
+    });
+    assert.ok(!html.includes('hero-camp-confirmation'), 'dialog is not rendered');
+  });
+
+  it('shows correct cost and balance-after', async () => {
+    const html = await renderHeroCampConfirmationFixture({
+      visible: true,
+      heading: 'Use 150 Hero Coins to invite Glossbloom?',
+      balanceAfter: 'Your balance will be 350 Hero Coins.',
+      actionLabel: 'invite',
+    });
+    assert.ok(html.includes('Use 150 Hero Coins to invite Glossbloom?'), 'heading shown');
+    assert.ok(html.includes('Your balance will be 350 Hero Coins.'), 'balance-after shown');
+  });
+
+  it('shows confirm and cancel buttons', async () => {
+    const html = await renderHeroCampConfirmationFixture({
+      visible: true,
+      heading: 'Use 300 Hero Coins to grow Loomrill?',
+      balanceAfter: 'Your balance will be 200 Hero Coins.',
+      actionLabel: 'grow',
+    });
+    assert.ok(html.includes('Yes, grow'), 'confirm button text');
+    assert.ok(html.includes('Not now'), 'cancel button text');
+  });
+
+  it('has dialog role and aria-modal', async () => {
+    const html = await renderHeroCampConfirmationFixture({
+      visible: true,
+      heading: 'Use 150 Hero Coins to invite Mirrane?',
+      balanceAfter: 'Your balance will be 350 Hero Coins.',
+      actionLabel: 'invite',
+    });
+    assert.ok(html.includes('role="dialog"'), 'has dialog role');
+    assert.ok(html.includes('aria-modal="true"'), 'has aria-modal');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Vocabulary boundary — no forbidden words in ANY rendered output
+// ---------------------------------------------------------------------------
+
+describe('Hero Camp vocabulary boundary', () => {
+  it('panel output contains no shop/deal/loot/limited-time/streak vocabulary', async () => {
+    const html = await renderHeroCampPanelFixture({
+      campModel: campModelEnabled(),
+      balance: 500,
+    });
+    const lower = html.toLowerCase();
+    for (const word of HERO_FORBIDDEN_VOCABULARY) {
+      assert.ok(
+        !lower.includes(word.toLowerCase()),
+        `forbidden word "${word}" found in panel output`,
+      );
+    }
+  });
+
+  it('monster card output contains no forbidden vocabulary', async () => {
+    const html = await renderHeroCampMonsterCardFixture({
+      monster: monsterDef('glossbloom'),
+      balance: 500,
+    });
+    const lower = html.toLowerCase();
+    for (const word of HERO_FORBIDDEN_VOCABULARY) {
+      assert.ok(
+        !lower.includes(word.toLowerCase()),
+        `forbidden word "${word}" found in monster card output`,
+      );
+    }
+  });
+
+  it('confirmation dialog output contains no forbidden vocabulary', async () => {
+    const html = await renderHeroCampConfirmationFixture({
+      visible: true,
+      heading: 'Use 150 Hero Coins to invite Glossbloom?',
+      balanceAfter: 'Your balance will be 350 Hero Coins.',
+      actionLabel: 'invite',
+    });
+    const lower = html.toLowerCase();
+    for (const word of HERO_FORBIDDEN_VOCABULARY) {
+      assert.ok(
+        !lower.includes(word.toLowerCase()),
+        `forbidden word "${word}" found in confirmation output`,
+      );
+    }
+  });
+
+  it('home surface with camp output contains no forbidden vocabulary', async () => {
+    const html = await renderHomeSurfaceWithCampFixture({
+      hero: heroModel(),
+      heroCamp: { campEnabled: true },
+    });
+    const lower = html.toLowerCase();
+    for (const word of HERO_FORBIDDEN_VOCABULARY) {
+      assert.ok(
+        !lower.includes(word.toLowerCase()),
+        `forbidden word "${word}" found in home surface with camp output`,
+      );
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Keyboard accessibility — buttons focusable with labels
+// ---------------------------------------------------------------------------
+
+describe('Hero Camp accessibility', () => {
+  it('monster card invite button has aria-label', async () => {
+    const html = await renderHeroCampMonsterCardFixture({
+      monster: monsterDef('glossbloom', { inviteCost: 150 }),
+      balance: 500,
+    });
+    assert.ok(html.includes('aria-label="Invite'), 'invite button has aria-label');
+    assert.ok(html.includes('type="button"'), 'button has type attribute');
+  });
+
+  it('monster card grow button has aria-label', async () => {
+    const html = await renderHeroCampMonsterCardFixture({
+      monster: ownedMonster('loomrill', 1, { nextGrowCost: 300 }),
+      balance: 500,
+    });
+    assert.ok(html.includes('aria-label="Grow'), 'grow button has aria-label');
+  });
+
+  it('confirmation confirm button has aria-label', async () => {
+    const html = await renderHeroCampConfirmationFixture({
+      visible: true,
+      heading: 'Use 150 Hero Coins to invite Glossbloom?',
+      balanceAfter: 'Your balance will be 350 Hero Coins.',
+      actionLabel: 'invite',
+    });
+    assert.ok(html.includes('aria-label="Yes, invite"'), 'confirm button has label');
+    assert.ok(html.includes('aria-label="Not now"'), 'cancel button has label');
+  });
+
+  it('camp panel section has aria-label', async () => {
+    const html = await renderHeroCampPanelFixture({
+      campModel: campModelEnabled(),
+      balance: 500,
+    });
+    assert.ok(html.includes('aria-label="Hero Camp"'), 'section has aria-label');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildHeroCampModel pure logic
+// ---------------------------------------------------------------------------
+
+describe('buildHeroCampModel', () => {
+  it('returns disabled model when camp is not in read model', () => {
+    const result = buildHeroCampModel(null);
+    assert.equal(result.campEnabled, false);
+  });
+
+  it('returns disabled model when camp.enabled is false', () => {
+    const result = buildHeroCampModel({ camp: { enabled: false } });
+    assert.equal(result.campEnabled, false);
+  });
+
+  it('returns enabled model with correct balance', () => {
+    const result = buildHeroCampModel({
+      camp: {
+        enabled: true,
+        balance: 750,
+        monsters: [],
+        selectedMonsterId: null,
+        rosterVersion: 'hero-pool-v1',
+        recentActions: [],
+      },
+    });
+    assert.equal(result.campEnabled, true);
+    assert.equal(result.balance, 750);
+    assert.equal(result.balanceLabel, '750 Hero Coins');
+  });
+});

--- a/tests/hero-p5-client-camp.test.js
+++ b/tests/hero-p5-client-camp.test.js
@@ -1,0 +1,603 @@
+// Hero Mode P5 U8 — Client Camp methods, UI model, and asset adapter.
+//
+// Tests cover:
+//   - unlockMonster sends correct payload without forbidden fields
+//   - evolveMonster sends correct payload with targetStage
+//   - Camp model derives 6 monster cards when camp enabled
+//   - Camp model shows balance from camp block
+//   - Camp disabled → campEnabled false, empty monsters array
+//   - Camp model computes actionLabel correctly for each state
+//   - Camp model computes balanceAfter for confirmation
+//   - Stale-write triggers onStaleWrite callback
+//   - Monster assets adapter returns a string path
+//   - Monster assets adapter handles unknown sourceAssetMonsterId gracefully
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createHeroModeClient, HeroModeClientError } from '../src/platform/hero/hero-client.js';
+import { buildHeroCampModel, buildInviteConfirmation, buildGrowConfirmation } from '../src/platform/hero/hero-camp-model.js';
+import { getHeroMonsterAssetSrc, hasHeroMonsterAsset } from '../src/platform/hero/hero-monster-assets.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createMockFetch(responses) {
+  let callIndex = 0;
+  const calls = [];
+
+  async function mockFetch(url, init) {
+    const parsedBody = init?.body ? JSON.parse(init.body) : undefined;
+    calls.push({ url, init, body: parsedBody });
+    const resp = responses[callIndex] || responses[responses.length - 1];
+    callIndex++;
+    return {
+      ok: resp.ok !== false,
+      status: resp.status || 200,
+      json: async () => resp.data,
+    };
+  }
+
+  mockFetch.calls = calls;
+  return mockFetch;
+}
+
+function defaultOpts(overrides = {}) {
+  return {
+    fetch: createMockFetch([{ ok: true, status: 200, data: { ok: true } }]),
+    getLearnerRevision: () => 42,
+    ...overrides,
+  };
+}
+
+// Forbidden fields that must NEVER appear in Camp command request bodies
+const FORBIDDEN_FIELDS = ['cost', 'amount', 'balance', 'ledgerEntryId', 'stage', 'owned', 'payload', 'subjectId'];
+
+// ---------------------------------------------------------------------------
+// unlockMonster — correct payload
+// ---------------------------------------------------------------------------
+
+describe('unlockMonster — sends correct payload without forbidden fields', () => {
+  it('sends command unlock-monster with monsterId and branch', async () => {
+    const fakeFetch = createMockFetch([{
+      ok: true, status: 200, data: { ok: true, camp: { action: 'invite' } },
+    }]);
+    const client = createHeroModeClient({ ...defaultOpts(), fetch: fakeFetch });
+
+    await client.unlockMonster({
+      learnerId: 'learner-1',
+      monsterId: 'glossbloom',
+      branch: 'b2',
+      requestId: 'req-unlock-1',
+    });
+
+    assert.equal(fakeFetch.calls.length, 1);
+    const { url, init, body } = fakeFetch.calls[0];
+    assert.equal(url, '/api/hero/command');
+    assert.equal(init.method, 'POST');
+    assert.equal(init.headers['content-type'], 'application/json');
+    assert.equal(body.command, 'unlock-monster');
+    assert.equal(body.learnerId, 'learner-1');
+    assert.equal(body.monsterId, 'glossbloom');
+    assert.equal(body.branch, 'b2');
+    assert.equal(body.requestId, 'req-unlock-1');
+    assert.equal(body.expectedLearnerRevision, 42);
+  });
+
+  it('NEVER includes forbidden fields in unlock payload', async () => {
+    const fakeFetch = createMockFetch([{
+      ok: true, status: 200, data: { ok: true },
+    }]);
+    const client = createHeroModeClient({ ...defaultOpts(), fetch: fakeFetch });
+
+    await client.unlockMonster({
+      learnerId: 'learner-1',
+      monsterId: 'colisk',
+      branch: 'b1',
+      requestId: 'req-u-2',
+    });
+
+    const body = fakeFetch.calls[0].body;
+    for (const field of FORBIDDEN_FIELDS) {
+      assert.ok(!(field in body), `body must not include ${field}`);
+    }
+  });
+
+  it('includes expectedLearnerRevision from getLearnerRevision', async () => {
+    const fakeFetch = createMockFetch([{
+      ok: true, status: 200, data: { ok: true },
+    }]);
+    const client = createHeroModeClient({
+      ...defaultOpts(),
+      fetch: fakeFetch,
+      getLearnerRevision: (id) => {
+        assert.equal(id, 'learner-7');
+        return 77;
+      },
+    });
+
+    await client.unlockMonster({
+      learnerId: 'learner-7',
+      monsterId: 'hyphang',
+      branch: 'b1',
+      requestId: 'req-u-3',
+    });
+
+    const body = fakeFetch.calls[0].body;
+    assert.equal(body.expectedLearnerRevision, 77);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// evolveMonster — correct payload with targetStage
+// ---------------------------------------------------------------------------
+
+describe('evolveMonster — sends correct payload with targetStage', () => {
+  it('sends command evolve-monster with monsterId and targetStage', async () => {
+    const fakeFetch = createMockFetch([{
+      ok: true, status: 200, data: { ok: true, camp: { action: 'grow' } },
+    }]);
+    const client = createHeroModeClient({ ...defaultOpts(), fetch: fakeFetch });
+
+    await client.evolveMonster({
+      learnerId: 'learner-2',
+      monsterId: 'loomrill',
+      targetStage: 3,
+      requestId: 'req-evolve-1',
+    });
+
+    assert.equal(fakeFetch.calls.length, 1);
+    const { body } = fakeFetch.calls[0];
+    assert.equal(body.command, 'evolve-monster');
+    assert.equal(body.learnerId, 'learner-2');
+    assert.equal(body.monsterId, 'loomrill');
+    assert.equal(body.targetStage, 3);
+    assert.equal(body.requestId, 'req-evolve-1');
+    assert.equal(body.expectedLearnerRevision, 42);
+  });
+
+  it('NEVER includes forbidden fields in evolve payload', async () => {
+    const fakeFetch = createMockFetch([{
+      ok: true, status: 200, data: { ok: true },
+    }]);
+    const client = createHeroModeClient({ ...defaultOpts(), fetch: fakeFetch });
+
+    await client.evolveMonster({
+      learnerId: 'learner-2',
+      monsterId: 'mirrane',
+      targetStage: 2,
+      requestId: 'req-e-2',
+    });
+
+    const body = fakeFetch.calls[0].body;
+    for (const field of FORBIDDEN_FIELDS) {
+      assert.ok(!(field in body), `body must not include ${field}`);
+    }
+  });
+
+  it('returns response JSON on success', async () => {
+    const responseData = { ok: true, camp: { action: 'grow', stageAfter: 3 } };
+    const fakeFetch = createMockFetch([{ ok: true, status: 200, data: responseData }]);
+    const client = createHeroModeClient({ ...defaultOpts(), fetch: fakeFetch });
+
+    const result = await client.evolveMonster({
+      learnerId: 'learner-2',
+      monsterId: 'loomrill',
+      targetStage: 3,
+      requestId: 'req-e-3',
+    });
+
+    assert.deepStrictEqual(result, responseData);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stale-write triggers onStaleWrite callback
+// ---------------------------------------------------------------------------
+
+describe('Camp commands — stale_write triggers onStaleWrite', () => {
+  it('unlockMonster stale_write triggers onStaleWrite', async () => {
+    const fakeFetch = createMockFetch([{
+      ok: false, status: 409, data: { ok: false, code: 'stale_write' },
+    }]);
+    const staleWrites = [];
+    const client = createHeroModeClient({
+      ...defaultOpts(),
+      fetch: fakeFetch,
+      onStaleWrite: (info) => staleWrites.push(info),
+    });
+
+    await client.unlockMonster({
+      learnerId: 'learner-stale',
+      monsterId: 'glossbloom',
+      branch: 'b1',
+      requestId: 'req-stale-1',
+    }).catch(() => {});
+
+    assert.equal(staleWrites.length, 1);
+    assert.equal(staleWrites[0].learnerId, 'learner-stale');
+    assert.ok(staleWrites[0].error instanceof HeroModeClientError);
+    assert.equal(staleWrites[0].error.code, 'stale_write');
+  });
+
+  it('evolveMonster stale_write triggers onStaleWrite', async () => {
+    const fakeFetch = createMockFetch([{
+      ok: false, status: 409, data: { ok: false, code: 'stale_write' },
+    }]);
+    const staleWrites = [];
+    const client = createHeroModeClient({
+      ...defaultOpts(),
+      fetch: fakeFetch,
+      onStaleWrite: (info) => staleWrites.push(info),
+    });
+
+    await client.evolveMonster({
+      learnerId: 'learner-stale-2',
+      monsterId: 'hyphang',
+      targetStage: 2,
+      requestId: 'req-stale-2',
+    }).catch(() => {});
+
+    assert.equal(staleWrites.length, 1);
+    assert.equal(staleWrites[0].learnerId, 'learner-stale-2');
+    assert.equal(staleWrites[0].error.code, 'stale_write');
+  });
+
+  it('non-stale errors do not trigger onStaleWrite', async () => {
+    const fakeFetch = createMockFetch([{
+      ok: false, status: 400, data: { ok: false, code: 'hero_pool_insufficient_balance' },
+    }]);
+    const staleWrites = [];
+    const client = createHeroModeClient({
+      ...defaultOpts(),
+      fetch: fakeFetch,
+      onStaleWrite: (info) => staleWrites.push(info),
+    });
+
+    await client.unlockMonster({
+      learnerId: 'learner-x',
+      monsterId: 'colisk',
+      branch: 'b1',
+      requestId: 'req-nsw',
+    }).catch(() => {});
+
+    assert.equal(staleWrites.length, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Camp model — derives 6 monster cards when camp enabled
+// ---------------------------------------------------------------------------
+
+describe('buildHeroCampModel — camp enabled with monsters', () => {
+  const sixMonsters = [
+    { monsterId: 'glossbloom', displayName: 'Glossbloom', childBlurb: 'Blooms with word classes.', sourceAssetMonsterId: 'glossbloom', owned: true, stage: 2, branch: 'b1', maxStage: 4, inviteCost: 150, nextGrowCost: 300, nextStage: 3, canInvite: false, canGrow: true, canAffordInvite: false, canAffordGrow: true, fullyGrown: false },
+    { monsterId: 'loomrill', displayName: 'Loomrill', childBlurb: 'Threads adverbials.', sourceAssetMonsterId: 'loomrill', owned: true, stage: 4, branch: 'b2', maxStage: 4, inviteCost: 150, nextGrowCost: null, nextStage: null, canInvite: false, canGrow: false, canAffordInvite: false, canAffordGrow: false, fullyGrown: true },
+    { monsterId: 'mirrane', displayName: 'Mirrane', childBlurb: 'Reflects roles.', sourceAssetMonsterId: 'mirrane', owned: false, stage: 0, branch: null, maxStage: 4, inviteCost: 150, nextGrowCost: null, nextStage: null, canInvite: true, canGrow: false, canAffordInvite: true, canAffordGrow: false, fullyGrown: false },
+    { monsterId: 'colisk', displayName: 'Colisk', childBlurb: 'Structure creature.', sourceAssetMonsterId: 'colisk', owned: false, stage: 0, branch: null, maxStage: 4, inviteCost: 150, nextGrowCost: null, nextStage: null, canInvite: true, canGrow: false, canAffordInvite: true, canAffordGrow: false, fullyGrown: false },
+    { monsterId: 'hyphang', displayName: 'Hyphang', childBlurb: 'Dash creature.', sourceAssetMonsterId: 'hyphang', owned: true, stage: 1, branch: 'b1', maxStage: 4, inviteCost: 150, nextGrowCost: 200, nextStage: 2, canInvite: false, canGrow: true, canAffordInvite: false, canAffordGrow: true, fullyGrown: false },
+    { monsterId: 'carillon', displayName: 'Carillon', childBlurb: 'Chord creature.', sourceAssetMonsterId: 'carillon', owned: false, stage: 0, branch: null, maxStage: 4, inviteCost: 150, nextGrowCost: null, nextStage: null, canInvite: true, canGrow: false, canAffordInvite: false, canAffordGrow: false, fullyGrown: false },
+  ];
+
+  const campReadModel = {
+    camp: {
+      enabled: true,
+      version: 1,
+      rosterVersion: 'pool-v1-6mon',
+      balance: 800,
+      selectedMonsterId: 'glossbloom',
+      monsters: sixMonsters,
+      recentActions: [
+        { type: 'invite', monsterId: 'hyphang', stageAfter: 0, cost: 150, createdAt: Date.now() - 2000 },
+        { type: 'grow', monsterId: 'glossbloom', stageAfter: 2, cost: 300, createdAt: Date.now() - 1000 },
+      ],
+    },
+  };
+
+  it('derives 6 monster cards when camp enabled', () => {
+    const model = buildHeroCampModel(campReadModel);
+
+    assert.equal(model.campEnabled, true);
+    assert.equal(model.monsters.length, 6);
+    assert.deepEqual(
+      model.monsters.map(m => m.monsterId),
+      ['glossbloom', 'loomrill', 'mirrane', 'colisk', 'hyphang', 'carillon'],
+    );
+  });
+
+  it('shows balance from camp block', () => {
+    const model = buildHeroCampModel(campReadModel);
+
+    assert.equal(model.balance, 800);
+    assert.equal(model.balanceLabel, '800 Hero Coins');
+  });
+
+  it('exposes rosterVersion and selectedMonsterId', () => {
+    const model = buildHeroCampModel(campReadModel);
+
+    assert.equal(model.rosterVersion, 'pool-v1-6mon');
+    assert.equal(model.selectedMonsterId, 'glossbloom');
+  });
+
+  it('hasAffordableAction true when at least one monster can be acted upon', () => {
+    const model = buildHeroCampModel(campReadModel);
+
+    assert.equal(model.hasAffordableAction, true);
+  });
+
+  it('empty false when at least one monster is owned', () => {
+    const model = buildHeroCampModel(campReadModel);
+
+    assert.equal(model.empty, false);
+  });
+
+  it('lastAction is the most recent action', () => {
+    const model = buildHeroCampModel(campReadModel);
+
+    assert.equal(model.lastAction.type, 'grow');
+    assert.equal(model.lastAction.monsterId, 'glossbloom');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Camp model — camp disabled
+// ---------------------------------------------------------------------------
+
+describe('buildHeroCampModel — camp disabled', () => {
+  it('null readModel → campEnabled false, empty monsters', () => {
+    const model = buildHeroCampModel(null);
+
+    assert.equal(model.campEnabled, false);
+    assert.deepEqual(model.monsters, []);
+    assert.equal(model.balance, 0);
+    assert.equal(model.selectedMonsterId, null);
+    assert.equal(model.hasAffordableAction, false);
+  });
+
+  it('camp.enabled === false → campEnabled false, empty monsters', () => {
+    const model = buildHeroCampModel({ camp: { enabled: false } });
+
+    assert.equal(model.campEnabled, false);
+    assert.deepEqual(model.monsters, []);
+    assert.equal(model.balance, 0);
+  });
+
+  it('no camp block at all → campEnabled false', () => {
+    const model = buildHeroCampModel({ economy: { balance: 500 } });
+
+    assert.equal(model.campEnabled, false);
+    assert.deepEqual(model.monsters, []);
+  });
+
+  it('empty true when camp disabled', () => {
+    const model = buildHeroCampModel(null);
+
+    assert.equal(model.empty, true);
+  });
+
+  it('empty true when all monsters are unowned', () => {
+    const readModel = {
+      camp: {
+        enabled: true,
+        balance: 200,
+        rosterVersion: 'v1',
+        selectedMonsterId: null,
+        monsters: [
+          { monsterId: 'colisk', displayName: 'Colisk', childBlurb: 'x', sourceAssetMonsterId: 'colisk', owned: false, stage: 0, branch: null, maxStage: 4, inviteCost: 150, nextGrowCost: null, nextStage: null, canInvite: true, canGrow: false, canAffordInvite: true, canAffordGrow: false, fullyGrown: false },
+          { monsterId: 'hyphang', displayName: 'Hyphang', childBlurb: 'x', sourceAssetMonsterId: 'hyphang', owned: false, stage: 0, branch: null, maxStage: 4, inviteCost: 150, nextGrowCost: null, nextStage: null, canInvite: true, canGrow: false, canAffordInvite: true, canAffordGrow: false, fullyGrown: false },
+        ],
+        recentActions: [],
+      },
+    };
+
+    const model = buildHeroCampModel(readModel);
+
+    assert.equal(model.empty, true);
+    assert.equal(model.campEnabled, true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Camp model — actionLabel derivation
+// ---------------------------------------------------------------------------
+
+describe('buildHeroCampModel — actionLabel derivation', () => {
+  it('unowned monster → actionLabel contains "invite"', () => {
+    const readModel = {
+      camp: {
+        enabled: true,
+        balance: 500,
+        rosterVersion: 'v1',
+        selectedMonsterId: null,
+        monsters: [
+          { monsterId: 'mirrane', displayName: 'Mirrane', childBlurb: 'x', sourceAssetMonsterId: 'mirrane', owned: false, stage: 0, branch: null, maxStage: 4, inviteCost: 150, nextGrowCost: null, nextStage: null, canInvite: true, canGrow: false, canAffordInvite: true, canAffordGrow: false, fullyGrown: false },
+        ],
+        recentActions: [],
+      },
+    };
+
+    const model = buildHeroCampModel(readModel);
+    const mirrane = model.monsters[0];
+
+    assert.ok(mirrane.actionLabel.toLowerCase().includes('invite'), `Expected "invite" in actionLabel, got: ${mirrane.actionLabel}`);
+  });
+
+  it('owned, not fully grown → actionLabel contains "grow"', () => {
+    const readModel = {
+      camp: {
+        enabled: true,
+        balance: 500,
+        rosterVersion: 'v1',
+        selectedMonsterId: null,
+        monsters: [
+          { monsterId: 'glossbloom', displayName: 'Glossbloom', childBlurb: 'x', sourceAssetMonsterId: 'glossbloom', owned: true, stage: 2, branch: 'b1', maxStage: 4, inviteCost: 150, nextGrowCost: 300, nextStage: 3, canInvite: false, canGrow: true, canAffordInvite: false, canAffordGrow: true, fullyGrown: false },
+        ],
+        recentActions: [],
+      },
+    };
+
+    const model = buildHeroCampModel(readModel);
+    const glossbloom = model.monsters[0];
+
+    assert.ok(glossbloom.actionLabel.toLowerCase().includes('grow'), `Expected "grow" in actionLabel, got: ${glossbloom.actionLabel}`);
+  });
+
+  it('fully grown → actionLabel is "Fully grown"', () => {
+    const readModel = {
+      camp: {
+        enabled: true,
+        balance: 500,
+        rosterVersion: 'v1',
+        selectedMonsterId: null,
+        monsters: [
+          { monsterId: 'loomrill', displayName: 'Loomrill', childBlurb: 'x', sourceAssetMonsterId: 'loomrill', owned: true, stage: 4, branch: 'b2', maxStage: 4, inviteCost: 150, nextGrowCost: null, nextStage: null, canInvite: false, canGrow: false, canAffordInvite: false, canAffordGrow: false, fullyGrown: true },
+        ],
+        recentActions: [],
+      },
+    };
+
+    const model = buildHeroCampModel(readModel);
+    const loomrill = model.monsters[0];
+
+    assert.equal(loomrill.actionLabel, 'Fully grown');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Camp model — balanceAfter for confirmation
+// ---------------------------------------------------------------------------
+
+describe('buildHeroCampModel — balanceAfter for confirmation', () => {
+  it('buildInviteConfirmation computes balanceAfter correctly', () => {
+    const monster = {
+      monsterId: 'colisk',
+      displayName: 'Colisk',
+      inviteCost: 150,
+      owned: false,
+      fullyGrown: false,
+    };
+
+    const confirmation = buildInviteConfirmation(monster, 800);
+
+    assert.ok(confirmation.heading.includes('150'));
+    assert.ok(confirmation.heading.includes('Colisk'));
+    assert.ok(confirmation.balanceAfter.includes('650'));
+    assert.equal(confirmation.canConfirm, true);
+  });
+
+  it('buildInviteConfirmation canConfirm false when balance insufficient', () => {
+    const monster = {
+      monsterId: 'colisk',
+      displayName: 'Colisk',
+      inviteCost: 150,
+      owned: false,
+      fullyGrown: false,
+    };
+
+    const confirmation = buildInviteConfirmation(monster, 100);
+
+    assert.equal(confirmation.canConfirm, false);
+    assert.ok(confirmation.balanceAfter.includes('-50'));
+  });
+
+  it('buildGrowConfirmation computes balanceAfter correctly', () => {
+    const monster = {
+      monsterId: 'glossbloom',
+      displayName: 'Glossbloom',
+      nextGrowCost: 300,
+      nextStage: 3,
+      owned: true,
+      fullyGrown: false,
+    };
+
+    const confirmation = buildGrowConfirmation(monster, 500);
+
+    assert.ok(confirmation.heading.includes('300'));
+    assert.ok(confirmation.heading.includes('Glossbloom'));
+    assert.ok(confirmation.heading.includes('stage 3'));
+    assert.ok(confirmation.balanceAfter.includes('200'));
+    assert.equal(confirmation.canConfirm, true);
+  });
+
+  it('buildGrowConfirmation canConfirm false when insufficient', () => {
+    const monster = {
+      monsterId: 'hyphang',
+      displayName: 'Hyphang',
+      nextGrowCost: 200,
+      nextStage: 2,
+      owned: true,
+      fullyGrown: false,
+    };
+
+    const confirmation = buildGrowConfirmation(monster, 50);
+
+    assert.equal(confirmation.canConfirm, false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Monster assets adapter — returns string path
+// ---------------------------------------------------------------------------
+
+describe('getHeroMonsterAssetSrc — returns string path', () => {
+  it('returns an object with src as a string for a known monster', () => {
+    const result = getHeroMonsterAssetSrc('glossbloom', 2, 'b1');
+
+    assert.equal(typeof result.src, 'string');
+    assert.ok(result.src.length > 0);
+    assert.ok(result.src.includes('glossbloom'));
+    assert.ok(result.src.includes('b1'));
+    assert.ok(result.src.includes('2'));
+  });
+
+  it('returns srcSet as a string with width descriptors', () => {
+    const result = getHeroMonsterAssetSrc('loomrill', 3, 'b2');
+
+    assert.equal(typeof result.srcSet, 'string');
+    assert.ok(result.srcSet.includes('320w'));
+    assert.ok(result.srcSet.includes('640w'));
+    assert.ok(result.srcSet.includes('1280w'));
+  });
+
+  it('includes fallback path for stage 0', () => {
+    const result = getHeroMonsterAssetSrc('mirrane', 3, 'b1');
+
+    assert.equal(typeof result.fallback, 'string');
+    assert.ok(result.fallback.includes('mirrane'));
+    assert.ok(result.fallback.includes('0'));
+  });
+
+  it('default branch is b1 when not specified', () => {
+    const result = getHeroMonsterAssetSrc('hyphang', 1);
+
+    assert.ok(result.src.includes('b1'));
+    assert.ok(result.key.includes('b1'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Monster assets adapter — unknown sourceAssetMonsterId
+// ---------------------------------------------------------------------------
+
+describe('getHeroMonsterAssetSrc — handles unknown sourceAssetMonsterId gracefully', () => {
+  it('returns valid path structure even for unknown monster id', () => {
+    const result = getHeroMonsterAssetSrc('unknown-creature', 0, 'b1');
+
+    assert.equal(typeof result.src, 'string');
+    assert.ok(result.src.length > 0);
+    // Still produces a valid-looking path structure
+    assert.ok(result.src.includes('unknown-creature'));
+    assert.ok(result.key.includes('unknown-creature'));
+  });
+
+  it('hasHeroMonsterAsset returns false for empty/null id', () => {
+    assert.equal(hasHeroMonsterAsset('', 0, 'b1'), false);
+    assert.equal(hasHeroMonsterAsset(null, 0, 'b1'), false);
+    assert.equal(hasHeroMonsterAsset(undefined, 0, 'b1'), false);
+  });
+
+  it('hasHeroMonsterAsset returns true for any non-empty id', () => {
+    assert.equal(hasHeroMonsterAsset('glossbloom', 2, 'b1'), true);
+    assert.equal(hasHeroMonsterAsset('unknown-thing', 0, 'b1'), true);
+  });
+});

--- a/tests/hero-p5-monster-economy.test.js
+++ b/tests/hero-p5-monster-economy.test.js
@@ -1,0 +1,449 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  computeMonsterInviteIntent,
+  computeMonsterGrowIntent,
+  deriveSpendLedgerEntryId,
+} from '../shared/hero/monster-economy.js';
+
+import {
+  HERO_MONSTER_INVITE_COST,
+  HERO_MONSTER_GROW_COSTS,
+  HERO_POOL_ROSTER_VERSION,
+} from '../shared/hero/hero-pool.js';
+
+// ── Fixtures ─────────────────────────────────────────────────────────
+
+const LEARNER = 'learner-abc-123';
+const NOW = 1714400000000;
+const ROSTER_V = HERO_POOL_ROSTER_VERSION;
+
+function makeEconomy(balance = 1000, lifetimeSpent = 0, lifetimeEarned = 1000) {
+  return { version: 1, balance, lifetimeEarned, lifetimeSpent, ledger: [], lastUpdatedAt: NOW - 1000 };
+}
+
+function makePoolWithOwned(monsterId, stage = 0, branch = 'b1') {
+  return {
+    version: 1,
+    rosterVersion: ROSTER_V,
+    selectedMonsterId: null,
+    monsters: {
+      [monsterId]: { monsterId, owned: true, stage, branch, investedCoins: HERO_MONSTER_INVITE_COST, invitedAt: NOW - 5000, lastGrownAt: null, lastLedgerEntryId: 'prev-entry' },
+    },
+    recentActions: [],
+    lastUpdatedAt: NOW - 1000,
+  };
+}
+
+function makeEmptyPool() {
+  return { version: 1, rosterVersion: ROSTER_V, selectedMonsterId: null, monsters: {}, recentActions: [], lastUpdatedAt: null };
+}
+
+// ── Invite: success ──────────────────────────────────────────────────
+
+test('invite with sufficient balance debits exactly HERO_MONSTER_INVITE_COST', () => {
+  const eco = makeEconomy(500);
+  const pool = makeEmptyPool();
+  const result = computeMonsterInviteIntent({
+    economyState: eco, heroPoolState: pool, monsterId: 'glossbloom', branch: 'b1',
+    learnerId: LEARNER, rosterVersion: ROSTER_V, nowTs: NOW,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.status, 'invited');
+  assert.equal(result.intent.newBalance, 500 - HERO_MONSTER_INVITE_COST);
+  assert.equal(result.intent.ledgerEntry.amount, -HERO_MONSTER_INVITE_COST);
+  assert.equal(result.intent.ledgerEntry.type, 'monster-invite');
+});
+
+test('invite: balance exactly equals cost succeeds with 0 remaining', () => {
+  const eco = makeEconomy(HERO_MONSTER_INVITE_COST);
+  const pool = makeEmptyPool();
+  const result = computeMonsterInviteIntent({
+    economyState: eco, heroPoolState: pool, monsterId: 'loomrill', branch: 'b2',
+    learnerId: LEARNER, rosterVersion: ROSTER_V, nowTs: NOW,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.status, 'invited');
+  assert.equal(result.intent.newBalance, 0);
+});
+
+test('invite: lifetimeSpent increments; lifetimeEarned unchanged', () => {
+  const eco = makeEconomy(500, 100, 600);
+  const pool = makeEmptyPool();
+  const result = computeMonsterInviteIntent({
+    economyState: eco, heroPoolState: pool, monsterId: 'mirrane', branch: 'b1',
+    learnerId: LEARNER, rosterVersion: ROSTER_V, nowTs: NOW,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.intent.newLifetimeSpent, 100 + HERO_MONSTER_INVITE_COST);
+  // lifetimeEarned is not in the intent — unchanged by spending
+});
+
+test('invite: ledger entry has correct deterministic ID', () => {
+  const eco = makeEconomy(500);
+  const pool = makeEmptyPool();
+  const r1 = computeMonsterInviteIntent({
+    economyState: eco, heroPoolState: pool, monsterId: 'glossbloom', branch: 'b1',
+    learnerId: LEARNER, rosterVersion: ROSTER_V, nowTs: NOW,
+  });
+  const r2 = computeMonsterInviteIntent({
+    economyState: eco, heroPoolState: pool, monsterId: 'glossbloom', branch: 'b1',
+    learnerId: LEARNER, rosterVersion: ROSTER_V, nowTs: NOW + 9999,
+  });
+
+  // Same idempotency key → same entry ID regardless of timestamp
+  assert.equal(r1.intent.ledgerEntry.entryId, r2.intent.ledgerEntry.entryId);
+  assert.match(r1.intent.ledgerEntry.entryId, /^hero-ledger-/);
+});
+
+test('invite: balance after = balance - cost', () => {
+  const eco = makeEconomy(800);
+  const pool = makeEmptyPool();
+  const result = computeMonsterInviteIntent({
+    economyState: eco, heroPoolState: pool, monsterId: 'colisk', branch: 'b2',
+    learnerId: LEARNER, rosterVersion: ROSTER_V, nowTs: NOW,
+  });
+
+  assert.equal(result.intent.newBalance, 800 - HERO_MONSTER_INVITE_COST);
+  assert.equal(result.intent.ledgerEntry.balanceAfter, 800 - HERO_MONSTER_INVITE_COST);
+});
+
+// ── Invite: already owned ────────────────────────────────────────────
+
+test('invite: already-owned returns ok:true with cost 0', () => {
+  const eco = makeEconomy(500);
+  const pool = makePoolWithOwned('glossbloom');
+  const result = computeMonsterInviteIntent({
+    economyState: eco, heroPoolState: pool, monsterId: 'glossbloom', branch: 'b1',
+    learnerId: LEARNER, rosterVersion: ROSTER_V, nowTs: NOW,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.status, 'already-owned');
+  assert.equal(result.cost, 0);
+  assert.equal(result.coinsUsed, 0);
+});
+
+// ── Invite: insufficient balance ─────────────────────────────────────
+
+test('invite: insufficient balance returns ok:false', () => {
+  const eco = makeEconomy(HERO_MONSTER_INVITE_COST - 1);
+  const pool = makeEmptyPool();
+  const result = computeMonsterInviteIntent({
+    economyState: eco, heroPoolState: pool, monsterId: 'glossbloom', branch: 'b1',
+    learnerId: LEARNER, rosterVersion: ROSTER_V, nowTs: NOW,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, 'hero_insufficient_coins');
+});
+
+// ── Invite: unknown monster ──────────────────────────────────────────
+
+test('invite: unknown monsterId returns hero_monster_unknown', () => {
+  const eco = makeEconomy(500);
+  const pool = makeEmptyPool();
+  const result = computeMonsterInviteIntent({
+    economyState: eco, heroPoolState: pool, monsterId: 'fake-monster', branch: 'b1',
+    learnerId: LEARNER, rosterVersion: ROSTER_V, nowTs: NOW,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, 'hero_monster_unknown');
+});
+
+// ── Invite: branch validation ────────────────────────────────────────
+
+test('invite: missing branch returns hero_monster_branch_required', () => {
+  const eco = makeEconomy(500);
+  const pool = makeEmptyPool();
+
+  for (const branch of [null, undefined, '']) {
+    const result = computeMonsterInviteIntent({
+      economyState: eco, heroPoolState: pool, monsterId: 'glossbloom', branch,
+      learnerId: LEARNER, rosterVersion: ROSTER_V, nowTs: NOW,
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.code, 'hero_monster_branch_required', `branch=${JSON.stringify(branch)}`);
+  }
+});
+
+test('invite: invalid branch returns hero_monster_branch_invalid', () => {
+  const eco = makeEconomy(500);
+  const pool = makeEmptyPool();
+  const result = computeMonsterInviteIntent({
+    economyState: eco, heroPoolState: pool, monsterId: 'glossbloom', branch: 'b3',
+    learnerId: LEARNER, rosterVersion: ROSTER_V, nowTs: NOW,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, 'hero_monster_branch_invalid');
+});
+
+// ── Grow: success (stage 0 → 1) ─────────────────────────────────────
+
+test('grow from stage 0 to 1 debits HERO_MONSTER_GROW_COSTS[1]', () => {
+  const eco = makeEconomy(1000);
+  const pool = makePoolWithOwned('glossbloom', 0);
+  const result = computeMonsterGrowIntent({
+    economyState: eco, heroPoolState: pool, monsterId: 'glossbloom', targetStage: 1,
+    learnerId: LEARNER, rosterVersion: ROSTER_V, nowTs: NOW,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.status, 'grown');
+  assert.equal(result.intent.ledgerEntry.amount, -HERO_MONSTER_GROW_COSTS[1]);
+  assert.equal(result.intent.newBalance, 1000 - HERO_MONSTER_GROW_COSTS[1]);
+});
+
+test('grow: lifetimeSpent increments; newMonsterState has correct stage', () => {
+  const eco = makeEconomy(2000, 50);
+  const pool = makePoolWithOwned('loomrill', 1, 'b2');
+  const result = computeMonsterGrowIntent({
+    economyState: eco, heroPoolState: pool, monsterId: 'loomrill', targetStage: 2,
+    learnerId: LEARNER, rosterVersion: ROSTER_V, nowTs: NOW,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.intent.newLifetimeSpent, 50 + HERO_MONSTER_GROW_COSTS[2]);
+  assert.equal(result.intent.newMonsterState.stage, 2);
+});
+
+test('grow: ledger entry has correct deterministic ID', () => {
+  const eco = makeEconomy(2000);
+  const pool = makePoolWithOwned('glossbloom', 0);
+  const r1 = computeMonsterGrowIntent({
+    economyState: eco, heroPoolState: pool, monsterId: 'glossbloom', targetStage: 1,
+    learnerId: LEARNER, rosterVersion: ROSTER_V, nowTs: NOW,
+  });
+  const r2 = computeMonsterGrowIntent({
+    economyState: eco, heroPoolState: pool, monsterId: 'glossbloom', targetStage: 1,
+    learnerId: LEARNER, rosterVersion: ROSTER_V, nowTs: NOW + 5000,
+  });
+
+  assert.equal(r1.intent.ledgerEntry.entryId, r2.intent.ledgerEntry.entryId);
+  assert.match(r1.intent.ledgerEntry.entryId, /^hero-ledger-/);
+});
+
+test('grow: balance exactly equals cost succeeds with 0 remaining', () => {
+  const cost = HERO_MONSTER_GROW_COSTS[1];
+  const eco = makeEconomy(cost);
+  const pool = makePoolWithOwned('glossbloom', 0);
+  const result = computeMonsterGrowIntent({
+    economyState: eco, heroPoolState: pool, monsterId: 'glossbloom', targetStage: 1,
+    learnerId: LEARNER, rosterVersion: ROSTER_V, nowTs: NOW,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.intent.newBalance, 0);
+});
+
+// ── Grow: already at stage ───────────────────────────────────────────
+
+test('grow: already at target stage returns ok:true with cost 0', () => {
+  const eco = makeEconomy(2000);
+  const pool = makePoolWithOwned('glossbloom', 2);
+  const result = computeMonsterGrowIntent({
+    economyState: eco, heroPoolState: pool, monsterId: 'glossbloom', targetStage: 2,
+    learnerId: LEARNER, rosterVersion: ROSTER_V, nowTs: NOW,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.status, 'already-stage');
+  assert.equal(result.cost, 0);
+  assert.equal(result.coinsUsed, 0);
+});
+
+// ── Grow: insufficient balance ───────────────────────────────────────
+
+test('grow: insufficient balance returns ok:false', () => {
+  const cost = HERO_MONSTER_GROW_COSTS[1];
+  const eco = makeEconomy(cost - 1);
+  const pool = makePoolWithOwned('glossbloom', 0);
+  const result = computeMonsterGrowIntent({
+    economyState: eco, heroPoolState: pool, monsterId: 'glossbloom', targetStage: 1,
+    learnerId: LEARNER, rosterVersion: ROSTER_V, nowTs: NOW,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, 'hero_insufficient_coins');
+});
+
+// ── Grow: unknown monster ────────────────────────────────────────────
+
+test('grow: unknown monsterId returns hero_monster_unknown', () => {
+  const eco = makeEconomy(2000);
+  const pool = makeEmptyPool();
+  const result = computeMonsterGrowIntent({
+    economyState: eco, heroPoolState: pool, monsterId: 'not-real', targetStage: 1,
+    learnerId: LEARNER, rosterVersion: ROSTER_V, nowTs: NOW,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, 'hero_monster_unknown');
+});
+
+// ── Grow: monster not owned ──────────────────────────────────────────
+
+test('grow: monster not owned returns hero_monster_not_owned', () => {
+  const eco = makeEconomy(2000);
+  const pool = makeEmptyPool();
+  // glossbloom exists in registry but not in pool state
+  const result = computeMonsterGrowIntent({
+    economyState: eco, heroPoolState: pool, monsterId: 'glossbloom', targetStage: 1,
+    learnerId: LEARNER, rosterVersion: ROSTER_V, nowTs: NOW,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, 'hero_monster_not_owned');
+});
+
+// ── Grow: stage not next ─────────────────────────────────────────────
+
+test('grow: target stage not next returns hero_monster_stage_not_next', () => {
+  const eco = makeEconomy(5000);
+  const pool = makePoolWithOwned('glossbloom', 0);
+  // Trying to jump from 0 to 2
+  const result = computeMonsterGrowIntent({
+    economyState: eco, heroPoolState: pool, monsterId: 'glossbloom', targetStage: 2,
+    learnerId: LEARNER, rosterVersion: ROSTER_V, nowTs: NOW,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, 'hero_monster_stage_not_next');
+});
+
+// ── Grow: target stage > maxStage ────────────────────────────────────
+
+test('grow: target stage exceeds max returns hero_monster_max_stage', () => {
+  const eco = makeEconomy(50000);
+  const pool = makePoolWithOwned('glossbloom', 3);
+  // maxStage is 4, so 5 exceeds it
+  const result = computeMonsterGrowIntent({
+    economyState: eco, heroPoolState: pool, monsterId: 'glossbloom', targetStage: 5,
+    learnerId: LEARNER, rosterVersion: ROSTER_V, nowTs: NOW,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, 'hero_monster_max_stage');
+});
+
+// ── Grow: stage invalid ──────────────────────────────────────────────
+
+test('grow: non-integer targetStage returns hero_monster_stage_invalid', () => {
+  const eco = makeEconomy(2000);
+  const pool = makePoolWithOwned('glossbloom', 0);
+
+  for (const stage of [0, -1, 1.5, NaN, 'two', null, undefined]) {
+    const result = computeMonsterGrowIntent({
+      economyState: eco, heroPoolState: pool, monsterId: 'glossbloom', targetStage: stage,
+      learnerId: LEARNER, rosterVersion: ROSTER_V, nowTs: NOW,
+    });
+    assert.equal(result.ok, false, `stage=${stage} should fail`);
+    // stage 0 and negatives are invalid; non-integers too
+    assert.ok(
+      result.code === 'hero_monster_stage_invalid' || result.code === 'hero_monster_max_stage',
+      `stage=${stage} got code=${result.code}`
+    );
+  }
+});
+
+// ── Idempotency: same key produces same ledger entry ID ──────────────
+
+test('same idempotency key produces same ledger entry ID across calls', () => {
+  const key = 'hero-monster-invite:v1:learner-x:glossbloom:b1';
+  const id1 = deriveSpendLedgerEntryId(key);
+  const id2 = deriveSpendLedgerEntryId(key);
+  assert.equal(id1, id2);
+  assert.match(id1, /^hero-ledger-/);
+});
+
+test('different keys produce different ledger entry IDs', () => {
+  const id1 = deriveSpendLedgerEntryId('hero-monster-invite:v1:learner-x:glossbloom:b1');
+  const id2 = deriveSpendLedgerEntryId('hero-monster-invite:v1:learner-x:glossbloom:b2');
+  assert.notEqual(id1, id2);
+});
+
+// ── Immutability: helpers never modify input objects ──────────────────
+
+test('computeMonsterInviteIntent does not modify input objects', () => {
+  const eco = makeEconomy(500);
+  const pool = makeEmptyPool();
+  const ecoSnapshot = JSON.stringify(eco);
+  const poolSnapshot = JSON.stringify(pool);
+
+  computeMonsterInviteIntent({
+    economyState: eco, heroPoolState: pool, monsterId: 'glossbloom', branch: 'b1',
+    learnerId: LEARNER, rosterVersion: ROSTER_V, nowTs: NOW,
+  });
+
+  assert.equal(JSON.stringify(eco), ecoSnapshot);
+  assert.equal(JSON.stringify(pool), poolSnapshot);
+});
+
+test('computeMonsterGrowIntent does not modify input objects', () => {
+  const eco = makeEconomy(2000);
+  const pool = makePoolWithOwned('glossbloom', 0);
+  const ecoSnapshot = JSON.stringify(eco);
+  const poolSnapshot = JSON.stringify(pool);
+
+  computeMonsterGrowIntent({
+    economyState: eco, heroPoolState: pool, monsterId: 'glossbloom', targetStage: 1,
+    learnerId: LEARNER, rosterVersion: ROSTER_V, nowTs: NOW,
+  });
+
+  assert.equal(JSON.stringify(eco), ecoSnapshot);
+  assert.equal(JSON.stringify(pool), poolSnapshot);
+});
+
+// ── Intent shape validation ──────────────────────────────────────────
+
+test('invite intent contains expected fields', () => {
+  const eco = makeEconomy(500);
+  const pool = makeEmptyPool();
+  const result = computeMonsterInviteIntent({
+    economyState: eco, heroPoolState: pool, monsterId: 'glossbloom', branch: 'b1',
+    learnerId: LEARNER, rosterVersion: ROSTER_V, nowTs: NOW,
+  });
+
+  const { intent } = result;
+  assert.equal(typeof intent.newBalance, 'number');
+  assert.equal(typeof intent.newLifetimeSpent, 'number');
+  assert.equal(intent.ledgerEntry.createdBy, 'system');
+  assert.equal(intent.ledgerEntry.createdAt, NOW);
+  assert.equal(intent.newMonsterState.owned, true);
+  assert.equal(intent.newMonsterState.stage, 0);
+  assert.equal(intent.newMonsterState.branch, 'b1');
+  assert.equal(intent.actionRecord.type, 'monster-invite');
+  assert.equal(intent.actionRecord.requestId, null);
+  assert.equal(intent.actionRecord.stageBefore, null);
+  assert.equal(intent.actionRecord.stageAfter, 0);
+  assert.equal(intent.actionRecord.actionId, intent.ledgerEntry.entryId);
+});
+
+test('grow intent contains expected fields', () => {
+  const eco = makeEconomy(2000);
+  const pool = makePoolWithOwned('mirrane', 1, 'b2');
+  const result = computeMonsterGrowIntent({
+    economyState: eco, heroPoolState: pool, monsterId: 'mirrane', targetStage: 2,
+    learnerId: LEARNER, rosterVersion: ROSTER_V, nowTs: NOW,
+  });
+
+  const { intent } = result;
+  assert.equal(typeof intent.newBalance, 'number');
+  assert.equal(typeof intent.newLifetimeSpent, 'number');
+  assert.equal(intent.ledgerEntry.type, 'monster-grow');
+  assert.equal(intent.ledgerEntry.stageBefore, 1);
+  assert.equal(intent.ledgerEntry.stageAfter, 2);
+  assert.equal(intent.ledgerEntry.source.kind, 'hero-camp-monster-grow');
+  assert.equal(intent.newMonsterState.stage, 2);
+  assert.equal(intent.actionRecord.type, 'monster-grow');
+  assert.equal(intent.actionRecord.branch, 'b2');
+  assert.equal(intent.actionRecord.stageBefore, 1);
+  assert.equal(intent.actionRecord.stageAfter, 2);
+  assert.equal(intent.actionRecord.actionId, intent.ledgerEntry.entryId);
+});

--- a/tests/hero-p5-read-model.test.js
+++ b/tests/hero-p5-read-model.test.js
@@ -1,0 +1,537 @@
+// Hero Mode P5 U7 — Read model v6 with child-safe Camp block.
+//
+// Tests verify that the read model correctly evolves to v6 when camp
+// is enabled, exposes child-safe Camp fields with monster roster,
+// ownership, affordability, recent actions, and preserves existing
+// v5 behaviour when camp is disabled.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildHeroShadowReadModel } from '../worker/src/hero/read-model.js';
+import { normaliseHeroProgressState } from '../shared/hero/progress-state.js';
+import {
+  HERO_POOL_INITIAL_MONSTER_IDS,
+  HERO_POOL_ROSTER_VERSION,
+  HERO_MONSTER_INVITE_COST,
+  HERO_MONSTER_GROW_COSTS,
+} from '../shared/hero/hero-pool.js';
+
+// ── Fixture helpers ───────────────────────────────────────────────────
+
+const BASE_ENV = {
+  HERO_MODE_SHADOW_ENABLED: 'true',
+  HERO_MODE_LAUNCH_ENABLED: 'true',
+  HERO_MODE_CHILD_UI_ENABLED: 'true',
+};
+
+const PROGRESS_ENV = {
+  ...BASE_ENV,
+  HERO_MODE_PROGRESS_ENABLED: 'true',
+};
+
+const ECONOMY_ENV = {
+  ...PROGRESS_ENV,
+  HERO_MODE_ECONOMY_ENABLED: 'true',
+};
+
+const CAMP_ENV = {
+  ...ECONOMY_ENV,
+  HERO_MODE_CAMP_ENABLED: 'true',
+};
+
+const SPELLING_DATA = {
+  stats: {
+    core: { total: 50, secure: 30, due: 10, fresh: 5, trouble: 5, attempts: 200, correct: 160, accuracy: 0.8 },
+    all: { total: 50, secure: 30, due: 10, fresh: 5, trouble: 5, attempts: 200, correct: 160, accuracy: 0.8 },
+  },
+};
+
+const PUNCTUATION_DATA = {
+  availability: { status: 'ready' },
+  stats: { total: 20, secure: 8, due: 5, fresh: 3, weak: 2, attempts: 100, correct: 75, accuracy: 75 },
+};
+
+function makeSubjectReadModels() {
+  return {
+    spelling: { data: SPELLING_DATA, ui: {} },
+    punctuation: { data: PUNCTUATION_DATA, ui: {} },
+  };
+}
+
+function buildV5(overrides = {}) {
+  return buildHeroShadowReadModel({
+    learnerId: 'learner-1',
+    accountId: 'account-1',
+    subjectReadModels: makeSubjectReadModels(),
+    now: Date.now(),
+    env: ECONOMY_ENV,
+    progressEnabled: true,
+    economyEnabled: true,
+    campEnabled: false,
+    heroProgressState: null,
+    recentCompletedSessions: [],
+    ...overrides,
+  });
+}
+
+function buildV6(overrides = {}) {
+  return buildHeroShadowReadModel({
+    learnerId: 'learner-1',
+    accountId: 'account-1',
+    subjectReadModels: makeSubjectReadModels(),
+    now: Date.now(),
+    env: CAMP_ENV,
+    progressEnabled: true,
+    economyEnabled: true,
+    campEnabled: true,
+    heroProgressState: null,
+    recentCompletedSessions: [],
+    ...overrides,
+  });
+}
+
+function makeProgressStateWithPool(poolOverride = {}, economyOverride = {}) {
+  return normaliseHeroProgressState({
+    version: 3,
+    daily: {
+      dateKey: '2026-04-29',
+      timezone: 'Europe/London',
+      questId: 'quest-test',
+      questFingerprint: 'fp-test',
+      schedulerVersion: 'p2-scheduler-v1',
+      status: 'active',
+      effortTarget: 12,
+      effortPlanned: 12,
+      effortCompleted: 0,
+      taskOrder: [],
+      completedTaskIds: [],
+      tasks: {},
+      generatedAt: Date.now() - 10000,
+      firstStartedAt: null,
+      completedAt: null,
+      lastUpdatedAt: Date.now(),
+    },
+    recentClaims: [],
+    economy: {
+      version: 1,
+      balance: 500,
+      lifetimeEarned: 500,
+      lifetimeSpent: 0,
+      ledger: [],
+      lastUpdatedAt: Date.now() - 1000,
+      ...economyOverride,
+    },
+    heroPool: {
+      version: 1,
+      rosterVersion: HERO_POOL_ROSTER_VERSION,
+      selectedMonsterId: null,
+      monsters: {},
+      recentActions: [],
+      lastUpdatedAt: null,
+      ...poolOverride,
+    },
+  });
+}
+
+// ── V6 shape: camp enabled + economy enabled ──────────────────────────
+
+test('camp enabled + economy enabled → v6 with camp block and 6 monsters', () => {
+  const model = buildV6();
+
+  assert.equal(model.version, 6);
+  assert.ok(model.camp, 'camp block must be present');
+  assert.equal(model.camp.enabled, true);
+  assert.equal(model.camp.version, 1);
+  assert.equal(model.camp.rosterVersion, HERO_POOL_ROSTER_VERSION);
+  assert.equal(model.camp.monsters.length, 6);
+  assert.deepEqual(
+    model.camp.monsters.map(m => m.monsterId),
+    HERO_POOL_INITIAL_MONSTER_IDS,
+  );
+});
+
+test('owned monster shows correct stage, branch, and costs', () => {
+  const state = makeProgressStateWithPool({
+    monsters: {
+      glossbloom: {
+        monsterId: 'glossbloom',
+        owned: true,
+        stage: 2,
+        branch: 'b1',
+        investedCoins: 1050,
+        invitedAt: Date.now() - 100000,
+        lastGrownAt: Date.now() - 50000,
+        lastLedgerEntryId: 'entry-1',
+      },
+    },
+  });
+
+  const model = buildV6({ heroProgressState: state });
+  const glossbloom = model.camp.monsters.find(m => m.monsterId === 'glossbloom');
+
+  assert.equal(glossbloom.owned, true);
+  assert.equal(glossbloom.stage, 2);
+  assert.equal(glossbloom.branch, 'b1');
+  assert.equal(glossbloom.canInvite, false);
+  assert.equal(glossbloom.canGrow, true);
+  assert.equal(glossbloom.nextStage, 3);
+  assert.equal(glossbloom.nextGrowCost, HERO_MONSTER_GROW_COSTS[3]);
+});
+
+test('canAffordInvite true when balance >= invite cost', () => {
+  const state = makeProgressStateWithPool(
+    { monsters: {} },
+    { balance: HERO_MONSTER_INVITE_COST },
+  );
+
+  const model = buildV6({ heroProgressState: state });
+  const glossbloom = model.camp.monsters.find(m => m.monsterId === 'glossbloom');
+
+  assert.equal(glossbloom.canInvite, true);
+  assert.equal(glossbloom.canAffordInvite, true);
+});
+
+test('canAffordInvite false when balance < invite cost', () => {
+  const state = makeProgressStateWithPool(
+    { monsters: {} },
+    { balance: HERO_MONSTER_INVITE_COST - 1 },
+  );
+
+  const model = buildV6({ heroProgressState: state });
+  const glossbloom = model.camp.monsters.find(m => m.monsterId === 'glossbloom');
+
+  assert.equal(glossbloom.canInvite, true);
+  assert.equal(glossbloom.canAffordInvite, false);
+});
+
+test('canAffordGrow true when balance >= next grow cost', () => {
+  const nextGrowCost = HERO_MONSTER_GROW_COSTS[2]; // cost to grow from stage 1 to 2
+  const state = makeProgressStateWithPool(
+    {
+      monsters: {
+        loomrill: {
+          monsterId: 'loomrill',
+          owned: true,
+          stage: 1,
+          branch: 'b2',
+          investedCoins: 450,
+          invitedAt: Date.now() - 100000,
+          lastGrownAt: Date.now() - 50000,
+          lastLedgerEntryId: 'entry-2',
+        },
+      },
+    },
+    { balance: nextGrowCost },
+  );
+
+  const model = buildV6({ heroProgressState: state });
+  const loomrill = model.camp.monsters.find(m => m.monsterId === 'loomrill');
+
+  assert.equal(loomrill.canGrow, true);
+  assert.equal(loomrill.canAffordGrow, true);
+  assert.equal(loomrill.nextStage, 2);
+  assert.equal(loomrill.nextGrowCost, nextGrowCost);
+});
+
+test('canAffordGrow false when balance < next grow cost', () => {
+  const state = makeProgressStateWithPool(
+    {
+      monsters: {
+        loomrill: {
+          monsterId: 'loomrill',
+          owned: true,
+          stage: 1,
+          branch: 'b2',
+          investedCoins: 450,
+          invitedAt: Date.now() - 100000,
+          lastGrownAt: Date.now() - 50000,
+          lastLedgerEntryId: 'entry-2',
+        },
+      },
+    },
+    { balance: 1 }, // far below grow cost
+  );
+
+  const model = buildV6({ heroProgressState: state });
+  const loomrill = model.camp.monsters.find(m => m.monsterId === 'loomrill');
+
+  assert.equal(loomrill.canGrow, true);
+  assert.equal(loomrill.canAffordGrow, false);
+});
+
+test('fully grown monster has canGrow: false, nextGrowCost: null', () => {
+  const state = makeProgressStateWithPool({
+    monsters: {
+      mirrane: {
+        monsterId: 'mirrane',
+        owned: true,
+        stage: 4, // maxStage
+        branch: 'b1',
+        investedCoins: 3650,
+        invitedAt: Date.now() - 200000,
+        lastGrownAt: Date.now() - 10000,
+        lastLedgerEntryId: 'entry-3',
+      },
+    },
+  });
+
+  const model = buildV6({ heroProgressState: state });
+  const mirrane = model.camp.monsters.find(m => m.monsterId === 'mirrane');
+
+  assert.equal(mirrane.owned, true);
+  assert.equal(mirrane.stage, 4);
+  assert.equal(mirrane.fullyGrown, true);
+  assert.equal(mirrane.canGrow, false);
+  assert.equal(mirrane.canAffordGrow, false);
+  assert.equal(mirrane.nextGrowCost, null);
+  assert.equal(mirrane.nextStage, null);
+});
+
+// ── Camp disabled → v5 shape unchanged ────────────────────────────────
+
+test('camp disabled → v5 shape unchanged (no camp block)', () => {
+  const model = buildV5();
+
+  assert.equal(model.version, 5);
+  assert.equal('camp' in model, false, 'No camp block in v5');
+  assert.equal(model.coinsEnabled, true);
+  assert.ok(model.economy);
+});
+
+// ── Camp enabled but economy disabled → camp: { enabled: false } ──────
+
+test('camp enabled but economy disabled → camp: { enabled: false }', () => {
+  const model = buildHeroShadowReadModel({
+    learnerId: 'learner-1',
+    accountId: 'account-1',
+    subjectReadModels: makeSubjectReadModels(),
+    now: Date.now(),
+    env: { ...PROGRESS_ENV, HERO_MODE_CAMP_ENABLED: 'true' },
+    progressEnabled: true,
+    economyEnabled: false,
+    campEnabled: true,
+    heroProgressState: null,
+    recentCompletedSessions: [],
+  });
+
+  assert.equal(model.version, 4);
+  assert.ok(model.camp, 'camp marker must be present');
+  assert.equal(model.camp.enabled, false);
+  assert.equal(Object.keys(model.camp).length, 1, 'only enabled: false, nothing else');
+});
+
+// ── Malformed heroPool → empty monsters array, no crash ───────────────
+
+test('malformed heroPool → empty camp block with all 6 monsters, no crash', () => {
+  const state = normaliseHeroProgressState({
+    version: 3,
+    daily: null,
+    recentClaims: [],
+    economy: { version: 1, balance: 200, lifetimeEarned: 200, lifetimeSpent: 0, ledger: [], lastUpdatedAt: null },
+    heroPool: 'not-an-object',
+  });
+
+  const model = buildV6({ heroProgressState: state });
+
+  assert.equal(model.version, 6);
+  assert.ok(model.camp);
+  assert.equal(model.camp.enabled, true);
+  assert.equal(model.camp.monsters.length, 6);
+  // All unowned
+  for (const m of model.camp.monsters) {
+    assert.equal(m.owned, false);
+    assert.equal(m.stage, 0);
+    assert.equal(m.branch, null);
+  }
+});
+
+test('null heroProgressState with camp enabled → empty camp block, no crash', () => {
+  const model = buildV6({ heroProgressState: null });
+
+  assert.equal(model.version, 6);
+  assert.ok(model.camp);
+  assert.equal(model.camp.enabled, true);
+  assert.equal(model.camp.monsters.length, 6);
+  assert.equal(model.camp.balance, 0);
+  assert.equal(model.camp.selectedMonsterId, null);
+  assert.deepEqual(model.camp.recentActions, []);
+});
+
+// ── Unowned monster shows correct defaults ────────────────────────────
+
+test('unowned monster shows stage 0, branch null, canInvite true', () => {
+  const state = makeProgressStateWithPool({ monsters: {} });
+
+  const model = buildV6({ heroProgressState: state });
+  const colisk = model.camp.monsters.find(m => m.monsterId === 'colisk');
+
+  assert.equal(colisk.owned, false);
+  assert.equal(colisk.stage, 0);
+  assert.equal(colisk.branch, null);
+  assert.equal(colisk.canInvite, true);
+  assert.equal(colisk.canGrow, false);
+  assert.equal(colisk.fullyGrown, false);
+  assert.equal(colisk.nextGrowCost, null);
+  assert.equal(colisk.nextStage, null);
+});
+
+// ── No subject mastery data inside camp block ─────────────────────────
+
+test('no subject mastery data inside camp block', () => {
+  const model = buildV6();
+
+  const campJson = JSON.stringify(model.camp);
+  assert.equal(campJson.includes('subjectId'), false, 'No subjectId in camp block');
+  assert.equal(campJson.includes('spelling'), false, 'No spelling reference in camp block');
+  assert.equal(campJson.includes('punctuation'), false, 'No punctuation reference in camp block');
+  assert.equal(campJson.includes('secure'), false, 'No mastery stats in camp block');
+});
+
+// ── No raw debug fields in child-safe output ──────────────────────────
+
+test('no raw debug fields (requestId, ledgerSource) in child-safe camp output', () => {
+  const state = makeProgressStateWithPool({
+    monsters: {
+      glossbloom: {
+        monsterId: 'glossbloom',
+        owned: true,
+        stage: 1,
+        branch: 'b1',
+        investedCoins: 450,
+        invitedAt: Date.now() - 100000,
+        lastGrownAt: Date.now() - 50000,
+        lastLedgerEntryId: 'entry-debug',
+      },
+    },
+  });
+
+  const model = buildV6({ heroProgressState: state });
+  const campJson = JSON.stringify(model.camp);
+
+  assert.equal(campJson.includes('requestId'), false, 'No requestId in camp block');
+  assert.equal(campJson.includes('ledgerSource'), false, 'No ledgerSource in camp block');
+  assert.equal(campJson.includes('investedCoins'), false, 'No investedCoins in camp block');
+  assert.equal(campJson.includes('invitedAt'), false, 'No invitedAt in camp block');
+  assert.equal(campJson.includes('lastGrownAt'), false, 'No lastGrownAt in camp block');
+  assert.equal(campJson.includes('lastLedgerEntryId'), false, 'No lastLedgerEntryId in camp block');
+});
+
+// ── Existing v5 economy fields still present in v6 output ─────────────
+
+test('existing v5 economy fields still present in v6 output', () => {
+  const state = makeProgressStateWithPool(
+    {},
+    { balance: 300, lifetimeEarned: 500, lifetimeSpent: 200 },
+  );
+
+  const model = buildV6({ heroProgressState: state });
+
+  assert.equal(model.version, 6);
+  assert.equal(model.coinsEnabled, true);
+  assert.ok(model.economy, 'economy block must be present in v6');
+  assert.equal(model.economy.enabled, true);
+  assert.equal(model.economy.balance, 300);
+  assert.equal(model.economy.lifetimeEarned, 500);
+  assert.equal(model.economy.lifetimeSpent, 200);
+  // Also v4 fields
+  assert.ok(model.progress);
+  assert.ok(model.claim);
+  assert.ok(model.launch);
+  assert.ok(model.ui);
+  assert.ok(model.dailyQuest);
+});
+
+// ── Recent actions capping and shape ──────────────────────────────────
+
+test('recentActions capped at 5 most recent', () => {
+  const actions = [];
+  for (let i = 0; i < 8; i++) {
+    actions.push({
+      action: `invite-${i}`,
+      type: 'invite',
+      monsterId: 'glossbloom',
+      stageAfter: 0,
+      cost: 150,
+      createdAt: Date.now() - (8 - i) * 1000,
+    });
+  }
+
+  const state = makeProgressStateWithPool({
+    recentActions: actions,
+  });
+
+  const model = buildV6({ heroProgressState: state });
+
+  assert.equal(model.camp.recentActions.length, 5);
+  // Should be the last 5 (most recent)
+  assert.equal(model.camp.recentActions[0].createdAt, actions[3].createdAt);
+  assert.equal(model.camp.recentActions[4].createdAt, actions[7].createdAt);
+});
+
+test('recentActions exposes only child-safe fields', () => {
+  const state = makeProgressStateWithPool({
+    recentActions: [{
+      action: 'invite',
+      type: 'invite',
+      monsterId: 'hyphang',
+      stageAfter: 0,
+      cost: 150,
+      createdAt: Date.now() - 1000,
+      // Extra fields that must NOT leak
+      ledgerEntryId: 'secret-entry',
+      learnerId: 'learner-secret',
+      requestId: 'req-123',
+    }],
+  });
+
+  const model = buildV6({ heroProgressState: state });
+  const action = model.camp.recentActions[0];
+
+  assert.equal(action.type, 'invite');
+  assert.equal(action.monsterId, 'hyphang');
+  assert.equal(action.stageAfter, 0);
+  assert.equal(action.cost, 150);
+  assert.ok(action.createdAt > 0);
+  // Disallowed
+  assert.equal('ledgerEntryId' in action, false);
+  assert.equal('learnerId' in action, false);
+  assert.equal('requestId' in action, false);
+  assert.equal('action' in action, false, 'raw action field must be excluded');
+});
+
+// ── Camp command routes in block ──────────────────────────────────────
+
+test('camp block contains commandRoute and commands', () => {
+  const model = buildV6();
+
+  assert.equal(model.camp.commandRoute, '/api/hero/command');
+  assert.deepEqual(model.camp.commands, {
+    unlockMonster: 'unlock-monster',
+    evolveMonster: 'evolve-monster',
+  });
+});
+
+// ── selectedMonsterId surfaces when set ───────────────────────────────
+
+test('selectedMonsterId surfaces when set in pool state', () => {
+  const state = makeProgressStateWithPool({
+    selectedMonsterId: 'carillon',
+    monsters: {
+      carillon: {
+        monsterId: 'carillon',
+        owned: true,
+        stage: 1,
+        branch: 'b2',
+        investedCoins: 450,
+        invitedAt: Date.now() - 100000,
+        lastGrownAt: Date.now() - 50000,
+        lastLedgerEntryId: 'entry-sel',
+      },
+    },
+  });
+
+  const model = buildV6({ heroProgressState: state });
+
+  assert.equal(model.camp.selectedMonsterId, 'carillon');
+});

--- a/tests/hero-p5-state-migration.test.js
+++ b/tests/hero-p5-state-migration.test.js
@@ -164,7 +164,7 @@ test('valid v3 normalises without data loss (owned monsters preserved)', () => {
           lastLedgerEntryId: 'ledger-abc',
         },
       },
-      recentActions: [{ action: 'invite', monsterId: 'loomrill', ts: 6000 }],
+      recentActions: [{ type: 'monster-invite', monsterId: 'loomrill', ts: 6000 }],
       lastUpdatedAt: 8000,
     },
   };
@@ -188,7 +188,7 @@ test('valid v3 normalises without data loss (owned monsters preserved)', () => {
   assert.equal(loomrill.stage, 1);
   assert.equal(loomrill.branch, null);
   assert.equal(loomrill.investedCoins, 150);
-  assert.deepEqual(result.heroPool.recentActions, [{ action: 'invite', monsterId: 'loomrill', ts: 6000 }]);
+  assert.deepEqual(result.heroPool.recentActions, [{ type: 'monster-invite', monsterId: 'loomrill', ts: 6000 }]);
   assert.equal(result.heroPool.lastUpdatedAt, 8000);
 });
 
@@ -548,4 +548,41 @@ test('version field is 3 after normalisation regardless of input version', () =>
     const result = normaliseHeroProgressState(input);
     assert.equal(result.version, 3, `failed for input: ${JSON.stringify(input)}`);
   }
+});
+
+// ── Write-normalise-read roundtrip for recentActions ─────────────
+
+test('recentActions produced by computeMonsterInviteIntent survive normalisation roundtrip', () => {
+  // Build an action record the same way monster-economy.js does
+  const actionRecord = {
+    actionId: 'hero-ledger-abc123',
+    requestId: null,
+    type: 'monster-invite',
+    monsterId: 'glossbloom',
+    stageBefore: null,
+    stageAfter: 0,
+    branch: 'b1',
+    cost: 150,
+    ledgerEntryId: 'hero-ledger-abc123',
+    createdAt: Date.now(),
+  };
+
+  const state = {
+    version: 3,
+    heroPool: {
+      version: 1,
+      rosterVersion: 'hero-pool-v1',
+      selectedMonsterId: null,
+      monsters: {},
+      recentActions: [actionRecord],
+      lastUpdatedAt: Date.now(),
+    },
+    economy: { version: 1, balance: 0, lifetimeEarned: 150, lifetimeSpent: 150, ledger: [], lastUpdatedAt: null },
+    daily: null,
+    recentClaims: [],
+  };
+
+  const normalised = normaliseHeroProgressState(state);
+  assert.equal(normalised.heroPool.recentActions.length, 1, 'recentActions must survive normalisation');
+  assert.equal(normalised.heroPool.recentActions[0].type, 'monster-invite');
 });

--- a/tests/hero-p5-state-migration.test.js
+++ b/tests/hero-p5-state-migration.test.js
@@ -1,0 +1,551 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  HERO_PROGRESS_VERSION,
+  HERO_POOL_STATE_VERSION,
+  HERO_POOL_ROSTER_VERSION,
+  emptyProgressState,
+  emptyHeroPoolState,
+  normaliseHeroProgressState,
+  normaliseHeroPoolState,
+} from '../shared/hero/progress-state.js';
+
+import { HERO_ECONOMY_VERSION, emptyEconomyState } from '../shared/hero/economy.js';
+
+// ── Fresh empty state ──────────────────────────────────────────────
+
+test('fresh empty state creates v3 with empty economy + empty heroPool', () => {
+  const result = emptyProgressState();
+  assert.equal(result.version, 3);
+  assert.equal(result.daily, null);
+  assert.deepEqual(result.recentClaims, []);
+  // economy
+  assert.equal(result.economy.version, HERO_ECONOMY_VERSION);
+  assert.equal(result.economy.balance, 0);
+  assert.equal(result.economy.lifetimeEarned, 0);
+  assert.equal(result.economy.lifetimeSpent, 0);
+  assert.deepEqual(result.economy.ledger, []);
+  assert.equal(result.economy.lastUpdatedAt, null);
+  // heroPool
+  assert.equal(result.heroPool.version, HERO_POOL_STATE_VERSION);
+  assert.equal(result.heroPool.rosterVersion, HERO_POOL_ROSTER_VERSION);
+  assert.equal(result.heroPool.selectedMonsterId, null);
+  assert.deepEqual(result.heroPool.monsters, {});
+  assert.deepEqual(result.heroPool.recentActions, []);
+  assert.equal(result.heroPool.lastUpdatedAt, null);
+});
+
+// ── v1 → v3 ───────────────────────────────────────────────────────
+
+test('v1 (progress-only) migrates to v3 with empty economy + empty heroPool', () => {
+  const input = {
+    version: 1,
+    daily: {
+      dateKey: '2026-04-20',
+      questId: 'quest-v1',
+      timezone: 'Europe/London',
+      status: 'active',
+      effortTarget: 12,
+      effortPlanned: 12,
+      effortCompleted: 6,
+      taskOrder: ['t1'],
+      completedTaskIds: [],
+      tasks: { t1: { taskId: 't1', status: 'started', effortTarget: 6 } },
+      generatedAt: 1000,
+      firstStartedAt: 1001,
+      completedAt: null,
+      lastUpdatedAt: 1002,
+    },
+    recentClaims: [{ claimId: 'old-claim', createdAt: 500 }],
+  };
+  const result = normaliseHeroProgressState(input);
+  assert.equal(result.version, 3);
+  assert.equal(result.daily.questId, 'quest-v1');
+  assert.equal(result.daily.tasks.t1.status, 'started');
+  assert.deepEqual(result.recentClaims, [{ claimId: 'old-claim', createdAt: 500 }]);
+  // empty economy
+  assert.equal(result.economy.version, HERO_ECONOMY_VERSION);
+  assert.equal(result.economy.balance, 0);
+  assert.deepEqual(result.economy.ledger, []);
+  // empty heroPool
+  assert.equal(result.heroPool.version, HERO_POOL_STATE_VERSION);
+  assert.deepEqual(result.heroPool.monsters, {});
+  assert.equal(result.heroPool.selectedMonsterId, null);
+});
+
+// ── v2 → v3 ───────────────────────────────────────────────────────
+
+test('v2 (economy) migrates to v3 with preserved economy + empty heroPool', () => {
+  const ledgerEntries = [
+    { entryId: 'e1', type: 'daily-completion-award', amount: 100, balanceAfter: 100, createdAt: 2000 },
+    { entryId: 'e2', type: 'daily-completion-award', amount: 100, balanceAfter: 200, createdAt: 3000 },
+  ];
+  const input = {
+    version: 2,
+    daily: {
+      dateKey: '2026-04-28',
+      questId: 'quest-v2',
+      timezone: 'Europe/London',
+      status: 'completed',
+      effortTarget: 18,
+      effortPlanned: 18,
+      effortCompleted: 18,
+      taskOrder: ['t1'],
+      completedTaskIds: ['t1'],
+      tasks: { t1: { taskId: 't1', status: 'completed', effortTarget: 18 } },
+      generatedAt: 1000,
+      firstStartedAt: 1001,
+      completedAt: 3000,
+      lastUpdatedAt: 3000,
+    },
+    recentClaims: [{ claimId: 'c-v2', createdAt: 3000 }],
+    economy: {
+      version: HERO_ECONOMY_VERSION,
+      balance: 200,
+      lifetimeEarned: 200,
+      lifetimeSpent: 0,
+      ledger: ledgerEntries,
+      lastUpdatedAt: 3000,
+    },
+  };
+  const result = normaliseHeroProgressState(input);
+  assert.equal(result.version, 3);
+  assert.equal(result.daily.questId, 'quest-v2');
+  // Economy preserved
+  assert.equal(result.economy.balance, 200);
+  assert.equal(result.economy.lifetimeEarned, 200);
+  assert.equal(result.economy.ledger.length, 2);
+  assert.equal(result.economy.ledger[0].entryId, 'e1');
+  assert.equal(result.economy.ledger[1].entryId, 'e2');
+  // heroPool empty
+  assert.equal(result.heroPool.version, HERO_POOL_STATE_VERSION);
+  assert.deepEqual(result.heroPool.monsters, {});
+});
+
+// ── v3 normalise without data loss ────────────────────────────────
+
+test('valid v3 normalises without data loss (owned monsters preserved)', () => {
+  const input = {
+    version: 3,
+    daily: null,
+    recentClaims: [],
+    economy: {
+      version: HERO_ECONOMY_VERSION,
+      balance: 50,
+      lifetimeEarned: 200,
+      lifetimeSpent: 150,
+      ledger: [{ entryId: 'e1', type: 'daily-completion-award', amount: 100 }],
+      lastUpdatedAt: 9000,
+    },
+    heroPool: {
+      version: HERO_POOL_STATE_VERSION,
+      rosterVersion: 'p5-initial-v1',
+      selectedMonsterId: 'glossbloom',
+      monsters: {
+        glossbloom: {
+          monsterId: 'glossbloom',
+          owned: true,
+          stage: 2,
+          branch: 'b1',
+          investedCoins: 450,
+          invitedAt: 5000,
+          lastGrownAt: 8000,
+          lastLedgerEntryId: 'ledger-xyz',
+        },
+        loomrill: {
+          monsterId: 'loomrill',
+          owned: true,
+          stage: 1,
+          branch: null,
+          investedCoins: 150,
+          invitedAt: 6000,
+          lastGrownAt: null,
+          lastLedgerEntryId: 'ledger-abc',
+        },
+      },
+      recentActions: [{ action: 'invite', monsterId: 'loomrill', ts: 6000 }],
+      lastUpdatedAt: 8000,
+    },
+  };
+  const result = normaliseHeroProgressState(input);
+  assert.equal(result.version, 3);
+  assert.equal(result.economy.balance, 50);
+  assert.equal(result.economy.lifetimeSpent, 150);
+  // heroPool monsters preserved exactly
+  assert.equal(result.heroPool.selectedMonsterId, 'glossbloom');
+  assert.equal(Object.keys(result.heroPool.monsters).length, 2);
+  const glossbloom = result.heroPool.monsters.glossbloom;
+  assert.equal(glossbloom.owned, true);
+  assert.equal(glossbloom.stage, 2);
+  assert.equal(glossbloom.branch, 'b1');
+  assert.equal(glossbloom.investedCoins, 450);
+  assert.equal(glossbloom.invitedAt, 5000);
+  assert.equal(glossbloom.lastGrownAt, 8000);
+  assert.equal(glossbloom.lastLedgerEntryId, 'ledger-xyz');
+  const loomrill = result.heroPool.monsters.loomrill;
+  assert.equal(loomrill.owned, true);
+  assert.equal(loomrill.stage, 1);
+  assert.equal(loomrill.branch, null);
+  assert.equal(loomrill.investedCoins, 150);
+  assert.deepEqual(result.heroPool.recentActions, [{ action: 'invite', monsterId: 'loomrill', ts: 6000 }]);
+  assert.equal(result.heroPool.lastUpdatedAt, 8000);
+});
+
+// ── v3 with unknown monster IDs → IDs dropped ─────────────────────
+
+test('v3 with unknown monster IDs drops those IDs', () => {
+  const input = {
+    version: 3,
+    daily: null,
+    recentClaims: [],
+    economy: emptyEconomyState(),
+    heroPool: {
+      version: HERO_POOL_STATE_VERSION,
+      rosterVersion: 'p5-initial-v1',
+      selectedMonsterId: null,
+      monsters: {
+        glossbloom: { monsterId: 'glossbloom', owned: true, stage: 1, branch: null, investedCoins: 150 },
+        unknown_beast: { monsterId: 'unknown_beast', owned: true, stage: 2, branch: 'b1', investedCoins: 300 },
+        another_fake: { monsterId: 'another_fake', owned: false, stage: 0, branch: null, investedCoins: 0 },
+      },
+      recentActions: [],
+      lastUpdatedAt: null,
+    },
+  };
+  const result = normaliseHeroProgressState(input);
+  assert.equal(Object.keys(result.heroPool.monsters).length, 1);
+  assert.ok(result.heroPool.monsters.glossbloom);
+  assert.equal(result.heroPool.monsters.unknown_beast, undefined);
+  assert.equal(result.heroPool.monsters.another_fake, undefined);
+});
+
+// ── v3 with stage 7 → clamped to 4 ───────────────────────────────
+
+test('v3 with stage 7 clamps to 4', () => {
+  const input = {
+    version: 3,
+    daily: null,
+    recentClaims: [],
+    economy: emptyEconomyState(),
+    heroPool: {
+      version: HERO_POOL_STATE_VERSION,
+      rosterVersion: 'p5-initial-v1',
+      selectedMonsterId: null,
+      monsters: {
+        colisk: { monsterId: 'colisk', owned: true, stage: 7, branch: 'b2', investedCoins: 1000 },
+      },
+      recentActions: [],
+      lastUpdatedAt: null,
+    },
+  };
+  const result = normaliseHeroProgressState(input);
+  assert.equal(result.heroPool.monsters.colisk.stage, 4);
+});
+
+// ── v3 with branch 'b5' → normalised to null ─────────────────────
+
+test('v3 with branch b5 normalises to null', () => {
+  const input = {
+    version: 3,
+    daily: null,
+    recentClaims: [],
+    economy: emptyEconomyState(),
+    heroPool: {
+      version: HERO_POOL_STATE_VERSION,
+      rosterVersion: 'p5-initial-v1',
+      selectedMonsterId: null,
+      monsters: {
+        hyphang: { monsterId: 'hyphang', owned: true, stage: 2, branch: 'b5', investedCoins: 300 },
+      },
+      recentActions: [],
+      lastUpdatedAt: null,
+    },
+  };
+  const result = normaliseHeroProgressState(input);
+  assert.equal(result.heroPool.monsters.hyphang.branch, null);
+});
+
+// ── v3 with malformed heroPool → safe empty heroPool, economy preserved ─
+
+test('v3 with malformed heroPool returns safe empty heroPool, economy preserved', () => {
+  const input = {
+    version: 3,
+    daily: null,
+    recentClaims: [],
+    economy: {
+      version: HERO_ECONOMY_VERSION,
+      balance: 300,
+      lifetimeEarned: 300,
+      lifetimeSpent: 0,
+      ledger: [{ entryId: 'e1', type: 'daily-completion-award', amount: 100 }],
+      lastUpdatedAt: 5000,
+    },
+    heroPool: 'corrupted-string',
+  };
+  const result = normaliseHeroProgressState(input);
+  assert.equal(result.version, 3);
+  // Economy preserved
+  assert.equal(result.economy.balance, 300);
+  assert.equal(result.economy.lifetimeEarned, 300);
+  assert.equal(result.economy.ledger.length, 1);
+  // heroPool safe empty
+  assert.equal(result.heroPool.version, HERO_POOL_STATE_VERSION);
+  assert.deepEqual(result.heroPool.monsters, {});
+  assert.equal(result.heroPool.selectedMonsterId, null);
+  assert.deepEqual(result.heroPool.recentActions, []);
+});
+
+// ── Completely invalid state_json → safe empty v3 ─────────────────
+
+test('completely invalid state_json returns safe empty v3', () => {
+  const inputs = [null, undefined, 42, 'garbage', [], true];
+  for (const input of inputs) {
+    const result = normaliseHeroProgressState(input);
+    assert.equal(result.version, 3, `failed for input: ${JSON.stringify(input)}`);
+    assert.equal(result.daily, null);
+    assert.deepEqual(result.recentClaims, []);
+    assert.equal(result.economy.version, HERO_ECONOMY_VERSION);
+    assert.equal(result.economy.balance, 0);
+    assert.equal(result.heroPool.version, HERO_POOL_STATE_VERSION);
+    assert.deepEqual(result.heroPool.monsters, {});
+  }
+});
+
+// ── v2 state with 180 ledger entries migrates without ledger loss ──
+
+test('v2 state with 180 ledger entries migrates without ledger loss', () => {
+  const ledger = [];
+  for (let i = 0; i < 180; i++) {
+    ledger.push({
+      entryId: `e-${i}`,
+      type: 'daily-completion-award',
+      amount: 100,
+      balanceAfter: (i + 1) * 100,
+      dateKey: `2026-04-${String(1 + (i % 28)).padStart(2, '0')}`,
+      createdAt: 1000 + i * 100,
+    });
+  }
+  const input = {
+    version: 2,
+    daily: null,
+    recentClaims: [],
+    economy: {
+      version: HERO_ECONOMY_VERSION,
+      balance: 18000,
+      lifetimeEarned: 18000,
+      lifetimeSpent: 0,
+      ledger,
+      lastUpdatedAt: 1000 + 179 * 100,
+    },
+  };
+  const result = normaliseHeroProgressState(input);
+  assert.equal(result.version, 3);
+  // All 180 entries preserved (economy normaliser keeps up to HERO_LEDGER_RECENT_LIMIT=180)
+  assert.equal(result.economy.ledger.length, 180);
+  assert.equal(result.economy.ledger[0].entryId, 'e-0');
+  assert.equal(result.economy.ledger[179].entryId, 'e-179');
+  assert.equal(result.economy.balance, 18000);
+  // heroPool empty (v2 migration)
+  assert.equal(result.heroPool.version, HERO_POOL_STATE_VERSION);
+  assert.deepEqual(result.heroPool.monsters, {});
+});
+
+// ── normaliseHeroPoolState direct tests ───────────────────────────
+
+test('normaliseHeroPoolState with null returns empty pool', () => {
+  const result = normaliseHeroPoolState(null);
+  assert.equal(result.version, HERO_POOL_STATE_VERSION);
+  assert.deepEqual(result.monsters, {});
+  assert.equal(result.selectedMonsterId, null);
+});
+
+test('normaliseHeroPoolState with selectedMonsterId pointing to unknown ID resets to null', () => {
+  const input = {
+    version: HERO_POOL_STATE_VERSION,
+    rosterVersion: 'p5-initial-v1',
+    selectedMonsterId: 'unknown_id',
+    monsters: {},
+    recentActions: [],
+    lastUpdatedAt: null,
+  };
+  const result = normaliseHeroPoolState(input);
+  assert.equal(result.selectedMonsterId, null);
+});
+
+test('normaliseHeroPoolState with negative investedCoins clamps to 0', () => {
+  const input = {
+    version: HERO_POOL_STATE_VERSION,
+    rosterVersion: 'p5-initial-v1',
+    selectedMonsterId: null,
+    monsters: {
+      mirrane: { monsterId: 'mirrane', owned: true, stage: 1, branch: null, investedCoins: -500 },
+    },
+    recentActions: [],
+    lastUpdatedAt: null,
+  };
+  const result = normaliseHeroPoolState(input);
+  assert.equal(result.monsters.mirrane.investedCoins, 0);
+});
+
+test('normaliseHeroPoolState with stage as string normalises to 0', () => {
+  const input = {
+    version: HERO_POOL_STATE_VERSION,
+    rosterVersion: 'p5-initial-v1',
+    selectedMonsterId: null,
+    monsters: {
+      carillon: { monsterId: 'carillon', owned: false, stage: 'two', branch: null, investedCoins: 0 },
+    },
+    recentActions: [],
+    lastUpdatedAt: null,
+  };
+  const result = normaliseHeroPoolState(input);
+  assert.equal(result.monsters.carillon.stage, 0);
+});
+
+test('normaliseHeroPoolState preserves rosterVersion string', () => {
+  const input = {
+    version: HERO_POOL_STATE_VERSION,
+    rosterVersion: 'custom-roster-v7',
+    selectedMonsterId: null,
+    monsters: {},
+    recentActions: [],
+    lastUpdatedAt: 9999,
+  };
+  const result = normaliseHeroPoolState(input);
+  assert.equal(result.rosterVersion, 'custom-roster-v7');
+  assert.equal(result.lastUpdatedAt, 9999);
+});
+
+// ── v3 with stage -1 → clamped to 0 ─────────────────────────────
+
+test('v3 with stage -1 clamps to 0', () => {
+  const input = {
+    version: 3,
+    daily: null,
+    recentClaims: [],
+    economy: emptyEconomyState(),
+    heroPool: {
+      version: HERO_POOL_STATE_VERSION,
+      rosterVersion: HERO_POOL_ROSTER_VERSION,
+      selectedMonsterId: null,
+      monsters: {
+        mirrane: { monsterId: 'mirrane', owned: false, stage: -1, branch: null, investedCoins: 0 },
+      },
+      recentActions: [],
+      lastUpdatedAt: null,
+    },
+  };
+  const result = normaliseHeroProgressState(input);
+  assert.equal(result.heroPool.monsters.mirrane.stage, 0);
+});
+
+// ── v3 with branch 'b5' on unowned monster → normalised to null ──
+
+test('v3 with branch b5 on unowned monster normalises to null', () => {
+  const input = {
+    version: 3,
+    daily: null,
+    recentClaims: [],
+    economy: emptyEconomyState(),
+    heroPool: {
+      version: HERO_POOL_STATE_VERSION,
+      rosterVersion: HERO_POOL_ROSTER_VERSION,
+      selectedMonsterId: null,
+      monsters: {
+        loomrill: { monsterId: 'loomrill', owned: false, stage: 0, branch: 'b5', investedCoins: 0 },
+      },
+      recentActions: [],
+      lastUpdatedAt: null,
+    },
+  };
+  const result = normaliseHeroProgressState(input);
+  assert.equal(result.heroPool.monsters.loomrill.branch, null);
+});
+
+// ── v3 with branch 'b1' on owned monster → preserved as 'b1' ────
+
+test('v3 with branch b1 on owned monster preserved as b1', () => {
+  const input = {
+    version: 3,
+    daily: null,
+    recentClaims: [],
+    economy: emptyEconomyState(),
+    heroPool: {
+      version: HERO_POOL_STATE_VERSION,
+      rosterVersion: HERO_POOL_ROSTER_VERSION,
+      selectedMonsterId: 'glossbloom',
+      monsters: {
+        glossbloom: { monsterId: 'glossbloom', owned: true, stage: 3, branch: 'b1', investedCoins: 750 },
+      },
+      recentActions: [],
+      lastUpdatedAt: null,
+    },
+  };
+  const result = normaliseHeroProgressState(input);
+  assert.equal(result.heroPool.monsters.glossbloom.branch, 'b1');
+  assert.equal(result.heroPool.monsters.glossbloom.owned, true);
+});
+
+// ── v3 with malformed heroPool (null/number) → safe empty heroPool, economy preserved ──
+
+test('v3 with heroPool as null returns safe empty heroPool, economy preserved', () => {
+  const input = {
+    version: 3,
+    daily: null,
+    recentClaims: [],
+    economy: {
+      version: HERO_ECONOMY_VERSION,
+      balance: 500,
+      lifetimeEarned: 500,
+      lifetimeSpent: 0,
+      ledger: [{ entryId: 'e1', type: 'daily-completion-award', amount: 100, balanceAfter: 100, createdAt: 1000 }],
+      lastUpdatedAt: 5000,
+    },
+    heroPool: null,
+  };
+  const result = normaliseHeroProgressState(input);
+  assert.equal(result.version, 3);
+  assert.equal(result.economy.balance, 500);
+  assert.equal(result.heroPool.version, HERO_POOL_STATE_VERSION);
+  assert.deepEqual(result.heroPool.monsters, {});
+});
+
+test('v3 with heroPool as number returns safe empty heroPool, economy preserved', () => {
+  const input = {
+    version: 3,
+    daily: null,
+    recentClaims: [],
+    economy: {
+      version: HERO_ECONOMY_VERSION,
+      balance: 250,
+      lifetimeEarned: 250,
+      lifetimeSpent: 0,
+      ledger: [],
+      lastUpdatedAt: 3000,
+    },
+    heroPool: 42,
+  };
+  const result = normaliseHeroProgressState(input);
+  assert.equal(result.version, 3);
+  assert.equal(result.economy.balance, 250);
+  assert.equal(result.heroPool.version, HERO_POOL_STATE_VERSION);
+  assert.deepEqual(result.heroPool.monsters, {});
+});
+
+// ── Version field is 3 after normalisation regardless of input version ──
+
+test('version field is 3 after normalisation regardless of input version', () => {
+  const inputs = [
+    { version: 1, daily: null, recentClaims: [] },
+    { version: 2, daily: null, recentClaims: [], economy: emptyEconomyState() },
+    { version: 3, daily: null, recentClaims: [], economy: emptyEconomyState(), heroPool: null },
+    null,
+    undefined,
+    'garbage',
+  ];
+  for (const input of inputs) {
+    const result = normaliseHeroProgressState(input);
+    assert.equal(result.version, 3, `failed for input: ${JSON.stringify(input)}`);
+  }
+});

--- a/tests/hero-pool-registry.test.js
+++ b/tests/hero-pool-registry.test.js
@@ -1,0 +1,214 @@
+'use strict';
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import {
+  HERO_POOL_REGISTRY,
+  HERO_POOL_INITIAL_MONSTER_IDS,
+  HERO_MONSTER_INVITE_COST,
+  HERO_MONSTER_GROW_COSTS,
+  getHeroMonsterDefinition,
+  getInviteCost,
+  getGrowCost,
+  isValidHeroMonsterId,
+  isValidBranch,
+  isValidHeroMonsterBranch,
+  getMaxStage,
+} from '../shared/hero/hero-pool.js';
+
+// ── Registry completeness ───────────────────────────────────────────
+
+describe('HERO_POOL_REGISTRY', () => {
+  it('contains exactly 6 unique monster IDs', () => {
+    const ids = Object.keys(HERO_POOL_REGISTRY);
+    assert.equal(ids.length, 6);
+    assert.equal(new Set(ids).size, 6);
+  });
+
+  it('initial monster IDs array matches registry keys in display order', () => {
+    assert.deepEqual(
+      HERO_POOL_INITIAL_MONSTER_IDS,
+      Object.keys(HERO_POOL_REGISTRY).sort(
+        (a, b) => HERO_POOL_REGISTRY[a].displayOrder - HERO_POOL_REGISTRY[b].displayOrder
+      )
+    );
+  });
+
+  it('all definitions have complete required fields', () => {
+    const requiredFields = [
+      'monsterId', 'displayName', 'sourceAssetMonsterId', 'origin',
+      'displayOrder', 'maxStage', 'inviteCost', 'growCosts',
+      'branchOptions', 'childBlurb',
+    ];
+    for (const [id, def] of Object.entries(HERO_POOL_REGISTRY)) {
+      for (const field of requiredFields) {
+        assert.ok(
+          field in def,
+          `Monster '${id}' is missing field '${field}'`
+        );
+      }
+      assert.equal(def.monsterId, id);
+    }
+  });
+});
+
+// ── Cost invariants ─────────────────────────────────────────────────
+
+describe('Cost contract', () => {
+  it('invite cost is a positive integer', () => {
+    assert.equal(typeof HERO_MONSTER_INVITE_COST, 'number');
+    assert.ok(HERO_MONSTER_INVITE_COST > 0);
+    assert.ok(Number.isInteger(HERO_MONSTER_INVITE_COST));
+  });
+
+  it('grow costs are positive integers that strictly increase by stage', () => {
+    const stages = Object.keys(HERO_MONSTER_GROW_COSTS).map(Number).sort((a, b) => a - b);
+    assert.deepEqual(stages, [1, 2, 3, 4]);
+
+    let prev = 0;
+    for (const stage of stages) {
+      const cost = HERO_MONSTER_GROW_COSTS[stage];
+      assert.equal(typeof cost, 'number');
+      assert.ok(Number.isInteger(cost));
+      assert.ok(cost > prev, `Stage ${stage} cost ${cost} must exceed prev ${prev}`);
+      prev = cost;
+    }
+  });
+
+  it('getInviteCost() returns the invite cost constant', () => {
+    assert.equal(getInviteCost(), HERO_MONSTER_INVITE_COST);
+  });
+
+  it('getGrowCost(targetStage) returns correct costs', () => {
+    assert.equal(getGrowCost(1), 300);
+    assert.equal(getGrowCost(2), 600);
+    assert.equal(getGrowCost(3), 1000);
+    assert.equal(getGrowCost(4), 1600);
+  });
+
+  it('getGrowCost(5) returns undefined (beyond max stage)', () => {
+    assert.equal(getGrowCost(5), undefined);
+  });
+});
+
+// ── Stage and branch invariants ─────────────────────────────────────
+
+describe('Stage and branch contract', () => {
+  it('max stage is 4 for all monsters', () => {
+    for (const [id, def] of Object.entries(HERO_POOL_REGISTRY)) {
+      assert.equal(def.maxStage, 4, `Monster '${id}' maxStage must be 4`);
+    }
+    assert.equal(getMaxStage(), 4);
+  });
+
+  it('branch options are b1 and b2 for all monsters', () => {
+    for (const [id, def] of Object.entries(HERO_POOL_REGISTRY)) {
+      const branches = def.branchOptions.map(b => b.branch);
+      assert.deepEqual(branches, ['b1', 'b2'], `Monster '${id}' branches`);
+    }
+  });
+
+  it('isValidBranch accepts b1 and b2', () => {
+    assert.equal(isValidBranch('b1'), true);
+    assert.equal(isValidBranch('b2'), true);
+  });
+
+  it('isValidBranch rejects b3', () => {
+    assert.equal(isValidBranch('b3'), false);
+  });
+
+  it('isValidBranch rejects non-strings', () => {
+    assert.equal(isValidBranch(null), false);
+    assert.equal(isValidBranch(undefined), false);
+    assert.equal(isValidBranch(1), false);
+  });
+
+  it('isValidHeroMonsterBranch is the same function', () => {
+    assert.equal(isValidHeroMonsterBranch, isValidBranch);
+  });
+});
+
+// ── Lookup helpers ──────────────────────────────────────────────────
+
+describe('Lookup helpers', () => {
+  it('getHeroMonsterDefinition returns correct definition', () => {
+    const def = getHeroMonsterDefinition('glossbloom');
+    assert.equal(def.monsterId, 'glossbloom');
+    assert.equal(def.displayName, 'Glossbloom');
+    assert.equal(def.origin, 'grammar-reserve');
+  });
+
+  it('getHeroMonsterDefinition returns undefined for unknown ID', () => {
+    assert.equal(getHeroMonsterDefinition('unknown'), undefined);
+  });
+
+  it('isValidHeroMonsterId validates known IDs', () => {
+    for (const id of HERO_POOL_INITIAL_MONSTER_IDS) {
+      assert.equal(isValidHeroMonsterId(id), true);
+    }
+  });
+
+  it('isValidHeroMonsterId rejects unknown strings', () => {
+    assert.equal(isValidHeroMonsterId('unknown'), false);
+    assert.equal(isValidHeroMonsterId(''), false);
+  });
+
+  it('isValidHeroMonsterId rejects non-strings', () => {
+    assert.equal(isValidHeroMonsterId(null), false);
+    assert.equal(isValidHeroMonsterId(123), false);
+  });
+});
+
+// ── Freeze contract ─────────────────────────────────────────────────
+
+describe('Freeze contract', () => {
+  it('HERO_POOL_REGISTRY is frozen — mutations throw in strict mode', () => {
+    assert.ok(Object.isFrozen(HERO_POOL_REGISTRY));
+    assert.throws(() => { HERO_POOL_REGISTRY.newMonster = {}; }, TypeError);
+  });
+
+  it('individual monster definitions are frozen', () => {
+    for (const def of Object.values(HERO_POOL_REGISTRY)) {
+      assert.ok(Object.isFrozen(def));
+    }
+  });
+
+  it('HERO_POOL_INITIAL_MONSTER_IDS is frozen', () => {
+    assert.ok(Object.isFrozen(HERO_POOL_INITIAL_MONSTER_IDS));
+    assert.throws(() => { HERO_POOL_INITIAL_MONSTER_IDS.push('x'); }, TypeError);
+  });
+
+  it('HERO_MONSTER_GROW_COSTS is frozen', () => {
+    assert.ok(Object.isFrozen(HERO_MONSTER_GROW_COSTS));
+    assert.throws(() => { HERO_MONSTER_GROW_COSTS[5] = 9999; }, TypeError);
+  });
+});
+
+// ── Purity contract ─────────────────────────────────────────────────
+
+describe('Purity contract', () => {
+  it('hero-pool.js has zero imports from worker/, src/, or subject modules', () => {
+    const filePath = resolve(import.meta.dirname, '..', 'shared', 'hero', 'hero-pool.js');
+    const source = readFileSync(filePath, 'utf8');
+
+    // Must not import from worker/, src/, or subject-specific modules
+    const forbidden = [
+      /from\s+['"].*worker\//,
+      /from\s+['"].*src\//,
+      /require\(['"].*worker\//,
+      /require\(['"].*src\//,
+      /from\s+['"]react/,
+      /from\s+['"]node:/,
+    ];
+    for (const pattern of forbidden) {
+      assert.equal(
+        pattern.test(source),
+        false,
+        `hero-pool.js must not match: ${pattern}`
+      );
+    }
+  });
+});

--- a/tests/hero-progress-mutation-safety.test.js
+++ b/tests/hero-progress-mutation-safety.test.js
@@ -114,7 +114,7 @@ test('readHeroProgressState with no existing row returns normalised empty state'
   // We verify the contract of normaliseHeroProgressState(null).
   const expected = normaliseHeroProgressState(null);
   assert.deepEqual(expected, emptyProgressState());
-  assert.equal(expected.version, 2);
+  assert.equal(expected.version, 3);
   assert.equal(expected.daily, null);
   assert.deepEqual(expected.recentClaims, []);
 
@@ -163,7 +163,7 @@ test('readHeroProgressState with valid existing row returns parsed state', async
   assert.ok(row, 'hero-mode row must exist after direct insert');
   const parsed = JSON.parse(row.state_json);
   const normalised = normaliseHeroProgressState(parsed);
-  assert.equal(normalised.version, 2);
+  assert.equal(normalised.version, 3);
   assert.equal(normalised.daily.questId, 'quest-abc');
   assert.equal(normalised.daily.status, 'active');
   assert.equal(normalised.daily.effortCompleted, 1);
@@ -676,7 +676,7 @@ test('normaliseHeroProgressState with wrong version returns empty progress', () 
 test('normaliseHeroProgressState with valid minimal state returns normalised', () => {
   const input = { version: 1, daily: null, recentClaims: [] };
   const result = normaliseHeroProgressState(input);
-  assert.equal(result.version, 2);
+  assert.equal(result.version, 3);
   assert.equal(result.daily, null);
   assert.deepEqual(result.recentClaims, []);
 });

--- a/tests/hero-progress-state.test.js
+++ b/tests/hero-progress-state.test.js
@@ -3,8 +3,11 @@ import assert from 'node:assert/strict';
 
 import {
   HERO_PROGRESS_VERSION,
+  HERO_POOL_STATE_VERSION,
+  HERO_POOL_ROSTER_VERSION,
   MAX_RECENT_CLAIMS_AGE_DAYS,
   emptyProgressState,
+  emptyHeroPoolState,
   normaliseHeroProgressState,
   initialiseDailyProgress,
   applyClaimToProgress,
@@ -16,25 +19,28 @@ import { HERO_ECONOMY_VERSION, emptyEconomyState } from '../shared/hero/economy.
 
 // ── normaliseHeroProgressState ────────────────────────────────────
 
-test('normaliseHeroProgressState with null returns empty v2 state', () => {
+test('normaliseHeroProgressState with null returns empty v3 state', () => {
   const result = normaliseHeroProgressState(null);
-  assert.equal(result.version, 2);
+  assert.equal(result.version, 3);
   assert.equal(result.daily, null);
   assert.deepEqual(result.recentClaims, []);
   assert.equal(result.economy.version, HERO_ECONOMY_VERSION);
   assert.equal(result.economy.balance, 0);
   assert.deepEqual(result.economy.ledger, []);
+  assert.equal(result.heroPool.version, HERO_POOL_STATE_VERSION);
+  assert.deepEqual(result.heroPool.monsters, {});
 });
 
-test('normaliseHeroProgressState with undefined returns empty v2 state', () => {
+test('normaliseHeroProgressState with undefined returns empty v3 state', () => {
   const result = normaliseHeroProgressState(undefined);
-  assert.equal(result.version, 2);
+  assert.equal(result.version, 3);
   assert.equal(result.daily, null);
   assert.deepEqual(result.recentClaims, []);
   assert.equal(result.economy.version, HERO_ECONOMY_VERSION);
+  assert.equal(result.heroPool.version, HERO_POOL_STATE_VERSION);
 });
 
-test('normaliseHeroProgressState v1 state migrates to v2 preserving daily and recentClaims', () => {
+test('normaliseHeroProgressState v1 state migrates to v3 preserving daily and recentClaims', () => {
   const input = {
     version: 1,
     daily: {
@@ -59,7 +65,7 @@ test('normaliseHeroProgressState v1 state migrates to v2 preserving daily and re
     recentClaims: [{ claimId: 'c1', createdAt: 999 }],
   };
   const result = normaliseHeroProgressState(input);
-  assert.equal(result.version, 2);
+  assert.equal(result.version, 3);
   assert.equal(result.daily.dateKey, '2026-04-28');
   assert.equal(result.daily.questId, 'quest-abc');
   assert.equal(result.daily.tasks.t1.status, 'completed');
@@ -72,9 +78,12 @@ test('normaliseHeroProgressState v1 state migrates to v2 preserving daily and re
   assert.equal(result.economy.lifetimeSpent, 0);
   assert.deepEqual(result.economy.ledger, []);
   assert.equal(result.economy.lastUpdatedAt, null);
+  // heroPool must be empty (v1 had no heroPool)
+  assert.equal(result.heroPool.version, HERO_POOL_STATE_VERSION);
+  assert.deepEqual(result.heroPool.monsters, {});
 });
 
-test('normaliseHeroProgressState v2 state with existing economy normalises correctly', () => {
+test('normaliseHeroProgressState v2 state with existing economy migrates to v3', () => {
   const input = {
     version: 2,
     daily: {
@@ -101,40 +110,46 @@ test('normaliseHeroProgressState v2 state with existing economy normalises corre
       balance: 100,
       lifetimeEarned: 200,
       lifetimeSpent: 100,
-      ledger: [{ id: 'entry-1', type: 'daily-completion-award', coins: 100 }],
+      ledger: [{ entryId: 'entry-1', type: 'daily-completion-award', amount: 100, balanceAfter: 100, createdAt: 5500 }],
       lastUpdatedAt: 5500,
     },
   };
   const result = normaliseHeroProgressState(input);
-  assert.equal(result.version, 2);
+  assert.equal(result.version, 3);
   assert.equal(result.daily.questId, 'quest-xyz');
   assert.equal(result.economy.balance, 100);
   assert.equal(result.economy.lifetimeEarned, 200);
   assert.equal(result.economy.lifetimeSpent, 100);
   assert.equal(result.economy.ledger.length, 1);
   assert.equal(result.economy.lastUpdatedAt, 5500);
+  // heroPool must be empty (v2 had no heroPool)
+  assert.equal(result.heroPool.version, HERO_POOL_STATE_VERSION);
+  assert.deepEqual(result.heroPool.monsters, {});
 });
 
-test('normaliseHeroProgressState with malformed version (99) returns empty v2 state', () => {
+test('normaliseHeroProgressState with malformed version (99) returns empty v3 state', () => {
   const result = normaliseHeroProgressState({ version: 99, daily: null, recentClaims: [] });
-  assert.equal(result.version, 2);
+  assert.equal(result.version, 3);
   assert.equal(result.daily, null);
   assert.equal(result.economy.version, HERO_ECONOMY_VERSION);
   assert.equal(result.economy.balance, 0);
+  assert.equal(result.heroPool.version, HERO_POOL_STATE_VERSION);
 });
 
-test('normaliseHeroProgressState with missing version returns empty v2 state', () => {
+test('normaliseHeroProgressState with missing version returns empty v3 state', () => {
   const result = normaliseHeroProgressState({ daily: null, recentClaims: [] });
-  assert.equal(result.version, 2);
+  assert.equal(result.version, 3);
   assert.equal(result.daily, null);
   assert.equal(result.economy.version, HERO_ECONOMY_VERSION);
+  assert.equal(result.heroPool.version, HERO_POOL_STATE_VERSION);
 });
 
-test('normaliseHeroProgressState with version as string returns empty v2 state', () => {
-  const result = normaliseHeroProgressState({ version: '2', daily: null, recentClaims: [] });
-  assert.equal(result.version, 2);
+test('normaliseHeroProgressState with version as string returns empty v3 state', () => {
+  const result = normaliseHeroProgressState({ version: '3', daily: null, recentClaims: [] });
+  assert.equal(result.version, 3);
   assert.equal(result.daily, null);
   assert.equal(result.economy.version, HERO_ECONOMY_VERSION);
+  assert.equal(result.heroPool.version, HERO_POOL_STATE_VERSION);
 });
 
 test('normaliseHeroProgressState v2 with partially corrupt economy normalises safely', () => {
@@ -169,6 +184,7 @@ test('normaliseHeroProgressState v2 with partially corrupt economy normalises sa
     },
   };
   const result = normaliseHeroProgressState(input);
+  assert.equal(result.version, 3);
   // Daily progress MUST survive
   assert.equal(result.daily.questId, 'quest-keep');
   assert.equal(result.daily.tasks.t1.status, 'planned');
@@ -178,6 +194,9 @@ test('normaliseHeroProgressState v2 with partially corrupt economy normalises sa
   assert.equal(result.economy.balance, 0); // 'corrupted' → 0
   assert.equal(result.economy.lifetimeEarned, 0); // Infinity → 0
   assert.deepEqual(result.economy.ledger, []); // 'not-an-array' → []
+  // heroPool must be empty (v2 migration)
+  assert.equal(result.heroPool.version, HERO_POOL_STATE_VERSION);
+  assert.deepEqual(result.heroPool.monsters, {});
 });
 
 test('normaliseHeroProgressState v2 with null economy gets empty economy', () => {
@@ -188,18 +207,21 @@ test('normaliseHeroProgressState v2 with null economy gets empty economy', () =>
     economy: null,
   };
   const result = normaliseHeroProgressState(input);
-  assert.equal(result.version, 2);
+  assert.equal(result.version, 3);
   assert.equal(result.economy.version, HERO_ECONOMY_VERSION);
   assert.equal(result.economy.balance, 0);
+  assert.equal(result.heroPool.version, HERO_POOL_STATE_VERSION);
 });
 
 test('normaliseHeroProgressState with malformed daily repairs safely', () => {
   const result = normaliseHeroProgressState({
-    version: 2,
+    version: 3,
     daily: { dateKey: '2026-04-28', questId: 'q1', status: 'garbage', effortTarget: 'abc' },
     recentClaims: 'not-an-array',
     economy: emptyEconomyState(),
+    heroPool: emptyHeroPoolState(),
   });
+  assert.equal(result.version, 3);
   assert.equal(result.daily.status, 'active'); // unknown status defaults to 'active'
   assert.equal(result.daily.effortTarget, 0); // NaN coerces to 0
   assert.deepEqual(result.recentClaims, []);
@@ -207,11 +229,13 @@ test('normaliseHeroProgressState with malformed daily repairs safely', () => {
 
 test('normaliseHeroProgressState with daily missing dateKey returns null daily', () => {
   const result = normaliseHeroProgressState({
-    version: 2,
+    version: 3,
     daily: { questId: 'q1' }, // no dateKey
     recentClaims: [],
     economy: emptyEconomyState(),
+    heroPool: emptyHeroPoolState(),
   });
+  assert.equal(result.version, 3);
   assert.equal(result.daily, null);
 });
 
@@ -458,10 +482,10 @@ test('markTaskStarted preserves existing firstStartedAt', () => {
 
 // ── emptyProgressState ────────────────────────────────────────────
 
-test('emptyProgressState returns correct v2 shape with economy', () => {
+test('emptyProgressState returns correct v3 shape with economy + heroPool', () => {
   const result = emptyProgressState();
   assert.equal(result.version, HERO_PROGRESS_VERSION);
-  assert.equal(result.version, 2);
+  assert.equal(result.version, 3);
   assert.equal(result.daily, null);
   assert.deepEqual(result.recentClaims, []);
   assert.equal(result.economy.version, HERO_ECONOMY_VERSION);
@@ -470,10 +494,16 @@ test('emptyProgressState returns correct v2 shape with economy', () => {
   assert.equal(result.economy.lifetimeSpent, 0);
   assert.deepEqual(result.economy.ledger, []);
   assert.equal(result.economy.lastUpdatedAt, null);
+  assert.equal(result.heroPool.version, HERO_POOL_STATE_VERSION);
+  assert.equal(result.heroPool.rosterVersion, HERO_POOL_ROSTER_VERSION);
+  assert.equal(result.heroPool.selectedMonsterId, null);
+  assert.deepEqual(result.heroPool.monsters, {});
+  assert.deepEqual(result.heroPool.recentActions, []);
+  assert.equal(result.heroPool.lastUpdatedAt, null);
 });
 
-// ── HERO_PROGRESS_VERSION is 2 ───────────────────────────────────
+// ── HERO_PROGRESS_VERSION is 3 ───────────────────────────────────
 
-test('HERO_PROGRESS_VERSION is 2', () => {
-  assert.equal(HERO_PROGRESS_VERSION, 2);
+test('HERO_PROGRESS_VERSION is 3', () => {
+  assert.equal(HERO_PROGRESS_VERSION, 3);
 });

--- a/tests/shared/hero/economy.test.js
+++ b/tests/shared/hero/economy.test.js
@@ -1,0 +1,323 @@
+// Hero Mode P5 U2 — Economy normaliser hardening for debit operations.
+//
+// Validates that normaliseHeroEconomyState() safely handles:
+// - Negative ledger entries (spending: monster-invite, monster-grow)
+// - NaN/Infinity/negative on scalar fields
+// - Unknown entry types (dropped)
+// - Polarity violations (earning with negative, spending with positive)
+// - balanceAfter validation
+// - Entirely malformed economy objects
+// - P4 earning-only state passes through unchanged
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  HERO_ECONOMY_VERSION,
+  HERO_DAILY_COMPLETION_COINS,
+  HERO_ECONOMY_ENTRY_TYPES,
+  HERO_EARNING_ENTRY_TYPES,
+  HERO_SPENDING_ENTRY_TYPES,
+  emptyEconomyState,
+  normaliseHeroEconomyState,
+  applyDailyCompletionCoinAward,
+} from '../../../shared/hero/economy.js';
+
+// ── Fixture builders ────────────────────────────────────────────────────
+
+function buildValidEarningEntry(overrides = {}) {
+  return {
+    entryId: 'hero-ledger-earn1',
+    idempotencyKey: 'hero-daily-coins:v1:l1:2026-04-29:q1:fp1',
+    type: 'daily-completion-award',
+    amount: 100,
+    balanceAfter: 100,
+    learnerId: 'learner-1',
+    dateKey: '2026-04-29',
+    questId: 'quest-1',
+    questFingerprint: 'fp-1',
+    createdAt: '2026-04-29T10:00:00Z',
+    createdBy: 'system',
+    ...overrides,
+  };
+}
+
+function buildValidSpendingEntry(type = 'monster-invite', overrides = {}) {
+  return {
+    entryId: 'hero-ledger-spend1',
+    idempotencyKey: `hero-spend:v1:l1:${type}:ts1`,
+    type,
+    amount: -30,
+    balanceAfter: 70,
+    learnerId: 'learner-1',
+    dateKey: '2026-04-29',
+    createdAt: '2026-04-29T11:00:00Z',
+    createdBy: 'system',
+    ...overrides,
+  };
+}
+
+function buildValidEconomyState(overrides = {}) {
+  return {
+    version: HERO_ECONOMY_VERSION,
+    balance: 100,
+    lifetimeEarned: 100,
+    lifetimeSpent: 0,
+    ledger: [buildValidEarningEntry()],
+    lastUpdatedAt: '2026-04-29T10:00:00Z',
+    ...overrides,
+  };
+}
+
+// ── 1. Valid P4 earning-only state passes through normaliser unchanged ──
+
+test('P5-U2: valid P4 earning-only state passes through normaliser unchanged', () => {
+  const input = buildValidEconomyState();
+  const result = normaliseHeroEconomyState(input);
+
+  assert.equal(result.version, HERO_ECONOMY_VERSION);
+  assert.equal(result.balance, 100);
+  assert.equal(result.lifetimeEarned, 100);
+  assert.equal(result.lifetimeSpent, 0);
+  assert.equal(result.ledger.length, 1);
+  assert.equal(result.ledger[0].type, 'daily-completion-award');
+  assert.equal(result.ledger[0].amount, 100);
+  assert.equal(result.lastUpdatedAt, '2026-04-29T10:00:00Z');
+});
+
+// ── 2. Valid state with monster-invite entry normalises correctly ──
+
+test('P5-U2: valid state with monster-invite entry (negative amount) normalises correctly', () => {
+  const input = buildValidEconomyState({
+    balance: 70,
+    lifetimeSpent: 30,
+    ledger: [
+      buildValidEarningEntry(),
+      buildValidSpendingEntry('monster-invite', { amount: -30, balanceAfter: 70 }),
+    ],
+  });
+  const result = normaliseHeroEconomyState(input);
+
+  assert.equal(result.balance, 70);
+  assert.equal(result.lifetimeSpent, 30);
+  assert.equal(result.ledger.length, 2);
+  assert.equal(result.ledger[1].type, 'monster-invite');
+  assert.equal(result.ledger[1].amount, -30);
+});
+
+// ── 3. Valid state with monster-grow entry normalises correctly ──
+
+test('P5-U2: valid state with monster-grow entry (negative amount) normalises correctly', () => {
+  const input = buildValidEconomyState({
+    balance: 50,
+    lifetimeSpent: 50,
+    ledger: [
+      buildValidEarningEntry(),
+      buildValidSpendingEntry('monster-grow', { amount: -50, balanceAfter: 50 }),
+    ],
+  });
+  const result = normaliseHeroEconomyState(input);
+
+  assert.equal(result.balance, 50);
+  assert.equal(result.lifetimeSpent, 50);
+  assert.equal(result.ledger.length, 2);
+  assert.equal(result.ledger[1].type, 'monster-grow');
+  assert.equal(result.ledger[1].amount, -50);
+});
+
+// ── 4. balance is NaN -> normalised to 0 ──
+
+test('P5-U2: balance is NaN -> normalised to 0', () => {
+  const input = buildValidEconomyState({ balance: NaN });
+  const result = normaliseHeroEconomyState(input);
+  assert.equal(result.balance, 0);
+});
+
+// ── 5. balance is -5 -> normalised to 0 ──
+
+test('P5-U2: balance is -5 -> normalised to 0', () => {
+  const input = buildValidEconomyState({ balance: -5 });
+  const result = normaliseHeroEconomyState(input);
+  assert.equal(result.balance, 0);
+});
+
+// ── 6. lifetimeSpent is negative -> normalised to 0 ──
+
+test('P5-U2: lifetimeSpent is negative -> normalised to 0', () => {
+  const input = buildValidEconomyState({ lifetimeSpent: -10 });
+  const result = normaliseHeroEconomyState(input);
+  assert.equal(result.lifetimeSpent, 0);
+});
+
+// ── 7. lifetimeEarned is Infinity -> normalised to 0 ──
+
+test('P5-U2: lifetimeEarned is Infinity -> normalised to 0', () => {
+  const input = buildValidEconomyState({ lifetimeEarned: Infinity });
+  const result = normaliseHeroEconomyState(input);
+  assert.equal(result.lifetimeEarned, 0);
+});
+
+// ── 8. Ledger entry with unknown type 'random-bonus' is dropped ──
+
+test('P5-U2: ledger entry with unknown type is dropped', () => {
+  const input = buildValidEconomyState({
+    ledger: [
+      buildValidEarningEntry(),
+      { entryId: 'bad-1', type: 'random-bonus', amount: 50, balanceAfter: 150, createdAt: 'x' },
+    ],
+  });
+  const result = normaliseHeroEconomyState(input);
+  assert.equal(result.ledger.length, 1);
+  assert.equal(result.ledger[0].type, 'daily-completion-award');
+});
+
+// ── 9. Earning entry (daily-completion-award) with negative amount is dropped ──
+
+test('P5-U2: earning entry (daily-completion-award) with negative amount is dropped', () => {
+  const input = buildValidEconomyState({
+    ledger: [
+      buildValidEarningEntry({ amount: -100, balanceAfter: 0 }),
+    ],
+  });
+  const result = normaliseHeroEconomyState(input);
+  assert.equal(result.ledger.length, 0);
+});
+
+// ── 10. Spending entry (monster-invite) with positive amount is dropped ──
+
+test('P5-U2: spending entry (monster-invite) with positive amount is dropped', () => {
+  const input = buildValidEconomyState({
+    ledger: [
+      buildValidEarningEntry(),
+      buildValidSpendingEntry('monster-invite', { amount: 30, balanceAfter: 130 }),
+    ],
+  });
+  const result = normaliseHeroEconomyState(input);
+  assert.equal(result.ledger.length, 1);
+  assert.equal(result.ledger[0].type, 'daily-completion-award');
+});
+
+// ── 11. Entry with balanceAfter: Infinity is dropped ──
+
+test('P5-U2: entry with balanceAfter: Infinity is dropped', () => {
+  const input = buildValidEconomyState({
+    ledger: [
+      buildValidEarningEntry({ balanceAfter: Infinity }),
+    ],
+  });
+  const result = normaliseHeroEconomyState(input);
+  assert.equal(result.ledger.length, 0);
+});
+
+// ── 12. Entry with balanceAfter: -5 is dropped ──
+
+test('P5-U2: entry with balanceAfter: -5 is dropped', () => {
+  const input = buildValidEconomyState({
+    ledger: [
+      buildValidEarningEntry({ balanceAfter: -5 }),
+    ],
+  });
+  const result = normaliseHeroEconomyState(input);
+  assert.equal(result.ledger.length, 0);
+});
+
+// ── 13. Entirely malformed economy object (string/null/number) -> safe empty state ──
+
+test('P5-U2: entirely malformed economy object (string) -> safe empty state', () => {
+  const result = normaliseHeroEconomyState('corrupted');
+  assert.deepEqual(result, emptyEconomyState());
+});
+
+test('P5-U2: entirely malformed economy object (null) -> safe empty state', () => {
+  const result = normaliseHeroEconomyState(null);
+  assert.deepEqual(result, emptyEconomyState());
+});
+
+test('P5-U2: entirely malformed economy object (number) -> safe empty state', () => {
+  const result = normaliseHeroEconomyState(42);
+  assert.deepEqual(result, emptyEconomyState());
+});
+
+test('P5-U2: entirely malformed economy object (array) -> safe empty state', () => {
+  const result = normaliseHeroEconomyState([1, 2, 3]);
+  assert.deepEqual(result, emptyEconomyState());
+});
+
+// ── 14. Existing P4 award flow still produces valid state after hardening ──
+
+test('P5-U2: existing P4 award flow produces valid state that passes normalisation', () => {
+  const heroState = {
+    daily: {
+      dateKey: '2026-04-29',
+      questId: 'quest-p4-1',
+      questFingerprint: 'hero-qf-p4check',
+      status: 'completed',
+      completedTaskIds: ['task-1', 'task-2', 'task-3'],
+      completedAt: '2026-04-29T09:00:00Z',
+      effortCompleted: 3,
+      effortPlanned: 3,
+      economy: null,
+    },
+    economy: emptyEconomyState(),
+  };
+
+  const result = applyDailyCompletionCoinAward(heroState, {
+    learnerId: 'learner-p4-check',
+    nowTs: '2026-04-29T10:00:00Z',
+    dailyCompletionCoins: HERO_DAILY_COMPLETION_COINS,
+  });
+
+  assert.equal(result.awarded, true);
+  assert.equal(result.amount, HERO_DAILY_COMPLETION_COINS);
+
+  // The produced economy state must survive normalisation unchanged
+  const normalised = normaliseHeroEconomyState(result.state.economy);
+  assert.equal(normalised.balance, result.state.economy.balance);
+  assert.equal(normalised.lifetimeEarned, result.state.economy.lifetimeEarned);
+  assert.equal(normalised.lifetimeSpent, result.state.economy.lifetimeSpent);
+  assert.equal(normalised.ledger.length, result.state.economy.ledger.length);
+  assert.equal(normalised.ledger[0].type, 'daily-completion-award');
+  assert.equal(normalised.ledger[0].amount, HERO_DAILY_COMPLETION_COINS);
+});
+
+// ── Entry type constants validation ─────────────────────────────────────
+
+test('P5-U2: HERO_ECONOMY_ENTRY_TYPES includes spending types', () => {
+  assert.ok(HERO_ECONOMY_ENTRY_TYPES.includes('monster-invite'));
+  assert.ok(HERO_ECONOMY_ENTRY_TYPES.includes('monster-grow'));
+  assert.ok(HERO_ECONOMY_ENTRY_TYPES.includes('admin-adjustment'));
+  assert.ok(HERO_ECONOMY_ENTRY_TYPES.includes('daily-completion-award'));
+});
+
+test('P5-U2: HERO_EARNING_ENTRY_TYPES and HERO_SPENDING_ENTRY_TYPES are disjoint', () => {
+  for (const t of HERO_EARNING_ENTRY_TYPES) {
+    assert.equal(HERO_SPENDING_ENTRY_TYPES.includes(t), false, `${t} must not be in both lists`);
+  }
+  for (const t of HERO_SPENDING_ENTRY_TYPES) {
+    assert.equal(HERO_EARNING_ENTRY_TYPES.includes(t), false, `${t} must not be in both lists`);
+  }
+});
+
+test('P5-U2: admin-adjustment entry with positive amount passes normalisation', () => {
+  const input = buildValidEconomyState({
+    ledger: [
+      { entryId: 'adj-1', type: 'admin-adjustment', amount: 50, balanceAfter: 150, createdAt: 'x', createdBy: 'admin' },
+    ],
+  });
+  const result = normaliseHeroEconomyState(input);
+  assert.equal(result.ledger.length, 1);
+  assert.equal(result.ledger[0].type, 'admin-adjustment');
+  assert.equal(result.ledger[0].amount, 50);
+});
+
+test('P5-U2: admin-adjustment entry with negative amount passes normalisation', () => {
+  const input = buildValidEconomyState({
+    ledger: [
+      { entryId: 'adj-2', type: 'admin-adjustment', amount: -20, balanceAfter: 80, createdAt: 'x', createdBy: 'admin' },
+    ],
+  });
+  const result = normaliseHeroEconomyState(input);
+  assert.equal(result.ledger.length, 1);
+  assert.equal(result.ledger[0].type, 'admin-adjustment');
+  assert.equal(result.ledger[0].amount, -20);
+});

--- a/tests/shared/hero/monster-economy.test.js
+++ b/tests/shared/hero/monster-economy.test.js
@@ -1,0 +1,683 @@
+'use strict';
+
+// Hero Mode P5 U4 — Monster economy pure spending computation tests.
+//
+// Validates computeMonsterInviteIntent and computeMonsterGrowIntent:
+// - Happy paths with correct debits
+// - Edge cases: already-owned, already-stage, exact balance
+// - Error paths: insufficient coins, unknown monster, invalid branch, stage violations
+// - Determinism: same inputs → same ledger entry ID
+// - Purity: input objects are never mutated
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  computeMonsterInviteIntent,
+  computeMonsterGrowIntent,
+} from '../../../shared/hero/monster-economy.js';
+
+import {
+  HERO_MONSTER_INVITE_COST,
+  HERO_MONSTER_GROW_COSTS,
+} from '../../../shared/hero/hero-pool.js';
+
+// ── Fixture builders ────────────────────────────────────────────────────
+
+const NOW = 1714400000000; // fixed timestamp for determinism
+
+function buildEconomyState(overrides = {}) {
+  return {
+    version: 1,
+    balance: 1000,
+    lifetimeEarned: 1000,
+    lifetimeSpent: 0,
+    ledger: [],
+    lastUpdatedAt: NOW - 86400000,
+    ...overrides,
+  };
+}
+
+function buildHeroPoolState(monsters = {}) {
+  return { monsters };
+}
+
+function buildOwnedMonster(overrides = {}) {
+  return {
+    monsterId: 'glossbloom',
+    owned: true,
+    stage: 0,
+    branch: 'b1',
+    investedCoins: HERO_MONSTER_INVITE_COST,
+    invitedAt: NOW - 86400000,
+    lastGrownAt: null,
+    lastLedgerEntryId: 'hero-ledger-prev',
+    ...overrides,
+  };
+}
+
+// ── computeMonsterInviteIntent — happy path ─────────────────────────────
+
+describe('computeMonsterInviteIntent — happy path', () => {
+  it('invite with sufficient balance debits exactly 150', () => {
+    const economy = buildEconomyState({ balance: 500 });
+    const pool = buildHeroPoolState({});
+
+    const result = computeMonsterInviteIntent({
+      economyState: economy,
+      heroPoolState: pool,
+      monsterId: 'glossbloom',
+      branch: 'b1',
+      learnerId: 'learner-1',
+      rosterVersion: 'hero-pool-v1',
+      nowTs: NOW,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.status, 'invited');
+    assert.equal(result.cost, HERO_MONSTER_INVITE_COST);
+    assert.equal(result.coinsUsed, HERO_MONSTER_INVITE_COST);
+    assert.equal(result.intent.ledgerEntry.amount, -HERO_MONSTER_INVITE_COST);
+    assert.equal(result.intent.ledgerEntry.type, 'monster-invite');
+    assert.equal(result.intent.monsterState.stage, 0);
+    assert.equal(result.intent.monsterState.owned, true);
+  });
+
+  it('balanceAfter = balance - cost', () => {
+    const economy = buildEconomyState({ balance: 400 });
+    const pool = buildHeroPoolState({});
+
+    const result = computeMonsterInviteIntent({
+      economyState: economy,
+      heroPoolState: pool,
+      monsterId: 'loomrill',
+      branch: 'b2',
+      learnerId: 'learner-1',
+      rosterVersion: 'hero-pool-v1',
+      nowTs: NOW,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.intent.ledgerEntry.balanceAfter, 400 - HERO_MONSTER_INVITE_COST);
+    assert.equal(result.intent.economyDelta.balanceAfter, 400 - HERO_MONSTER_INVITE_COST);
+  });
+
+  it('ledger entry has deterministic ID (same inputs → same ID)', () => {
+    const economy = buildEconomyState({ balance: 500 });
+    const pool = buildHeroPoolState({});
+    const params = {
+      economyState: economy,
+      heroPoolState: pool,
+      monsterId: 'glossbloom',
+      branch: 'b1',
+      learnerId: 'learner-1',
+      rosterVersion: 'hero-pool-v1',
+      nowTs: NOW,
+    };
+
+    const r1 = computeMonsterInviteIntent(params);
+    const r2 = computeMonsterInviteIntent(params);
+
+    assert.equal(r1.ledgerEntryId, r2.ledgerEntryId);
+    assert.equal(r1.intent.ledgerEntry.entryId, r2.intent.ledgerEntry.entryId);
+  });
+
+  it('balance exactly equals cost → succeeds with 0 remaining', () => {
+    const economy = buildEconomyState({ balance: HERO_MONSTER_INVITE_COST });
+    const pool = buildHeroPoolState({});
+
+    const result = computeMonsterInviteIntent({
+      economyState: economy,
+      heroPoolState: pool,
+      monsterId: 'glossbloom',
+      branch: 'b1',
+      learnerId: 'learner-1',
+      rosterVersion: 'hero-pool-v1',
+      nowTs: NOW,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.status, 'invited');
+    assert.equal(result.intent.ledgerEntry.balanceAfter, 0);
+    assert.equal(result.intent.economyDelta.balanceAfter, 0);
+  });
+});
+
+// ── computeMonsterInviteIntent — edge cases ─────────────────────────────
+
+describe('computeMonsterInviteIntent — edge cases', () => {
+  it('already-owned → { ok: true, status: "already-owned", cost: 0, coinsUsed: 0 }', () => {
+    const economy = buildEconomyState({ balance: 500 });
+    const pool = buildHeroPoolState({
+      glossbloom: buildOwnedMonster({ monsterId: 'glossbloom' }),
+    });
+
+    const result = computeMonsterInviteIntent({
+      economyState: economy,
+      heroPoolState: pool,
+      monsterId: 'glossbloom',
+      branch: 'b1',
+      learnerId: 'learner-1',
+      rosterVersion: 'hero-pool-v1',
+      nowTs: NOW,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.status, 'already-owned');
+    assert.equal(result.cost, 0);
+    assert.equal(result.coinsUsed, 0);
+    assert.equal(result.ledgerEntryId, null);
+  });
+});
+
+// ── computeMonsterInviteIntent — error paths ────────────────────────────
+
+describe('computeMonsterInviteIntent — error paths', () => {
+  it('insufficient balance → { ok: false, code: "hero_insufficient_coins" }', () => {
+    const economy = buildEconomyState({ balance: HERO_MONSTER_INVITE_COST - 1 });
+    const pool = buildHeroPoolState({});
+
+    const result = computeMonsterInviteIntent({
+      economyState: economy,
+      heroPoolState: pool,
+      monsterId: 'glossbloom',
+      branch: 'b1',
+      learnerId: 'learner-1',
+      rosterVersion: 'hero-pool-v1',
+      nowTs: NOW,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.code, 'hero_insufficient_coins');
+  });
+
+  it('unknown monsterId → { ok: false, code: "hero_monster_unknown" }', () => {
+    const economy = buildEconomyState({ balance: 500 });
+    const pool = buildHeroPoolState({});
+
+    const result = computeMonsterInviteIntent({
+      economyState: economy,
+      heroPoolState: pool,
+      monsterId: 'unknown-creature',
+      branch: 'b1',
+      learnerId: 'learner-1',
+      rosterVersion: 'hero-pool-v1',
+      nowTs: NOW,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.code, 'hero_monster_unknown');
+  });
+
+  it('invalid branch "b3" → { ok: false, code: "hero_monster_branch_invalid" }', () => {
+    const economy = buildEconomyState({ balance: 500 });
+    const pool = buildHeroPoolState({});
+
+    const result = computeMonsterInviteIntent({
+      economyState: economy,
+      heroPoolState: pool,
+      monsterId: 'glossbloom',
+      branch: 'b3',
+      learnerId: 'learner-1',
+      rosterVersion: 'hero-pool-v1',
+      nowTs: NOW,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.code, 'hero_monster_branch_invalid');
+  });
+
+  it('missing branch (null) → { ok: false, code: "hero_monster_branch_required" }', () => {
+    const economy = buildEconomyState({ balance: 500 });
+    const pool = buildHeroPoolState({});
+
+    const result = computeMonsterInviteIntent({
+      economyState: economy,
+      heroPoolState: pool,
+      monsterId: 'glossbloom',
+      branch: null,
+      learnerId: 'learner-1',
+      rosterVersion: 'hero-pool-v1',
+      nowTs: NOW,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.code, 'hero_monster_branch_required');
+  });
+
+  it('missing branch (undefined) → { ok: false, code: "hero_monster_branch_required" }', () => {
+    const economy = buildEconomyState({ balance: 500 });
+    const pool = buildHeroPoolState({});
+
+    const result = computeMonsterInviteIntent({
+      economyState: economy,
+      heroPoolState: pool,
+      monsterId: 'glossbloom',
+      branch: undefined,
+      learnerId: 'learner-1',
+      rosterVersion: 'hero-pool-v1',
+      nowTs: NOW,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.code, 'hero_monster_branch_required');
+  });
+});
+
+// ── computeMonsterGrowIntent — happy path ───────────────────────────────
+
+describe('computeMonsterGrowIntent — happy path', () => {
+  it('grow stage 0→1 debits 300', () => {
+    const economy = buildEconomyState({ balance: 1000 });
+    const pool = buildHeroPoolState({
+      glossbloom: buildOwnedMonster({ stage: 0 }),
+    });
+
+    const result = computeMonsterGrowIntent({
+      economyState: economy,
+      heroPoolState: pool,
+      monsterId: 'glossbloom',
+      targetStage: 1,
+      learnerId: 'learner-1',
+      rosterVersion: 'hero-pool-v1',
+      nowTs: NOW,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.status, 'grown');
+    assert.equal(result.cost, HERO_MONSTER_GROW_COSTS[1]);
+    assert.equal(result.coinsUsed, 300);
+    assert.equal(result.intent.ledgerEntry.amount, -300);
+    assert.equal(result.intent.ledgerEntry.type, 'monster-grow');
+    assert.equal(result.intent.ledgerEntry.stageBefore, 0);
+    assert.equal(result.intent.ledgerEntry.stageAfter, 1);
+  });
+
+  it('grow stage 1→2 debits 600', () => {
+    const economy = buildEconomyState({ balance: 1000 });
+    const pool = buildHeroPoolState({
+      glossbloom: buildOwnedMonster({ stage: 1 }),
+    });
+
+    const result = computeMonsterGrowIntent({
+      economyState: economy,
+      heroPoolState: pool,
+      monsterId: 'glossbloom',
+      targetStage: 2,
+      learnerId: 'learner-1',
+      rosterVersion: 'hero-pool-v1',
+      nowTs: NOW,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.status, 'grown');
+    assert.equal(result.cost, HERO_MONSTER_GROW_COSTS[2]);
+    assert.equal(result.coinsUsed, 600);
+    assert.equal(result.intent.ledgerEntry.amount, -600);
+    assert.equal(result.intent.ledgerEntry.stageBefore, 1);
+    assert.equal(result.intent.ledgerEntry.stageAfter, 2);
+  });
+
+  it('lifetimeSpent increments by cost; lifetimeEarned unchanged', () => {
+    const economy = buildEconomyState({ balance: 1000, lifetimeEarned: 2000, lifetimeSpent: 300 });
+    const pool = buildHeroPoolState({
+      glossbloom: buildOwnedMonster({ stage: 0 }),
+    });
+
+    const result = computeMonsterGrowIntent({
+      economyState: economy,
+      heroPoolState: pool,
+      monsterId: 'glossbloom',
+      targetStage: 1,
+      learnerId: 'learner-1',
+      rosterVersion: 'hero-pool-v1',
+      nowTs: NOW,
+    });
+
+    assert.equal(result.ok, true);
+    // The intent's economyDelta tells the caller how to update lifetimeSpent
+    assert.equal(result.intent.economyDelta.lifetimeSpentDelta, HERO_MONSTER_GROW_COSTS[1]);
+    // No earning delta on a spend operation
+    assert.equal(result.intent.economyDelta.balanceDelta, -HERO_MONSTER_GROW_COSTS[1]);
+  });
+
+  it('balanceAfter = balance - cost for grow', () => {
+    const economy = buildEconomyState({ balance: 700 });
+    const pool = buildHeroPoolState({
+      glossbloom: buildOwnedMonster({ stage: 0 }),
+    });
+
+    const result = computeMonsterGrowIntent({
+      economyState: economy,
+      heroPoolState: pool,
+      monsterId: 'glossbloom',
+      targetStage: 1,
+      learnerId: 'learner-1',
+      rosterVersion: 'hero-pool-v1',
+      nowTs: NOW,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.intent.ledgerEntry.balanceAfter, 700 - 300);
+    assert.equal(result.intent.economyDelta.balanceAfter, 400);
+  });
+
+  it('investedCoins increments by cost on grow', () => {
+    const economy = buildEconomyState({ balance: 1000 });
+    const pool = buildHeroPoolState({
+      glossbloom: buildOwnedMonster({ stage: 0, investedCoins: 150 }),
+    });
+
+    const result = computeMonsterGrowIntent({
+      economyState: economy,
+      heroPoolState: pool,
+      monsterId: 'glossbloom',
+      targetStage: 1,
+      learnerId: 'learner-1',
+      rosterVersion: 'hero-pool-v1',
+      nowTs: NOW,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.intent.monsterState.investedCoins, 150 + 300);
+  });
+});
+
+// ── computeMonsterGrowIntent — edge cases ───────────────────────────────
+
+describe('computeMonsterGrowIntent — edge cases', () => {
+  it('already at target stage → { ok: true, status: "already-stage", cost: 0, coinsUsed: 0 }', () => {
+    const economy = buildEconomyState({ balance: 1000 });
+    const pool = buildHeroPoolState({
+      glossbloom: buildOwnedMonster({ stage: 2 }),
+    });
+
+    const result = computeMonsterGrowIntent({
+      economyState: economy,
+      heroPoolState: pool,
+      monsterId: 'glossbloom',
+      targetStage: 2,
+      learnerId: 'learner-1',
+      rosterVersion: 'hero-pool-v1',
+      nowTs: NOW,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.status, 'already-stage');
+    assert.equal(result.cost, 0);
+    assert.equal(result.coinsUsed, 0);
+    assert.equal(result.ledgerEntryId, null);
+  });
+
+  it('already past target stage → { ok: true, status: "already-stage" }', () => {
+    const economy = buildEconomyState({ balance: 1000 });
+    const pool = buildHeroPoolState({
+      glossbloom: buildOwnedMonster({ stage: 3 }),
+    });
+
+    const result = computeMonsterGrowIntent({
+      economyState: economy,
+      heroPoolState: pool,
+      monsterId: 'glossbloom',
+      targetStage: 2,
+      learnerId: 'learner-1',
+      rosterVersion: 'hero-pool-v1',
+      nowTs: NOW,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.status, 'already-stage');
+    assert.equal(result.cost, 0);
+    assert.equal(result.coinsUsed, 0);
+  });
+
+  it('balance exactly equals grow cost → succeeds with 0 remaining', () => {
+    const economy = buildEconomyState({ balance: HERO_MONSTER_GROW_COSTS[1] });
+    const pool = buildHeroPoolState({
+      glossbloom: buildOwnedMonster({ stage: 0 }),
+    });
+
+    const result = computeMonsterGrowIntent({
+      economyState: economy,
+      heroPoolState: pool,
+      monsterId: 'glossbloom',
+      targetStage: 1,
+      learnerId: 'learner-1',
+      rosterVersion: 'hero-pool-v1',
+      nowTs: NOW,
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.status, 'grown');
+    assert.equal(result.intent.ledgerEntry.balanceAfter, 0);
+    assert.equal(result.intent.economyDelta.balanceAfter, 0);
+  });
+});
+
+// ── computeMonsterGrowIntent — error paths ──────────────────────────────
+
+describe('computeMonsterGrowIntent — error paths', () => {
+  it('insufficient balance → { ok: false, code: "hero_insufficient_coins" }', () => {
+    const economy = buildEconomyState({ balance: 299 });
+    const pool = buildHeroPoolState({
+      glossbloom: buildOwnedMonster({ stage: 0 }),
+    });
+
+    const result = computeMonsterGrowIntent({
+      economyState: economy,
+      heroPoolState: pool,
+      monsterId: 'glossbloom',
+      targetStage: 1,
+      learnerId: 'learner-1',
+      rosterVersion: 'hero-pool-v1',
+      nowTs: NOW,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.code, 'hero_insufficient_coins');
+  });
+
+  it('unknown monsterId → { ok: false, code: "hero_monster_unknown" }', () => {
+    const economy = buildEconomyState({ balance: 1000 });
+    const pool = buildHeroPoolState({});
+
+    const result = computeMonsterGrowIntent({
+      economyState: economy,
+      heroPoolState: pool,
+      monsterId: 'unknown-creature',
+      targetStage: 1,
+      learnerId: 'learner-1',
+      rosterVersion: 'hero-pool-v1',
+      nowTs: NOW,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.code, 'hero_monster_unknown');
+  });
+
+  it('monster not owned → { ok: false, code: "hero_monster_not_owned" }', () => {
+    const economy = buildEconomyState({ balance: 1000 });
+    const pool = buildHeroPoolState({
+      glossbloom: { monsterId: 'glossbloom', owned: false, stage: 0 },
+    });
+
+    const result = computeMonsterGrowIntent({
+      economyState: economy,
+      heroPoolState: pool,
+      monsterId: 'glossbloom',
+      targetStage: 1,
+      learnerId: 'learner-1',
+      rosterVersion: 'hero-pool-v1',
+      nowTs: NOW,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.code, 'hero_monster_not_owned');
+  });
+
+  it('target stage not next sequential (skip stage 0→2) → { ok: false, code: "hero_monster_stage_not_next" }', () => {
+    const economy = buildEconomyState({ balance: 5000 });
+    const pool = buildHeroPoolState({
+      glossbloom: buildOwnedMonster({ stage: 0 }),
+    });
+
+    const result = computeMonsterGrowIntent({
+      economyState: economy,
+      heroPoolState: pool,
+      monsterId: 'glossbloom',
+      targetStage: 2,
+      learnerId: 'learner-1',
+      rosterVersion: 'hero-pool-v1',
+      nowTs: NOW,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.code, 'hero_monster_stage_not_next');
+  });
+
+  it('target stage 5 (> max) → { ok: false, code: "hero_monster_max_stage" }', () => {
+    const economy = buildEconomyState({ balance: 10000 });
+    const pool = buildHeroPoolState({
+      glossbloom: buildOwnedMonster({ stage: 4 }),
+    });
+
+    const result = computeMonsterGrowIntent({
+      economyState: economy,
+      heroPoolState: pool,
+      monsterId: 'glossbloom',
+      targetStage: 5,
+      learnerId: 'learner-1',
+      rosterVersion: 'hero-pool-v1',
+      nowTs: NOW,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.code, 'hero_monster_max_stage');
+  });
+});
+
+// ── Determinism / idempotency ───────────────────────────────────────────
+
+describe('Determinism — idempotency key contract', () => {
+  it('same invite inputs always produce same ledger entry ID', () => {
+    const economy = buildEconomyState({ balance: 500 });
+    const pool = buildHeroPoolState({});
+    const params = {
+      economyState: economy,
+      heroPoolState: pool,
+      monsterId: 'colisk',
+      branch: 'b2',
+      learnerId: 'learner-abc',
+      rosterVersion: 'hero-pool-v1',
+      nowTs: NOW,
+    };
+
+    const r1 = computeMonsterInviteIntent(params);
+    const r2 = computeMonsterInviteIntent({ ...params, nowTs: NOW + 99999 });
+
+    // Entry ID is derived from idempotency key only — NOT from timestamp
+    assert.equal(r1.ledgerEntryId, r2.ledgerEntryId);
+    assert.equal(r1.intent.ledgerEntry.idempotencyKey, r2.intent.ledgerEntry.idempotencyKey);
+  });
+
+  it('same grow inputs always produce same ledger entry ID', () => {
+    const economy = buildEconomyState({ balance: 1000 });
+    const pool = buildHeroPoolState({
+      loomrill: buildOwnedMonster({ monsterId: 'loomrill', stage: 1 }),
+    });
+    const params = {
+      economyState: economy,
+      heroPoolState: pool,
+      monsterId: 'loomrill',
+      targetStage: 2,
+      learnerId: 'learner-xyz',
+      rosterVersion: 'hero-pool-v1',
+      nowTs: NOW,
+    };
+
+    const r1 = computeMonsterGrowIntent(params);
+    const r2 = computeMonsterGrowIntent({ ...params, nowTs: NOW + 10000 });
+
+    assert.equal(r1.ledgerEntryId, r2.ledgerEntryId);
+    assert.equal(r1.intent.ledgerEntry.idempotencyKey, r2.intent.ledgerEntry.idempotencyKey);
+  });
+});
+
+// ── Purity — no mutation of inputs ──────────────────────────────────────
+
+describe('Purity — no input mutation', () => {
+  it('computeMonsterInviteIntent never modifies input economyState', () => {
+    const economy = buildEconomyState({ balance: 500 });
+    const frozenCopy = JSON.parse(JSON.stringify(economy));
+    const pool = buildHeroPoolState({});
+
+    computeMonsterInviteIntent({
+      economyState: economy,
+      heroPoolState: pool,
+      monsterId: 'glossbloom',
+      branch: 'b1',
+      learnerId: 'learner-1',
+      rosterVersion: 'hero-pool-v1',
+      nowTs: NOW,
+    });
+
+    assert.deepEqual(economy, frozenCopy);
+  });
+
+  it('computeMonsterInviteIntent never modifies input heroPoolState', () => {
+    const pool = buildHeroPoolState({});
+    const frozenCopy = JSON.parse(JSON.stringify(pool));
+    const economy = buildEconomyState({ balance: 500 });
+
+    computeMonsterInviteIntent({
+      economyState: economy,
+      heroPoolState: pool,
+      monsterId: 'glossbloom',
+      branch: 'b1',
+      learnerId: 'learner-1',
+      rosterVersion: 'hero-pool-v1',
+      nowTs: NOW,
+    });
+
+    assert.deepEqual(pool, frozenCopy);
+  });
+
+  it('computeMonsterGrowIntent never modifies input economyState', () => {
+    const economy = buildEconomyState({ balance: 1000 });
+    const frozenCopy = JSON.parse(JSON.stringify(economy));
+    const pool = buildHeroPoolState({
+      glossbloom: buildOwnedMonster({ stage: 0 }),
+    });
+
+    computeMonsterGrowIntent({
+      economyState: economy,
+      heroPoolState: pool,
+      monsterId: 'glossbloom',
+      targetStage: 1,
+      learnerId: 'learner-1',
+      rosterVersion: 'hero-pool-v1',
+      nowTs: NOW,
+    });
+
+    assert.deepEqual(economy, frozenCopy);
+  });
+
+  it('computeMonsterGrowIntent never modifies input heroPoolState', () => {
+    const monster = buildOwnedMonster({ stage: 0 });
+    const pool = buildHeroPoolState({ glossbloom: monster });
+    const frozenCopy = JSON.parse(JSON.stringify(pool));
+    const economy = buildEconomyState({ balance: 1000 });
+
+    computeMonsterGrowIntent({
+      economyState: economy,
+      heroPoolState: pool,
+      monsterId: 'glossbloom',
+      targetStage: 1,
+      learnerId: 'learner-1',
+      rosterVersion: 'hero-pool-v1',
+      nowTs: NOW,
+    });
+
+    assert.deepEqual(pool, frozenCopy);
+  });
+});

--- a/worker/src/app.js
+++ b/worker/src/app.js
@@ -47,11 +47,13 @@ import { isResetableBreakerName } from '../../src/platform/core/circuit-breaker.
 import { handleHeroReadModel } from './hero/routes.js';
 import { resolveHeroStartTaskCommand } from './hero/launch.js';
 import { resolveHeroClaimCommand } from './hero/claim.js';
+import { resolveHeroCampCommand } from './hero/camp.js';
 import {
   initialiseDailyProgress,
   markTaskStarted,
   applyClaimToProgress,
   pruneRecentClaims,
+  HERO_POOL_ROSTER_VERSION,
 } from '../../shared/hero/progress-state.js';
 import { buildClaimRecord } from '../../shared/hero/claim-contract.js';
 import { canAwardDailyCompletionCoins, applyDailyCompletionCoinAward, HERO_DAILY_COMPLETION_COINS } from '../../shared/hero/economy.js';
@@ -1730,6 +1732,142 @@ export function createWorkerApp({
                 dailyCoinsAlreadyAwarded: mutationResult.economyResult?.alreadyAwarded || false,
                 heroStatePersistenceEnabled: true,
               },
+              mutation: mutationResult.mutation || null,
+            });
+          }
+
+          // P5 U6: Camp spending commands (unlock-monster, evolve-monster)
+          if (body?.command === 'unlock-monster' || body?.command === 'evolve-monster') {
+            // Gate 1: Camp feature flag
+            if (!envFlagEnabled(env.HERO_MODE_CAMP_ENABLED)) {
+              return json({ ok: false, error: { code: 'hero_camp_disabled', message: 'Hero Camp is not enabled' } }, 409);
+            }
+            // Gate 2: Economy required for spending
+            if (!envFlagEnabled(env.HERO_MODE_ECONOMY_ENABLED)) {
+              return json({ ok: false, error: { code: 'hero_camp_misconfigured', message: 'Hero Camp requires economy to be enabled' } }, 409);
+            }
+            // Gate 3: Child UI required
+            if (!envFlagEnabled(env.HERO_MODE_CHILD_UI_ENABLED)) {
+              return json({ ok: false, error: { code: 'hero_camp_disabled', message: 'Hero Camp requires child UI to be enabled' } }, 409);
+            }
+
+            const nowTs = now();
+            const heroProgressState = await repository.readHeroProgress(heroLearnerId);
+
+            // Resolve the camp command (pure function)
+            const campResult = resolveHeroCampCommand({
+              command: body.command,
+              body,
+              heroState: heroProgressState,
+              learnerId: heroLearnerId,
+              rosterVersion: heroProgressState.heroPool?.rosterVersion || HERO_POOL_ROSTER_VERSION,
+              nowTs,
+            });
+
+            // Handle rejection
+            if (!campResult.ok) {
+              try {
+                // eslint-disable-next-line no-console
+                console.log(JSON.stringify({
+                  event: 'hero_camp_command_rejected',
+                  learnerId: heroLearnerId,
+                  command: body.command,
+                  monsterId: body.monsterId || '',
+                  code: campResult.code,
+                }));
+              } catch { /* best-effort */ }
+              return json({ ok: false, error: { code: campResult.code, message: campResult.reason || campResult.code } }, campResult.httpStatus || 400);
+            }
+
+            // Handle idempotent duplicates (no mutation needed)
+            if (campResult.heroCampAction?.status === 'already-owned' || campResult.heroCampAction?.status === 'already-stage') {
+              try {
+                // eslint-disable-next-line no-console
+                console.log(JSON.stringify({
+                  event: 'hero_camp_command_idempotent',
+                  learnerId: heroLearnerId,
+                  command: body.command,
+                  monsterId: body.monsterId || '',
+                  status: campResult.heroCampAction.status,
+                }));
+              } catch { /* best-effort */ }
+              return json({ ok: true, heroCampAction: campResult.heroCampAction });
+            }
+
+            // Execute mutation through runHeroCommand (same CAS / receipt / batch pattern as claim-task)
+            const heroCommand = {
+              command: body.command,
+              learnerId: heroLearnerId,
+              requestId: body.requestId,
+              correlationId: body.correlationId || null,
+              expectedLearnerRevision: body.expectedLearnerRevision,
+            };
+
+            const mutationResult = await repository.runHeroCommand(session.accountId, heroLearnerId, heroCommand, async () => {
+              const intent = campResult.intent;
+              const updatedHeroPool = { ...heroProgressState.heroPool };
+              updatedHeroPool.monsters = { ...updatedHeroPool.monsters, [intent.newMonsterState.monsterId]: intent.newMonsterState };
+              updatedHeroPool.lastUpdatedAt = nowTs;
+              updatedHeroPool.recentActions = [
+                ...(updatedHeroPool.recentActions || []),
+                intent.actionRecord,
+              ].slice(-30);
+
+              const updatedEconomy = { ...heroProgressState.economy };
+              updatedEconomy.ledger = [...(updatedEconomy.ledger || []), intent.ledgerEntry].slice(-180);
+              updatedEconomy.balance = intent.newBalance;
+              updatedEconomy.lifetimeSpent = intent.newLifetimeSpent;
+              updatedEconomy.lastUpdatedAt = nowTs;
+
+              const updatedState = {
+                ...heroProgressState,
+                heroPool: updatedHeroPool,
+                economy: updatedEconomy,
+              };
+
+              return { state: updatedState };
+            });
+
+            // Fire-and-forget event_log (non-fatal)
+            try {
+              const db = requireDatabase(env);
+              const eventType = body.command === 'unlock-monster'
+                ? 'hero.camp.monster.invited'
+                : 'hero.camp.monster.grown';
+              await run(db, `
+                INSERT INTO event_log (id, learner_id, subject_id, system_id, event_type, event_json, created_at, actor_account_id)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(id) DO NOTHING
+              `, [
+                `hero-evt-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
+                heroLearnerId,
+                null,
+                'hero-mode',
+                eventType,
+                JSON.stringify({ command: body.command, monsterId: body.monsterId, ledgerEntryId: campResult.intent.ledgerEntry.entryId }),
+                nowTs,
+                session.accountId,
+              ]);
+            } catch (err) {
+              // eslint-disable-next-line no-console
+              console.error('[hero] camp event_log write failed:', err.message);
+            }
+
+            try {
+              // eslint-disable-next-line no-console
+              console.log(JSON.stringify({
+                event: 'hero_camp_command_succeeded',
+                learnerId: heroLearnerId,
+                command: body.command,
+                monsterId: body.monsterId || '',
+                cost: campResult.intent.ledgerEntry.amount * -1,
+                balanceAfter: campResult.intent.newBalance,
+              }));
+            } catch { /* best-effort */ }
+
+            return json({
+              ok: true,
+              heroCampAction: campResult.heroCampAction,
               mutation: mutationResult.mutation || null,
             });
           }

--- a/worker/src/app.js
+++ b/worker/src/app.js
@@ -1740,6 +1740,10 @@ export function createWorkerApp({
           if (body?.command === 'unlock-monster' || body?.command === 'evolve-monster') {
             // Gate 1: Camp feature flag
             if (!envFlagEnabled(env.HERO_MODE_CAMP_ENABLED)) {
+              try {
+                // eslint-disable-next-line no-console
+                console.log(JSON.stringify({ event: 'hero_camp_disabled_attempt', learnerId: heroLearnerId }));
+              } catch { /* best-effort */ }
               return json({ ok: false, error: { code: 'hero_camp_disabled', message: 'Hero Camp is not enabled' } }, 409);
             }
             // Gate 2: Economy required for spending
@@ -1775,6 +1779,17 @@ export function createWorkerApp({
                   monsterId: body.monsterId || '',
                   code: campResult.code,
                 }));
+                // Specific insufficient-coins telemetry
+                if (campResult.code === 'hero_insufficient_coins') {
+                  // eslint-disable-next-line no-console
+                  console.log(JSON.stringify({
+                    event: 'hero_monster_insufficient_coins',
+                    learnerId: heroLearnerId,
+                    monsterId: body.monsterId || '',
+                    balance: heroProgressState?.economy?.balance ?? 0,
+                    required: campResult.reason,
+                  }));
+                }
               } catch { /* best-effort */ }
               return json({ ok: false, error: { code: campResult.code, message: campResult.reason || campResult.code } }, campResult.httpStatus || 400);
             }
@@ -1784,9 +1799,8 @@ export function createWorkerApp({
               try {
                 // eslint-disable-next-line no-console
                 console.log(JSON.stringify({
-                  event: 'hero_camp_command_idempotent',
+                  event: 'hero_monster_duplicate_prevented',
                   learnerId: heroLearnerId,
-                  command: body.command,
                   monsterId: body.monsterId || '',
                   status: campResult.heroCampAction.status,
                 }));
@@ -1863,6 +1877,29 @@ export function createWorkerApp({
                 cost: campResult.intent.ledgerEntry.amount * -1,
                 balanceAfter: campResult.intent.newBalance,
               }));
+              // Specific invite/grow telemetry
+              if (body.command === 'unlock-monster') {
+                // eslint-disable-next-line no-console
+                console.log(JSON.stringify({
+                  event: 'hero_monster_invited',
+                  learnerId: heroLearnerId,
+                  monsterId: body.monsterId || '',
+                  branch: body.branch || '',
+                  cost: campResult.intent.ledgerEntry.amount * -1,
+                  balance: campResult.intent.newBalance,
+                }));
+              } else {
+                // eslint-disable-next-line no-console
+                console.log(JSON.stringify({
+                  event: 'hero_monster_grown',
+                  learnerId: heroLearnerId,
+                  monsterId: body.monsterId || '',
+                  stageBefore: campResult.intent.ledgerEntry.stageBefore,
+                  stageAfter: campResult.intent.ledgerEntry.stageAfter,
+                  cost: campResult.intent.ledgerEntry.amount * -1,
+                  balance: campResult.intent.newBalance,
+                }));
+              }
             } catch { /* best-effort */ }
 
             return json({

--- a/worker/src/hero/camp.js
+++ b/worker/src/hero/camp.js
@@ -1,0 +1,212 @@
+// Hero Camp — pure command resolver (P5).
+// Returns mutation intent or typed error. No DB access.
+
+import { computeMonsterInviteIntent, computeMonsterGrowIntent } from '../../../shared/hero/monster-economy.js';
+import { isValidHeroMonsterId, isValidHeroMonsterBranch } from '../../../shared/hero/hero-pool.js';
+import { HERO_POOL_ROSTER_VERSION } from '../../../shared/hero/progress-state.js';
+
+// ── Forbidden fields ────────────────────────────────────────────────
+
+export const FORBIDDEN_CAMP_FIELDS = Object.freeze([
+  'cost', 'amount', 'balance', 'ledgerEntryId', 'stage', 'owned',
+  'payload', 'subjectId', 'shop', 'reward', 'coins', 'economy',
+  'ledger', 'lifetimeSpent', 'lifetimeEarned', 'stageAfter', 'stageBefore',
+]);
+
+// ── Supported commands ──────────────────────────────────────────────
+
+const CAMP_COMMANDS = new Set(['unlock-monster', 'evolve-monster']);
+
+// ── Main resolver ───────────────────────────────────────────────────
+
+export function resolveHeroCampCommand({ command, body, heroState, learnerId, nowTs }) {
+  // 1. Validate command
+  if (!CAMP_COMMANDS.has(command)) {
+    return { ok: false, code: 'hero_command_unknown', httpStatus: 400 };
+  }
+
+  // 2. Check for forbidden client fields
+  const rejectedFields = FORBIDDEN_CAMP_FIELDS.filter(f => body[f] !== undefined);
+  if (rejectedFields.length > 0) {
+    return { ok: false, code: 'hero_client_field_rejected', httpStatus: 400, rejectedFields };
+  }
+
+  // 3. Dispatch to command handler
+  if (command === 'unlock-monster') {
+    return resolveUnlockMonster(body, heroState, learnerId, nowTs);
+  }
+  return resolveEvolveMonster(body, heroState, learnerId, nowTs);
+}
+
+// ── unlock-monster ──────────────────────────────────────────────────
+
+function resolveUnlockMonster(body, heroState, learnerId, nowTs) {
+  const { monsterId, branch } = body;
+
+  if (!monsterId || !isValidHeroMonsterId(monsterId)) {
+    return { ok: false, code: 'hero_monster_unknown', httpStatus: 400 };
+  }
+
+  if (!branch || !isValidHeroMonsterBranch(branch)) {
+    return { ok: false, code: 'hero_monster_branch_invalid', httpStatus: 400 };
+  }
+
+  const result = computeMonsterInviteIntent({
+    economyState: heroState.economy,
+    heroPoolState: heroState.heroPool,
+    monsterId,
+    branch,
+    learnerId,
+    rosterVersion: HERO_POOL_ROSTER_VERSION,
+    nowTs,
+  });
+
+  if (!result.ok) {
+    return {
+      ok: false,
+      code: result.code,
+      httpStatus: result.code === 'hero_insufficient_coins' ? 409 : 400,
+    };
+  }
+
+  if (result.status === 'already-owned') {
+    return {
+      ok: true,
+      status: 'already-owned',
+      httpStatus: 200,
+      response: buildAlreadyOwnedResponse(learnerId, monsterId, heroState.heroPool),
+    };
+  }
+
+  // status === 'invited'
+  return {
+    ok: true,
+    status: 'invited',
+    httpStatus: 200,
+    intent: result.intent,
+    response: buildInviteResponse(result, learnerId, monsterId, branch),
+  };
+}
+
+// ── evolve-monster ──────────────────────────────────────────────────
+
+function resolveEvolveMonster(body, heroState, learnerId, nowTs) {
+  const { monsterId, targetStage } = body;
+
+  if (!monsterId || !isValidHeroMonsterId(monsterId)) {
+    return { ok: false, code: 'hero_monster_unknown', httpStatus: 400 };
+  }
+
+  const result = computeMonsterGrowIntent({
+    economyState: heroState.economy,
+    heroPoolState: heroState.heroPool,
+    monsterId,
+    targetStage,
+    learnerId,
+    rosterVersion: HERO_POOL_ROSTER_VERSION,
+    nowTs,
+  });
+
+  if (!result.ok) {
+    return {
+      ok: false,
+      code: result.code,
+      httpStatus: result.code === 'hero_insufficient_coins' ? 409 : 400,
+    };
+  }
+
+  if (result.status === 'already-stage') {
+    return {
+      ok: true,
+      status: 'already-stage',
+      httpStatus: 200,
+      response: buildAlreadyStageResponse(learnerId, monsterId, heroState.heroPool),
+    };
+  }
+
+  // status === 'grown'
+  return {
+    ok: true,
+    status: 'grown',
+    httpStatus: 200,
+    intent: result.intent,
+    response: buildGrowResponse(result, learnerId, monsterId),
+  };
+}
+
+// ── Response builders ───────────────────────────────────────────────
+
+function buildInviteResponse(result, learnerId, monsterId, branch) {
+  return {
+    ok: true,
+    heroCampAction: {
+      version: 1,
+      status: 'invited',
+      learnerId,
+      monsterId,
+      branch,
+      stageAfter: 0,
+      cost: result.intent.ledgerEntry.amount * -1,
+      coinsUsed: result.intent.ledgerEntry.amount * -1,
+      coinBalance: result.intent.newBalance,
+      ledgerEntryId: result.intent.ledgerEntry.entryId,
+    },
+  };
+}
+
+function buildAlreadyOwnedResponse(learnerId, monsterId, heroPoolState) {
+  const monster = heroPoolState.monsters[monsterId];
+  return {
+    ok: true,
+    heroCampAction: {
+      version: 1,
+      status: 'already-owned',
+      learnerId,
+      monsterId,
+      branch: monster?.branch || null,
+      stageAfter: monster?.stage ?? 0,
+      cost: 0,
+      coinsUsed: 0,
+      coinBalance: null,
+      ledgerEntryId: null,
+    },
+  };
+}
+
+function buildGrowResponse(result, learnerId, monsterId) {
+  return {
+    ok: true,
+    heroCampAction: {
+      version: 1,
+      status: 'grown',
+      learnerId,
+      monsterId,
+      branch: result.intent.newMonsterState.branch || null,
+      stageBefore: result.intent.ledgerEntry.stageBefore,
+      stageAfter: result.intent.ledgerEntry.stageAfter,
+      cost: result.intent.ledgerEntry.amount * -1,
+      coinsUsed: result.intent.ledgerEntry.amount * -1,
+      coinBalance: result.intent.newBalance,
+      ledgerEntryId: result.intent.ledgerEntry.entryId,
+    },
+  };
+}
+
+function buildAlreadyStageResponse(learnerId, monsterId, heroPoolState) {
+  const monster = heroPoolState.monsters[monsterId];
+  return {
+    ok: true,
+    heroCampAction: {
+      version: 1,
+      status: 'already-stage',
+      learnerId,
+      monsterId,
+      branch: monster?.branch || null,
+      stageAfter: monster?.stage ?? 0,
+      cost: 0,
+      coinsUsed: 0,
+      coinBalance: null,
+      ledgerEntryId: null,
+    },
+  };
+}

--- a/worker/src/hero/camp.js
+++ b/worker/src/hero/camp.js
@@ -1,55 +1,58 @@
-// Hero Camp — pure command resolver (P5).
-// Returns mutation intent or typed error. No DB access.
+'use strict';
+
+// ── Hero Camp — pure command resolver (P5) ─────────────────────────
+// Returns mutation intent or typed error. No database access, no React.
+// Imports ONLY from shared/hero/ siblings.
 
 import { computeMonsterInviteIntent, computeMonsterGrowIntent } from '../../../shared/hero/monster-economy.js';
 import { isValidHeroMonsterId, isValidHeroMonsterBranch } from '../../../shared/hero/hero-pool.js';
-import { HERO_POOL_ROSTER_VERSION } from '../../../shared/hero/progress-state.js';
 
-// ── Forbidden fields ────────────────────────────────────────────────
+// ── Forbidden fields — client must NEVER send these ────────────────
 
 export const FORBIDDEN_CAMP_FIELDS = Object.freeze([
   'cost', 'amount', 'balance', 'ledgerEntryId', 'stage', 'owned',
   'payload', 'subjectId', 'shop', 'reward', 'coins', 'economy',
-  'ledger', 'lifetimeSpent', 'lifetimeEarned', 'stageAfter', 'stageBefore',
+  'entryId', 'ledger',
 ]);
 
-// ── Supported commands ──────────────────────────────────────────────
+// ── Supported commands ─────────────────────────────────────────────
 
 const CAMP_COMMANDS = new Set(['unlock-monster', 'evolve-monster']);
 
-// ── Main resolver ───────────────────────────────────────────────────
+// ── Main resolver ──────────────────────────────────────────────────
 
-export function resolveHeroCampCommand({ command, body, heroState, learnerId, nowTs }) {
+/**
+ * Pure camp command resolver — receives pre-loaded state, returns intent.
+ * Does NOT perform DB reads or writes.
+ */
+export function resolveHeroCampCommand({ command, body, heroState, learnerId, rosterVersion, nowTs }) {
   // 1. Validate command
   if (!CAMP_COMMANDS.has(command)) {
-    return { ok: false, code: 'hero_command_unknown', httpStatus: 400 };
+    return { ok: false, code: 'hero_camp_disabled', httpStatus: 400, reason: `Unknown camp command: ${command}` };
   }
 
   // 2. Check for forbidden client fields
   const rejectedFields = FORBIDDEN_CAMP_FIELDS.filter(f => body[f] !== undefined);
   if (rejectedFields.length > 0) {
-    return { ok: false, code: 'hero_client_field_rejected', httpStatus: 400, rejectedFields };
+    return {
+      ok: false,
+      code: 'hero_client_field_rejected',
+      httpStatus: 400,
+      reason: `Client must not send: ${rejectedFields.join(', ')}`,
+    };
   }
 
   // 3. Dispatch to command handler
   if (command === 'unlock-monster') {
-    return resolveUnlockMonster(body, heroState, learnerId, nowTs);
+    return resolveUnlockMonster(body, heroState, learnerId, rosterVersion, nowTs);
   }
-  return resolveEvolveMonster(body, heroState, learnerId, nowTs);
+  return resolveEvolveMonster(body, heroState, learnerId, rosterVersion, nowTs);
 }
 
-// ── unlock-monster ──────────────────────────────────────────────────
+// ── unlock-monster ─────────────────────────────────────────────────
 
-function resolveUnlockMonster(body, heroState, learnerId, nowTs) {
+function resolveUnlockMonster(body, heroState, learnerId, rosterVersion, nowTs) {
   const { monsterId, branch } = body;
-
-  if (!monsterId || !isValidHeroMonsterId(monsterId)) {
-    return { ok: false, code: 'hero_monster_unknown', httpStatus: 400 };
-  }
-
-  if (!branch || !isValidHeroMonsterBranch(branch)) {
-    return { ok: false, code: 'hero_monster_branch_invalid', httpStatus: 400 };
-  }
 
   const result = computeMonsterInviteIntent({
     economyState: heroState.economy,
@@ -57,7 +60,7 @@ function resolveUnlockMonster(body, heroState, learnerId, nowTs) {
     monsterId,
     branch,
     learnerId,
-    rosterVersion: HERO_POOL_ROSTER_VERSION,
+    rosterVersion,
     nowTs,
   });
 
@@ -66,36 +69,50 @@ function resolveUnlockMonster(body, heroState, learnerId, nowTs) {
       ok: false,
       code: result.code,
       httpStatus: result.code === 'hero_insufficient_coins' ? 409 : 400,
+      reason: result.reason,
     };
   }
 
   if (result.status === 'already-owned') {
     return {
       ok: true,
-      status: 'already-owned',
-      httpStatus: 200,
-      response: buildAlreadyOwnedResponse(learnerId, monsterId, heroState.heroPool),
+      heroCampAction: {
+        version: 1,
+        status: 'already-owned',
+        learnerId,
+        monsterId,
+        branch: heroState.heroPool.monsters[monsterId]?.branch || null,
+        cost: 0,
+        coinsUsed: 0,
+        coinBalance: null,
+        ledgerEntryId: null,
+      },
     };
   }
 
   // status === 'invited'
+  const intent = result.intent;
   return {
     ok: true,
-    status: 'invited',
-    httpStatus: 200,
-    intent: result.intent,
-    response: buildInviteResponse(result, learnerId, monsterId, branch),
+    intent,
+    heroCampAction: {
+      version: 1,
+      status: 'invited',
+      learnerId,
+      monsterId,
+      branch,
+      cost: intent.ledgerEntry.amount * -1,
+      coinsUsed: intent.ledgerEntry.amount * -1,
+      coinBalance: intent.newBalance,
+      ledgerEntryId: intent.ledgerEntry.entryId,
+    },
   };
 }
 
-// ── evolve-monster ──────────────────────────────────────────────────
+// ── evolve-monster ─────────────────────────────────────────────────
 
-function resolveEvolveMonster(body, heroState, learnerId, nowTs) {
+function resolveEvolveMonster(body, heroState, learnerId, rosterVersion, nowTs) {
   const { monsterId, targetStage } = body;
-
-  if (!monsterId || !isValidHeroMonsterId(monsterId)) {
-    return { ok: false, code: 'hero_monster_unknown', httpStatus: 400 };
-  }
 
   const result = computeMonsterGrowIntent({
     economyState: heroState.economy,
@@ -103,7 +120,7 @@ function resolveEvolveMonster(body, heroState, learnerId, nowTs) {
     monsterId,
     targetStage,
     learnerId,
-    rosterVersion: HERO_POOL_ROSTER_VERSION,
+    rosterVersion,
     nowTs,
   });
 
@@ -112,101 +129,44 @@ function resolveEvolveMonster(body, heroState, learnerId, nowTs) {
       ok: false,
       code: result.code,
       httpStatus: result.code === 'hero_insufficient_coins' ? 409 : 400,
+      reason: result.reason,
     };
   }
 
   if (result.status === 'already-stage') {
     return {
       ok: true,
-      status: 'already-stage',
-      httpStatus: 200,
-      response: buildAlreadyStageResponse(learnerId, monsterId, heroState.heroPool),
+      heroCampAction: {
+        version: 1,
+        status: 'already-stage',
+        learnerId,
+        monsterId,
+        stageBefore: heroState.heroPool.monsters[monsterId]?.stage ?? 0,
+        stageAfter: heroState.heroPool.monsters[monsterId]?.stage ?? 0,
+        cost: 0,
+        coinsUsed: 0,
+        coinBalance: null,
+        ledgerEntryId: null,
+      },
     };
   }
 
   // status === 'grown'
+  const intent = result.intent;
   return {
     ok: true,
-    status: 'grown',
-    httpStatus: 200,
-    intent: result.intent,
-    response: buildGrowResponse(result, learnerId, monsterId),
-  };
-}
-
-// ── Response builders ───────────────────────────────────────────────
-
-function buildInviteResponse(result, learnerId, monsterId, branch) {
-  return {
-    ok: true,
-    heroCampAction: {
-      version: 1,
-      status: 'invited',
-      learnerId,
-      monsterId,
-      branch,
-      stageAfter: 0,
-      cost: result.intent.ledgerEntry.amount * -1,
-      coinsUsed: result.intent.ledgerEntry.amount * -1,
-      coinBalance: result.intent.newBalance,
-      ledgerEntryId: result.intent.ledgerEntry.entryId,
-    },
-  };
-}
-
-function buildAlreadyOwnedResponse(learnerId, monsterId, heroPoolState) {
-  const monster = heroPoolState.monsters[monsterId];
-  return {
-    ok: true,
-    heroCampAction: {
-      version: 1,
-      status: 'already-owned',
-      learnerId,
-      monsterId,
-      branch: monster?.branch || null,
-      stageAfter: monster?.stage ?? 0,
-      cost: 0,
-      coinsUsed: 0,
-      coinBalance: null,
-      ledgerEntryId: null,
-    },
-  };
-}
-
-function buildGrowResponse(result, learnerId, monsterId) {
-  return {
-    ok: true,
+    intent,
     heroCampAction: {
       version: 1,
       status: 'grown',
       learnerId,
       monsterId,
-      branch: result.intent.newMonsterState.branch || null,
-      stageBefore: result.intent.ledgerEntry.stageBefore,
-      stageAfter: result.intent.ledgerEntry.stageAfter,
-      cost: result.intent.ledgerEntry.amount * -1,
-      coinsUsed: result.intent.ledgerEntry.amount * -1,
-      coinBalance: result.intent.newBalance,
-      ledgerEntryId: result.intent.ledgerEntry.entryId,
-    },
-  };
-}
-
-function buildAlreadyStageResponse(learnerId, monsterId, heroPoolState) {
-  const monster = heroPoolState.monsters[monsterId];
-  return {
-    ok: true,
-    heroCampAction: {
-      version: 1,
-      status: 'already-stage',
-      learnerId,
-      monsterId,
-      branch: monster?.branch || null,
-      stageAfter: monster?.stage ?? 0,
-      cost: 0,
-      coinsUsed: 0,
-      coinBalance: null,
-      ledgerEntryId: null,
+      stageBefore: intent.ledgerEntry.stageBefore,
+      stageAfter: intent.ledgerEntry.stageAfter,
+      cost: intent.ledgerEntry.amount * -1,
+      coinsUsed: intent.ledgerEntry.amount * -1,
+      coinBalance: intent.newBalance,
+      ledgerEntryId: intent.ledgerEntry.entryId,
     },
   };
 }

--- a/worker/src/hero/read-model.js
+++ b/worker/src/hero/read-model.js
@@ -1,4 +1,4 @@
-// Hero Mode — Shadow read-model assembler (v3 / v4 / v5).
+// Hero Mode — Shadow read-model assembler (v3 / v4 / v5 / v6).
 //
 // Orchestrates providers, eligibility, and the scheduler into a complete
 // shadow response. Pure read-only path — MUST NOT mutate any state, write
@@ -12,6 +12,9 @@
 //
 // v5 adds: child-safe economy block (balance, today award status, recent
 // ledger summary), coinsEnabled=true, behind HERO_MODE_ECONOMY_ENABLED.
+//
+// v6 adds: child-safe Camp block (monster roster, ownership, affordability,
+// recent actions), behind HERO_MODE_CAMP_ENABLED.
 
 import {
   HERO_DEFAULT_EFFORT_TARGET,
@@ -32,6 +35,8 @@ import { deriveHeroQuestFingerprint } from '../../../shared/hero/quest-fingerpri
 import { resolveChildLabel, resolveChildReason } from '../../../shared/hero/hero-copy.js';
 import { deriveTaskCompletionStatus, deriveDailyCompletionStatus } from '../../../shared/hero/completion-status.js';
 import { selectChildSafeEconomyReadModel } from '../../../shared/hero/economy.js';
+import { HERO_POOL_REGISTRY, HERO_POOL_INITIAL_MONSTER_IDS, getGrowCost } from '../../../shared/hero/hero-pool.js';
+import { HERO_POOL_ROSTER_VERSION } from '../../../shared/hero/progress-state.js';
 import { mapHeroEnvelopeToSubjectPayload } from './launch-adapters/index.js';
 import { runProvider } from './providers/index.js';
 
@@ -121,7 +126,8 @@ function detectPendingCompletedSession(heroProgressState, recentCompletedSession
  * @param {Array}  [params.recentCompletedSessions] — recent completed practice session rows (v4+)
  * @param {boolean} [params.progressEnabled] — whether progress mode is enabled (v4+)
  * @param {boolean} [params.economyEnabled] — whether economy (coins) is enabled (v5)
- * @returns {Object} shadow read model v3, v4, or v5
+ * @param {boolean} [params.campEnabled] — whether camp (monster pool) is enabled (v6)
+ * @returns {Object} shadow read model v3, v4, v5, or v6
  */
 export function buildHeroShadowReadModel({
   learnerId,
@@ -133,6 +139,7 @@ export function buildHeroShadowReadModel({
   recentCompletedSessions = [],
   progressEnabled = false,
   economyEnabled = false,
+  campEnabled = false,
 } = {}) {
   const dateKey = deriveDateKey(now, HERO_DEFAULT_TIMEZONE);
   const safeEnv = env || {};
@@ -457,7 +464,13 @@ export function buildHeroShadowReadModel({
   };
 
   // 17. If economy enabled → evolve to v5 with child-safe economy block
-  if (!economyEnabled) return v4Base;
+  if (!economyEnabled) {
+    // Camp enabled but economy disabled → camp cannot function (needs balance)
+    if (campEnabled) {
+      return { ...v4Base, camp: { enabled: false } };
+    }
+    return v4Base;
+  }
 
   const economyBlock = selectChildSafeEconomyReadModel(
     heroProgressState,
@@ -465,7 +478,7 @@ export function buildHeroShadowReadModel({
     quest.questId,
   );
 
-  return {
+  const v5Result = {
     ...v4Base,
     version: 5,
     coinsEnabled: true,
@@ -486,5 +499,118 @@ export function buildHeroShadowReadModel({
       },
       recentLedger: [],
     },
+  };
+
+  // 18. If camp enabled → evolve to v6 with child-safe Camp block
+  if (!campEnabled) return v5Result;
+
+  const campBlock = buildChildSafeCampBlock(heroProgressState, economyBlock?.balance ?? 0);
+
+  return {
+    ...v5Result,
+    version: 6,
+    camp: campBlock,
+  };
+}
+
+// ── Camp block helpers ────────────────────────────────────────────────
+
+function buildChildSafeCampBlock(heroProgressState, balance) {
+  const heroPool = heroProgressState?.heroPool;
+
+  if (!heroPool || typeof heroPool !== 'object') {
+    return buildEmptyCampBlock(balance);
+  }
+
+  const monsters = HERO_POOL_INITIAL_MONSTER_IDS.map(monsterId => {
+    const def = HERO_POOL_REGISTRY[monsterId];
+    const owned = heroPool.monsters?.[monsterId];
+
+    const stage = owned?.stage ?? 0;
+    const isOwned = owned?.owned === true;
+    const fullyGrown = isOwned && stage >= def.maxStage;
+    const nextStage = isOwned && !fullyGrown ? stage + 1 : null;
+    const nextGrowCost = nextStage ? getGrowCost(nextStage) : null;
+
+    return {
+      monsterId: def.monsterId,
+      displayName: def.displayName,
+      childBlurb: def.childBlurb,
+      sourceAssetMonsterId: def.sourceAssetMonsterId,
+      owned: isOwned,
+      stage,
+      branch: owned?.branch || null,
+      maxStage: def.maxStage,
+      inviteCost: def.inviteCost,
+      nextGrowCost,
+      nextStage,
+      canInvite: !isOwned,
+      canGrow: isOwned && !fullyGrown,
+      canAffordInvite: !isOwned && balance >= def.inviteCost,
+      canAffordGrow: isOwned && !fullyGrown && nextGrowCost !== null && balance >= nextGrowCost,
+      fullyGrown,
+    };
+  });
+
+  const recentActions = Array.isArray(heroPool.recentActions)
+    ? heroPool.recentActions.slice(-5).map(a => ({
+        type: a.type,
+        monsterId: a.monsterId,
+        stageAfter: a.stageAfter,
+        cost: a.cost,
+        createdAt: a.createdAt,
+      }))
+    : [];
+
+  return {
+    enabled: true,
+    version: 1,
+    commandRoute: '/api/hero/command',
+    commands: {
+      unlockMonster: 'unlock-monster',
+      evolveMonster: 'evolve-monster',
+    },
+    rosterVersion: HERO_POOL_ROSTER_VERSION,
+    balance,
+    selectedMonsterId: heroPool.selectedMonsterId || null,
+    monsters,
+    recentActions,
+  };
+}
+
+function buildEmptyCampBlock(balance) {
+  return {
+    enabled: true,
+    version: 1,
+    commandRoute: '/api/hero/command',
+    commands: {
+      unlockMonster: 'unlock-monster',
+      evolveMonster: 'evolve-monster',
+    },
+    rosterVersion: HERO_POOL_ROSTER_VERSION,
+    balance: balance || 0,
+    selectedMonsterId: null,
+    monsters: HERO_POOL_INITIAL_MONSTER_IDS.map(monsterId => {
+      const def = HERO_POOL_REGISTRY[monsterId];
+      return {
+        monsterId: def.monsterId,
+        displayName: def.displayName,
+        childBlurb: def.childBlurb,
+        sourceAssetMonsterId: def.sourceAssetMonsterId,
+        owned: false,
+        stage: 0,
+        branch: null,
+        maxStage: def.maxStage,
+        inviteCost: def.inviteCost,
+        nextGrowCost: null,
+        nextStage: null,
+        canInvite: true,
+        canGrow: false,
+        canAffordInvite: (balance || 0) >= def.inviteCost,
+        canAffordGrow: false,
+        fullyGrown: false,
+      };
+    }),
+    recentActions: [],
   };
 }

--- a/worker/src/hero/routes.js
+++ b/worker/src/hero/routes.js
@@ -61,11 +61,12 @@ export async function handleHeroReadModel({
   // 4b. P3 U7: load progress bundle for the v4 read model when progress enabled.
   const progressFlagEnabled = envFlagEnabled(env.HERO_MODE_PROGRESS_ENABLED);
   const economyFlagEnabled = envFlagEnabled(env.HERO_MODE_ECONOMY_ENABLED);
+  const campFlagEnabled = envFlagEnabled(env.HERO_MODE_CAMP_ENABLED);
   const heroProgressData = progressFlagEnabled
     ? await repository.readHeroProgressData(learnerId)
     : { heroProgressState: null, recentCompletedSessions: [] };
 
-  // 5. Assemble the shadow read model (v3, v4, or v5: pass accountId and env for
+  // 5. Assemble the shadow read model (v3, v4, v5, or v6: pass accountId and env for
   //    quest fingerprint and the HERO_MODE_CHILD_UI_ENABLED gate).
   const nowTs = typeof now === 'function' ? now() : Date.now();
   const result = buildHeroShadowReadModel({
@@ -78,6 +79,7 @@ export async function handleHeroReadModel({
     recentCompletedSessions: heroProgressData.recentCompletedSessions,
     progressEnabled: progressFlagEnabled,
     economyEnabled: progressFlagEnabled && economyFlagEnabled,
+    campEnabled: progressFlagEnabled && economyFlagEnabled && campFlagEnabled,
   });
 
   // U10: structured observability — fire-and-forget, never blocks the response.

--- a/worker/wrangler.example.jsonc
+++ b/worker/wrangler.example.jsonc
@@ -30,7 +30,8 @@
     "HERO_MODE_SHADOW_ENABLED": "false",
     "HERO_MODE_LAUNCH_ENABLED": "false",
     "HERO_MODE_CHILD_UI_ENABLED": "false",
-    "HERO_MODE_ECONOMY_ENABLED": "false"
+    "HERO_MODE_ECONOMY_ENABLED": "false",
+    "HERO_MODE_CAMP_ENABLED": "false"
   },
   "d1_databases": [
     {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -46,7 +46,8 @@
     "HERO_MODE_LAUNCH_ENABLED": "false",
     "HERO_MODE_CHILD_UI_ENABLED": "false",
     "HERO_MODE_PROGRESS_ENABLED": "false",
-    "HERO_MODE_ECONOMY_ENABLED": "false"
+    "HERO_MODE_ECONOMY_ENABLED": "false",
+    "HERO_MODE_CAMP_ENABLED": "false"
   },
   "d1_databases": [
     {


### PR DESCRIPTION
## Summary

Hero Mode P5 adds **Hero Camp** — a calm, child-led spending surface where children use Hero Coins (earned in P4) to invite and grow Hero-owned monsters. This is the first Hero debit phase.

- 🏕️ Hero Camp UI with 6 Hero Pool monsters (invite + grow)
- 💰 Deterministic spending ledger with triple-layer idempotency
- 🔒 Server-derived costs — client cannot supply amount/balance/cost
- 🧩 Hero state v3 with heroPool block (no new D1 tables)
- 📖 Read model v6 with child-safe Camp block
- 🚫 No shop/deal/loot/random/streak mechanics — calm choice only
- ✅ 388 tests, 0 failures, full P0-P4 regression pass

## Implementation Units

| Unit | Description | Tests |
|------|-------------|-------|
| U1 | Hero Pool registry and cost contract | 24 |
| U2 | Economy normaliser hardening for debits | 21 |
| U3 | Hero state v3 with heroPool + migration | 21 |
| U4 | Pure spending helpers + deterministic ledger | 29 |
| U5 | Worker Camp command resolver (pure) | 17 |
| U6 | Route wiring + flag gates + CAS mutation | 18 |
| U7 | Read model v6 with Camp block | 19 |
| U8 | Client methods, UI model, asset adapter | 34 |
| U9 | Hero Camp UI surface + monster cards | 32 |
| U10 | Boundary, vocabulary, telemetry, regression | 20 |

## Key Design Decisions

- **State shape extension, not new table**: heroPool embeds in existing `child_game_state` JSON
- **Same mutation boundary**: Camp commands use `runHeroCommandMutation` (CAS + receipt + batch)
- **Triple idempotency**: receipt replay + already-owned check + deterministic ledger IDs
- **Feature flag**: `HERO_MODE_CAMP_ENABLED=false` (safe rollback preserves state dormant)
- **No subject contamination**: Hero Camp never writes subject state/Stars/mastery

## Test plan

- [x] All 388 Hero tests pass (P0-P5)
- [x] Vocabulary boundary: no forbidden pressure words in UI
- [x] Import boundary: shared pure, worker isolated, no subject imports
- [x] Economy regression: P4 award flow unchanged
- [x] Idempotency: same requestId replays, already-owned returns no debit
- [ ] Manual QA with flags enabled (post-merge staging)