### PR TITLE
feat(grammar-qg): P7 Wave 3 — action candidates, decision gates

### DIFF
--- a/scripts/grammar-qg-action-candidates.mjs
+++ b/scripts/grammar-qg-action-candidates.mjs
@@ -1,0 +1,366 @@
+#!/usr/bin/env node
+/**
+ * Grammar QG P7 — Evidence-led Action Candidate Generation (U5)
+ *
+ * CLI: node scripts/grammar-qg-action-candidates.mjs
+ *        --health=<health.json> --mixed-transfer=<mt.json>
+ *        --retention=<retention.json> --output=<output.json>
+ *        [--output-md=<output.md>]
+ *
+ * Or: import { generateActionCandidates } from './grammar-qg-action-candidates.mjs'
+ *
+ * Classifies each template/concept into one of 9 action categories based on
+ * evidence from health, mixed-transfer, and retention reports.
+ *
+ * Analysis-only script — does not import or invoke any write/mutation modules.
+ */
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const CONFIDENCE_THRESHOLD = 30; // non-keep candidates require ≥30 attempts
+
+const CATEGORIES = {
+  KEEP: 'keep',
+  WARM_UP_ONLY: 'warm_up_only',
+  REVIEW_WORDING: 'review_wording',
+  ADD_BRIDGE_PRACTICE: 'add_bridge_practice',
+  EXPAND_CASE_BANK: 'expand_case_bank',
+  REWRITE_DISTRACTORS: 'rewrite_distractors',
+  REDUCE_SCHEDULER_WEIGHT: 'reduce_scheduler_weight',
+  RETIRE_CANDIDATE: 'retire_candidate',
+  INCREASE_MAINTENANCE: 'increase_maintenance',
+  INSUFFICIENT_DATA: 'insufficient_data',
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function safeRate(numerator, denominator) {
+  return denominator > 0 ? numerator / denominator : 0;
+}
+
+function confidenceLevel(count) {
+  if (count > 100) return 'high';
+  if (count >= 30) return 'medium';
+  if (count >= 10) return 'low';
+  return 'insufficient';
+}
+
+// ─── Classification logic ─────────────────────────────────────────────────────
+
+/**
+ * Classify a single template into an action category.
+ *
+ * @param {string} templateId
+ * @param {Object} healthMetrics - From health report templates[templateId]
+ * @param {Object|null} mixedTransferMetrics - From mixed-transfer report templates[templateId]
+ * @param {Object} conceptRetentionFlags - Map of conceptId→retentionGapFlagged
+ * @returns {Object} Action candidate
+ */
+function classifyTemplate(templateId, healthMetrics, mixedTransferMetrics, conceptRetentionFlags) {
+  const attemptCount = healthMetrics.attemptCount || 0;
+  const confidence = confidenceLevel(attemptCount);
+  const conceptId = healthMetrics.conceptId || templateId.split('-').slice(1, -1).join('-') || templateId;
+
+  // Base candidate structure
+  const base = {
+    templateId,
+    conceptId,
+    confidence,
+    evidenceCount: attemptCount,
+    sourceMetrics: {
+      classification: healthMetrics.classification,
+      attemptCount,
+      independentFirstAttemptSuccessRate: healthMetrics.independentFirstAttemptSuccessRate,
+      wrongAfterSupportRate: healthMetrics.wrongAfterSupportRate,
+      retrySuccessRate: healthMetrics.retrySuccessRate,
+      retryAttemptCount: healthMetrics.retryAttemptCount,
+      medianElapsedBucket: healthMetrics.medianElapsedBucket,
+    },
+  };
+
+  // Below confidence threshold → always insufficient_data (never non-keep)
+  if (attemptCount < CONFIDENCE_THRESHOLD) {
+    return {
+      ...base,
+      category: CATEGORIES.INSUFFICIENT_DATA,
+      rationale: `Only ${attemptCount} attempts recorded — below the ${CONFIDENCE_THRESHOLD}-attempt confidence threshold for action classification.`,
+    };
+  }
+
+  // 1. too_easy with high confidence (>95% success, >100 attempts) → warm_up_only
+  if (
+    healthMetrics.classification === 'too_easy' &&
+    attemptCount > 100 &&
+    healthMetrics.independentFirstAttemptSuccessRate > 0.95
+  ) {
+    return {
+      ...base,
+      category: CATEGORIES.WARM_UP_ONLY,
+      rationale: `Template classified as too_easy with ${(healthMetrics.independentFirstAttemptSuccessRate * 100).toFixed(1)}% independent success across ${attemptCount} attempts. Consider as warm-up only.`,
+    };
+  }
+
+  // 2. ambiguous classification OR high wrongAfterSupportRate (>40%) → review_wording
+  if (
+    healthMetrics.classification === 'ambiguous' ||
+    healthMetrics.wrongAfterSupportRate > 0.4
+  ) {
+    return {
+      ...base,
+      category: CATEGORIES.REVIEW_WORDING,
+      rationale: `Template flagged as ${healthMetrics.classification} with wrongAfterSupportRate=${(healthMetrics.wrongAfterSupportRate * 100).toFixed(1)}%. Wording review recommended.`,
+    };
+  }
+
+  // 3. transfer_gap flagged (local healthy, mixed weak) → add_bridge_practice
+  if (mixedTransferMetrics && mixedTransferMetrics.transferGapFlagged) {
+    return {
+      ...base,
+      category: CATEGORIES.ADD_BRIDGE_PRACTICE,
+      rationale: `Transfer gap detected: local success healthy but mixed-transfer success significantly lower (${(mixedTransferMetrics.successRate * 100).toFixed(1)}%). Bridge practice needed.`,
+    };
+  }
+
+  // 4. support_dependent + >100 attempts → retire_candidate
+  if (healthMetrics.classification === 'support_dependent' && attemptCount > 100) {
+    return {
+      ...base,
+      category: CATEGORIES.RETIRE_CANDIDATE,
+      rationale: `Persistently support_dependent after ${attemptCount} attempts. Template cannot be answered independently — retirement candidate.`,
+    };
+  }
+
+  // 5. retry_ineffective + >100 attempts → retire_candidate
+  if (healthMetrics.classification === 'retry_ineffective' && attemptCount > 100) {
+    return {
+      ...base,
+      category: CATEGORIES.RETIRE_CANDIDATE,
+      rationale: `Retry ineffective after ${attemptCount} attempts (retry success rate ${(healthMetrics.retrySuccessRate * 100).toFixed(1)}%). Retirement candidate.`,
+    };
+  }
+
+  // 6. rewrite_distractors — emit if tagged as support_dependent (proxy for distractor clustering)
+  if (healthMetrics.classification === 'support_dependent' && attemptCount <= 100) {
+    return {
+      ...base,
+      category: CATEGORIES.REWRITE_DISTRACTORS,
+      rationale: `Support-dependent classification suggests distractor issues — learners cannot succeed independently. Distractor rewrite recommended.`,
+    };
+  }
+
+  // 7. too_hard with high confidence → reduce_scheduler_weight
+  if (healthMetrics.classification === 'too_hard') {
+    return {
+      ...base,
+      category: CATEGORIES.REDUCE_SCHEDULER_WEIGHT,
+      rationale: `Template classified as too_hard (independent success ${(healthMetrics.independentFirstAttemptSuccessRate * 100).toFixed(1)}%) with ${confidence} confidence. Scheduler weight reduction recommended.`,
+    };
+  }
+
+  // 8. high use + retry rate >30% OR timing collapse (median >20s with >50 attempts) → expand_case_bank
+  const retryRate = safeRate(healthMetrics.retryAttemptCount, attemptCount);
+  if (
+    (attemptCount > 50 && retryRate > 0.3) ||
+    (healthMetrics.medianElapsedBucket === '>20s' && attemptCount > 50)
+  ) {
+    return {
+      ...base,
+      category: CATEGORIES.EXPAND_CASE_BANK,
+      rationale: `High retry rate (${(retryRate * 100).toFixed(1)}%) or timing collapse (${healthMetrics.medianElapsedBucket}) across ${attemptCount} attempts. Case bank expansion needed.`,
+    };
+  }
+
+  // 9. retention_gap for associated concept → increase_maintenance
+  if (conceptRetentionFlags[conceptId]) {
+    return {
+      ...base,
+      category: CATEGORIES.INCREASE_MAINTENANCE,
+      rationale: `Concept "${conceptId}" flagged with retention gap (lapse rate >${conceptRetentionFlags[conceptId].lapseRate ? (conceptRetentionFlags[conceptId].lapseRate * 100).toFixed(0) : '25'}%). Increased maintenance scheduling recommended.`,
+    };
+  }
+
+  // Default: healthy and stable → keep
+  return {
+    ...base,
+    category: CATEGORIES.KEEP,
+    rationale: `Template healthy and stable with ${confidence} confidence. No action required.`,
+  };
+}
+
+// ─── Main generation function ─────────────────────────────────────────────────
+
+/**
+ * Generate action candidates from calibration sub-reports.
+ *
+ * @param {Object} healthReport - Output from buildTemplateHealthReport
+ * @param {Object} mixedTransferReport - Output from buildMixedTransferCalibration
+ * @param {Object} retentionReport - Output from buildRetentionReport
+ * @returns {{ candidates: Object[], summary: Object }}
+ */
+export function generateActionCandidates(healthReport, mixedTransferReport, retentionReport) {
+  const candidates = [];
+
+  // Build retention gap flags from retention report
+  const conceptRetentionFlags = {};
+  if (retentionReport && retentionReport.concepts) {
+    for (const [cid, concept] of Object.entries(retentionReport.concepts)) {
+      if (concept.classification === 'retention_risk' || concept.lapseRate > 0.25) {
+        conceptRetentionFlags[cid] = {
+          lapseRate: concept.lapseRate,
+          securedAttempts: concept.securedAttemptCount,
+        };
+      }
+    }
+  }
+
+  // Build mixed-transfer flags
+  const mixedTransferFlags = {};
+  if (mixedTransferReport && mixedTransferReport.templates) {
+    for (const [tid, tmpl] of Object.entries(mixedTransferReport.templates)) {
+      // Transfer gap: local success healthy but mixed success significantly lower
+      if (
+        tmpl.conceptLocalSuccessRate > 0.7 &&
+        tmpl.successRate < 0.5 &&
+        tmpl.attemptCount >= 10
+      ) {
+        mixedTransferFlags[tid] = { ...tmpl, transferGapFlagged: true };
+      } else {
+        mixedTransferFlags[tid] = tmpl;
+      }
+    }
+  }
+
+  // Process each template from health report
+  if (healthReport && healthReport.templates) {
+    for (const [tid, metrics] of Object.entries(healthReport.templates)) {
+      const mtMetrics = mixedTransferFlags[tid] || null;
+      const candidate = classifyTemplate(tid, metrics, mtMetrics, conceptRetentionFlags);
+      candidates.push(candidate);
+    }
+  }
+
+  // Process concept-level retention gaps not covered by templates
+  for (const [cid, retFlag] of Object.entries(conceptRetentionFlags)) {
+    const alreadyCovered = candidates.some(
+      (c) => c.conceptId === cid && c.category === CATEGORIES.INCREASE_MAINTENANCE,
+    );
+    if (!alreadyCovered) {
+      candidates.push({
+        templateId: `concept:${cid}`,
+        conceptId: cid,
+        category: CATEGORIES.INCREASE_MAINTENANCE,
+        confidence: retFlag.securedAttempts > 100 ? 'high' : retFlag.securedAttempts >= 30 ? 'medium' : 'low',
+        evidenceCount: retFlag.securedAttempts,
+        rationale: `Concept "${cid}" has retention gap with lapse rate ${(retFlag.lapseRate * 100).toFixed(1)}% across ${retFlag.securedAttempts} secured attempts.`,
+        sourceMetrics: { lapseRate: retFlag.lapseRate, securedAttempts: retFlag.securedAttempts },
+      });
+    }
+  }
+
+  // Summary statistics
+  const categoryCounts = {};
+  for (const c of candidates) {
+    categoryCounts[c.category] = (categoryCounts[c.category] || 0) + 1;
+  }
+
+  return {
+    candidates,
+    summary: {
+      totalCandidates: candidates.length,
+      categoryCounts,
+      actionableCount: candidates.filter(
+        (c) => c.category !== CATEGORIES.KEEP && c.category !== CATEGORIES.INSUFFICIENT_DATA,
+      ).length,
+      generatedAt: new Date().toISOString(),
+    },
+  };
+}
+
+// ─── Markdown formatting ──────────────────────────────────────────────────────
+
+function formatMarkdown(result) {
+  const lines = [
+    '# Grammar QG P7 — Action Candidates Report',
+    '',
+    `Generated: ${result.summary.generatedAt}`,
+    `Total candidates: ${result.summary.totalCandidates}`,
+    `Actionable (non-keep, non-insufficient): ${result.summary.actionableCount}`,
+    '',
+    '## Category Breakdown',
+    '',
+  ];
+
+  for (const [cat, count] of Object.entries(result.summary.categoryCounts).sort((a, b) => b[1] - a[1])) {
+    lines.push(`- **${cat}**: ${count}`);
+  }
+
+  lines.push('', '## Actionable Candidates', '', '| Template | Category | Confidence | Evidence | Rationale |');
+  lines.push('|---|---|---|---|---|');
+
+  for (const c of result.candidates) {
+    if (c.category === CATEGORIES.KEEP || c.category === CATEGORIES.INSUFFICIENT_DATA) continue;
+    lines.push(`| ${c.templateId} | ${c.category} | ${c.confidence} | ${c.evidenceCount} | ${c.rationale} |`);
+  }
+
+  return lines.join('\n');
+}
+
+// ─── CLI ──────────────────────────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const args = {};
+  for (const arg of argv) {
+    if (arg.startsWith('--')) {
+      const eqIdx = arg.indexOf('=');
+      if (eqIdx !== -1) {
+        args[arg.slice(2, eqIdx)] = arg.slice(eqIdx + 1);
+      } else {
+        args[arg.slice(2)] = true;
+      }
+    }
+  }
+  return args;
+}
+
+const isMainModule =
+  typeof process !== 'undefined' &&
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === path.resolve(__filename);
+
+if (isMainModule) {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (!args.health || !args['mixed-transfer'] || !args.retention || !args.output) {
+    console.error(
+      'Usage: grammar-qg-action-candidates.mjs --health=<health.json> --mixed-transfer=<mt.json> --retention=<retention.json> --output=<output.json> [--output-md=<output.md>]',
+    );
+    process.exit(1);
+  }
+
+  const healthReport = JSON.parse(readFileSync(path.resolve(args.health), 'utf-8'));
+  const mixedTransferReport = JSON.parse(readFileSync(path.resolve(args['mixed-transfer']), 'utf-8'));
+  const retentionReport = JSON.parse(readFileSync(path.resolve(args.retention), 'utf-8'));
+
+  const result = generateActionCandidates(healthReport, mixedTransferReport, retentionReport);
+
+  const outputPath = path.resolve(args.output);
+  mkdirSync(path.dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, JSON.stringify(result, null, 2) + '\n');
+
+  if (args['output-md']) {
+    writeFileSync(path.resolve(args['output-md']), formatMarkdown(result) + '\n');
+  }
+
+  console.log(`Action candidates written to ${outputPath}`);
+  console.log(`  Total: ${result.summary.totalCandidates}`);
+  console.log(`  Actionable: ${result.summary.actionableCount}`);
+  for (const [cat, count] of Object.entries(result.summary.categoryCounts)) {
+    console.log(`    ${cat}: ${count}`);
+  }
+}

