### PR TITLE
feat(grammar-qg): P7 Wave 2 — production export, calibration runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "verify:grammar-qg-p6": "npm run audit:grammar-qg && npm run audit:grammar-qg:deep && node --test tests/grammar-question-generator-audit.test.js tests/grammar-qg-p5-depth.test.js tests/grammar-qg-p5-content-quality.test.js tests/grammar-qg-p5-report-validation.test.js tests/grammar-qg-p6-governance.test.js tests/grammar-qg-p6-telemetry.test.js tests/grammar-qg-p6-health-report.test.js tests/grammar-qg-p6-mixed-transfer-calibration.test.js tests/grammar-qg-p6-retention.test.js tests/grammar-qg-p6-review-pack.test.js tests/grammar-functionality-completeness.test.js tests/grammar-production-smoke.test.js tests/grammar-selection.test.js tests/grammar-engine.test.js",
 
     "verify:grammar-qg-p7": "npm run verify:grammar-qg-p6 && node --test tests/grammar-qg-p7-governance.test.js tests/grammar-qg-p7-elapsed-timing.test.js tests/grammar-qg-p7-event-expansion.test.js tests/grammar-qg-p7-health-report.test.js tests/grammar-qg-p7-action-candidates.test.js tests/grammar-qg-p7-production-evidence.test.js",
+    "grammar:qg:calibrate": "node scripts/grammar-qg-calibrate.mjs",
     "verify:punctuation-qg": "node scripts/verify-punctuation-qg.mjs",
     "verify:punctuation-qg:p5": "node scripts/verify-punctuation-qg-p5.mjs"
   },

