### PR TITLE
feat(grammar-qg): P7 Wave 4 — adult-facing calibration panel

### DIFF
--- a/src/subjects/grammar/calibration-view-model.js
+++ b/src/subjects/grammar/calibration-view-model.js
@@ -1,0 +1,381 @@
+// Grammar QG P7 — Calibration View Model (U8)
+//
+// Pure function that transforms raw calibration report JSON artefacts into
+// a display-ready view model for GrammarCalibrationPanel. No React imports.
+// No side effects. No answer keys. No raw learner identifiers.
+//
+// The data shape consumed here mirrors the outputs of:
+//   scripts/grammar-qg-calibrate.mjs  → healthReport, mixedTransferCalibration, retentionReport
+//   scripts/grammar-qg-action-candidates.mjs  → actionCandidates
+//   scripts/grammar-qg-mixed-transfer-decision.mjs  → mixedTransferDecision
+//   scripts/grammar-qg-retention-decision.mjs  → retentionDecision
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const CLASSIFICATION_PRIORITY = Object.freeze({
+  support_dependent: 0,
+  retry_ineffective: 1,
+  too_hard: 2,
+  ambiguous: 3,
+  too_easy: 4,
+  healthy: 5,
+});
+
+const CATEGORY_PRIORITY = Object.freeze({
+  retire_candidate: 0,
+  reduce_scheduler_weight: 1,
+  rewrite_distractors: 2,
+  review_wording: 3,
+  add_bridge_practice: 4,
+  expand_case_bank: 5,
+  increase_maintenance: 6,
+  warm_up_only: 7,
+  insufficient_data: 8,
+  keep: 9,
+});
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function classificationColour(classification) {
+  switch (classification) {
+    case 'healthy': return 'green';
+    case 'too_easy': return 'amber';
+    case 'ambiguous': return 'amber';
+    case 'too_hard': return 'red';
+    case 'support_dependent': return 'red';
+    case 'retry_ineffective': return 'red';
+    default: return 'grey';
+  }
+}
+
+function categoryColour(category) {
+  switch (category) {
+    case 'keep': return 'green';
+    case 'warm_up_only': return 'amber';
+    case 'review_wording': return 'amber';
+    case 'add_bridge_practice': return 'amber';
+    case 'expand_case_bank': return 'amber';
+    case 'increase_maintenance': return 'amber';
+    case 'rewrite_distractors': return 'red';
+    case 'reduce_scheduler_weight': return 'red';
+    case 'retire_candidate': return 'red';
+    case 'insufficient_data': return 'grey';
+    default: return 'grey';
+  }
+}
+
+function confidenceBadge(confidence) {
+  switch (confidence) {
+    case 'high': return 'green';
+    case 'medium': return 'amber';
+    case 'low': return 'grey';
+    case 'insufficient': return 'red-outline';
+    default: return 'grey';
+  }
+}
+
+function confidenceLevel(count) {
+  if (count > 100) return 'high';
+  if (count >= 30) return 'medium';
+  if (count >= 10) return 'low';
+  return 'insufficient';
+}
+
+function decisionColour(decision) {
+  switch (decision) {
+    case 'keep_shadow_only': return 'green';
+    case 'prepare_scoring_experiment': return 'amber';
+    case 'do_not_promote': return 'red';
+    case 'no_action_needed': return 'green';
+    case 'recommend_maintenance_experiment': return 'amber';
+    case 'defer_insufficient_data': return 'grey';
+    default: return 'grey';
+  }
+}
+
+function safeRate(n, d) {
+  return d > 0 ? n / d : 0;
+}
+
+function formatPercent(rate) {
+  if (rate == null || Number.isNaN(rate)) return '—';
+  return `${(rate * 100).toFixed(1)}%`;
+}
+
+// ─── Main builder ─────────────────────────────────────────────────────────────
+
+/**
+ * Transform raw calibration data into a view-ready model.
+ *
+ * @param {Object|null|undefined} calibrationData
+ * @returns {Object} View model with sections for display
+ */
+export function buildCalibrationViewModel(calibrationData) {
+  if (!calibrationData || typeof calibrationData !== 'object') {
+    return {
+      empty: true,
+      emptyMessage: 'No calibration data available. Run `npm run grammar:qg:calibrate` first.',
+      header: null,
+      templateHealthRows: [],
+      actionCandidateGroups: [],
+      keepCount: 0,
+      mixedTransferEvidence: null,
+      retentionEvidence: null,
+      confidenceWarnings: [],
+    };
+  }
+
+  const {
+    healthReport,
+    mixedTransferCalibration,
+    retentionReport,
+    actionCandidates,
+    mixedTransferDecision,
+    retentionDecision,
+  } = calibrationData;
+
+  // ── Header ──
+  const header = buildHeader(healthReport);
+
+  // ── Template health ──
+  const templateHealthRows = buildTemplateHealthRows(healthReport);
+
+  // ── Action candidates ──
+  const { groups: actionCandidateGroups, keepCount } = buildActionCandidateGroups(actionCandidates);
+
+  // ── Mixed-transfer evidence ──
+  const mixedTransferEvidence = buildMixedTransferEvidence(mixedTransferDecision, mixedTransferCalibration);
+
+  // ── Retention evidence ──
+  const retentionEvidence = buildRetentionEvidence(retentionDecision, retentionReport);
+
+  // ── Confidence warnings ──
+  const confidenceWarnings = buildConfidenceWarnings(templateHealthRows, actionCandidates);
+
+  return {
+    empty: false,
+    emptyMessage: null,
+    header,
+    templateHealthRows,
+    actionCandidateGroups,
+    keepCount,
+    mixedTransferEvidence,
+    retentionEvidence,
+    confidenceWarnings,
+  };
+}
+
+// ─── Section builders ─────────────────────────────────────────────────────────
+
+function buildHeader(healthReport) {
+  if (!healthReport || typeof healthReport !== 'object') {
+    return { releaseId: '—', dateRange: '—', schemaVersion: '—', inputRowCount: 0 };
+  }
+
+  const provenance = healthReport.provenance || {};
+  const templates = healthReport.templates || {};
+  const templateIds = Object.keys(templates);
+
+  let totalAttempts = 0;
+  for (const tpl of Object.values(templates)) {
+    totalAttempts += tpl.attemptCount || 0;
+  }
+
+  return {
+    releaseId: provenance.releaseId || provenance.calibrationSchemaVersion || '—',
+    dateRange: provenance.dateRange || '—',
+    schemaVersion: provenance.calibrationSchemaVersion || '—',
+    inputRowCount: totalAttempts,
+  };
+}
+
+function buildTemplateHealthRows(healthReport) {
+  if (!healthReport || !healthReport.templates) return [];
+
+  const templates = healthReport.templates;
+  const rows = [];
+
+  for (const [templateId, metrics] of Object.entries(templates)) {
+    const classification = metrics.classification || 'unknown';
+    const attemptCount = metrics.attemptCount || 0;
+    const successRate = metrics.independentFirstAttemptSuccessRate ?? metrics.successRate ?? null;
+    const confidence = confidenceLevel(attemptCount);
+
+    rows.push({
+      templateId,
+      classification,
+      classificationColour: classificationColour(classification),
+      attemptCount,
+      successRate,
+      successRateDisplay: formatPercent(successRate),
+      confidence,
+      confidenceBadge: confidenceBadge(confidence),
+    });
+  }
+
+  // Sort: unhealthy first (lower priority number = higher priority for display)
+  rows.sort((a, b) => {
+    const aPri = CLASSIFICATION_PRIORITY[a.classification] ?? 99;
+    const bPri = CLASSIFICATION_PRIORITY[b.classification] ?? 99;
+    if (aPri !== bPri) return aPri - bPri;
+    return a.templateId.localeCompare(b.templateId);
+  });
+
+  return rows;
+}
+
+function buildActionCandidateGroups(actionCandidates) {
+  if (!actionCandidates || !Array.isArray(actionCandidates)) {
+    // Check if it's an object with an array property
+    const candidates = actionCandidates?.candidates || actionCandidates?.actions || [];
+    if (!Array.isArray(candidates) || candidates.length === 0) {
+      return { groups: [], keepCount: 0 };
+    }
+    return groupCandidates(candidates);
+  }
+  return groupCandidates(actionCandidates);
+}
+
+function groupCandidates(candidates) {
+  let keepCount = 0;
+  const grouped = {};
+
+  for (const candidate of candidates) {
+    const category = candidate.category || 'unknown';
+    if (category === 'keep') {
+      keepCount++;
+      continue; // skip keep entries by default
+    }
+
+    if (!grouped[category]) {
+      grouped[category] = {
+        category,
+        categoryColour: categoryColour(category),
+        rows: [],
+      };
+    }
+
+    grouped[category].rows.push({
+      templateId: candidate.templateId || '—',
+      conceptId: candidate.conceptId || '—',
+      category,
+      categoryColour: categoryColour(category),
+      confidence: candidate.confidence || 'insufficient',
+      confidenceBadge: confidenceBadge(candidate.confidence || 'insufficient'),
+      rationale: candidate.rationale || '—',
+    });
+  }
+
+  // Sort groups by category priority
+  const groups = Object.values(grouped).sort((a, b) => {
+    const aPri = CATEGORY_PRIORITY[a.category] ?? 99;
+    const bPri = CATEGORY_PRIORITY[b.category] ?? 99;
+    return aPri - bPri;
+  });
+
+  return { groups, keepCount };
+}
+
+function buildMixedTransferEvidence(mixedTransferDecision, mixedTransferCalibration) {
+  if (!mixedTransferDecision || typeof mixedTransferDecision !== 'object') {
+    return null;
+  }
+
+  const decision = mixedTransferDecision.decision || 'unknown';
+  const perTemplateEvidence = mixedTransferDecision.perTemplateEvidence || [];
+  const summary = mixedTransferDecision.summary || '';
+
+  const templateRows = perTemplateEvidence.map((entry) => ({
+    templateId: entry.templateId || '—',
+    attemptCount: entry.attemptCount || 0,
+    successRate: formatPercent(entry.successRate),
+    confidenceLevel: entry.confidenceLevel || 'low',
+    confidenceBadge: confidenceBadge(entry.confidenceLevel || 'low'),
+  }));
+
+  return {
+    decision,
+    decisionColour: decisionColour(decision),
+    summary,
+    templateRows,
+  };
+}
+
+function buildRetentionEvidence(retentionDecision, retentionReport) {
+  if (!retentionDecision || typeof retentionDecision !== 'object') {
+    return null;
+  }
+
+  const decision = retentionDecision.decision || 'unknown';
+  const perConceptEvidence = retentionDecision.perConceptEvidence || [];
+  const familyClustering = retentionDecision.familyClustering || [];
+  const summary = retentionDecision.summary || '';
+
+  const conceptRows = perConceptEvidence.map((entry) => ({
+    conceptId: entry.conceptId || '—',
+    securedAttempts: entry.securedAttempts || entry.securedAttemptCount || 0,
+    lapseRate: formatPercent(entry.lapseRate),
+    confidenceLevel: entry.hasSufficientData ? 'medium' : 'insufficient',
+    confidenceBadge: confidenceBadge(entry.hasSufficientData ? 'medium' : 'insufficient'),
+  }));
+
+  const clusterRows = familyClustering.map((entry) => ({
+    familyId: entry.familyId || '—',
+    templateCount: entry.templateCount || 0,
+    totalLapses: entry.totalLapses || 0,
+    lapseConcentration: formatPercent(entry.lapseConcentration),
+  }));
+
+  return {
+    decision,
+    decisionColour: decisionColour(decision),
+    summary,
+    conceptRows,
+    clusterRows,
+  };
+}
+
+function buildConfidenceWarnings(templateHealthRows, actionCandidates) {
+  const warnings = [];
+
+  // Templates with insufficient data
+  for (const row of templateHealthRows) {
+    if (row.confidence === 'insufficient') {
+      warnings.push({
+        type: 'template',
+        id: row.templateId,
+        reason: `Template has only ${row.attemptCount} attempts — insufficient data for reliable classification.`,
+      });
+    }
+  }
+
+  // Action candidates with insufficient_data category
+  const candidates = Array.isArray(actionCandidates)
+    ? actionCandidates
+    : (actionCandidates?.candidates || actionCandidates?.actions || []);
+
+  for (const candidate of candidates) {
+    if (candidate.category === 'insufficient_data') {
+      warnings.push({
+        type: 'action_candidate',
+        id: candidate.templateId || candidate.conceptId || '—',
+        reason: candidate.rationale || 'Insufficient data for action classification.',
+      });
+    }
+  }
+
+  return warnings;
+}
+
+// ─── Exports for testing ──────────────────────────────────────────────────────
+
+export {
+  classificationColour,
+  categoryColour,
+  confidenceBadge,
+  confidenceLevel,
+  decisionColour,
+  formatPercent,
+  CLASSIFICATION_PRIORITY,
+  CATEGORY_PRIORITY,
+};

