### PR TITLE
feat(admin-p7): Security hardening closure (U11)

### DIFF
--- a/src/platform/hubs/admin-action-classification.js
+++ b/src/platform/hubs/admin-action-classification.js
@@ -48,6 +48,13 @@ const REGISTRY = new Map([
   // medium: asset draft deletion (recoverable via restore)
   ['asset-delete-draft', { level: LEVELS.medium }],
 
+  // medium: asset draft save (single-entity write, CAS-protected)
+  ['asset-draft-save', { level: LEVELS.medium }],
+
+  // low: asset read / preview (no mutation)
+  ['asset-preview', { level: LEVELS.low }],
+  ['asset-read', { level: LEVELS.low }],
+
   // critical: broad-audience mutations, irreversible deletes, seed operations
   ['post-mega-seed-apply', { level: LEVELS.critical }],
   ['grammar-transfer-admin-delete', { level: LEVELS.critical }],

--- a/src/platform/hubs/admin-asset-registry.js
+++ b/src/platform/hubs/admin-asset-registry.js
@@ -1,4 +1,5 @@
 // U10 (Admin Console P3): Asset & Effect Registry adapter.
+// P7 U11: Security hardening — URL allowlist integration + handler capability metadata.
 //
 // Transforms the existing `monsterVisualConfig` admin read-model (produced by
 // `normaliseMonsterVisualConfigAdminModel` in admin-read-model.js) into a
@@ -13,6 +14,8 @@
 //
 // The adapter is pure: it accepts the read-model sibling and returns a
 // registry entry array. No side effects, no storage, no fetch.
+
+import { getSafePreviewUrl, getPreviewBlockedReason } from './admin-asset-url-allowlist.js';
 
 /**
  * @typedef {object} RegistryEntry
@@ -98,10 +101,12 @@ export function buildMonsterVisualRegistryEntry(monsterVisualConfig) {
   const canManage = permissions.canManageMonsterVisualConfig === true;
   const hasDraft = mvc.draft != null && isPlainObject(mvc.draft);
 
-  // P6 U8: preview URL — derived from status when available (Worker provides it).
-  const previewUrl = typeof status.previewUrl === 'string' && status.previewUrl
+  // P6 U8 + P7 U11: preview URL — derived from status, validated via allowlist.
+  const rawPreviewUrl = typeof status.previewUrl === 'string' && status.previewUrl
     ? status.previewUrl
     : null;
+  const previewUrl = getSafePreviewUrl(rawPreviewUrl);
+  const previewBlockedReason = getPreviewBlockedReason(rawPreviewUrl);
 
   // P6 U8: reduced-motion and fallback status — surfaced from the asset metadata.
   const reducedMotionStatus = typeof status.reducedMotionStatus === 'string'
@@ -134,6 +139,7 @@ export function buildMonsterVisualRegistryEntry(monsterVisualConfig) {
     versions: Array.isArray(mvc.versions) ? mvc.versions : [],
     publishBlockers: derivePublishBlockers(validation, hasDraft, canManage),
     previewUrl,
+    previewBlockedReason,
     reducedMotionStatus,
     fallbackStatus,
   };
@@ -154,3 +160,73 @@ export function buildAssetRegistry(model) {
     buildMonsterVisualRegistryEntry(hub.monsterVisualConfig),
   ];
 }
+
+// ─── P7 U11: Handler Capability Registry ──────────────────────────────────────
+//
+// Each asset handler declares its security and operational metadata:
+//   - roleRequired: minimum RBAC role to invoke the handler
+//   - mutationClass: 'read' | 'draft-write' | 'publish' | 'delete'
+//   - casFields: fields used for CAS conflict detection
+//   - auditBehaviour: 'silent' | 'log' | 'log-and-notify'
+
+/**
+ * @typedef {object} HandlerCapability
+ * @property {string} roleRequired
+ * @property {string} mutationClass
+ * @property {string[]} casFields
+ * @property {string} auditBehaviour
+ */
+
+const HANDLER_CAPABILITY_REGISTRY = Object.freeze({
+  'monster-visual-config-read': Object.freeze({
+    roleRequired: 'viewer',
+    mutationClass: 'read',
+    casFields: [],
+    auditBehaviour: 'silent',
+  }),
+  'monster-visual-config-draft-save': Object.freeze({
+    roleRequired: 'editor',
+    mutationClass: 'draft-write',
+    casFields: ['draftRevision'],
+    auditBehaviour: 'log',
+  }),
+  'monster-visual-config-publish': Object.freeze({
+    roleRequired: 'publisher',
+    mutationClass: 'publish',
+    casFields: ['draftRevision', 'publishedVersion'],
+    auditBehaviour: 'log-and-notify',
+  }),
+  'monster-visual-config-restore': Object.freeze({
+    roleRequired: 'publisher',
+    mutationClass: 'publish',
+    casFields: ['publishedVersion'],
+    auditBehaviour: 'log-and-notify',
+  }),
+  'monster-visual-config-delete-draft': Object.freeze({
+    roleRequired: 'editor',
+    mutationClass: 'delete',
+    casFields: ['draftRevision'],
+    auditBehaviour: 'log',
+  }),
+});
+
+/**
+ * Retrieve the capability metadata for a handler by key.
+ *
+ * @param {string} handlerKey
+ * @returns {HandlerCapability|null}
+ */
+export function getHandlerCapability(handlerKey) {
+  return HANDLER_CAPABILITY_REGISTRY[handlerKey] || null;
+}
+
+/**
+ * List all registered handler keys.
+ *
+ * @returns {string[]}
+ */
+export function listHandlerKeys() {
+  return Object.keys(HANDLER_CAPABILITY_REGISTRY);
+}
+
+export { HANDLER_CAPABILITY_REGISTRY };

--- a/src/platform/hubs/admin-asset-registry.js
+++ b/src/platform/hubs/admin-asset-registry.js
@@ -217,7 +217,7 @@ const HANDLER_CAPABILITY_REGISTRY = Object.freeze({
  * @returns {HandlerCapability|null}
  */
 export function getHandlerCapability(handlerKey) {
-  return HANDLER_CAPABILITY_REGISTRY[handlerKey] || null;
+  return Object.hasOwn(HANDLER_CAPABILITY_REGISTRY, handlerKey) ? HANDLER_CAPABILITY_REGISTRY[handlerKey] : null;
 }
 
 /**

--- a/src/platform/hubs/admin-asset-url-allowlist.js
+++ b/src/platform/hubs/admin-asset-url-allowlist.js
@@ -56,6 +56,14 @@ export function isAllowedPreviewUrl(url, options) {
     return { allowed: false, reason: 'URL is malformed.' };
   }
 
+  // Post-parse protocol check — catches evasion via tab/newline injection
+  if (parsed.protocol === 'javascript:') {
+    return { allowed: false, reason: 'javascript: protocol is forbidden.' };
+  }
+  if (parsed.protocol === 'data:') {
+    return { allowed: false, reason: 'data: protocol is forbidden.' };
+  }
+
   // Reject non-HTTPS
   if (parsed.protocol !== 'https:') {
     return { allowed: false, reason: 'Only HTTPS URLs are permitted.' };
@@ -89,7 +97,7 @@ export function isAllowedPreviewUrl(url, options) {
  */
 export function getSafePreviewUrl(url, options) {
   const result = isAllowedPreviewUrl(url, options);
-  return result.allowed ? url : null;
+  return result.allowed ? url.trim() : null;
 }
 
 /**

--- a/src/platform/hubs/admin-asset-url-allowlist.js
+++ b/src/platform/hubs/admin-asset-url-allowlist.js
@@ -1,0 +1,109 @@
+// P7 U11: Asset preview URL allowlist.
+//
+// Validates that preview URLs are safe to render as clickable links.
+// Rejects dangerous protocols (javascript:, data:), protocol-relative URLs,
+// non-HTTPS, and unapproved origins.
+//
+// Pure function — no side effects, no fetch, no storage.
+
+/**
+ * Default domain allowlist. In production, the app's own Pages domain is the
+ * primary source of preview assets. Extend as new CDN origins are approved.
+ */
+const DEFAULT_ALLOWED_DOMAINS = Object.freeze([
+  'ks2-mastery.pages.dev',
+]);
+
+/**
+ * Validate whether a preview URL is safe to render as a clickable link.
+ *
+ * @param {string|null|undefined} url — the URL to validate
+ * @param {object} [options]
+ * @param {string[]} [options.allowedDomains] — override the domain allowlist
+ * @returns {{ allowed: boolean, reason?: string }}
+ */
+export function isAllowedPreviewUrl(url, options) {
+  if (url == null || url === '') {
+    return { allowed: false, reason: 'URL is empty or missing.' };
+  }
+
+  if (typeof url !== 'string') {
+    return { allowed: false, reason: 'URL is not a string.' };
+  }
+
+  const trimmed = url.trim();
+
+  // Reject javascript: protocol (case-insensitive, whitespace-tolerant)
+  if (/^\s*javascript\s*:/i.test(trimmed)) {
+    return { allowed: false, reason: 'javascript: protocol is forbidden.' };
+  }
+
+  // Reject data: protocol
+  if (/^\s*data\s*:/i.test(trimmed)) {
+    return { allowed: false, reason: 'data: protocol is forbidden.' };
+  }
+
+  // Reject protocol-relative URLs (//example.com/...)
+  if (/^\/\//.test(trimmed)) {
+    return { allowed: false, reason: 'Protocol-relative URLs are forbidden.' };
+  }
+
+  // Parse as URL — reject if unparseable
+  let parsed;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return { allowed: false, reason: 'URL is malformed.' };
+  }
+
+  // Reject non-HTTPS
+  if (parsed.protocol !== 'https:') {
+    return { allowed: false, reason: 'Only HTTPS URLs are permitted.' };
+  }
+
+  // Domain allowlist check
+  const domains = (options && Array.isArray(options.allowedDomains))
+    ? options.allowedDomains
+    : DEFAULT_ALLOWED_DOMAINS;
+
+  const hostname = parsed.hostname.toLowerCase();
+  const domainAllowed = domains.some((d) => {
+    const lower = d.toLowerCase();
+    return hostname === lower || hostname.endsWith('.' + lower);
+  });
+
+  if (!domainAllowed) {
+    return { allowed: false, reason: `Origin "${parsed.hostname}" is not in the allowlist.` };
+  }
+
+  return { allowed: true };
+}
+
+/**
+ * Given a raw preview URL, return either the validated URL string (safe to
+ * render) or null (meaning the UI should show a placeholder instead of a link).
+ *
+ * @param {string|null|undefined} url
+ * @param {object} [options]
+ * @returns {string|null}
+ */
+export function getSafePreviewUrl(url, options) {
+  const result = isAllowedPreviewUrl(url, options);
+  return result.allowed ? url : null;
+}
+
+/**
+ * Return a user-facing reason why a preview URL was rejected.
+ * Returns null when the URL is allowed or absent.
+ *
+ * @param {string|null|undefined} url
+ * @param {object} [options]
+ * @returns {string|null}
+ */
+export function getPreviewBlockedReason(url, options) {
+  if (url == null || url === '') return null;
+  const result = isAllowedPreviewUrl(url, options);
+  return result.allowed ? null : (result.reason || 'Preview unavailable (unsafe URL)');
+}
+
+export { DEFAULT_ALLOWED_DOMAINS };

--- a/tests/admin-asset-preview-url-safety.test.js
+++ b/tests/admin-asset-preview-url-safety.test.js
@@ -252,6 +252,37 @@ describe('action classification — new asset actions (P7 U11)', () => {
   });
 });
 
+// ─── P7 review fixes — prototype pollution guard ────────────────────────────────
+
+describe('getHandlerCapability — prototype pollution guard', () => {
+  it('returns null for "constructor" (not a registered handler)', () => {
+    assert.equal(getHandlerCapability('constructor'), null);
+  });
+
+  it('returns null for "__proto__" (not a registered handler)', () => {
+    assert.equal(getHandlerCapability('__proto__'), null);
+  });
+});
+
+// ─── P7 review fixes — trimmed URL return ────────────────────────────────────
+
+describe('getSafePreviewUrl — trimmed URL', () => {
+  it('returns trimmed URL when input has surrounding whitespace', () => {
+    const result = getSafePreviewUrl('  https://ks2-mastery.pages.dev/x  ');
+    assert.equal(result, 'https://ks2-mastery.pages.dev/x');
+  });
+});
+
+// ─── P7 review fixes — post-parse protocol evasion ──────────────────────────
+
+describe('isAllowedPreviewUrl — post-parse protocol evasion', () => {
+  it('rejects javascript: with embedded tab (tab injection bypass)', () => {
+    const result = isAllowedPreviewUrl('java\tscript:alert(1)');
+    assert.equal(result.allowed, false);
+    assert.ok(result.reason.includes('javascript:'));
+  });
+});
+
 // ─── DEFAULT_ALLOWED_DOMAINS is frozen ────────────────────────────────────────
 
 describe('DEFAULT_ALLOWED_DOMAINS', () => {

--- a/tests/admin-asset-preview-url-safety.test.js
+++ b/tests/admin-asset-preview-url-safety.test.js
@@ -1,0 +1,265 @@
+// P7 U11: Asset preview URL safety — allowlist validation and handler capability registry.
+//
+// Verifies that dangerous URLs are rejected, safe URLs are allowed, and every
+// registered handler declares the required capability metadata fields.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  isAllowedPreviewUrl,
+  getSafePreviewUrl,
+  getPreviewBlockedReason,
+  DEFAULT_ALLOWED_DOMAINS,
+} from '../src/platform/hubs/admin-asset-url-allowlist.js';
+
+import {
+  buildMonsterVisualRegistryEntry,
+  getHandlerCapability,
+  listHandlerKeys,
+  HANDLER_CAPABILITY_REGISTRY,
+} from '../src/platform/hubs/admin-asset-registry.js';
+
+import {
+  classifyAction,
+  LEVELS,
+} from '../src/platform/hubs/admin-action-classification.js';
+
+// ─── isAllowedPreviewUrl — dangerous protocols ────────────────────────────────
+
+describe('isAllowedPreviewUrl — rejects dangerous URLs', () => {
+  it('rejects javascript:alert(1)', () => {
+    const result = isAllowedPreviewUrl('javascript:alert(1)');
+    assert.equal(result.allowed, false);
+    assert.ok(result.reason.includes('javascript:'));
+  });
+
+  it('rejects JavaScript: with mixed case', () => {
+    const result = isAllowedPreviewUrl('JavaScript:void(0)');
+    assert.equal(result.allowed, false);
+  });
+
+  it('rejects data:text/html,...', () => {
+    const result = isAllowedPreviewUrl('data:text/html,<script>alert(1)</script>');
+    assert.equal(result.allowed, false);
+    assert.ok(result.reason.includes('data:'));
+  });
+
+  it('rejects protocol-relative //evil.com/img.png', () => {
+    const result = isAllowedPreviewUrl('//evil.com/img.png');
+    assert.equal(result.allowed, false);
+    assert.ok(result.reason.includes('Protocol-relative'));
+  });
+
+  it('rejects http://allowed.com/img.png (non-HTTPS)', () => {
+    const result = isAllowedPreviewUrl('http://ks2-mastery.pages.dev/img.png');
+    assert.equal(result.allowed, false);
+    assert.ok(result.reason.includes('HTTPS'));
+  });
+
+  it('rejects HTTPS from unapproved origin', () => {
+    const result = isAllowedPreviewUrl('https://evil.com/payload.png');
+    assert.equal(result.allowed, false);
+    assert.ok(result.reason.includes('not in the allowlist'));
+  });
+});
+
+// ─── isAllowedPreviewUrl — allowed URLs ───────────────────────────────────────
+
+describe('isAllowedPreviewUrl — allows safe URLs', () => {
+  it('allows https://ks2-mastery.pages.dev/preview.png (app domain)', () => {
+    const result = isAllowedPreviewUrl('https://ks2-mastery.pages.dev/preview.png');
+    assert.equal(result.allowed, true);
+    assert.equal(result.reason, undefined);
+  });
+
+  it('allows subdomain of an allowed domain', () => {
+    const result = isAllowedPreviewUrl('https://assets.ks2-mastery.pages.dev/img.webp');
+    assert.equal(result.allowed, true);
+  });
+
+  it('allows custom domain via options', () => {
+    const result = isAllowedPreviewUrl('https://cdn.example.org/file.png', {
+      allowedDomains: ['cdn.example.org'],
+    });
+    assert.equal(result.allowed, true);
+  });
+});
+
+// ─── Null/undefined URL handling ──────────────────────────────────────────────
+
+describe('isAllowedPreviewUrl — null/undefined/empty', () => {
+  it('rejects null URL gracefully (no crash)', () => {
+    const result = isAllowedPreviewUrl(null);
+    assert.equal(result.allowed, false);
+    assert.ok(result.reason.includes('empty'));
+  });
+
+  it('rejects undefined URL gracefully (no crash)', () => {
+    const result = isAllowedPreviewUrl(undefined);
+    assert.equal(result.allowed, false);
+  });
+
+  it('rejects empty string', () => {
+    const result = isAllowedPreviewUrl('');
+    assert.equal(result.allowed, false);
+  });
+
+  it('rejects non-string values', () => {
+    const result = isAllowedPreviewUrl(12345);
+    assert.equal(result.allowed, false);
+    assert.ok(result.reason.includes('not a string'));
+  });
+});
+
+// ─── getSafePreviewUrl integration ────────────────────────────────────────────
+
+describe('getSafePreviewUrl', () => {
+  it('returns the URL when allowed', () => {
+    const url = 'https://ks2-mastery.pages.dev/preview.png';
+    assert.equal(getSafePreviewUrl(url), url);
+  });
+
+  it('returns null when rejected', () => {
+    assert.equal(getSafePreviewUrl('javascript:alert(1)'), null);
+  });
+
+  it('returns null for null input', () => {
+    assert.equal(getSafePreviewUrl(null), null);
+  });
+});
+
+// ─── getPreviewBlockedReason ──────────────────────────────────────────────────
+
+describe('getPreviewBlockedReason', () => {
+  it('returns null for allowed URLs', () => {
+    assert.equal(getPreviewBlockedReason('https://ks2-mastery.pages.dev/ok.png'), null);
+  });
+
+  it('returns reason for rejected URLs', () => {
+    const reason = getPreviewBlockedReason('javascript:void(0)');
+    assert.ok(reason.includes('javascript:'));
+  });
+
+  it('returns null for null/empty URLs (no link to block)', () => {
+    assert.equal(getPreviewBlockedReason(null), null);
+    assert.equal(getPreviewBlockedReason(''), null);
+  });
+});
+
+// ─── Registry integration — previewUrl safety ─────────────────────────────────
+
+describe('buildMonsterVisualRegistryEntry — URL safety integration', () => {
+  it('rejects unsafe previewUrl in registry entry', () => {
+    const config = {
+      status: {
+        previewUrl: 'javascript:alert(1)',
+        validation: { ok: true, errorCount: 0 },
+      },
+      permissions: { canManageMonsterVisualConfig: true },
+      draft: { monsters: [] },
+    };
+    const entry = buildMonsterVisualRegistryEntry(config);
+    assert.equal(entry.previewUrl, null);
+    assert.ok(entry.previewBlockedReason.includes('javascript:'));
+  });
+
+  it('allows safe previewUrl through the registry', () => {
+    const config = {
+      status: {
+        previewUrl: 'https://ks2-mastery.pages.dev/monster-visual-config',
+        validation: { ok: true, errorCount: 0 },
+      },
+      permissions: { canManageMonsterVisualConfig: true },
+      draft: { monsters: [] },
+    };
+    const entry = buildMonsterVisualRegistryEntry(config);
+    assert.equal(entry.previewUrl, 'https://ks2-mastery.pages.dev/monster-visual-config');
+    assert.equal(entry.previewBlockedReason, null);
+  });
+
+  it('null previewUrl produces no crash and no blocked reason', () => {
+    const entry = buildMonsterVisualRegistryEntry(null);
+    assert.equal(entry.previewUrl, null);
+    assert.equal(entry.previewBlockedReason, null);
+  });
+});
+
+// ─── Handler capability registry ──────────────────────────────────────────────
+
+const REQUIRED_CAPABILITY_FIELDS = ['roleRequired', 'mutationClass', 'casFields', 'auditBehaviour'];
+
+describe('HANDLER_CAPABILITY_REGISTRY — metadata completeness', () => {
+  const keys = listHandlerKeys();
+
+  it('has at least one registered handler', () => {
+    assert.ok(keys.length > 0);
+  });
+
+  for (const key of keys) {
+    it(`handler "${key}" declares all required metadata fields`, () => {
+      const cap = getHandlerCapability(key);
+      assert.ok(cap !== null, `Handler ${key} not found`);
+      for (const field of REQUIRED_CAPABILITY_FIELDS) {
+        assert.ok(field in cap, `Handler "${key}" missing field "${field}"`);
+      }
+    });
+
+    it(`handler "${key}" has a valid mutationClass`, () => {
+      const cap = getHandlerCapability(key);
+      const valid = ['read', 'draft-write', 'publish', 'delete'];
+      assert.ok(valid.includes(cap.mutationClass),
+        `Handler "${key}" has invalid mutationClass: "${cap.mutationClass}"`);
+    });
+
+    it(`handler "${key}" has a valid auditBehaviour`, () => {
+      const cap = getHandlerCapability(key);
+      const valid = ['silent', 'log', 'log-and-notify'];
+      assert.ok(valid.includes(cap.auditBehaviour),
+        `Handler "${key}" has invalid auditBehaviour: "${cap.auditBehaviour}"`);
+    });
+
+    it(`handler "${key}" has casFields as an array`, () => {
+      const cap = getHandlerCapability(key);
+      assert.equal(Array.isArray(cap.casFields), true);
+    });
+  }
+
+  it('getHandlerCapability returns null for unknown key', () => {
+    assert.equal(getHandlerCapability('nonexistent-handler'), null);
+  });
+});
+
+// ─── Action classification — new asset actions ────────────────────────────────
+
+describe('action classification — new asset actions (P7 U11)', () => {
+  it('classifies asset-draft-save at MEDIUM level', () => {
+    const result = classifyAction('asset-draft-save');
+    assert.equal(result.level, LEVELS.medium);
+    assert.equal(result.requiresConfirmation, false);
+  });
+
+  it('classifies asset-preview at LOW level', () => {
+    const result = classifyAction('asset-preview');
+    assert.equal(result.level, LEVELS.low);
+    assert.equal(result.requiresConfirmation, false);
+  });
+
+  it('classifies asset-read at LOW level', () => {
+    const result = classifyAction('asset-read');
+    assert.equal(result.level, LEVELS.low);
+    assert.equal(result.requiresConfirmation, false);
+  });
+});
+
+// ─── DEFAULT_ALLOWED_DOMAINS is frozen ────────────────────────────────────────
+
+describe('DEFAULT_ALLOWED_DOMAINS', () => {
+  it('is frozen (immutable)', () => {
+    assert.equal(Object.isFrozen(DEFAULT_ALLOWED_DOMAINS), true);
+  });
+
+  it('contains at least the app domain', () => {
+    assert.ok(DEFAULT_ALLOWED_DOMAINS.includes('ks2-mastery.pages.dev'));
+  });
+});

--- a/tests/admin-asset-registry-v1.test.js
+++ b/tests/admin-asset-registry-v1.test.js
@@ -26,7 +26,7 @@ const PUBLISHABLE_CONFIG = {
     manifestHash: 'abc123def456',
     publishedAt: 1714300800000,
     publishedByAccountId: 'account-admin-42',
-    previewUrl: 'https://preview.example.com/monster-visual-config',
+    previewUrl: 'https://ks2-mastery.pages.dev/monster-visual-config',
     reducedMotionStatus: 'available',
     fallbackStatus: 'static-sprite',
     validation: {
@@ -142,7 +142,7 @@ describe('buildMonsterVisualRegistryEntry — publishBlockers', () => {
 describe('buildMonsterVisualRegistryEntry — previewUrl', () => {
   it('populates previewUrl from status.previewUrl', () => {
     const entry = buildMonsterVisualRegistryEntry(PUBLISHABLE_CONFIG);
-    assert.equal(entry.previewUrl, 'https://preview.example.com/monster-visual-config');
+    assert.equal(entry.previewUrl, 'https://ks2-mastery.pages.dev/monster-visual-config');
   });
 
   it('returns null when previewUrl is not present', () => {
@@ -199,7 +199,7 @@ describe('buildAssetRegistry — v1 extended shape', () => {
   it('entries include previewUrl', () => {
     const model = { monsterVisualConfig: PUBLISHABLE_CONFIG };
     const registry = buildAssetRegistry(model);
-    assert.equal(registry[0].previewUrl, 'https://preview.example.com/monster-visual-config');
+    assert.equal(registry[0].previewUrl, 'https://ks2-mastery.pages.dev/monster-visual-config');
   });
 
   it('entries include reducedMotionStatus and fallbackStatus', () => {


### PR DESCRIPTION
## Summary
- Asset preview URL allowlist rejects javascript:, data:, protocol-relative, and non-HTTPS URLs
- Handler capability registry declares role/mutation/CAS/audit per asset handler
- New asset actions (draft-save, preview, read) registered in action classification
- Existing clipboard CI gate preserved

## Test plan
- [x] All unsafe URL variants rejected (javascript:, data:, //, http:, unapproved origin)
- [x] HTTPS from allowed domain passes
- [x] Null/undefined URL handled gracefully (no crash)
- [x] Handler metadata fields verified for all registered handlers
- [x] ci-no-raw-clipboard test still passes
- [x] Existing admin-asset-registry-v1 tests still pass (fixture updated to use allowed domain)