--- a/scripts/export-grammar-qg-events.mjs
+++ b/scripts/export-grammar-qg-events.mjs
@@ -1,0 +1,261 @@
+#!/usr/bin/env node
+/**
+ * Grammar QG P7 — Production Telemetry Export & Anonymisation
+ *
+ * CLI: node scripts/export-grammar-qg-events.mjs --input=<path> --output=<path> --expanded-output=<path>
+ *       [--salt-file=<path>] [--release-id=<id>] [--date-from=<iso>] [--date-to=<iso>]
+ *       [--template-id=<id>] [--concept-id=<id>] [--dry-run]
+ *
+ * Exports grammar answer events with:
+ * - Filtering by subject (grammar), release IDs (grammar-qg-p6-2026-04-29 onward)
+ * - HMAC-SHA-256 anonymisation of learner IDs (with salt) or 'anonymous' (without)
+ * - Scrubbing learnerId from event.id field (production format: grammar.answer.{learnerId}.{requestId}.{itemId})
+ * - Event expansion via expandEvents for downstream calibration
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { createHmac } from 'node:crypto';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { expandEvents } from './grammar-qg-expand-events.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// ─── Constants ─────────────────────────────────────────────────────────────
+
+const VALID_SUBJECT = 'grammar';
+const MIN_RELEASE_ID = 'grammar-qg-p6-2026-04-29';
+
+// ─── Anonymisation ─────────────────────────────────────────────────────────
+
+/**
+ * Anonymise a learner ID using HMAC-SHA-256 with optional salt.
+ * With salt: truncated 16-hex HMAC. Without salt: 'anonymous'.
+ *
+ * @param {string} learnerId - Raw learner ID
+ * @param {string|null} salt - HMAC salt (null → 'anonymous')
+ * @returns {string} Anonymised ID
+ */
+export function anonymiseLearnerId(learnerId, salt) {
+  if (!salt) return 'anonymous';
+  if (!learnerId || typeof learnerId !== 'string') return 'anonymous';
+  const hmac = createHmac('sha256', salt);
+  hmac.update(learnerId);
+  return hmac.digest('hex').slice(0, 16);
+}
+
+/**
+ * Scrub learnerId from an event.id field.
+ * Production format: grammar.answer-submitted.{learnerId}.{requestId}.{itemId}
+ * After scrub: grammar.answer-submitted.{anonymisedId}.{requestId}.{itemId}
+ *
+ * @param {string} eventId - Raw event ID
+ * @param {string} learnerId - Raw learner ID to scrub
+ * @param {string} anonymisedId - Replacement anonymised ID
+ * @returns {string} Scrubbed event ID
+ */
+function scrubEventId(eventId, learnerId, anonymisedId) {
+  if (!eventId || typeof eventId !== 'string') return eventId;
+  if (!learnerId) return eventId;
+  // Replace all occurrences of the raw learner ID in the event ID
+  return eventId.split(learnerId).join(anonymisedId);
+}
+
+/**
+ * Anonymise a single event — scrub learnerId from all fields.
+ *
+ * @param {Object} event - Raw event
+ * @param {string|null} salt - HMAC salt
+ * @returns {Object} Anonymised event (new object)
+ */
+export function anonymiseEvent(event, salt) {
+  if (!event || typeof event !== 'object') return event;
+
+  const rawLearnerId = event.learnerId || '';
+  const anonymisedId = anonymiseLearnerId(rawLearnerId, salt);
+
+  const result = { ...event };
+  result.learnerId = anonymisedId;
+
+  // Scrub learner ID from event.id field
+  if (result.id && rawLearnerId) {
+    result.id = scrubEventId(result.id, rawLearnerId, anonymisedId);
+  }
+
+  return result;
+}
+
+// ─── Filtering ─────────────────────────────────────────────────────────────
+
+/**
+ * Compare release IDs lexicographically to enforce minimum release.
+ */
+function releaseIdAtOrAfter(releaseId, minReleaseId) {
+  if (!releaseId) return false;
+  return releaseId >= minReleaseId;
+}
+
+/**
+ * Filter events by subject, release ID, date range, template, and concept.
+ *
+ * @param {Object[]} events - Array of events
+ * @param {Object} options - Filter options
+ * @param {string} [options.releaseId] - Exact release ID filter
+ * @param {string} [options.dateFrom] - ISO date lower bound (inclusive)
+ * @param {string} [options.dateTo] - ISO date upper bound (inclusive)
+ * @param {string} [options.templateId] - Filter to specific template
+ * @param {string} [options.conceptId] - Filter to specific concept
+ * @returns {Object[]} Filtered events
+ */
+export function filterEvents(events, options = {}) {
+  const { releaseId, dateFrom, dateTo, templateId, conceptId } = options;
+
+  return events.filter((event) => {
+    if (!event || typeof event !== 'object') return false;
+
+    // Subject must be grammar
+    if (event.subject && event.subject !== VALID_SUBJECT) return false;
+
+    // Release ID must be at or after minimum
+    const evtRelease = event.releaseId || event.release || '';
+    if (!releaseIdAtOrAfter(evtRelease, MIN_RELEASE_ID)) return false;
+
+    // Exact release ID filter
+    if (releaseId && evtRelease !== releaseId) return false;
+
+    // Date range filter
+    const ts = event.timestamp || event.createdAt;
+    if (dateFrom && ts && ts < dateFrom) return false;
+    if (dateTo && ts && ts > dateTo) return false;
+
+    // Template filter
+    if (templateId && event.templateId !== templateId) return false;
+
+    // Concept filter
+    if (conceptId) {
+      const conceptIds = Array.isArray(event.conceptIds) ? event.conceptIds : [];
+      if (event.conceptId !== conceptId && !conceptIds.includes(conceptId)) return false;
+    }
+
+    return true;
+  });
+}
+
+// ─── Main export function ──────────────────────────────────────────────────
+
+/**
+ * Full export pipeline: filter → anonymise → expand.
+ *
+ * @param {Object[]} events - Raw events
+ * @param {Object} options
+ * @param {string|null} options.salt - HMAC salt for anonymisation
+ * @param {string} [options.releaseId] - Release ID filter
+ * @param {string} [options.dateFrom] - ISO date lower bound
+ * @param {string} [options.dateTo] - ISO date upper bound
+ * @param {string} [options.templateId] - Template ID filter
+ * @param {string} [options.conceptId] - Concept ID filter
+ * @param {boolean} [options.dryRun=false] - If true, return summary only
+ * @returns {{ filtered: Object[], anonymised: Object[], expanded: Object, summary: Object }}
+ */
+export function exportGrammarEvents(events, options = {}) {
+  const { salt, releaseId, dateFrom, dateTo, templateId, conceptId, dryRun } = options;
+
+  // Step 1: Filter
+  const filtered = filterEvents(events, { releaseId, dateFrom, dateTo, templateId, conceptId });
+
+  // Step 2: Anonymise
+  const anonymised = filtered.map((evt) => anonymiseEvent(evt, salt));
+
+  // Step 3: Expand (for calibration downstream)
+  const expanded = expandEvents(anonymised);
+
+  const summary = {
+    inputCount: events.length,
+    filteredCount: filtered.length,
+    anonymisedCount: anonymised.length,
+    expandedRowCount: expanded.totalOutput,
+    malformedCount: expanded.malformedCount,
+    dryRun: !!dryRun,
+    salt: salt ? 'provided' : 'none',
+  };
+
+  if (dryRun) {
+    return { filtered: [], anonymised: [], expanded: { rows: [], totalInput: 0, totalOutput: 0, malformedCount: 0 }, summary };
+  }
+
+  return { filtered, anonymised, expanded, summary };
+}
+
+// ─── CLI ───────────────────────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const args = {};
+  for (const arg of argv) {
+    if (arg.startsWith('--')) {
+      const eqIdx = arg.indexOf('=');
+      if (eqIdx !== -1) {
+        args[arg.slice(2, eqIdx)] = arg.slice(eqIdx + 1);
+      } else {
+        args[arg.slice(2)] = true;
+      }
+    }
+  }
+  return args;
+}
+
+const isMainModule =
+  typeof process !== 'undefined' &&
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === path.resolve(__filename);
+
+if (isMainModule) {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (!args.input) {
+    console.error(
+      'Usage: export-grammar-qg-events.mjs --input=<path> --output=<path> --expanded-output=<path>\n' +
+      '       [--salt-file=<path>] [--release-id=<id>] [--date-from=<iso>] [--date-to=<iso>]\n' +
+      '       [--template-id=<id>] [--concept-id=<id>] [--dry-run]',
+    );
+    process.exit(1);
+  }
+
+  const inputPath = path.resolve(args.input);
+  const raw = readFileSync(inputPath, 'utf-8');
+  const events = JSON.parse(raw);
+
+  if (!Array.isArray(events)) {
+    console.error('Input must be a JSON array of events');
+    process.exit(1);
+  }
+
+  // Load salt
+  let salt = null;
+  if (args['salt-file']) {
+    salt = readFileSync(path.resolve(args['salt-file']), 'utf-8').trim();
+  }
+
+  const result = exportGrammarEvents(events, {
+    salt,
+    releaseId: args['release-id'] || undefined,
+    dateFrom: args['date-from'] || undefined,
+    dateTo: args['date-to'] || undefined,
+    templateId: args['template-id'] || undefined,
+    conceptId: args['concept-id'] || undefined,
+    dryRun: !!args['dry-run'],
+  });
+
+  // Output summary to stdout
+  console.log(JSON.stringify(result.summary, null, 2));
+
+  if (!args['dry-run']) {
+    if (args.output) {
+      writeFileSync(path.resolve(args.output), JSON.stringify(result.anonymised, null, 2) + '\n', 'utf8');
+      process.stderr.write(`Anonymised events written to ${args.output}\n`);
+    }
+    if (args['expanded-output']) {
+      writeFileSync(path.resolve(args['expanded-output']), JSON.stringify(result.expanded.rows, null, 2) + '\n', 'utf8');
+      process.stderr.write(`Expanded rows written to ${args['expanded-output']}\n`);
+    }
+  }
+}

