### PR TITLE
refactor(platform-ui): extract SetupSidePanel (U3)

### DIFF
--- a/src/platform/ui/SetupSidePanel.jsx
+++ b/src/platform/ui/SetupSidePanel.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+/* Slot-based Setup-scene sidebar shell. Lifts .ss-card / .ss-head /
+ * body / footer shape out of Spelling's SpellingSetupScene and
+ * Grammar's GrammarSetupScene.
+ *
+ * Props:
+ *   head?: ReactNode — optional content for the top-of-card head row
+ *   body: ReactNode — required card body content
+ *   footer?: ReactNode — optional footer link or CTA block
+ *   asideClassName?: string — extra class appended to "setup-side"
+ *   cardClassName?: string — extra class appended to "ss-card"
+ *   headClassName?: string — extra class appended to "ss-head"
+ *   headTag?: 'div' | 'header' — defaults to 'div' to preserve Spelling's DOM
+ *   ariaLabel?: string — aria-label on the <aside>
+ *
+ * Subject-specific classes (grammar-setup-sidebar, etc) are passed via
+ * the className props; the platform component is subject-agnostic.
+ */
+export function SetupSidePanel({
+  head = null,
+  body,
+  footer = null,
+  asideClassName = '',
+  cardClassName = '',
+  headClassName = '',
+  headTag = 'div',
+  ariaLabel = '',
+}) {
+  const asideClasses = asideClassName ? `setup-side ${asideClassName}` : 'setup-side';
+  const cardClasses = cardClassName ? `ss-card ${cardClassName}` : 'ss-card';
+  const headClasses = headClassName ? `ss-head ${headClassName}` : 'ss-head';
+  const HeadTag = headTag === 'header' ? 'header' : 'div';
+  return (
+    <aside className={asideClasses} aria-label={ariaLabel || undefined}>
+      <div className={cardClasses}>
+        {head != null ? <HeadTag className={headClasses}>{head}</HeadTag> : null}
+        {body}
+        {footer != null ? footer : null}
+      </div>
+    </aside>
+  );
+}

--- a/src/subjects/grammar/components/GrammarSetupScene.jsx
+++ b/src/subjects/grammar/components/GrammarSetupScene.jsx
@@ -5,6 +5,7 @@ import { heroBgStyle } from '../../../platform/ui/hero-bg.js';
 import { SetupMorePractice } from '../../../platform/ui/SetupMorePractice.jsx';
 import { LengthPicker } from '../../../platform/ui/LengthPicker.jsx';
 import { HeroWelcome } from '../../../platform/ui/HeroWelcome.jsx';
