### PR TITLE
refactor(punctuation): adopt platform HeroBackdrop on Session scene (U5)

### DIFF
--- a/src/subjects/punctuation/components/PunctuationSessionScene.jsx
+++ b/src/subjects/punctuation/components/PunctuationSessionScene.jsx
@@ -44,6 +44,7 @@
 
 import React, { useState } from 'react';
 
+import { HeroBackdrop } from '../../../platform/ui/HeroBackdrop.jsx';
 import { useSubmitLock } from '../../../platform/react/use-submit-lock.js';
 import {
   bellstormSceneForPhase,
@@ -326,7 +327,7 @@ function GpsDelayedFeedbackChips({ session }) {
 
 // --- Active-item branch ----------------------------------------------------
 
-function ActiveItemBranch({ ui, actions }) {
+function ActiveItemBranch({ ui, actions, heroUrl = '', previousHeroUrl = '' }) {
   // SH2-U1: JSX-layer guard for Skip. The primary Submit is inside
   // `ChoiceItem` / `TextItem` sub-components and already uses the
   // shared `composeIsDisabled` adapter-state gate; the hook is
@@ -343,7 +344,6 @@ function ActiveItemBranch({ ui, actions }) {
   const skillName = skillHeaderName(item);
   const modeLabel = sessionModeHeaderLabel(session.mode);
   const help = punctuationSessionHelpVisibility(session, 'active-item');
-  const scene = bellstormSceneForPhase('active-item');
   const shape = punctuationSessionInputShape(item.mode);
   const submit = (payload) => actions.dispatch('punctuation-submit-form', payload);
   // SH2-U7: surface a session error banner via `role="alert"` and link it
@@ -371,15 +371,21 @@ function ActiveItemBranch({ ui, actions }) {
       data-punctuation-phase="active-item"
       style={{ borderTopColor: '#B8873F' }}
     >
-      <div className="punctuation-strip">
-        <img
-          src={scene.src}
-          srcSet={scene.srcSet}
-          sizes="(max-width: 980px) 100vw, 960px"
-          alt=""
-          aria-hidden="true"
+      {/* U5: platform HeroBackdrop replaces the legacy static <img> inside
+          `.punctuation-strip`. The outer `.punctuation-session-hero`
+          establishes the positioning ancestor — `.hero-backdrop` is
+          `position:absolute; inset:0` so it clips to this card-frame-shaped
+          box. `.punctuation-session-hero-content` sits above via
+          `z-index: 1`. URLs + previousUrl are threaded from the phase-stable
+          `PunctuationSessionScene` parent so active-item ↔ feedback cross-
+          fade works across the two JSX branches. */}
+      <section className="punctuation-session-hero">
+        <HeroBackdrop
+          url={heroUrl}
+          previousUrl={previousHeroUrl}
+          extraBackdropClassName="punctuation-hero-backdrop"
         />
-        <div>
+        <div className="punctuation-session-hero-content">
           <div
             className="eyebrow punctuation-session-progress"
             data-punctuation-session-progress
@@ -395,7 +401,7 @@ function ActiveItemBranch({ ui, actions }) {
           <h2 className="section-title">{punctuationChildRegisterOverrideString(item.prompt) || 'Punctuation practice'}</h2>
           <p className="subtitle">{currentItemInstruction(item)}</p>
         </div>
-      </div>
+      </section>
 
       {isGps ? <GpsDelayedFeedbackChips session={session} /> : null}
       {help.showTeachBox ? <CollapsedTeachBox guided={session.guided} /> : null}
@@ -498,7 +504,7 @@ function ActiveItemBranch({ ui, actions }) {
 //   - `<details>` → "Show model answer" revealing `feedback.displayCorrection`.
 //   - `<details>` → "Show more" revealing up to 2 child-labelled facet chips
 //     and any `misconceptionTags` that pass `punctuationChildMisconceptionLabel`.
-function FeedbackBranch({ ui, actions }) {
+function FeedbackBranch({ ui, actions, heroUrl = '', previousHeroUrl = '' }) {
   // SH2-U1: JSX-layer guard for Continue (minimal GPS + normal branches).
   // The hook instance is shared across the two Continue buttons because
   // only one branch renders at a time — a learner cannot tap a GPS
@@ -514,7 +520,6 @@ function FeedbackBranch({ ui, actions }) {
   // no override entries match.
   const feedback = punctuationChildRegisterOverride(ui.feedback) || ui.feedback || {};
   const session = ui.session || {};
-  const scene = bellstormSceneForPhase('feedback');
   const isDisabled = composeIsDisabled(ui);
   const help = punctuationSessionHelpVisibility(session, 'feedback');
   const borderColor = feedback.kind === 'success' ? '#2E8479' : '#B8873F';
@@ -543,15 +548,18 @@ function FeedbackBranch({ ui, actions }) {
         data-punctuation-phase="feedback"
         style={{ borderTopColor: borderColor }}
       >
-        <div className="punctuation-strip">
-          <img
-            src={scene.src}
-            srcSet={scene.srcSet}
-            sizes="(max-width: 980px) 100vw, 960px"
-            alt=""
-            aria-hidden="true"
+        {/* U5: minimal-feedback / GPS early-return — same HeroBackdrop
+            pattern as active-item and scored-feedback. The prior URL comes
+            from the phase-stable parent so active-item → feedback cross-
+            fades. */}
+        <section className="punctuation-session-hero">
+          <HeroBackdrop
+            url={heroUrl}
+            previousUrl={previousHeroUrl}
+            extraBackdropClassName="punctuation-hero-backdrop"
           />
           <div
+            className="punctuation-session-hero-content"
             role="status"
             aria-live="polite"
             data-punctuation-session-feedback-live
@@ -560,7 +568,7 @@ function FeedbackBranch({ ui, actions }) {
             <h2 className="section-title">Saved</h2>
             <p className="subtitle">Your answer is locked in. Answers come at the end of the round.</p>
           </div>
-        </div>
+        </section>
         <div className="actions" style={{ marginTop: 16 }}>
           <button
             className="btn primary"
@@ -600,15 +608,16 @@ function FeedbackBranch({ ui, actions }) {
       data-punctuation-phase="feedback"
       style={{ borderTopColor: borderColor }}
     >
-      <div className="punctuation-strip">
-        <img
-          src={scene.src}
-          srcSet={scene.srcSet}
-          sizes="(max-width: 980px) 100vw, 960px"
-          alt=""
-          aria-hidden="true"
+      {/* U5: scored-feedback — HeroBackdrop with previousUrl threaded from
+          the phase-stable parent for active-item → feedback cross-fade. */}
+      <section className="punctuation-session-hero">
+        <HeroBackdrop
+          url={heroUrl}
+          previousUrl={previousHeroUrl}
+          extraBackdropClassName="punctuation-hero-backdrop"
         />
         <div
+          className="punctuation-session-hero-content"
           role="status"
           aria-live="polite"
           data-punctuation-session-feedback-live
@@ -617,7 +626,7 @@ function FeedbackBranch({ ui, actions }) {
           <h2 className="section-title">{feedback.headline || 'Feedback'}</h2>
           {feedback.body ? <p className="subtitle">{feedback.body}</p> : null}
         </div>
-      </div>
+      </section>
 
       {hasDisplayCorrection ? (
         <details
@@ -696,10 +705,57 @@ function FeedbackBranch({ ui, actions }) {
 
 // --- Default export --------------------------------------------------------
 
+// U5 (refactor ui-consolidation): owner of the in-scene bellstorm URL +
+// `previousUrl` handoff. The ref is declared HERE (phase-stable parent)
+// rather than inside the two branches so the active-item → feedback
+// transition threads the prior URL into `HeroBackdrop` for a cross-fade,
+// even though each branch mounts / unmounts as `ui.phase` flips (React
+// discards their local refs on unmount).
+//
+// Declared BEFORE any conditional return — React's rules of hooks require
+// unconditional ordering. Each branch continues to own its own early
+// returns for missing `session` / `currentItem`.
+//
+// Cross-scene handoff (feedback → summary) is explicitly deferred per the
+// plan's Scope Boundaries: lifting a ref into `PunctuationPracticeSurface`
+// (as Spelling does at SpellingPracticeSurface.jsx:152-157) is a follow-up
+// PR once the in-scene cross-fade is proven clean.
 export function PunctuationSessionScene({ ui, actions }) {
   const phase = ui?.phase;
+  const sceneUrl = bellstormSceneForPhase(phase === 'feedback' ? 'feedback' : 'active-item').src;
+
+  // Mount-stable ref captures the prior bellstorm URL across phase flips.
+  // `previousHeroUrl` is derived at render time — only non-empty when the
+  // last recorded URL differs from the current one (first paint of a new
+  // phase, e.g. active-item → feedback).
+  const previousHeroBgRef = React.useRef('');
+  const previousHeroUrl = previousHeroBgRef.current && previousHeroBgRef.current !== sceneUrl
+    ? previousHeroBgRef.current
+    : '';
+
+  // Update the ref AFTER paint so the next phase flip reads the
+  // just-painted URL as its `previousUrl`. Mirrors
+  // `SpellingPracticeSurface.jsx:156-158`.
+  React.useEffect(() => {
+    if (sceneUrl) previousHeroBgRef.current = sceneUrl;
+  }, [sceneUrl]);
+
   if (phase === 'feedback') {
-    return <FeedbackBranch ui={ui} actions={actions} />;
+    return (
+      <FeedbackBranch
+        ui={ui}
+        actions={actions}
+        heroUrl={sceneUrl}
+        previousHeroUrl={previousHeroUrl}
+      />
+    );
   }
-  return <ActiveItemBranch ui={ui} actions={actions} />;
+  return (
+    <ActiveItemBranch
+      ui={ui}
+      actions={actions}
+      heroUrl={sceneUrl}
+      previousHeroUrl={previousHeroUrl}
+    />
+  );
 }

--- a/styles/app.css
+++ b/styles/app.css
@@ -10560,6 +10560,34 @@ html { scroll-behavior: smooth; }
   }
 }
 
+/* --- U5 (refactor ui-consolidation): Session-scene hero chrome --------- */
+/* `.punctuation-session-hero` is the positioning ancestor for the
+   platform `HeroBackdrop` which paints via `position: absolute; inset: 0`
+   (app.css:5526-5532). Without a `position: relative` wrapper the backdrop
+   would escape to the page root. `overflow: hidden` clips the slow pan
+   animation to the card frame; `border-radius: inherit` keeps the painted
+   region inside the rounded card corners (matches `.setup-main` behaviour
+   at app.css:4604-4607).
+
+   `.punctuation-session-hero-content` sits above the absolute-positioned
+   backdrop via `z-index: 1` so the eyebrow / section-title / subtitle
+   render on top, not behind, the painted artwork. The explicit
+   `position: relative` establishes a stacking context that z-index can
+   act on. */
+.punctuation-session-hero {
+  position: relative;
+  overflow: hidden;
+  border-radius: inherit;
+  min-height: 160px;
+}
+.punctuation-session-hero-content {
+  position: relative;
+  z-index: 1;
+  padding: 18px 20px;
+  display: grid;
+  gap: 6px;
+}
+
 /* Progress row — compact stats strip */
 .punctuation-progress-row {
   padding: 0;

--- a/tests/playwright/shared.mjs
+++ b/tests/playwright/shared.mjs
@@ -66,6 +66,16 @@ const SCREENSHOT_DETERMINISM_CSS = `
 .grammar-hero > img,
 .punctuation-hero img,
 .punctuation-strip img,
+/* U5 (refactor ui-consolidation) extension — the Punctuation Session
+   scene now paints via platform HeroBackdrop. The legacy `.punctuation-
+   strip img` rule above stays as harmless coverage; the new rule hides
+   the `background-image` paints on HeroBackdrop layers so deterministic
+   screenshot diffs do not see per-phase bellstorm variance. Matches both
+   the Session scene's scoped wrapper (`.punctuation-session-hero`) and
+   the Setup scene's one (`.punctuation-hero-backdrop` — already in place
+   from U4) so both surfaces stay deterministic. */
+.punctuation-hero-backdrop [data-hero-layer="true"],
+.punctuation-session-hero [data-hero-layer="true"],
 .monster-celebration-overlay,
 .monster-celebration-parts,
 .toast-shelf {
@@ -345,14 +355,21 @@ export function defaultMasks(page) {
     // viewport.
     page.locator('.grammar-prompt'),
     // SH2-U6 review nit-1 fix: the punctuation session renders its
-    // prompt as `<h2 className="section-title">` inside the
-    // `.punctuation-strip` header. The item source text lives in
-    // `[data-punctuation-session-source]` (a `<blockquote>`); both
-    // carry per-item variable content. `.punctuation-prompt` /
-    // `.punctuation-question` never existed in the DOM — removing
-    // the phantom selectors so the default-mask audit (NIT-2) shows
-    // every entry resolves to ≥1 element.
+    // prompt as `<h2 className="section-title">` inside the header.
+    // The item source text lives in `[data-punctuation-session-source]`
+    // (a `<blockquote>`); both carry per-item variable content.
+    // `.punctuation-prompt` / `.punctuation-question` never existed in
+    // the DOM — removing the phantom selectors so the default-mask
+    // audit (NIT-2) shows every entry resolves to ≥1 element.
     page.locator('[data-punctuation-session-source]'),
+    // U5 (refactor ui-consolidation): the Session scene header moved
+    // from `.punctuation-strip .section-title` to
+    // `.punctuation-session-hero-content .section-title` when the scene
+    // adopted the platform `HeroBackdrop`. The legacy selector stays as
+    // belt-and-braces so baselines captured against pre-U5 DOM remain
+    // masked during rollout; the new anchor is authoritative going
+    // forward.
+    page.locator('.punctuation-session-hero-content .section-title'),
     page.locator('.punctuation-strip .section-title'),
   ];
 }

--- a/tests/playwright/visual-baselines.playwright.test.mjs
+++ b/tests/playwright/visual-baselines.playwright.test.mjs
@@ -261,6 +261,13 @@ async function injectFixedPromptContent(page) {
       '.prompt-sentence',
       '.cloze',
       '.grammar-prompt',
+      // U5 (refactor ui-consolidation): the Session-scene prompt moved
+      // from `.punctuation-strip .section-title` to
+      // `.punctuation-session-hero-content .section-title` when the
+      // scene adopted the platform `HeroBackdrop`. Both selectors are
+      // kept so this helper still stabilises text content on pre-U5
+      // baselines AND post-U5 DOM.
+      '.punctuation-session-hero-content .section-title',
       '.punctuation-strip .section-title',
       '[data-punctuation-session-source]',
     ];

--- a/tests/punctuation-session-hero-backdrop.test.js
+++ b/tests/punctuation-session-hero-backdrop.test.js
@@ -1,0 +1,249 @@
+// U5 (refactor ui-consolidation): PunctuationSessionScene adopts the
+// platform hero engine on all three `.punctuation-strip` call-sites
+// (active-item, minimal-feedback / GPS early-return, scored-feedback).
+// These tests pin the new DOM landmarks so later refactors don't
+// silently move the Session scene off `.punctuation-session-hero` /
+// `.punctuation-session-hero-content` rhythm or regress the bellstorm
+// phase → URL wiring the Playwright locators depend on.
+//
+// Coverage:
+//   * Active-item phase paints its hero via `HeroBackdrop` with the
+//     `active-item` bellstorm URL in its `--hero-bg` custom property.
+//   * Feedback phase paints via `HeroBackdrop` with the `feedback`
+//     bellstorm URL (both the minimal-feedback / GPS early-return branch
+//     and the scored-feedback branch use the same URL).
+//   * `.punctuation-session-hero-content .section-title` resolves on
+//     every branch — this is the anchor Playwright locators (shared.mjs
+//     `defaultMasks` + visual-baselines `injectFixedPromptContent`)
+//     re-point to after the `.punctuation-strip` removal.
+//   * The legacy `<img src srcSet>` hero element is gone from every
+//     branch — a lingering `<img>` with a bellstorm src would signal a
+//     half-migrated scene.
+//   * GPS session type still shows the `.punctuation-test-mode-banner`
+//     chip row underneath the hero (the chip row lives OUTSIDE the
+//     hero wrapper — the refactor must not accidentally move it
+//     inside).
+//   * React rules-of-hooks discipline: the `previousHeroBgRef` lives on
+//     `PunctuationSessionScene` (phase-stable parent), not inside the
+//     two branches whose mounts flip with `ui.phase`.
+//
+// Uses the standalone SSR renderer so we can control `ui.phase`
+// directly without routing through the app-harness (which always seeds
+// a specific phase on `open-subject`). The renderer composes
+// `renderToStaticMarkup` so `useEffect` bodies do not flush — this is
+// fine because the hero-URL wiring is visible in the initial markup
+// (the `HeroBackdrop` first render paints a single `is-active` layer
+// with the current URL).
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { renderPunctuationSessionSceneStandalone } from './helpers/punctuation-scene-render.js';
+import { bellstormSceneForPhase } from '../src/subjects/punctuation/components/punctuation-view-model.js';
+
+function stubActions() {
+  return {
+    dispatch() {},
+    updateSubjectUi() {},
+  };
+}
+
+function activeItemProps() {
+  return {
+    ui: {
+      phase: 'active-item',
+      session: {
+        id: 'test-session',
+        mode: 'endmarks',
+        length: 4,
+        answeredCount: 0,
+        currentItem: {
+          id: 'item-1',
+          inputKind: 'choice',
+          prompt: 'Pick the correct endmark.',
+          instruction: 'Choose one.',
+          mode: 'choice',
+          options: [
+            { index: 0, text: 'Full stop' },
+            { index: 1, text: 'Question mark' },
+            { index: 2, text: 'Exclamation mark' },
+          ],
+          skillIds: [],
+        },
+      },
+    },
+    actions: stubActions(),
+  };
+}
+
+function feedbackProps({ gps = false } = {}) {
+  return {
+    ui: {
+      phase: 'feedback',
+      session: {
+        id: 'test-session',
+        mode: gps ? 'gps' : 'endmarks',
+        length: 4,
+        answeredCount: 1,
+        currentItem: { id: 'item-1', inputKind: 'choice', prompt: 'p', options: [] },
+      },
+      feedback: {
+        kind: 'success',
+        headline: 'Nice work',
+        body: 'The full stop goes there.',
+        displayCorrection: 'Full stop.',
+      },
+    },
+    actions: stubActions(),
+  };
+}
+
+// --- Hero URL wiring -------------------------------------------------------
+
+test('active-item phase paints the hero via HeroBackdrop with the active-item bellstorm URL', () => {
+  const html = renderPunctuationSessionSceneStandalone(activeItemProps());
+  const expectedUrl = bellstormSceneForPhase('active-item').src;
+
+  // Platform HeroBackdrop stamps `.hero-backdrop` + the Punctuation-
+  // scoped `.punctuation-hero-backdrop` so Playwright has a stable
+  // class anchor to replace the pre-U5 `.punctuation-strip img`
+  // selector.
+  assert.match(html, /class="hero-backdrop punctuation-hero-backdrop"/);
+
+  // The bellstorm URL reaches the layer via the `--hero-bg` CSS custom
+  // property (see src/platform/ui/hero-bg.js::heroBgStyle). HTML
+  // renderers escape the single quotes; matching against the encoded
+  // sequence is the stable assertion shape.
+  const escapedUrl = expectedUrl.replace(/\//g, '\\/');
+  const pattern = new RegExp(`--hero-bg:url\\(&#x27;${escapedUrl}&#x27;\\)`);
+  assert.match(html, pattern);
+
+  // The legacy `<img src srcSet>` hero element is GONE. A lingering
+  // `<img>` with a bellstorm `src` would signal a half-migrated
+  // scene — both in terms of visual engine alignment AND the
+  // SCREENSHOT_DETERMINISM_CSS rule that used to hide `.punctuation-
+  // strip img`.
+  assert.doesNotMatch(html, /<img[^>]+bellstorm-coast[^>]+srcSet/i);
+});
+
+test('active-item phase renders `.punctuation-session-hero-content .section-title` with the child-register-overridden prompt', () => {
+  const html = renderPunctuationSessionSceneStandalone(activeItemProps());
+
+  // The new stable anchor that Playwright locators re-point to. The
+  // `<h2 className="section-title">` now sits INSIDE
+  // `.punctuation-session-hero-content`, not inside the deprecated
+  // `.punctuation-strip` wrapper.
+  assert.match(html, /<div class="punctuation-session-hero-content">/);
+  // Title text survives the HeroBackdrop swap.
+  assert.match(html, /<h2 class="section-title">Pick the correct endmark\.<\/h2>/);
+});
+
+test('active-item phase on a GPS session still renders the delayed-feedback chip row underneath the hero', () => {
+  const html = renderPunctuationSessionSceneStandalone({
+    ...activeItemProps(),
+    ui: {
+      ...activeItemProps().ui,
+      session: { ...activeItemProps().ui.session, mode: 'gps' },
+    },
+  });
+
+  // The GPS chip row (`.punctuation-test-mode-banner`) must sit
+  // OUTSIDE the `.punctuation-session-hero` wrapper — refactors that
+  // accidentally fold it inside would push the chip behind the
+  // `HeroBackdrop` z-index-0 backdrop.
+  assert.match(html, /data-gps-banner/);
+  assert.match(html, /Test mode: answers at the end/);
+  // And the hero itself still paints.
+  assert.match(html, /punctuation-session-hero-content/);
+});
+
+// --- Feedback branches -----------------------------------------------------
+
+test('scored-feedback phase paints the hero via HeroBackdrop with the feedback bellstorm URL', () => {
+  const html = renderPunctuationSessionSceneStandalone(feedbackProps());
+  const expectedUrl = bellstormSceneForPhase('feedback').src;
+
+  assert.match(html, /class="hero-backdrop punctuation-hero-backdrop"/);
+  const escapedUrl = expectedUrl.replace(/\//g, '\\/');
+  assert.match(html, new RegExp(`--hero-bg:url\\(&#x27;${escapedUrl}&#x27;\\)`));
+
+  // The feedback headline + body still render inside the new anchor.
+  assert.match(html, /<div class="punctuation-session-hero-content"[^>]*>/);
+  assert.match(html, /<h2 class="section-title">Nice work<\/h2>/);
+  assert.match(html, /The full stop goes there\./);
+
+  // No legacy `<img>` survives the swap on the feedback branch.
+  assert.doesNotMatch(html, /<img[^>]+bellstorm-coast[^>]+srcSet/i);
+});
+
+test('minimal-feedback / GPS early-return branch paints the hero via HeroBackdrop with the feedback bellstorm URL', () => {
+  const html = renderPunctuationSessionSceneStandalone(feedbackProps({ gps: true }));
+  const expectedUrl = bellstormSceneForPhase('feedback').src;
+
+  assert.match(html, /class="hero-backdrop punctuation-hero-backdrop"/);
+  const escapedUrl = expectedUrl.replace(/\//g, '\\/');
+  assert.match(html, new RegExp(`--hero-bg:url\\(&#x27;${expectedUrl.replace(/\//g, '\\/')}&#x27;\\)`));
+
+  // The GPS "Saved" headline renders on the new anchor — this is the
+  // minimal-feedback branch (no scored feedback content; just a
+  // "Saved / answers come at the end" surface).
+  assert.match(html, /<div class="punctuation-session-hero-content"[^>]*>/);
+  assert.match(html, /<h2 class="section-title">Saved<\/h2>/);
+  assert.match(html, /Your answer is locked in/);
+
+  // `aria-live="polite"` + `role="status"` move with the content
+  // wrapper — the `role="status"` region is now on the content div,
+  // not on a bare inner div inside `.punctuation-strip`.
+  assert.match(html, /role="status"/);
+  // Make sure the feedback banner STILL announces — the content wrapper
+  // is the correct ancestor for the live region.
+  assert.match(html, /data-punctuation-session-feedback-live/);
+
+  // GPS (gps mode) AND feedback phase: no legacy `<img>` element.
+  assert.doesNotMatch(html, /<img[^>]+bellstorm-coast[^>]+srcSet/i);
+});
+
+// --- React rules-of-hooks parent ownership ---------------------------------
+
+test('PunctuationSessionScene owns the bellstorm URL derivation — every phase branch receives a hero backdrop layer', () => {
+  // Active-item phase: renders the `.punctuation-hero-backdrop` wrapper.
+  const activeHtml = renderPunctuationSessionSceneStandalone(activeItemProps());
+  // Exactly one hero-backdrop wrapper emits on the active-item
+  // render (no previousUrl to paint a second layer).
+  const activeMatches = activeHtml.match(/class="hero-backdrop punctuation-hero-backdrop"/g) || [];
+  assert.equal(activeMatches.length, 1);
+
+  // Feedback phase: same singleton wrapper count. `previousUrl` is only
+  // supplied when the ref captured a different URL — on a fresh SSR
+  // render the ref starts at '' so no cross-fade second layer renders
+  // on the initial paint. (The cross-fade is a mount-time transition
+  // that needs `useEffect` flush to observe.)
+  const feedbackHtml = renderPunctuationSessionSceneStandalone(feedbackProps());
+  const feedbackMatches = feedbackHtml.match(/class="hero-backdrop punctuation-hero-backdrop"/g) || [];
+  assert.equal(feedbackMatches.length, 1);
+});
+
+test('PunctuationSessionScene threads the bellstorm URL phase-specifically — active-item differs from feedback', () => {
+  // This is a characterisation guard on the `phase → URL` routing in
+  // `PunctuationSessionScene`. The parent chooses `'feedback'` when
+  // `ui.phase === 'feedback'` and `'active-item'` otherwise; a regression
+  // that passed `'setup'` or a hardcoded phase would surface here.
+  const activeHtml = renderPunctuationSessionSceneStandalone(activeItemProps());
+  const feedbackHtml = renderPunctuationSessionSceneStandalone(feedbackProps());
+
+  const activeUrl = bellstormSceneForPhase('active-item').src;
+  const feedbackUrl = bellstormSceneForPhase('feedback').src;
+  // The two phases must map to different URLs in the baseline
+  // `bellstormSceneForPhase` contract (active-item → C1, feedback →
+  // D2); if this changes someone has edited the phase → index map
+  // in the view-model.
+  assert.notEqual(activeUrl, feedbackUrl);
+
+  // The active-item render includes the active-item URL, not feedback.
+  assert.ok(activeHtml.includes(activeUrl));
+  assert.ok(!activeHtml.includes(feedbackUrl));
+
+  // And vice versa.
+  assert.ok(feedbackHtml.includes(feedbackUrl));
+  assert.ok(!feedbackHtml.includes(activeUrl));
+});


### PR DESCRIPTION
## Summary

U5 of the Grammar-pilot → Punctuation UI consolidation plan
(`docs/plans/2026-04-29-008-refactor-ui-consolidation-grammar-pilot-to-punctuation-plan.md`).
Replaces the three `.punctuation-strip` `<img srcSet>` call-sites in
`PunctuationSessionScene` with the platform `HeroBackdrop`, matching the
Grammar-pilot visual engine already in place on Setup (U4).

**What changed**

- `PunctuationSessionScene.jsx` — all three hero chunks (active-item,
  minimal-feedback / GPS early-return, scored-feedback) paint via
  `HeroBackdrop` with `extraBackdropClassName="punctuation-hero-backdrop"`.
- The `previousHeroBgRef` lives on the phase-stable
  `PunctuationSessionScene` parent (above early returns — React rules of
  hooks) so active-item ↔ feedback transitions cross-fade via
  `previousUrl` even though each branch mounts / unmounts on `ui.phase`.
- New CSS anchors `.punctuation-session-hero` (positioning ancestor) +
  `.punctuation-session-hero-content` (`z-index: 1`) added to
  `styles/app.css`. Legacy `.punctuation-strip` rules retained as dead
  selectors per the plan's one-release-cycle policy.
- Playwright locator updates:
  - `tests/playwright/shared.mjs` — `SCREENSHOT_DETERMINISM_CSS` now
    hides `[data-hero-layer="true"]` on both `.punctuation-hero-backdrop`
    and the new `.punctuation-session-hero` scope. `defaultMasks` gains
    the new `.punctuation-session-hero-content .section-title` anchor
    while retaining the legacy selector as belt-and-braces.
  - `tests/playwright/visual-baselines.playwright.test.mjs` —
    `injectFixedPromptContent` extended with the new anchor.

**Scope guardrails**

- Cross-scene `previousUrl` handoff (feedback → summary) stays deferred
  per plan Scope Boundaries. This PR is in-scene cross-fade only.
- No IA changes; every `data-punctuation-*` / `data-section` / telemetry
  emit preserved on the same content they anchor to.
- Responsive image `srcSet` drops to a single 1280px `background-image`
  paint — acknowledged R11c mobile LCP cost of visual-engine alignment.

## Bundle delta

Gzip: **226,795 → 226,930 B** (+135 B). Ceiling `BUDGET_GZIP_BYTES =
227,000`. Headroom ~70 B — comfortably within budget; no budget bump
required. Contingency (dropping legacy `.punctuation-dashboard-hero`
CSS) not invoked — kept per the plan's deliberate "one release cycle"
dead-selector bridge.

## Test plan

- [x] New `tests/punctuation-session-hero-backdrop.test.js` — 7
  scenarios covering hero URL wiring on active-item + both feedback
  branches, the new `.punctuation-session-hero-content .section-title`
  anchor, GPS delayed-feedback chip row still below the hero, and
  `bellstormSceneForPhase` phase → URL routing for active-item vs
  feedback.
- [x] Existing suites green: `tests/react-punctuation-scene.test.js`
  (168 pass), `tests/punctuation-view-model.test.js` +
  `tests/react-punctuation-assets.test.js` +
  `tests/punctuation-setup-hero-backdrop.test.js` (129 additional pass),
  full `tests/punctuation-*.test.js` + `tests/react-punctuation-*.test.js`
  (1191 pass), wider `tests/react-*.test.js` + `tests/grammar-*.test.js`
  + `tests/spelling-view-model.test.js` (2421 pass).
- [x] Bundle-byte-budget and client-bundle-audit tests pass.
- [ ] Playwright visual baselines — will update under CI run; the
  determinism rule extension should keep screenshots stable without
  re-snapshotting for U5 alone.

Part of the Grammar-pilot consolidation plan (U1–U4 landed in PRs that
preceded this; U6/U7 follow).