### PR TITLE
fix(rewards): render Egg Found celebrations as eggs

### DIFF
--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -72,11 +72,11 @@ function prefersReducedMotion() {
     && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 }
 
-function SharedOverlays({ appState, actions, controller }) {
+function SharedOverlays({ appState, actions, controller, activeSubjectId = '' }) {
   return (
     <div className="home-overlays">
       <ToastShelf toasts={appState.toasts || []} onDismiss={(index) => actions.dispatch('toast-dismiss', { index })} />
-      <CelebrationLayer store={controller?.store} controller={controller} />
+      <CelebrationLayer store={controller?.store} controller={controller} activeSubjectId={activeSubjectId} />
     </div>
   );
 }
@@ -245,7 +245,7 @@ export function App({ controller, runtime }) {
             <SubjectTopNav chrome={runtime.buildSurfaceChromeModel(appState)} actions={actions} currentScreen={screen} />
             <PersistenceBanner snapshot={appState.persistence} onRetry={actions.retryPersistence} />
             <SubjectRoute key={routedSubjectId} appState={appState} context={context} actions={actions} heroLastLaunch={matchingLastLaunch} />
-            <SharedOverlays appState={appState} actions={actions} controller={controller} />
+            <SharedOverlays appState={appState} actions={actions} controller={controller} activeSubjectId={routedSubjectId} />
           </div>
         );
       })()}