--- a/scripts/grammar-qg-mixed-transfer-decision.mjs
+++ b/scripts/grammar-qg-mixed-transfer-decision.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+/**
+ * Grammar QG P7 — Mixed-Transfer Evidence Decision Gate (U6)
+ *
+ * CLI: node scripts/grammar-qg-mixed-transfer-decision.mjs
+ *        --calibration=<mixed-transfer-calibration.json> --output=<decision.json>
+ *
+ * Or: import { decideMixedTransferMaturity } from './grammar-qg-mixed-transfer-decision.mjs'
+ *
+ * Decision logic:
+ * - Count how many of the mixed-transfer templates have ≥30 attempts (medium) and ≥100 (high)
+ * - If ≥6 templates at medium AND ≥3 at high → prepare_scoring_experiment
+ * - If evidence shows clear harm → do_not_promote
+ * - Otherwise → keep_shadow_only
+ *
+ * Analysis-only script — does not import or invoke any write/mutation modules.
+ */
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const MEDIUM_THRESHOLD = 30;
+const HIGH_THRESHOLD = 100;
+const MIN_MEDIUM_FOR_EXPERIMENT = 6;
+const MIN_HIGH_FOR_EXPERIMENT = 3;
+const HARM_THRESHOLD = 0.15; // mixed-transfer success must be ≥15% lower than local to flag harm
+
+// ─── Decision logic ───────────────────────────────────────────────────────────
+
+/**
+ * Decide whether mixed-transfer scoring is mature enough to promote.
+ *
+ * @param {Object} mixedTransferReport - Output from buildMixedTransferCalibration
+ * @returns {{ decision: string, perTemplateEvidence: Object[], summary: string, futureActionRef: string }}
+ */
+export function decideMixedTransferMaturity(mixedTransferReport) {
+  const templates = mixedTransferReport?.templates || {};
+  const templateIds = Object.keys(templates);
+
+  // Build per-template evidence
+  const perTemplateEvidence = [];
+  let mediumCount = 0;
+  let highCount = 0;
+  let harmfulCount = 0;
+  let highConfidenceHarmCount = 0;
+  let highConfidenceTemplates = 0;
+
+  for (const [tid, metrics] of Object.entries(templates)) {
+    const attemptCount = metrics.attemptCount || 0;
+    const successRate = metrics.successRate || 0;
+    const conceptLocalSuccessRate = metrics.conceptLocalSuccessRate || 0;
+
+    const isMedium = attemptCount >= MEDIUM_THRESHOLD;
+    const isHigh = attemptCount >= HIGH_THRESHOLD;
+    if (isMedium) mediumCount++;
+    if (isHigh) highCount++;
+
+    // Harm detection: mixed-transfer success significantly lower than local
+    const gap = conceptLocalSuccessRate - successRate;
+    const harmful = gap > HARM_THRESHOLD && isMedium;
+    if (harmful) harmfulCount++;
+    if (harmful && isHigh) {
+      highConfidenceHarmCount++;
+      highConfidenceTemplates++;
+    } else if (isHigh) {
+      highConfidenceTemplates++;
+    }
+
+    perTemplateEvidence.push({
+      templateId: tid,
+      attemptCount,
+      successRate,
+      conceptLocalSuccessRate,
+      gap: Math.round(gap * 1000) / 1000,
+      confidenceLevel: isHigh ? 'high' : isMedium ? 'medium' : 'low',
+      harmful,
+    });
+  }
+
+  // Decision logic
+  let decision;
+  let summary;
+
+  // Clear harm: majority of high-confidence templates show harm
+  if (highConfidenceTemplates > 0 && highConfidenceHarmCount / highConfidenceTemplates > 0.5) {
+    decision = 'do_not_promote';
+    summary = `Mixed-transfer shows clear harm: ${highConfidenceHarmCount}/${highConfidenceTemplates} high-confidence templates have success significantly lower than local practice. Do not promote to scored mode.`;
+  }
+  // Sufficient maturity for experiment
+  else if (mediumCount >= MIN_MEDIUM_FOR_EXPERIMENT && highCount >= MIN_HIGH_FOR_EXPERIMENT) {
+    decision = 'prepare_scoring_experiment';
+    summary = `Mixed-transfer evidence sufficient: ${mediumCount} templates at medium confidence, ${highCount} at high confidence. Ready for controlled scoring experiment.`;
+  }
+  // Insufficient evidence
+  else {
+    decision = 'keep_shadow_only';
+    summary = `Insufficient maturity: only ${mediumCount} templates at medium (need ${MIN_MEDIUM_FOR_EXPERIMENT}) and ${highCount} at high (need ${MIN_HIGH_FOR_EXPERIMENT}). Keep in shadow-only mode.`;
+  }
+
+  return {
+    decision,
+    perTemplateEvidence,
+    summary,
+    futureActionRef: 'Requires separate reviewed scoring plan',
+  };
+}
+
+// ─── CLI ──────────────────────────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const args = {};
+  for (const arg of argv) {
+    if (arg.startsWith('--')) {
+      const eqIdx = arg.indexOf('=');
+      if (eqIdx !== -1) {
+        args[arg.slice(2, eqIdx)] = arg.slice(eqIdx + 1);
+      } else {
+        args[arg.slice(2)] = true;
+      }
+    }
+  }
+  return args;
+}
+
+const isMainModule =
+  typeof process !== 'undefined' &&
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === path.resolve(__filename);
+
+if (isMainModule) {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (!args.calibration || !args.output) {
+    console.error(
+      'Usage: grammar-qg-mixed-transfer-decision.mjs --calibration=<mixed-transfer-calibration.json> --output=<decision.json>',
+    );
+    process.exit(1);
+  }
+
+  const mixedTransferReport = JSON.parse(readFileSync(path.resolve(args.calibration), 'utf-8'));
+  const result = decideMixedTransferMaturity(mixedTransferReport);
+
+  const outputPath = path.resolve(args.output);
+  mkdirSync(path.dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, JSON.stringify(result, null, 2) + '\n');
+
+  console.log(`Mixed-transfer decision: ${result.decision}`);
+  console.log(`  ${result.summary}`);
+  console.log(`  Templates analysed: ${result.perTemplateEvidence.length}`);
+}

