### PR TITLE
fix(deploy): extend production audit settle window

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "db:migrations:list:remote:oauth": "npm run db:migrations:list:remote",
     "db:backup:remote": "node ./scripts/d1-backup.mjs --remote",
     "db:reset:remote": "node ./scripts/d1-reset.mjs --remote",
-    "deploy": "node ./scripts/wrangler-oauth.mjs deploy && npm run audit:production -- --skip-local --retries 5 --retry-delay-ms 2000",
+    "deploy": "node ./scripts/wrangler-oauth.mjs deploy && npm run audit:production -- --skip-local --retries 30 --retry-delay-ms 5000",
     "deploy:oauth": "npm run deploy",
     "deploy:ci": "npm run deploy",
     "ops:tail": "node ./scripts/wrangler-oauth.mjs tail ks2-mastery --format pretty",

--- a/tests/deploy-scripts.test.js
+++ b/tests/deploy-scripts.test.js
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+test('deploy script gives the production audit enough Cloudflare propagation time', async () => {
+  const pkg = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'));
+  const deployScript = pkg.scripts?.deploy || '';
+
+  assert.match(deployScript, /node \.\/scripts\/wrangler-oauth\.mjs deploy/);
+  assert.match(deployScript, /npm run audit:production -- --skip-local/);
+
+  const retries = Number(deployScript.match(/--retries\s+(\d+)/)?.[1] || 0);
+  const retryDelayMs = Number(deployScript.match(/--retry-delay-ms\s+(\d+)/)?.[1] || 0);
+
+  // Cloudflare Workers Assets can serve the previous SEO/static asset view for
+  // a short period after Wrangler reports a successful deploy. Keep this gate
+  // strict, but give the edge enough time to converge before failing the build.
+  assert.ok(retries >= 30, `expected at least 30 production-audit retries, got ${retries}`);
+  assert.ok(retryDelayMs >= 5000, `expected at least 5000 ms retry delay, got ${retryDelayMs}`);
+});


### PR DESCRIPTION
## Summary
- extend the post-deploy production audit retry window so Cloudflare Workers Assets has time to converge after Wrangler reports success
- add a deploy-script regression test so the Cloudflare gate does not drift back to the too-short window

## Verification
- node --test tests/deploy-scripts.test.js
- npm run audit:production -- --skip-local --retries 0
- npm test
- npm run check