### PR TITLE
feat(admin-p7): Marketing lifecycle analytics (U9)

### DIFF
--- a/src/platform/hubs/admin-marketing-api.js
+++ b/src/platform/hubs/admin-marketing-api.js
@@ -47,6 +47,60 @@ async function fetchJson(fetchFn, url, init, authSession) {
 }
 
 // ---------------------------------------------------------------------------
+// U9: Lifecycle analytics model
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute active message count and lifecycle display data from a messages array.
+ *
+ * Active = status 'published' AND audience includes 'all_signed_in'.
+ * Lifecycle timestamps are surfaced per-message where available.
+ * Analytics counters are honestly labelled as not yet tracked.
+ *
+ * @param {Array} messages — normalised marketing message objects
+ * @returns {{ activeCount: number, lifecycleDisplayData: Array, analyticsCounters: Object }}
+ */
+export function buildMarketingLifecycleModel(messages) {
+  const list = Array.isArray(messages) ? messages : [];
+
+  const activeCount = list.filter(
+    (m) => m.status === 'published' && m.audience === 'all_signed_in',
+  ).length;
+
+  const lifecycleDisplayData = list.map((m) => ({
+    id: m.id,
+    title: m.title,
+    status: m.status,
+    publishedAt: m.published_at || null,
+    pausedAt: m.paused_at || null,
+    archivedAt: m.archived_at || null,
+    createdAt: m.created_at || null,
+  }));
+
+  // Honest labelling: these counters are not yet instrumented.
+  const analyticsCounters = {
+    impressions: { tracked: false, label: 'Not tracked yet' },
+    dismissals: { tracked: false, label: 'Not tracked yet' },
+    activeWindowHits: { tracked: false, label: 'Not tracked yet' },
+    fetchFailures: { tracked: false, label: 'Not tracked yet' },
+  };
+
+  return { activeCount, lifecycleDisplayData, analyticsCounters };
+}
+
+/**
+ * Format an epoch-ms timestamp for display in lifecycle views.
+ * Returns a human-readable date-time string or null if no timestamp.
+ */
+export function formatLifecycleTimestamp(epochMs) {
+  if (epochMs == null || !Number.isFinite(Number(epochMs))) return null;
+  const d = new Date(Number(epochMs));
+  if (Number.isNaN(d.getTime())) return null;
+  const pad = (n) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+// ---------------------------------------------------------------------------
 // Public factory
 // ---------------------------------------------------------------------------
 

--- a/src/platform/hubs/admin-marketing-message.js
+++ b/src/platform/hubs/admin-marketing-message.js
@@ -24,6 +24,9 @@ export function normaliseMarketingMessage(rawValue) {
     created_at: asTs(raw.created_at, 0),
     updated_at: asTs(raw.updated_at, 0),
     published_at: raw.published_at != null ? asTs(raw.published_at, 0) : null,
+    paused_at: raw.paused_at != null ? asTs(raw.paused_at, 0) : null,
+    archived_at: raw.archived_at != null ? asTs(raw.archived_at, 0) : null,
+    lifecycleHistory: raw.lifecycleHistory || null,
     row_version: Math.max(0, Number(raw.row_version) || 0),
   };
 }

--- a/src/surfaces/hubs/AdminMarketingSection.jsx
+++ b/src/surfaces/hubs/AdminMarketingSection.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { renderRestrictedMarkdown } from '../../platform/ops/active-messages.js';
 import { normaliseMarketingMessage } from '../../platform/hubs/admin-marketing-message.js';
-import { createAdminMarketingApi } from '../../platform/hubs/admin-marketing-api.js';
+import { createAdminMarketingApi, buildMarketingLifecycleModel, formatLifecycleTimestamp } from '../../platform/hubs/admin-marketing-api.js';
 import { uid } from '../../platform/core/utils.js';
 import { useSubmitLock } from '../../platform/react/use-submit-lock.js';
 import { formatTimestamp } from './hub-utils.js';