--- a/scripts/grammar-qg-calibrate.mjs
+++ b/scripts/grammar-qg-calibrate.mjs
@@ -1,0 +1,290 @@
+#!/usr/bin/env node
+/**
+ * Grammar QG P7 — Calibration Report Runner
+ *
+ * CLI: node scripts/grammar-qg-calibrate.mjs --input=<expanded-events.json> [--output-dir=reports/grammar]
+ *
+ * Runs all three P6 sub-reports (health, mixed-transfer, retention) and generates
+ * cross-report classifications:
+ * - transfer_gap: local success >70% AND mixed-transfer <50% AND >=10 attempts each
+ * - retention_gap: secure concepts lapse >25% with medium+ confidence (>=30 secured attempts)
+ * - weakCorrectAttemptRate: correct attempts where conceptStatusBefore === 'weak' / total weak attempts
+ * - weakToSecureRecoveryRate: weak→secure/secured transitions / total weak attempts
+ *
+ * Outputs 4 JSON files + provenance metadata.
+ */
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { buildTemplateHealthReport } from './grammar-qg-health-report.mjs';
+import { buildMixedTransferCalibration } from './grammar-qg-mixed-transfer-calibration.mjs';
+import { buildRetentionReport } from './grammar-qg-retention-monitor.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT_DIR = path.resolve(__dirname, '..');
+
+const SCHEMA_VERSION = 'grammar-qg-p7-calibration-v1';
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+function safeRate(numerator, denominator) {
+  return denominator > 0 ? numerator / denominator : 0;
+}
+
+/**
+ * Normalise rows for sub-reports: convert numeric createdAt (epoch ms)
+ * to ISO string for the `timestamp` field.
+ *
+ * @param {Object[]} rows - Expanded event rows
+ * @returns {Object[]} Normalised rows with valid timestamp strings
+ */
+function normaliseRows(rows) {
+  return rows.map((row) => {
+    const result = { ...row };
+
+    // If timestamp is already a valid ISO string, keep it
+    if (typeof result.timestamp === 'string' && result.timestamp.length > 0) {
+      return result;
+    }
+
+    // Convert numeric createdAt (epoch ms) to ISO string
+    if (typeof result.createdAt === 'number' && result.createdAt > 0) {
+      result.timestamp = new Date(result.createdAt).toISOString();
+      return result;
+    }
+
+    // Convert string createdAt that is numeric
+    if (typeof result.createdAt === 'string' && /^\d+$/.test(result.createdAt)) {
+      result.timestamp = new Date(Number(result.createdAt)).toISOString();
+      return result;
+    }
+
+    // If createdAt is already an ISO string, use it as timestamp
+    if (typeof result.createdAt === 'string' && result.createdAt.length > 0) {
+      result.timestamp = result.createdAt;
+      return result;
+    }
+
+    return result;
+  });
+}
+
+// ─── Cross-report classifications ──────────────────────────────────────────
+
+/**
+ * Compute cross-report calibration classifications from normalised events.
+ *
+ * @param {Object[]} events - Normalised expanded events
+ * @returns {Object} Classification results per concept
+ */
+function computeClassifications(events) {
+  const conceptStats = {};
+
+  for (const event of events) {
+    const cid = event.conceptId;
+    if (!cid) continue;
+
+    if (!conceptStats[cid]) {
+      conceptStats[cid] = {
+        localCorrect: 0,
+        localAttempts: 0,
+        mixedCorrect: 0,
+        mixedAttempts: 0,
+        securedAttempts: 0,
+        securedLapses: 0,
+        weakCorrect: 0,
+        weakAttempts: 0,
+        weakToSecureRecoveries: 0,
+      };
+    }
+
+    const cs = conceptStats[cid];
+    const correct = !!event.correct;
+    const tags = Array.isArray(event.tags) ? event.tags : [];
+    const isMixed = tags.includes('mixed-transfer') || !!event.isMixedTransfer;
+    const conceptStatusBefore = event.conceptStatusBefore || 'new';
+    const conceptStatusAfter = event.conceptStatusAfter || '';
+
+    // Local vs mixed attempt tracking
+    if (isMixed) {
+      cs.mixedAttempts++;
+      if (correct) cs.mixedCorrect++;
+    } else {
+      cs.localAttempts++;
+      if (correct) cs.localCorrect++;
+    }
+
+    // Secured concept tracking
+    if (conceptStatusBefore === 'secured') {
+      cs.securedAttempts++;
+      if (!correct) cs.securedLapses++;
+    }
+
+    // Weak concept tracking
+    if (conceptStatusBefore === 'weak') {
+      cs.weakAttempts++;
+      if (correct) cs.weakCorrect++;
+      if (conceptStatusAfter === 'secure' || conceptStatusAfter === 'secured') {
+        cs.weakToSecureRecoveries++;
+      }
+    }
+  }
+
+  // Build classifications
+  const transferGaps = {};
+  const retentionGaps = {};
+  const weakMetrics = {};
+
+  for (const [cid, cs] of Object.entries(conceptStats)) {
+    const localRate = safeRate(cs.localCorrect, cs.localAttempts);
+    const mixedRate = safeRate(cs.mixedCorrect, cs.mixedAttempts);
+    const lapseRate = safeRate(cs.securedLapses, cs.securedAttempts);
+    const weakCorrectRate = safeRate(cs.weakCorrect, cs.weakAttempts);
+    const weakRecoveryRate = safeRate(cs.weakToSecureRecoveries, cs.weakAttempts);
+
+    // transfer_gap: local >70% AND mixed <50% AND >=10 attempts in EACH modality
+    if (cs.localAttempts >= 10 && cs.mixedAttempts >= 10 && localRate > 0.7 && mixedRate < 0.5) {
+      transferGaps[cid] = {
+        localSuccessRate: localRate,
+        mixedSuccessRate: mixedRate,
+        localAttempts: cs.localAttempts,
+        mixedAttempts: cs.mixedAttempts,
+        gap: localRate - mixedRate,
+      };
+    }
+
+    // retention_gap: lapse >25% with medium+ confidence (>=30 secured attempts)
+    if (cs.securedAttempts >= 30 && lapseRate > 0.25) {
+      retentionGaps[cid] = {
+        lapseRate,
+        securedAttempts: cs.securedAttempts,
+        securedLapses: cs.securedLapses,
+        confidence: cs.securedAttempts > 100 ? 'high' : 'medium',
+      };
+    }
+
+    // Weak metrics (only if there are weak attempts)
+    if (cs.weakAttempts > 0) {
+      weakMetrics[cid] = {
+        weakCorrectAttemptRate: weakCorrectRate,
+        weakToSecureRecoveryRate: weakRecoveryRate,
+        weakAttempts: cs.weakAttempts,
+        weakCorrect: cs.weakCorrect,
+        weakToSecureRecoveries: cs.weakToSecureRecoveries,
+      };
+    }
+  }
+
+  return { transferGaps, retentionGaps, weakMetrics };
+}
+
+// ─── Main calibration runner ───────────────────────────────────────────────
+
+/**
+ * Run the full calibration pipeline: sub-reports + cross-report classifications.
+ *
+ * @param {Object[]} expandedEvents - Expanded event rows (from expandEvents)
+ * @param {Object} [options]
+ * @param {string} [options.outputDir] - Output directory
+ * @returns {{ healthReport: Object, mixedTransferReport: Object, retentionReport: Object, classifications: Object, provenance: Object }}
+ */
+export function runCalibration(expandedEvents, options = {}) {
+  // Normalise rows — convert numeric createdAt to ISO timestamp
+  const normalised = normaliseRows(expandedEvents);
+
+  // Run sub-reports
+  const healthReport = buildTemplateHealthReport(normalised);
+  const mixedTransferReport = buildMixedTransferCalibration(normalised);
+  const retentionReport = buildRetentionReport(normalised);
+
+  // Cross-report classifications
+  const classifications = computeClassifications(normalised);
+
+  // Provenance metadata
+  const provenance = {
+    calibrationSchemaVersion: SCHEMA_VERSION,
+    generatedAt: new Date().toISOString(),
+    inputRowCount: expandedEvents.length,
+    normalisedRowCount: normalised.length,
+    transferGapCount: Object.keys(classifications.transferGaps).length,
+    retentionGapCount: Object.keys(classifications.retentionGaps).length,
+    weakMetricsCount: Object.keys(classifications.weakMetrics).length,
+  };
+
+  return {
+    healthReport: { ...healthReport, provenance: { calibrationSchemaVersion: SCHEMA_VERSION } },
+    mixedTransferReport: { ...mixedTransferReport, provenance: { calibrationSchemaVersion: SCHEMA_VERSION } },
+    retentionReport: { ...retentionReport, provenance: { calibrationSchemaVersion: SCHEMA_VERSION } },
+    classifications: { ...classifications, provenance },
+  };
+}
+
+// ─── CLI ───────────────────────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const args = {};
+  for (const arg of argv) {
+    if (arg.startsWith('--')) {
+      const eqIdx = arg.indexOf('=');
+      if (eqIdx !== -1) {
+        args[arg.slice(2, eqIdx)] = arg.slice(eqIdx + 1);
+      } else {
+        args[arg.slice(2)] = true;
+      }
+    }
+  }
+  return args;
+}
+
+const isMainModule =
+  typeof process !== 'undefined' &&
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === path.resolve(__filename);
+
+if (isMainModule) {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (!args.input) {
+    console.error('Usage: grammar-qg-calibrate.mjs --input=<expanded-events.json> [--output-dir=reports/grammar]');
+    process.exit(1);
+  }
+
+  const inputPath = path.resolve(args.input);
+  const outputDir = args['output-dir'] || path.join(ROOT_DIR, 'reports', 'grammar');
+
+  const raw = readFileSync(inputPath, 'utf-8');
+  const events = JSON.parse(raw);
+
+  if (!Array.isArray(events)) {
+    console.error('Input must be a JSON array of expanded events');
+    process.exit(1);
+  }
+
+  const result = runCalibration(events);
+
+  mkdirSync(outputDir, { recursive: true });
+
+  writeFileSync(
+    path.join(outputDir, 'grammar-qg-p7-health-report.json'),
+    JSON.stringify(result.healthReport, null, 2) + '\n',
+  );
+  writeFileSync(
+    path.join(outputDir, 'grammar-qg-p7-mixed-transfer.json'),
+    JSON.stringify(result.mixedTransferReport, null, 2) + '\n',
+  );
+  writeFileSync(
+    path.join(outputDir, 'grammar-qg-p7-retention.json'),
+    JSON.stringify(result.retentionReport, null, 2) + '\n',
+  );
+  writeFileSync(
+    path.join(outputDir, 'grammar-qg-p7-classifications.json'),
+    JSON.stringify(result.classifications, null, 2) + '\n',
+  );
+
+  console.log(`Calibration reports written to ${outputDir}`);
+  console.log(`  Transfer gaps: ${result.classifications.provenance.transferGapCount}`);
+  console.log(`  Retention gaps: ${result.classifications.provenance.retentionGapCount}`);
+  console.log(`  Weak metrics: ${result.classifications.provenance.weakMetricsCount}`);
+  console.log(`  Schema version: ${SCHEMA_VERSION}`);
+}