+import { SetupSidePanel } from '../../../platform/ui/SetupSidePanel.jsx';
 import {
   heroBgForGrammarSetup,
   heroContrastProfileForGrammarBg,
@@ -289,9 +290,14 @@ export function GrammarSetupScene({ learner, grammar, rewardState, actions, runt
           </div>
         </section>
 
-        <aside className="setup-side grammar-setup-sidebar" aria-label="Where you stand">
-          <div className="ss-card grammar-setup-sidebar-card">
-            <header className="ss-head grammar-setup-sidebar-head">
+        <SetupSidePanel
+          asideClassName="grammar-setup-sidebar"
+          cardClassName="grammar-setup-sidebar-card"
+          headClassName="grammar-setup-sidebar-head"
+          headTag="header"
+          ariaLabel="Where you stand"
+          head={(
+            <>
               <p className="eyebrow">Where you stand</p>
               <button
                 type="button"
@@ -303,32 +309,36 @@ export function GrammarSetupScene({ learner, grammar, rewardState, actions, runt
               >
                 Open bank →
               </button>
-            </header>
+            </>
+          )}
+          body={(
+            <>
+              <section className="grammar-monster-strip" aria-label="Your Grammar creatures">
+                {dashboard.monsterStrip.map((entry) => (
+                  <MonsterStripEntry entry={entry} key={entry.monsterId} />
+                ))}
+                <p className="grammar-monster-strip-hint">{GRAMMAR_MONSTER_STRIP_CHILD_COPY}</p>
+              </section>
 
-            <section className="grammar-monster-strip" aria-label="Your Grammar creatures">
-              {dashboard.monsterStrip.map((entry) => (
-                <MonsterStripEntry entry={entry} key={entry.monsterId} />
-              ))}
-              <p className="grammar-monster-strip-hint">{GRAMMAR_MONSTER_STRIP_CHILD_COPY}</p>
-            </section>
-
-            <section className="grammar-today" aria-label="Today at a glance">
-              {dashboard.isEmpty ? (
-                <div className="grammar-today-empty" data-testid="grammar-today-empty">
-                  <EmptyState
-                    title="No rounds yet"
-                    body="No rounds yet. Progress is saved as you practise. Start your first round to see your scores here."
-                  />
-                </div>
-              ) : (
-                <div className="grammar-today-grid">
-                  {dashboard.todayCards.map((card) => (
-                    <TodayCard card={card} key={card.id} />
-                  ))}
-                </div>
-              )}
-            </section>
-
+              <section className="grammar-today" aria-label="Today at a glance">
+                {dashboard.isEmpty ? (
+                  <div className="grammar-today-empty" data-testid="grammar-today-empty">
+                    <EmptyState
+                      title="No rounds yet"
+                      body="No rounds yet. Progress is saved as you practise. Start your first round to see your scores here."
+                    />
+                  </div>
+                ) : (
+                  <div className="grammar-today-grid">
+                    {dashboard.todayCards.map((card) => (
+                      <TodayCard card={card} key={card.id} />
+                    ))}
+                  </div>
+                )}
+              </section>
+            </>
+          )}
+          footer={(
             <button
               type="button"
               className="ss-bank-link grammar-setup-sidebar-bank-link"
@@ -342,8 +352,8 @@ export function GrammarSetupScene({ learner, grammar, rewardState, actions, runt
               </span>
               <span className="ss-bank-link-arrow grammar-setup-sidebar-bank-link-arrow" aria-hidden="true">→</span>
             </button>
-          </div>
-        </aside>
+          )}
+        />
 
         {/* "More practice" disclosure — optional, decision-light tail of
          * secondary modes (Learn / Surgery / Builder / Worked / Faded /

--- a/src/subjects/spelling/components/SpellingSetupScene.jsx
+++ b/src/subjects/spelling/components/SpellingSetupScene.jsx
@@ -4,6 +4,7 @@ import { SpellingHeroBackdrop } from './SpellingHeroBackdrop.jsx';
 import { ArrowRightIcon, CheckIcon } from './spelling-icons.jsx';
 import { useSetupHeroContrast } from './useSetupHeroContrast.js';
 import { LengthPicker } from '../../../platform/ui/LengthPicker.jsx';
+import { SetupSidePanel } from '../../../platform/ui/SetupSidePanel.jsx';
 import {
   BOSS_DEFAULT_ROUND_LENGTH,
   SPELLING_DURABLE_PERSISTENCE_WARNING_COPY,
@@ -471,9 +472,10 @@ export function SpellingSetupScene({
         </div>
       </section>
 
-      <aside className="setup-side">
-        <div className="ss-card">
-          <div className="ss-head">
+      <SetupSidePanel
+        headTag="div"
+        head={(
+          <>
             <p className="eyebrow">Where you stand</p>
             <button
               type="button"
@@ -484,9 +486,15 @@ export function SpellingSetupScene({
             >
               Open codex →
             </button>
-          </div>
-          <SetupMeadow codex={codex} repositories={repositories} />
-          <SetupStatGrid stats={stats} />
+          </>
+        )}
+        body={(
+          <>
+            <SetupMeadow codex={codex} repositories={repositories} />
+            <SetupStatGrid stats={stats} />
+          </>
+        )}
+        footer={(
           <button
             type="button"
             className="ss-bank-link"
@@ -499,8 +507,8 @@ export function SpellingSetupScene({
             </span>
             <span className="ss-bank-link-arrow" aria-hidden="true">→</span>
           </button>
-        </div>
-      </aside>
+        )}
+      />
     </div>
   );
 }

--- a/tests/platform-setup-side-panel.test.js
+++ b/tests/platform-setup-side-panel.test.js
@@ -1,0 +1,342 @@
+// U3 (refactor ui-consolidation): platform `SetupSidePanel`
+// characterisation tests.
+//
+// The component lives at `src/platform/ui/SetupSidePanel.jsx`. Spelling
+// and Grammar setup scenes both consume it; Punctuation does NOT adopt
+// this pass (see plan R3). The DOM + class rhythm MUST stay
+// byte-identical to the prior inline <aside class="setup-side"><div
+// class="ss-card">…</div></aside> trees so existing `.ss-card`,
+// `.ss-head`, `.ss-bank-link`, `.grammar-setup-sidebar*` selectors, and
+// Playwright / surface test locators all still resolve.
+//
+// Test harness: bundles a small probe entry through esbuild, invokes
+// `renderToStaticMarkup` in a child Node process, and asserts on the
+// emitted HTML. Pattern mirrors `tests/platform-length-picker.test.js`.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const componentSpec = path.join(rootDir, 'src/platform/ui/SetupSidePanel.jsx');
+
+function nodePaths() {
+  return [
+    path.join(rootDir, 'node_modules'),
+    ...String(process.env.NODE_PATH || '').split(path.delimiter),
+  ].filter((entry) => entry && existsSync(entry));
+}
+
+function normaliseLineEndings(value) {
+  return String(value).replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+}
+
+async function runFixture(entrySource) {
+  const tmpDir = await mkdtemp(path.join(tmpdir(), 'ks2-setup-side-panel-'));
+  const entryPath = path.join(tmpDir, 'entry.jsx');
+  const bundlePath = path.join(tmpDir, 'entry.cjs');
+  try {
+    await writeFile(entryPath, entrySource);
+    await build({
+      absWorkingDir: rootDir,
+      entryPoints: [entryPath],
+      outfile: bundlePath,
+      bundle: true,
+      platform: 'node',
+      format: 'cjs',
+      target: ['node24'],
+      jsx: 'automatic',
+      jsxImportSource: 'react',
+      loader: { '.js': 'jsx' },
+      nodePaths: nodePaths(),
+      logLevel: 'silent',
+    });
+    const output = execFileSync(process.execPath, [bundlePath], {
+      cwd: rootDir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return normaliseLineEndings(output).replace(/\n+$/, '');
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
+function renderHeader(spec) {
+  return `
+    const React = require('react');
+    const { renderToStaticMarkup } = require('react-dom/server');
+    const { SetupSidePanel } = require(${JSON.stringify(spec)});
+  `;
+}
+
+// ---------------------------------------------------------------
+// Happy path: all three slots populated.
+// ---------------------------------------------------------------
+
+test('SetupSidePanel: renders aside > card > head + body + footer when all three slots populated (Spelling-shape defaults)', async () => {
+  const html = await runFixture(`
+    ${renderHeader(componentSpec)}
+    const tree = React.createElement(SetupSidePanel, {
+      head: React.createElement('p', { className: 'eyebrow' }, 'Where you stand'),
+      body: React.createElement('div', { className: 'body-content' }, 'body'),
+      footer: React.createElement('button', { className: 'ss-bank-link' }, 'Browse'),
+    });
+    console.log(renderToStaticMarkup(tree));
+  `);
+  // Outer <aside> carries only .setup-side with no extra class and no aria-label.
+  assert.match(html, /^<aside class="setup-side">/);
+  assert.doesNotMatch(html, /aria-label=/);
+  // Inner card is the bare .ss-card (default Spelling shape).
+  assert.match(html, /<div class="ss-card">/);
+  // Head renders inside a <div class="ss-head"> — `headTag` default is 'div'.
+  assert.match(html, /<div class="ss-head"><p class="eyebrow">Where you stand<\/p><\/div>/);
+  // Body + footer render bare after the head.
+  assert.match(html, /<div class="body-content">body<\/div>/);
+  assert.match(html, /<button class="ss-bank-link">Browse<\/button>/);
+  // Closure.
+  assert.match(html, /<\/div><\/aside>$/);
+});
+
+// ---------------------------------------------------------------
+// Happy path: only `body` slot — no head, no footer.
+// ---------------------------------------------------------------
+
+test('SetupSidePanel: body-only renders no .ss-head row and no footer node', async () => {
+  const html = await runFixture(`
+    ${renderHeader(componentSpec)}
+    const tree = React.createElement(SetupSidePanel, {
+      body: React.createElement('div', { className: 'body-only' }, 'body-only'),
+    });
+    console.log(renderToStaticMarkup(tree));
+  `);
+  // No .ss-head anywhere.
+  assert.doesNotMatch(html, /ss-head/);
+  // Card contains only the body child.
+  assert.match(html, /<div class="ss-card"><div class="body-only">body-only<\/div><\/div>/);
+  // Closure reflects only aside > card > body.
+  assert.match(html, /<\/aside>$/);
+});
+
+// ---------------------------------------------------------------
+// Grammar-shape: aside + card + head class append, plus ariaLabel + headTag='header'.
+// ---------------------------------------------------------------
+
+test('SetupSidePanel: asideClassName / cardClassName / headClassName append with single space separators (Grammar shape)', async () => {
+  const html = await runFixture(`
+    ${renderHeader(componentSpec)}
+    const tree = React.createElement(SetupSidePanel, {
+      asideClassName: 'grammar-setup-sidebar',
+      cardClassName: 'grammar-setup-sidebar-card',
+      headClassName: 'grammar-setup-sidebar-head',
+      headTag: 'header',
+      ariaLabel: 'Where you stand',
+      head: React.createElement('p', { className: 'eyebrow' }, 'Where you stand'),
+      body: React.createElement('section', { className: 'grammar-monster-strip' }, 'monsters'),
+      footer: React.createElement('button', { className: 'ss-bank-link grammar-setup-sidebar-bank-link' }, 'Bank'),
+    });
+    console.log(renderToStaticMarkup(tree));
+  `);
+  // aside class = exactly "setup-side grammar-setup-sidebar" (single space).
+  assert.match(html, /<aside class="setup-side grammar-setup-sidebar" aria-label="Where you stand">/);
+  // card class = "ss-card grammar-setup-sidebar-card".
+  assert.match(html, /<div class="ss-card grammar-setup-sidebar-card">/);
+  // head renders as <header> (not <div>), class composed.
+  assert.match(html, /<header class="ss-head grammar-setup-sidebar-head"><p class="eyebrow">Where you stand<\/p><\/header>/);
+  // Body + footer still render bare.
+  assert.match(html, /<section class="grammar-monster-strip">monsters<\/section>/);
+  assert.match(html, /<button class="ss-bank-link grammar-setup-sidebar-bank-link">Bank<\/button>/);
+  // Negative: no doubled spaces, no missing separator.
+  assert.doesNotMatch(html, /class="setup-sidegrammar-/);
+  assert.doesNotMatch(html, /class="setup-side {2,}grammar-/);
+  assert.doesNotMatch(html, /class="ss-cardgrammar-/);
+  assert.doesNotMatch(html, /class="ss-headgrammar-/);
+});
+
+// ---------------------------------------------------------------
+// headTag toggle: 'header' vs 'div' vs default.
+// ---------------------------------------------------------------
+
+test('SetupSidePanel: headTag="header" renders a <header> element for the head row', async () => {
+  const html = await runFixture(`
+    ${renderHeader(componentSpec)}
+    const tree = React.createElement(SetupSidePanel, {
+      headTag: 'header',
+      head: React.createElement('span', null, 'head-text'),
+      body: React.createElement('div', null, 'body'),
+    });
+    console.log(renderToStaticMarkup(tree));
+  `);
+  assert.match(html, /<header class="ss-head"><span>head-text<\/span><\/header>/);
+  assert.doesNotMatch(html, /<div class="ss-head"/);
+});
+
+test('SetupSidePanel: headTag="div" renders a <div> element for the head row', async () => {
+  const html = await runFixture(`
+    ${renderHeader(componentSpec)}
+    const tree = React.createElement(SetupSidePanel, {
+      headTag: 'div',
+      head: React.createElement('span', null, 'head-text'),
+      body: React.createElement('div', null, 'body'),
+    });
+    console.log(renderToStaticMarkup(tree));
+  `);
+  assert.match(html, /<div class="ss-head"><span>head-text<\/span><\/div>/);
+  assert.doesNotMatch(html, /<header class="ss-head"/);
+});
+
+test('SetupSidePanel: headTag default (omitted) renders a <div> — preserves Spelling DOM', async () => {
+  const html = await runFixture(`
+    ${renderHeader(componentSpec)}
+    const tree = React.createElement(SetupSidePanel, {
+      head: React.createElement('span', null, 'head-text'),
+      body: React.createElement('div', null, 'body'),
+    });
+    console.log(renderToStaticMarkup(tree));
+  `);
+  assert.match(html, /<div class="ss-head"><span>head-text<\/span><\/div>/);
+  assert.doesNotMatch(html, /<header class="ss-head"/);
+});
+
+// ---------------------------------------------------------------
+// ariaLabel: threads to <aside aria-label=...>; absent omits attr.
+// ---------------------------------------------------------------
+
+test('SetupSidePanel: ariaLabel threads to the <aside aria-label> attribute', async () => {
+  const html = await runFixture(`
+    ${renderHeader(componentSpec)}
+    const tree = React.createElement(SetupSidePanel, {
+      ariaLabel: 'Where you stand',
+      body: React.createElement('div', null, 'body'),
+    });
+    console.log(renderToStaticMarkup(tree));
+  `);
+  assert.match(html, /<aside class="setup-side" aria-label="Where you stand">/);
+});
+
+test('SetupSidePanel: empty/omitted ariaLabel omits the aria-label attribute', async () => {
+  const html = await runFixture(`
+    ${renderHeader(componentSpec)}
+    const tree = React.createElement(SetupSidePanel, {
+      body: React.createElement('div', null, 'body'),
+    });
+    console.log(renderToStaticMarkup(tree));
+  `);
+  assert.doesNotMatch(html, /aria-label=/);
+  assert.match(html, /<aside class="setup-side">/);
+});
+
+// ---------------------------------------------------------------
+// Edge case: head=null + footer=null still renders card chrome + body.
+// ---------------------------------------------------------------
+
+test('SetupSidePanel: head=null + footer=null still renders card chrome and body only', async () => {
+  const html = await runFixture(`
+    ${renderHeader(componentSpec)}
+    const tree = React.createElement(SetupSidePanel, {
+      head: null,
+      footer: null,
+      body: React.createElement('div', { className: 'body' }, 'just-body'),
+    });
+    console.log(renderToStaticMarkup(tree));
+  `);
+  // Outer chrome still wraps the body.
+  assert.match(html, /^<aside class="setup-side"><div class="ss-card"><div class="body">just-body<\/div><\/div><\/aside>$/);
+  // No ss-head, no extra sibling.
+  assert.doesNotMatch(html, /ss-head/);
+});
+
+// ---------------------------------------------------------------
+// Edge case: head explicitly undefined behaves the same as null.
+// ---------------------------------------------------------------
+
+test('SetupSidePanel: head=undefined behaves like head=null (no head row rendered)', async () => {
+  const html = await runFixture(`
+    ${renderHeader(componentSpec)}
+    const tree = React.createElement(SetupSidePanel, {
+      head: undefined,
+      body: React.createElement('div', null, 'body'),
+    });
+    console.log(renderToStaticMarkup(tree));
+  `);
+  assert.doesNotMatch(html, /ss-head/);
+  assert.match(html, /<aside class="setup-side"><div class="ss-card"><div>body<\/div><\/div><\/aside>/);
+});
+
+// ---------------------------------------------------------------
+// Characterisation: a complex nested body subtree passes through
+// unchanged (Grammar-shape monster strip + today cards).
+// ---------------------------------------------------------------
+
+test('SetupSidePanel: complex nested body subtree passes through byte-identical', async () => {
+  const html = await runFixture(`
+    ${renderHeader(componentSpec)}
+    const body = React.createElement(
+      React.Fragment,
+      null,
+      React.createElement(
+        'section',
+        { className: 'grammar-monster-strip', 'aria-label': 'Your Grammar creatures' },
+        React.createElement('div', { className: 'grammar-monster-strip-entry', key: 'a' }, 'A'),
+        React.createElement('div', { className: 'grammar-monster-strip-entry', key: 'b' }, 'B'),
+        React.createElement('p', { className: 'grammar-monster-strip-hint' }, 'Hint line'),
+      ),
+      React.createElement(
+        'section',
+        { className: 'grammar-today', 'aria-label': 'Today at a glance' },
+        React.createElement(
+          'div',
+          { className: 'grammar-today-grid' },
+          React.createElement('div', { className: 'grammar-today-card', 'data-today-id': 't1' }, 'card1'),
+        ),
+      ),
+    );
+    const tree = React.createElement(SetupSidePanel, {
+      asideClassName: 'grammar-setup-sidebar',
+      cardClassName: 'grammar-setup-sidebar-card',
+      headClassName: 'grammar-setup-sidebar-head',
+      headTag: 'header',
+      ariaLabel: 'Where you stand',
+      head: React.createElement('p', { className: 'eyebrow' }, 'Where you stand'),
+      body,
+      footer: React.createElement('button', { className: 'ss-bank-link grammar-setup-sidebar-bank-link' }, 'Bank'),
+    });
+    console.log(renderToStaticMarkup(tree));
+  `);
+  // Byte-identical expected shell.
+  assert.match(html, /^<aside class="setup-side grammar-setup-sidebar" aria-label="Where you stand"><div class="ss-card grammar-setup-sidebar-card"><header class="ss-head grammar-setup-sidebar-head"><p class="eyebrow">Where you stand<\/p><\/header>/);
+  // Monster strip section intact.
+  assert.match(html, /<section class="grammar-monster-strip" aria-label="Your Grammar creatures"><div class="grammar-monster-strip-entry">A<\/div><div class="grammar-monster-strip-entry">B<\/div><p class="grammar-monster-strip-hint">Hint line<\/p><\/section>/);
+  // Today section intact.
+  assert.match(html, /<section class="grammar-today" aria-label="Today at a glance"><div class="grammar-today-grid"><div class="grammar-today-card" data-today-id="t1">card1<\/div><\/div><\/section>/);
+  // Footer intact.
+  assert.match(html, /<button class="ss-bank-link grammar-setup-sidebar-bank-link">Bank<\/button><\/div><\/aside>$/);
+});
+
+// ---------------------------------------------------------------
+// Child ordering: head always precedes body, body always precedes footer.
+// ---------------------------------------------------------------
+
+test('SetupSidePanel: slot ordering is strictly head → body → footer inside the card', async () => {
+  const html = await runFixture(`
+    ${renderHeader(componentSpec)}
+    const tree = React.createElement(SetupSidePanel, {
+      head: React.createElement('p', { className: 'H' }, 'H'),
+      body: React.createElement('p', { className: 'B' }, 'B'),
+      footer: React.createElement('p', { className: 'F' }, 'F'),
+    });
+    console.log(renderToStaticMarkup(tree));
+  `);
+  const headIndex = html.indexOf('class="H"');
+  const bodyIndex = html.indexOf('class="B"');
+  const footerIndex = html.indexOf('class="F"');
+  assert.ok(headIndex >= 0 && bodyIndex >= 0 && footerIndex >= 0, 'all three slots should render');
+  assert.ok(headIndex < bodyIndex, 'head must appear before body');
+  assert.ok(bodyIndex < footerIndex, 'body must appear before footer');
+});


### PR DESCRIPTION
## Summary
- New `src/platform/ui/SetupSidePanel.jsx`: slot-based `.setup-side` > `.ss-card` shell with optional head / body / footer slots.
- Spelling and Grammar adopt; Punctuation does NOT adopt this pass (see plan R3 — adopting a new right-rail in Punctuation's single-column dashboard would be an IA change, not chrome).
- `headTag` prop defaults to `'div'` (preserves Spelling's existing DOM); Grammar explicitly passes `'header'`.
- Subject-specific classes (`grammar-setup-sidebar`, `grammar-setup-sidebar-card`, `grammar-setup-sidebar-head`) pass through via className props.

## Plan
- docs/plans/2026-04-29-008-refactor-ui-consolidation-grammar-pilot-to-punctuation-plan.md (U3)

## Test plan
- [x] `tests/platform-setup-side-panel.test.js` — 12 assertions covering slot rendering, class composition, `headTag` toggle, aria-label, null/undefined head, complex nested body, slot ordering
- [x] Existing Grammar (114 tests) + Spelling (26 tests) surface tests still pass
- [x] Byte-identical DOM to prior inline implementations
- [x] Bundle byte budget: +176 B gzip (226,300 -> 226,476), within 227,000 B budget and 227,630 B upper guard

Generated autonomously in the ui-refactor SDLC cycle