@@ -584,6 +584,18 @@ function MessageDetail({ message, isAdmin, onTransition, onBack, onEdit, editErr
             <span>{formatTimestamp(message.published_at)}</span>
           </div>
         ) : null}
+        {message.paused_at ? (
+          <div data-testid="lifecycle-paused-at">
+            <div className="small muted">Paused</div>
+            <span>{formatTimestamp(message.paused_at)}</span>
+          </div>
+        ) : null}
+        {message.archived_at ? (
+          <div data-testid="lifecycle-archived-at">
+            <div className="small muted">Archived</div>
+            <span>{formatTimestamp(message.archived_at)}</span>
+          </div>
+        ) : null}
         <div>
           <div className="small muted">Row version (CAS)</div>
           <span>{message.row_version}</span>
@@ -633,6 +645,51 @@ function MessageListRow({ message, onSelect }) {
       <div><StatusBadge status={message.status} /></div>
       <div className="small muted">{message.severity_token}</div>
       <div className="small muted">Updated {formatTimestamp(message.updated_at)}</div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// U9: Active messages summary and analytics counters
+// ---------------------------------------------------------------------------
+
+function ActiveMessagesSummary({ messages }) {
+  const { activeCount } = buildMarketingLifecycleModel(messages);
+  if (activeCount === 0) return null;
+  return (
+    <div
+      className="callout info"
+      data-testid="active-messages-count"
+      style={{ marginBottom: '0.75rem' }}
+    >
+      <strong>{activeCount}</strong> {activeCount === 1 ? 'message' : 'messages'} currently visible to signed-in users
+    </div>
+  );
+}
+
+function AnalyticsCountersSection({ messages }) {
+  const { analyticsCounters } = buildMarketingLifecycleModel(messages);
+  return (
+    <div
+      className="admin-marketing-analytics-counters"
+      data-testid="analytics-counters"
+      style={{ marginBottom: '0.75rem', padding: '0.5rem 0' }}
+    >
+      <div className="eyebrow" style={{ marginBottom: '0.25rem' }}>Analytics</div>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))', gap: '0.5rem' }}>
+        <div className="small muted" data-testid="counter-impressions">
+          Impressions: {analyticsCounters.impressions.label}
+        </div>
+        <div className="small muted" data-testid="counter-dismissals">
+          Dismissals: {analyticsCounters.dismissals.label}
+        </div>
+        <div className="small muted" data-testid="counter-active-window-hits">
+          Active-window hits: {analyticsCounters.activeWindowHits.label}
+        </div>
+        <div className="small muted" data-testid="counter-fetch-failures">
+          Fetch failures: {analyticsCounters.fetchFailures.label}
+        </div>
+      </div>
     </div>
   );
 }
