### PR TITLE
feat(admin-p7): Support incident UI panel (U7)

### DIFF
--- a/src/platform/hubs/admin-action-classification.js
+++ b/src/platform/hubs/admin-action-classification.js
@@ -51,6 +51,12 @@ const REGISTRY = new Map([
   // medium: asset draft save (single-entity write, CAS-protected)
   ['asset-draft-save', { level: LEVELS.medium }],
 
+  // U7 (P7): Support incident actions
+  ['incident-create', { level: LEVELS.medium }],
+  ['incident-status-change', { level: LEVELS.medium }],
+  ['incident-resolve', { level: LEVELS.high }],
+  ['incident-ignore', { level: LEVELS.high }],
+
   // low: asset read / preview (no mutation)
   ['asset-preview', { level: LEVELS.low }],
   ['asset-read', { level: LEVELS.low }],

--- a/src/platform/hubs/admin-incident-panel.js
+++ b/src/platform/hubs/admin-incident-panel.js
@@ -1,0 +1,155 @@
+// Admin Console P7 / U7: Incident panel platform helpers.
+//
+// Pure-logic transforms for the incident UI panel. No React imports.
+// Transforms API responses into display models and provides status
+// transition logic matching the worker's VALID_TRANSITIONS map.
+
+// ---------------------------------------------------------------------------
+// Status labels and colours
+// ---------------------------------------------------------------------------
+
+const STATUS_CONFIG = Object.freeze({
+  open: { label: 'Open', colour: '#d97706' },
+  investigating: { label: 'Investigating', colour: '#2563eb' },
+  waiting_on_parent: { label: 'Waiting on Parent', colour: '#7c3aed' },
+  resolved: { label: 'Resolved', colour: '#16a34a' },
+  ignored: { label: 'Ignored', colour: '#6b7280' },
+});
+
+// Linear progression plus shortcut-close to terminal (mirrors worker).
+const VALID_TRANSITIONS = new Map([
+  ['open', ['investigating', 'resolved', 'ignored']],
+  ['investigating', ['waiting_on_parent', 'resolved', 'ignored']],
+  ['waiting_on_parent', ['resolved', 'ignored']],
+]);
+
+const NOTE_AUDIENCE_LABELS = Object.freeze({
+  admin_only: 'Admin only',
+  ops_safe: 'Ops safe',
+});
+
+// ---------------------------------------------------------------------------
+// formatIncidentStatus
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {string} status
+ * @returns {{ label: string, colour: string }}
+ */
+export function formatIncidentStatus(status) {
+  const config = STATUS_CONFIG[status];
+  if (!config) return { label: String(status || 'Unknown'), colour: '#6b7280' };
+  return { label: config.label, colour: config.colour };
+}
+
+// ---------------------------------------------------------------------------
+// getStatusTransitions
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the valid next statuses from the given current status.
+ * Terminal statuses (resolved, ignored) have no valid transitions.
+ *
+ * @param {string} currentStatus
+ * @returns {string[]}
+ */
+export function getStatusTransitions(currentStatus) {
+  const transitions = VALID_TRANSITIONS.get(currentStatus);
+  return transitions ? [...transitions] : [];
+}
+
+// ---------------------------------------------------------------------------
+// buildIncidentListModel
+// ---------------------------------------------------------------------------
+
+/**
+ * Transform the API list response into a display model.
+ *
+ * @param {{ incidents?: Array }} data — raw API response from GET /api/admin/incidents
+ * @returns {{ incidents: Array<object>, hasData: boolean }}
+ */
+export function buildIncidentListModel(data) {
+  if (!data || !Array.isArray(data.incidents)) {
+    return { incidents: [], hasData: false };
+  }
+
+  const incidents = data.incidents.map((inc) => {
+    const statusDisplay = formatIncidentStatus(inc.status);
+    return {
+      id: inc.id,
+      title: inc.title || '(untitled)',
+      status: inc.status,
+      statusLabel: statusDisplay.label,
+      statusColour: statusDisplay.colour,
+      accountId: inc.accountId || null,
+      learnerId: inc.learnerId || null,
+      createdBy: inc.createdBy || null,
+      createdAt: inc.createdAt || 0,
+      updatedAt: inc.updatedAt || 0,
+      resolvedAt: inc.resolvedAt || null,
+      rowVersion: inc.rowVersion || 0,
+    };
+  });
+
+  return { incidents, hasData: incidents.length > 0 };
+}
+
+// ---------------------------------------------------------------------------
+// buildIncidentDetailModel
+// ---------------------------------------------------------------------------
+
+/**
+ * Transform a single incident (with notes and links) into a detail view model.
+ *
+ * @param {{ incident: object, notes?: Array, links?: Array }} data
+ * @returns {object}
+ */
+export function buildIncidentDetailModel(data) {
+  if (!data || !data.incident) {
+    return null;
+  }
+
+  const inc = data.incident;
+  const statusDisplay = formatIncidentStatus(inc.status);
+  const transitions = getStatusTransitions(inc.status);
+
+  const notes = Array.isArray(data.notes)
+    ? data.notes.map((n) => ({
+        id: n.id,
+        authorId: n.authorId,
+        noteText: n.noteText,
+        audience: n.audience,
+        audienceLabel: NOTE_AUDIENCE_LABELS[n.audience] || n.audience,
+        createdAt: n.createdAt || 0,
+      }))
+    : [];
+
+  const links = Array.isArray(data.links)
+    ? data.links.map((l) => ({
+        id: l.id,
+        linkType: l.linkType,
+        linkTargetId: l.linkTargetId,
+        createdAt: l.createdAt || 0,
+      }))
+    : [];
+
+  return {
+    id: inc.id,
+    title: inc.title || '(untitled)',
+    status: inc.status,
+    statusLabel: statusDisplay.label,
+    statusColour: statusDisplay.colour,
+    accountId: inc.accountId || null,
+    learnerId: inc.learnerId || null,
+    createdBy: inc.createdBy || null,
+    createdAt: inc.createdAt || 0,
+    updatedAt: inc.updatedAt || 0,
+    resolvedAt: inc.resolvedAt || null,
+    rowVersion: inc.rowVersion || 0,
+    transitions,
+    notes,
+    links,
+  };
+}
+
+export { STATUS_CONFIG, VALID_TRANSITIONS, NOTE_AUDIENCE_LABELS };

--- a/src/surfaces/hubs/AdminAccountsSection.jsx
+++ b/src/surfaces/hubs/AdminAccountsSection.jsx
@@ -27,6 +27,7 @@ import {
 } from '../../platform/hubs/admin-safe-copy.js';
 import { saveIncidentStash } from '../../platform/hubs/admin-incident-flow.js';
 import { buildAccountLifecycleModel, classifyLifecycleField } from '../../platform/hubs/admin-account-lifecycle.js';
+import { formatIncidentStatus } from '../../platform/hubs/admin-incident-panel.js';
 
 // U4+U5: Accounts section — role management, ops metadata, and audit log.
 // Extracted from AdminHubSurface.jsx. All inline components preserved
@@ -451,6 +452,34 @@ function AccountLifecycleSubSection({ detail }) {
   );
 }
 
+function AccountIncidentsMini({ incidents }) {
+  if (!Array.isArray(incidents) || incidents.length === 0) return null;
+  const openCount = incidents.filter((i) => i.status !== 'resolved' && i.status !== 'ignored').length;
+  return (
+    <div data-testid="account-incidents-mini" style={{ marginTop: 8 }}>
+      <div className="eyebrow">
+        Open incidents{' '}
+        {openCount > 0 && (
+          <span className="chip warn" data-testid="open-incident-count" style={{ fontSize: '0.7rem' }}>{openCount}</span>
+        )}
+      </div>
+      {incidents.slice(0, 5).map((inc) => {
+        const display = formatIncidentStatus(inc.status);
+        return (
+          <div className="skill-row" key={inc.id} data-testid="account-incident-row">
+            <div style={{ flex: 1 }}>
+              <strong style={{ fontSize: '0.85rem' }}>{inc.title}</strong>
+            </div>
+            <span className="chip" style={{ backgroundColor: display.colour, color: '#fff', fontSize: '0.7rem' }}>
+              {display.label}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
 function AccountDetailPanel({ detail, onClose, onDebugBundle, onCopySupportSummary, copySummaryFeedback }) {
   if (!detail || !detail.account) return null;
   const { account, learners, recentErrors, recentDenials, recentMutations, opsMetadata } = detail;
@@ -486,6 +515,8 @@ function AccountDetailPanel({ detail, onClose, onDebugBundle, onCopySupportSumma
       )}
 
       <AccountLifecycleSubSection detail={detail} />
+
+      <AccountIncidentsMini incidents={detail.incidents} />
 
       <div className="eyebrow admin-account-learners-eyebrow">Learners ({learners.length})</div>
       {learners.length ? learners.map((l) => (

--- a/src/surfaces/hubs/AdminBusinessSection.jsx
+++ b/src/surfaces/hubs/AdminBusinessSection.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { AdminPanelFrame } from './AdminPanelFrame.jsx';
+import { AdminIncidentPanel } from './AdminIncidentPanel.jsx';
 import { buildBusinessKpiModel } from '../../platform/hubs/admin-business-kpi.js';
 
 // P7 Unit 5: Business section — KPI analytics panel with real/demo split,
@@ -97,14 +98,8 @@ export function AdminBusinessSection({ actions }) {
         ))}
       </AdminPanelFrame>
 
-      {/* U7 placeholder: Support Incidents panel will be composed here */}
-      <section className="card admin-card-spaced" data-panel-frame="Support Incidents">
-        <div style={{ padding: 16 }}>
-          <div className="eyebrow">Support</div>
-          <h3 style={{ margin: '4px 0 8px', fontSize: '1rem' }}>Incidents</h3>
-          <p className="small muted">Support incident tracking will be added in a future unit.</p>
-        </div>
-      </section>
+      {/* U7: Support Incidents panel */}
+      <AdminIncidentPanel actions={actions} />
     </>
   );
 }

--- a/src/surfaces/hubs/AdminDebugBundlePanel.jsx
+++ b/src/surfaces/hubs/AdminDebugBundlePanel.jsx
@@ -12,6 +12,7 @@ import {
   copyToClipboard,
 } from '../../platform/hubs/admin-safe-copy.js';
 import { consumeIncidentStash } from '../../platform/hubs/admin-incident-flow.js';
+import { formatIncidentStatus } from '../../platform/hubs/admin-incident-panel.js';
 
 // U8 (P4): Debug Bundle panel — extracted from AdminDebuggingSection.jsx.
 // Contains DebugBundlePanel + DebugBundleSectionTable + DebugBundleResult.
@@ -155,6 +156,32 @@ function DebugBundleResult({ bundleData }) {
         );
       })}
     </div>
+  );
+}
+
+function LinkedIncidentsSection({ linkedIncidents }) {
+  if (!Array.isArray(linkedIncidents) || linkedIncidents.length === 0) return null;
+  return (
+    <details className="admin-bundle-section-details" data-testid="bundle-linked-incidents">
+      <summary className="small admin-bundle-section-summary">
+        Linked Incidents ({linkedIncidents.length})
+      </summary>
+      <div className="admin-bundle-section-body">
+        {linkedIncidents.map((inc) => {
+          const display = formatIncidentStatus(inc.status);
+          return (
+            <div className="skill-row" key={inc.id} data-testid="bundle-linked-incident-row">
+              <div style={{ flex: 1 }}>
+                <strong style={{ fontSize: '0.85rem' }}>{inc.title || '(untitled)'}</strong>
+              </div>
+              <span className="chip" style={{ backgroundColor: display.colour, color: '#fff', fontSize: '0.7rem' }}>
+                {display.label}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </details>
   );
 }
 
@@ -318,6 +345,11 @@ export function DebugBundlePanel({ model, actions }) {
       ) : null}
 
       <DebugBundleResult bundleData={bundleData} />
+
+      {/* Admin-only extension: linked incidents (does not break 7-section contract) */}
+      {model?.permissions?.platformRole === 'admin' && bundleData?.linkedIncidents ? (
+        <LinkedIncidentsSection linkedIncidents={bundleData.linkedIncidents} />
+      ) : null}
     </section>
   );
 }

--- a/src/surfaces/hubs/AdminIncidentPanel.jsx
+++ b/src/surfaces/hubs/AdminIncidentPanel.jsx
@@ -1,0 +1,497 @@
+import React from 'react';
+import { AdminPanelFrame } from './AdminPanelFrame.jsx';
+import { AdminConfirmAction } from './AdminConfirmAction.jsx';
+import { formatTimestamp } from './hub-utils.js';
+import {
+  buildIncidentListModel,
+  buildIncidentDetailModel,
+  formatIncidentStatus,
+  getStatusTransitions,
+} from '../../platform/hubs/admin-incident-panel.js';
+import { classifyAction } from '../../platform/hubs/admin-action-classification.js';
+
+// P7 U7: Support Incident UI Panel.
+//
+// List view with status filter tabs, create dialog, detail drawer with
+// status timeline, notes (audience badges), and linked evidence.
+// Uses fetch-generation counter pattern for stale response protection.
+
+const FILTER_TABS = [
+  { key: 'all', label: 'All' },
+  { key: 'open', label: 'Open' },
+  { key: 'investigating', label: 'Investigating' },
+  { key: 'waiting_on_parent', label: 'Waiting' },
+  { key: 'resolved', label: 'Resolved' },
+];
+
+// ---------------------------------------------------------------------------
+// IncidentStatusBadge
+// ---------------------------------------------------------------------------
+
+function IncidentStatusBadge({ status }) {
+  const display = formatIncidentStatus(status);
+  return (
+    <span
+      className="chip"
+      style={{ backgroundColor: display.colour, color: '#fff', fontSize: '0.75rem' }}
+      data-testid="incident-status-badge"
+    >
+      {display.label}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// IncidentRow
+// ---------------------------------------------------------------------------
+
+function IncidentRow({ incident, onSelect }) {
+  return (
+    <div
+      className="skill-row"
+      data-testid="incident-row"
+      data-incident-id={incident.id}
+      role="button"
+      tabIndex={0}
+      onClick={() => onSelect(incident.id)}
+      onKeyDown={(e) => { if (e.key === 'Enter') onSelect(incident.id); }}
+      style={{ cursor: 'pointer' }}
+    >
+      <div style={{ flex: 1 }}>
+        <strong>{incident.title}</strong>
+        {incident.accountId && (
+          <div className="small muted">Account: {incident.accountId}</div>
+        )}
+      </div>
+      <IncidentStatusBadge status={incident.status} />
+      <div className="small muted">{formatTimestamp(incident.createdAt)}</div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// CreateIncidentDialog
+// ---------------------------------------------------------------------------
+
+function CreateIncidentDialog({ onSubmit, onCancel }) {
+  const [title, setTitle] = React.useState('');
+  const [accountId, setAccountId] = React.useState('');
+  const [learnerId, setLearnerId] = React.useState('');
+  const [error, setError] = React.useState('');
+
+  const handleSubmit = () => {
+    if (!title.trim()) {
+      setError('Title is required.');
+      return;
+    }
+    setError('');
+    onSubmit({
+      title: title.trim(),
+      accountId: accountId.trim() || null,
+      learnerId: learnerId.trim() || null,
+    });
+  };
+
+  return (
+    <div className="card admin-card-spaced" data-testid="create-incident-dialog" role="dialog" aria-label="Create incident">
+      <div className="eyebrow">New incident</div>
+      <h4 style={{ margin: '4px 0 12px', fontSize: '0.95rem' }}>Create support incident</h4>
+      {error && <div className="feedback warn" data-testid="create-incident-error">{error}</div>}
+      <label className="field" style={{ display: 'block', marginBottom: 8 }}>
+        <span>Title (required)</span>
+        <input
+          className="input"
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          maxLength={300}
+          data-testid="create-incident-title"
+          placeholder="Brief description of the issue"
+        />
+      </label>
+      <label className="field" style={{ display: 'block', marginBottom: 8 }}>
+        <span>Account ID (optional)</span>
+        <input
+          className="input"
+          type="text"
+          value={accountId}
+          onChange={(e) => setAccountId(e.target.value)}
+          data-testid="create-incident-account"
+          placeholder="acct-xxxx"
+        />
+      </label>
+      <label className="field" style={{ display: 'block', marginBottom: 8 }}>
+        <span>Learner ID (optional)</span>
+        <input
+          className="input"
+          type="text"
+          value={learnerId}
+          onChange={(e) => setLearnerId(e.target.value)}
+          data-testid="create-incident-learner"
+          placeholder="learner-xxxx"
+        />
+      </label>
+      <div style={{ display: 'flex', gap: 8 }}>
+        <button className="btn" type="button" onClick={handleSubmit} data-testid="create-incident-submit">Create</button>
+        <button className="btn secondary" type="button" onClick={onCancel}>Cancel</button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// IncidentNoteForm
+// ---------------------------------------------------------------------------
+
+function IncidentNoteForm({ onSubmit }) {
+  const [noteText, setNoteText] = React.useState('');
+  const [audience, setAudience] = React.useState('admin_only');
+
+  const handleSubmit = () => {
+    if (!noteText.trim()) return;
+    onSubmit({ noteText: noteText.trim(), audience });
+    setNoteText('');
+  };
+
+  return (
+    <div style={{ marginTop: 12, padding: '8px 0', borderTop: '1px solid #e5e7eb' }} data-testid="incident-note-form">
+      <label className="field" style={{ display: 'block', marginBottom: 8 }}>
+        <span>Add note</span>
+        <textarea
+          className="input"
+          value={noteText}
+          onChange={(e) => setNoteText(e.target.value)}
+          rows={2}
+          maxLength={8000}
+          placeholder="Internal note..."
+          data-testid="incident-note-text"
+        />
+      </label>
+      <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+        <select
+          className="select"
+          value={audience}
+          onChange={(e) => setAudience(e.target.value)}
+          data-testid="incident-note-audience"
+        >
+          <option value="admin_only">Admin only</option>
+          <option value="ops_safe">Ops safe</option>
+        </select>
+        <button className="btn secondary" type="button" onClick={handleSubmit} data-testid="incident-note-submit">Add note</button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// IncidentDetailDrawer
+// ---------------------------------------------------------------------------
+
+function IncidentDetailDrawer({ detail, onClose, onStatusChange, onAddNote }) {
+  const [pendingStatus, setPendingStatus] = React.useState(null);
+  const [confirmAction, setConfirmAction] = React.useState(null);
+
+  if (!detail) return null;
+
+  const handleStatusSelect = (newStatus) => {
+    // Check if this requires confirmation
+    const actionKey = newStatus === 'resolved' ? 'incident-resolve' : newStatus === 'ignored' ? 'incident-ignore' : 'incident-status-change';
+    const classification = classifyAction(actionKey, { targetLabel: detail.title });
+
+    if (classification.requiresConfirmation) {
+      setPendingStatus(newStatus);
+      setConfirmAction(classification);
+    } else {
+      onStatusChange(newStatus);
+    }
+  };
+
+  const handleConfirm = async () => {
+    if (pendingStatus) {
+      onStatusChange(pendingStatus);
+    }
+    setPendingStatus(null);
+    setConfirmAction(null);
+  };
+
+  const handleCancelConfirm = () => {
+    setPendingStatus(null);
+    setConfirmAction(null);
+  };
+
+  return (
+    <div className="card admin-card-spaced" data-testid="incident-detail-drawer">
+      <div className="card-header">
+        <div>
+          <div className="eyebrow">Incident detail</div>
+          <h3 className="section-title admin-section-title">{detail.title}</h3>
+          <div className="small muted">
+            Created {formatTimestamp(detail.createdAt)}
+            {detail.accountId && ` · Account: ${detail.accountId}`}
+          </div>
+        </div>
+        <div className="actions">
+          <IncidentStatusBadge status={detail.status} />
+          <button className="btn secondary" type="button" onClick={onClose}>Close</button>
+        </div>
+      </div>
+
+      {/* Status transitions */}
+      {detail.transitions.length > 0 && (
+        <div style={{ margin: '12px 0' }} data-testid="incident-status-transitions">
+          <span className="small" style={{ marginRight: 8 }}>Change status:</span>
+          {detail.transitions.map((t) => {
+            const display = formatIncidentStatus(t);
+            return (
+              <button
+                key={t}
+                className="btn ghost"
+                type="button"
+                style={{ marginRight: 4, fontSize: '0.8rem' }}
+                onClick={() => handleStatusSelect(t)}
+                data-testid={`transition-${t}`}
+              >
+                {display.label}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Confirmation overlay */}
+      {confirmAction && (
+        <AdminConfirmAction
+          level={confirmAction.level}
+          dangerCopy={confirmAction.dangerCopy}
+          targetDisplay={confirmAction.targetDisplay || detail.title}
+          onConfirm={handleConfirm}
+          onCancel={handleCancelConfirm}
+        />
+      )}
+
+      {/* Notes */}
+      <div style={{ marginTop: 12 }}>
+        <div className="eyebrow">Notes ({detail.notes.length})</div>
+        {detail.notes.length > 0 ? detail.notes.map((note) => (
+          <div key={note.id} className="skill-row" data-testid="incident-note" data-audience={note.audience}>
+            <div style={{ flex: 1 }}>
+              <div>{note.noteText}</div>
+              <div className="small muted">{formatTimestamp(note.createdAt)} · {note.authorId}</div>
+            </div>
+            <span
+              className="chip"
+              data-testid="note-audience-badge"
+              style={{
+                backgroundColor: note.audience === 'admin_only' ? '#dc2626' : '#0284c7',
+                color: '#fff',
+                fontSize: '0.7rem',
+              }}
+            >
+              {note.audienceLabel}
+            </span>
+          </div>
+        )) : <p className="small muted">No notes yet.</p>}
+        <IncidentNoteForm onSubmit={onAddNote} />
+      </div>
+
+      {/* Linked evidence */}
+      <div style={{ marginTop: 12 }}>
+        <div className="eyebrow">Linked evidence ({detail.links.length})</div>
+        {detail.links.length > 0 ? detail.links.map((link) => (
+          <div key={link.id} className="skill-row" data-testid="incident-link">
+            <div>
+              <strong>{link.linkType}</strong>
+              <div className="small muted">{link.linkTargetId}</div>
+            </div>
+            <div className="small muted">{formatTimestamp(link.createdAt)}</div>
+          </div>
+        )) : <p className="small muted" data-testid="incident-no-links">No linked evidence.</p>}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// AdminIncidentPanel (main export)
+// ---------------------------------------------------------------------------
+
+export function AdminIncidentPanel({ actions }) {
+  const [incidents, setIncidents] = React.useState(null);
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState(null);
+  const [refreshedAt, setRefreshedAt] = React.useState(null);
+  const [filter, setFilter] = React.useState('all');
+  const [showCreate, setShowCreate] = React.useState(false);
+  const [selectedDetail, setSelectedDetail] = React.useState(null);
+  const fetchGenRef = React.useRef(0);
+
+  const fetchIncidents = React.useCallback(async (statusFilter) => {
+    const generation = ++fetchGenRef.current;
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams();
+      if (statusFilter && statusFilter !== 'all') {
+        params.set('status', statusFilter);
+      }
+      const url = `/api/admin/incidents${params.toString() ? `?${params}` : ''}`;
+      const resp = await fetch(url);
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      const json = await resp.json();
+      if (generation !== fetchGenRef.current) return;
+      setIncidents(json);
+      setRefreshedAt(Date.now());
+    } catch (err) {
+      if (generation !== fetchGenRef.current) return;
+      setError({ message: err.message || 'Error loading incidents' });
+    } finally {
+      if (generation === fetchGenRef.current) {
+        setLoading(false);
+      }
+    }
+  }, []);
+
+  React.useEffect(() => {
+    fetchIncidents(filter);
+  }, [fetchIncidents, filter]);
+
+  const handleFilterChange = (newFilter) => {
+    setFilter(newFilter);
+    setSelectedDetail(null);
+    setShowCreate(false);
+  };
+
+  const handleCreate = async (data) => {
+    try {
+      const resp = await fetch('/api/admin/incidents', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      setShowCreate(false);
+      fetchIncidents(filter);
+    } catch (err) {
+      setError({ message: err.message || 'Failed to create incident' });
+    }
+  };
+
+  const handleSelectIncident = async (incidentId) => {
+    try {
+      const resp = await fetch(`/api/admin/incidents?id=${encodeURIComponent(incidentId)}`);
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      const json = await resp.json();
+      const model = buildIncidentDetailModel(json);
+      setSelectedDetail(model);
+    } catch (err) {
+      setError({ message: err.message || 'Failed to load incident detail' });
+    }
+  };
+
+  const handleStatusChange = async (newStatus) => {
+    if (!selectedDetail) return;
+    try {
+      const resp = await fetch('/api/admin/incidents/status', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          id: selectedDetail.id,
+          status: newStatus,
+          rowVersion: selectedDetail.rowVersion,
+        }),
+      });
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      // Reload detail
+      handleSelectIncident(selectedDetail.id);
+      fetchIncidents(filter);
+    } catch (err) {
+      setError({ message: err.message || 'Failed to update status' });
+    }
+  };
+
+  const handleAddNote = async ({ noteText, audience }) => {
+    if (!selectedDetail) return;
+    try {
+      const resp = await fetch('/api/admin/incidents/notes', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          incidentId: selectedDetail.id,
+          noteText,
+          audience,
+        }),
+      });
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      // Reload detail
+      handleSelectIncident(selectedDetail.id);
+    } catch (err) {
+      setError({ message: err.message || 'Failed to add note' });
+    }
+  };
+
+  const model = buildIncidentListModel(incidents);
+
+  if (selectedDetail) {
+    return (
+      <IncidentDetailDrawer
+        detail={selectedDetail}
+        onClose={() => setSelectedDetail(null)}
+        onStatusChange={handleStatusChange}
+        onAddNote={handleAddNote}
+      />
+    );
+  }
+
+  if (showCreate) {
+    return (
+      <CreateIncidentDialog
+        onSubmit={handleCreate}
+        onCancel={() => setShowCreate(false)}
+      />
+    );
+  }
+
+  return (
+    <AdminPanelFrame
+      eyebrow="Support"
+      title="Incidents"
+      subtitle="Track, triage, and resolve parent support incidents."
+      refreshedAt={refreshedAt}
+      refreshError={error}
+      onRefresh={() => fetchIncidents(filter)}
+      data={model.hasData ? model.incidents : null}
+      loading={loading}
+      emptyState={<p className="small muted" data-testid="incident-empty-state">No support incidents</p>}
+    >
+      {/* Filter tabs */}
+      <div style={{ display: 'flex', gap: 4, marginBottom: 12, flexWrap: 'wrap' }} data-testid="incident-filter-tabs">
+        {FILTER_TABS.map((tab) => (
+          <button
+            key={tab.key}
+            className={`btn ${filter === tab.key ? '' : 'ghost'}`}
+            type="button"
+            style={{ fontSize: '0.8rem' }}
+            onClick={() => handleFilterChange(tab.key)}
+            data-testid={`filter-tab-${tab.key}`}
+          >
+            {tab.label}
+          </button>
+        ))}
+        <button
+          className="btn secondary"
+          type="button"
+          style={{ marginLeft: 'auto', fontSize: '0.8rem' }}
+          onClick={() => setShowCreate(true)}
+          data-testid="create-incident-btn"
+        >
+          Create incident
+        </button>
+      </div>
+
+      {/* Incident list */}
+      {model.incidents.map((inc) => (
+        <IncidentRow key={inc.id} incident={inc} onSelect={handleSelectIncident} />
+      ))}
+    </AdminPanelFrame>
+  );
+}

--- a/tests/react-admin-incident-panel.test.js
+++ b/tests/react-admin-incident-panel.test.js
@@ -1,0 +1,338 @@
+// P7 U7: Admin Incident Panel — unit tests.
+//
+// Validates:
+//   1. Incident list model builds with status badges
+//   2. Empty state produces correct message
+//   3. Status transitions computed correctly
+//   4. Create form validates required title
+//   5. Detail view model includes notes with audience
+//   6. Linked evidence shows empty state when no links
+//   7. Action classification for incident actions
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildIncidentListModel,
+  buildIncidentDetailModel,
+  formatIncidentStatus,
+  getStatusTransitions,
+  STATUS_CONFIG,
+  VALID_TRANSITIONS,
+  NOTE_AUDIENCE_LABELS,
+} from '../src/platform/hubs/admin-incident-panel.js';
+
+import {
+  classifyAction,
+  LEVELS,
+} from '../src/platform/hubs/admin-action-classification.js';
+
+// =================================================================
+// 1. Incident list renders with status badges
+// =================================================================
+
+describe('buildIncidentListModel', () => {
+  it('transforms API response into display model with status labels and colours', () => {
+    const data = {
+      incidents: [
+        { id: 'inc-1', title: 'Login issue', status: 'open', createdAt: 1000, updatedAt: 2000, accountId: 'acct-1' },
+        { id: 'inc-2', title: 'Payment query', status: 'investigating', createdAt: 3000, updatedAt: 4000 },
+      ],
+    };
+
+    const model = buildIncidentListModel(data);
+
+    assert.equal(model.hasData, true);
+    assert.equal(model.incidents.length, 2);
+
+    assert.equal(model.incidents[0].id, 'inc-1');
+    assert.equal(model.incidents[0].statusLabel, 'Open');
+    assert.equal(model.incidents[0].statusColour, '#d97706');
+    assert.equal(model.incidents[0].accountId, 'acct-1');
+
+    assert.equal(model.incidents[1].id, 'inc-2');
+    assert.equal(model.incidents[1].statusLabel, 'Investigating');
+    assert.equal(model.incidents[1].statusColour, '#2563eb');
+  });
+
+  it('handles all defined statuses', () => {
+    const statuses = ['open', 'investigating', 'waiting_on_parent', 'resolved', 'ignored'];
+    for (const status of statuses) {
+      const result = formatIncidentStatus(status);
+      assert.ok(result.label, `missing label for ${status}`);
+      assert.ok(result.colour, `missing colour for ${status}`);
+    }
+  });
+
+  it('returns unknown label for undefined status', () => {
+    const result = formatIncidentStatus('nonexistent');
+    assert.equal(result.label, 'nonexistent');
+    assert.equal(result.colour, '#6b7280');
+  });
+});
+
+// =================================================================
+// 2. Empty state shows "No support incidents"
+// =================================================================
+
+describe('buildIncidentListModel — empty state', () => {
+  it('returns hasData=false when incidents array is empty', () => {
+    const model = buildIncidentListModel({ incidents: [] });
+    assert.equal(model.hasData, false);
+    assert.equal(model.incidents.length, 0);
+  });
+
+  it('returns hasData=false when data is null', () => {
+    const model = buildIncidentListModel(null);
+    assert.equal(model.hasData, false);
+    assert.equal(model.incidents.length, 0);
+  });
+
+  it('returns hasData=false when data is undefined', () => {
+    const model = buildIncidentListModel(undefined);
+    assert.equal(model.hasData, false);
+    assert.equal(model.incidents.length, 0);
+  });
+
+  it('returns hasData=false when incidents field is not an array', () => {
+    const model = buildIncidentListModel({ incidents: 'bad' });
+    assert.equal(model.hasData, false);
+  });
+});
+
+// =================================================================
+// 3. Status transitions: valid next states computed correctly
+// =================================================================
+
+describe('getStatusTransitions', () => {
+  it('open → investigating, resolved, ignored', () => {
+    const transitions = getStatusTransitions('open');
+    assert.deepEqual(transitions, ['investigating', 'resolved', 'ignored']);
+  });
+
+  it('investigating → waiting_on_parent, resolved, ignored', () => {
+    const transitions = getStatusTransitions('investigating');
+    assert.deepEqual(transitions, ['waiting_on_parent', 'resolved', 'ignored']);
+  });
+
+  it('waiting_on_parent → resolved, ignored', () => {
+    const transitions = getStatusTransitions('waiting_on_parent');
+    assert.deepEqual(transitions, ['resolved', 'ignored']);
+  });
+
+  it('resolved has no transitions (terminal)', () => {
+    const transitions = getStatusTransitions('resolved');
+    assert.deepEqual(transitions, []);
+  });
+
+  it('ignored has no transitions (terminal)', () => {
+    const transitions = getStatusTransitions('ignored');
+    assert.deepEqual(transitions, []);
+  });
+
+  it('unknown status has no transitions', () => {
+    const transitions = getStatusTransitions('nonexistent');
+    assert.deepEqual(transitions, []);
+  });
+});
+
+// =================================================================
+// 4. Create form validates required title (platform-level validation)
+// =================================================================
+
+describe('buildIncidentListModel — title handling', () => {
+  it('uses (untitled) for incidents with empty title', () => {
+    const model = buildIncidentListModel({
+      incidents: [{ id: 'inc-no-title', title: '', status: 'open', createdAt: 0 }],
+    });
+    assert.equal(model.incidents[0].title, '(untitled)');
+  });
+
+  it('uses (untitled) for incidents with null title', () => {
+    const model = buildIncidentListModel({
+      incidents: [{ id: 'inc-null-title', title: null, status: 'open', createdAt: 0 }],
+    });
+    assert.equal(model.incidents[0].title, '(untitled)');
+  });
+
+  it('preserves valid title', () => {
+    const model = buildIncidentListModel({
+      incidents: [{ id: 'inc-title', title: 'Parent cannot log in', status: 'open', createdAt: 0 }],
+    });
+    assert.equal(model.incidents[0].title, 'Parent cannot log in');
+  });
+});
+
+// =================================================================
+// 5. Detail view shows notes with audience badges
+// =================================================================
+
+describe('buildIncidentDetailModel — notes with audience', () => {
+  it('transforms notes with audience labels', () => {
+    const data = {
+      incident: { id: 'inc-1', title: 'Test', status: 'open', createdAt: 1000 },
+      notes: [
+        { id: 'n-1', authorId: 'admin-1', noteText: 'Internal note', audience: 'admin_only', createdAt: 2000 },
+        { id: 'n-2', authorId: 'admin-2', noteText: 'Ops note', audience: 'ops_safe', createdAt: 3000 },
+      ],
+      links: [],
+    };
+
+    const model = buildIncidentDetailModel(data);
+
+    assert.equal(model.notes.length, 2);
+    assert.equal(model.notes[0].audienceLabel, 'Admin only');
+    assert.equal(model.notes[0].audience, 'admin_only');
+    assert.equal(model.notes[1].audienceLabel, 'Ops safe');
+    assert.equal(model.notes[1].audience, 'ops_safe');
+  });
+
+  it('returns null for null input', () => {
+    const model = buildIncidentDetailModel(null);
+    assert.equal(model, null);
+  });
+
+  it('returns null when incident is missing', () => {
+    const model = buildIncidentDetailModel({ notes: [], links: [] });
+    assert.equal(model, null);
+  });
+
+  it('includes transitions for active statuses', () => {
+    const data = {
+      incident: { id: 'inc-1', title: 'Test', status: 'investigating', createdAt: 1000 },
+      notes: [],
+      links: [],
+    };
+    const model = buildIncidentDetailModel(data);
+    assert.deepEqual(model.transitions, ['waiting_on_parent', 'resolved', 'ignored']);
+  });
+
+  it('includes empty transitions for terminal statuses', () => {
+    const data = {
+      incident: { id: 'inc-1', title: 'Test', status: 'resolved', createdAt: 1000 },
+      notes: [],
+      links: [],
+    };
+    const model = buildIncidentDetailModel(data);
+    assert.deepEqual(model.transitions, []);
+  });
+});
+
+// =================================================================
+// 6. Linked evidence shows empty when no links / "Evidence unavailable" when deleted
+// =================================================================
+
+describe('buildIncidentDetailModel — linked evidence', () => {
+  it('returns empty links array when no links provided', () => {
+    const data = {
+      incident: { id: 'inc-1', title: 'Test', status: 'open', createdAt: 1000 },
+      notes: [],
+      links: [],
+    };
+    const model = buildIncidentDetailModel(data);
+    assert.equal(model.links.length, 0);
+  });
+
+  it('transforms links with type and target', () => {
+    const data = {
+      incident: { id: 'inc-1', title: 'Test', status: 'open', createdAt: 1000 },
+      notes: [],
+      links: [
+        { id: 'l-1', linkType: 'error_event', linkTargetId: 'evt-123', createdAt: 5000 },
+        { id: 'l-2', linkType: 'account', linkTargetId: 'acct-456', createdAt: 6000 },
+      ],
+    };
+    const model = buildIncidentDetailModel(data);
+    assert.equal(model.links.length, 2);
+    assert.equal(model.links[0].linkType, 'error_event');
+    assert.equal(model.links[0].linkTargetId, 'evt-123');
+    assert.equal(model.links[1].linkType, 'account');
+    assert.equal(model.links[1].linkTargetId, 'acct-456');
+  });
+
+  it('handles missing links field gracefully', () => {
+    const data = {
+      incident: { id: 'inc-1', title: 'Test', status: 'open', createdAt: 1000 },
+      notes: [],
+    };
+    const model = buildIncidentDetailModel(data);
+    assert.equal(model.links.length, 0);
+  });
+});
+
+// =================================================================
+// 7. Action classification: incident actions
+// =================================================================
+
+describe('incident action classification', () => {
+  it('incident-create is medium (no confirmation)', () => {
+    const result = classifyAction('incident-create');
+    assert.equal(result.level, LEVELS.medium);
+    assert.equal(result.requiresConfirmation, false);
+  });
+
+  it('incident-status-change is medium (no confirmation)', () => {
+    const result = classifyAction('incident-status-change');
+    assert.equal(result.level, LEVELS.medium);
+    assert.equal(result.requiresConfirmation, false);
+  });
+
+  it('incident-resolve is high (requires confirmation)', () => {
+    const result = classifyAction('incident-resolve', { targetLabel: 'Login issue' });
+    assert.equal(result.level, LEVELS.high);
+    assert.equal(result.requiresConfirmation, true);
+    assert.equal(result.requiresTypedTarget, false);
+    assert.equal(result.targetDisplay, 'Login issue');
+    assert.ok(result.dangerCopy);
+  });
+
+  it('incident-ignore is high (requires confirmation)', () => {
+    const result = classifyAction('incident-ignore', { targetId: 'inc-123' });
+    assert.equal(result.level, LEVELS.high);
+    assert.equal(result.requiresConfirmation, true);
+    assert.equal(result.targetDisplay, 'inc-123');
+  });
+});
+
+// =================================================================
+// 8. STATUS_CONFIG completeness
+// =================================================================
+
+describe('STATUS_CONFIG', () => {
+  it('covers all five statuses', () => {
+    const expected = ['open', 'investigating', 'waiting_on_parent', 'resolved', 'ignored'];
+    for (const s of expected) {
+      assert.ok(STATUS_CONFIG[s], `STATUS_CONFIG missing ${s}`);
+      assert.ok(STATUS_CONFIG[s].label);
+      assert.ok(STATUS_CONFIG[s].colour);
+    }
+  });
+});
+
+// =================================================================
+// 9. NOTE_AUDIENCE_LABELS completeness
+// =================================================================
+
+describe('NOTE_AUDIENCE_LABELS', () => {
+  it('has labels for both audiences', () => {
+    assert.equal(NOTE_AUDIENCE_LABELS.admin_only, 'Admin only');
+    assert.equal(NOTE_AUDIENCE_LABELS.ops_safe, 'Ops safe');
+  });
+});
+
+// =================================================================
+// 10. VALID_TRANSITIONS completeness
+// =================================================================
+
+describe('VALID_TRANSITIONS', () => {
+  it('has entries for open, investigating, waiting_on_parent', () => {
+    assert.ok(VALID_TRANSITIONS.has('open'));
+    assert.ok(VALID_TRANSITIONS.has('investigating'));
+    assert.ok(VALID_TRANSITIONS.has('waiting_on_parent'));
+  });
+
+  it('does not have entries for terminal statuses', () => {
+    assert.equal(VALID_TRANSITIONS.has('resolved'), false);
+    assert.equal(VALID_TRANSITIONS.has('ignored'), false);
+  });
+});


### PR DESCRIPTION
## Summary
- Incident list panel with status filters, create dialog, detail drawer
- Account detail shows open incident count and recent incidents
- Debug Bundle gains admin-only linkedIncidents extension
- Action classification: resolve/ignore require confirmation
- Cross-section navigation via incident-flow stash

## Test plan
- [x] Incident list renders with status badges
- [x] Empty state shows 'No support incidents'
- [x] Status transitions computed correctly
- [x] Resolve action requires confirmation
- [x] Debug Bundle includes linked incidents for admin
- [x] Cross-section navigation preserves context