### PR TITLE
refactor(punctuation): classify telemetry tests as proof-level or smoke-level (P6-U8)

### DIFF
--- a/scripts/punctuation-qg-health-report.mjs
+++ b/scripts/punctuation-qg-health-report.mjs
@@ -200,6 +200,24 @@ function computeUnsupportedReservedEvents() {
   return { reserved, deprecated };
 }
 
+function computeTelemetryTestClassification() {
+  const declared = [];
+  const emitted = [];
+  const proofTested = [];
+  const smokeTested = [];
+  const reserved = [];
+
+  for (const [key, entry] of Object.entries(PUNCTUATION_TELEMETRY_MANIFEST)) {
+    declared.push(key);
+    if (entry.status === 'emitted') emitted.push(key);
+    if (entry.testLevel === 'proof') proofTested.push(key);
+    if (entry.testLevel === 'smoke') smokeTested.push(key);
+    if (entry.status === 'reserved') reserved.push(key);
+  }
+
+  return { declared, emitted, proofTested, smokeTested, reserved };
+}
+
 function countEmittedEvents() {
   return Object.values(PUNCTUATION_TELEMETRY_MANIFEST)
     .filter((entry) => entry.status === 'emitted')
@@ -248,6 +266,7 @@ export function buildHealthReport({ fixture = null, manifest = PUNCTUATION_CONTE
   const duplicateStemModelClusters = computeDuplicateStemModelClusters(manifest);
   const unsupportedReservedEvents = computeUnsupportedReservedEvents();
   const emittedEventCount = countEmittedEvents();
+  const telemetryTestClassification = computeTelemetryTestClassification();
 
   return {
     signatureExposure,
@@ -262,6 +281,7 @@ export function buildHealthReport({ fixture = null, manifest = PUNCTUATION_CONTE
     duplicateStemModelClusters,
     unsupportedReservedEvents,
     emittedEventCount,
+    telemetryTestClassification,
   };
 }
 
@@ -385,6 +405,19 @@ export function formatHealthReportMarkdown(report) {
       }
     }
   }
+  lines.push('');
+
+  // l. Telemetry test classification
+  lines.push('## Telemetry Test Classification');
+  lines.push('');
+  const tc = report.telemetryTestClassification;
+  lines.push('| Category | Count | Events |');
+  lines.push('|----------|-------|--------|');
+  lines.push(`| Declared | ${tc.declared.length} | — |`);
+  lines.push(`| Emitted | ${tc.emitted.length} | — |`);
+  lines.push(`| Proof-tested | ${tc.proofTested.length} | ${tc.proofTested.join(', ') || '—'} |`);
+  lines.push(`| Smoke-tested | ${tc.smokeTested.length} | ${tc.smokeTested.join(', ') || '—'} |`);
+  lines.push(`| Reserved | ${tc.reserved.length} | ${tc.reserved.join(', ') || '—'} |`);
   lines.push('');
 
   return lines.join('\n');

--- a/shared/punctuation/telemetry-manifest.js
+++ b/shared/punctuation/telemetry-manifest.js
@@ -1,10 +1,18 @@
-// P5-U2 — Punctuation telemetry manifest with emitted/reserved/deprecated status.
+// P6-U8 — Punctuation telemetry manifest with lifecycle status and test classification.
 //
 // Manifest-leaf module (zero imports from sibling modules, Object.freeze).
 // Maps each telemetry event name to a lifecycle status:
 //   - `emitted`: the event has a callsite in the Worker command handler
 //   - `reserved`: the event name is registered but no callsite exists yet
 //   - `deprecated`: the event name is retired and must NOT be emitted
+//
+// Test classification (`testLevel`):
+//   - `proof`:  the command-path test deterministically forces the event to fire;
+//               the test CANNOT pass without the event being emitted.
+//   - `smoke`:  the command-path test exercises a scenario that MAY trigger the
+//               event depending on scheduling randomness; useful coverage but
+//               not a guarantee of emission on every run.
+//   - `null`:   no test applies (reserved/deprecated events with no callsite).
 //
 // The `telemetry-events.js` sibling remains the canonical name-list;
 // this module layers lifecycle metadata on top without importing it.
@@ -13,45 +21,56 @@ export const PUNCTUATION_TELEMETRY_MANIFEST = Object.freeze({
   GENERATED_SIGNATURE_EXPOSED: Object.freeze({
     event: 'punctuation.generated_signature_exposed',
     status: 'emitted',
+    testLevel: 'smoke',
   }),
   GENERATED_SIGNATURE_REPEATED: Object.freeze({
     event: 'punctuation.generated_signature_repeated',
     status: 'emitted',
+    testLevel: 'smoke',
   }),
   SCHEDULER_REASON_SELECTED: Object.freeze({
     event: 'punctuation.scheduler_reason_selected',
     status: 'emitted',
+    testLevel: 'proof',
   }),
   MISCONCEPTION_RETRY_SCHEDULED: Object.freeze({
     event: 'punctuation.misconception_retry_scheduled',
     status: 'emitted',
+    testLevel: 'smoke',
   }),
   MISCONCEPTION_RETRY_PASSED: Object.freeze({
     event: 'punctuation.misconception_retry_passed',
     status: 'emitted',
+    testLevel: 'smoke',
   }),
   SPACED_RETURN_SCHEDULED: Object.freeze({
     event: 'punctuation.spaced_return_scheduled',
     status: 'emitted',
+    testLevel: 'smoke',
   }),
   SPACED_RETURN_PASSED: Object.freeze({
     event: 'punctuation.spaced_return_passed',
     status: 'emitted',
+    testLevel: 'smoke',
   }),
   RETENTION_AFTER_SECURE_SCHEDULED: Object.freeze({
     event: 'punctuation.retention_after_secure_scheduled',
     status: 'emitted',
+    testLevel: 'smoke',
   }),
   RETENTION_AFTER_SECURE_PASSED: Object.freeze({
     event: 'punctuation.retention_after_secure_passed',
     status: 'emitted',
+    testLevel: 'smoke',
   }),
   STAR_EVIDENCE_DEDUPED_BY_SIGNATURE: Object.freeze({
     event: 'punctuation.star_evidence_deduped_by_signature',
     status: 'emitted',
+    testLevel: 'smoke',
   }),
   STAR_EVIDENCE_DEDUPED_BY_TEMPLATE: Object.freeze({
     event: 'punctuation.star_evidence_deduped_by_template',
     status: 'reserved',
+    testLevel: null,
   }),
 });

--- a/tests/punctuation-telemetry-command-path.test.js
+++ b/tests/punctuation-telemetry-command-path.test.js
@@ -795,6 +795,27 @@ test('telemetry manifest event values match telemetry-events.js values', () => {
   for (const [key, entry] of Object.entries(PUNCTUATION_TELEMETRY_MANIFEST)) {
     assert.equal(entry.event, PUNCTUATION_TELEMETRY_EVENTS[key], `Event value mismatch for ${key}`);
     assert.ok(['emitted', 'reserved', 'deprecated'].includes(entry.status), `Invalid status for ${key}: ${entry.status}`);
+    assert.ok(
+      entry.testLevel === 'proof' || entry.testLevel === 'smoke' || entry.testLevel === null,
+      `Invalid testLevel for ${key}: ${entry.testLevel} (must be 'proof', 'smoke', or null)`,
+    );
+  }
+});
+
+test('telemetry manifest testLevel is null only for non-emitted events', () => {
+  for (const [key, entry] of Object.entries(PUNCTUATION_TELEMETRY_MANIFEST)) {
+    if (entry.status === 'emitted') {
+      assert.notEqual(
+        entry.testLevel, null,
+        `Emitted event ${key} must have testLevel 'proof' or 'smoke', not null`,
+      );
+    }
+    if (entry.status === 'reserved') {
+      assert.equal(
+        entry.testLevel, null,
+        `Reserved event ${key} must have testLevel null`,
+      );
+    }
   }
 });
 


### PR DESCRIPTION
## Summary

- Adds `testLevel` field (`'proof'` | `'smoke'` | `null`) to each entry in `shared/punctuation/telemetry-manifest.js`
- Updates `scripts/punctuation-qg-health-report.mjs` to surface a Telemetry Test Classification table distinguishing declared, emitted, proof-tested, smoke-tested, and reserved events
- Adds manifest structure tests enforcing testLevel invariants (emitted events must be proof or smoke; reserved events must be null)

Classification: SCHEDULER_REASON_SELECTED is the sole proof-level event (deterministically fires on every start/continue). The remaining 9 emitted events are smoke-level (scheduler-dependent with fallback assertions). STAR_EVIDENCE_DEDUPED_BY_TEMPLATE remains reserved with testLevel null.

## Test plan

- [x] All 22 telemetry command-path tests pass
- [x] Health report runs in `--strict --fixture synthetic` mode without failure
- [x] New testLevel invariant tests validate manifest consistency
- [x] Star-projection tests unaffected