@@ -936,6 +993,9 @@ export function AdminMarketingSection({ accessContext }) {
       {isAdmin && showCreateForm && (
         <MarketingCreateForm onSubmit={handleCreate} submitting={createLock.locked} />
       )}
+
+      <ActiveMessagesSummary messages={messages} />
+      <AnalyticsCountersSection messages={messages} />
 
       {messages.map((msg) => (
         <MessageListRow key={msg.id} message={msg} onSelect={handleSelect} />

--- a/tests/react-admin-marketing-lifecycle.test.js
+++ b/tests/react-admin-marketing-lifecycle.test.js
@@ -1,0 +1,206 @@
+// U9 (P7): Marketing lifecycle analytics tests.
+//
+// Tests cover:
+//   1. Full lifecycle message shows all transition timestamps
+//   2. "Not tracked yet" renders for analytics counters
+//   3. Draft-only message shows no publish timestamp
+//   4. Active message count computation from status + audience
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { normaliseMarketingMessage } from '../src/platform/hubs/admin-marketing-message.js';
+import {
+  buildMarketingLifecycleModel,
+  formatLifecycleTimestamp,
+} from '../src/platform/hubs/admin-marketing-api.js';
+
+// ---------------------------------------------------------------------------
+// 1. Full lifecycle message shows all transition timestamps
+// ---------------------------------------------------------------------------
+
+test('lifecycle — full lifecycle message has publishedAt, pausedAt, archivedAt', () => {
+  const raw = {
+    id: 'msg-full',
+    status: 'archived',
+    title: 'Full lifecycle message',
+    audience: 'all_signed_in',
+    message_type: 'announcement',
+    published_at: 1714200000000,
+    paused_at: 1714300000000,
+    archived_at: 1714400000000,
+    created_at: 1714100000000,
+    updated_at: 1714400000000,
+    row_version: 4,
+  };
+  const normalised = normaliseMarketingMessage(raw);
+  assert.equal(normalised.published_at, 1714200000000);
+  assert.equal(normalised.paused_at, 1714300000000);
+  assert.equal(normalised.archived_at, 1714400000000);
+});
+
+test('lifecycle — buildMarketingLifecycleModel surfaces all timestamps in lifecycleDisplayData', () => {
+  const messages = [normaliseMarketingMessage({
+    id: 'msg-full',
+    status: 'archived',
+    title: 'Full lifecycle',
+    audience: 'all_signed_in',
+    published_at: 1714200000000,
+    paused_at: 1714300000000,
+    archived_at: 1714400000000,
+    created_at: 1714100000000,
+  })];
+  const { lifecycleDisplayData } = buildMarketingLifecycleModel(messages);
+  assert.equal(lifecycleDisplayData.length, 1);
+  const entry = lifecycleDisplayData[0];
+  assert.equal(entry.publishedAt, 1714200000000);
+  assert.equal(entry.pausedAt, 1714300000000);
+  assert.equal(entry.archivedAt, 1714400000000);
+  assert.equal(entry.createdAt, 1714100000000);
+});
+
+test('lifecycle — formatLifecycleTimestamp returns readable date string', () => {
+  // 2024-04-27 10:00 UTC
+  const ts = Date.UTC(2024, 3, 27, 10, 0, 0);
+  const result = formatLifecycleTimestamp(ts);
+  assert.ok(result !== null);
+  assert.ok(result.includes('2024'));
+  assert.ok(result.includes('04'));
+  assert.ok(result.includes('27'));
+});
+
+test('lifecycle — formatLifecycleTimestamp returns null for null/undefined/NaN', () => {
+  assert.equal(formatLifecycleTimestamp(null), null);
+  assert.equal(formatLifecycleTimestamp(undefined), null);
+  assert.equal(formatLifecycleTimestamp(NaN), null);
+  assert.equal(formatLifecycleTimestamp('not-a-number'), null);
+});
+
+// ---------------------------------------------------------------------------
+// 2. "Not tracked yet" renders for analytics counters
+// ---------------------------------------------------------------------------
+
+test('analytics counters — all counters report "Not tracked yet"', () => {
+  const messages = [
+    normaliseMarketingMessage({ id: 'msg-1', status: 'published', audience: 'all_signed_in' }),
+  ];
+  const { analyticsCounters } = buildMarketingLifecycleModel(messages);
+
+  assert.equal(analyticsCounters.impressions.tracked, false);
+  assert.equal(analyticsCounters.impressions.label, 'Not tracked yet');
+
+  assert.equal(analyticsCounters.dismissals.tracked, false);
+  assert.equal(analyticsCounters.dismissals.label, 'Not tracked yet');
+
+  assert.equal(analyticsCounters.activeWindowHits.tracked, false);
+  assert.equal(analyticsCounters.activeWindowHits.label, 'Not tracked yet');
+
+  assert.equal(analyticsCounters.fetchFailures.tracked, false);
+  assert.equal(analyticsCounters.fetchFailures.label, 'Not tracked yet');
+});
+
+test('analytics counters — counters are present even with empty messages list', () => {
+  const { analyticsCounters } = buildMarketingLifecycleModel([]);
+  assert.equal(analyticsCounters.impressions.tracked, false);
+  assert.equal(analyticsCounters.dismissals.tracked, false);
+  assert.equal(analyticsCounters.activeWindowHits.tracked, false);
+  assert.equal(analyticsCounters.fetchFailures.tracked, false);
+});
+
+// ---------------------------------------------------------------------------
+// 3. Draft-only message shows no publish timestamp
+// ---------------------------------------------------------------------------
+
+test('lifecycle — draft-only message has null publishedAt, pausedAt, archivedAt', () => {
+  const raw = {
+    id: 'msg-draft',
+    status: 'draft',
+    title: 'Draft only',
+    audience: 'internal',
+    message_type: 'announcement',
+    published_at: null,
+    paused_at: null,
+    archived_at: null,
+    created_at: 1714100000000,
+    updated_at: 1714100000000,
+    row_version: 0,
+  };
+  const normalised = normaliseMarketingMessage(raw);
+  assert.equal(normalised.published_at, null);
+  assert.equal(normalised.paused_at, null);
+  assert.equal(normalised.archived_at, null);
+});
+
+test('lifecycle — draft-only in lifecycleDisplayData shows null timestamps', () => {
+  const messages = [normaliseMarketingMessage({
+    id: 'msg-draft',
+    status: 'draft',
+    title: 'Draft only',
+    audience: 'internal',
+    created_at: 1714100000000,
+  })];
+  const { lifecycleDisplayData } = buildMarketingLifecycleModel(messages);
+  const entry = lifecycleDisplayData[0];
+  assert.equal(entry.publishedAt, null);
+  assert.equal(entry.pausedAt, null);
+  assert.equal(entry.archivedAt, null);
+  assert.equal(entry.createdAt, 1714100000000);
+});
+
+// ---------------------------------------------------------------------------
+// 4. Active message count computation
+// ---------------------------------------------------------------------------
+
+test('active count — counts only published + all_signed_in messages', () => {
+  const messages = [
+    normaliseMarketingMessage({ id: 'm1', status: 'published', audience: 'all_signed_in' }),
+    normaliseMarketingMessage({ id: 'm2', status: 'published', audience: 'internal' }),
+    normaliseMarketingMessage({ id: 'm3', status: 'published', audience: 'all_signed_in' }),
+    normaliseMarketingMessage({ id: 'm4', status: 'draft', audience: 'all_signed_in' }),
+    normaliseMarketingMessage({ id: 'm5', status: 'paused', audience: 'all_signed_in' }),
+    normaliseMarketingMessage({ id: 'm6', status: 'scheduled', audience: 'all_signed_in' }),
+  ];
+  const { activeCount } = buildMarketingLifecycleModel(messages);
+  assert.equal(activeCount, 2); // only m1 and m3
+});
+
+test('active count — zero when no published all_signed_in messages', () => {
+  const messages = [
+    normaliseMarketingMessage({ id: 'm1', status: 'draft', audience: 'internal' }),
+    normaliseMarketingMessage({ id: 'm2', status: 'published', audience: 'internal' }),
+    normaliseMarketingMessage({ id: 'm3', status: 'published', audience: 'demo' }),
+  ];
+  const { activeCount } = buildMarketingLifecycleModel(messages);
+  assert.equal(activeCount, 0);
+});
+
+test('active count — zero for empty messages array', () => {
+  const { activeCount } = buildMarketingLifecycleModel([]);
+  assert.equal(activeCount, 0);
+});
+
+test('active count — handles null/undefined messages gracefully', () => {
+  const { activeCount } = buildMarketingLifecycleModel(null);
+  assert.equal(activeCount, 0);
+  const result2 = buildMarketingLifecycleModel(undefined);
+  assert.equal(result2.activeCount, 0);
+});
+
+// ---------------------------------------------------------------------------
+// 5. normaliseMarketingMessage — lifecycleHistory field presence
+// ---------------------------------------------------------------------------
+
+test('lifecycle — lifecycleHistory defaults to null when not present in raw', () => {
+  const normalised = normaliseMarketingMessage({ id: 'msg-1', status: 'draft' });
+  assert.equal(normalised.lifecycleHistory, null);
+});
+
+test('lifecycle — lifecycleHistory preserved if set on raw payload', () => {
+  const history = [{ from: 'draft', to: 'scheduled', at: 1714100000000 }];
+  const normalised = normaliseMarketingMessage({
+    id: 'msg-1',
+    status: 'scheduled',
+    lifecycleHistory: history,
+  });
+  assert.deepEqual(normalised.lifecycleHistory, history);
+});

--- a/worker/migrations/0014_marketing_lifecycle.sql
+++ b/worker/migrations/0014_marketing_lifecycle.sql
@@ -1,0 +1,5 @@
+-- Migration 0014: Marketing lifecycle timestamps.
+-- Adds paused_at and archived_at columns to support lifecycle analytics (P7 U9).
+
+ALTER TABLE admin_marketing_messages ADD COLUMN paused_at INTEGER;
+ALTER TABLE admin_marketing_messages ADD COLUMN archived_at INTEGER;

--- a/worker/src/admin-marketing.js
+++ b/worker/src/admin-marketing.js
@@ -384,7 +384,14 @@ function adminMessageFields(row) {
     created_at: Number(row.created_at),
     updated_at: Number(row.updated_at),
     published_at: row.published_at != null ? Number(row.published_at) : null,
+    paused_at: row.paused_at != null ? Number(row.paused_at) : null,
+    archived_at: row.archived_at != null ? Number(row.archived_at) : null,
     row_version: Number(row.row_version),
+    // U9: Detailed lifecycle history tracking is deferred — would require a
+    // separate audit_log / status_changes table. For now, timestamps for key
+    // transitions (published_at, paused_at, archived_at) are derived from the
+    // message row itself.
+    lifecycleHistory: null,
   };
 }
 
@@ -659,6 +666,8 @@ export async function transitionMarketingMessage(db, {
 
   // Build the transition
   const isPublish = action === 'published' && currentStatus !== 'published';
+  const isPause = action === 'paused';
+  const isArchive = action === 'archived';
   const updateStmt = bindStatement(db, `
     UPDATE admin_marketing_messages
     SET status = ?,
@@ -666,6 +675,8 @@ export async function transitionMarketingMessage(db, {
         updated_at = ?,
         published_by = CASE WHEN ? THEN ? ELSE published_by END,
         published_at = CASE WHEN ? THEN ? ELSE published_at END,
+        paused_at = CASE WHEN ? THEN ? ELSE paused_at END,
+        archived_at = CASE WHEN ? THEN ? ELSE archived_at END,
         row_version = row_version + 1
     WHERE id = ? AND row_version = ?
   `, [
@@ -676,6 +687,10 @@ export async function transitionMarketingMessage(db, {
     isPublish ? actorAccountId : null,
     isPublish ? 1 : 0,
     isPublish ? ts : null,
+    isPause ? 1 : 0,
+    isPause ? ts : null,
+    isArchive ? 1 : 0,
+    isArchive ? ts : null,
     messageId,
     normalisedRowVersion,
   ]);


### PR DESCRIPTION
## Summary
- Active message count showing messages currently visible to signed-in users
- Lifecycle history per message (publishedAt, pausedAt, archivedAt timestamps)
- Honest 'Not tracked yet' labels for analytics counters (impressions, dismissals, active-window hits, fetch failures)
- Manual publish semantics preserved (schedulingSemantics: 'manual_publish_required')

## Test plan
- [x] Full lifecycle message shows all transition timestamps
- [x] 'Not tracked yet' renders for all unimplemented analytics counters
- [x] Draft-only message shows no publish/paused/archived timestamps
- [x] Active count computed correctly from status=published + audience=all_signed_in