--- a/scripts/grammar-qg-retention-decision.mjs
+++ b/scripts/grammar-qg-retention-decision.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+/**
+ * Grammar QG P7 — Retention-After-Secure Maintenance Decision Gate (U7)
+ *
+ * CLI: node scripts/grammar-qg-retention-decision.mjs
+ *        --retention=<retention-report.json> --output=<decision.json>
+ *
+ * Or: import { decideRetentionMaintenance } from './grammar-qg-retention-decision.mjs'
+ *
+ * Decision logic:
+ * - Per concept: count secured attempts, compute lapse rate, days-to-first-lapse
+ * - If average lapse rate >20% across concepts with ≥30 secured attempts → recommend_maintenance_experiment
+ * - If insufficient data (<30 secured attempts average) → defer_insufficient_data
+ * - If lapse rate <10% → no_action_needed
+ * - Template-family clustering: group lapses by generatorFamilyId, report highest lapse concentration
+ *
+ * Analysis-only script — does not import or invoke any write/mutation modules.
+ */
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const SUFFICIENT_SECURED_ATTEMPTS = 30;
+const HIGH_LAPSE_THRESHOLD = 0.2;
+const LOW_LAPSE_THRESHOLD = 0.1;
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function safeRate(numerator, denominator) {
+  return denominator > 0 ? numerator / denominator : 0;
+}
+
+/**
+ * Derive generatorFamilyId from templateId.
+ * Convention: strip trailing `-NN` digits to get family.
+ * E.g. "tpl-possessive-apostrophe-01" → "tpl-possessive-apostrophe"
+ */
+function deriveFamily(templateId) {
+  if (!templateId || typeof templateId !== 'string') return 'unknown';
+  // Strip concept: prefix for concept-level entries
+  if (templateId.startsWith('concept:')) return templateId;
+  // Strip trailing number segment
+  const parts = templateId.split('-');
+  const lastPart = parts[parts.length - 1];
+  if (/^\d+$/.test(lastPart) && parts.length > 1) {
+    return parts.slice(0, -1).join('-');
+  }
+  return templateId;
+}
+
+// ─── Decision logic ───────────────────────────────────────────────────────────
+
+/**
+ * Decide whether retention-after-secure warrants a maintenance experiment.
+ *
+ * @param {Object} retentionReport - Output from buildRetentionReport
+ * @returns {{ decision: string, perConceptEvidence: Object[], familyClustering: Object[], summary: string, futureActionRef: string }}
+ */
+export function decideRetentionMaintenance(retentionReport) {
+  const concepts = retentionReport?.concepts || {};
+  const conceptIds = Object.keys(concepts);
+
+  // Build per-concept evidence
+  const perConceptEvidence = [];
+  const sufficientConcepts = [];
+  const familyLapseMap = {};
+
+  for (const [cid, concept] of Object.entries(concepts)) {
+    const securedAttempts = concept.securedAttemptCount || 0;
+    const lapseRate = concept.lapseRate || 0;
+    const daysToFirstLapse = concept.daysFromSecureToFirstLapse ?? null;
+    const hasSufficientData = securedAttempts >= SUFFICIENT_SECURED_ATTEMPTS;
+
+    const evidence = {
+      conceptId: cid,
+      securedAttempts,
+      lapseRate,
+      daysToFirstLapse,
+      hasSufficientData,
+      classification: concept.classification || 'unknown',
+    };
+    perConceptEvidence.push(evidence);
+
+    if (hasSufficientData) {
+      sufficientConcepts.push(evidence);
+    }
+
+    // Family clustering — derive family from conceptId
+    const family = deriveFamily(cid);
+    if (!familyLapseMap[family]) {
+      familyLapseMap[family] = { totalLapses: 0, totalAttempts: 0, concepts: [] };
+    }
+    if (securedAttempts > 0) {
+      const lapseCount = Math.round(lapseRate * securedAttempts);
+      familyLapseMap[family].totalLapses += lapseCount;
+      familyLapseMap[family].totalAttempts += securedAttempts;
+      familyLapseMap[family].concepts.push(cid);
+    }
+  }
+
+  // Compute family clustering results
+  const familyClustering = Object.entries(familyLapseMap)
+    .map(([family, data]) => ({
+      generatorFamilyId: family,
+      lapseRate: safeRate(data.totalLapses, data.totalAttempts),
+      totalLapses: data.totalLapses,
+      totalAttempts: data.totalAttempts,
+      conceptCount: data.concepts.length,
+      concepts: data.concepts,
+    }))
+    .filter((f) => f.totalAttempts > 0)
+    .sort((a, b) => b.lapseRate - a.lapseRate);
+
+  // Decision logic
+  let decision;
+  let summary;
+
+  if (sufficientConcepts.length === 0) {
+    decision = 'defer_insufficient_data';
+    summary = `No concepts have ≥${SUFFICIENT_SECURED_ATTEMPTS} secured attempts. Cannot make a maintenance decision — defer until more data accumulates.`;
+  } else {
+    // Average lapse rate across concepts with sufficient data
+    const avgLapseRate =
+      sufficientConcepts.reduce((sum, c) => sum + c.lapseRate, 0) / sufficientConcepts.length;
+
+    if (avgLapseRate > HIGH_LAPSE_THRESHOLD) {
+      decision = 'recommend_maintenance_experiment';
+      summary = `Average lapse rate ${(avgLapseRate * 100).toFixed(1)}% across ${sufficientConcepts.length} concepts with sufficient data exceeds ${HIGH_LAPSE_THRESHOLD * 100}% threshold. Maintenance scheduling experiment recommended.`;
+    } else if (avgLapseRate < LOW_LAPSE_THRESHOLD) {
+      decision = 'no_action_needed';
+      summary = `Average lapse rate ${(avgLapseRate * 100).toFixed(1)}% across ${sufficientConcepts.length} concepts with sufficient data is below ${LOW_LAPSE_THRESHOLD * 100}% threshold. Retention is healthy.`;
+    } else {
+      // Between 10% and 20% — monitor but no action
+      decision = 'no_action_needed';
+      summary = `Average lapse rate ${(avgLapseRate * 100).toFixed(1)}% across ${sufficientConcepts.length} concepts is between thresholds. Monitoring continues — no immediate action required.`;
+    }
+  }
+
+  return {
+    decision,
+    perConceptEvidence,
+    familyClustering,
+    summary,
+    futureActionRef: 'Requires separate scheduler adjustment plan',
+  };
+}
+
+// ─── CLI ──────────────────────────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const args = {};
+  for (const arg of argv) {
+    if (arg.startsWith('--')) {
+      const eqIdx = arg.indexOf('=');
+      if (eqIdx !== -1) {
+        args[arg.slice(2, eqIdx)] = arg.slice(eqIdx + 1);
+      } else {
+        args[arg.slice(2)] = true;
+      }
+    }
+  }
+  return args;
+}
+
+const isMainModule =
+  typeof process !== 'undefined' &&
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === path.resolve(__filename);
+
+if (isMainModule) {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (!args.retention || !args.output) {
+    console.error(
+      'Usage: grammar-qg-retention-decision.mjs --retention=<retention-report.json> --output=<decision.json>',
+    );
+    process.exit(1);
+  }
+
+  const retentionReport = JSON.parse(readFileSync(path.resolve(args.retention), 'utf-8'));
+  const result = decideRetentionMaintenance(retentionReport);
+
+  const outputPath = path.resolve(args.output);
+  mkdirSync(path.dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, JSON.stringify(result, null, 2) + '\n');
+
+  console.log(`Retention maintenance decision: ${result.decision}`);
+  console.log(`  ${result.summary}`);
+  console.log(`  Concepts analysed: ${result.perConceptEvidence.length}`);
+  if (result.familyClustering.length > 0) {
+    console.log(`  Highest-lapse family: ${result.familyClustering[0].generatorFamilyId} (${(result.familyClustering[0].lapseRate * 100).toFixed(1)}%)`);
+  }
+}