--- a/tests/grammar-qg-p7-health-report.test.js
+++ b/tests/grammar-qg-p7-health-report.test.js
@@ -1,0 +1,329 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { runCalibration } from '../scripts/grammar-qg-calibrate.mjs';
+import { buildTemplateHealthReport } from '../scripts/grammar-qg-health-report.mjs';
+
+// ─── Fixtures ──────────────────────────────────────────────────────────────
+
+function makeExpandedEvent(overrides = {}) {
+  return {
+    templateId: 'tpl-possessive-01',
+    conceptId: 'possessive-apostrophe',
+    conceptIds: ['possessive-apostrophe'],
+    timestamp: '2026-04-29T10:00:00Z',
+    correct: true,
+    tags: [],
+    firstAttemptIndependent: true,
+    supportUsed: false,
+    wasRetry: false,
+    conceptStatusBefore: 'weak',
+    conceptStatusAfter: 'secure',
+    mode: 'practice',
+    ...overrides,
+  };
+}
+
+/**
+ * Generate N events with specific parameters for threshold testing.
+ */
+function generateEvents(count, overrides = {}) {
+  return Array.from({ length: count }, (_, i) =>
+    makeExpandedEvent({ timestamp: `2026-04-29T${String(10 + (i % 12)).padStart(2, '0')}:00:00Z`, ...overrides }),
+  );
+}
+
+// ─── U4: Calibration runner tests ──────────────────────────────────────────
+
+describe('Grammar QG P7 — Calibration Runner', () => {
+  describe('full pipeline produces all outputs', () => {
+    it('generates all 4 output objects with provenance', () => {
+      const events = generateEvents(15);
+      const result = runCalibration(events);
+
+      assert.ok(result.healthReport);
+      assert.ok(result.mixedTransferReport);
+      assert.ok(result.retentionReport);
+      assert.ok(result.classifications);
+
+      // Check provenance on each
+      assert.equal(result.healthReport.provenance.calibrationSchemaVersion, 'grammar-qg-p7-calibration-v1');
+      assert.equal(result.mixedTransferReport.provenance.calibrationSchemaVersion, 'grammar-qg-p7-calibration-v1');
+      assert.equal(result.retentionReport.provenance.calibrationSchemaVersion, 'grammar-qg-p7-calibration-v1');
+      assert.equal(result.classifications.provenance.calibrationSchemaVersion, 'grammar-qg-p7-calibration-v1');
+    });
+
+    it('schema version present in all outputs', () => {
+      const events = generateEvents(5);
+      const result = runCalibration(events);
+      const stringified = JSON.stringify(result);
+      const matches = stringified.match(/grammar-qg-p7-calibration-v1/g);
+      assert.ok(matches.length >= 4, 'schema version must appear in all 4 outputs');
+    });
+  });
+
+  describe('transfer_gap detection', () => {
+    it('flags transfer_gap when local >70% AND mixed <50% AND >=10 attempts each', () => {
+      const localEvents = generateEvents(12, {
+        conceptId: 'concept-a',
+        correct: true, // 100% local
+        tags: [],
+      });
+      const mixedEvents = generateEvents(12, {
+        conceptId: 'concept-a',
+        correct: false, // 0% mixed
+        tags: ['mixed-transfer'],
+      });
+      const events = [...localEvents, ...mixedEvents];
+      const result = runCalibration(events);
+
+      assert.ok(result.classifications.transferGaps['concept-a'], 'concept-a must be flagged as transfer_gap');
+      assert.ok(result.classifications.transferGaps['concept-a'].localSuccessRate > 0.7);
+      assert.ok(result.classifications.transferGaps['concept-a'].mixedSuccessRate < 0.5);
+    });
+
+    it('does NOT flag transfer_gap with 0 mixed-transfer attempts', () => {
+      const localEvents = generateEvents(15, {
+        conceptId: 'concept-b',
+        correct: true,
+        tags: [],
+      });
+      // No mixed-transfer events at all
+      const result = runCalibration(localEvents);
+      assert.equal(result.classifications.transferGaps['concept-b'], undefined);
+    });
+
+    it('does NOT flag transfer_gap with <10 local attempts', () => {
+      const localEvents = generateEvents(8, {
+        conceptId: 'concept-c',
+        correct: true,
+        tags: [],
+      });
+      const mixedEvents = generateEvents(12, {
+        conceptId: 'concept-c',
+        correct: false,
+        tags: ['mixed-transfer'],
+      });
+      const events = [...localEvents, ...mixedEvents];
+      const result = runCalibration(events);
+      assert.equal(result.classifications.transferGaps['concept-c'], undefined);
+    });
+
+    it('does NOT flag transfer_gap with <10 mixed attempts', () => {
+      const localEvents = generateEvents(12, {
+        conceptId: 'concept-d',
+        correct: true,
+        tags: [],
+      });
+      const mixedEvents = generateEvents(8, {
+        conceptId: 'concept-d',
+        correct: false,
+        tags: ['mixed-transfer'],
+      });
+      const events = [...localEvents, ...mixedEvents];
+      const result = runCalibration(events);
+      assert.equal(result.classifications.transferGaps['concept-d'], undefined);
+    });
+  });
+
+  describe('retention_gap detection', () => {
+    it('flags retention_gap when lapse >25% with >=30 secured attempts', () => {
+      // 20 correct + 12 incorrect = 32 total, lapse rate = 12/32 = 37.5%
+      const retainedEvents = generateEvents(20, {
+        conceptId: 'concept-retain',
+        conceptStatusBefore: 'secured',
+        correct: true,
+      });
+      const lapsedEvents = generateEvents(12, {
+        conceptId: 'concept-retain',
+        conceptStatusBefore: 'secured',
+        correct: false,
+      });
+      const events = [...retainedEvents, ...lapsedEvents];
+      const result = runCalibration(events);
+
+      assert.ok(result.classifications.retentionGaps['concept-retain'], 'must be flagged as retention_gap');
+      assert.ok(result.classifications.retentionGaps['concept-retain'].lapseRate > 0.25);
+    });
+
+    it('does NOT flag retention_gap with <30 secured attempts', () => {
+      const retainedEvents = generateEvents(15, {
+        conceptId: 'concept-few',
+        conceptStatusBefore: 'secured',
+        correct: true,
+      });
+      const lapsedEvents = generateEvents(10, {
+        conceptId: 'concept-few',
+        conceptStatusBefore: 'secured',
+        correct: false,
+      });
+      const events = [...retainedEvents, ...lapsedEvents];
+      const result = runCalibration(events);
+      assert.equal(result.classifications.retentionGaps['concept-few'], undefined);
+    });
+  });
+
+  describe('weak metrics distinction', () => {
+    it('computes weakCorrectAttemptRate as correct/total weak attempts', () => {
+      const weakCorrect = generateEvents(6, {
+        conceptId: 'concept-w',
+        conceptStatusBefore: 'weak',
+        correct: true,
+        conceptStatusAfter: 'weak', // Stays weak despite correct
+      });
+      const weakIncorrect = generateEvents(4, {
+        conceptId: 'concept-w',
+        conceptStatusBefore: 'weak',
+        correct: false,
+        conceptStatusAfter: 'weak',
+      });
+      const events = [...weakCorrect, ...weakIncorrect];
+      const result = runCalibration(events);
+
+      const wm = result.classifications.weakMetrics['concept-w'];
+      assert.ok(wm);
+      assert.equal(wm.weakCorrectAttemptRate, 0.6); // 6/10
+    });
+
+    it('computes weakToSecureRecoveryRate as weak→secure transitions / total weak', () => {
+      const weakToSecure = generateEvents(3, {
+        conceptId: 'concept-wr',
+        conceptStatusBefore: 'weak',
+        correct: true,
+        conceptStatusAfter: 'secured',
+      });
+      const weakStays = generateEvents(7, {
+        conceptId: 'concept-wr',
+        conceptStatusBefore: 'weak',
+        correct: true,
+        conceptStatusAfter: 'weak',
+      });
+      const events = [...weakToSecure, ...weakStays];
+      const result = runCalibration(events);
+
+      const wm = result.classifications.weakMetrics['concept-wr'];
+      assert.ok(wm);
+      assert.equal(wm.weakToSecureRecoveryRate, 0.3); // 3/10
+      assert.equal(wm.weakCorrectAttemptRate, 1.0); // 10/10 all correct
+    });
+
+    it('distinguishes weakCorrectAttemptRate from weakToSecureRecoveryRate', () => {
+      // All correct but only some transition to secure
+      const events = [
+        ...generateEvents(5, {
+          conceptId: 'concept-distinct',
+          conceptStatusBefore: 'weak',
+          correct: true,
+          conceptStatusAfter: 'secure',
+        }),
+        ...generateEvents(5, {
+          conceptId: 'concept-distinct',
+          conceptStatusBefore: 'weak',
+          correct: true,
+          conceptStatusAfter: 'weak',
+        }),
+      ];
+      const result = runCalibration(events);
+      const wm = result.classifications.weakMetrics['concept-distinct'];
+      assert.equal(wm.weakCorrectAttemptRate, 1.0); // all correct
+      assert.equal(wm.weakToSecureRecoveryRate, 0.5); // only half transition
+    });
+  });
+
+  describe('numeric createdAt normalisation', () => {
+    it('processes events with numeric createdAt (epoch ms) correctly', () => {
+      const epochMs = new Date('2026-04-29T10:00:00Z').getTime();
+      const events = generateEvents(12, {
+        conceptId: 'concept-epoch',
+        timestamp: undefined, // Remove timestamp
+        createdAt: epochMs,
+      });
+      // Remove timestamp field entirely
+      for (const e of events) {
+        delete e.timestamp;
+        e.createdAt = epochMs;
+      }
+
+      const result = runCalibration(events);
+      // Should not skip — the health report should process them
+      assert.ok(result.healthReport.templates['tpl-possessive-01']);
+      assert.ok(result.healthReport.templates['tpl-possessive-01'].attemptCount >= 12);
+    });
+
+    it('does not skip events that only have numeric createdAt', () => {
+      const epochMs = new Date('2026-04-29T12:00:00Z').getTime();
+      const events = [
+        {
+          templateId: 'tpl-numeric',
+          conceptId: 'concept-num',
+          conceptIds: ['concept-num'],
+          createdAt: epochMs,
+          correct: true,
+          tags: [],
+          firstAttemptIndependent: true,
+          conceptStatusBefore: 'new',
+        },
+      ];
+      const result = runCalibration(events);
+      assert.ok(result.healthReport.templates['tpl-numeric']);
+      assert.equal(result.healthReport.templates['tpl-numeric'].attemptCount, 1);
+    });
+  });
+
+  describe('empty input handling', () => {
+    it('empty input produces all insufficient_data', () => {
+      const result = runCalibration([]);
+      assert.deepEqual(result.classifications.transferGaps, {});
+      assert.deepEqual(result.classifications.retentionGaps, {});
+      assert.deepEqual(result.classifications.weakMetrics, {});
+      assert.deepEqual(result.healthReport.templates, {});
+      assert.deepEqual(result.retentionReport.concepts, {});
+    });
+  });
+
+  describe('P6 health classifications still work', () => {
+    it('classifies templates via existing buildTemplateHealthReport', () => {
+      // Directly test the P6 health report with standard fixture
+      const events = [
+        ...generateEvents(50, {
+          templateId: 'tpl-easy',
+          timestamp: '2026-04-29T10:00:00Z',
+          correct: true,
+          firstAttemptIndependent: true,
+          elapsedMs: 1500,
+        }),
+        ...generateEvents(50, {
+          templateId: 'tpl-hard',
+          timestamp: '2026-04-29T10:00:00Z',
+          correct: false,
+          firstAttemptIndependent: true,
+          elapsedMs: 8000,
+        }),
+      ];
+
+      const report = buildTemplateHealthReport(events);
+      assert.equal(report.templates['tpl-easy'].classification, 'too_easy');
+      assert.equal(report.templates['tpl-hard'].classification, 'too_hard');
+    });
+
+    it('healthy classification for moderate success rate', () => {
+      // 70% success rate
+      const correct = generateEvents(35, {
+        templateId: 'tpl-moderate',
+        timestamp: '2026-04-29T10:00:00Z',
+        correct: true,
+        firstAttemptIndependent: true,
+        elapsedMs: 5000,
+      });
+      const incorrect = generateEvents(15, {
+        templateId: 'tpl-moderate',
+        timestamp: '2026-04-29T10:00:00Z',
+        correct: false,
+        firstAttemptIndependent: true,
+        elapsedMs: 5000,
+      });
+      const report = buildTemplateHealthReport([...correct, ...incorrect]);
+      assert.equal(report.templates['tpl-moderate'].classification, 'healthy');
+    });
+  });
+});

