### PR TITLE
feat(grammar): align setup with Spelling — shared hero engine, slide-button picker, setup-grid layout

### DIFF
--- a/scripts/audit-client-bundle.mjs
+++ b/scripts/audit-client-bundle.mjs
@@ -31,14 +31,17 @@ const DEFAULT_PUBLIC_DIR = 'dist/public';
 // adds another tiny cross-subject utility slice. The reward presentation
 // queue, toast compatibility layers, Hero Mode P3 daily-progress shell,
 // Grammar's bridge-ownership display gate, the Concordium Grand Star tier
-// model, and Hero Mode P5 Camp's child-facing spending surface keep Node 22/24
-// gzip output near 223.9 KB, so the committed ceiling is 224,500: still tight
-// enough to catch an adult-surface re-import, without blocking on
-// sub-kilobyte compression/runtime drift. Override via CLI
+// model, Hero Mode P5 Camp's child-facing spending surface, and the
+// Grammar setup-aligned refactor (shared hero-bg + HeroBackdrop +
+// useSetupHeroContrast platform engines + slide-button RoundLengthPicker
+// + grammar-hero-bg view-model) keep Node 22/24 gzip output near 226.3 KB,
+// so the committed ceiling is 227,000: still tight enough to catch an
+// adult-surface re-import, without blocking on sub-kilobyte
+// compression/runtime drift. Override via CLI
 // `--main-bundle-budget-bytes` for experimentation. See
 // `tests/bundle-byte-budget.test.js` for the committed baseline +
 // rationale.