--- a/src/subjects/grammar/components/GrammarCalibrationPanel.css
+++ b/src/subjects/grammar/components/GrammarCalibrationPanel.css
@@ -1,0 +1,168 @@
+/* GrammarCalibrationPanel.css — Admin calibration panel styles (P7 U8).
+ * Minimal, consistent with existing admin-panels.css patterns.
+ * Root class: .grammar-calibration-panel */
+
+.grammar-calibration-panel {
+  padding: 4px 0;
+}
+
+/* Header metadata rows */
+.grammar-calibration-header {
+  margin-bottom: 16px;
+  padding: 8px 12px;
+  background: #f9fafb;
+  border-radius: 6px;
+  border: 1px solid #e5e7eb;
+}
+
+.grammar-calibration-header-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 2px 0;
+}
+
+.grammar-calibration-meta-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #6b7280;
+  min-width: 110px;
+}
+
+.grammar-calibration-meta-value {
+  font-size: 0.8rem;
+  color: #111827;
+}
+
+/* Section layout */
+.grammar-calibration-section {
+  margin-top: 20px;
+  padding-top: 16px;
+  border-top: 1px solid #e5e7eb;
+}
+
+.grammar-calibration-section-title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0 0 10px 0;
+}
+
+/* Tables */
+.grammar-calibration-table-wrap {
+  overflow-x: auto;
+}
+
+.grammar-calibration-table {
+  width: 100%;
+  font-size: 0.8rem;
+  border-collapse: collapse;
+}
+
+.grammar-calibration-table th {
+  text-align: left;
+  padding: 4px 8px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #6b7280;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.grammar-calibration-table td {
+  padding: 4px 8px;
+  border-bottom: 1px solid #f3f4f6;
+  vertical-align: middle;
+}
+
+/* Action candidate groups */
+.grammar-calibration-action-group {
+  margin-top: 12px;
+}
+
+.grammar-calibration-group-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  margin: 0 0 6px 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.grammar-calibration-keep-note {
+  margin: 0 0 8px 0;
+}
+
+/* Decision row */
+.grammar-calibration-decision-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.grammar-calibration-summary {
+  margin: 4px 0 12px 0;
+}
+
+/* Confidence warnings */
+.grammar-calibration-warnings-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.grammar-calibration-warning-item {
+  padding: 4px 0;
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+/* Badge colour classes — extend existing .badge base */
+.badge-green {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.badge-amber {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.badge-red {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.badge-grey {
+  background: #f3f4f6;
+  color: #4b5563;
+}
+
+.badge-red-outline {
+  background: transparent;
+  color: #991b1b;
+  border: 1px solid #fca5a5;
+}
+
+/* Responsive: stack on narrow screens */
+@media (max-width: 640px) {
+  .grammar-calibration-header-row {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2px;
+  }
+
+  .grammar-calibration-meta-label {
+    min-width: unset;
+  }
+
+  .grammar-calibration-decision-row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .grammar-calibration-warning-item {
+    flex-direction: column;
+  }
+}

--- a/src/subjects/grammar/components/GrammarCalibrationPanel.jsx
+++ b/src/subjects/grammar/components/GrammarCalibrationPanel.jsx
@@ -1,0 +1,299 @@
+import React from 'react';
+import { AdminPanelFrame } from '../../surfaces/hubs/AdminPanelFrame.jsx';
+import { buildCalibrationViewModel } from '../calibration-view-model.js';
+import './GrammarCalibrationPanel.css';
+
+// Grammar QG P7 U8 — Adult-facing calibration panel.
+//
+// Admin-only. Reads pre-generated P7 calibration report JSON artefacts and
+// displays template health, action candidates, decision gate evidence, and
+// confidence warnings.
+//
+// Constraints:
+//   - No answer keys displayed
+//   - No raw learner identifiers
+//   - Read-only — no mutation actions
+//   - Graceful empty state when no data available
+
+/**
+ * @param {object} props
+ * @param {Object|null} props.calibrationData — Pre-loaded calibration report data
+ */
+export function GrammarCalibrationPanel({ calibrationData }) {
+  const vm = buildCalibrationViewModel(calibrationData);
+
+  return (
+    <AdminPanelFrame
+      eyebrow="Grammar QG"
+      title="Grammar QG Calibration"
+      subtitle="Template health, action candidates, and decision gate evidence"
+      refreshedAt={null}
+      refreshError={null}
+      data={vm.empty ? null : vm}
+      loading={false}
+      emptyState={
+        <p className="small muted">
+          {vm.emptyMessage || 'No calibration data available. Run `npm run grammar:qg:calibrate` first.'}
+        </p>
+      }
+    >
+      <div className="grammar-calibration-panel">
+        {/* Header */}
+        {vm.header ? <CalibrationHeader header={vm.header} /> : null}
+
+        {/* Template Health Overview */}
+        {vm.templateHealthRows.length > 0 ? (
+          <TemplateHealthSection rows={vm.templateHealthRows} />
+        ) : null}
+
+        {/* Action Candidates */}
+        {vm.actionCandidateGroups.length > 0 || vm.keepCount > 0 ? (
+          <ActionCandidatesSection groups={vm.actionCandidateGroups} keepCount={vm.keepCount} />
+        ) : null}
+
+        {/* Mixed-Transfer Evidence */}
+        {vm.mixedTransferEvidence ? (
+          <MixedTransferSection evidence={vm.mixedTransferEvidence} />
+        ) : null}
+
+        {/* Retention Evidence */}
+        {vm.retentionEvidence ? (
+          <RetentionSection evidence={vm.retentionEvidence} />
+        ) : null}
+
+        {/* Confidence Warnings */}
+        {vm.confidenceWarnings.length > 0 ? (
+          <ConfidenceWarningsSection warnings={vm.confidenceWarnings} />
+        ) : null}
+      </div>
+    </AdminPanelFrame>
+  );
+}
+
+// ─── Sub-components ──────────────────────────────────────────────────────────
+
+function CalibrationHeader({ header }) {
+  return (
+    <div className="grammar-calibration-header">
+      <div className="grammar-calibration-header-row">
+        <span className="grammar-calibration-meta-label">Release ID:</span>
+        <span className="grammar-calibration-meta-value">{header.releaseId}</span>
+      </div>
+      <div className="grammar-calibration-header-row">
+        <span className="grammar-calibration-meta-label">Schema version:</span>
+        <span className="grammar-calibration-meta-value">{header.schemaVersion}</span>
+      </div>
+      <div className="grammar-calibration-header-row">
+        <span className="grammar-calibration-meta-label">Date range:</span>
+        <span className="grammar-calibration-meta-value">{header.dateRange}</span>
+      </div>
+      <div className="grammar-calibration-header-row">
+        <span className="grammar-calibration-meta-label">Input rows:</span>
+        <span className="grammar-calibration-meta-value">{header.inputRowCount.toLocaleString()}</span>
+      </div>
+    </div>
+  );
+}
+
+function ColourBadge({ colour, label }) {
+  return (
+    <span className={`badge badge-${colour}`} data-badge-colour={colour}>
+      {label}
+    </span>
+  );
+}
+
+function TemplateHealthSection({ rows }) {
+  return (
+    <section className="grammar-calibration-section">
+      <h3 className="grammar-calibration-section-title">Template Health Overview</h3>
+      <div className="grammar-calibration-table-wrap">
+        <table className="admin-table grammar-calibration-table">
+          <thead>
+            <tr>
+              <th>Template ID</th>
+              <th>Classification</th>
+              <th>Attempts</th>
+              <th>Success Rate</th>
+              <th>Confidence</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.templateId}>
+                <td className="small">{row.templateId}</td>
+                <td><ColourBadge colour={row.classificationColour} label={row.classification} /></td>
+                <td>{row.attemptCount}</td>
+                <td>{row.successRateDisplay}</td>
+                <td><ColourBadge colour={row.confidenceBadge} label={row.confidence} /></td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+function ActionCandidatesSection({ groups, keepCount }) {
+  return (
+    <section className="grammar-calibration-section">
+      <h3 className="grammar-calibration-section-title">Action Candidates</h3>
+      {keepCount > 0 ? (
+        <p className="small muted grammar-calibration-keep-note">
+          {keepCount} template{keepCount !== 1 ? 's' : ''} classified as <ColourBadge colour="green" label="keep" /> (hidden).
+        </p>
+      ) : null}
+      {groups.map((group) => (
+        <div key={group.category} className="grammar-calibration-action-group">
+          <h4 className="grammar-calibration-group-title">
+            <ColourBadge colour={group.categoryColour} label={group.category.replace(/_/g, ' ')} />
+            <span className="small muted"> ({group.rows.length})</span>
+          </h4>
+          <div className="grammar-calibration-table-wrap">
+            <table className="admin-table grammar-calibration-table">
+              <thead>
+                <tr>
+                  <th>Template ID</th>
+                  <th>Concept</th>
+                  <th>Confidence</th>
+                  <th>Rationale</th>
+                </tr>
+              </thead>
+              <tbody>
+                {group.rows.map((row) => (
+                  <tr key={row.templateId}>
+                    <td className="small">{row.templateId}</td>
+                    <td className="small">{row.conceptId}</td>
+                    <td><ColourBadge colour={row.confidenceBadge} label={row.confidence} /></td>
+                    <td className="small muted">{row.rationale}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      ))}
+    </section>
+  );
+}
+
+function MixedTransferSection({ evidence }) {
+  return (
+    <section className="grammar-calibration-section">
+      <h3 className="grammar-calibration-section-title">Mixed-Transfer Evidence</h3>
+      <div className="grammar-calibration-decision-row">
+        <span className="grammar-calibration-meta-label">Decision:</span>
+        <ColourBadge colour={evidence.decisionColour} label={evidence.decision.replace(/_/g, ' ')} />
+      </div>
+      {evidence.summary ? (
+        <p className="small muted grammar-calibration-summary">{evidence.summary}</p>
+      ) : null}
+      {evidence.templateRows.length > 0 ? (
+        <div className="grammar-calibration-table-wrap">
+          <table className="admin-table grammar-calibration-table">
+            <thead>
+              <tr>
+                <th>Template ID</th>
+                <th>Attempts</th>
+                <th>Success Rate</th>
+                <th>Confidence</th>
+              </tr>
+            </thead>
+            <tbody>
+              {evidence.templateRows.map((row) => (
+                <tr key={row.templateId}>
+                  <td className="small">{row.templateId}</td>
+                  <td>{row.attemptCount}</td>
+                  <td>{row.successRate}</td>
+                  <td><ColourBadge colour={row.confidenceBadge} label={row.confidenceLevel} /></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function RetentionSection({ evidence }) {
+  return (
+    <section className="grammar-calibration-section">
+      <h3 className="grammar-calibration-section-title">Retention Evidence</h3>
+      <div className="grammar-calibration-decision-row">
+        <span className="grammar-calibration-meta-label">Decision:</span>
+        <ColourBadge colour={evidence.decisionColour} label={evidence.decision.replace(/_/g, ' ')} />
+      </div>
+      {evidence.summary ? (
+        <p className="small muted grammar-calibration-summary">{evidence.summary}</p>
+      ) : null}
+      {evidence.conceptRows.length > 0 ? (
+        <div className="grammar-calibration-table-wrap">
+          <table className="admin-table grammar-calibration-table">
+            <thead>
+              <tr>
+                <th>Concept ID</th>
+                <th>Secured Attempts</th>
+                <th>Lapse Rate</th>
+                <th>Confidence</th>
+              </tr>
+            </thead>
+            <tbody>
+              {evidence.conceptRows.map((row) => (
+                <tr key={row.conceptId}>
+                  <td className="small">{row.conceptId}</td>
+                  <td>{row.securedAttempts}</td>
+                  <td>{row.lapseRate}</td>
+                  <td><ColourBadge colour={row.confidenceBadge} label={row.confidenceLevel} /></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : null}
+      {evidence.clusterRows.length > 0 ? (
+        <div className="grammar-calibration-table-wrap">
+          <h4 className="grammar-calibration-group-title small">Family Clustering</h4>
+          <table className="admin-table grammar-calibration-table">
+            <thead>
+              <tr>
+                <th>Family ID</th>
+                <th>Templates</th>
+                <th>Total Lapses</th>
+                <th>Concentration</th>
+              </tr>
+            </thead>
+            <tbody>
+              {evidence.clusterRows.map((row) => (
+                <tr key={row.familyId}>
+                  <td className="small">{row.familyId}</td>
+                  <td>{row.templateCount}</td>
+                  <td>{row.totalLapses}</td>
+                  <td>{row.lapseConcentration}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function ConfidenceWarningsSection({ warnings }) {
+  return (
+    <section className="grammar-calibration-section">
+      <h3 className="grammar-calibration-section-title">Confidence Warnings</h3>
+      <ul className="grammar-calibration-warnings-list">
+        {warnings.map((w, i) => (
+          <li key={`${w.type}-${w.id}-${i}`} className="grammar-calibration-warning-item">
+            <ColourBadge colour="red-outline" label={w.type === 'template' ? 'Template' : 'Action'} />
+            <span className="small"> {w.id}: </span>
+            <span className="small muted">{w.reason}</span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/tests/grammar-qg-p7-analytics-view.test.js
+++ b/tests/grammar-qg-p7-analytics-view.test.js
@@ -1,0 +1,392 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildCalibrationViewModel,
+  classificationColour,
+  categoryColour,
+  confidenceBadge,
+  confidenceLevel,
+  decisionColour,
+  formatPercent,
+  CLASSIFICATION_PRIORITY,
+  CATEGORY_PRIORITY,
+} from '../src/subjects/grammar/calibration-view-model.js';
+
+// ─── Fixtures ──────────────────────────────────────────────────────────────
+
+function makeHealthReport(templateOverrides = {}) {
+  return {
+    provenance: {
+      calibrationSchemaVersion: 'grammar-qg-p7-calibration-v1',
+      releaseId: 'test-release-001',
+      dateRange: '2026-04-20 to 2026-04-29',
+    },
+    templates: {
+      'tpl-possessive-01': {
+        classification: 'healthy',
+        attemptCount: 120,
+        independentFirstAttemptSuccessRate: 0.82,
+        conceptId: 'possessive-apostrophe',
+        ...templateOverrides['tpl-possessive-01'],
+      },
+      'tpl-comma-splice-01': {
+        classification: 'too_hard',
+        attemptCount: 45,
+        independentFirstAttemptSuccessRate: 0.31,
+        conceptId: 'comma-splice',
+        ...templateOverrides['tpl-comma-splice-01'],
+      },
+      'tpl-verb-tense-01': {
+        classification: 'support_dependent',
+        attemptCount: 8,
+        independentFirstAttemptSuccessRate: 0.25,
+        conceptId: 'verb-tense',
+        ...templateOverrides['tpl-verb-tense-01'],
+      },
+    },
+  };
+}
+
+function makeActionCandidates() {
+  return [
+    {
+      templateId: 'tpl-possessive-01',
+      conceptId: 'possessive-apostrophe',
+      category: 'keep',
+      confidence: 'high',
+      rationale: 'Template performing well with high confidence.',
+    },
+    {
+      templateId: 'tpl-comma-splice-01',
+      conceptId: 'comma-splice',
+      category: 'review_wording',
+      confidence: 'medium',
+      rationale: 'Template flagged as too_hard with wrongAfterSupportRate=42.3%.',
+    },
+    {
+      templateId: 'tpl-verb-tense-01',
+      conceptId: 'verb-tense',
+      category: 'insufficient_data',
+      confidence: 'insufficient',
+      rationale: 'Only 8 attempts recorded — below the 30-attempt confidence threshold.',
+    },
+    {
+      templateId: 'tpl-relative-clause-01',
+      conceptId: 'relative-clause',
+      category: 'retire_candidate',
+      confidence: 'high',
+      rationale: 'Persistently support_dependent after 150 attempts.',
+    },
+    {
+      templateId: 'tpl-modal-verb-01',
+      conceptId: 'modal-verb',
+      category: 'keep',
+      confidence: 'medium',
+      rationale: 'Template performing within thresholds.',
+    },
+  ];
+}
+
+function makeMixedTransferDecision() {
+  return {
+    decision: 'keep_shadow_only',
+    perTemplateEvidence: [
+      { templateId: 'tpl-possessive-01', attemptCount: 50, successRate: 0.72, confidenceLevel: 'medium' },
+      { templateId: 'tpl-comma-splice-01', attemptCount: 110, successRate: 0.45, confidenceLevel: 'high' },
+    ],
+    summary: 'Insufficient templates at high confidence for experiment promotion.',
+  };
+}
+
+function makeRetentionDecision() {
+  return {
+    decision: 'no_action_needed',
+    perConceptEvidence: [
+      { conceptId: 'possessive-apostrophe', securedAttempts: 80, lapseRate: 0.05, hasSufficientData: true },
+      { conceptId: 'comma-splice', securedAttempts: 12, lapseRate: 0.18, hasSufficientData: false },
+    ],
+    familyClustering: [
+      { familyId: 'tpl-possessive', templateCount: 3, totalLapses: 4, lapseConcentration: 0.12 },
+    ],
+    summary: 'Average lapse rate below threshold — no maintenance action needed.',
+  };
+}
+
+function makeFullCalibrationData() {
+  return {
+    healthReport: makeHealthReport(),
+    mixedTransferCalibration: { templates: {} },
+    retentionReport: { concepts: {} },
+    actionCandidates: makeActionCandidates(),
+    mixedTransferDecision: makeMixedTransferDecision(),
+    retentionDecision: makeRetentionDecision(),
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('Grammar QG P7 — Calibration View Model (U8)', () => {
+  describe('buildCalibrationViewModel — empty/missing data', () => {
+    it('returns empty state when calibrationData is null', () => {
+      const vm = buildCalibrationViewModel(null);
+      assert.equal(vm.empty, true);
+      assert.ok(vm.emptyMessage.includes('npm run grammar:qg:calibrate'));
+      assert.equal(vm.header, null);
+      assert.deepEqual(vm.templateHealthRows, []);
+      assert.deepEqual(vm.actionCandidateGroups, []);
+      assert.equal(vm.keepCount, 0);
+      assert.equal(vm.mixedTransferEvidence, null);
+      assert.equal(vm.retentionEvidence, null);
+      assert.deepEqual(vm.confidenceWarnings, []);
+    });
+
+    it('returns empty state when calibrationData is undefined', () => {
+      const vm = buildCalibrationViewModel(undefined);
+      assert.equal(vm.empty, true);
+    });
+
+    it('returns empty state when calibrationData is a non-object', () => {
+      const vm = buildCalibrationViewModel('some-string');
+      assert.equal(vm.empty, true);
+    });
+
+    it('handles empty object gracefully', () => {
+      const vm = buildCalibrationViewModel({});
+      assert.equal(vm.empty, false);
+      assert.equal(vm.header.releaseId, '—');
+      assert.deepEqual(vm.templateHealthRows, []);
+    });
+  });
+
+  describe('buildCalibrationViewModel — header', () => {
+    it('extracts provenance fields into header', () => {
+      const data = makeFullCalibrationData();
+      const vm = buildCalibrationViewModel(data);
+      assert.equal(vm.header.releaseId, 'test-release-001');
+      assert.equal(vm.header.schemaVersion, 'grammar-qg-p7-calibration-v1');
+      assert.equal(vm.header.dateRange, '2026-04-20 to 2026-04-29');
+    });
+
+    it('computes inputRowCount from sum of template attempt counts', () => {
+      const data = makeFullCalibrationData();
+      const vm = buildCalibrationViewModel(data);
+      // 120 + 45 + 8 = 173
+      assert.equal(vm.header.inputRowCount, 173);
+    });
+  });
+
+  describe('buildCalibrationViewModel — template health rows sorted by classification', () => {
+    it('sorts unhealthy templates first (support_dependent before too_hard before healthy)', () => {
+      const data = makeFullCalibrationData();
+      const vm = buildCalibrationViewModel(data);
+
+      assert.equal(vm.templateHealthRows.length, 3);
+      // support_dependent (priority 0) first
+      assert.equal(vm.templateHealthRows[0].classification, 'support_dependent');
+      // too_hard (priority 2) second
+      assert.equal(vm.templateHealthRows[1].classification, 'too_hard');
+      // healthy (priority 5) last
+      assert.equal(vm.templateHealthRows[2].classification, 'healthy');
+    });
+
+    it('assigns correct classification colours', () => {
+      const data = makeFullCalibrationData();
+      const vm = buildCalibrationViewModel(data);
+      assert.equal(vm.templateHealthRows[0].classificationColour, 'red'); // support_dependent
+      assert.equal(vm.templateHealthRows[1].classificationColour, 'red'); // too_hard
+      assert.equal(vm.templateHealthRows[2].classificationColour, 'green'); // healthy
+    });
+
+    it('assigns correct confidence badges based on attempt count', () => {
+      const data = makeFullCalibrationData();
+      const vm = buildCalibrationViewModel(data);
+      // 120 attempts → high → green
+      const healthyRow = vm.templateHealthRows.find(r => r.templateId === 'tpl-possessive-01');
+      assert.equal(healthyRow.confidence, 'high');
+      assert.equal(healthyRow.confidenceBadge, 'green');
+      // 8 attempts → insufficient → red-outline
+      const lowRow = vm.templateHealthRows.find(r => r.templateId === 'tpl-verb-tense-01');
+      assert.equal(lowRow.confidence, 'insufficient');
+      assert.equal(lowRow.confidenceBadge, 'red-outline');
+    });
+
+    it('formats success rate as percentage', () => {
+      const data = makeFullCalibrationData();
+      const vm = buildCalibrationViewModel(data);
+      const healthyRow = vm.templateHealthRows.find(r => r.templateId === 'tpl-possessive-01');
+      assert.equal(healthyRow.successRateDisplay, '82.0%');
+    });
+  });
+
+  describe('buildCalibrationViewModel — action candidates', () => {
+    it('filters out "keep" entries from groups', () => {
+      const data = makeFullCalibrationData();
+      const vm = buildCalibrationViewModel(data);
+      for (const group of vm.actionCandidateGroups) {
+        for (const row of group.rows) {
+          assert.notEqual(row.category, 'keep');
+        }
+      }
+    });
+
+    it('reports keepCount for hidden keep entries', () => {
+      const data = makeFullCalibrationData();
+      const vm = buildCalibrationViewModel(data);
+      assert.equal(vm.keepCount, 2); // tpl-possessive-01 + tpl-modal-verb-01
+    });
+
+    it('groups remaining candidates by category', () => {
+      const data = makeFullCalibrationData();
+      const vm = buildCalibrationViewModel(data);
+      const categories = vm.actionCandidateGroups.map(g => g.category);
+      assert.ok(categories.includes('retire_candidate'));
+      assert.ok(categories.includes('review_wording'));
+      assert.ok(categories.includes('insufficient_data'));
+    });
+
+    it('sorts groups by category priority (retire first, insufficient last)', () => {
+      const data = makeFullCalibrationData();
+      const vm = buildCalibrationViewModel(data);
+      const categories = vm.actionCandidateGroups.map(g => g.category);
+      const retireIdx = categories.indexOf('retire_candidate');
+      const reviewIdx = categories.indexOf('review_wording');
+      const insuffIdx = categories.indexOf('insufficient_data');
+      assert.ok(retireIdx < reviewIdx);
+      assert.ok(reviewIdx < insuffIdx);
+    });
+  });
+
+  describe('buildCalibrationViewModel — mixed-transfer evidence', () => {
+    it('extracts decision and colour', () => {
+      const data = makeFullCalibrationData();
+      const vm = buildCalibrationViewModel(data);
+      assert.equal(vm.mixedTransferEvidence.decision, 'keep_shadow_only');
+      assert.equal(vm.mixedTransferEvidence.decisionColour, 'green');
+    });
+
+    it('maps per-template attempt counts', () => {
+      const data = makeFullCalibrationData();
+      const vm = buildCalibrationViewModel(data);
+      assert.equal(vm.mixedTransferEvidence.templateRows.length, 2);
+      assert.equal(vm.mixedTransferEvidence.templateRows[0].attemptCount, 50);
+      assert.equal(vm.mixedTransferEvidence.templateRows[1].attemptCount, 110);
+    });
+
+    it('returns null when no decision data', () => {
+      const data = makeFullCalibrationData();
+      data.mixedTransferDecision = null;
+      const vm = buildCalibrationViewModel(data);
+      assert.equal(vm.mixedTransferEvidence, null);
+    });
+  });
+
+  describe('buildCalibrationViewModel — retention evidence', () => {
+    it('extracts decision and colour', () => {
+      const data = makeFullCalibrationData();
+      const vm = buildCalibrationViewModel(data);
+      assert.equal(vm.retentionEvidence.decision, 'no_action_needed');
+      assert.equal(vm.retentionEvidence.decisionColour, 'green');
+    });
+
+    it('maps per-concept lapse rates', () => {
+      const data = makeFullCalibrationData();
+      const vm = buildCalibrationViewModel(data);
+      assert.equal(vm.retentionEvidence.conceptRows.length, 2);
+      assert.equal(vm.retentionEvidence.conceptRows[0].lapseRate, '5.0%');
+      assert.equal(vm.retentionEvidence.conceptRows[1].lapseRate, '18.0%');
+    });
+
+    it('maps family clustering table', () => {
+      const data = makeFullCalibrationData();
+      const vm = buildCalibrationViewModel(data);
+      assert.equal(vm.retentionEvidence.clusterRows.length, 1);
+      assert.equal(vm.retentionEvidence.clusterRows[0].familyId, 'tpl-possessive');
+      assert.equal(vm.retentionEvidence.clusterRows[0].templateCount, 3);
+    });
+
+    it('returns null when no decision data', () => {
+      const data = makeFullCalibrationData();
+      data.retentionDecision = null;
+      const vm = buildCalibrationViewModel(data);
+      assert.equal(vm.retentionEvidence, null);
+    });
+  });
+
+  describe('buildCalibrationViewModel — confidence warnings', () => {
+    it('flags templates with insufficient data', () => {
+      const data = makeFullCalibrationData();
+      const vm = buildCalibrationViewModel(data);
+      const templateWarnings = vm.confidenceWarnings.filter(w => w.type === 'template');
+      // tpl-verb-tense-01 has only 8 attempts
+      assert.ok(templateWarnings.some(w => w.id === 'tpl-verb-tense-01'));
+    });
+
+    it('flags action candidates with insufficient_data category', () => {
+      const data = makeFullCalibrationData();
+      const vm = buildCalibrationViewModel(data);
+      const actionWarnings = vm.confidenceWarnings.filter(w => w.type === 'action_candidate');
+      assert.ok(actionWarnings.some(w => w.id === 'tpl-verb-tense-01'));
+    });
+  });
+
+  describe('buildCalibrationViewModel — no answer keys in output', () => {
+    it('view model contains no answer keys', () => {
+      const data = makeFullCalibrationData();
+      const vm = buildCalibrationViewModel(data);
+      const serialised = JSON.stringify(vm);
+      // Ensure no answer/key/correct_answer/solution fields leak through
+      assert.ok(!serialised.includes('"answerKey"'));
+      assert.ok(!serialised.includes('"correctAnswer"'));
+      assert.ok(!serialised.includes('"solution"'));
+    });
+  });
+
+  describe('buildCalibrationViewModel — no raw learner IDs in output', () => {
+    it('view model contains no learner identifiers', () => {
+      const data = makeFullCalibrationData();
+      const vm = buildCalibrationViewModel(data);
+      const serialised = JSON.stringify(vm);
+      assert.ok(!serialised.includes('"learnerId"'));
+      assert.ok(!serialised.includes('"userId"'));
+      assert.ok(!serialised.includes('"studentId"'));
+      assert.ok(!serialised.includes('"childId"'));
+    });
+  });
+
+  describe('confidenceBadge helper', () => {
+    it('high → green', () => assert.equal(confidenceBadge('high'), 'green'));
+    it('medium → amber', () => assert.equal(confidenceBadge('medium'), 'amber'));
+    it('low → grey', () => assert.equal(confidenceBadge('low'), 'grey'));
+    it('insufficient → red-outline', () => assert.equal(confidenceBadge('insufficient'), 'red-outline'));
+    it('unknown → grey', () => assert.equal(confidenceBadge('something_else'), 'grey'));
+  });
+
+  describe('confidenceLevel helper', () => {
+    it('>100 → high', () => assert.equal(confidenceLevel(101), 'high'));
+    it('30-100 → medium', () => assert.equal(confidenceLevel(50), 'medium'));
+    it('10-29 → low', () => assert.equal(confidenceLevel(15), 'low'));
+    it('<10 → insufficient', () => assert.equal(confidenceLevel(5), 'insufficient'));
+    it('boundary: 100 → medium', () => assert.equal(confidenceLevel(100), 'medium'));
+    it('boundary: 30 → medium', () => assert.equal(confidenceLevel(30), 'medium'));
+    it('boundary: 10 → low', () => assert.equal(confidenceLevel(10), 'low'));
+  });
+
+  describe('formatPercent helper', () => {
+    it('formats 0.82 as 82.0%', () => assert.equal(formatPercent(0.82), '82.0%'));
+    it('formats 0 as 0.0%', () => assert.equal(formatPercent(0), '0.0%'));
+    it('formats 1 as 100.0%', () => assert.equal(formatPercent(1), '100.0%'));
+    it('returns — for null', () => assert.equal(formatPercent(null), '—'));
+    it('returns — for NaN', () => assert.equal(formatPercent(NaN), '—'));
+  });
+
+  describe('decisionColour helper', () => {
+    it('keep_shadow_only → green', () => assert.equal(decisionColour('keep_shadow_only'), 'green'));
+    it('prepare_scoring_experiment → amber', () => assert.equal(decisionColour('prepare_scoring_experiment'), 'amber'));
+    it('do_not_promote → red', () => assert.equal(decisionColour('do_not_promote'), 'red'));
+    it('no_action_needed → green', () => assert.equal(decisionColour('no_action_needed'), 'green'));
+    it('recommend_maintenance_experiment → amber', () => assert.equal(decisionColour('recommend_maintenance_experiment'), 'amber'));
+    it('defer_insufficient_data → grey', () => assert.equal(decisionColour('defer_insufficient_data'), 'grey'));
+    it('unknown → grey', () => assert.equal(decisionColour('anything'), 'grey'));
+  });
+});


### PR DESCRIPTION
## Summary

- Create `GrammarCalibrationPanel.jsx` — admin-only panel reading P7 report artefacts
- Create `calibration-view-model.js` — pure data transform (no React deps)
- Template health table sorted unhealthy-first, action candidates grouped by category
- Mixed-transfer and retention decision gates with evidence tables
- Graceful empty state when no calibration data available
- No answer keys, no raw learner IDs in display

## Test plan

- [x] 49 tests covering all view model transforms and invariants
- [x] No answer keys verified in output
- [x] No raw learner IDs verified in output
- [x] Empty/missing data → graceful fallback message
- [x] Admin-only (uses AdminPanelFrame)