--- a/tests/grammar-qg-p7-production-evidence.test.js
+++ b/tests/grammar-qg-p7-production-evidence.test.js
@@ -1,0 +1,208 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { anonymiseEvent, filterEvents, exportGrammarEvents } from '../scripts/export-grammar-qg-events.mjs';
+
+// ─── Fixtures ──────────────────────────────────────────────────────────────
+
+function makeEvent(overrides = {}) {
+  return {
+    id: 'grammar.answer-submitted.learner-alice.req1.item1',
+    learnerId: 'learner-alice',
+    subject: 'grammar',
+    releaseId: 'grammar-qg-p6-2026-04-29',
+    templateId: 'tpl-possessive-apostrophe-01',
+    conceptIds: ['possessive-apostrophe'],
+    conceptStatusBefore: 'weak',
+    conceptStatusAfter: 'secure',
+    timestamp: '2026-04-29T10:00:00Z',
+    correct: true,
+    tags: [],
+    ...overrides,
+  };
+}
+
+const SALT = 'test-salt-value-abc123';
+
+// ─── U3: HMAC anonymisation tests ─────────────────────────────────────────
+
+describe('Grammar QG P7 — Production Evidence Export', () => {
+  describe('anonymisation with salt', () => {
+    it('produces consistent HMAC across runs', () => {
+      const event = makeEvent();
+      const a1 = anonymiseEvent(event, SALT);
+      const a2 = anonymiseEvent(event, SALT);
+      assert.equal(a1.learnerId, a2.learnerId);
+      assert.notEqual(a1.learnerId, 'learner-alice');
+      assert.equal(a1.learnerId.length, 16);
+    });
+
+    it('produces hex-only output', () => {
+      const event = makeEvent();
+      const result = anonymiseEvent(event, SALT);
+      assert.match(result.learnerId, /^[0-9a-f]{16}$/);
+    });
+
+    it('different learners get different anonymised IDs', () => {
+      const e1 = anonymiseEvent(makeEvent({ learnerId: 'alice' }), SALT);
+      const e2 = anonymiseEvent(makeEvent({ learnerId: 'bob' }), SALT);
+      assert.notEqual(e1.learnerId, e2.learnerId);
+    });
+  });
+
+  describe('anonymisation without salt', () => {
+    it('produces "anonymous" when no salt provided', () => {
+      const event = makeEvent();
+      const result = anonymiseEvent(event, null);
+      assert.equal(result.learnerId, 'anonymous');
+    });
+
+    it('produces "anonymous" with empty string salt', () => {
+      const event = makeEvent();
+      const result = anonymiseEvent(event, '');
+      assert.equal(result.learnerId, 'anonymous');
+    });
+  });
+
+  describe('event.id scrubbing', () => {
+    it('scrubs learner ID from production-format event.id', () => {
+      const event = makeEvent({
+        id: 'grammar.answer-submitted.learner-alice.req1.item1',
+        learnerId: 'learner-alice',
+      });
+      const result = anonymiseEvent(event, SALT);
+      assert.ok(!result.id.includes('learner-alice'), 'raw learner ID must not appear in event.id');
+      // The anonymised ID should replace the learner part
+      assert.ok(result.id.includes(result.learnerId));
+      assert.ok(result.id.startsWith('grammar.answer-submitted.'));
+      assert.ok(result.id.endsWith('.req1.item1'));
+    });
+
+    it('scrubs learner ID from event.id even without salt (becomes anonymous)', () => {
+      const event = makeEvent({
+        id: 'grammar.answer-submitted.learner-alice.req1.item1',
+        learnerId: 'learner-alice',
+      });
+      const result = anonymiseEvent(event, null);
+      assert.ok(!result.id.includes('learner-alice'));
+      assert.ok(result.id.includes('anonymous'));
+    });
+
+    it('raw learner ID never appears in stringified output (anonymised + expanded)', () => {
+      const events = [
+        makeEvent({ learnerId: 'learner-alice' }),
+        makeEvent({ learnerId: 'learner-bob', id: 'grammar.answer-submitted.learner-bob.req2.item2' }),
+      ];
+      const result = exportGrammarEvents(events, { salt: SALT });
+      // Check the exported outputs (anonymised + expanded) — the deliverables
+      const anonymisedStr = JSON.stringify(result.anonymised);
+      const expandedStr = JSON.stringify(result.expanded);
+      assert.ok(!anonymisedStr.includes('learner-alice'), 'learner-alice must not appear in anonymised output');
+      assert.ok(!anonymisedStr.includes('learner-bob'), 'learner-bob must not appear in anonymised output');
+      assert.ok(!expandedStr.includes('learner-alice'), 'learner-alice must not appear in expanded output');
+      assert.ok(!expandedStr.includes('learner-bob'), 'learner-bob must not appear in expanded output');
+    });
+  });
+
+  describe('filtering by release ID', () => {
+    it('includes events at or after grammar-qg-p6-2026-04-29', () => {
+      const events = [
+        makeEvent({ releaseId: 'grammar-qg-p6-2026-04-29' }),
+        makeEvent({ releaseId: 'grammar-qg-p7-2026-04-30' }),
+      ];
+      const filtered = filterEvents(events);
+      assert.equal(filtered.length, 2);
+    });
+
+    it('excludes events before grammar-qg-p6-2026-04-29', () => {
+      const events = [
+        makeEvent({ releaseId: 'grammar-qg-p5-2026-04-28' }),
+        makeEvent({ releaseId: 'grammar-qg-p4-2026-04-27' }),
+      ];
+      const filtered = filterEvents(events);
+      assert.equal(filtered.length, 0);
+    });
+
+    it('filters to exact release ID when specified', () => {
+      const events = [
+        makeEvent({ releaseId: 'grammar-qg-p6-2026-04-29' }),
+        makeEvent({ releaseId: 'grammar-qg-p7-2026-04-30' }),
+      ];
+      const filtered = filterEvents(events, { releaseId: 'grammar-qg-p6-2026-04-29' });
+      assert.equal(filtered.length, 1);
+      assert.equal(filtered[0].releaseId, 'grammar-qg-p6-2026-04-29');
+    });
+  });
+
+  describe('filtering by date range', () => {
+    it('includes events within date range', () => {
+      const events = [
+        makeEvent({ timestamp: '2026-04-29T10:00:00Z' }),
+        makeEvent({ timestamp: '2026-04-30T10:00:00Z' }),
+        makeEvent({ timestamp: '2026-05-01T10:00:00Z' }),
+      ];
+      const filtered = filterEvents(events, {
+        dateFrom: '2026-04-29T00:00:00Z',
+        dateTo: '2026-04-30T23:59:59Z',
+      });
+      assert.equal(filtered.length, 2);
+    });
+
+    it('excludes events outside date range', () => {
+      const events = [
+        makeEvent({ timestamp: '2026-04-28T10:00:00Z' }),
+      ];
+      const filtered = filterEvents(events, { dateFrom: '2026-04-29T00:00:00Z' });
+      assert.equal(filtered.length, 0);
+    });
+  });
+
+  describe('dry-run mode', () => {
+    it('produces summary without writing data', () => {
+      const events = [makeEvent(), makeEvent()];
+      const result = exportGrammarEvents(events, { salt: SALT, dryRun: true });
+      assert.equal(result.summary.dryRun, true);
+      assert.equal(result.summary.inputCount, 2);
+      assert.equal(result.summary.filteredCount, 2);
+      // Dry-run returns empty arrays
+      assert.equal(result.filtered.length, 0);
+      assert.equal(result.anonymised.length, 0);
+      assert.equal(result.expanded.rows.length, 0);
+    });
+
+    it('summary includes filter counts even in dry-run', () => {
+      const events = [
+        makeEvent(),
+        makeEvent({ releaseId: 'grammar-qg-p4-old' }), // will be filtered out
+      ];
+      const result = exportGrammarEvents(events, { salt: SALT, dryRun: true });
+      assert.equal(result.summary.inputCount, 2);
+      assert.equal(result.summary.filteredCount, 1);
+    });
+  });
+
+  describe('full pipeline integration', () => {
+    it('export produces anonymised and expanded output', () => {
+      const events = [
+        makeEvent({ learnerId: 'alice', id: 'grammar.answer-submitted.alice.req1.item1', conceptIds: ['c1', 'c2'] }),
+      ];
+      const result = exportGrammarEvents(events, { salt: SALT });
+      assert.equal(result.anonymised.length, 1);
+      assert.equal(result.expanded.totalOutput, 2); // 2 concepts
+      // The exported deliverables must not leak the raw learner ID
+      const anonymisedStr = JSON.stringify(result.anonymised);
+      const expandedStr = JSON.stringify(result.expanded);
+      assert.ok(!anonymisedStr.includes('"alice"'), 'raw learnerId must not appear in anonymised');
+      assert.ok(!expandedStr.includes('"alice"'), 'raw learnerId must not appear in expanded');
+    });
+
+    it('filters non-grammar subject events', () => {
+      const events = [
+        makeEvent({ subject: 'grammar' }),
+        makeEvent({ subject: 'punctuation' }),
+      ];
+      const result = exportGrammarEvents(events, { salt: SALT });
+      assert.equal(result.anonymised.length, 1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Create `scripts/export-grammar-qg-events.mjs` with HMAC-SHA-256 learner anonymisation
- Scrub learner ID from event.id field (security: no PII leakage)
- Create `scripts/grammar-qg-calibrate.mjs` orchestrating health/mixed-transfer/retention reports
- Add `transfer_gap` (requires >=10 attempts each modality) and `retention_gap` classifications
- Add `weakCorrectAttemptRate` and `weakToSecureRecoveryRate` as distinct metrics
- Numeric createdAt (production epoch ms) normalised to ISO string for sub-reports

## Test plan

- [x] 32 new tests across 2 test files pass (production-evidence + health-report)
- [x] P6 health/mixed-transfer/retention tests (28) pass — no regression
- [x] Learner ID scrubbed from event.id field (production format tested)
- [x] transfer_gap NOT flagged with 0 mixed-transfer attempts
- [x] Numeric createdAt processed correctly (not skipped)
- [x] No mastery-write/reward/Star imports in analytics scripts