--- a/src/platform/game/monster-celebrations.js
+++ b/src/platform/game/monster-celebrations.js
@@ -24,13 +24,26 @@ function isLegacyMonsterCelebrationEvent(event) {
 
 function normaliseProgressSnapshot(value) {
   const raw = value && typeof value === 'object' && !Array.isArray(value) ? value : {};
-  return {
+  const snapshot = {
     mastered: Math.max(0, Number(raw.mastered) || 0),
     stage: Math.max(0, Math.min(4, Number(raw.stage) || 0)),
     level: Math.max(0, Math.min(10, Number(raw.level) || 0)),
     caught: raw.caught === true,
     branch: normaliseMonsterBranch(raw.branch),
   };
+  if (typeof raw.displayState === 'string' && raw.displayState.trim()) {
+    snapshot.displayState = raw.displayState.trim();
+  }
+  if ('displayStars' in raw || 'stars' in raw || 'starHighWater' in raw) {
+    snapshot.displayStars = Math.max(0, Math.floor(Number(raw.displayStars ?? raw.stars ?? raw.starHighWater) || 0));
+  }
+  if ('displayStage' in raw) {
+    snapshot.displayStage = Math.max(0, Math.min(5, Math.floor(Number(raw.displayStage) || 0)));
+  }
+  if ('starStage' in raw) {
+    snapshot.starStage = Math.max(0, Math.min(5, Math.floor(Number(raw.starStage) || 0)));
+  }
+  return snapshot;
 }
 
 export function normaliseMonsterCelebrationEvent(event) {
@@ -52,6 +65,7 @@ function normaliseLegacyMonsterCelebrationEvent(event) {
     type: 'reward.monster',
     kind: event.kind,
     learnerId: typeof event.learnerId === 'string' ? event.learnerId : 'default',
+    subjectId: cleanString(event.subjectId),
     monsterId: event.monsterId,
     monster: {
       id: typeof monster.id === 'string' ? monster.id : event.monsterId,
@@ -116,6 +130,10 @@ function normalisePresentationCelebrationEvent(event) {
     type: REWARD_PRESENTATION_TYPE,
     kind: celebrationIntent.visualKind || event.kind,
     learnerId: event.learnerId,
+    subjectId: cleanString(event.subjectId, event.producerType === 'subject' ? event.producerId : ''),
+    producerType: cleanString(event.producerType),
+    producerId: cleanString(event.producerId),
+    rewardType: cleanString(event.rewardType),
     monsterId,
     monster: normalisedMonster,
     previous: normaliseProgressSnapshot(previous),
@@ -137,6 +155,10 @@ function normaliseQueuedPresentationCelebrationEvent(event) {
     type: REWARD_PRESENTATION_TYPE,
     kind,
     learnerId: cleanString(event.learnerId, 'default'),
+    subjectId: cleanString(event.subjectId, event.producerType === 'subject' ? event.producerId : ''),
+    producerType: cleanString(event.producerType),
+    producerId: cleanString(event.producerId),
+    rewardType: cleanString(event.rewardType),
     monsterId: cleanString(event.monsterId),
     monster: {
       ...event.monster,

--- a/src/platform/game/render/CelebrationLayer.jsx
+++ b/src/platform/game/render/CelebrationLayer.jsx
@@ -16,15 +16,20 @@ import { lookupEffect } from './registry.js';
 import { warnOnce } from './composition.js';
 import { acknowledgeMonsterCelebrationEvents } from '../monster-celebration-acks.js';
 import { useMonsterEffectConfig } from '../MonsterEffectConfigContext.jsx';
+import { MONSTERS_BY_SUBJECT } from '../monsters.js';
+
+const ACTIVE_SUBJECT_IDS = Object.freeze(['spelling', 'punctuation', 'grammar']);
 
 function resolveCelebrationTunables(effectConfig, event) {
-  // Per the plan: assetKey = monsterId + (next.branch ?? previous.branch) + next.stage.
+  // Per the plan: assetKey = monsterId + (next.branch ?? previous.branch) + visual stage.
   // Returns the tunables row for the (asset, kind) pair, or null when any
   // step is missing — callers omit `tunables` when this returns null.
   if (!effectConfig || !effectConfig.celebrationTunables) return null;
   const monsterId = event?.monster?.id;
   const branch = event?.next?.branch || event?.previous?.branch;
-  const stage = event?.next?.stage;
+  const stage = event?.kind === 'caught' && event?.next?.displayState === 'egg-found'
+    ? 0
+    : event?.next?.stage;
   if (!monsterId || !branch || stage == null) return null;
   const assetKey = `${monsterId}-${branch}-${stage}`;
   const row = effectConfig.celebrationTunables[assetKey];
@@ -37,6 +42,26 @@ function getQueue(store) {
   const state = store?.getState?.();
   const queue = state?.monsterCelebrations?.queue;
   return Array.isArray(queue) ? queue : [];
+}
+
+function subjectIdForEvent(event) {
+  if (typeof event?.subjectId === 'string' && event.subjectId) return event.subjectId;
+  if (event?.producerType === 'subject' && typeof event?.producerId === 'string') return event.producerId;
+  const monsterId = typeof event?.monster?.id === 'string' && event.monster.id
+    ? event.monster.id
+    : (typeof event?.monsterId === 'string' && event.monsterId ? event.monsterId : '');
+  if (monsterId) {
+    for (const subjectId of ACTIVE_SUBJECT_IDS) {
+      if ((MONSTERS_BY_SUBJECT[subjectId] || []).includes(monsterId)) return subjectId;
+    }
+  }
+  return '';
+}
+
+function shouldRenderForActiveSubject(event, activeSubjectId) {
+  if (!activeSubjectId) return true;
+  const eventSubjectId = subjectIdForEvent(event);
+  return !eventSubjectId || eventSubjectId === activeSubjectId;
 }
 
 function buildOnComplete(store, controller, event) {
@@ -65,7 +90,7 @@ function buildOnComplete(store, controller, event) {
   };
 }
 
-export function CelebrationLayer({ store, controller, context = 'lesson' }) {
+export function CelebrationLayer({ store, controller, context = 'lesson', activeSubjectId = '' }) {
   // useSyncExternalStore needs stable subscribe / getSnapshot references
   // across renders. We can't call hooks conditionally, so guard via a
   // null-safe subscribe + snapshot when the caller forgets the store.
@@ -80,6 +105,7 @@ export function CelebrationLayer({ store, controller, context = 'lesson' }) {
   const queue = getQueue(store);
   const event = queue[0];
   if (!event) return null;
+  if (!shouldRenderForActiveSubject(event, activeSubjectId)) return null;
 
   const effect = lookupEffect(event.kind);
 

--- a/src/platform/game/render/effect-templates/particles-burst.js
+++ b/src/platform/game/render/effect-templates/particles-burst.js
@@ -18,16 +18,21 @@ function eyebrowForEvolve(fromStage, toStage) {
   return 'Evolved';
 }
 
+function isEggFoundCaught(event) {
+  return event?.next?.displayState === 'egg-found';
+}
+
 function renderCaught({ event, onComplete, tunables }) {
+  const isEggFound = isEggFoundCaught(event);
   return (
     <CelebrationShell
       kind="caught"
       monster={event.monster}
-      toStage={clampStage(event.next?.stage)}
-      branch={event.previous?.branch || event.next?.branch}
+      toStage={isEggFound ? 0 : clampStage(event.next?.stage)}
+      branch={event.next?.branch || event.previous?.branch}
       showParticles
-      eyebrow="New friend"
-      body="You caught a new friend!"
+      eyebrow={isEggFound ? 'Egg found' : 'New friend'}
+      body={isEggFound ? 'You found a new egg!' : 'You caught a new friend!'}
       onComplete={onComplete}
       tunables={tunables}
     />

--- a/tests/helpers/react-render.js
+++ b/tests/helpers/react-render.js
@@ -186,6 +186,7 @@ export function renderCelebrationLayerFixture({
   registrations = '',
   setup = '',
   context = 'lesson',
+  activeSubjectId = '',
   effectConfigValue = undefined,
 } = {}) {
   // Run the full integration in-process so we can drive the store via the
@@ -238,7 +239,11 @@ export function renderCelebrationLayerFixture({
     }
 
     const __before = snapshot();
-    const __layerNode = React.createElement(CelebrationLayer, { store, context: ${JSON.stringify(context)} });
+    const __layerNode = React.createElement(CelebrationLayer, {
+      store,
+      context: ${JSON.stringify(context)},
+      activeSubjectId: ${JSON.stringify(activeSubjectId)},
+    });
     ${useProvider
       ? `const __layerWrapped = React.createElement(MonsterEffectConfigProvider, { value: ${JSON.stringify(effectConfigValue)} }, __layerNode);`
       : 'const __layerWrapped = __layerNode;'}

--- a/tests/monster-celebrations.test.js
+++ b/tests/monster-celebrations.test.js
@@ -74,6 +74,9 @@ test('reward.presentation celebration intents can enter the legacy monster celeb
   const normalised = normaliseMonsterCelebrationEvent(event);
   assert.equal(normalised.type, 'reward.presentation');
   assert.equal(normalised.kind, 'evolve');
+  assert.equal(normalised.subjectId, 'grammar');
+  assert.equal(normalised.producerType, 'subject');
+  assert.equal(normalised.producerId, 'grammar');
   assert.equal(normalised.monsterId, 'bracehart');
   assert.equal(normalised.monster.name, 'Bracehart');
   assert.equal(normalised.next.stage, 1);
@@ -81,6 +84,32 @@ test('reward.presentation celebration intents can enter the legacy monster celeb
     normalised.presentationAckKey,
     'reward:reward.presentation:subject:grammar:reward.monster:evolve:bracehart:hatch:celebration:hatch',
   );
+});
+
+test('monster celebration normalisation preserves Star display fields for Egg Found overlays', () => {
+  const event = {
+    id: 'reward.monster:learner-a:punctuation:first-star:pealark:caught',
+    type: 'reward.monster',
+    kind: 'caught',
+    subjectId: 'punctuation',
+    learnerId: 'learner-a',
+    monsterId: 'pealark',
+    monster: { id: 'pealark', name: 'Pealark' },
+    previous: { stage: 0, displayState: 'not-found', displayStars: 0, branch: 'b1' },
+    next: { stage: 1, displayState: 'egg-found', displayStars: 1, displayStage: 1, branch: 'b2' },
+    createdAt: 1777399200000,
+  };
+
+  const normalised = normaliseMonsterCelebrationEvent(event);
+
+  assert.equal(normalised.next.displayState, 'egg-found');
+  assert.equal(normalised.next.displayStars, 1);
+  assert.equal(normalised.next.displayStage, 1);
+  assert.equal(normalised.next.stage, 1);
+  assert.equal(normalised.next.branch, 'b2');
+  assert.equal(normalised.subjectId, 'punctuation');
+  assert.equal(normalised.previous.displayState, 'not-found');
+  assert.equal(normalised.previous.displayStars, 0);
 });
 
 test('monster celebration acknowledgement writes legacy id and presentation intent key', () => {

--- a/tests/render-effect-caught.test.js
+++ b/tests/render-effect-caught.test.js
@@ -82,12 +82,26 @@ test('caught effect: happy path — reward.monster event renders with toast text
   assert.equal(warnings.length, 0, `unexpected warnings: ${JSON.stringify(warnings)}`);
 });
 
-test('caught effect: first-Star Punctuation event uses the shared caught celebration kind', async () => {
+test('caught effect: first-Star unit-subject event renders the Egg Found visual', async () => {
   const event = makeRewardEvent({
-    id: 'reward.monster:learner-a:inklet:caught:first-star',
+    id: 'reward.monster:learner-a:bracehart:caught:first-star',
     kind: 'caught',
+    monsterId: 'bracehart',
+    monster: makeMonster({
+      id: 'bracehart',
+      name: 'Bracehart',
+      nameByStage: ['Bracehart Egg', 'Bracehart', 'Clausecub', 'Archhart', 'Mega Archhart'],
+    }),
     previous: { mastered: 0, stage: 0, displayState: 'not-found', caught: false, branch: 'b1' },
-    next: { mastered: 0, stage: 0, displayState: 'egg-found', caught: false, branch: 'b1' },
+    next: {
+      mastered: 0,
+      stage: 1,
+      displayStars: 1,
+      displayStage: 1,
+      displayState: 'egg-found',
+      caught: false,
+      branch: 'b2',
+    },
   });
   const out = await renderCelebrationLayerFixture({
     registrations: REGISTER_CAUGHT,
@@ -99,10 +113,132 @@ test('caught effect: first-Star Punctuation event uses the shared caught celebra
 
   assert.equal(before.queue.length, 1);
   assert.equal(after.queue.length, 1, 'render alone must not advance the queue');
-  assert.match(html, /Inklet Egg/);
-  assert.match(html, /You caught a new friend!/);
-  assert.match(html, /New friend/);
+  assert.match(html, /Bracehart Egg/);
+  assert.match(html, /You found a new egg!/);
+  assert.match(html, /Egg found/);
   assert.match(html, /class="monster-celebration-overlay caught"/);
+  assert.match(html, /assets\/monsters\/bracehart\/b2\/bracehart-b2-0/);
+  assert.doesNotMatch(html, /assets\/monsters\/bracehart\/b2\/bracehart-b2-1/);
+  assert.match(html, /data-stage="0"/);
+  assert.equal(warnings.length, 0, `unexpected warnings: ${JSON.stringify(warnings)}`);
+});
+
+test('caught effect: subject-scoped celebrations do not render on another subject landing', async () => {
+  const event = makeRewardEvent({
+    id: 'reward.monster:learner-a:grammar:bracehart:caught:first-star',
+    kind: 'caught',
+    subjectId: 'grammar',
+    monsterId: 'bracehart',
+    monster: makeMonster({
+      id: 'bracehart',
+      name: 'Bracehart',
+      nameByStage: ['Bracehart Egg', 'Bracehart', 'Clausecub', 'Archhart', 'Mega Archhart'],
+    }),
+    previous: { mastered: 0, stage: 0, displayState: 'not-found', caught: false, branch: 'b1' },
+    next: {
+      mastered: 0,
+      stage: 1,
+      displayStars: 1,
+      displayStage: 1,
+      displayState: 'egg-found',
+      caught: false,
+      branch: 'b1',
+    },
+  });
+  const out = await renderCelebrationLayerFixture({
+    registrations: REGISTER_CAUGHT,
+    activeSubjectId: 'spelling',
+    setup: `
+      store.pushMonsterCelebrations([${JSON.stringify(event)}]);
+    `,
+  });
+  const { html, before, after, warnings } = JSON.parse(out);
+
+  assert.equal(html, '');
+  assert.equal(before.queue.length, 1);
+  assert.equal(after.queue.length, 1, 'mismatched subject event must stay queued, not auto-dismiss');
+  assert.equal(after.queue[0].subjectId, 'grammar');
+  assert.equal(warnings.length, 0, `unexpected warnings: ${JSON.stringify(warnings)}`);
+});
+
+test('caught effect: legacy queued events infer subject scope from monster id', async () => {
+  const event = makeRewardEvent({
+    id: 'reward.monster:learner-a:legacy:bracehart:caught:first-star',
+    kind: 'caught',
+    subjectId: undefined,
+    producerType: undefined,
+    producerId: undefined,
+    monsterId: 'bracehart',
+    monster: makeMonster({
+      id: 'bracehart',
+      name: 'Bracehart',
+      nameByStage: ['Bracehart Egg', 'Bracehart', 'Clausecub', 'Archhart', 'Mega Archhart'],
+    }),
+    previous: { mastered: 0, stage: 0, displayState: 'not-found', caught: false, branch: 'b1' },
+    next: {
+      mastered: 0,
+      stage: 1,
+      displayStars: 1,
+      displayStage: 1,
+      displayState: 'egg-found',
+      caught: false,
+      branch: 'b1',
+    },
+  });
+  delete event.subjectId;
+  delete event.producerType;
+  delete event.producerId;
+  const out = await renderCelebrationLayerFixture({
+    registrations: REGISTER_CAUGHT,
+    activeSubjectId: 'spelling',
+    setup: `
+      store.pushMonsterCelebrations([${JSON.stringify(event)}]);
+    `,
+  });
+  const { html, before, after, warnings } = JSON.parse(out);
+
+  assert.equal(html, '');
+  assert.equal(before.queue.length, 1);
+  assert.equal(after.queue.length, 1, 'legacy Grammar event must stay queued on the Spelling route');
+  assert.equal(after.queue[0].monster.id, 'bracehart');
+  assert.equal(warnings.length, 0, `unexpected warnings: ${JSON.stringify(warnings)}`);
+});
+
+test('caught effect: subject-scoped celebrations render on their own subject landing', async () => {
+  const event = makeRewardEvent({
+    id: 'reward.monster:learner-a:grammar:bracehart:caught:first-star',
+    kind: 'caught',
+    subjectId: 'grammar',
+    monsterId: 'bracehart',
+    monster: makeMonster({
+      id: 'bracehart',
+      name: 'Bracehart',
+      nameByStage: ['Bracehart Egg', 'Bracehart', 'Clausecub', 'Archhart', 'Mega Archhart'],
+    }),
+    previous: { mastered: 0, stage: 0, displayState: 'not-found', caught: false, branch: 'b1' },
+    next: {
+      mastered: 0,
+      stage: 1,
+      displayStars: 1,
+      displayStage: 1,
+      displayState: 'egg-found',
+      caught: false,
+      branch: 'b1',
+    },
+  });
+  const out = await renderCelebrationLayerFixture({
+    registrations: REGISTER_CAUGHT,
+    activeSubjectId: 'grammar',
+    setup: `
+      store.pushMonsterCelebrations([${JSON.stringify(event)}]);
+    `,
+  });
+  const { html, before, after, warnings } = JSON.parse(out);
+
+  assert.match(html, /Bracehart Egg/);
+  assert.match(html, /You found a new egg!/);
+  assert.equal(before.queue.length, 1);
+  assert.equal(after.queue.length, 1);
   assert.equal(warnings.length, 0, `unexpected warnings: ${JSON.stringify(warnings)}`);
 });
 


### PR DESCRIPTION
## Summary
- Preserve Star display metadata (`displayState`, `displayStars`, `displayStage`) through monster celebration normalisation.
- Render `caught` events with `next.displayState === 'egg-found'` as Egg Found overlays instead of stage-0 monster/kid overlays.
- Preserve reward producer/source subject metadata and gate subject-route celebration rendering so a Punctuation/Grammar event cannot appear on the Spelling landing.
- Infer source subject from `monster.id` for older queued events that do not yet carry `subjectId`, so stale Bracehart queue entries are also blocked on the Spelling route.

## Root cause
- The Option A rename unified first-Star reward events under `kind: 'caught'`, but the visual layer still selected assets purely from `next.stage`.
- The celebration queue normaliser stripped `displayState`, so the renderer could not distinguish first-Star Egg Found from legacy Spelling caught.
- The normaliser also stripped source subject metadata, so queued events could bleed across subject routes. Older queue entries may still lack subject metadata, so the runtime now falls back to monster-roster inference.

## Verification
- `node --test tests/monster-celebrations.test.js tests/render-effect-caught.test.js tests/render-celebration-layer.test.js` (32 pass)
- `node --test tests/punctuation-mastery.test.js tests/grammar-star-events.test.js tests/reward-presentations.test.js` (97 pass)
- `node --test tests/app-controller.test.js tests/render.test.js` (43 pass)
- `npm test` (7633 tests / 198 suites / 7627 pass / 0 fail / 6 skipped)
- `npm run check` (main bundle 223873 / 224500 bytes gzip)
- `git diff --check`