--- a/tests/grammar-qg-p7-action-candidates.test.js
+++ b/tests/grammar-qg-p7-action-candidates.test.js
@@ -1,0 +1,594 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { generateActionCandidates } from '../scripts/grammar-qg-action-candidates.mjs';
+import { decideMixedTransferMaturity } from '../scripts/grammar-qg-mixed-transfer-decision.mjs';
+import { decideRetentionMaintenance } from '../scripts/grammar-qg-retention-decision.mjs';
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+function makeHealthReport(templateOverrides = {}) {
+  const defaults = {
+    'tpl-possessive-01': {
+      attemptCount: 120,
+      independentFirstAttemptSuccessRate: 0.75,
+      supportedSuccessRate: 0.6,
+      wrongAfterSupportRate: 0.15,
+      medianElapsedBucket: '5-10s',
+      retrySuccessRate: 0.5,
+      retryAttemptCount: 20,
+      partialCreditRate: 0.1,
+      skipEmptyRate: 0.02,
+      confidence: 'high',
+      classification: 'healthy',
+    },
+  };
+  return { templates: { ...defaults, ...templateOverrides }, concepts: {}, meta: {} };
+}
+
+function makeMixedTransferReport(templateOverrides = {}) {
+  return { templates: { ...templateOverrides }, meta: {} };
+}
+
+function makeRetentionReport(conceptOverrides = {}) {
+  return { concepts: { ...conceptOverrides }, meta: {} };
+}
+
+// ─── U5: Action Candidate Generation ─────────────────────────────────────────
+
+describe('Grammar QG P7 — U5: Action Candidate Generation', () => {
+  describe('9-category classification', () => {
+    it('healthy template → keep', () => {
+      const health = makeHealthReport({
+        'tpl-healthy-01': {
+          attemptCount: 120,
+          independentFirstAttemptSuccessRate: 0.75,
+          supportedSuccessRate: 0.6,
+          wrongAfterSupportRate: 0.15,
+          medianElapsedBucket: '5-10s',
+          retrySuccessRate: 0.5,
+          retryAttemptCount: 10,
+          confidence: 'high',
+          classification: 'healthy',
+        },
+      });
+      const result = generateActionCandidates(health, makeMixedTransferReport(), makeRetentionReport());
+      const candidate = result.candidates.find((c) => c.templateId === 'tpl-healthy-01');
+      assert.equal(candidate.category, 'keep');
+    });
+
+    it('too_easy + >100 attempts → warm_up_only', () => {
+      const health = makeHealthReport({
+        'tpl-easy-01': {
+          attemptCount: 150,
+          independentFirstAttemptSuccessRate: 0.98,
+          supportedSuccessRate: 0.99,
+          wrongAfterSupportRate: 0.01,
+          medianElapsedBucket: '<2s',
+          retrySuccessRate: 0.9,
+          retryAttemptCount: 5,
+          confidence: 'high',
+          classification: 'too_easy',
+        },
+      });
+      const result = generateActionCandidates(health, makeMixedTransferReport(), makeRetentionReport());
+      const candidate = result.candidates.find((c) => c.templateId === 'tpl-easy-01');
+      assert.equal(candidate.category, 'warm_up_only');
+    });
+
+    it('ambiguous classification → review_wording', () => {
+      const health = makeHealthReport({
+        'tpl-ambiguous-01': {
+          attemptCount: 80,
+          independentFirstAttemptSuccessRate: 0.5,
+          supportedSuccessRate: 0.6,
+          wrongAfterSupportRate: 0.45,
+          medianElapsedBucket: '10-20s',
+          retrySuccessRate: 0.4,
+          retryAttemptCount: 15,
+          confidence: 'medium',
+          classification: 'ambiguous',
+        },
+      });
+      const result = generateActionCandidates(health, makeMixedTransferReport(), makeRetentionReport());
+      const candidate = result.candidates.find((c) => c.templateId === 'tpl-ambiguous-01');
+      assert.equal(candidate.category, 'review_wording');
+    });
+
+    it('high wrongAfterSupportRate (>40%) → review_wording even if not classified ambiguous', () => {
+      const health = makeHealthReport({
+        'tpl-wrongsupport-01': {
+          attemptCount: 60,
+          independentFirstAttemptSuccessRate: 0.55,
+          supportedSuccessRate: 0.4,
+          wrongAfterSupportRate: 0.45,
+          medianElapsedBucket: '5-10s',
+          retrySuccessRate: 0.5,
+          retryAttemptCount: 10,
+          confidence: 'medium',
+          classification: 'healthy',
+        },
+      });
+      const result = generateActionCandidates(health, makeMixedTransferReport(), makeRetentionReport());
+      const candidate = result.candidates.find((c) => c.templateId === 'tpl-wrongsupport-01');
+      assert.equal(candidate.category, 'review_wording');
+    });
+
+    it('transfer_gap → add_bridge_practice', () => {
+      const health = makeHealthReport({
+        'tpl-transfer-01': {
+          attemptCount: 80,
+          independentFirstAttemptSuccessRate: 0.8,
+          supportedSuccessRate: 0.7,
+          wrongAfterSupportRate: 0.1,
+          medianElapsedBucket: '5-10s',
+          retrySuccessRate: 0.6,
+          retryAttemptCount: 8,
+          confidence: 'medium',
+          classification: 'healthy',
+        },
+      });
+      const mt = makeMixedTransferReport({
+        'tpl-transfer-01': {
+          attemptCount: 30,
+          successRate: 0.35,
+          conceptLocalSuccessRate: 0.85,
+          independentRate: 0.3,
+          transferGapFlagged: true,
+        },
+      });
+      const result = generateActionCandidates(health, mt, makeRetentionReport());
+      const candidate = result.candidates.find((c) => c.templateId === 'tpl-transfer-01');
+      assert.equal(candidate.category, 'add_bridge_practice');
+    });
+
+    it('too_hard + high confidence → reduce_scheduler_weight', () => {
+      const health = makeHealthReport({
+        'tpl-hard-01': {
+          attemptCount: 120,
+          independentFirstAttemptSuccessRate: 0.25,
+          supportedSuccessRate: 0.4,
+          wrongAfterSupportRate: 0.3,
+          medianElapsedBucket: '>20s',
+          retrySuccessRate: 0.2,
+          retryAttemptCount: 30,
+          confidence: 'high',
+          classification: 'too_hard',
+        },
+      });
+      const result = generateActionCandidates(health, makeMixedTransferReport(), makeRetentionReport());
+      const candidate = result.candidates.find((c) => c.templateId === 'tpl-hard-01');
+      assert.equal(candidate.category, 'reduce_scheduler_weight');
+    });
+
+    it('support_dependent + >100 attempts → retire_candidate', () => {
+      const health = makeHealthReport({
+        'tpl-supportdep-01': {
+          attemptCount: 150,
+          independentFirstAttemptSuccessRate: 0.3,
+          supportedSuccessRate: 0.85,
+          wrongAfterSupportRate: 0.1,
+          medianElapsedBucket: '10-20s',
+          retrySuccessRate: 0.4,
+          retryAttemptCount: 25,
+          confidence: 'high',
+          classification: 'support_dependent',
+        },
+      });
+      const result = generateActionCandidates(health, makeMixedTransferReport(), makeRetentionReport());
+      const candidate = result.candidates.find((c) => c.templateId === 'tpl-supportdep-01');
+      assert.equal(candidate.category, 'retire_candidate');
+    });
+
+    it('retention_gap → increase_maintenance', () => {
+      const health = makeHealthReport({
+        'tpl-retain-01': {
+          attemptCount: 80,
+          independentFirstAttemptSuccessRate: 0.7,
+          supportedSuccessRate: 0.6,
+          wrongAfterSupportRate: 0.15,
+          medianElapsedBucket: '5-10s',
+          retrySuccessRate: 0.5,
+          retryAttemptCount: 10,
+          confidence: 'medium',
+          classification: 'healthy',
+          conceptId: 'retain-concept',
+        },
+      });
+      const retention = makeRetentionReport({
+        'retain-concept': {
+          securedAttemptCount: 50,
+          retainedPassRate: 0.6,
+          lapseRate: 0.4,
+          classification: 'retention_risk',
+        },
+      });
+      const result = generateActionCandidates(health, makeMixedTransferReport(), retention);
+      const maintenanceCandidates = result.candidates.filter((c) => c.category === 'increase_maintenance');
+      assert.ok(maintenanceCandidates.length > 0, 'at least one increase_maintenance candidate expected');
+    });
+
+    it('below 30 attempts → insufficient_data (never non-keep)', () => {
+      const health = makeHealthReport({
+        'tpl-low-01': {
+          attemptCount: 15,
+          independentFirstAttemptSuccessRate: 0.2,
+          supportedSuccessRate: 0.9,
+          wrongAfterSupportRate: 0.5,
+          medianElapsedBucket: '>20s',
+          retrySuccessRate: 0.1,
+          retryAttemptCount: 5,
+          confidence: 'low',
+          classification: 'too_hard',
+        },
+      });
+      const result = generateActionCandidates(health, makeMixedTransferReport(), makeRetentionReport());
+      const candidate = result.candidates.find((c) => c.templateId === 'tpl-low-01');
+      assert.equal(candidate.category, 'insufficient_data');
+    });
+
+    it('every candidate has non-empty rationale string', () => {
+      const health = makeHealthReport({
+        'tpl-a': { attemptCount: 120, independentFirstAttemptSuccessRate: 0.75, wrongAfterSupportRate: 0.1, medianElapsedBucket: '5-10s', retrySuccessRate: 0.5, retryAttemptCount: 10, confidence: 'high', classification: 'healthy' },
+        'tpl-b': { attemptCount: 15, independentFirstAttemptSuccessRate: 0.9, wrongAfterSupportRate: 0.05, medianElapsedBucket: '<2s', retrySuccessRate: 0.8, retryAttemptCount: 2, confidence: 'low', classification: 'too_easy' },
+        'tpl-c': { attemptCount: 200, independentFirstAttemptSuccessRate: 0.98, wrongAfterSupportRate: 0.01, medianElapsedBucket: '<2s', retrySuccessRate: 0.9, retryAttemptCount: 3, confidence: 'high', classification: 'too_easy' },
+      });
+      const result = generateActionCandidates(health, makeMixedTransferReport(), makeRetentionReport());
+      for (const candidate of result.candidates) {
+        assert.ok(typeof candidate.rationale === 'string', `rationale must be a string for ${candidate.templateId}`);
+        assert.ok(candidate.rationale.length > 0, `rationale must be non-empty for ${candidate.templateId}`);
+      }
+    });
+
+    it('expand_case_bank when retry rate >30% with >50 attempts', () => {
+      const health = makeHealthReport({
+        'tpl-retry-heavy-01': {
+          attemptCount: 80,
+          independentFirstAttemptSuccessRate: 0.6,
+          supportedSuccessRate: 0.5,
+          wrongAfterSupportRate: 0.15,
+          medianElapsedBucket: '5-10s',
+          retrySuccessRate: 0.5,
+          retryAttemptCount: 30, // 30/80 = 37.5%
+          confidence: 'medium',
+          classification: 'healthy',
+        },
+      });
+      const result = generateActionCandidates(health, makeMixedTransferReport(), makeRetentionReport());
+      const candidate = result.candidates.find((c) => c.templateId === 'tpl-retry-heavy-01');
+      assert.equal(candidate.category, 'expand_case_bank');
+    });
+
+    it('rewrite_distractors when support_dependent with ≤100 attempts', () => {
+      const health = makeHealthReport({
+        'tpl-distractor-01': {
+          attemptCount: 60,
+          independentFirstAttemptSuccessRate: 0.35,
+          supportedSuccessRate: 0.85,
+          wrongAfterSupportRate: 0.1,
+          medianElapsedBucket: '10-20s',
+          retrySuccessRate: 0.4,
+          retryAttemptCount: 10,
+          confidence: 'medium',
+          classification: 'support_dependent',
+        },
+      });
+      const result = generateActionCandidates(health, makeMixedTransferReport(), makeRetentionReport());
+      const candidate = result.candidates.find((c) => c.templateId === 'tpl-distractor-01');
+      assert.equal(candidate.category, 'rewrite_distractors');
+    });
+  });
+
+  describe('confidence threshold enforcement', () => {
+    it('29 attempts always yields insufficient_data regardless of other signals', () => {
+      const health = makeHealthReport({
+        'tpl-few-01': {
+          attemptCount: 29,
+          independentFirstAttemptSuccessRate: 0.1,
+          supportedSuccessRate: 0.9,
+          wrongAfterSupportRate: 0.6,
+          medianElapsedBucket: '>20s',
+          retrySuccessRate: 0.05,
+          retryAttemptCount: 10,
+          confidence: 'low',
+          classification: 'too_hard',
+        },
+      });
+      const result = generateActionCandidates(health, makeMixedTransferReport(), makeRetentionReport());
+      const candidate = result.candidates.find((c) => c.templateId === 'tpl-few-01');
+      assert.equal(candidate.category, 'insufficient_data');
+    });
+
+    it('30 attempts is minimum for non-keep classification', () => {
+      const health = makeHealthReport({
+        'tpl-threshold-01': {
+          attemptCount: 30,
+          independentFirstAttemptSuccessRate: 0.2,
+          supportedSuccessRate: 0.5,
+          wrongAfterSupportRate: 0.3,
+          medianElapsedBucket: '>20s',
+          retrySuccessRate: 0.1,
+          retryAttemptCount: 5,
+          confidence: 'medium',
+          classification: 'too_hard',
+        },
+      });
+      const result = generateActionCandidates(health, makeMixedTransferReport(), makeRetentionReport());
+      const candidate = result.candidates.find((c) => c.templateId === 'tpl-threshold-01');
+      assert.notEqual(candidate.category, 'insufficient_data');
+    });
+  });
+
+  describe('no mastery-write imports', () => {
+    it('action-candidates script has no mastery-write/writeReward/writeStar/updateMastery/submitScore imports', () => {
+      const scriptPath = path.resolve(import.meta.dirname, '..', 'scripts', 'grammar-qg-action-candidates.mjs');
+      const content = readFileSync(scriptPath, 'utf-8');
+      assert.ok(!content.includes('mastery-write'), 'must not import mastery-write');
+      assert.ok(!content.includes('writeReward'), 'must not import writeReward');
+      assert.ok(!content.includes('writeStar'), 'must not import writeStar');
+      assert.ok(!content.includes('updateMastery'), 'must not import updateMastery');
+      assert.ok(!content.includes('submitScore'), 'must not import submitScore');
+    });
+
+    it('mixed-transfer-decision script has no mastery-write imports', () => {
+      const scriptPath = path.resolve(import.meta.dirname, '..', 'scripts', 'grammar-qg-mixed-transfer-decision.mjs');
+      const content = readFileSync(scriptPath, 'utf-8');
+      assert.ok(!content.includes('mastery-write'), 'must not import mastery-write');
+      assert.ok(!content.includes('writeReward'), 'must not import writeReward');
+      assert.ok(!content.includes('writeStar'), 'must not import writeStar');
+      assert.ok(!content.includes('updateMastery'), 'must not import updateMastery');
+      assert.ok(!content.includes('submitScore'), 'must not import submitScore');
+    });
+
+    it('retention-decision script has no mastery-write imports', () => {
+      const scriptPath = path.resolve(import.meta.dirname, '..', 'scripts', 'grammar-qg-retention-decision.mjs');
+      const content = readFileSync(scriptPath, 'utf-8');
+      assert.ok(!content.includes('mastery-write'), 'must not import mastery-write');
+      assert.ok(!content.includes('writeReward'), 'must not import writeReward');
+      assert.ok(!content.includes('writeStar'), 'must not import writeStar');
+      assert.ok(!content.includes('updateMastery'), 'must not import updateMastery');
+      assert.ok(!content.includes('submitScore'), 'must not import submitScore');
+    });
+  });
+
+  describe('summary statistics', () => {
+    it('summary includes category counts and actionable count', () => {
+      const health = makeHealthReport({
+        'tpl-a': { attemptCount: 120, independentFirstAttemptSuccessRate: 0.75, wrongAfterSupportRate: 0.1, medianElapsedBucket: '5-10s', retrySuccessRate: 0.5, retryAttemptCount: 10, confidence: 'high', classification: 'healthy' },
+        'tpl-b': { attemptCount: 150, independentFirstAttemptSuccessRate: 0.98, wrongAfterSupportRate: 0.01, medianElapsedBucket: '<2s', retrySuccessRate: 0.9, retryAttemptCount: 3, confidence: 'high', classification: 'too_easy' },
+      });
+      const result = generateActionCandidates(health, makeMixedTransferReport(), makeRetentionReport());
+      assert.equal(typeof result.summary.totalCandidates, 'number');
+      assert.equal(typeof result.summary.actionableCount, 'number');
+      assert.ok(result.summary.categoryCounts !== undefined);
+      assert.ok(result.summary.generatedAt !== undefined);
+    });
+  });
+});
+
+// ─── U6: Mixed-Transfer Decision Gate ─────────────────────────────────────────
+
+describe('Grammar QG P7 — U6: Mixed-Transfer Decision Gate', () => {
+  function makeTemplateSet(count, attemptCount, successRate, conceptLocalRate) {
+    const templates = {};
+    for (let i = 0; i < count; i++) {
+      templates[`tpl-mixed-${String(i + 1).padStart(2, '0')}`] = {
+        attemptCount,
+        successRate,
+        conceptLocalSuccessRate: conceptLocalRate,
+        independentRate: successRate * 0.9,
+      };
+    }
+    return templates;
+  }
+
+  it('all 8 templates at high confidence → prepare_scoring_experiment', () => {
+    const report = makeMixedTransferReport(makeTemplateSet(8, 150, 0.7, 0.75));
+    const result = decideMixedTransferMaturity(report);
+    assert.equal(result.decision, 'prepare_scoring_experiment');
+  });
+
+  it('only 2 templates at medium → keep_shadow_only', () => {
+    const templates = {
+      ...makeTemplateSet(2, 50, 0.7, 0.75),
+      ...makeTemplateSet(6, 10, 0.6, 0.7), // below medium threshold
+    };
+    // Fix keys to avoid collision
+    const fixed = {};
+    let i = 0;
+    for (const [, v] of Object.entries(templates)) {
+      fixed[`tpl-mt-${String(++i).padStart(2, '0')}`] = v;
+    }
+    const report = makeMixedTransferReport(fixed);
+    const result = decideMixedTransferMaturity(report);
+    assert.equal(result.decision, 'keep_shadow_only');
+  });
+
+  it('mixed evidence with some harmful → do_not_promote when majority of high-confidence are harmful', () => {
+    const templates = {};
+    // 4 high-confidence templates that are harmful (local success much higher than mixed)
+    for (let i = 0; i < 4; i++) {
+      templates[`tpl-harm-${i}`] = { attemptCount: 120, successRate: 0.3, conceptLocalSuccessRate: 0.8 };
+    }
+    // 2 high-confidence templates that are fine
+    for (let i = 0; i < 2; i++) {
+      templates[`tpl-ok-${i}`] = { attemptCount: 120, successRate: 0.7, conceptLocalSuccessRate: 0.75 };
+    }
+    const report = makeMixedTransferReport(templates);
+    const result = decideMixedTransferMaturity(report);
+    assert.equal(result.decision, 'do_not_promote');
+  });
+
+  it('decision includes per-template attempt counts', () => {
+    const report = makeMixedTransferReport(makeTemplateSet(4, 80, 0.65, 0.7));
+    const result = decideMixedTransferMaturity(report);
+    assert.ok(Array.isArray(result.perTemplateEvidence));
+    assert.equal(result.perTemplateEvidence.length, 4);
+    for (const tmpl of result.perTemplateEvidence) {
+      assert.equal(typeof tmpl.attemptCount, 'number');
+      assert.equal(typeof tmpl.successRate, 'number');
+      assert.ok(tmpl.templateId);
+    }
+  });
+
+  it('result always includes futureActionRef', () => {
+    const report = makeMixedTransferReport(makeTemplateSet(8, 150, 0.7, 0.75));
+    const result = decideMixedTransferMaturity(report);
+    assert.equal(result.futureActionRef, 'Requires separate reviewed scoring plan');
+  });
+
+  it('6 medium + 3 high is the minimum for prepare_scoring_experiment', () => {
+    const templates = {};
+    // 3 at high confidence
+    for (let i = 0; i < 3; i++) {
+      templates[`tpl-high-${i}`] = { attemptCount: 110, successRate: 0.7, conceptLocalSuccessRate: 0.75 };
+    }
+    // 3 more at medium confidence (total 6 medium)
+    for (let i = 0; i < 3; i++) {
+      templates[`tpl-med-${i}`] = { attemptCount: 50, successRate: 0.65, conceptLocalSuccessRate: 0.7 };
+    }
+    const report = makeMixedTransferReport(templates);
+    const result = decideMixedTransferMaturity(report);
+    assert.equal(result.decision, 'prepare_scoring_experiment');
+  });
+
+  it('5 medium + 3 high is NOT sufficient → keep_shadow_only', () => {
+    const templates = {};
+    for (let i = 0; i < 3; i++) {
+      templates[`tpl-high-${i}`] = { attemptCount: 110, successRate: 0.7, conceptLocalSuccessRate: 0.75 };
+    }
+    for (let i = 0; i < 2; i++) {
+      templates[`tpl-med-${i}`] = { attemptCount: 50, successRate: 0.65, conceptLocalSuccessRate: 0.7 };
+    }
+    // 3 below medium
+    for (let i = 0; i < 3; i++) {
+      templates[`tpl-low-${i}`] = { attemptCount: 15, successRate: 0.6, conceptLocalSuccessRate: 0.65 };
+    }
+    const report = makeMixedTransferReport(templates);
+    const result = decideMixedTransferMaturity(report);
+    assert.equal(result.decision, 'keep_shadow_only');
+  });
+});
+
+// ─── U7: Retention Maintenance Decision Gate ──────────────────────────────────
+
+describe('Grammar QG P7 — U7: Retention Maintenance Decision Gate', () => {
+  it('high lapse rate + sufficient data → recommend_maintenance_experiment', () => {
+    const retention = makeRetentionReport({
+      'possessive-apostrophe': {
+        securedAttemptCount: 50,
+        retainedPassRate: 0.7,
+        lapseRate: 0.3,
+        classification: 'retention_risk',
+      },
+      'comma-in-list': {
+        securedAttemptCount: 40,
+        retainedPassRate: 0.75,
+        lapseRate: 0.25,
+        classification: 'minor_lapse',
+      },
+    });
+    const result = decideRetentionMaintenance(retention);
+    assert.equal(result.decision, 'recommend_maintenance_experiment');
+  });
+
+  it('low lapse rate + sufficient data → no_action_needed', () => {
+    const retention = makeRetentionReport({
+      'possessive-apostrophe': {
+        securedAttemptCount: 80,
+        retainedPassRate: 0.95,
+        lapseRate: 0.05,
+        classification: 'retained',
+      },
+      'comma-in-list': {
+        securedAttemptCount: 60,
+        retainedPassRate: 0.93,
+        lapseRate: 0.07,
+        classification: 'retained',
+      },
+    });
+    const result = decideRetentionMaintenance(retention);
+    assert.equal(result.decision, 'no_action_needed');
+  });
+
+  it('insufficient data → defer_insufficient_data', () => {
+    const retention = makeRetentionReport({
+      'possessive-apostrophe': {
+        securedAttemptCount: 10,
+        retainedPassRate: 0.8,
+        lapseRate: 0.2,
+        classification: 'minor_lapse',
+      },
+      'comma-in-list': {
+        securedAttemptCount: 5,
+        retainedPassRate: 0.6,
+        lapseRate: 0.4,
+        classification: 'retention_risk',
+      },
+    });
+    const result = decideRetentionMaintenance(retention);
+    assert.equal(result.decision, 'defer_insufficient_data');
+  });
+
+  it('family clustering identifies which families have highest lapse', () => {
+    const retention = makeRetentionReport({
+      'possessive-apostrophe': {
+        securedAttemptCount: 50,
+        retainedPassRate: 0.6,
+        lapseRate: 0.4,
+        classification: 'retention_risk',
+      },
+      'comma-in-list': {
+        securedAttemptCount: 50,
+        retainedPassRate: 0.95,
+        lapseRate: 0.05,
+        classification: 'retained',
+      },
+      'relative-clause': {
+        securedAttemptCount: 40,
+        retainedPassRate: 0.7,
+        lapseRate: 0.3,
+        classification: 'retention_risk',
+      },
+    });
+    const result = decideRetentionMaintenance(retention);
+    assert.ok(Array.isArray(result.familyClustering));
+    assert.ok(result.familyClustering.length > 0);
+    // First entry should have the highest lapse rate
+    const highest = result.familyClustering[0];
+    assert.ok(highest.lapseRate >= result.familyClustering[result.familyClustering.length - 1].lapseRate);
+    assert.ok(typeof highest.generatorFamilyId === 'string');
+    assert.ok(typeof highest.totalLapses === 'number');
+  });
+
+  it('result always includes futureActionRef', () => {
+    const retention = makeRetentionReport({
+      'concept-a': { securedAttemptCount: 50, lapseRate: 0.3, classification: 'retention_risk' },
+    });
+    const result = decideRetentionMaintenance(retention);
+    assert.equal(result.futureActionRef, 'Requires separate scheduler adjustment plan');
+  });
+
+  it('perConceptEvidence includes all concepts from input', () => {
+    const retention = makeRetentionReport({
+      'concept-a': { securedAttemptCount: 50, lapseRate: 0.1, classification: 'retained' },
+      'concept-b': { securedAttemptCount: 10, lapseRate: 0.2, classification: 'minor_lapse' },
+      'concept-c': { securedAttemptCount: 80, lapseRate: 0.05, classification: 'retained' },
+    });
+    const result = decideRetentionMaintenance(retention);
+    assert.equal(result.perConceptEvidence.length, 3);
+    const ids = result.perConceptEvidence.map((e) => e.conceptId).sort();
+    assert.deepEqual(ids, ['concept-a', 'concept-b', 'concept-c']);
+  });
+
+  it('mixed lapse rate between 10% and 20% → no_action_needed (monitor zone)', () => {
+    const retention = makeRetentionReport({
+      'concept-a': { securedAttemptCount: 50, lapseRate: 0.15, retainedPassRate: 0.85, classification: 'minor_lapse' },
+      'concept-b': { securedAttemptCount: 60, lapseRate: 0.12, retainedPassRate: 0.88, classification: 'minor_lapse' },
+    });
+    const result = decideRetentionMaintenance(retention);
+    assert.equal(result.decision, 'no_action_needed');
+  });
+});


### PR DESCRIPTION
## Summary

- Create `scripts/grammar-qg-action-candidates.mjs` — 9-category template/concept classification with confidence thresholds
- Create `scripts/grammar-qg-mixed-transfer-decision.mjs` — maturity gate (keep_shadow/prepare_experiment/do_not_promote)
- Create `scripts/grammar-qg-retention-decision.mjs` — maintenance gate with family-clustering
- All decision gates reference "separate future plan" — no auto-action in P7
- Confidence enforced: non-keep candidates require >=30 attempts

## Test plan

- [x] 32 new tests covering all 9 categories + decision gates
- [x] 125/125 full P7 gate passes
- [x] No mastery-write/reward/Star imports (grep-checked in tests)
- [x] Insufficient data → never emits non-keep candidates