-const DEFAULT_MAIN_BUNDLE_GZIP_BUDGET_BYTES = 224_500;
+const DEFAULT_MAIN_BUNDLE_GZIP_BUDGET_BYTES = 227_000;
 
 const FORBIDDEN_MODULES = [
   { pattern: /^src\/subjects\/spelling\/data\//, reason: 'full spelling content dataset' },

--- a/scripts/inventory-inline-styles.mjs
+++ b/scripts/inventory-inline-styles.mjs
@@ -156,6 +156,12 @@ export const CLASSIFICATION = Object.freeze({
   // Profile
   'src/surfaces/profile/ProfileSettingsSurface.jsx': 'shared-pattern-available',
 
+  // Platform UI — shared hero backdrop primitive (cross-fade + pan).
+  // Sets `--hero-bg` and `--hero-pan-delay` per layer; both are
+  // dynamic per render and per learner so they cannot be hoisted to a
+  // static class.
+  'src/platform/ui/HeroBackdrop.jsx': 'dynamic-content-driven',
+
   // Subjects — spelling
   'src/subjects/spelling/components/SpellingCommon.jsx': 'css-var-ready',
   'src/subjects/spelling/components/SpellingHeroBackdrop.jsx': 'dynamic-content-driven',

--- a/src/platform/core/utils.js
+++ b/src/platform/core/utils.js
@@ -1,3 +1,19 @@
+/* Tiny deterministic hash over a string. Used as a stable, framework-free
+ * way to pick a "random-looking" but learner-stable index from a known
+ * pool — e.g. which hero tone or region to assign per learner. The hash
+ * is intentionally simple and JavaScript-bitwise so the same input
+ * yields the same output across browsers, the SSR harness, and the
+ * Worker runtime. */
+export function stableHash(value) {
+  const text = String(value || '');
+  let hash = 0;
+  for (let i = 0; i < text.length; i += 1) {
+    hash = (hash << 5) - hash + text.charCodeAt(i);
+    hash |= 0;
+  }
+  return Math.abs(hash);
+}
+
 export function uid(prefix = 'id') {
   const random = Math.random().toString(36).slice(2, 10);
   return `${prefix}-${Date.now().toString(36)}-${random}`;

--- a/src/platform/ui/HeroBackdrop.jsx
+++ b/src/platform/ui/HeroBackdrop.jsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import { HERO_TRANSITION_MS, heroBgStyle, heroPanDelayStyle } from './hero-bg.js';
+
+/* Subject-agnostic hero backdrop with cross-fade + slow horizontal pan.
+ *
+ * Setup scenes (Spelling, Grammar, future Punctuation) all paint a
+ * region artwork behind the mode cards. When the URL changes — e.g. a
+ * mode flip swaps the region — we render the new layer on top with
+ * `is-entering`, demote prior layers to `is-exiting`, and after the
+ * dissolve duration prune everything except the freshly active layer.
+ *
+ * The handoff slot lets a parent surface (typically the
+ * SubjectPracticeSurface) supply the URL the previous scene was painting
+ * so the backdrop animates in from THAT artwork rather than from a flat
+ * panel — keeping the visual continuity even when the underlying scene
+ * remounts.
+ *
+ * Each layer carries `data-hero-layer="true"` so the platform-level
+ * luminance probe (`probeHeroTextTones`) can locate the active layer
+ * by attribute regardless of which subject is calling it.
+ *
+ * Optional class hooks:
+ *   * `extraBackdropClassName` — additional class on the wrapper, e.g.
+ *     `spelling-hero-backdrop` for the legacy `.spelling-in-session`
+ *     selector. Grammar and any new subject can leave this blank.
+ *   * `extraLayerClassName` — additional class on each layer element,
+ *     used by the same legacy selectors. New callers should leave blank
+ *     and rely on `.hero-layer`.
+ *
+ * Why a config prop instead of a CSS-only switch: the legacy CSS rules
+ * for spelling reach DOWN through `.spelling-in-session .spelling-hero-
+ * layer::after` — we cannot drop the class without rewriting the
+ * mid-session backdrop tinting. Carrying both names is the lightest
+ * touch that keeps Spelling's rules and contracts intact while letting
+ * Grammar use the clean primitive.
+ */
+export function HeroBackdrop({
+  url,
+  previousUrl = '',
+  extraBackdropClassName = '',
+  extraLayerClassName = '',
+}) {
+  const handoffUrl = previousUrl && previousUrl !== url ? previousUrl : '';
+  const layerId = React.useRef(handoffUrl ? 1 : 0);
+  const currentUrl = React.useRef(url || '');
+  const initialTransitionId = React.useRef(handoffUrl ? 1 : null);
+  const [layers, setLayers] = React.useState(() => (
+    (() => {
+      if (!url) return [];
+      const panStyle = heroPanDelayStyle();
+      return [
+        ...(handoffUrl ? [{ id: 0, url: handoffUrl, phase: 'exiting', panStyle }] : []),
+        { id: handoffUrl ? 1 : 0, url, phase: handoffUrl ? 'entering' : 'active', panStyle },
+      ];
+    })()
+  ));
+
+  React.useEffect(() => {
+    const nextId = initialTransitionId.current;
+    if (nextId == null || !url) return undefined;
+    const transitionUrl = url;
+    const timer = setTimeout(() => {
+      setLayers((current) => {
+        if (currentUrl.current !== transitionUrl) return current;
+        return current
+          .filter((layer) => layer.id === nextId)
+          .map((layer) => ({ ...layer, phase: 'active' }));
+      });
+    }, HERO_TRANSITION_MS);
+    return () => clearTimeout(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-once handoff settle
+  }, []);
+
+  React.useEffect(() => {
+    if (!url) {
+      currentUrl.current = '';
+      setLayers([]);
+      return undefined;
+    }
+
+    if (currentUrl.current === url) return undefined;
+    currentUrl.current = url;
+    layerId.current += 1;
+    const nextId = layerId.current;
+    const panStyle = heroPanDelayStyle();
+    setLayers((current) => [
+      ...current.slice(-2).map((layer) => ({ ...layer, phase: 'exiting' })),
+      { id: nextId, url, phase: 'entering', panStyle },
+    ]);
+
+    const timer = setTimeout(() => {
+      setLayers((current) => current
+        .filter((layer) => layer.id === nextId)
+        .map((layer) => ({ ...layer, phase: 'active' })));
+    }, HERO_TRANSITION_MS);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [url]);
+
+  if (!layers.length) return null;
+
+  const backdropClasses = ['hero-backdrop'];
+  if (extraBackdropClassName) backdropClasses.push(extraBackdropClassName);
+
+  return (
+    <div className={backdropClasses.join(' ')} aria-hidden="true">
+      {layers.map((layer) => {
+        const layerClasses = ['hero-art', 'pan', 'hero-layer', `is-${layer.phase}`];
+        if (extraLayerClassName) layerClasses.push(extraLayerClassName);
+        return (
+          <div
+            className={layerClasses.join(' ')}
+            data-hero-layer="true"
+            style={{ ...heroBgStyle(layer.url), ...(layer.panStyle || {}) }}
+            key={layer.id}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/src/platform/ui/SetupMorePractice.jsx
+++ b/src/platform/ui/SetupMorePractice.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+
+/* Subject-agnostic "More practice" disclosure inside a Setup scene.
+ *
+ * Currently used only by Grammar (the only subject that splits its
+ * mode catalogue between a primary 3-card row and a longer secondary
+ * tail). Refactored ahead of need so when Spelling or Punctuation
+ * eventually adds a similar tail of optional drills, the disclosure
+ * shell + grid layout already exists at the platform layer.
+ *
+ * Contract:
+ *   * `summary` — the accordion eyebrow (default: "More practice").
+ *   * `cards` — array of card definitions; opaque to the disclosure.
+ *   * `renderCard(card, index)` — caller-supplied factory because
+ *     each subject's secondary card carries its own dispatch contract
+ *     (Grammar's "Writing Try" dispatches `grammar-open-transfer`,
+ *     other secondary cards dispatch `grammar-set-mode`). Returning a
+ *     render function from the caller keeps the disclosure shell free
+ *     of subject knowledge.
+ *   * `disclosureClassName` / `gridClassName` — subject-namespaced
+ *     class hooks the caller can override; default to the
+ *     `.setup-more-practice` / `.setup-more-practice-grid` shared
+ *     rhythm so a subject can adopt the platform CSS unchanged or
+ *     extend with its own brand colour by appending its own class.
+ *   * `defaultOpen` — `true` to render the `<details>` open on first
+ *     paint. Defaults to `false` so the surface stays decision-light
+ *     until the learner opts in.
+ */
+export function SetupMorePractice({
+  summary = 'More practice',
+  cards,
+  renderCard,
+  disclosureClassName = 'setup-more-practice',
+  gridClassName = 'setup-more-practice-grid',
+  defaultOpen = false,
+}) {
+  const safeCards = Array.isArray(cards) ? cards : [];
+  if (!safeCards.length || typeof renderCard !== 'function') return null;
+  return (
+    <details className={disclosureClassName} {...(defaultOpen ? { open: true } : {})}>
+      <summary>{summary}</summary>
+      <div className={gridClassName}>
+        {safeCards.map((card, index) => renderCard(card, index))}
+      </div>
+    </details>
+  );
+}

--- a/src/platform/ui/hero-bg.js
+++ b/src/platform/ui/hero-bg.js
@@ -1,0 +1,31 @@
+/* Subject-agnostic hero backdrop primitives.
+ *
+ * Every Setup scene renders a layered backdrop with a slow horizontal pan
+ * and a cross-fade when the URL changes. The CSS keyframes (`hero-pan`,
+ * `spelling-hero-dissolve-in`, `spelling-hero-dissolve-out`) live in
+ * `styles/app.css` and are referenced through CSS custom properties so
+ * they stay tuned in one place.
+ *
+ * The pan duration constant is shared with the React backdrop so the JS
+ * layer's transition timer (`HERO_TRANSITION_MS`) and the CSS animation
+ * stay in sync; the inline `--hero-pan-delay` style randomises each
+ * mount's start point so simultaneous backdrop layers do not lock-step.
+ *
+ * Centralising these helpers under `src/platform/ui/` lets each subject
+ * (Spelling, Grammar, future Punctuation) reuse the identical engine
+ * without re-implementing the cross-fade contract or drifting on the
+ * pan period.
+ */
+
+export const HERO_PAN_SECONDS = 96;
+export const HERO_TRANSITION_MS = 920;
+
+export function heroBgStyle(url) {
+  return url ? { '--hero-bg': `url('${url}')` } : {};
+}
+
+export function heroPanDelayStyle() {
+  if (typeof performance === 'undefined') return {};
+  const elapsed = (performance.now() / 1000) % (HERO_PAN_SECONDS * 2);
+  return { '--hero-pan-delay': `-${elapsed.toFixed(3)}s` };
+}

--- a/src/platform/ui/luminance.js
+++ b/src/platform/ui/luminance.js
@@ -158,7 +158,16 @@ function fallbackToneResults(container, probes) {
 }
 
 function resolveHeroLayer(container, url) {
-  const layers = Array.from(container.querySelectorAll?.('.spelling-hero-layer') || []);
+  // Subject-agnostic layer lookup. The shared `HeroBackdrop` stamps
+  // `data-hero-layer="true"` onto every layer it renders so any subject
+  // (Spelling, Grammar, future Punctuation) can be probed without us
+  // hard-coding a per-subject CSS class. Falls back to the legacy
+  // `.spelling-hero-layer` selector for any caller still on the older
+  // wrapper before the mid-2026-04-29 platform extraction.
+  const byAttr = Array.from(container.querySelectorAll?.('[data-hero-layer="true"]') || []);
+  const layers = byAttr.length
+    ? byAttr
+    : Array.from(container.querySelectorAll?.('.spelling-hero-layer') || []);
   if (!layers.length) return null;
   const reversed = layers.slice().reverse();
   return reversed.find((layer) => (

--- a/src/platform/ui/useSetupHeroContrast.js
+++ b/src/platform/ui/useSetupHeroContrast.js
@@ -1,0 +1,184 @@
+import React from 'react';
+import { probeHeroTextTones } from './luminance.js';
+
+/* Subject-agnostic Setup hero contrast hook.
+ *
+ * Each subject's Setup scene paints a hero backdrop with three
+ * region/tone combinations. The contrast that the mode cards, ledes,
+ * and tweak labels need depends on which region+tone is active — and
+ * sometimes we already know it statically (via the per-tone curated
+ * profile in the subject view-model), sometimes we have to probe the
+ * actual artwork because the region was authored after the curated
+ * table.
+ *
+ * The hook is platform-level so Spelling, Grammar, and any new subject
+ * can share a single implementation. It accepts:
+ *
+ *   * `staticContrastForBg(url, mode)` — fast lookup that returns the
+ *     curated `{ tone, shell, controls, cards[] }` profile or `null`
+ *     when the subject does not have one for this URL.
+ *   * `cardSelector` — DOM selector for mode cards. Spelling uses
+ *     `.mode-card`; Grammar uses `.grammar-primary-mode`.
+ *   * `controlSelectors` — array of selectors for tweak labels (the
+ *     elements whose colour we adapt to the active region tone).
+ *
+ * Defaults intentionally match Spelling's existing call-site so the
+ * Spelling wrapper can keep its previous behaviour by simply forwarding
+ * `staticContrastForBg`.
+ */
+
+const DEFAULT_CONTRAST = Object.freeze({
+  tone: '',
+  shell: 'dark',
+  controls: 'dark',
+  cards: Object.freeze(['dark', 'dark', 'dark']),
+});
+
+const CARD_GLASS_ALPHA = 0.28;
+const SELECTED_CARD_GLASS_ALPHA = 0.42;
+const CONTROL_REFRESH_MS = 6000;
+
+const DEFAULT_CARD_SELECTOR = '.mode-card';
+const DEFAULT_CONTROL_SELECTORS = Object.freeze(['.tool-label', '.length-unit']);
+const DEFAULT_OBSERVE_SELECTORS = Object.freeze([
+  '.mode-card',
+  '.setup-control-stack',
+  '.title',
+  '.lede',
+]);
+
+export function useSetupHeroContrast(heroBg, mode, options = {}) {
+  const ref = React.useRef(null);
+  const {
+    staticContrastForBg,
+    cardSelector = DEFAULT_CARD_SELECTOR,
+    controlSelectors = DEFAULT_CONTROL_SELECTORS,
+    observeSelectors = DEFAULT_OBSERVE_SELECTORS,
+  } = options;
+  const staticContrast = React.useMemo(() => (
+    typeof staticContrastForBg === 'function'
+      ? staticContrastForBg(heroBg, mode)
+      : null
+  ), [heroBg, mode, staticContrastForBg]);
+  const [probedContrast, setProbedContrast] = React.useState(staticContrast || DEFAULT_CONTRAST);
+
+  React.useEffect(() => {
+    if (staticContrast) {
+      setProbedContrast(staticContrast);
+      return undefined;
+    }
+
+    const shell = ref.current;
+    if (!shell || !heroBg || typeof window === 'undefined') {
+      setProbedContrast(DEFAULT_CONTRAST);
+      return undefined;
+    }
+
+    let cancelled = false;
+    let frame = 0;
+    let observer = null;
+
+    const scheduleProbe = () => {
+      if (cancelled || frame) return;
+      frame = window.requestAnimationFrame(() => {
+        frame = 0;
+        runProbe(shell, heroBg, { cardSelector, controlSelectors }).then((nextContrast) => {
+          if (cancelled) return;
+          setProbedContrast((current) => (
+            sameContrast(current, nextContrast) ? current : nextContrast
+          ));
+        });
+      });
+    };
+
+    scheduleProbe();
+    const interval = window.setInterval(scheduleProbe, CONTROL_REFRESH_MS);
+    if (typeof ResizeObserver !== 'undefined') {
+      observer = new ResizeObserver(scheduleProbe);
+      observer.observe(shell);
+      observeSelectors.forEach((selector) => {
+        shell.querySelectorAll(selector).forEach((element) => observer.observe(element));
+      });
+    }
+
+    return () => {
+      cancelled = true;
+      if (frame) window.cancelAnimationFrame(frame);
+      window.clearInterval(interval);
+      observer?.disconnect();
+    };
+  }, [heroBg, mode, staticContrast, cardSelector, controlSelectors, observeSelectors]);
+
+  return { ref, contrast: staticContrast || probedContrast };
+}
+
+async function runProbe(shell, heroBg, { cardSelector, controlSelectors }) {
+  const cards = Array.from(shell.querySelectorAll(cardSelector));
+  const cardProbes = cards.map((card, index) => ({
+    key: `card:${index}`,
+    element: cardTextRegion(card) || card,
+    glassAlpha: card.classList.contains('selected') ? SELECTED_CARD_GLASS_ALPHA : CARD_GLASS_ALPHA,
+  }));
+  const controlElements = controlSelectors.flatMap((selector) => (
+    Array.from(shell.querySelectorAll(selector))
+  )).filter((element) => visibleForProbe(element, shell));
+  const probes = [
+    { key: 'shell', element: shell.querySelector('.lede') || shell.querySelector('.title') || shell, glassAlpha: 0 },
+    ...cardProbes,
+    ...controlElements.map((element, index) => ({ key: `control:${index}`, element, glassAlpha: 0 })),
+  ];
+
+  const results = await probeHeroTextTones(heroBg, shell, probes);
+  const byKey = new Map(results.map((result) => [result.key, result]));
+  const controlResults = results.filter((result) => String(result.key || '').startsWith('control:'));
+  return {
+    tone: '',
+    shell: byKey.get('shell')?.tone || DEFAULT_CONTRAST.shell,
+    cards: cards.map((_, index) => byKey.get(`card:${index}`)?.tone || DEFAULT_CONTRAST.cards[index] || DEFAULT_CONTRAST.shell),
+    controls: combinedTone(controlResults) || DEFAULT_CONTRAST.controls,
+  };
+}
+
+function cardTextRegion(card) {
+  const title = card.querySelector('h4, h3, .grammar-primary-mode-title');
+  const copy = card.querySelector('p, .grammar-primary-mode-desc');
+  if (!title && !copy) return null;
+  return {
+    getBoundingClientRect() {
+      const rects = [title, copy]
+        .filter(Boolean)
+        .map((element) => element.getBoundingClientRect())
+        .filter((rect) => rect.width && rect.height);
+      if (!rects.length) return card.getBoundingClientRect();
+      const left = Math.min(...rects.map((rect) => rect.left));
+      const top = Math.min(...rects.map((rect) => rect.top));
+      const right = Math.max(...rects.map((rect) => rect.right));
+      const bottom = Math.max(...rects.map((rect) => rect.bottom));
+      return { left, top, right, bottom, width: right - left, height: bottom - top };
+    },
+  };
+}
+
+function visibleForProbe(element, shell) {
+  const rect = element.getBoundingClientRect();
+  if (!rect.width || !rect.height) return false;
+  for (let current = element; current && current.nodeType === Node.ELEMENT_NODE; current = current.parentElement) {
+    const style = getComputedStyle(current);
+    if (style.visibility === 'hidden' || Number.parseFloat(style.opacity || '1') <= 0.05) return false;
+    if (current === shell) break;
+  }
+  return true;
+}
+
+function combinedTone(results) {
+  if (!results.length) return '';
+  return results.some((result) => result.tone === 'light') ? 'light' : 'dark';
+}
+
+function sameContrast(left, right) {
+  return left.tone === right.tone
+    && left.shell === right.shell
+    && left.controls === right.controls
+    && left.cards.length === right.cards.length
+    && left.cards.every((tone, index) => tone === right.cards[index]);
+}

--- a/src/subjects/grammar/components/GrammarConceptBankScene.jsx
+++ b/src/subjects/grammar/components/GrammarConceptBankScene.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { GrammarAnalyticsScene } from './GrammarAnalyticsScene.jsx';
 import { GrammarConceptDetailModal } from './GrammarConceptDetailModal.jsx';
 import {
   GRAMMAR_BANK_CLUSTER_CHIPS,
@@ -137,7 +138,14 @@ function ConceptCard({ card, onPractise, onOpenDetail }) {
   );
 }
 
-export function GrammarConceptBankScene({ grammar, actions }) {
+export function GrammarConceptBankScene({
+  grammar,
+  actions,
+  learner = null,
+  rewardState = null,
+  subject = null,
+  runtimeReadOnly = false,
+}) {
   const bankUi = grammar?.bank || {};
   const activeStatus = bankUi.statusFilter || 'all';
   const activeCluster = bankUi.clusterFilter || 'all';
@@ -209,63 +217,83 @@ export function GrammarConceptBankScene({ grammar, actions }) {
 
       <AggregateCards counts={bankModel.counts} total={bankModel.total} />
 
-      <div className="grammar-bank-toolbar">
-        <label className="grammar-bank-search">
-          <span className="grammar-bank-search-label">Search concepts</span>
-          <input
-            type="search"
-            name="grammarConceptBankSearch"
-            autoComplete="off"
-            placeholder="Search concepts"
-            value={draftQuery}
-            data-action="grammar-concept-bank-search"
-            aria-label="Search Grammar concepts"
-            onChange={(event) => setDraftQuery(event.currentTarget.value.slice(0, 80))}
-            onBlur={(event) => commitSearch(event.currentTarget.value)}
-            onKeyDown={(event) => {
-              if (event.key !== 'Enter') return;
-              event.preventDefault();
-              commitSearch(event.currentTarget.value);
-            }}
-          />
-        </label>
-        <div className="grammar-bank-filter-stack">
-          <StatusFilterChips
-            counts={bankModel.counts}
-            activeFilter={activeStatus}
-            onChange={handleStatusChange}
-          />
-          <ClusterFilterChips
-            counts={bankModel.clusterCounts}
-            activeFilter={activeCluster}
-            onChange={handleClusterChange}
-          />
-        </div>
-      </div>
-
-      <p className="grammar-bank-summary" role="status">{summaryText}</p>
-
-      <div className="grammar-bank-grid">
-        {bankModel.cards.length
-          ? bankModel.cards.map((card) => (
-            <ConceptCard
-              card={card}
-              onPractise={handlePractise}
-              onOpenDetail={handleOpenDetail}
-              key={card.id}
+      <div className="grammar-bank-card-wrap">
+        <div className="grammar-bank-toolbar">
+          <label className="grammar-bank-search">
+            <span className="grammar-bank-search-label">Search concepts</span>
+            <input
+              type="search"
+              name="grammarConceptBankSearch"
+              autoComplete="off"
+              placeholder="Search concepts"
+              value={draftQuery}
+              data-action="grammar-concept-bank-search"
+              aria-label="Search Grammar concepts"
+              onChange={(event) => setDraftQuery(event.currentTarget.value.slice(0, 80))}
+              onBlur={(event) => commitSearch(event.currentTarget.value)}
+              onKeyDown={(event) => {
+                if (event.key !== 'Enter') return;
+                event.preventDefault();
+                commitSearch(event.currentTarget.value);
+              }}
             />
-          ))
-          : (
-            <div className="grammar-bank-empty" role="status">
-              {draftQuery ? GRAMMAR_BANK_HERO.emptyWithSearch : GRAMMAR_BANK_HERO.empty}
-            </div>
-          )
-        }
+          </label>
+          <div className="grammar-bank-filter-stack">
+            <StatusFilterChips
+              counts={bankModel.counts}
+              activeFilter={activeStatus}
+              onChange={handleStatusChange}
+            />
+            <ClusterFilterChips
+              counts={bankModel.clusterCounts}
+              activeFilter={activeCluster}
+              onChange={handleClusterChange}
+            />
+          </div>
+        </div>
+
+        <p className="grammar-bank-summary" role="status">{summaryText}</p>
+
+        <div className="grammar-bank-grid">
+          {bankModel.cards.length
+            ? bankModel.cards.map((card) => (
+              <ConceptCard
+                card={card}
+                onPractise={handlePractise}
+                onOpenDetail={handleOpenDetail}
+                key={card.id}
+              />
+            ))
+            : (
+              <div className="grammar-bank-empty" role="status">
+                {draftQuery ? GRAMMAR_BANK_HERO.emptyWithSearch : GRAMMAR_BANK_HERO.empty}
+              </div>
+            )
+          }
+        </div>
       </div>
 
       {detailCard ? (
         <GrammarConceptDetailModal card={detailCard} actions={actions} />
       ) : null}
+
+      {/* Aligned design: the adult escape hatch lives at the bottom of the
+       * Grammar Bank rather than as a sibling of the dashboard. The bank
+       * is the comprehensive concept view, so the parent / teacher lens
+       * sits naturally as a closed-by-default disclosure underneath. The
+       * `<details>` keeps the surface child-first — the parent has to
+       * explicitly opt in. */}
+      <details className="grammar-grown-up-view">
+        <summary>Grown-up view</summary>
+        <GrammarAnalyticsScene
+          subject={subject}
+          learner={learner}
+          grammar={grammar}
+          rewardState={rewardState}
+          actions={actions}
+          runtimeReadOnly={runtimeReadOnly}
+        />
+      </details>
     </section>
   );
 }

--- a/src/subjects/grammar/components/GrammarPracticeSurface.jsx
+++ b/src/subjects/grammar/components/GrammarPracticeSurface.jsx
@@ -128,14 +128,6 @@ export function GrammarPracticeSurface({
   return (
     <div className="grammar-surface">
       <GrammarSetupScene {...shared} />
-      {/* Phase 3 U1 keeps the analytics surface reachable but demoted from
-          the dashboard primary view — it now lives behind a "Grown-up view"
-          disclosure per the U5 summary decision. Until U5/U7 land the
-          full split, this stays here as the non-primary grown-up surface. */}
-      <details className="grammar-grown-up-view">
-        <summary>Grown-up view</summary>
-        <GrammarAnalyticsScene {...shared} />
-      </details>
     </div>
   );
 }

--- a/src/subjects/grammar/components/GrammarSessionScene.jsx
+++ b/src/subjects/grammar/components/GrammarSessionScene.jsx
@@ -626,6 +626,29 @@ export function GrammarSessionScene({ grammar, actions, runtimeReadOnly }) {
           <div className="eyebrow">Grammar practice</div>
           <h2 id="grammar-session-title">{sessionTitle}</h2>
         </div>
+        <div
+          className="grammar-progress-dots"
+          role="progressbar"
+          aria-valuemin={0}
+          aria-valuemax={progressTotal}
+          aria-valuenow={Math.min(progressDone, progressTotal)}
+          aria-label={`Question ${Math.min(progressDone + 1, progressTotal)} of ${progressTotal}`}
+        >
+          {Array.from({ length: progressTotal }, (_, index) => {
+            const stateClass = index < progressDone
+              ? ' done'
+              : index === progressDone
+                ? ' current'
+                : '';
+            return (
+              <span
+                className={`grammar-progress-step${stateClass}`}
+                key={`grammar-progress-step-${index}`}
+                aria-hidden="true"
+              />
+            );
+          })}
+        </div>
         <div className="grammar-progress" aria-label="Round progress">
           <span>{progressDone}</span>
           <small>of {progressTotal}</small>
@@ -633,9 +656,9 @@ export function GrammarSessionScene({ grammar, actions, runtimeReadOnly }) {
       </div>
 
       <div className="grammar-prompt-card">
-        <div className="chip-row">
-          {infoChips.map((chip) => (
-            <span className="chip" key={chip}>{chip}</span>
+        <div className="chip-row grammar-info-chip-row">
+          {infoChips.map((chip, index) => (
+            <span className={`chip grammar-info-chip${index === 0 ? ' accent' : ''}`} key={chip}>{chip}</span>
           ))}
           {!isMiniTest ? <SessionGoalChip goal={session.goal} /> : null}
         </div>

--- a/src/subjects/grammar/components/GrammarSetupScene.jsx
+++ b/src/subjects/grammar/components/GrammarSetupScene.jsx
@@ -1,53 +1,44 @@
 import React from 'react';
+import { HeroBackdrop } from '../../../platform/ui/HeroBackdrop.jsx';
+import { useSetupHeroContrast } from '../../../platform/ui/useSetupHeroContrast.js';
+import { heroBgStyle } from '../../../platform/ui/hero-bg.js';
+import { SetupMorePractice } from '../../../platform/ui/SetupMorePractice.jsx';
 import {
-  GRAMMAR_REGION_IMAGE,
-  GRAMMAR_REGION_IMAGE_SMALL,
+  heroBgForGrammarSetup,
+  heroContrastProfileForGrammarBg,
+  heroToneForGrammarBg,
+} from './grammar-hero-bg.js';
+import {
   grammarMonsterAsset,
 } from '../metadata.js';
-import { normaliseGrammarSpeechRate } from '../speech.js';
 import {
   GRAMMAR_DASHBOARD_HERO,
   GRAMMAR_MORE_PRACTICE_MODES,
   GRAMMAR_PRIMARY_MODE_CARDS,
-  GRAMMAR_SECONDARY_MODE_LINKS,
   GRAMMAR_MONSTER_STRIP_CHILD_COPY,
   buildGrammarDashboardModel,
 } from './grammar-view-model.js';
-// SH2-U5: fresh-learner `dashboard.isEmpty` branch surfaces the canonical
-// three-part copy through the shared primitive. The pre-U5 bespoke
-// `.grammar-today-empty` div kept a single sentence and no reassurance —
-// the primitive also preserves the existing `data-testid` so the
-// grammar-phase3-child-copy test continues to find the anchor.
 import { EmptyState } from '../../../platform/ui/EmptyState.jsx';
 
-// Phase 5 U7+U8: Child-facing Grammar dashboard. Every label, mode id,
-// and card comes from the view-model (`grammar-view-model.js`). The JSX
-// layer is a layout-only component — we do not restate copy, filter ids,
-// or mode ids inline. Hero copy is driven by `GRAMMAR_DASHBOARD_HERO` so
-// James can swap the wording in one place after review.
-//
-// Layout (top → bottom):
-//   - Hero (headline + subheadline)
-//   - Monster strip (active creatures with Star progress bars)
-//   - Primary CTA (Start Smart Practice button)
-//   - Today cards (Due / Trouble spots / Secure / Streak)
-//   - Secondary links (Grammar Bank, Mini Test, Fix Trouble Spots)
-//   - More practice <details> disclosure (Learn, Surgery, Builder,
-//     Worked, Faded, Writing Try). Closed by default.
-//   - Quiet round-length + speech-rate controls.
-//
-// Everything the old adult-diagnostic surface said (`Worker-marked modes`,
-// `Worker marked` chip, `full map`, `Full placeholder map`, `All 18
-// Grammar concepts` grid) is removed. U10's fixture-driven absence test
-// covers regressions.
+/* Aligned Grammar setup scene.
+ *
+ * The previous layout collapsed hero copy + mode cards + controls into
+ * a bespoke `.grammar-primary-modes` panel with a static `<picture>`
+ * backdrop. The aligned design uses the same `.setup-grid` /
+ * `.setup-main` / `.setup-content` rhythm Spelling does, paints the
+ * region artwork via the shared `HeroBackdrop` (cross-fade + slow pan),
+ * and reads contrast tokens from the platform `useSetupHeroContrast`
+ * hook so text colour adapts to whatever artwork is on screen.
+ *
+ * Outer landmark + every existing `data-*` and `.grammar-*` test hook
+ * is preserved (`data-grammar-phase-root="dashboard"`,
+ * `.grammar-primary-mode`, `[data-action="grammar-set-mode"]`, etc).
+ *
+ * Round length is now a slide-button picker (`.length-picker`) instead
+ * of a `<select>`, mirroring Spelling's tweak-row pattern. */
 
-const SPEECH_RATE_OPTIONS = Object.freeze([
-  { value: 0.6, label: '0.6x slow' },
-  { value: 0.8, label: '0.8x steady' },
-  { value: 1, label: '1x normal' },
-  { value: 1.2, label: '1.2x quicker' },
-  { value: 1.4, label: '1.4x fast' },
-]);
+const NORMAL_ROUND_OPTIONS = ['3', '5', '8', '10', '15'];
+const MINI_TEST_ROUND_OPTIONS = ['8', '12'];
 
 function TodayCard({ card }) {
   return (
@@ -59,7 +50,6 @@ function TodayCard({ card }) {
   );
 }
 
-// U7 Phase 5: Monster strip entry — one per active Grammar monster.
 function MonsterStripEntry({ entry }) {
   const pct = entry.starMax > 0 ? Math.round((entry.stars / entry.starMax) * 100) : 0;
   const displayState = entry.displayState || 'not-found';
@@ -86,12 +76,22 @@ function MonsterStripEntry({ entry }) {
   );
 }
 
-function PrimaryModeCard({ card, selected, disabled, actions }) {
+function PrimaryModeCard({ card, selected, disabled, actions, textTone = 'dark' }) {
   const featured = card.featured === true;
-  const classes = ['grammar-primary-mode'];
-  if (selected) classes.push('selected');
+  // The card carries `.grammar-primary-mode` (the existing test hook +
+  // brand variant) AND `.mode-card` (the shared visual identity that
+  // Spelling tunes). Keep `grammar-primary-mode` FIRST in the class
+  // string so existing tests pinning `class="grammar-primary-mode..."`
+  // still match exactly. Both classes apply regardless of order at the
+  // CSS layer.
+  const classes = ['grammar-primary-mode', 'mode-card'];
+  if (selected && !disabled) classes.push('selected');
   if (disabled) classes.push('is-disabled');
   if (featured) classes.push('is-recommended');
+  const disabledEmpty = disabled && card.disabledWhenNoTrouble === true;
+  const showBadge = featured ? card.badge || 'RECOMMENDED' : null;
+  const badgeIsPlaceholder = !showBadge && disabledEmpty;
+  const description = disabledEmpty && card.disabledCopy ? card.disabledCopy : card.desc;
   return (
     <button
       type="button"
@@ -99,16 +99,28 @@ function PrimaryModeCard({ card, selected, disabled, actions }) {
       data-mode-id={card.id}
       data-action="grammar-set-mode"
       data-featured={featured ? 'true' : 'false'}
-      aria-pressed={selected ? 'true' : 'false'}
+      data-text-tone={textTone}
+      aria-pressed={selected && !disabled ? 'true' : 'false'}
       disabled={disabled}
       onClick={() => {
         if (disabled) return;
         actions.dispatch('grammar-set-mode', { value: card.id });
       }}
     >
-      {featured ? <span className="grammar-primary-mode-eyebrow">Recommended</span> : null}
+      <div className="mc-top">
+        <span className="mc-icon mc-icon-glyph" aria-hidden="true">
+          <span className="mc-glyph">{card.title.charAt(0)}</span>
+        </span>
+        {showBadge ? (
+          <span className={`mc-badge${featured ? ' recommended' : ''}`}>{showBadge}</span>
+        ) : badgeIsPlaceholder ? (
+          <span className="mc-badge is-placeholder">NONE YET</span>
+        ) : (
+          <span className="mc-badge-spacer" aria-hidden="true" />
+        )}
+      </div>
       <h4 className="grammar-primary-mode-title">{card.title}</h4>
-      <p className="grammar-primary-mode-desc">{card.desc}</p>
+      <p className="grammar-primary-mode-desc">{description}</p>
     </button>
   );
 }
@@ -117,15 +129,7 @@ function MoreModeCard({ card, selected, disabled, actions }) {
   const classes = ['grammar-secondary-mode'];
   if (selected) classes.push('selected');
   if (disabled) classes.push('is-disabled');
-  // U5 Phase 4: Surgery and Builder cards carry a "Mixed practice" label
-  // from `GRAMMAR_MORE_PRACTICE_MODES` so the dashboard surfaces the
-  // child-facing truth that these modes do not honour a focused concept
-  // id. Label renders under the mode title with `data-mode-label` so
-  // tests and QA can scope by the mode id. The label is decorative and
-  // does not change mode behaviour.
   const label = typeof card.label === 'string' && card.label ? card.label : '';
-  // U8 Phase 5: Writing Try (id: 'transfer') dispatches 'grammar-open-transfer'
-  // instead of 'grammar-set-mode' since it routes to the transfer scene.
   const isTransfer = card.id === 'transfer';
   const action = isTransfer ? 'grammar-open-transfer' : 'grammar-set-mode';
   return (
@@ -154,14 +158,55 @@ function MoreModeCard({ card, selected, disabled, actions }) {
   );
 }
 
+/* Slide-button round-length picker — same DOM rhythm as Spelling's
+ * `LengthPicker`, dynamic option list per mode (mini-test gives a
+ * shorter palette). The active index drives the `--selected-index`
+ * CSS variable; the slider transform is animated by the existing
+ * `.length-slider { transition: transform 260ms }` rule in app.css. */
+function RoundLengthPicker({ options, selectedValue, onChange, disabled, ariaLabel }) {
+  const selectedIndex = Math.max(0, options.indexOf(String(selectedValue)));
+  return (
+    <div className="length-control">
+      <div
+        className="length-picker"
+        role="radiogroup"
+        aria-label={ariaLabel}
+        style={{
+          '--option-count': String(options.length),
+          '--selected-index': String(selectedIndex),
+        }}
+      >
+        <span className="length-slider" aria-hidden="true" />
+        {options.map((value) => {
+          const selected = String(selectedValue) === value;
+          return (
+            <button
+              type="button"
+              role="radio"
+              aria-checked={selected ? 'true' : 'false'}
+              className={`length-option${selected ? ' selected' : ''}`}
+              data-action="grammar-set-round-length"
+              data-pref="roundLength"
+              value={value}
+              disabled={disabled}
+              key={value}
+              onClick={() => onChange(value)}
+            >
+              <span>{value}</span>
+            </button>
+          );
+        })}
+      </div>
+      <span className="length-unit">questions</span>
+    </div>
+  );
+}
+
 export function GrammarSetupScene({ learner, grammar, rewardState, actions, runtimeReadOnly }) {
-  // U6 Phase 6: build concept nodes map + recent attempts from the grammar
-  // read-model, then thread them into the dashboard model so that
-  // dashboard.monsterStrip reflects live evidence derivation rather than
-  // only the persisted starHighWater latch.
+  // U6 Phase 6: build concept nodes map + recent attempts so the dashboard
+  // model reflects live evidence, not just persisted star high-water.
   const conceptNodesMap = {};
-  const analyticsConcepts = Array.isArray(grammar?.analytics?.concepts)
-    ? grammar.analytics.concepts : [];
+  const analyticsConcepts = Array.isArray(grammar?.analytics?.concepts) ? grammar.analytics.concepts : [];
   for (const c of analyticsConcepts) {
     if (c && typeof c === 'object' && typeof c.id === 'string') {
       conceptNodesMap[c.id] = c;
@@ -173,12 +218,39 @@ export function GrammarSetupScene({ learner, grammar, rewardState, actions, runt
   const selectedMode = dashboard.primaryMode;
   const miniTestMode = selectedMode === 'satsset';
   const setupDisabled = runtimeReadOnly || Boolean(grammar.pendingCommand);
-  const lengthOptions = miniTestMode ? [8, 12] : [3, 5, 8, 10, 15];
+
+  const lengthOptions = miniTestMode ? MINI_TEST_ROUND_OPTIONS : NORMAL_ROUND_OPTIONS;
+  const rawLength = Number(grammar.prefs?.roundLength);
   const selectedLength = miniTestMode
-    ? (Number(grammar.prefs?.roundLength) >= 10 ? 12 : 8)
-    : (Number(grammar.prefs?.roundLength) || 5);
-  const selectedSpeechRate = normaliseGrammarSpeechRate(grammar.prefs?.speechRate);
+    ? (rawLength >= 10 ? '12' : '8')
+    : (Number.isFinite(rawLength) && rawLength > 0 ? String(rawLength) : '5');
   const { title: heroTitle, subtitle: heroSubtitle } = GRAMMAR_DASHBOARD_HERO;
+
+  const troubleCard = (dashboard.todayCards || []).find((card) => card.id === 'trouble');
+  const troubleCount = Number(troubleCard?.value || 0);
+
+  const selectedModeCard = GRAMMAR_PRIMARY_MODE_CARDS.find((card) => card.id === selectedMode);
+  const selectedModeStartLabel = selectedMode === 'trouble'
+    ? 'Fix Trouble Spots'
+    : selectedMode === 'satsset'
+      ? 'Start Mini Test'
+      : `Start ${selectedModeCard?.title || 'Smart Practice'}`;
+
+  // Hero backdrop URL + contrast probe. The hook reads the curated
+  // per-tone profile when one is available and falls back to a runtime
+  // luminance probe when the active artwork is outside the table.
+  const heroBg = heroBgForGrammarSetup(learner?.id || '', { mode: selectedMode });
+  const mergedHeroStyle = { ...heroBgStyle(heroBg) };
+  const heroContrast = useSetupHeroContrast(heroBg, selectedMode, {
+    staticContrastForBg: heroContrastProfileForGrammarBg,
+    cardSelector: '.grammar-primary-mode',
+    controlSelectors: ['.tool-label', '.length-unit'],
+  });
+  const heroTone = heroContrast.contrast.tone || heroToneForGrammarBg(heroBg);
+  const setupClasses = ['setup-main', 'grammar-setup-main'];
+  if (heroContrast.contrast.shell === 'light') setupClasses.push('hero-dark');
+
+  const openConceptBank = () => actions.dispatch('grammar-open-concept-bank');
 
   return (
     <section
@@ -186,143 +258,148 @@ export function GrammarSetupScene({ learner, grammar, rewardState, actions, runt
       aria-labelledby="grammar-dashboard-title"
       data-grammar-phase-root="dashboard"
     >
-      {/* Hero section */}
-      <div
-        className="grammar-hero"
-        style={{ '--grammar-hero-bg': `url(${GRAMMAR_REGION_IMAGE})` }}
-      >
-        <picture aria-hidden="true">
-          <source media="(max-width: 720px)" srcSet={GRAMMAR_REGION_IMAGE_SMALL} />
-          <img src={GRAMMAR_REGION_IMAGE} alt="" />
-        </picture>
-        <div className="grammar-hero-copy">
-          <h2 id="grammar-dashboard-title" className="grammar-hero-title">{heroTitle}</h2>
-          <p className="grammar-hero-subtitle">{heroSubtitle}</p>
-          {learner?.name ? (
-            <p className="grammar-hero-welcome">Hi {learner.name} — ready for a short round?</p>
-          ) : null}
-        </div>
-      </div>
+      <div className="setup-grid">
+        <section
+          className={setupClasses.join(' ')}
+          data-react-hero-contrast="true"
+          data-hero-tone={heroTone || undefined}
+          data-controls-tone={heroContrast.contrast.controls}
+          ref={heroContrast.ref}
+          style={mergedHeroStyle}
+          aria-label="Start practising"
+        >
+          <HeroBackdrop url={heroBg} />
+          <div className="setup-content">
+            <p className="eyebrow">Grammar · today</p>
+            <h1 id="grammar-dashboard-title" className="title grammar-hero-title">{heroTitle}</h1>
+            <p className="lede grammar-hero-subtitle">{heroSubtitle}</p>
+            {learner?.name ? (
+              <p className="grammar-hero-welcome">Hi {learner.name} — ready for a short round?</p>
+            ) : null}
 
-      {/* U7: Monster strip — 4 active monsters with Star progress */}
-      <section className="grammar-monster-strip" aria-label="Your Grammar creatures">
-        {dashboard.monsterStrip.map((entry) => (
-          <MonsterStripEntry entry={entry} key={entry.monsterId} />
-        ))}
-        <p className="grammar-monster-strip-hint">{GRAMMAR_MONSTER_STRIP_CHILD_COPY}</p>
-      </section>
+            <div className="mode-row grammar-mode-row">
+              {GRAMMAR_PRIMARY_MODE_CARDS.map((card, index) => {
+                const cardDisabled = setupDisabled
+                  || (card.disabledWhenNoTrouble === true && troubleCount === 0);
+                return (
+                  <PrimaryModeCard
+                    card={card}
+                    selected={card.id === selectedMode}
+                    disabled={cardDisabled}
+                    actions={actions}
+                    textTone={heroContrast.contrast.cards[index] || heroContrast.contrast.shell}
+                    key={card.id}
+                  />
+                );
+              })}
+            </div>
 
-      {/* U8: Primary CTA — Smart Practice only */}
-      <section className="grammar-primary-modes" aria-label="Start practising">
-        <div className="grammar-primary-grid">
-          {GRAMMAR_PRIMARY_MODE_CARDS.map((card) => (
-            <PrimaryModeCard
-              card={card}
-              selected={card.id === selectedMode}
-              disabled={setupDisabled}
-              actions={actions}
-              key={card.id}
-            />
-          ))}
-        </div>
+            <div className="setup-control-stack">
+              <div className="tweak-row">
+                <span className="tool-label">{miniTestMode ? 'Mini-set size' : 'Round length'}</span>
+                <RoundLengthPicker
+                  options={lengthOptions}
+                  selectedValue={selectedLength}
+                  onChange={(value) => actions.dispatch('grammar-set-round-length', { value })}
+                  disabled={setupDisabled}
+                  ariaLabel={miniTestMode ? 'Mini-set size' : 'Round length'}
+                />
+              </div>
+            </div>
 
-        <div className="grammar-round-controls">
-          <label className="field">
-            <span>{miniTestMode ? 'Mini-set size' : 'Round length'}</span>
-            <select
-              className="input"
-              value={String(selectedLength)}
-              disabled={setupDisabled}
-              onChange={(event) => actions.dispatch('grammar-set-round-length', { value: event.currentTarget.value })}
-            >
-              {lengthOptions.map((length) => <option value={length} key={length}>{length}</option>)}
-            </select>
-          </label>
-          <label className="field">
-            <span>Speech rate</span>
-            <select
-              className="input"
-              value={String(selectedSpeechRate)}
-              disabled={setupDisabled}
-              onChange={(event) => actions.dispatch('grammar-set-speech-rate', { value: event.currentTarget.value })}
-            >
-              {SPEECH_RATE_OPTIONS.map((option) => (
-                <option value={option.value} key={option.value}>{option.label}</option>
+            {grammar.error ? (
+              <div className="feedback bad" role="alert">
+                <strong>Grammar is unavailable right now</strong>
+                <div>{grammar.error}</div>
+              </div>
+            ) : null}
+
+            <div className="setup-begin-row grammar-start-row">
+              <button
+                className="btn primary xl"
+                type="button"
+                data-featured="true"
+                disabled={setupDisabled}
+                onClick={() => actions.dispatch('grammar-start')}
+              >
+                {grammar.pendingCommand === 'start-session'
+                  ? 'Starting...'
+                  : selectedModeStartLabel}
+              </button>
+            </div>
+          </div>
+        </section>
+
+        <aside className="setup-side grammar-setup-sidebar" aria-label="Where you stand">
+          <div className="ss-card grammar-setup-sidebar-card">
+            <header className="ss-head grammar-setup-sidebar-head">
+              <p className="eyebrow">Where you stand</p>
+              <button
+                type="button"
+                className="ss-codex-link grammar-setup-sidebar-codex-link"
+                data-action="grammar-open-concept-bank"
+                aria-label="Open the Grammar Bank"
+                onClick={openConceptBank}
+                disabled={setupDisabled}
+              >
+                Open bank →
+              </button>
+            </header>
+
+            <section className="grammar-monster-strip" aria-label="Your Grammar creatures">
+              {dashboard.monsterStrip.map((entry) => (
+                <MonsterStripEntry entry={entry} key={entry.monsterId} />
               ))}
-            </select>
-          </label>
-        </div>
+              <p className="grammar-monster-strip-hint">{GRAMMAR_MONSTER_STRIP_CHILD_COPY}</p>
+            </section>
 
-        {grammar.error ? (
-          <div className="feedback bad" role="alert">
-            <strong>Grammar is unavailable right now</strong>
-            <div>{grammar.error}</div>
+            <section className="grammar-today" aria-label="Today at a glance">
+              {dashboard.isEmpty ? (
+                <div className="grammar-today-empty" data-testid="grammar-today-empty">
+                  <EmptyState
+                    title="No rounds yet"
+                    body="No rounds yet. Progress is saved as you practise. Start your first round to see your scores here."
+                  />
+                </div>
+              ) : (
+                <div className="grammar-today-grid">
+                  {dashboard.todayCards.map((card) => (
+                    <TodayCard card={card} key={card.id} />
+                  ))}
+                </div>
+              )}
+            </section>
+
+            <button
+              type="button"
+              className="ss-bank-link grammar-setup-sidebar-bank-link"
+              data-action="grammar-open-concept-bank"
+              onClick={openConceptBank}
+              disabled={setupDisabled}
+            >
+              <span className="ss-bank-link-body grammar-setup-sidebar-bank-link-body">
+                <span className="ss-bank-link-head grammar-setup-sidebar-bank-link-head">Browse the Grammar Bank</span>
+                <span className="ss-bank-link-sub grammar-setup-sidebar-bank-link-sub">Every concept, with progress and accuracy.</span>
+              </span>
+              <span className="ss-bank-link-arrow grammar-setup-sidebar-bank-link-arrow" aria-hidden="true">→</span>
+            </button>
           </div>
-        ) : null}
+        </aside>
 
-        <div className="grammar-start-row">
-          <button
-            className="btn primary xl"
-            type="button"
-            data-featured="true"
-            disabled={setupDisabled}
-            onClick={() => actions.dispatch('grammar-start')}
-          >
-            {grammar.pendingCommand === 'start-session' ? 'Starting...' : 'Start Smart Practice'}
-          </button>
-        </div>
-      </section>
-
-      {/* U8: Today cards — repositioned below primary CTA, above secondary links */}
-      <section className="grammar-today" aria-label="Today at a glance">
-        {dashboard.isEmpty ? (
-          <div className="grammar-today-empty" data-testid="grammar-today-empty">
-            <EmptyState
-              title="No rounds yet"
-              body="No rounds yet. Progress is saved as you practise. Start your first round to see your scores here."
-            />
-          </div>
-        ) : (
-          <div className="grammar-today-grid">
-            {dashboard.todayCards.map((card) => (
-              <TodayCard card={card} key={card.id} />
-            ))}
-          </div>
-        )}
-      </section>
-
-      {/* U8: Secondary links — Grammar Bank, Mini Test, Fix Trouble Spots */}
-      <nav className="grammar-secondary-links" aria-label="Other practice modes">
-        {GRAMMAR_SECONDARY_MODE_LINKS.map((link) => (
-          <button
-            type="button"
-            className={`grammar-secondary-link${selectedMode === link.id ? ' selected' : ''}`}
-            aria-pressed={selectedMode === link.id ? 'true' : 'false'}
-            key={link.id}
-            data-mode-id={link.id}
-            data-action={link.action}
-            disabled={setupDisabled}
-            onClick={() => {
-              if (setupDisabled) return;
-              if (link.action === 'grammar-open-concept-bank') {
-                actions.dispatch('grammar-open-concept-bank');
-              } else {
-                actions.dispatch('grammar-set-mode', { value: link.id });
-              }
-            }}
-          >
-            {link.title}
-          </button>
-        ))}
-      </nav>
-
-      {/* U8: More practice disclosure — Learn, Surgery, Builder, Worked, Faded, Writing Try */}
-      <details className="grammar-more-practice">
-        <summary>More practice</summary>
-        <div className="grammar-more-practice-grid">
-          {GRAMMAR_MORE_PRACTICE_MODES.filter(
-            (m) => m.id !== 'transfer' || dashboard.writingTryAvailable
-          ).map((card) => (
+        {/* "More practice" disclosure — optional, decision-light tail of
+         * secondary modes (Learn / Surgery / Builder / Worked / Faded /
+         * Writing Try). Lives INSIDE `.setup-grid` at row 2 column 1
+         * so its width matches `.setup-main` exactly. The disclosure is
+         * still detached from the panel itself (own div, opt-in
+         * `<details>`) so the primary panel keeps the single CTA. */}
+        <SetupMorePractice
+          summary="More practice"
+          disclosureClassName="setup-more-practice grammar-more-practice"
+          gridClassName="setup-more-practice-grid grammar-more-practice-grid"
+          cards={GRAMMAR_MORE_PRACTICE_MODES.filter(
+            (m) => m.id !== 'transfer' || dashboard.writingTryAvailable,
+          )}
+          renderCard={(card) => (
             <MoreModeCard
               card={card}
               selected={card.id === selectedMode}
@@ -330,9 +407,9 @@ export function GrammarSetupScene({ learner, grammar, rewardState, actions, runt
               actions={actions}
               key={card.id}
             />
-          ))}
-        </div>
-      </details>
+          )}
+        />
+      </div>
     </section>
   );
 }

--- a/src/subjects/grammar/components/GrammarSummaryScene.jsx
+++ b/src/subjects/grammar/components/GrammarSummaryScene.jsx
@@ -68,6 +68,46 @@ function SummaryCards({ cards }) {
   );
 }
 
+// Aligned ribbon header — sits above the five summary stat cards on the
+// regular-practice branch. Tone is "good" when every answered question was
+// correct, otherwise "warn". Headline + sub-copy mirror the prototype but
+// pull live numbers from the summary cards so we never duplicate state.
+function SummaryRibbon({ cards }) {
+  const cardMap = {};
+  for (const card of cards) {
+    if (card && typeof card.id === 'string') cardMap[card.id] = card;
+  }
+  const answered = Number(cardMap.answered?.value ?? 0);
+  const correct = Number(cardMap.correct?.value ?? 0);
+  const trouble = Number(cardMap.trouble?.value ?? 0);
+  const cleanRound = answered > 0 && correct === answered && trouble === 0;
+  const tone = cleanRound ? 'good' : 'warn';
+  const headline = cleanRound
+    ? 'Clean round — every answer landed.'
+    : `${correct} of ${answered} correct.`;
+  const sub = cleanRound
+    ? 'Your monsters earned a Star this round.'
+    : trouble > 0
+      ? `${trouble} concept${trouble === 1 ? '' : 's'} to revisit below.`
+      : 'A few wobbles to come back to next round.';
+  return (
+    <div
+      className="grammar-summary-ribbon"
+      data-tone={tone}
+      role="status"
+      aria-live="polite"
+    >
+      <div className="grammar-summary-ribbon-icon" aria-hidden="true">
+        {cleanRound ? '✓' : '!'}
+      </div>
+      <div className="grammar-summary-ribbon-copy">
+        <p className="grammar-summary-ribbon-headline">{headline}</p>
+        <p className="grammar-summary-ribbon-sub">{sub}</p>
+      </div>
+    </div>
+  );
+}
+
 function ScoreCard({ summary }) {
   const questions = Array.isArray(summary?.miniTestReview?.questions)
     ? summary.miniTestReview.questions
@@ -256,6 +296,7 @@ export function GrammarSummaryScene({ grammar, rewardState, actions, learner, ru
         <h2 className="section-title" id="grammar-summary-title">
           Nice work — round complete
         </h2>
+        <SummaryRibbon cards={cards} />
         <SummaryCards cards={cards} />
         <PrimaryActions buttons={buttons} disabled={disabled} />
         <SecondaryActions onGrownUp={handleGrownUp} disabled={disabled} />

--- a/src/subjects/grammar/components/grammar-hero-bg.js
+++ b/src/subjects/grammar/components/grammar-hero-bg.js
@@ -1,0 +1,145 @@
+import { stableHash } from '../../../platform/core/utils.js';
+
+/* Grammar hero backdrop view-model.
+ *
+ * Mirrors the shape of `spelling-view-model.js`'s hero helpers so the
+ * platform-level engine (`HeroBackdrop`, `useSetupHeroContrast`,
+ * `probeHeroTextTones`) can drive Grammar's setup scene with the same
+ * cross-fade, pan, and contrast probing it gives Spelling.
+ *
+ * Asset layout:
+ *   /assets/regions/the-clause-conservatory/the-clause-conservatory-{region}{tone}.{size}.webp
+ *
+ * Region letters map to the three primary modes:
+ *   smart    → a
+ *   trouble  → b
+ *   satsset  → c
+ *
+ * `d` and `e` are reserved for future surfaces (e.g. a transfer scene
+ * background) so the URL space stays unified with the existing
+ * Conservatory artwork.
+ *
+ * Tones (1 / 2 / 3) are picked per learner via a stable hash so a
+ * learner sees the same vista across reloads. Setup tones can rotate via
+ * `selectGrammarSetupTone` when the controller wants to refresh — same
+ * pattern Spelling uses for its tone shuffle. */
+
+const CLAUSE_CONSERVATORY_BASE = '/assets/regions/the-clause-conservatory';
+
+export const grammarHeroUrl = (variant, size = 1280) => (
+  `${CLAUSE_CONSERVATORY_BASE}/the-clause-conservatory-${variant}.${size}.webp`
+);
+
+export const GRAMMAR_HERO_REGIONS = Object.freeze({
+  smart: Object.freeze(['a']),
+  trouble: Object.freeze(['b']),
+  satsset: Object.freeze(['c']),
+});
+
+export const GRAMMAR_HERO_TONES = Object.freeze(['1', '2', '3']);
+export const GRAMMAR_HERO_MODE_INDEX = Object.freeze({ smart: 0, trouble: 1, satsset: 2 });
+
+const CONTRAST_DARK = 'dark';
+const CONTRAST_LIGHT = 'light';
+
+/* Curated per-tone contrast envelope. Tone 1 sits over light dawn skies
+ * (clean dark ink reads), tones 2 + 3 sit over saturated jungle tones
+ * (light ink reads). The runtime probe will refine per-card if the
+ * artwork ever evolves and one of these defaults stops fitting. */
+export const GRAMMAR_HERO_CONTRAST_BY_TONE = Object.freeze({
+  1: Object.freeze({
+    shell: CONTRAST_DARK,
+    controls: CONTRAST_DARK,
+    cards: Object.freeze([CONTRAST_DARK, CONTRAST_DARK, CONTRAST_DARK]),
+  }),
+  2: Object.freeze({
+    shell: CONTRAST_LIGHT,
+    controls: CONTRAST_LIGHT,
+    cards: Object.freeze([CONTRAST_LIGHT, CONTRAST_LIGHT, CONTRAST_LIGHT]),
+  }),
+  3: Object.freeze({
+    shell: CONTRAST_LIGHT,
+    controls: CONTRAST_LIGHT,
+    cards: Object.freeze([CONTRAST_LIGHT, CONTRAST_LIGHT, CONTRAST_LIGHT]),
+  }),
+});
+
+export function grammarHeroMode(mode) {
+  if (mode === 'trouble') return 'trouble';
+  if (mode === 'satsset') return 'satsset';
+  return 'smart';
+}
+
+export function grammarHeroTone(learnerId) {
+  const index = stableHash(`grammar:tone:${learnerId}`) % GRAMMAR_HERO_TONES.length;
+  return GRAMMAR_HERO_TONES[index];
+}
+
+export function selectGrammarSetupTone(learnerId, previousTone = '') {
+  if (!GRAMMAR_HERO_TONES.length) return '1';
+  let entropy = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
+  if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
+    const bucket = new Uint32Array(1);
+    crypto.getRandomValues(bucket);
+    entropy = bucket[0];
+  }
+  const index = stableHash(`grammar:setup-tone:${learnerId}:${Date.now()}:${entropy}`) % GRAMMAR_HERO_TONES.length;
+  const tone = GRAMMAR_HERO_TONES[index];
+  if (previousTone && tone === previousTone && GRAMMAR_HERO_TONES.length > 1) {
+    return GRAMMAR_HERO_TONES[(index + 1) % GRAMMAR_HERO_TONES.length];
+  }
+  return tone;
+}
+
+export function heroBgForGrammarMode(mode, learnerId, options = {}) {
+  const heroMode = grammarHeroMode(mode);
+  const regions = GRAMMAR_HERO_REGIONS[heroMode] || GRAMMAR_HERO_REGIONS.smart;
+  if (!regions.length) return '';
+  const regionIndex = stableHash(`grammar:region:${heroMode}:${learnerId}`) % regions.length;
+  const tone = GRAMMAR_HERO_TONES.includes(String(options.tone))
+    ? String(options.tone)
+    : grammarHeroTone(learnerId);
+  return grammarHeroUrl(`${regions[regionIndex]}${tone}`);
+}
+
+export function heroBgForGrammarSetup(learnerId, prefs, options = {}) {
+  return heroBgForGrammarMode(prefs?.mode, learnerId, options);
+}
+
+export function heroToneForGrammarBg(url) {
+  const text = String(url || '');
+  const variant = text.match(/the-clause-conservatory-[a-e]([1-3])\.\d+\.webp(?:$|[?#])/);
+  return variant?.[1] || '';
+}
+
+export function heroContrastProfileForGrammarBg(url, mode = 'smart') {
+  const text = String(url || '');
+  const variant = text.match(/the-clause-conservatory-([a-e])([1-3])\.\d+\.webp(?:$|[?#])/);
+  if (!variant) return null;
+  const base = GRAMMAR_HERO_CONTRAST_BY_TONE[variant[2]];
+  if (!base) return null;
+  /* For the very first tone (1, light dawn artwork) we keep the selected
+   * card a solid dark ink so the active mode card sits highest on the
+   * type ladder. Tones 2 / 3 inherit the base envelope unchanged. */
+  const selectedIndex = GRAMMAR_HERO_MODE_INDEX[grammarHeroMode(mode)];
+  const preferSelectedDark = variant[2] === '1';
+  const cards = base.cards.map((tone, index) => (
+    index === selectedIndex && preferSelectedDark ? CONTRAST_DARK : tone
+  ));
+  return {
+    tone: variant[2],
+    shell: base.shell,
+    controls: base.controls,
+    cards,
+  };
+}
+
+export function grammarHeroPreloadUrls(learnerId, prefs = {}) {
+  if (!learnerId) return [];
+  const modes = ['smart', 'trouble', 'satsset'];
+  const setupTone = grammarHeroTone(learnerId);
+  const setupUrls = modes.map((mode) => heroBgForGrammarMode(mode, learnerId, { tone: setupTone }));
+  const sessionMode = prefs?.mode || 'smart';
+  const sessionUrls = GRAMMAR_HERO_TONES.map((tone) => heroBgForGrammarMode(sessionMode, learnerId, { tone }));
+  return [...new Set([...setupUrls, ...sessionUrls].filter(Boolean))];
+}

--- a/src/subjects/grammar/components/grammar-view-model.js
+++ b/src/subjects/grammar/components/grammar-view-model.js
@@ -60,39 +60,45 @@ export function isGrammarFocusAllowedMode(mode) {
 // this as a prominent button above the fold with `data-featured="true"`.
 // Grammar Bank, Mini Test, and Fix Trouble Spots are demoted to secondary
 // links below the monster strip.
+// Aligned design language (post-prototype): the three decision-weight modes
+// — Smart Practice, Fix Trouble Spots, Mini Test — render as a 3-card row
+// inside the unified setup panel, mirroring the Spelling mode-row rhythm.
+// `featured: true` pins the recommended badge on Smart only. The two new
+// cards (`trouble`, `satsset`) carry their own short child-facing copy and
+// inherit the same `data-action="grammar-set-mode"` dispatch as Smart.
+//
+// `trouble` is `disabledWhenNoTrouble` so the JSX can render it greyed-out
+// with the prototype's "No trouble spots yet — try a round first." copy
+// when the dashboard read model reports zero trouble concepts.
 export const GRAMMAR_PRIMARY_MODE_CARDS = Object.freeze([
   Object.freeze({
     id: 'smart',
     title: 'Smart Practice',
-    desc: 'Due · weak · one fresh concept.',
+    desc: 'Mixed concepts shaped to today — what is due, where you wobbled.',
     featured: true,
-  }),
-]);
-
-// U8 Phase 5: Three modes demoted from primary cards to secondary links.
-// Order: Grammar Bank · Mini Test · Fix Trouble Spots. The JSX renders these
-// as text links below the monster strip — still accessible, but no longer
-// primary decision-weight buttons.
-export const GRAMMAR_SECONDARY_MODE_LINKS = Object.freeze([
-  Object.freeze({
-    id: 'bank',
-    title: 'Grammar Bank',
-    desc: 'Browse every concept with child-friendly statuses.',
-    action: 'grammar-open-concept-bank',
-  }),
-  Object.freeze({
-    id: 'satsset',
-    title: 'Mini Test',
-    desc: 'Short timed set. Marks at the end.',
-    action: 'grammar-set-mode',
+    badge: 'RECOMMENDED',
   }),
   Object.freeze({
     id: 'trouble',
     title: 'Fix Trouble Spots',
-    desc: 'Only the concepts you usually miss.',
-    action: 'grammar-set-mode',
+    desc: 'Drill the concepts that slipped most this week.',
+    featured: false,
+    disabledWhenNoTrouble: true,
+    disabledCopy: 'No trouble spots yet — try a round first.',
+  }),
+  Object.freeze({
+    id: 'satsset',
+    title: 'Mini Test',
+    desc: 'A short SATs-style set — no hints, marked at the end.',
+    featured: false,
   }),
 ]);
+
+// Aligned design language: every former secondary mode is now either a
+// primary card (`trouble`, `satsset`) or surfaced from the sidebar
+// (`bank` via the "Browse the Grammar Bank" shortcut). The empty array
+// keeps the export shape stable for callers that iterate it.
+export const GRAMMAR_SECONDARY_MODE_LINKS = Object.freeze([]);
 
 // Secondary modes disclosed under the dashboard's "More practice" details
 // block. U8 Phase 5: Writing Try moves here from the primary area, joining

--- a/src/subjects/spelling/components/SpellingHeroBackdrop.jsx
+++ b/src/subjects/spelling/components/SpellingHeroBackdrop.jsx
@@ -1,78 +1,22 @@
 import React from 'react';
-import { heroBgStyle, heroPanDelayStyle } from './spelling-view-model.js';
+import { HeroBackdrop } from '../../../platform/ui/HeroBackdrop.jsx';
 
+/* Thin Spelling wrapper around the platform HeroBackdrop.
+ *
+ * The legacy CSS rules under `.spelling-in-session .spelling-hero-layer
+ * ::after { ... }` (mid-session tinting) and the existing playwright
+ * mask coverage probes still pin `.spelling-hero-backdrop` /
+ * `.spelling-hero-layer`. Carrying those class names through this
+ * wrapper preserves the contracts while delegating every behaviour to
+ * the shared component, so Grammar and Punctuation can render the same
+ * primitive without inheriting Spelling-specific selectors. */
 export function SpellingHeroBackdrop({ url, previousUrl = '' }) {
-  const handoffUrl = previousUrl && previousUrl !== url ? previousUrl : '';
-  const layerId = React.useRef(handoffUrl ? 1 : 0);
-  const currentUrl = React.useRef(url || '');
-  const initialTransitionId = React.useRef(handoffUrl ? 1 : null);
-  const [layers, setLayers] = React.useState(() => (
-    (() => {
-      if (!url) return [];
-      const panStyle = heroPanDelayStyle();
-      return [
-        ...(handoffUrl ? [{ id: 0, url: handoffUrl, phase: 'exiting', panStyle }] : []),
-        { id: handoffUrl ? 1 : 0, url, phase: handoffUrl ? 'entering' : 'active', panStyle },
-      ];
-    })()
-  ));
-
-  React.useEffect(() => {
-    const nextId = initialTransitionId.current;
-    if (nextId == null || !url) return undefined;
-    const transitionUrl = url;
-    const timer = setTimeout(() => {
-      setLayers((current) => {
-        if (currentUrl.current !== transitionUrl) return current;
-        return current
-          .filter((layer) => layer.id === nextId)
-          .map((layer) => ({ ...layer, phase: 'active' }));
-      });
-    }, 920);
-    return () => clearTimeout(timer);
-  }, []);
-
-  React.useEffect(() => {
-    if (!url) {
-      currentUrl.current = '';
-      setLayers([]);
-      return undefined;
-    }
-
-    if (currentUrl.current === url) return undefined;
-    currentUrl.current = url;
-    layerId.current += 1;
-    const nextId = layerId.current;
-    const panStyle = heroPanDelayStyle();
-    setLayers((current) => {
-      return [
-        ...current.slice(-2).map((layer) => ({ ...layer, phase: 'exiting' })),
-        { id: nextId, url, phase: 'entering', panStyle },
-      ];
-    });
-
-    const timer = setTimeout(() => {
-      setLayers((current) => current
-        .filter((layer) => layer.id === nextId)
-        .map((layer) => ({ ...layer, phase: 'active' })));
-    }, 920);
-
-    return () => {
-      clearTimeout(timer);
-    };
-  }, [url]);
-
-  if (!layers.length) return null;
-
   return (
-    <div className="spelling-hero-backdrop" aria-hidden="true">
-      {layers.map((layer) => (
-        <div
-          className={`hero-art pan spelling-hero-layer is-${layer.phase}`}
-          style={{ ...heroBgStyle(layer.url), ...(layer.panStyle || {}) }}
-          key={layer.id}
-        />
-      ))}
-    </div>
+    <HeroBackdrop
+      url={url}
+      previousUrl={previousUrl}
+      extraBackdropClassName="spelling-hero-backdrop"
+      extraLayerClassName="spelling-hero-layer"
+    />
   );
 }

--- a/src/subjects/spelling/components/spelling-view-model.js
+++ b/src/subjects/spelling/components/spelling-view-model.js
@@ -1,12 +1,16 @@
 import { monsterSummaryFromSpellingAnalytics } from '../../../platform/game/monster-system.js';
 import { resolveMonsterVisual } from '../../../platform/game/monster-visual-config.js';
 import { monsterVisualFrameStyle } from '../../../platform/game/monster-visual-style.js';
-import { formatElapsedMinutes } from '../../../platform/core/utils.js';
+import { formatElapsedMinutes, stableHash as platformStableHash } from '../../../platform/core/utils.js';
+import {
+  HERO_PAN_SECONDS,
+  heroBgStyle as platformHeroBgStyle,
+  heroPanDelayStyle as platformHeroPanDelayStyle,
+} from '../../../platform/ui/hero-bg.js';
 import { createLockedPostMasteryState, isGuardianEligibleSlug } from '../service-contract.js';
 
 export const SPELLING_ACCENT = '#3E6FA8';
 export const DAY_MS = 24 * 60 * 60 * 1000;
-const HERO_PAN_SECONDS = 96;
 export const MODE_CARDS = Object.freeze([
   {
     id: 'smart',
@@ -214,15 +218,7 @@ export function accentFor(subject) {
   return subject?.accent || SPELLING_ACCENT;
 }
 
-export function stableHash(value) {
-  const text = String(value || '');
-  let hash = 0;
-  for (let i = 0; i < text.length; i += 1) {
-    hash = (hash << 5) - hash + text.charCodeAt(i);
-    hash |= 0;
-  }
-  return Math.abs(hash);
-}
+export const stableHash = platformStableHash;
 
 export function spellingHeroMode(mode) {
   if (mode === 'trouble') return 'trouble';
@@ -399,15 +395,13 @@ export function heroContrastProfileForBg(url, mode = 'smart') {
   };
 }
 
-export function heroBgStyle(url) {
-  return url ? { '--hero-bg': `url('${url}')` } : {};
-}
-
-export function heroPanDelayStyle() {
-  if (typeof performance === 'undefined') return {};
-  const elapsed = (performance.now() / 1000) % (HERO_PAN_SECONDS * 2);
-  return { '--hero-pan-delay': `-${elapsed.toFixed(3)}s` };
-}
+// Backwards-compat re-exports — callers in this module and Spelling
+// components still import `heroBgStyle` / `heroPanDelayStyle` from
+// `spelling-view-model.js`; routing through the platform helpers keeps
+// the behaviour identical while letting Grammar / Punctuation share the
+// same engine without dragging the spelling view-model along.
+export const heroBgStyle = platformHeroBgStyle;
+export const heroPanDelayStyle = platformHeroPanDelayStyle;
 
 export function beginLabel(prefs) {
   if (prefs.mode === 'test') return 'Begin SATs test';

--- a/src/subjects/spelling/components/useSetupHeroContrast.js
+++ b/src/subjects/spelling/components/useSetupHeroContrast.js
@@ -1,139 +1,18 @@
-import React from 'react';
-import { probeHeroTextTones } from '../../../platform/ui/luminance.js';
+import { useSetupHeroContrast as platformUseSetupHeroContrast } from '../../../platform/ui/useSetupHeroContrast.js';
 import { heroContrastProfileForBg } from './spelling-view-model.js';
 
-const DEFAULT_CONTRAST = Object.freeze({
-  tone: '',
-  shell: 'dark',
-  controls: 'dark',
-  cards: Object.freeze(['dark', 'dark', 'dark']),
-});
-
-const CARD_GLASS_ALPHA = 0.28;
-const SELECTED_CARD_GLASS_ALPHA = 0.42;
-const CONTROL_REFRESH_MS = 6000;
-
+/* Spelling-flavoured wrapper around the platform contrast hook.
+ *
+ * The platform hook is selector-agnostic; Spelling threads its
+ * curated `heroContrastProfileForBg` (per-tone shell / controls / card
+ * tone profiles) and the `.mode-card` / `.tool-label` / `.length-unit`
+ * selectors that Spelling's setup scene paints. Existing callers do not
+ * change — they still call `useSetupHeroContrast(heroBg, mode)` and get
+ * back `{ ref, contrast }`. */
 export function useSetupHeroContrast(heroBg, mode) {
-  const ref = React.useRef(null);
-  const staticContrast = React.useMemo(() => heroContrastProfileForBg(heroBg, mode), [heroBg, mode]);
-  const [probedContrast, setProbedContrast] = React.useState(staticContrast || DEFAULT_CONTRAST);
-
-  React.useEffect(() => {
-    if (staticContrast) {
-      setProbedContrast(staticContrast);
-      return undefined;
-    }
-
-    const shell = ref.current;
-    if (!shell || !heroBg || typeof window === 'undefined') {
-      setProbedContrast(DEFAULT_CONTRAST);
-      return undefined;
-    }
-
-    let cancelled = false;
-    let frame = 0;
-    let observer = null;
-
-    const scheduleProbe = () => {
-      if (cancelled || frame) return;
-      frame = window.requestAnimationFrame(() => {
-        frame = 0;
-        runProbe(shell, heroBg).then((nextContrast) => {
-          if (cancelled) return;
-          setProbedContrast((current) => (
-            sameContrast(current, nextContrast) ? current : nextContrast
-          ));
-        });
-      });
-    };
-
-    scheduleProbe();
-    const interval = window.setInterval(scheduleProbe, CONTROL_REFRESH_MS);
-    if (typeof ResizeObserver !== 'undefined') {
-      observer = new ResizeObserver(scheduleProbe);
-      observer.observe(shell);
-      shell.querySelectorAll('.mode-card, .setup-control-stack, .title, .lede').forEach((element) => {
-        observer.observe(element);
-      });
-    }
-
-    return () => {
-      cancelled = true;
-      if (frame) window.cancelAnimationFrame(frame);
-      window.clearInterval(interval);
-      observer?.disconnect();
-    };
-  }, [heroBg, mode, staticContrast]);
-
-  return { ref, contrast: staticContrast || probedContrast };
-}
-
-async function runProbe(shell, heroBg) {
-  const cards = Array.from(shell.querySelectorAll('.mode-card'));
-  const cardProbes = cards.map((card, index) => ({
-    key: `card:${index}`,
-    element: cardTextRegion(card) || card,
-    glassAlpha: card.classList.contains('selected') ? SELECTED_CARD_GLASS_ALPHA : CARD_GLASS_ALPHA,
-  }));
-  const controlElements = Array.from(shell.querySelectorAll('.tool-label, .length-unit'))
-    .filter((element) => visibleForProbe(element));
-  const probes = [
-    { key: 'shell', element: shell.querySelector('.lede') || shell.querySelector('.title') || shell, glassAlpha: 0 },
-    ...cardProbes,
-    ...controlElements.map((element, index) => ({ key: `control:${index}`, element, glassAlpha: 0 })),
-  ];
-
-  const results = await probeHeroTextTones(heroBg, shell, probes);
-  const byKey = new Map(results.map((result) => [result.key, result]));
-  const controlResults = results.filter((result) => String(result.key || '').startsWith('control:'));
-  return {
-    tone: '',
-    shell: byKey.get('shell')?.tone || DEFAULT_CONTRAST.shell,
-    cards: cards.map((_, index) => byKey.get(`card:${index}`)?.tone || DEFAULT_CONTRAST.cards[index] || DEFAULT_CONTRAST.shell),
-    controls: combinedTone(controlResults) || DEFAULT_CONTRAST.controls,
-  };
-}
-
-function cardTextRegion(card) {
-  const title = card.querySelector('h4');
-  const copy = card.querySelector('p');
-  if (!title && !copy) return null;
-  return {
-    getBoundingClientRect() {
-      const rects = [title, copy]
-        .filter(Boolean)
-        .map((element) => element.getBoundingClientRect())
-        .filter((rect) => rect.width && rect.height);
-      if (!rects.length) return card.getBoundingClientRect();
-      const left = Math.min(...rects.map((rect) => rect.left));
-      const top = Math.min(...rects.map((rect) => rect.top));
-      const right = Math.max(...rects.map((rect) => rect.right));
-      const bottom = Math.max(...rects.map((rect) => rect.bottom));
-      return { left, top, right, bottom, width: right - left, height: bottom - top };
-    },
-  };
-}
-
-function visibleForProbe(element) {
-  const rect = element.getBoundingClientRect();
-  if (!rect.width || !rect.height) return false;
-  for (let current = element; current && current.nodeType === Node.ELEMENT_NODE; current = current.parentElement) {
-    const style = getComputedStyle(current);
-    if (style.visibility === 'hidden' || Number.parseFloat(style.opacity || '1') <= 0.05) return false;
-    if (current.classList?.contains('setup-main')) break;
-  }
-  return true;
-}
-
-function combinedTone(results) {
-  if (!results.length) return '';
-  return results.some((result) => result.tone === 'light') ? 'light' : 'dark';
-}
-
-function sameContrast(left, right) {
-  return left.tone === right.tone
-    && left.shell === right.shell
-    && left.controls === right.controls
-    && left.cards.length === right.cards.length
-    && left.cards.every((tone, index) => tone === right.cards[index]);
+  return platformUseSetupHeroContrast(heroBg, mode, {
+    staticContrastForBg: heroContrastProfileForBg,
+    cardSelector: '.mode-card',
+    controlSelectors: ['.tool-label', '.length-unit'],
+  });
 }

--- a/styles/app.css
+++ b/styles/app.css
@@ -4575,6 +4575,15 @@ textarea:focus-visible {
 }
 @media (max-width: 900px) {
   .setup-grid { grid-template-columns: 1fr; }
+  /* Single-column layout: stack in DOM order (setup-main, side,
+   * more-practice). Reset the explicit grid placements so every
+   * child takes the next auto-flow row without forcing columns. */
+  .setup-grid > .setup-main,
+  .setup-grid > .setup-side,
+  .setup-grid > .setup-more-practice {
+    grid-column: auto;
+    grid-row: auto;
+  }
 }
 .setup-main {
   --setup-label-ink: #213247;
@@ -4631,6 +4640,7 @@ textarea:focus-visible {
   background: color-mix(in oklab, var(--line-strong) 60%, transparent);
   z-index: 2;
 }
+.setup-main > .hero-backdrop,
 .setup-main > .spelling-hero-backdrop { z-index: 0; }
 .setup-content {
   position: relative;
@@ -5507,6 +5517,13 @@ textarea:focus-visible {
   animation: hero-pan 96s ease-in-out var(--hero-pan-delay, 0s) infinite alternate;
   will-change: background-position;
 }
+/* Subject-agnostic hero backdrop primitives.
+ *
+ * The platform `HeroBackdrop` stamps `.hero-backdrop` + `.hero-layer`
+ * onto its DOM. Spelling carries an extra `.spelling-hero-*` class on
+ * the same elements so the legacy mid-session tint selectors below keep
+ * working. Grammar / Punctuation only need the platform classes. */
+.hero-backdrop,
 .spelling-hero-backdrop {
   position: absolute;
   inset: 0;
@@ -5514,24 +5531,28 @@ textarea:focus-visible {
   overflow: hidden;
   pointer-events: none;
 }
+.hero-backdrop .hero-layer,
 .spelling-hero-backdrop .spelling-hero-layer {
   opacity: 0;
   transition: opacity 880ms var(--ease-in-out);
 }
+.hero-backdrop .hero-layer.is-entering,
 .spelling-hero-backdrop .spelling-hero-layer.is-entering {
   opacity: 1;
   animation:
     hero-pan 96s ease-in-out var(--hero-pan-delay, 0s) infinite alternate,
-    spelling-hero-dissolve-in 880ms var(--ease-in-out) 0s both;
+    hero-dissolve-in 880ms var(--ease-in-out) 0s both;
 }
+.hero-backdrop .hero-layer.is-active,
 .spelling-hero-backdrop .spelling-hero-layer.is-active {
   opacity: 1;
 }
+.hero-backdrop .hero-layer.is-exiting,
 .spelling-hero-backdrop .spelling-hero-layer.is-exiting {
   opacity: 0;
   animation:
     hero-pan 96s ease-in-out var(--hero-pan-delay, 0s) infinite alternate,
-    spelling-hero-dissolve-out 880ms var(--ease-in-out) 0s both;
+    hero-dissolve-out 880ms var(--ease-in-out) 0s both;
 }
 .spelling-in-session > .spelling-hero-backdrop {
   z-index: 0;
@@ -5551,6 +5572,16 @@ textarea:focus-visible {
   from { background-position: 0% 42%; }
   to   { background-position: 100% 42%; }
 }
+@keyframes hero-dissolve-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+@keyframes hero-dissolve-out {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+/* Legacy alias keyframes — retained so any cached stylesheet referencing
+ * the old `spelling-hero-*` keyframe identifiers still resolves. */
 @keyframes spelling-hero-dissolve-in {
   from { opacity: 0; }
   to { opacity: 1; }
@@ -5561,6 +5592,7 @@ textarea:focus-visible {
 }
 @media (prefers-reduced-motion: reduce) {
   .hero-art.pan { animation: none; }
+  .hero-backdrop .hero-layer,
   .spelling-hero-backdrop .spelling-hero-layer {
     animation: none;
     transition: none;
@@ -8685,41 +8717,6 @@ textarea:focus-visible {
   margin-top: 0.5rem;
 }
 
-/* Primary CTA — featured start button */
-.grammar-start-row [data-featured="true"] {
-  font-size: 1.1rem;
-  padding: 0.9rem 2rem;
-  font-weight: 700;
-  max-width: 20rem;
-  width: 100%;
-  margin: 0.75rem auto;
-}
-
-/* Secondary mode links — Grammar Bank, Mini Test, Fix Trouble Spots */
-.grammar-secondary-links {
-  display: flex;
-  gap: 1rem;
-  justify-content: center;
-  margin: 0.75rem 0;
-}
-
-.grammar-secondary-link {
-  font-size: 0.85rem;
-  color: var(--accent, #3E6FA8);
-  background: none;
-  border: 1px solid currentColor;
-  border-radius: 6px;
-  padding: 0.4rem 0.8rem;
-  cursor: pointer;
-  min-height: 44px;
-}
-
-.grammar-secondary-link.selected,
-.grammar-secondary-link[aria-pressed="true"] {
-  background: color-mix(in srgb, currentColor 10%, transparent);
-  font-weight: 600;
-}
-
 /* Today cards grid */
 .grammar-today-grid {
   display: grid;
@@ -8749,118 +8746,6 @@ textarea:focus-visible {
 .grammar-today-detail {
   font-size: 0.75rem;
   color: var(--muted, #666);
-}
-
-/* Primary mode cards grid */
-.grammar-primary-grid {
-  display: grid;
-  gap: 12px;
-}
-
-.grammar-primary-mode {
-  display: grid;
-  gap: 6px;
-  padding: 12px 16px;
-  border: 1px solid var(--line, #e0e0e0);
-  border-radius: 8px;
-  background: var(--panel-soft, #fafafa);
-  cursor: pointer;
-  text-align: left;
-}
-
-.grammar-primary-mode.selected {
-  border-color: var(--accent, #3E6FA8);
-  background: color-mix(in srgb, var(--accent, #3E6FA8) 6%, transparent);
-}
-
-.grammar-primary-mode.is-disabled {
-  opacity: 0.5;
-  cursor: default;
-}
-
-.grammar-primary-mode.is-recommended {
-  border-color: var(--accent, #3E6FA8);
-}
-
-.grammar-primary-mode-eyebrow {
-  font-size: 0.72rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: var(--accent, #3E6FA8);
-}
-
-.grammar-primary-mode-title {
-  font-size: 1rem;
-  margin: 0;
-}
-
-.grammar-primary-mode-desc {
-  font-size: 0.85rem;
-  color: var(--muted, #666);
-  margin: 0;
-}
-
-/* Round controls — length + speech rate selectors */
-.grammar-round-controls {
-  display: flex;
-  gap: 1rem;
-  margin-top: 0.75rem;
-}
-
-/* More practice disclosure */
-.grammar-more-practice {
-  margin-top: 0.75rem;
-}
-
-.grammar-more-practice summary {
-  cursor: pointer;
-  font-weight: 600;
-  padding: 0.5rem 0;
-}
-
-.grammar-more-practice-grid {
-  display: grid;
-  gap: 10px;
-  margin-top: 0.5rem;
-}
-
-.grammar-secondary-mode {
-  display: grid;
-  gap: 4px;
-  padding: 10px 14px;
-  border: 1px solid var(--line, #e0e0e0);
-  border-radius: 8px;
-  background: var(--panel-soft, #fafafa);
-  cursor: pointer;
-  text-align: left;
-}
-
-.grammar-secondary-mode.selected {
-  border-color: var(--accent, #3E6FA8);
-  background: color-mix(in srgb, var(--accent, #3E6FA8) 6%, transparent);
-}
-
-.grammar-secondary-mode.is-disabled {
-  opacity: 0.5;
-  cursor: default;
-}
-
-.grammar-secondary-mode-title {
-  font-size: 0.92rem;
-  font-weight: 600;
-  margin: 0;
-}
-
-.grammar-secondary-mode-label {
-  font-size: 0.75rem;
-  color: var(--muted, #666);
-}
-
-.grammar-secondary-mode-desc {
-  font-size: 0.82rem;
-  color: var(--muted, #666);
-  margin: 0;
 }
 
 @media (max-width: 980px) {
@@ -8914,9 +8799,6 @@ textarea:focus-visible {
   }
   .grammar-today-grid {
     grid-template-columns: repeat(2, 1fr);
-  }
-  .grammar-secondary-links {
-    flex-wrap: wrap;
   }
 }
 
@@ -11917,4 +11799,1431 @@ html { scroll-behavior: smooth; }
 
 .admin-registry-section-eyebrow {
   margin-bottom: 12px;
+}
+
+/* =============================================================================
+ * Grammar — Aligned visual layer (sourced from `Grammar - Aligned.html`)
+ * -----------------------------------------------------------------------------
+ * Imports Spelling's design language onto Grammar surfaces without renaming
+ * markup hooks. Plum (#7E5BB6) is the Grammar accent; Spelling's mode-card,
+ * setup-grid, ss-card, prompt-card, summary-shell, ribbon, wb-card, and
+ * agg-card tokens carry the layout, with grammar-* classes adopting them.
+ * ============================================================================= */
+
+/* Plum accent tokens — scoped so the rest of the app keeps brand blue. */
+.grammar-dashboard,
+.grammar-summary-shell,
+.grammar-session,
+.grammar-bank-scene,
+.grammar-bank-modal-scrim,
+.grammar-transfer,
+.grammar-analytics {
+  --grammar-accent: #7e5bb6;
+  --grammar-accent-ink: #5c4490;
+  --grammar-accent-soft: #ece1f6;
+  --grammar-accent-border: color-mix(in oklab, var(--grammar-accent) 30%, var(--line));
+}
+:root[data-theme="dark"] .grammar-dashboard,
+:root[data-theme="dark"] .grammar-summary-shell,
+:root[data-theme="dark"] .grammar-session,
+:root[data-theme="dark"] .grammar-bank-scene,
+:root[data-theme="dark"] .grammar-bank-modal-scrim,
+:root[data-theme="dark"] .grammar-transfer,
+:root[data-theme="dark"] .grammar-analytics {
+  --grammar-accent: #b89be5;
+  --grammar-accent-ink: #d6c4f2;
+  --grammar-accent-soft: color-mix(in oklab, #7e5bb6 26%, var(--bg));
+}
+
+/* ---------- Setup landing — two-column grid ---------- */
+
+/* Grammar setup — uses the shared `.setup-grid` / `.setup-main` /
+ * `.setup-content` rhythm (see `.setup-grid` block ~L4570). The outer
+ * `.grammar-dashboard` element is the React landmark only; it does NOT
+ * own the grid, and tests pin its literal class + the
+ * `data-grammar-phase-root="dashboard"` attribute, both preserved. */
+.grammar-dashboard {
+  display: block;
+}
+
+/* `.grammar-setup-main` is the Grammar variant of `.setup-main`. It
+ * inherits every layout token from the shared rule and overrides only
+ * the brand accent (plum) and CTA tinting. The shared `.setup-main`
+ * rule already handles padding, hero-art positioning, post-content
+ * stacking, and the contrast-tone CSS variables that
+ * `useSetupHeroContrast` toggles via `data-controls-tone`. */
+.grammar-setup-main {
+  --accent: var(--grammar-accent, var(--brand));
+  --btn-accent: var(--grammar-accent, var(--brand));
+  view-transition-name: grammar-hero-card;
+}
+.grammar-setup-main .grammar-hero-title {
+  font-family: var(--font-display, "Fraunces", Georgia, serif);
+  font-size: clamp(1.8rem, 2.8vw, 2.4rem);
+  line-height: 1.05;
+  letter-spacing: -0.015em;
+  font-weight: 500;
+}
+.grammar-setup-main .grammar-hero-welcome {
+  margin: 4px 0 0;
+  color: var(--mode-card-copy, var(--ink-2));
+  font-weight: 600;
+  font-size: 0.94rem;
+}
+/* Mode-row spacing — the shared `.mode-row` rule uses 3 columns with
+ * an auto-row floor; Grammar reuses it as-is. The plum accent is
+ * already in scope via the `--accent` override above so the selected
+ * card halo and badge tints follow brand. */
+.grammar-mode-row {
+  margin-top: 18px;
+}
+
+/* Setup begin-row plum CTA. The shared `.btn.primary.xl` is fine on
+ * Spelling but Grammar wants the plum tint front-and-centre to match
+ * the brand language. We also ensure the row right-aligns the button
+ * the same way Spelling does (already inherited from `.setup-begin-row`). */
+.grammar-setup-main .setup-begin-row .btn.primary[data-featured="true"] {
+  background: var(--grammar-accent);
+  color: #fff;
+  border-color: var(--grammar-accent);
+  box-shadow: 0 10px 24px color-mix(in oklab, var(--grammar-accent) 30%, transparent);
+}
+.grammar-setup-main .setup-begin-row .btn.primary[data-featured="true"]:hover {
+  filter: brightness(0.95);
+}
+.grammar-setup-main .setup-begin-row .btn.primary[data-featured="true"]:active {
+  transform: translateY(1px);
+}
+
+/* mc-icon variant for the Grammar mode card. The Spelling card uses an
+ * <img> glyph; Grammar uses a typographic glyph in a plum-tinted
+ * gradient frame. Same silhouette, different fill. */
+.grammar-setup-main .mode-card .mc-icon-glyph {
+  background: linear-gradient(135deg,
+    color-mix(in oklab, var(--grammar-accent) 30%, var(--panel-soft)),
+    color-mix(in oklab, var(--brand) 22%, var(--panel-soft)));
+  color: var(--grammar-accent-ink);
+  font-family: var(--font-display, "Fraunces", Georgia, serif);
+  font-weight: 600;
+  font-size: 1.2rem;
+  letter-spacing: -0.02em;
+  line-height: 1;
+}
+.grammar-setup-main .mode-card .mc-glyph {
+  display: block;
+}
+.grammar-setup-main .mode-card .mc-badge {
+  font-size: 0.66rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  font-weight: 800;
+  padding: 5px 9px;
+  border-radius: 999px;
+  background: color-mix(in oklab, var(--grammar-accent) 18%, transparent);
+  color: var(--grammar-accent-ink);
+  border: 1px solid color-mix(in oklab, var(--grammar-accent) 24%, transparent);
+}
+.grammar-setup-main .mode-card .mc-badge.recommended {
+  background: var(--grammar-accent);
+  color: #fff;
+  border-color: var(--grammar-accent);
+}
+.grammar-setup-main .mode-card .mc-badge.is-placeholder {
+  background: transparent;
+  color: var(--muted);
+  border-color: var(--line);
+}
+.grammar-setup-main .mode-card .mc-badge-spacer {
+  display: inline-block;
+  width: 1px;
+  height: 1px;
+}
+
+/* Platform-level "More practice" disclosure rhythm. The shell lives
+ * inside `.setup-grid` at row 2 / column 1 so its width matches
+ * `.setup-main` exactly. We pin BOTH columns explicitly — without
+ * `.setup-main` getting an explicit column the previous `grid-row:
+ * 1 / -1` rule on `.setup-side` (a definite-row / indefinite-column
+ * item) was sliding the sidebar into column 1 and pushing the panel
+ * to column 2. Pinning every child keeps the layout deterministic
+ * regardless of DOM order. The disclosure remains visually detached
+ * from the panel — own card-shaped surface, opt-in `<details>` — so
+ * the primary panel keeps its single-CTA reading. Subjects layer
+ * brand-flavoured overrides through their own class (e.g.
+ * `.grammar-more-practice`). */
+.setup-grid > .setup-main {
+  grid-column: 1;
+  grid-row: 1;
+}
+.setup-grid > .setup-side {
+  grid-column: 2;
+  grid-row: 1;
+}
+.setup-grid > .setup-more-practice {
+  grid-column: 1;
+  grid-row: 2;
+}
+.setup-more-practice {
+  background: color-mix(in oklab, var(--panel) 78%, transparent);
+  border: 1px solid color-mix(in oklab, var(--line) 60%, transparent);
+  border-radius: 14px;
+  padding: 4px 16px;
+}
+.setup-more-practice summary {
+  list-style: none;
+  font-weight: 700;
+  color: var(--ink-2);
+  padding: 12px 0;
+  cursor: pointer;
+}
+.setup-more-practice summary::-webkit-details-marker {
+  display: none;
+}
+.setup-more-practice-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  margin: 10px 0 16px;
+}
+@media (max-width: 780px) {
+  .setup-more-practice-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Grammar variant: warmer paper tone for the disclosure body. */
+.grammar-more-practice {
+  background: var(--panel-soft);
+  border-color: var(--line-soft);
+}
+.grammar-dashboard .grammar-secondary-mode {
+  background: color-mix(in oklab, var(--panel) 86%, transparent);
+  border: 1px solid color-mix(in oklab, var(--line) 60%, transparent);
+  border-radius: 16px;
+  padding: 14px 16px;
+  display: grid;
+  gap: 4px;
+  cursor: pointer;
+  text-align: left;
+  transition: transform var(--dur, 240ms) var(--ease-out, cubic-bezier(.2,.8,.2,1)),
+              border-color var(--dur, 240ms) var(--ease-out, cubic-bezier(.2,.8,.2,1));
+}
+.grammar-dashboard .grammar-secondary-mode:hover {
+  transform: translateY(-1px);
+  border-color: var(--line-strong);
+}
+.grammar-dashboard .grammar-secondary-mode.selected {
+  border-color: var(--grammar-accent);
+  background: color-mix(in oklab, var(--grammar-accent-soft) 60%, var(--panel));
+}
+.grammar-dashboard .grammar-secondary-mode-title {
+  font-family: var(--font-display, "Fraunces", Georgia, serif);
+  font-size: 1.04rem;
+  font-weight: 500;
+  margin: 0;
+  letter-spacing: -0.01em;
+}
+.grammar-dashboard .grammar-secondary-mode-label {
+  display: inline-block;
+  font-size: 0.66rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  font-weight: 800;
+  color: var(--grammar-accent-ink);
+  background: var(--grammar-accent-soft);
+  padding: 2px 8px;
+  border-radius: 999px;
+  width: fit-content;
+}
+.grammar-dashboard .grammar-secondary-mode-desc {
+  font-size: 0.86rem;
+  color: var(--ink-2);
+  margin: 4px 0 0;
+  line-height: 1.45;
+}
+
+/* ---------- Setup sidebar (Where you stand) ---------- */
+
+.grammar-setup-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.grammar-setup-sidebar .grammar-setup-sidebar-card {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg, 28px);
+  box-shadow: var(--shadow);
+  padding: 20px;
+}
+.grammar-setup-sidebar-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+.grammar-setup-sidebar-head .eyebrow {
+  margin: 0;
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--muted);
+  font-weight: 700;
+}
+.grammar-setup-sidebar-codex-link {
+  border: 0;
+  background: transparent;
+  color: var(--grammar-accent);
+  font-weight: 700;
+  font-size: 0.9rem;
+  cursor: pointer;
+  padding: 0;
+}
+.grammar-setup-sidebar-codex-link:hover {
+  color: var(--grammar-accent-ink);
+}
+
+/* Monster strip restyled to a 4-cell paper meadow inside the sidebar. */
+.grammar-setup-sidebar .grammar-monster-strip {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+  background: linear-gradient(180deg, var(--bg-tint, #efeadd), var(--panel-soft));
+  border: 1px solid var(--line-soft);
+  border-radius: 14px;
+  padding: 12px;
+  margin: 0 0 14px;
+}
+.grammar-setup-sidebar .grammar-monster-entry {
+  background: var(--panel);
+  border: 1px solid var(--line-soft);
+  border-radius: 12px;
+  padding: 8px 6px;
+  min-width: 0;
+  align-items: center;
+  gap: 4px;
+}
+.grammar-setup-sidebar .grammar-monster-entry-image {
+  width: 40px;
+  height: 40px;
+}
+.grammar-setup-sidebar .grammar-monster-entry-info {
+  display: grid;
+  gap: 2px;
+  width: 100%;
+  text-align: center;
+}
+.grammar-setup-sidebar .grammar-monster-entry-name {
+  font-family: var(--font-display, "Fraunces", Georgia, serif);
+  font-weight: 500;
+  font-size: 0.84rem;
+  color: var(--ink);
+  letter-spacing: -0.005em;
+}
+.grammar-setup-sidebar .grammar-monster-entry-stage {
+  font-size: 0.66rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+  font-weight: 700;
+}
+.grammar-setup-sidebar .grammar-star-bar {
+  height: 5px;
+  background: var(--panel-sunken, var(--panel-soft));
+  border-radius: 999px;
+  max-width: none;
+}
+.grammar-setup-sidebar .grammar-star-bar-fill {
+  border-radius: 999px;
+  background: var(--grammar-accent);
+}
+.grammar-setup-sidebar .grammar-monster-entry-stars {
+  font-size: 0.66rem;
+  font-weight: 700;
+  color: var(--ink-2);
+}
+.grammar-setup-sidebar .grammar-monster-strip-hint {
+  display: none; /* The sidebar header replaces this hint copy. */
+}
+
+/* Today cards as the sidebar stat grid (ss-stat-grid pattern). */
+.grammar-setup-sidebar .grammar-today {
+  margin: 0;
+}
+.grammar-setup-sidebar .grammar-today-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+.grammar-setup-sidebar .grammar-today-card {
+  display: grid;
+  gap: 2px;
+  text-align: left;
+  padding: 11px 12px;
+  background: var(--panel-soft);
+  border: 1px solid var(--line-soft);
+  border-radius: 12px;
+}
+.grammar-setup-sidebar .grammar-today-label {
+  font-size: 0.74rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+  font-weight: 700;
+}
+.grammar-setup-sidebar .grammar-today-value {
+  font-family: var(--font-display, "Fraunces", Georgia, serif);
+  font-weight: 500;
+  font-size: 1.45rem;
+  letter-spacing: -0.01em;
+  margin-top: 2px;
+}
+.grammar-setup-sidebar .grammar-today-detail {
+  font-size: 0.78rem;
+  color: var(--ink-2);
+  margin-top: 2px;
+}
+.grammar-setup-sidebar .grammar-today-empty {
+  background: var(--panel-soft);
+  border: 1px dashed var(--line-strong);
+  border-radius: 12px;
+  padding: 14px;
+  color: var(--muted);
+  font-size: 0.86rem;
+}
+
+/* Sidebar bank shortcut — adopts ss-bank-link silhouette with plum accent. */
+.grammar-setup-sidebar-bank-link {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  width: 100%;
+  text-align: left;
+  margin-top: 14px;
+  padding: 12px 14px;
+  border: 1px dashed var(--line-strong);
+  border-radius: 14px;
+  background: var(--panel-soft);
+  color: var(--ink);
+  font: inherit;
+  cursor: pointer;
+  transition: background var(--dur, 240ms) var(--ease-out, cubic-bezier(.2,.8,.2,1)),
+              border-color var(--dur, 240ms) var(--ease-out, cubic-bezier(.2,.8,.2,1));
+}
+.grammar-setup-sidebar-bank-link:hover {
+  background: var(--grammar-accent-soft);
+  border-color: var(--grammar-accent);
+  border-style: solid;
+}
+.grammar-setup-sidebar-bank-link-body {
+  display: grid;
+  gap: 2px;
+}
+.grammar-setup-sidebar-bank-link-head {
+  font-weight: 700;
+  color: var(--ink);
+}
+.grammar-setup-sidebar-bank-link-sub {
+  font-size: 0.85rem;
+  color: var(--muted);
+  font-weight: 500;
+}
+.grammar-setup-sidebar-bank-link-arrow {
+  color: var(--grammar-accent-ink);
+  font-weight: 800;
+  transition: transform var(--dur-fast, 160ms) var(--ease-out, cubic-bezier(.2,.8,.2,1));
+}
+.grammar-setup-sidebar-bank-link:hover .grammar-setup-sidebar-bank-link-arrow {
+  transform: translateX(3px);
+}
+
+/* ---------- Session — prompt-card rhythm ---------- */
+
+.grammar-session {
+  border-radius: var(--radius-xl, 32px);
+  background:
+    radial-gradient(900px 360px at 90% -10%, color-mix(in oklab, var(--grammar-accent) 14%, transparent), transparent 60%),
+    radial-gradient(700px 320px at 0% 110%, color-mix(in oklab, var(--brand) 14%, transparent), transparent 60%),
+    var(--panel);
+  border: 1px solid var(--line);
+  box-shadow: var(--shadow-md);
+  padding: 28px;
+  position: relative;
+  overflow: hidden;
+}
+.grammar-session .grammar-session-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+  /* Reset the legacy stage-1 head — it forced a green gradient + white
+   * type. The aligned visual language uses paper-on-paper rhythm. */
+  background: transparent;
+  color: var(--ink);
+  padding: 0;
+  min-height: 0;
+  border-radius: 0;
+}
+.grammar-session .grammar-session-head .eyebrow {
+  color: var(--muted);
+}
+.grammar-session .grammar-session-head h2 {
+  margin: 0;
+  font-family: var(--font-display, "Fraunces", Georgia, serif);
+  font-size: clamp(1.4rem, 2.4vw, 1.85rem);
+  letter-spacing: -0.015em;
+  font-weight: 500;
+  color: var(--ink);
+}
+.grammar-session .grammar-progress {
+  display: inline-flex;
+  align-items: baseline;
+  justify-content: center;
+  gap: 4px;
+  width: auto;
+  height: auto;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: var(--panel-soft);
+  border: 1px solid var(--line);
+  color: var(--ink-2);
+}
+.grammar-session .grammar-progress span {
+  font-family: var(--font-display, "Fraunces", Georgia, serif);
+  font-weight: 600;
+  font-size: 1.1rem;
+  line-height: 1;
+  color: var(--ink);
+}
+.grammar-session .grammar-progress small {
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  opacity: 1;
+}
+.grammar-session .grammar-progress-dots {
+  display: flex;
+  flex: 1;
+  gap: 6px;
+  align-items: center;
+}
+.grammar-session .grammar-progress-step {
+  flex: 1;
+  height: 8px;
+  border-radius: 999px;
+  background: var(--panel-sunken, var(--panel-soft));
+  border: 1px solid var(--line-soft);
+}
+.grammar-session .grammar-progress-step.done {
+  background: var(--grammar-accent);
+  border-color: var(--grammar-accent);
+}
+.grammar-session .grammar-progress-step.current {
+  background: var(--grammar-accent-soft);
+  border-color: var(--grammar-accent-border);
+}
+.grammar-session .grammar-progress-count {
+  font-size: 0.86rem;
+  font-weight: 700;
+  color: var(--muted);
+  white-space: nowrap;
+}
+.grammar-session .grammar-prompt-card {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg, 28px);
+  padding: 28px;
+  box-shadow: var(--shadow-xs);
+}
+.grammar-session .grammar-info-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 10px;
+}
+.grammar-session .grammar-info-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--panel-soft);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 5px 12px;
+  font-size: 0.84rem;
+  font-weight: 700;
+  color: var(--ink-2);
+}
+.grammar-session .grammar-info-chip.accent {
+  background: var(--grammar-accent-soft);
+  border-color: var(--grammar-accent-border);
+  color: var(--grammar-accent-ink);
+}
+.grammar-session .grammar-prompt-instr {
+  color: var(--muted);
+  font-size: 0.86rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+.grammar-session .grammar-prompt-sentence {
+  font-family: var(--font-display, "Fraunces", Georgia, serif);
+  font-size: clamp(1.4rem, 2.4vw, 1.85rem);
+  line-height: 1.35;
+  color: var(--ink);
+  margin: 0 0 18px;
+  letter-spacing: -0.005em;
+}
+.grammar-session .grammar-choice-list {
+  display: grid;
+  gap: 8px;
+  margin: 10px 0 14px;
+}
+.grammar-session .grammar-choice-list.tokens {
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 10px;
+}
+.grammar-session .grammar-choice {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  background: var(--panel-soft);
+  border: 1.5px solid var(--line);
+  border-radius: 14px;
+  padding: 13px 16px;
+  font-weight: 600;
+  color: var(--ink);
+  min-height: 48px;
+  transition: background var(--dur, 240ms) var(--ease-out, cubic-bezier(.2,.8,.2,1)),
+              border-color var(--dur, 240ms) var(--ease-out, cubic-bezier(.2,.8,.2,1)),
+              color var(--dur, 240ms) var(--ease-out, cubic-bezier(.2,.8,.2,1));
+}
+.grammar-session .grammar-choice:hover {
+  border-color: var(--line-strong);
+  background: var(--panel);
+}
+.grammar-session .grammar-choice input {
+  accent-color: var(--grammar-accent);
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+}
+.grammar-session .grammar-choice:has(input:checked) {
+  background: var(--grammar-accent-soft);
+  border-color: var(--grammar-accent);
+  color: var(--grammar-accent-ink);
+}
+.grammar-session .grammar-choice.correct {
+  background: var(--good-soft, #e1f2e7);
+  border-color: #b8dfca;
+  color: var(--good, #2f8f5d);
+}
+.grammar-session .grammar-choice.wrong {
+  background: var(--bad-soft, #f4dcdc);
+  border-color: #e8c3c3;
+  color: var(--bad, #c04b4b);
+}
+.grammar-session .grammar-input,
+.grammar-session .grammar-textarea {
+  width: 100%;
+  padding: 16px 18px;
+  font-family: var(--font-display, "Fraunces", Georgia, serif);
+  font-size: 1.25rem;
+  border-radius: 14px;
+  border: 1.5px solid var(--line);
+  background: var(--panel-soft);
+  color: var(--ink);
+  transition: border-color var(--dur, 240ms) var(--ease-out, cubic-bezier(.2,.8,.2,1)),
+              box-shadow var(--dur, 240ms) var(--ease-out, cubic-bezier(.2,.8,.2,1));
+}
+.grammar-session .grammar-input:focus,
+.grammar-session .grammar-textarea:focus {
+  outline: none;
+  border-color: var(--grammar-accent);
+  box-shadow: 0 0 0 4px color-mix(in oklab, var(--grammar-accent) 22%, transparent);
+  background: var(--panel);
+}
+.grammar-session .feedback {
+  margin-top: 14px;
+  padding: 14px 16px;
+  border-radius: 14px;
+  border: 1px solid var(--line);
+  background: var(--panel-soft);
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  animation: grammarFeedbackSlide var(--dur, 240ms) var(--ease-out, cubic-bezier(.2,.8,.2,1)) both;
+}
+.grammar-session .feedback.good {
+  background: var(--good-soft, #e1f2e7);
+  border-color: #b8dfca;
+  color: var(--good, #2f8f5d);
+}
+.grammar-session .feedback.bad {
+  background: var(--bad-soft, #f4dcdc);
+  border-color: #e8c3c3;
+  color: var(--bad, #c04b4b);
+}
+/* The session FeedbackPanel uses `warn` for an incorrect-but-known answer
+ * (the engine reserves `.bad` for hard errors / banner alerts). Map warn
+ * onto the amber palette so a wrong answer reads warm, not alarming. */
+.grammar-session .feedback.warn {
+  background: var(--warn-soft, #f7ebd0);
+  border-color: #edd9ae;
+  color: var(--warn-strong, #9e6a19);
+}
+.grammar-session .feedback.neutral {
+  background: var(--panel-soft);
+  border-color: var(--line);
+  color: var(--ink-2);
+}
+@keyframes grammarFeedbackSlide {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: none; }
+}
+
+/* ---------- Summary — ribbon + stat grid ---------- */
+
+.grammar-summary-shell {
+  border-radius: var(--radius-xl, 32px);
+  background:
+    radial-gradient(900px 360px at 50% -10%, color-mix(in oklab, var(--grammar-accent) 16%, transparent), transparent 60%),
+    var(--panel);
+  border: 1px solid var(--line);
+  box-shadow: var(--shadow-md);
+  padding: 32px;
+  position: relative;
+  overflow: hidden;
+}
+.grammar-summary-shell .grammar-summary-card-wrap {
+  background: transparent;
+  border: 0;
+  box-shadow: none;
+  padding: 0;
+}
+.grammar-summary-shell .grammar-summary-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 10px;
+  margin: 18px 0;
+}
+.grammar-summary-shell .grammar-summary-card {
+  padding: 16px 18px;
+  background: var(--panel-soft);
+  border: 1px solid var(--line-soft);
+  border-radius: 14px;
+  display: grid;
+  gap: 6px;
+}
+.grammar-summary-shell .grammar-summary-card-label {
+  font-size: 0.74rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+  font-weight: 700;
+  order: 2;
+}
+.grammar-summary-shell .grammar-summary-card-value {
+  font-family: var(--font-display, "Fraunces", Georgia, serif);
+  font-size: 2rem;
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  line-height: 1;
+  order: 1;
+}
+.grammar-summary-shell .grammar-summary-card-detail {
+  font-size: 0.84rem;
+  color: var(--ink-2);
+  order: 3;
+}
+.grammar-summary-shell .grammar-summary-card--monster {
+  grid-column: 1 / -1;
+  background: color-mix(in oklab, var(--grammar-accent-soft) 30%, var(--panel-soft));
+  border-style: dashed;
+  border-color: var(--line-strong);
+}
+.grammar-summary-shell .grammar-summary-card--monster .grammar-summary-card-label {
+  order: 1;
+  margin-bottom: 4px;
+}
+.grammar-summary-shell .grammar-summary-monster-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 8px;
+  order: 2;
+}
+.grammar-summary-shell .grammar-summary-monster {
+  background: var(--panel);
+  border: 1px solid var(--line-soft);
+  border-radius: 12px;
+  padding: 10px 12px;
+  display: grid;
+  gap: 2px;
+}
+.grammar-summary-shell .grammar-summary-monster strong {
+  font-family: var(--font-display, "Fraunces", Georgia, serif);
+  font-weight: 500;
+  font-size: 0.96rem;
+}
+.grammar-summary-shell .grammar-summary-monster span {
+  font-size: 0.78rem;
+  color: var(--muted);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.grammar-summary-shell .grammar-summary-ribbon {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  background: var(--panel-soft);
+  border: 1px solid var(--line);
+  border-radius: var(--radius, 20px);
+  padding: 16px 18px;
+  margin-bottom: 18px;
+}
+.grammar-summary-shell .grammar-summary-ribbon[data-tone="good"] {
+  background: var(--good-soft, #e1f2e7);
+  border-color: #b8dfca;
+}
+.grammar-summary-shell .grammar-summary-ribbon[data-tone="warn"] {
+  background: var(--warn-soft, #f7ebd0);
+  border-color: #edd9ae;
+}
+.grammar-summary-shell .grammar-summary-ribbon-icon {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: #fff;
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+  box-shadow: var(--shadow-xs);
+  color: var(--good, #2f8f5d);
+  font-family: var(--font-display, "Fraunces", Georgia, serif);
+  font-weight: 600;
+  font-size: 1.4rem;
+}
+.grammar-summary-shell .grammar-summary-ribbon[data-tone="warn"] .grammar-summary-ribbon-icon {
+  color: var(--warn-strong, #9e6a19);
+}
+.grammar-summary-shell .grammar-summary-ribbon-headline {
+  font-family: var(--font-display, "Fraunces", Georgia, serif);
+  font-size: 1.25rem;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  margin: 0;
+}
+.grammar-summary-shell .grammar-summary-ribbon-sub {
+  color: var(--ink-2);
+  font-size: 0.92rem;
+  margin: 2px 0 0;
+}
+
+.grammar-summary-shell .grammar-summary-primary-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 22px;
+  align-items: center;
+}
+.grammar-summary-shell .grammar-summary-primary-actions .btn.primary {
+  background: var(--grammar-accent);
+  color: #fff;
+  border: 1px solid var(--grammar-accent);
+}
+.grammar-summary-shell .grammar-summary-primary-actions .btn.primary:hover {
+  filter: brightness(0.95);
+}
+.grammar-summary-shell .grammar-summary-secondary-actions {
+  margin-top: 10px;
+}
+
+.grammar-summary-shell .grammar-summary-score {
+  background: var(--panel-soft);
+  border: 1px solid var(--line);
+  border-radius: var(--radius, 20px);
+  padding: 18px 22px;
+  margin: 6px 0 18px;
+}
+.grammar-summary-shell .grammar-summary-score-headline strong {
+  font-family: var(--font-display, "Fraunces", Georgia, serif);
+  font-size: 1.6rem;
+  letter-spacing: -0.015em;
+  font-weight: 500;
+}
+.grammar-summary-shell .grammar-summary-score-headline small {
+  display: block;
+  font-size: 0.86rem;
+  color: var(--muted);
+  font-weight: 700;
+  margin-top: 4px;
+}
+.grammar-summary-shell .grammar-summary-score-detail {
+  font-size: 0.78rem;
+  color: var(--muted);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-weight: 700;
+  margin-top: 6px;
+}
+
+/* ---------- Concept Bank — wb-card + agg-card ---------- */
+
+.grammar-bank-scene {
+  display: grid;
+  gap: 18px;
+}
+.grammar-bank-topbar {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+.grammar-bank-topbar-copy {
+  display: grid;
+  gap: 2px;
+}
+.grammar-bank-title {
+  font-family: var(--font-display, "Fraunces", Georgia, serif);
+  font-size: 1.6rem;
+  letter-spacing: -0.015em;
+  font-weight: 500;
+  margin: 0;
+}
+.grammar-bank-subtitle {
+  margin: 0;
+  color: var(--ink-2);
+  max-width: 62ch;
+  line-height: 1.5;
+}
+.grammar-bank-aggregates {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 14px;
+}
+.grammar-bank-aggregate-card {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--radius, 20px);
+  padding: 18px;
+  box-shadow: var(--shadow-xs);
+  display: grid;
+  gap: 4px;
+}
+.grammar-bank-aggregate-label {
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--muted);
+  font-weight: 700;
+}
+.grammar-bank-aggregate-value {
+  font-family: var(--font-display, "Fraunces", Georgia, serif);
+  font-size: 1.6rem;
+  font-weight: 500;
+  letter-spacing: -0.015em;
+}
+.grammar-bank-aggregate-sub {
+  font-size: 0.84rem;
+  color: var(--ink-2);
+}
+
+.grammar-bank-card-wrap {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--radius, 20px);
+  box-shadow: var(--shadow);
+  padding: 24px;
+}
+.grammar-bank-toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 16px 0 18px;
+}
+.grammar-bank-search {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: var(--panel-soft);
+  border: 1.5px solid var(--line);
+  border-radius: 14px;
+  padding: 10px 14px;
+  transition: border-color var(--dur, 240ms) var(--ease-out, cubic-bezier(.2,.8,.2,1)),
+              box-shadow var(--dur, 240ms) var(--ease-out, cubic-bezier(.2,.8,.2,1));
+}
+.grammar-bank-search:focus-within {
+  border-color: var(--grammar-accent);
+  box-shadow: 0 0 0 4px color-mix(in oklab, var(--grammar-accent) 22%, transparent);
+  background: var(--panel);
+}
+.grammar-bank-search-label {
+  font-size: 0.72rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: var(--muted);
+  flex-shrink: 0;
+}
+.grammar-bank-search input {
+  flex: 1;
+  border: 0;
+  background: transparent;
+  color: var(--ink);
+  font-size: 0.96rem;
+  outline: none;
+  min-width: 0;
+}
+.grammar-bank-filter-stack {
+  display: grid;
+  gap: 10px;
+}
+.grammar-bank-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.grammar-bank-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--panel-soft);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 6px 12px;
+  font-size: 0.84rem;
+  font-weight: 700;
+  color: var(--ink-2);
+  cursor: pointer;
+  min-height: 36px;
+  transition: background var(--dur, 240ms) var(--ease-out, cubic-bezier(.2,.8,.2,1)),
+              border-color var(--dur, 240ms) var(--ease-out, cubic-bezier(.2,.8,.2,1)),
+              color var(--dur, 240ms) var(--ease-out, cubic-bezier(.2,.8,.2,1));
+}
+.grammar-bank-chip:hover {
+  border-color: var(--line-strong);
+  color: var(--ink);
+}
+.grammar-bank-chip.on {
+  background: var(--grammar-accent-soft);
+  border-color: var(--grammar-accent);
+  color: var(--grammar-accent-ink);
+}
+.grammar-bank-chip-count {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 1px 8px;
+  font-size: 0.74rem;
+  font-weight: 800;
+  min-width: 24px;
+  text-align: center;
+}
+.grammar-bank-chip.on .grammar-bank-chip-count {
+  background: var(--panel);
+  border-color: var(--grammar-accent);
+  color: var(--grammar-accent-ink);
+}
+.grammar-bank-chip-swatch {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--muted);
+}
+.grammar-bank-chip-swatch.tone-due { background: var(--warn, #b97a1b); }
+.grammar-bank-chip-swatch.tone-trouble { background: var(--bad, #c04b4b); }
+.grammar-bank-chip-swatch.tone-learning { background: var(--brand, #3e6fa8); }
+.grammar-bank-chip-swatch.tone-secure { background: var(--good, #2f8f5d); }
+.grammar-bank-chip-swatch.tone-nearly-secure { background: color-mix(in oklab, var(--good, #2f8f5d) 60%, var(--brand, #3e6fa8)); }
+.grammar-bank-chip-swatch.tone-new { background: var(--subtle, #a9b1bd); }
+.grammar-bank-chip-swatch.tone-all { background: var(--grammar-accent); }
+
+.grammar-bank-summary {
+  margin: 0 0 12px;
+  font-size: 0.86rem;
+  color: var(--muted);
+}
+.grammar-bank-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 12px;
+}
+.grammar-bank-card {
+  background: var(--panel);
+  border: 1.5px solid var(--line);
+  border-radius: 16px;
+  padding: 16px 18px;
+  display: grid;
+  gap: 10px;
+  transition: transform var(--dur, 240ms) var(--ease-out, cubic-bezier(.2,.8,.2,1)),
+              border-color var(--dur, 240ms) var(--ease-out, cubic-bezier(.2,.8,.2,1)),
+              box-shadow var(--dur, 240ms) var(--ease-out, cubic-bezier(.2,.8,.2,1));
+}
+.grammar-bank-card:hover {
+  transform: translateY(-2px);
+  border-color: var(--grammar-accent);
+  box-shadow: var(--shadow);
+}
+.grammar-bank-card-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 10px;
+}
+.grammar-bank-card-head-copy {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+.grammar-bank-card-title {
+  font-family: var(--font-display, "Fraunces", Georgia, serif);
+  font-size: 1.08rem;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  margin: 0;
+}
+.grammar-bank-card-domain {
+  font-size: 0.78rem;
+  color: var(--muted);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  margin: 0;
+}
+.grammar-bank-card-status-chip {
+  display: inline-flex;
+  align-items: center;
+  background: var(--panel-soft);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 0.74rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  color: var(--ink-2);
+  flex-shrink: 0;
+}
+.grammar-bank-card-status-chip.tone-due { background: var(--warn-soft, #f7ebd0); border-color: #edd9ae; color: var(--warn-strong, #9e6a19); }
+.grammar-bank-card-status-chip.tone-trouble { background: var(--bad-soft, #f4dcdc); border-color: #e8c3c3; color: var(--bad, #c04b4b); }
+.grammar-bank-card-status-chip.tone-learning { background: var(--brand-soft, #dce6f3); border-color: color-mix(in oklab, var(--brand) 30%, var(--line)); color: var(--brand-ink, #274d79); }
+.grammar-bank-card-status-chip.tone-secure { background: var(--good-soft, #e1f2e7); border-color: #b8dfca; color: var(--good, #2f8f5d); }
+.grammar-bank-card-status-chip.tone-nearly-secure { background: color-mix(in oklab, var(--good-soft, #e1f2e7) 70%, var(--brand-soft, #dce6f3)); border-color: #b8dfca; color: var(--good, #2f8f5d); }
+.grammar-bank-card-status-chip.tone-new { background: var(--panel-soft); border-color: var(--line); color: var(--muted); }
+.grammar-bank-card-summary {
+  margin: 0;
+  color: var(--ink-2);
+  font-size: 0.92rem;
+  line-height: 1.5;
+}
+.grammar-bank-card-example {
+  margin: 0;
+  font-family: var(--font-display, "Fraunces", Georgia, serif);
+  font-style: italic;
+  color: var(--ink);
+  background: color-mix(in oklab, var(--grammar-accent-soft) 40%, var(--panel-soft));
+  border-left: 3px solid var(--grammar-accent);
+  border-radius: 6px;
+  padding: 8px 12px;
+  font-size: 0.96rem;
+}
+.grammar-bank-card-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.grammar-bank-card-cluster-badge {
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-weight: 800;
+  color: var(--ink-2);
+  background: var(--panel-soft);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 3px 9px;
+}
+.grammar-bank-card-actions {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.grammar-bank-card-actions .btn.primary {
+  background: var(--grammar-accent);
+  color: #fff;
+  border: 1px solid var(--grammar-accent);
+}
+.grammar-bank-card-actions .btn.primary:hover {
+  filter: brightness(0.95);
+}
+.grammar-bank-empty {
+  padding: 30px;
+  text-align: center;
+  color: var(--muted);
+  background: var(--panel-soft);
+  border-radius: 14px;
+  border: 1px dashed var(--line);
+  grid-column: 1 / -1;
+}
+
+/* ---------- Concept detail modal ---------- */
+
+.grammar-bank-modal-scrim {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 24px;
+  background: rgba(15, 22, 32, 0.48);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  z-index: 100;
+  animation: grammarModalScrimIn var(--dur, 240ms) var(--ease-out, cubic-bezier(.2,.8,.2,1));
+}
+@keyframes grammarModalScrimIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+.grammar-bank-modal-backdrop {
+  position: absolute;
+  inset: 0;
+  appearance: none;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  cursor: pointer;
+}
+.grammar-bank-modal {
+  position: relative;
+  z-index: 1;
+  width: min(640px, calc(100vw - 48px));
+  max-height: calc(100vh - 48px);
+  overflow-y: auto;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg, 28px);
+  box-shadow: var(--shadow-md);
+  padding: 24px;
+  animation: grammarModalIn var(--dur, 240ms) var(--ease-out, cubic-bezier(.2,.8,.2,1));
+}
+@keyframes grammarModalIn {
+  from { opacity: 0; transform: translateY(12px) scale(0.98); }
+  to { opacity: 1; transform: none; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .grammar-bank-modal-scrim,
+  .grammar-bank-modal { animation: none; }
+}
+.grammar-bank-modal-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 14px;
+  margin-bottom: 14px;
+}
+.grammar-bank-modal-head-main {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+.grammar-bank-modal-eyebrow {
+  margin: 0;
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: var(--muted);
+}
+.grammar-bank-modal-title {
+  margin: 0;
+  font-family: var(--font-display, "Fraunces", Georgia, serif);
+  font-size: 1.5rem;
+  letter-spacing: -0.015em;
+  font-weight: 500;
+}
+.grammar-bank-modal-status {
+  margin: 6px 0 0;
+  display: inline-flex;
+  align-items: center;
+  background: var(--panel-soft);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  color: var(--ink-2);
+  width: fit-content;
+}
+.grammar-bank-modal-status.tone-due { background: var(--warn-soft, #f7ebd0); border-color: #edd9ae; color: var(--warn-strong, #9e6a19); }
+.grammar-bank-modal-status.tone-trouble { background: var(--bad-soft, #f4dcdc); border-color: #e8c3c3; color: var(--bad, #c04b4b); }
+.grammar-bank-modal-status.tone-learning { background: var(--brand-soft, #dce6f3); border-color: color-mix(in oklab, var(--brand) 30%, var(--line)); color: var(--brand-ink, #274d79); }
+.grammar-bank-modal-status.tone-secure { background: var(--good-soft, #e1f2e7); border-color: #b8dfca; color: var(--good, #2f8f5d); }
+.grammar-bank-modal-status.tone-nearly-secure { background: color-mix(in oklab, var(--good-soft, #e1f2e7) 70%, var(--brand-soft, #dce6f3)); border-color: #b8dfca; color: var(--good, #2f8f5d); }
+.grammar-bank-modal-status.tone-new { background: var(--panel-soft); border-color: var(--line); color: var(--muted); }
+.grammar-bank-modal-close {
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: 1px solid var(--line);
+  background: var(--panel-soft);
+  color: var(--ink-2);
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  font-size: 1.1rem;
+  line-height: 1;
+  transition: background var(--dur, 240ms) var(--ease-out, cubic-bezier(.2,.8,.2,1)),
+              color var(--dur, 240ms) var(--ease-out, cubic-bezier(.2,.8,.2,1));
+}
+.grammar-bank-modal-close:hover {
+  background: var(--panel);
+  color: var(--ink);
+}
+.grammar-bank-modal-body {
+  display: grid;
+  gap: 16px;
+}
+.grammar-bank-modal-section {
+  display: grid;
+  gap: 6px;
+}
+.grammar-bank-modal-section-label {
+  margin: 0;
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: var(--muted);
+}
+.grammar-bank-modal-summary,
+.grammar-bank-modal-evidence {
+  margin: 0;
+  color: var(--ink-2);
+  line-height: 1.55;
+}
+.grammar-bank-modal-examples {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 6px;
+}
+.grammar-bank-modal-example {
+  font-family: var(--font-display, "Fraunces", Georgia, serif);
+  font-style: italic;
+  background: color-mix(in oklab, var(--grammar-accent-soft) 40%, var(--panel-soft));
+  border-left: 3px solid var(--grammar-accent);
+  border-radius: 6px;
+  padding: 8px 12px;
+  color: var(--ink);
+  font-size: 0.96rem;
+}
+.grammar-bank-modal-empty {
+  margin: 0;
+  color: var(--muted);
+  font-style: italic;
+  font-size: 0.9rem;
+}
+.grammar-bank-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 18px;
+  flex-wrap: wrap;
+}
+.grammar-bank-modal-actions .btn.primary {
+  background: var(--grammar-accent);
+  color: #fff;
+  border: 1px solid var(--grammar-accent);
+}
+.grammar-bank-modal-actions .btn.primary:hover {
+  filter: brightness(0.95);
+}
+
+/* ---------- Mobile tap targets ---------- */
+
+@media (max-width: 720px) {
+  .grammar-bank-chip {
+    min-height: 44px;
+  }
+}
+
+/* ---------- Grammar Bank — grown-up-view escape hatch ---------- */
+
+/* Aligned design: the adult lens lives at the bottom of the Grammar Bank
+ * as a closed-by-default `<details>`. Visual rhythm: faded divider, plum
+ * accent on hover, subdued summary icon. The analytics scene inside keeps
+ * its own typography rules — these styles only chrome the disclosure. */
+.grammar-bank-scene .grammar-grown-up-view {
+  margin-top: 20px;
+  padding: 6px 22px;
+  background: var(--panel-soft);
+  border: 1px dashed var(--line-strong);
+  border-radius: 18px;
+  transition: background var(--dur, 240ms) var(--ease-out, cubic-bezier(.2,.8,.2,1)),
+              border-color var(--dur, 240ms) var(--ease-out, cubic-bezier(.2,.8,.2,1));
+}
+.grammar-bank-scene .grammar-grown-up-view[open] {
+  background: var(--panel);
+  border-color: color-mix(in oklab, var(--grammar-accent) 30%, var(--line-strong));
+  border-style: solid;
+  box-shadow: var(--shadow-xs);
+}
+.grammar-bank-scene .grammar-grown-up-view summary {
+  list-style: none;
+  cursor: pointer;
+  font-family: var(--font-display, "Fraunces", Georgia, serif);
+  font-weight: 500;
+  font-size: 1.02rem;
+  letter-spacing: -0.01em;
+  color: var(--ink);
+  padding: 12px 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+.grammar-bank-scene .grammar-grown-up-view summary::-webkit-details-marker {
+  display: none;
+}
+.grammar-bank-scene .grammar-grown-up-view summary::before {
+  content: "Grown-up";
+  font-family: var(--font-sans, system-ui, sans-serif);
+  font-size: 0.66rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  font-weight: 800;
+  color: var(--grammar-accent-ink);
+  background: var(--grammar-accent-soft);
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in oklab, var(--grammar-accent) 30%, var(--line));
+  margin-right: auto;
+}
+.grammar-bank-scene .grammar-grown-up-view summary::after {
+  content: "▾";
+  color: var(--ink-2);
+  font-size: 0.86rem;
+  transition: transform var(--dur, 240ms) var(--ease-out, cubic-bezier(.2,.8,.2,1));
+}
+.grammar-bank-scene .grammar-grown-up-view[open] summary::after {
+  transform: rotate(180deg);
+}
+.grammar-bank-scene .grammar-grown-up-view > :not(summary) {
+  margin-top: 4px;
+  padding-top: 12px;
+  border-top: 1px solid var(--line-soft);
 }

--- a/tests/browser-react-migration-smoke.test.js
+++ b/tests/browser-react-migration-smoke.test.js
@@ -109,7 +109,7 @@ test('browser migration smoke covers the React app root, Grammar completeness co
       ['js', "document.querySelector('[data-action=\"open-subject\"][data-subject-id=\"grammar\"]')?.click(); 'opened grammar';"],
       ['wait', '.grammar-dashboard'],
       ['text'],
-      ['js', "document.querySelector('.grammar-secondary-link[data-mode-id=\"satsset\"]')?.click(); 'selected mini-test';"],
+      ['js', "document.querySelector('.grammar-primary-mode[data-mode-id=\"satsset\"]')?.click(); 'selected mini-test';"],
       ['js', "document.querySelector('.grammar-dashboard .grammar-start-row .btn.primary')?.click(); 'started grammar mini-test';"],
       ['wait', '.grammar-mini-test-panel'],
       ['text'],

--- a/tests/bundle-byte-budget.test.js
+++ b/tests/bundle-byte-budget.test.js
@@ -70,15 +70,18 @@ const REPO_ROOT = path.resolve(__dirname, '..');
 // utility footprint; Grammar's matching display-state parity adds another
 // tiny cross-subject utility slice. The reward presentation queue, toast
 // compatibility layers, Hero Mode P3 daily-progress shell, Grammar's
-// bridge-ownership display gate, the Concordium Grand Star tier model, and
-// Hero Mode P5 Camp's child-facing spending surface keep Node 22/24 gzip
-// output near 223.9 KB, so the committed ceiling is 224,500
-// (matches `DEFAULT_MAIN_BUNDLE_GZIP_BUDGET_BYTES` in
+// bridge-ownership display gate, the Concordium Grand Star tier model,
+// Hero Mode P5 Camp's child-facing spending surface, and the Grammar
+// setup-aligned refactor (shared hero-bg / HeroBackdrop /
+// useSetupHeroContrast platform engines + slide-button RoundLengthPicker
+// + grammar-hero-bg view-model) keep Node 22/24 gzip output near
+// 226.3 KB, so the committed ceiling is 227,000 (matches
+// `DEFAULT_MAIN_BUNDLE_GZIP_BUDGET_BYTES` in
 // `scripts/audit-client-bundle.mjs`). The narrow headroom lets the team
 // land small copy / utility growth without an audit bump, but trips the
 // gate when ~50 KB of adult-only JS sneaks back into the critical path.
-const BASELINE_GZIP_BYTES = 203_227;
-const BUDGET_GZIP_BYTES = 224_500;
+const BASELINE_GZIP_BYTES = 206_000;
+const BUDGET_GZIP_BYTES = 227_000;
 const TEST_MODE_BUNDLE_MARKER = '__ks2_capacityMeta__';
 
 function isPlaywrightTestModeBundle(bundleBytes) {

--- a/tests/button-label-consistency.test.js
+++ b/tests/button-label-consistency.test.js
@@ -417,6 +417,11 @@ test('button labels: every statically extractable label is classified', () => {
     'Learn',
     'Practise',
     'Open Punctuation Map',
+    // Aligned Grammar setup sidebar shortcut into the Grammar Bank. Bespoke
+    // because the sibling sidebar already carries `Browse the Grammar Bank`
+    // as the row-link copy; the small "Open bank →" button is the inline
+    // header affordance and intentionally short.
+    'Open bank →',
     'Open codex →',
     'Drill all',
     'Load more',

--- a/tests/grammar-phase3-scopers.test.js
+++ b/tests/grammar-phase3-scopers.test.js
@@ -106,14 +106,14 @@ for (const { label, scoper, tag } of SCOPER_MATRIX) {
 // Edge case — dashboard/summary/transfer require a sibling boundary marker
 // -----------------------------------------------------------------------------
 
-test('U2: scopeDashboard throws when grown-up-view sibling boundary is missing', () => {
-  // Dashboard's regex pins the root `</section>` via lookahead to the
-  // sibling `<details class="grammar-grown-up-view">`. If the sibling is
-  // absent (e.g. a broken shell), the lookahead fails and the scoper
-  // throws rather than walking to the first nested `</section>`.
-  const noSibling = '<section data-grammar-phase-root="dashboard"><section>inner</section></section>';
+test('U2: scopeDashboard throws when </div></main> shell boundary is missing', () => {
+  // Post Grammar-Aligned redesign: the dashboard's regex pins the root
+  // `</section>` via lookahead to the surrounding `</div></main>` close
+  // (the `grammar-surface` wrapper). Without that sibling pair the
+  // scoper refuses to walk to the first nested `</section>`.
+  const noShellClose = '<section data-grammar-phase-root="dashboard"><section>inner</section></section>';
   assert.throws(
-    () => scopeDashboard(noSibling),
+    () => scopeDashboard(noShellClose),
     /scopeDashboard: no data-grammar-phase-root="dashboard" landmark found/,
   );
 });
@@ -144,11 +144,15 @@ test('U2: scopeTransfer throws when </div></main> boundary is missing', () => {
 // -----------------------------------------------------------------------------
 
 test('U2: scopeDashboard returns a narrowed substring on well-formed HTML', () => {
-  const html = '<main><section data-grammar-phase-root="dashboard" class="grammar-dashboard">body</section><details class="grammar-grown-up-view">adult</details></main>';
+  // Well-formed shell: the dashboard root `</section>` is followed
+  // immediately by `</div></main>` (the `grammar-surface` wrapper close).
+  // Trailing app-shell siblings (e.g. home overlays) sit outside the
+  // boundary so the scope helper excludes them from the child sweep.
+  const html = '<main><div class="grammar-surface"><section data-grammar-phase-root="dashboard" class="grammar-dashboard">body</section></div></main><div class="home-overlays">adult</div>';
   const scoped = scopeDashboard(html);
   assert.match(scoped, /data-grammar-phase-root="dashboard"/);
   assert.match(scoped, /body/);
-  assert.doesNotMatch(scoped, /adult/, 'scoped must exclude the sibling grown-up content');
+  assert.doesNotMatch(scoped, /adult/, 'scoped must exclude the trailing app-shell content');
   assert.ok(scoped.length < html.length, 'scoped must be strictly narrower than full HTML');
 });
 
@@ -281,10 +285,14 @@ const LIVE_HARNESS_PHASES = Object.freeze([
   'analytics',
 ]);
 
-// Only `analytics` legitimately carries the adult copy; every other live
-// phase in the harness is a child scene whose scoped output must exclude
-// the disclosure and its adult vocabulary.
-const ADULT_LIVE_PHASES = Object.freeze(['analytics']);
+// `analytics` and `bank` legitimately carry the adult copy. Analytics IS
+// the adult surface; the bank embeds the Grown-up view as a
+// closed-by-default `<details>` (post Grammar-Aligned redesign — the
+// adult escape hatch was moved off the dashboard so the child landing is
+// fully child-first). Every other live phase in the harness is a pure
+// child scene whose scoped output must exclude the disclosure and its
+// adult vocabulary.
+const ADULT_LIVE_PHASES = Object.freeze(['analytics', 'bank']);
 
 for (const phase of LIVE_HARNESS_PHASES) {
   test(`U2: live ${phase} render carries the data-grammar-phase-root landmark`, () => {

--- a/tests/grammar-ui-model.test.js
+++ b/tests/grammar-ui-model.test.js
@@ -268,50 +268,53 @@ test('P2 session-ui: grammarFeedbackTone treats non-scored manual-review feedbac
 // GRAMMAR_PRIMARY_MODE_CARDS — roster + shape contract
 // -----------------------------------------------------------------------------
 
-// U8 Phase 5: GRAMMAR_PRIMARY_MODE_CARDS is now Smart Practice only.
-test('P5-U8 view-model: GRAMMAR_PRIMARY_MODE_CARDS has exactly one card (Smart Practice)', () => {
-  assert.equal(GRAMMAR_PRIMARY_MODE_CARDS.length, 1);
-  assert.equal(GRAMMAR_PRIMARY_MODE_CARDS[0].id, 'smart');
-  assert.equal(GRAMMAR_PRIMARY_MODE_CARDS[0].featured, true);
+// Aligned design language: GRAMMAR_PRIMARY_MODE_CARDS now carries the
+// three decision-weight modes (Smart, Trouble, Mini Test) so they render
+// as a 3-card mode-row matching Spelling's setup panel.
+test('aligned view-model: GRAMMAR_PRIMARY_MODE_CARDS has three cards (smart, trouble, satsset)', () => {
+  assert.equal(GRAMMAR_PRIMARY_MODE_CARDS.length, 3);
+  const ids = GRAMMAR_PRIMARY_MODE_CARDS.map((card) => card.id);
+  assert.deepEqual(ids, ['smart', 'trouble', 'satsset']);
 });
 
-test('P5-U8 view-model: GRAMMAR_PRIMARY_MODE_CARDS title is Smart Practice', () => {
-  assert.equal(GRAMMAR_PRIMARY_MODE_CARDS[0].title, 'Smart Practice');
+test('aligned view-model: only Smart Practice carries featured/recommended', () => {
+  const featured = GRAMMAR_PRIMARY_MODE_CARDS.filter((card) => card.featured === true);
+  assert.equal(featured.length, 1);
+  assert.equal(featured[0].id, 'smart');
+  assert.equal(featured[0].title, 'Smart Practice');
+  assert.equal(featured[0].badge, 'RECOMMENDED');
 });
 
-test('P5-U8 view-model: GRAMMAR_PRIMARY_MODE_CARDS is frozen and deeply frozen', () => {
+test('aligned view-model: GRAMMAR_PRIMARY_MODE_CARDS is frozen and deeply frozen', () => {
   assert.equal(Object.isFrozen(GRAMMAR_PRIMARY_MODE_CARDS), true);
   for (const card of GRAMMAR_PRIMARY_MODE_CARDS) {
     assert.equal(Object.isFrozen(card), true);
   }
 });
 
-test('P5-U8 view-model: GRAMMAR_PRIMARY_MODE_CARDS titles use only child copy', () => {
+test('aligned view-model: GRAMMAR_PRIMARY_MODE_CARDS titles use only child copy', () => {
   for (const card of GRAMMAR_PRIMARY_MODE_CARDS) {
     assert.equal(isGrammarChildCopy(card.title), true, `title "${card.title}" contains forbidden term`);
     assert.equal(isGrammarChildCopy(card.desc), true, `desc "${card.desc}" contains forbidden term`);
   }
 });
 
-// U8 Phase 5: Three demoted modes as secondary links.
-test('P5-U8 view-model: GRAMMAR_SECONDARY_MODE_LINKS has Grammar Bank, Mini Test, Fix Trouble Spots', () => {
-  assert.equal(GRAMMAR_SECONDARY_MODE_LINKS.length, 3);
-  const ids = GRAMMAR_SECONDARY_MODE_LINKS.map((link) => link.id);
-  assert.deepEqual(ids, ['bank', 'satsset', 'trouble']);
+test('aligned view-model: trouble card declares disabledWhenNoTrouble + child-facing disabled copy', () => {
+  const trouble = GRAMMAR_PRIMARY_MODE_CARDS.find((card) => card.id === 'trouble');
+  assert.ok(trouble, 'trouble card exists');
+  assert.equal(trouble.disabledWhenNoTrouble, true);
+  assert.equal(typeof trouble.disabledCopy, 'string');
+  assert.ok(trouble.disabledCopy.length > 0);
+  assert.equal(isGrammarChildCopy(trouble.disabledCopy), true);
 });
 
-test('P5-U8 view-model: GRAMMAR_SECONDARY_MODE_LINKS is frozen and deeply frozen', () => {
+// Aligned design language: every former secondary mode is now either a
+// primary card or sidebar shortcut. The export stays as an empty frozen
+// array so iteration sites do not need to special-case undefined.
+test('aligned view-model: GRAMMAR_SECONDARY_MODE_LINKS is empty (callers iterate no rows)', () => {
+  assert.equal(Array.isArray(GRAMMAR_SECONDARY_MODE_LINKS), true);
+  assert.equal(GRAMMAR_SECONDARY_MODE_LINKS.length, 0);
   assert.equal(Object.isFrozen(GRAMMAR_SECONDARY_MODE_LINKS), true);
-  for (const link of GRAMMAR_SECONDARY_MODE_LINKS) {
-    assert.equal(Object.isFrozen(link), true);
-  }
-});
-
-test('P5-U8 view-model: GRAMMAR_SECONDARY_MODE_LINKS titles use only child copy', () => {
-  for (const link of GRAMMAR_SECONDARY_MODE_LINKS) {
-    assert.equal(isGrammarChildCopy(link.title), true, `title "${link.title}" contains forbidden term`);
-    assert.equal(isGrammarChildCopy(link.desc), true, `desc "${link.desc}" contains forbidden term`);
-  }
 });
 
 // -----------------------------------------------------------------------------
@@ -595,11 +598,11 @@ test('U8 view-model: isGrammarChildCopy safe on empty / non-string', () => {
 // buildGrammarDashboardModel
 // -----------------------------------------------------------------------------
 
-test('P5-U8 view-model: buildGrammarDashboardModel returns safe empty shape on null inputs', () => {
+test('aligned view-model: buildGrammarDashboardModel returns safe empty shape on null inputs', () => {
   const model = buildGrammarDashboardModel(null, null, null);
   assert.equal(Array.isArray(model.modeCards), true);
-  // U8 Phase 5: modeCards now contains only Smart Practice.
-  assert.equal(model.modeCards.length, 1);
+  // Aligned design: modeCards now carries 3 decision-weight modes.
+  assert.equal(model.modeCards.length, 3);
   assert.equal(model.modeCards[0].id, 'smart');
   assert.equal(model.modeCards[0].featured, true);
   assert.equal(model.todayCards.length, 4);
@@ -608,12 +611,13 @@ test('P5-U8 view-model: buildGrammarDashboardModel returns safe empty shape on n
   assert.equal(model.concordiumProgress.total, 18);
   assert.equal(model.primaryMode, 'smart');
   assert.equal(Array.isArray(model.moreModes), true);
-  // U8 Phase 5: moreModes now includes Writing Try (6 total).
+  // U8 Phase 5: moreModes still carries six modes (Writing Try included).
   assert.equal(model.moreModes.length, 6);
   assert.equal(typeof model.writingTryAvailable, 'boolean');
-  // U8 Phase 5: secondaryLinks has 3 demoted modes.
+  // Aligned design: secondaryLinks is empty — bank moved to sidebar,
+  // satsset + trouble promoted to primary cards.
   assert.equal(Array.isArray(model.secondaryLinks), true);
-  assert.equal(model.secondaryLinks.length, 3);
+  assert.equal(model.secondaryLinks.length, 0);
 });
 
 test('U8 view-model: buildGrammarDashboardModel surfaces concept counts', () => {
@@ -1107,8 +1111,9 @@ test('P5-U7 view-model: GRAMMAR_MONSTER_STRIP_CHILD_COPY is correct child-facing
 test('P5-U7 view-model: buildGrammarMonsterStripModel + buildGrammarDashboardModel compose without conflict', () => {
   const dashboard = buildGrammarDashboardModel({}, null, {});
   const strip = buildGrammarMonsterStripModel({}, null, null);
-  // Both return valid shapes without overwriting each other.
-  assert.equal(dashboard.modeCards.length, 1);
+  // Both return valid shapes without overwriting each other. Aligned design
+  // surfaces the three decision-weight modes as primary cards.
+  assert.equal(dashboard.modeCards.length, 3);
   assert.equal(strip.length, 4);
   assert.equal(dashboard.concordiumProgress.total, 18);
 });
@@ -1124,21 +1129,22 @@ test('P5-U8 view-model: Smart Practice is the only data-featured=true element', 
   assert.equal(featuredCards[0].id, 'smart');
 });
 
-test('P5-U8 view-model: Grammar Bank, Mini Test, Fix Trouble Spots appear as secondary links', () => {
-  const ids = GRAMMAR_SECONDARY_MODE_LINKS.map((link) => link.id);
-  assert.ok(ids.includes('bank'), 'Grammar Bank in secondary links');
-  assert.ok(ids.includes('satsset'), 'Mini Test in secondary links');
-  assert.ok(ids.includes('trouble'), 'Fix Trouble Spots in secondary links');
+test('aligned view-model: Mini Test + Fix Trouble Spots are primary cards; Grammar Bank moved to sidebar', () => {
+  const primaryIds = GRAMMAR_PRIMARY_MODE_CARDS.map((card) => card.id);
+  assert.ok(primaryIds.includes('satsset'), 'Mini Test in primary cards');
+  assert.ok(primaryIds.includes('trouble'), 'Fix Trouble Spots in primary cards');
+  // Grammar Bank no longer occupies a mode slot — the sidebar surfaces it
+  // via the `Browse the Grammar Bank` shortcut and `data-action="grammar-open-concept-bank"`.
+  assert.equal(primaryIds.includes('bank'), false, 'Grammar Bank is not a mode card');
+  assert.equal(GRAMMAR_SECONDARY_MODE_LINKS.length, 0, 'no secondary mode links remain');
 });
 
-test('P5-U8 view-model: Writing Try appears inside collapsed More practice', () => {
+test('aligned view-model: Writing Try appears inside collapsed More practice', () => {
   const moreIds = GRAMMAR_MORE_PRACTICE_MODES.map((mode) => mode.id);
   assert.ok(moreIds.includes('transfer'), 'Writing Try (transfer) in More practice');
   // Writing Try is NOT in primary or secondary.
   const primaryIds = GRAMMAR_PRIMARY_MODE_CARDS.map((c) => c.id);
-  const secondaryIds = GRAMMAR_SECONDARY_MODE_LINKS.map((l) => l.id);
   assert.equal(primaryIds.includes('transfer'), false, 'Writing Try not in primary');
-  assert.equal(secondaryIds.includes('transfer'), false, 'Writing Try not in secondary links');
 });
 
 test('P5-U8 view-model: More practice disclosure contains all 6 secondary modes', () => {
@@ -1148,12 +1154,13 @@ test('P5-U8 view-model: More practice disclosure contains all 6 secondary modes'
   );
 });
 
-test('P5-U8 view-model: fresh learner (no progress) still produces valid dashboard with Smart Practice accessible', () => {
+test('aligned view-model: fresh learner (no progress) still produces valid dashboard with Smart Practice accessible', () => {
   const model = buildGrammarDashboardModel({}, null, null);
   assert.equal(model.isEmpty, true);
-  assert.equal(model.modeCards.length, 1);
+  // Aligned design: 3 primary cards, 0 secondary, 6 in More practice.
+  assert.equal(model.modeCards.length, 3);
   assert.equal(model.modeCards[0].id, 'smart');
-  assert.equal(model.secondaryLinks.length, 3);
+  assert.equal(model.secondaryLinks.length, 0);
   assert.equal(model.moreModes.length, 6);
 });
 

--- a/tests/helpers/grammar-phase3-renders.js
+++ b/tests/helpers/grammar-phase3-renders.js
@@ -520,9 +520,14 @@ function scopeLandmark(html, phase, rootTag, boundary = null) {
 }
 
 export function scopeDashboard(html) {
-  // Dashboard root section ends right before the sibling
-  // `<details class="grammar-grown-up-view">` disclosure.
-  return scopeLandmark(html, 'dashboard', 'section', '<details class="grammar-grown-up-view">');
+  // Post Grammar-Aligned redesign: the dashboard surface no longer carries
+  // the `<details class="grammar-grown-up-view">` disclosure as a sibling
+  // — that escape hatch was relocated into the Grammar Bank scene so the
+  // child landing is fully child-first. The boundary check now pins the
+  // root `</section>` against the surrounding `</div></main>` close
+  // (the `grammar-surface` wrapper closing inside the app shell). A
+  // refactor that re-orders the wrapper structure would still fail loud.
+  return scopeLandmark(html, 'dashboard', 'section', '</div></main>');
 }
 
 export function scopeSession(html) {
@@ -537,7 +542,49 @@ export function scopeSummary(html) {
 }
 
 export function scopeBank(html) {
-  return scopeLandmark(html, 'bank', 'section', null);
+  // Bank embeds the adult escape hatch (`<details class="grammar-grown-up-view">`)
+  // at the bottom — the post Grammar-Aligned design moved the disclosure off
+  // the dashboard and into the bank so the child landing stays fully
+  // child-first. The disclosure body renders `GrammarAnalyticsScene` with
+  // adult-only copy, so the child forbidden-term sweep MUST exclude that
+  // subtree from the narrowed bank HTML. We narrow to the landmark first,
+  // then snip the grown-up-view block by depth-balanced walk over the
+  // `<details>` open/close tags so a nested `<details>` inside the
+  // disclosure (none today, but defended against) does not bleed in.
+  const scoped = scopeLandmark(html, 'bank', 'section', null);
+  return stripDetailsSubtree(scoped, 'class="grammar-grown-up-view"');
+}
+
+function stripDetailsSubtree(html, attributeSignature) {
+  const openIdx = html.indexOf(`<details ${attributeSignature}`);
+  if (openIdx < 0) return html;
+  const openTagEnd = html.indexOf('>', openIdx);
+  if (openTagEnd < 0) return html;
+  const openMarker = '<details';
+  const closeMarker = '</details>';
+  let depth = 1;
+  let i = openTagEnd + 1;
+  while (i < html.length) {
+    if (html.slice(i, i + openMarker.length) === openMarker) {
+      const afterName = html[i + openMarker.length];
+      if (afterName === ' ' || afterName === '>' || afterName === '\t' || afterName === '\n') {
+        depth += 1;
+        i += openMarker.length;
+        continue;
+      }
+    }
+    if (html.slice(i, i + closeMarker.length) === closeMarker) {
+      depth -= 1;
+      if (depth === 0) {
+        const closeEnd = i + closeMarker.length;
+        return html.slice(0, openIdx) + html.slice(closeEnd);
+      }
+      i += closeMarker.length;
+      continue;
+    }
+    i += 1;
+  }
+  return html;
 }
 
 export function scopeTransfer(html) {

--- a/tests/playwright/grammar-golden-path.playwright.test.mjs
+++ b/tests/playwright/grammar-golden-path.playwright.test.mjs
@@ -983,9 +983,11 @@ test.describe('P6 U9: Desktop viewport (1280x800) — landing + monster strip', 
     const todaySection = page.locator('.grammar-today');
     await expect(todaySection).toBeVisible();
 
-    // Secondary links nav is visible.
-    const secondaryNav = page.locator('.grammar-secondary-links');
-    await expect(secondaryNav).toBeVisible();
+    // Primary modes panel (merged hero + 3 mode cards) is visible. The
+    // aligned design uses the shared `.setup-main` shape with a Grammar
+    // brand variant via `.grammar-setup-main`.
+    const primaryModes = page.locator('.grammar-setup-main');
+    await expect(primaryModes).toBeVisible();
   });
 
   test('Smart Practice is the primary CTA with data-featured="true"', async ({ page }) => {
@@ -1143,13 +1145,13 @@ test.describe('P6 U9: Mobile viewport — responsive + touch', () => {
     const strip = page.locator('.grammar-monster-strip');
     await expect(strip).toBeVisible();
 
-    // Secondary links (Grammar Bank, Mini Test) visible.
+    // Grammar Bank (sidebar) and Mini Test (primary card) visible.
     const bankLink = page.locator('[data-action="grammar-open-concept-bank"]').first();
     await expect(bankLink).toBeVisible();
     await expect(bankLink).toBeEnabled();
-    const miniTestLink = page.locator('.grammar-secondary-link[data-mode-id="satsset"]');
-    await expect(miniTestLink).toBeVisible();
-    await expect(miniTestLink).toBeEnabled();
+    const miniTestCard = page.locator('.grammar-primary-mode[data-mode-id="satsset"]');
+    await expect(miniTestCard).toBeVisible();
+    await expect(miniTestCard).toBeEnabled();
   });
 
   test('Monster strip is readable and Star counts visible at mobile viewport', async ({ page }) => {
@@ -1199,13 +1201,15 @@ test.describe('P6 U9: Mobile viewport — responsive + touch', () => {
     expect(smartBox.width, 'Smart card width should be >= 40 for touch').toBeGreaterThanOrEqual(40);
     expect(smartBox.height, 'Smart card height should be >= 40 for touch').toBeGreaterThanOrEqual(40);
 
-    // Check secondary link buttons (Grammar Bank, Mini Test, etc.).
-    const secondaryLinks = page.locator('.grammar-secondary-link');
-    const linkCount = await secondaryLinks.count();
-    for (let i = 0; i < linkCount; i += 1) {
-      const box = await secondaryLinks.nth(i).boundingBox();
+    // Check every primary mode card (Smart Practice, Fix Trouble Spots,
+    // Mini Test) meets the 40x40 touch target.
+    const primaryCards = page.locator('.grammar-primary-mode');
+    const cardCount = await primaryCards.count();
+    expect(cardCount, 'Three primary mode cards should render').toBe(3);
+    for (let i = 0; i < cardCount; i += 1) {
+      const box = await primaryCards.nth(i).boundingBox();
       if (box) {
-        expect(box.height, `Secondary link ${i} height should be >= 40 for touch`).toBeGreaterThanOrEqual(40);
+        expect(box.height, `Primary card ${i} height should be >= 40 for touch`).toBeGreaterThanOrEqual(40);
       }
     }
   });
@@ -1355,15 +1359,15 @@ test.describe('P6 U9: Regression — Grammar Bank navigation + mode access', () 
     await seedFreshLearner(page);
     await openGrammarDashboard(page);
 
-    // Grammar Bank secondary link is visible and clickable.
+    // Grammar Bank sidebar link is visible and clickable.
     const bankLink = page.locator('[data-action="grammar-open-concept-bank"]').first();
     await expect(bankLink).toBeVisible();
     await expect(bankLink).toBeEnabled();
 
-    // Mini Test secondary link is visible and clickable.
-    const miniTestLink = page.locator('[data-mode-id="satsset"]').first();
-    await expect(miniTestLink).toBeVisible();
-    await expect(miniTestLink).toBeEnabled();
+    // Mini Test primary card is visible and clickable.
+    const miniTestCard = page.locator('.grammar-primary-mode[data-mode-id="satsset"]');
+    await expect(miniTestCard).toBeVisible();
+    await expect(miniTestCard).toBeEnabled();
 
     // Click Grammar Bank and verify it opens.
     await bankLink.click();
@@ -1376,12 +1380,11 @@ test.describe('P6 U9: Regression — Grammar Bank navigation + mode access', () 
     await closeBank.click();
     await expect(page.locator('.grammar-dashboard')).toBeVisible({ timeout: 15_000 });
 
-    // Click Mini Test secondary link and verify the mode is selected.
-    // The secondary link dispatches `grammar-set-mode` with value
-    // `satsset`. After clicking, the link gains `aria-pressed="true"`.
-    const miniTestSecondary = page.locator('.grammar-secondary-link[data-mode-id="satsset"]');
-    await expect(miniTestSecondary).toBeVisible();
-    await miniTestSecondary.click();
-    await expect(miniTestSecondary).toHaveAttribute('aria-pressed', 'true', { timeout: 5_000 });
+    // Click Mini Test primary card and verify the mode is selected.
+    // The card dispatches `grammar-set-mode` with value `satsset`.
+    // After clicking, the card gains `aria-pressed="true"`.
+    await expect(miniTestCard).toBeVisible();
+    await miniTestCard.click();
+    await expect(miniTestCard).toHaveAttribute('aria-pressed', 'true', { timeout: 5_000 });
   });
 });

--- a/tests/react-accessibility-contract.test.js
+++ b/tests/react-accessibility-contract.test.js
@@ -101,11 +101,16 @@ test('Grammar dashboard exposes labelled form controls and a single primary acti
   const harness = openGrammarDashboard();
   const html = harness.render();
 
-  // Round length and speech rate selects live inside wrapping `<label>`
-  // elements (implicit labelling).
-  assert.match(html, /<label class="field"><span>Round length<\/span>/);
-  assert.match(html, /<label class="field"><span>Speech rate<\/span>/);
-  // Exactly one primary CTA in the default dashboard state (`Begin round`).
+  // Aligned design: round length is a slide-button radiogroup with an
+  // explicit `aria-label`, mirroring Spelling's setup picker. The
+  // speech-rate picker is removed from the dashboard surface — the
+  // session scene still owns the audio-replay control. The visible
+  // tweak label sits in a sibling `<span class="tool-label">` so screen
+  // readers also have a textual anchor adjacent to the picker.
+  assert.match(html, /<span class="tool-label">Round length<\/span>/);
+  assert.match(html, /<div class="length-picker" role="radiogroup" aria-label="Round length"/);
+  assert.doesNotMatch(html, /Speech rate/);
+  // Exactly one primary CTA in the default dashboard state (`Start ...`).
   const primaryMatches = html.match(/class="btn primary[^"]*"/g) || [];
   assert.equal(primaryMatches.length, 1, 'dashboard must render a single .btn.primary');
 });

--- a/tests/react-grammar-surface.test.js
+++ b/tests/react-grammar-surface.test.js
@@ -38,9 +38,10 @@ test('Grammar opens as the child-facing Grammar Garden dashboard', () => {
   // Phase 3 U1: hero copy comes from `GRAMMAR_DASHBOARD_HERO`.
   assert.match(html, /Grammar Garden/);
   assert.match(html, /Grow your Grammar creatures/);
-  // U8 Phase 5: Smart Practice is the sole primary CTA.
+  // Aligned design: Smart Practice + Mini Test + Fix Trouble Spots are
+  // the three decision-weight primary cards. Grammar Bank moves to the
+  // sidebar shortcut so the chip rail no longer carries it.
   assert.match(html, /Smart Practice/);
-  // U8 Phase 5: Grammar Bank, Mini Test, Fix Trouble Spots are secondary links.
   assert.match(html, /Fix Trouble Spots/);
   assert.match(html, /Mini Test/);
   assert.match(html, /Grammar Bank/);
@@ -50,7 +51,9 @@ test('Grammar opens as the child-facing Grammar Garden dashboard', () => {
   // Smart Practice is marked featured/recommended (U1 follower, cta_hierarchy).
   assert.match(html, /data-mode-id="smart"[^>]*data-featured="true"/);
   assert.match(html, /class="grammar-primary-mode[^"]*is-recommended[^"]*"[^>]*data-mode-id="smart"/);
-  assert.match(html, /Recommended/);
+  // Aligned design: badge is uppercase "RECOMMENDED" inside the mc-top
+  // row to match Spelling's mode-card silhouette.
+  assert.match(html, /RECOMMENDED/);
   // U7 Phase 5: Monster strip with 4 active creatures + child-facing copy.
   assert.match(html, /grammar-monster-strip/);
   assert.match(html, /data-monster-id="bracehart"/);
@@ -59,7 +62,7 @@ test('Grammar opens as the child-facing Grammar Garden dashboard', () => {
   assert.match(html, /0 \/ 100 Stars/);
   assert.match(html, /Get 1 Star to find the Egg\. Reach 100 Stars for Mega\./);
   // More practice disclosure is present and closed by default.
-  assert.match(html, /<details class="grammar-more-practice"><summary>More practice<\/summary>/);
+  assert.match(html, /<details class="setup-more-practice grammar-more-practice"><summary>More practice<\/summary>/);
   // U8 Phase 5: Writing Try now inside More practice (not primary area).
   assert.match(html, /data-action="grammar-open-transfer"/);
   assert.match(html, /Writing Try/);
@@ -77,7 +80,12 @@ test('Grammar dashboard omits adult-diagnostic copy and reserved monster names',
   // Narrow the absence check to the dashboard panel. The adult-only
   // analytics surface lives behind a sibling `<details class="grammar-grown-up-view">`
   // disclosure, so we scope to the dashboard section alone.
-  const dashboardMatch = html.match(/<section class="grammar-dashboard"[\s\S]*?<\/section><details class="grammar-grown-up-view">/);
+  // Aligned design: the dashboard <section> no longer carries a sibling
+  // <details class="grammar-grown-up-view"> — that adult escape hatch
+  // moved into the Grammar Bank. The boundary therefore terminates at
+  // the outer `</section></div>` pair (close of the dashboard, then
+  // close of the wrapping `<div class="grammar-surface">`).
+  const dashboardMatch = html.match(/<section class="grammar-dashboard"[\s\S]*?<\/section><\/div>/);
   assert.ok(dashboardMatch, 'dashboard section was rendered');
   const dashboardHtml = dashboardMatch[0];
 
@@ -204,7 +212,11 @@ test('Grammar surface runs KS2 mini-set mode with delayed feedback and end revie
   harness.dispatch('grammar-set-mode', { value: 'satsset' });
   let html = harness.render();
   assert.match(html, /Mini-set size/);
-  assert.match(html, /<option value="8" selected="">8<\/option><option value="12">12<\/option>/);
+  // Aligned design: round length is a slide-button picker (`length-picker`),
+  // not a `<select>`. Mini-set mode swaps the option list to 8 / 12 and
+  // selects 8 by default.
+  assert.match(html, /<button[^>]*class="length-option selected"[^>]*value="8"[^>]*><span>8<\/span><\/button>/);
+  assert.match(html, /<button[^>]*class="length-option"[^>]*value="12"[^>]*><span>12<\/span><\/button>/);
 
   harness.dispatch('grammar-start', {
     payload: {
@@ -835,7 +847,12 @@ test('Grammar analytics exposes parent summary draft enrichment', () => {
   const storage = installMemoryStorage();
   const harness = createGrammarHarness({ storage });
 
+  // Aligned design: the adult analytics surface lives inside the Grammar
+  // Bank's `<details class="grammar-grown-up-view">` disclosure. Navigate
+  // to the bank phase to render that tree (the `<details>` keeps its
+  // children in the DOM regardless of the open attribute).
   harness.dispatch('open-subject', { subjectId: 'grammar' });
+  harness.dispatch('grammar-open-concept-bank');
   let html = harness.render();
   assert.match(html, /Parent summary draft/);
 
@@ -886,11 +903,20 @@ test('Grammar dashboard disables mode cards, controls, and Begin button while a 
   }));
 
   const html = harness.render();
-  // U8 Phase 5: Smart Practice is the sole primary card, disabled during pending.
-  assert.match(html, /<button type="button" class="grammar-primary-mode selected is-disabled is-recommended" data-mode-id="smart" data-action="grammar-set-mode" data-featured="true" aria-pressed="true" disabled="">/);
-  // Round length select is disabled and shows the default 5 value selected.
-  assert.match(html, /<select class="input" disabled=""[^>]*><option value="3">3<\/option><option value="5" selected="">5<\/option>/);
-  // U8 Phase 5: Begin button renders the pending label.
+  // Aligned design: Smart Practice card disabled during pending. The
+  // `selected` class is suppressed while disabled so the card does not
+  // read as both pending and chosen — matches Spelling's mode-card
+  // disabled state and avoids double-affordance signal. The card now
+  // also carries the shared `mode-card` class for visual identity, in
+  // addition to the existing `grammar-primary-mode` test hook.
+  // `data-text-tone` is contrast-driven (depends on the active region
+  // tone) so the assertion accepts either dark or light without pinning
+  // the specific learner's tone hash.
+  assert.match(html, /<button type="button" class="grammar-primary-mode mode-card is-disabled is-recommended" data-mode-id="smart" data-action="grammar-set-mode" data-featured="true" data-text-tone="(?:dark|light)" aria-pressed="false" disabled="">/);
+  // Round-length picker (slide-button) renders the default 5 value
+  // selected and the option buttons reflect the pending-disabled state.
+  assert.match(html, /<button[^>]*class="length-option selected"[^>]*value="5"[^>]*disabled="">/);
+  // Aligned design: CTA renders the pending label inside the merged panel.
   assert.match(html, /<button class="btn primary xl" type="button" data-featured="true" disabled="">Starting\.\.\.<\/button>/);
 });
 
@@ -900,9 +926,11 @@ test('Grammar dashboard hides adult-diagnostic goal/teaching toggles but preserv
 
   harness.dispatch('open-subject', { subjectId: 'grammar' });
   let html = harness.render();
-  // Child dashboard surfaces Speech rate only; adult-diagnostic toggles
-  // move out of the primary dashboard as of U1.
-  assert.match(html, /Speech rate/);
+  // Aligned design: Speech rate picker is removed from the dashboard so
+  // the child surface stays decision-light. The dispatch round-trip below
+  // still verifies the module accepts speech-rate updates, which the
+  // session scene applies via the audio replay control.
+  assert.doesNotMatch(html, /Speech rate/);
   assert.doesNotMatch(html, /Smart Review teaching items/);
   assert.doesNotMatch(html, /Show domain before answering/);
   assert.doesNotMatch(html, /Session goal/);
@@ -992,6 +1020,8 @@ test('Grammar monster progress rehydrates from persisted Codex state after reloa
   });
   harness.store.updateSubjectUi('grammar', normaliseGrammarReadModel({}, learnerId));
   harness.dispatch('open-subject', { subjectId: 'grammar' });
+  // Aligned design: Codex copy lives inside the bank's grown-up-view.
+  harness.dispatch('grammar-open-concept-bank');
 
   const html = harness.render();
 
@@ -1194,6 +1224,8 @@ test('Grammar analytics renders normalised recent activity before raw attempts',
     },
   }, learnerId));
   harness.dispatch('open-subject', { subjectId: 'grammar' });
+  // Aligned design: analytics renders inside the Grammar Bank.
+  harness.dispatch('grammar-open-concept-bank');
 
   const html = harness.render();
 
@@ -1218,6 +1250,8 @@ test('Grammar analytics falls back to legacy recent attempt result payloads', ()
     },
   }, learnerId));
   harness.dispatch('open-subject', { subjectId: 'grammar' });
+  // Aligned design: analytics renders inside the Grammar Bank.
+  harness.dispatch('grammar-open-concept-bank');
 
   const html = harness.render();
 
@@ -1498,7 +1532,7 @@ test('Grammar "More practice" disclosure exposes secondary modes without locked 
 
   // Secondary modes from `GRAMMAR_MORE_PRACTICE_MODES` render inside the
   // `<details class="grammar-more-practice">` disclosure as active cards.
-  assert.match(html, /<details class="grammar-more-practice"><summary>More practice<\/summary>/);
+  assert.match(html, /<details class="setup-more-practice grammar-more-practice"><summary>More practice<\/summary>/);
   assert.match(html, /data-mode-id="learn"/);
   assert.match(html, /Learn a concept/);
   assert.match(html, /data-mode-id="surgery"/);
@@ -1524,7 +1558,7 @@ test('U5: Grammar dashboard renders "Mixed practice" label on Surgery and Builde
 
   // Scope to the More practice disclosure so a stray "Mixed practice"
   // somewhere else in the app shell does not false-positive the assertion.
-  const disclosureMatch = html.match(/<details class="grammar-more-practice"[\s\S]*?<\/details>/);
+  const disclosureMatch = html.match(/<details class="setup-more-practice grammar-more-practice"[\s\S]*?<\/details>/);
   assert.ok(disclosureMatch, 'More practice disclosure renders');
   const disclosure = disclosureMatch[0];
 
@@ -1545,7 +1579,7 @@ test('U5: Grammar dashboard does NOT render "Mixed practice" on Learn, Worked, o
   harness.dispatch('open-subject', { subjectId: 'grammar' });
   const html = harness.render();
 
-  const disclosureMatch = html.match(/<details class="grammar-more-practice"[\s\S]*?<\/details>/);
+  const disclosureMatch = html.match(/<details class="setup-more-practice grammar-more-practice"[\s\S]*?<\/details>/);
   assert.ok(disclosureMatch, 'More practice disclosure renders');
   const disclosure = disclosureMatch[0];
 
@@ -1567,11 +1601,14 @@ test('U5: Grammar primary cards (Smart, Trouble, Mini Test, Bank) never render t
   harness.dispatch('open-subject', { subjectId: 'grammar' });
   const html = harness.render();
 
-  // Primary mode cards live outside the "More practice" disclosure. Scope
-  // to the primary section and assert no Mixed practice copy leaks into
-  // Smart / Trouble / Mini Test / Bank cards.
-  const primaryMatch = html.match(/<section class="grammar-primary-modes"[\s\S]*?<\/section>/);
-  assert.ok(primaryMatch, 'primary modes section renders');
+  // Primary mode cards live in the `.mode-row.grammar-mode-row` grid
+  // inside the setup-main panel (Spelling-style `setup-main` variant).
+  // Scope to that grid only — the "More practice" disclosure now lives
+  // INSIDE setup-main below the begin row, and it legitimately carries
+  // the `Mixed practice` label on Surgery + Builder. We are testing
+  // that the primary cards do NOT carry that label, not the whole panel.
+  const primaryMatch = html.match(/<div class="mode-row grammar-mode-row">[\s\S]*?<\/div>/);
+  assert.ok(primaryMatch, 'primary modes grid renders');
   assert.doesNotMatch(primaryMatch[0], /Mixed practice/);
   assert.doesNotMatch(primaryMatch[0], /data-mode-label="/);
 });
@@ -1792,6 +1829,8 @@ test('Grammar surface routes persisted retired-id state through the normaliser b
   });
   harness.store.updateSubjectUi('grammar', normaliseGrammarReadModel({}, learnerId));
   harness.dispatch('open-subject', { subjectId: 'grammar' });
+  // Aligned design: Codex copy now lives in the bank's grown-up-view.
+  harness.dispatch('grammar-open-concept-bank');
 
   const html = harness.render();
 
@@ -3331,18 +3370,20 @@ test('U7: analytics phase empty state — no recent activity and no question typ
   assert.match(html, /No question-type evidence recorded yet\./);
 });
 
-test('U7: dashboard <details class="grammar-grown-up-view"> stays as a closed-by-default escape hatch', () => {
+test('aligned design: <details class="grammar-grown-up-view"> lives in the Grammar Bank, not the dashboard', () => {
   const storage = installMemoryStorage();
   const harness = createAppHarness({ storage });
   harness.dispatch('open-subject', { subjectId: 'grammar' });
-  const html = harness.render();
+  const dashboardHtml = harness.render();
 
-  // The disclosure is present but closed — no `open` attribute. SSR cannot
-  // flip it programmatically; this assertion guards against drift that would
-  // render the disclosure open by default and leak adult copy into the child
-  // dashboard flow.
-  const details = html.match(/<details class="grammar-grown-up-view"[^>]*>/)?.[0];
-  assert.ok(details, 'grown-up view disclosure rendered on the dashboard');
+  // Dashboard surface is child-first — the adult escape hatch is gone.
+  assert.doesNotMatch(dashboardHtml, /<details class="grammar-grown-up-view"/);
+
+  // Navigate to the bank: the disclosure is present but closed by default.
+  harness.dispatch('grammar-open-concept-bank');
+  const bankHtml = harness.render();
+  const details = bankHtml.match(/<details class="grammar-grown-up-view"[^>]*>/)?.[0];
+  assert.ok(details, 'grown-up view disclosure rendered inside the bank');
   assert.doesNotMatch(details, /\bopen\b/, 'grown-up view disclosure must NOT be open by default');
 });
 
@@ -3354,7 +3395,12 @@ test('U7: default dashboard HTML carries no Grown-up intro copy outside the anal
 
   // Narrow to the dashboard panel so we do not sweep the sibling `<details>`
   // disclosure which legitimately holds adult copy ready for opening.
-  const dashboardMatch = html.match(/<section class="grammar-dashboard"[\s\S]*?<\/section><details class="grammar-grown-up-view">/);
+  // Aligned design: the dashboard <section> no longer carries a sibling
+  // <details class="grammar-grown-up-view"> — that adult escape hatch
+  // moved into the Grammar Bank. The boundary therefore terminates at
+  // the outer `</section></div>` pair (close of the dashboard, then
+  // close of the wrapping `<div class="grammar-surface">`).
+  const dashboardMatch = html.match(/<section class="grammar-dashboard"[\s\S]*?<\/section><\/div>/);
   assert.ok(dashboardMatch, 'dashboard section rendered');
   const dashboardHtml = dashboardMatch[0];
   assert.doesNotMatch(dashboardHtml, /Nothing here is a grade/i);
@@ -3432,7 +3478,12 @@ test('U10: forbidden-term sweep still passes on the child dashboard', () => {
   const harness = createAppHarness({ storage });
   harness.dispatch('open-subject', { subjectId: 'grammar' });
   const html = harness.render();
-  const dashboardMatch = html.match(/<section class="grammar-dashboard"[\s\S]*?<\/section><details class="grammar-grown-up-view">/);
+  // Aligned design: the dashboard <section> no longer carries a sibling
+  // <details class="grammar-grown-up-view"> — that adult escape hatch
+  // moved into the Grammar Bank. The boundary therefore terminates at
+  // the outer `</section></div>` pair (close of the dashboard, then
+  // close of the wrapping `<div class="grammar-surface">`).
+  const dashboardMatch = html.match(/<section class="grammar-dashboard"[\s\S]*?<\/section><\/div>/);
   assert.ok(dashboardMatch, 'dashboard section was rendered');
   const dashboardHtml = dashboardMatch[0];
   for (const term of GRAMMAR_CHILD_FORBIDDEN_TERMS) {


### PR DESCRIPTION
## Summary
- Refactor Grammar setup to share Spelling's visual engine. Extract `HeroBackdrop`, `useSetupHeroContrast`, `heroBgStyle`/`heroPanDelayStyle` to `src/platform/ui/`; lift `stableHash` to `src/platform/core/utils.js`. Spelling's wrappers stay tiny so legacy `.spelling-hero-*` selectors keep working.
- Add `src/subjects/grammar/components/grammar-hero-bg.js` (the-clause-conservatory URLs, mode→region map, per-tone curated contrast envelope, preload list) so Grammar drives the same cross-fade + slow pan + runtime contrast probe.
- Rewrite `GrammarSetupScene` with `.setup-grid` / `.setup-main` / `.setup-content` rhythm, slide-button `RoundLengthPicker` (mirrors Spelling's `.length-picker`), merged hero copy + 3-card primary mode row + plum CTA. Move Grammar Bank link to the sidebar; relocate `<details class="grammar-grown-up-view">` from setup surface into the Grammar Bank scene.
- Extract `SetupMorePractice` disclosure shell to `src/platform/ui/SetupMorePractice.jsx` (Grammar-only consumer for now); place it as the third child of `.setup-grid` at row 2 column 1 so its width matches `.setup-main` while staying detached from the panel.
- Update CSS: subject-agnostic `.hero-backdrop` / `.hero-layer` rules with `.spelling-hero-*` aliases retained; new `.setup-more-practice` rules; `.setup-grid` row spans pinned for stable 2-column layout. Bundle budget 224.5 KB → 227 KB (matches measured 226.3 KB gzip), baseline 203.2 → 206 KB.

## Test plan
- [x] Touched-slice node tests: 437 / 437 pass for grammar + spelling + a11y + button-label + CSP budget + bundle byte budget (rebased)
- [x] `node ./scripts/build-bundles.mjs` + `node ./scripts/build-public.mjs` green; gzip 226.3 KB sits under the 227 KB ceiling
- [x] Local dev (`wrangler dev --config ./wrangler.local.jsonc` against local D1) — verified setup-grid layout: setup-main col 1, sidebar col 2, "More practice" row 2 col 1 matching panel width
- [ ] Cross-browser smoke after merge (Chromium / Firefox / Safari) — backdrop cross-fade + length-picker slider transitions
- [ ] Production audit (`npm run audit:production`) once branch is on main

## Notes
- Three pre-existing failures in the broader sweep (`button labels: every statically extractable label is classified`, `live grep count stays <= POST_MIGRATION_TOTAL`, `every file with >0 sites has a committed classification`) come from mainline's admin-p7 incident UI (`AdminIncidentPanel.jsx`, `AdminProductionEvidencePanel.jsx`, `AdminBusinessSection.jsx`) — not modified in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)