### PR TITLE
feat(punctuation): add rule-specific explanations to all 25 DSL families

### DIFF
--- a/shared/punctuation/dsl-families/apostrophe-contractions-fix.js
+++ b/shared/punctuation/dsl-families/apostrophe-contractions-fix.js
@@ -4,11 +4,14 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  * DSL definitions for gen_apostrophe_contractions_fix family.
  */
 
+const EXPLANATION = 'The apostrophe shows where letters have been removed to shorten two words into one.';
+
 const TEMPLATES = [
   {
     prompt: 'Correct the apostrophes in the contractions.',
     stem: 'We cant start because its raining.',
     model: "We can't start because it's raining.",
+    explanation: EXPLANATION,
     misconceptionTags: ['apostrophe.contraction_missing'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
   },
@@ -16,6 +19,7 @@ const TEMPLATES = [
     prompt: 'Correct the apostrophes in the contractions.',
     stem: 'Theyre sure we wont be late.',
     model: "They're sure we won't be late.",
+    explanation: EXPLANATION,
     misconceptionTags: ['apostrophe.contraction_missing'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
   },
@@ -23,6 +27,7 @@ const TEMPLATES = [
     prompt: 'Correct the apostrophes in the contractions.',
     stem: 'I dont think theyve finished.',
     model: "I don't think they've finished.",
+    explanation: EXPLANATION,
     misconceptionTags: ['apostrophe.contraction_missing'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
   },
@@ -30,6 +35,7 @@ const TEMPLATES = [
     prompt: 'Correct the apostrophes in the contractions.',
     stem: 'Youre sure he isnt coming.',
     model: "You're sure he isn't coming.",
+    explanation: EXPLANATION,
     misconceptionTags: ['apostrophe.contraction_missing'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
   },
@@ -37,6 +43,7 @@ const TEMPLATES = [
     prompt: 'Correct the missing apostrophes in the contractions.',
     stem: 'We havent checked because the phones arent working.',
     model: "We haven't checked because the phones aren't working.",
+    explanation: EXPLANATION,
     misconceptionTags: ['apostrophe.contraction_missing'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
   },
@@ -44,6 +51,7 @@ const TEMPLATES = [
     prompt: 'Fix only the contraction apostrophes.',
     stem: 'Itll be easier if youre ready.',
     model: "It'll be easier if you're ready.",
+    explanation: EXPLANATION,
     misconceptionTags: ['apostrophe.contraction_missing'],
     readiness: ['proofreading', 'transfer', 'misconception', 'negative_test'],
   },
@@ -51,6 +59,7 @@ const TEMPLATES = [
     prompt: 'Proofread the sentence and repair the contractions.',
     stem: 'They didnt know we couldnt see.',
     model: "They didn't know we couldn't see.",
+    explanation: EXPLANATION,
     misconceptionTags: ['apostrophe.contraction_missing'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
   },
@@ -58,6 +67,7 @@ const TEMPLATES = [
     prompt: 'Rewrite with standard contraction punctuation.',
     stem: 'Shes sure it doesnt matter.',
     model: "She's sure it doesn't matter.",
+    explanation: EXPLANATION,
     misconceptionTags: ['apostrophe.contraction_missing'],
     readiness: ['proofreading', 'transfer', 'misconception', 'negative_test'],
   },
@@ -78,6 +88,7 @@ export const apostropheContractionsDsl = TEMPLATES.map((t, i) =>
       prompt: t.prompt,
       stem: t.stem,
       model: t.model,
+      explanation: t.explanation,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/apostrophe-mix-paragraph.js
+++ b/shared/punctuation/dsl-families/apostrophe-mix-paragraph.js
@@ -6,6 +6,8 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  * Templates 4-7: capacity expansion (new for P4-U8).
  */
 
+const EXPLANATION = 'The apostrophe marks contractions where letters are missing and possession where something belongs to a noun.';
+
 const TEMPLATES = [
   // ─── Legacy parity (indices 0-3) ─────────────────────────────────────────────
   {
@@ -20,11 +22,14 @@ const TEMPLATES = [
         {
           type: 'requiresApostropheForms',
           tokens: ["won't", "children's", "teachers' notes"],
-          forbidden: ['wont', 'childrens', 'teachers notes'],
+          forbidden: ['wont', 'childrens', 'teachers notes'],    explanation: EXPLANATION,
+
           misconceptionTags: ['apostrophe.contraction_missing', 'apostrophe.possession_missing', 'apostrophe.possession_number'],
         },
       ],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['apostrophe.contraction_missing', 'apostrophe.possession_missing', 'apostrophe.possession_number'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -40,11 +45,14 @@ const TEMPLATES = [
         {
           type: 'requiresApostropheForms',
           tokens: ["can't", "men's", "boys' jackets"],
-          forbidden: ['cant', 'mens', 'boys jackets'],
+          forbidden: ['cant', 'mens', 'boys jackets'],    explanation: EXPLANATION,
+
           misconceptionTags: ['apostrophe.contraction_missing', 'apostrophe.possession_missing', 'apostrophe.possession_number'],
         },
       ],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['apostrophe.contraction_missing', 'apostrophe.possession_missing', 'apostrophe.possession_number'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -60,11 +68,14 @@ const TEMPLATES = [
         {
           type: 'requiresApostropheForms',
           tokens: ["they're", "captain's", "don't", "team's"],
-          forbidden: ['theyre', 'captains', 'dont', 'teams plan'],
+          forbidden: ['theyre', 'captains', 'dont', 'teams plan'],    explanation: EXPLANATION,
+
           misconceptionTags: ['apostrophe.contraction_missing', 'apostrophe.possession_missing'],
         },
       ],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['apostrophe.contraction_missing', 'apostrophe.possession_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -80,11 +91,14 @@ const TEMPLATES = [
         {
           type: 'requiresApostropheForms',
           tokens: ["won't", "girl's", "it's", "teacher's"],
-          forbidden: ['wont', 'girls pencil', 'its', 'teachers shelf'],
+          forbidden: ['wont', 'girls pencil', 'its', 'teachers shelf'],    explanation: EXPLANATION,
+
           misconceptionTags: ['apostrophe.contraction_missing', 'apostrophe.possession_missing'],
         },
       ],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['apostrophe.contraction_missing', 'apostrophe.possession_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -101,11 +115,14 @@ const TEMPLATES = [
         {
           type: 'requiresApostropheForms',
           tokens: ["doesn't", "driver's", "passengers' bags"],
-          forbidden: ['doesnt', 'drivers', 'passengers bags'],
+          forbidden: ['doesnt', 'drivers', 'passengers bags'],    explanation: EXPLANATION,
+
           misconceptionTags: ['apostrophe.contraction_missing', 'apostrophe.possession_missing', 'apostrophe.possession_number'],
         },
       ],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['apostrophe.contraction_missing', 'apostrophe.possession_missing', 'apostrophe.possession_number'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -121,11 +138,14 @@ const TEMPLATES = [
         {
           type: 'requiresApostropheForms',
           tokens: ["haven't", "nurse's", "doctors' notes"],
-          forbidden: ['havent', 'nurses', 'doctors notes'],
+          forbidden: ['havent', 'nurses', 'doctors notes'],    explanation: EXPLANATION,
+
           misconceptionTags: ['apostrophe.contraction_missing', 'apostrophe.possession_missing', 'apostrophe.possession_number'],
         },
       ],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['apostrophe.contraction_missing', 'apostrophe.possession_missing', 'apostrophe.possession_number'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -141,11 +161,14 @@ const TEMPLATES = [
         {
           type: 'requiresApostropheForms',
           tokens: ["shouldn't", "builder's", "plumber's"],
-          forbidden: ['shouldnt', 'builders tools', 'plumbers van'],
+          forbidden: ['shouldnt', 'builders tools', 'plumbers van'],    explanation: EXPLANATION,
+
           misconceptionTags: ['apostrophe.contraction_missing', 'apostrophe.possession_missing'],
         },
       ],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['apostrophe.contraction_missing', 'apostrophe.possession_missing'],
     readiness: ['constrained_transfer', 'transfer', 'misconception', 'negative_test'],
   },
@@ -161,11 +184,14 @@ const TEMPLATES = [
         {
           type: 'requiresApostropheForms',
           tokens: ["you're", "cat's", "kitten's", "isn't"],
-          forbidden: ['youre', 'cats bowl', 'kittens bed', 'isnt'],
+          forbidden: ['youre', 'cats bowl', 'kittens bed', 'isnt'],    explanation: EXPLANATION,
+
           misconceptionTags: ['apostrophe.contraction_missing', 'apostrophe.possession_missing'],
         },
       ],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['apostrophe.contraction_missing', 'apostrophe.possession_missing'],
     readiness: ['constrained_transfer', 'transfer', 'misconception', 'negative_test'],
   },
@@ -189,6 +215,7 @@ export const apostropheMixParagraphDsl = TEMPLATES.map((t, i) =>
       skillIds: t.skillIds,
       clusterId: t.clusterId,
       validator: t.validator,
+      explanation: t.explanation,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/apostrophe-possession-insert.js
+++ b/shared/punctuation/dsl-families/apostrophe-possession-insert.js
@@ -6,6 +6,8 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  * Templates 4-7: capacity expansion (new for P4-U8).
  */
 
+const EXPLANATION = 'The apostrophe before the s shows that the item belongs to the noun.';
+
 const TEMPLATES = [
   // ─── Legacy parity (indices 0-3) ─────────────────────────────────────────────
   {
@@ -16,6 +18,8 @@ const TEMPLATES = [
       type: 'requiresTokens',
       tokens: ["captain's", "team's"],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['apostrophe.possession_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
   },
@@ -27,6 +31,8 @@ const TEMPLATES = [
       type: 'requiresTokens',
       tokens: ["children's", "teacher's"],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['apostrophe.possession_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
   },
@@ -38,6 +44,8 @@ const TEMPLATES = [
       type: 'requiresTokens',
       tokens: ["artist's", "museum's"],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['apostrophe.possession_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
   },
@@ -49,6 +57,8 @@ const TEMPLATES = [
       type: 'requiresTokens',
       tokens: ["sailor's", "harbour's"],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['apostrophe.possession_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
   },
@@ -61,6 +71,8 @@ const TEMPLATES = [
       type: 'requiresTokens',
       tokens: ["gardener's", "school's"],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['apostrophe.possession_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
   },
@@ -72,6 +84,8 @@ const TEMPLATES = [
       type: 'requiresTokens',
       tokens: ["dog's", "owner's"],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['apostrophe.possession_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
   },
@@ -83,6 +97,8 @@ const TEMPLATES = [
       type: 'requiresTokens',
       tokens: ["pilot's", "passenger's"],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['apostrophe.possession_missing'],
     readiness: ['insertion', 'transfer', 'misconception', 'negative_test'],
   },
@@ -94,6 +110,8 @@ const TEMPLATES = [
       type: 'requiresTokens',
       tokens: ["knight's", "castle's"],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['apostrophe.possession_missing'],
     readiness: ['insertion', 'transfer', 'misconception', 'negative_test'],
   },
@@ -115,6 +133,7 @@ export const apostrophePossessionInsertDsl = TEMPLATES.map((t, i) =>
       stem: t.stem,
       model: t.model,
       validator: t.validator,
+      explanation: t.explanation,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/bullet-points-fix.js
+++ b/shared/punctuation/dsl-families/bullet-points-fix.js
@@ -6,6 +6,8 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  * Templates 4-7: capacity expansion (new for P4-U10).
  */
 
+const EXPLANATION = 'Every bullet in a list must follow the same punctuation pattern so the reader knows the list is consistent.';
+
 const TEMPLATES = [
   // ─── Legacy parity (indices 0-3) ─────────────────────────────────────────────
   {
@@ -17,6 +19,8 @@ const TEMPLATES = [
       stem: 'Bring',
       items: ['a coat', 'a torch', 'a notebook'],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.bullet_punctuation_inconsistent'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
   },
@@ -29,6 +33,8 @@ const TEMPLATES = [
       stem: 'Pack',
       items: ['pencils', 'rulers', 'glue sticks'],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.bullet_punctuation_inconsistent'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
   },
@@ -41,6 +47,8 @@ const TEMPLATES = [
       stem: 'Take',
       items: ['water', 'snacks', 'a hat'],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.bullet_punctuation_inconsistent'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
   },
@@ -53,6 +61,8 @@ const TEMPLATES = [
       stem: 'Check',
       items: ['doors', 'windows', 'lights'],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.bullet_punctuation_inconsistent'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
   },
@@ -66,6 +76,8 @@ const TEMPLATES = [
       stem: 'Collect',
       items: ['shells', 'feathers', 'pebbles'],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.bullet_punctuation_inconsistent'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
   },
@@ -78,6 +90,8 @@ const TEMPLATES = [
       stem: 'Prepare',
       items: ['flour', 'butter', 'sugar'],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.bullet_punctuation_inconsistent'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
   },
@@ -90,6 +104,8 @@ const TEMPLATES = [
       stem: 'Remember',
       items: ['keys', 'phone', 'wallet'],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.bullet_punctuation_inconsistent'],
     readiness: ['proofreading', 'transfer', 'misconception', 'negative_test'],
   },
@@ -102,6 +118,8 @@ const TEMPLATES = [
       stem: 'Buy',
       items: ['milk', 'bread', 'eggs'],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.bullet_punctuation_inconsistent'],
     readiness: ['proofreading', 'transfer', 'misconception', 'negative_test'],
   },
@@ -123,6 +141,7 @@ export const bulletPointsFixDsl = TEMPLATES.map((t, i) =>
       stem: t.stem,
       model: t.model,
       validator: t.validator,
+      explanation: t.explanation,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/bullet-points-paragraph.js
+++ b/shared/punctuation/dsl-families/bullet-points-paragraph.js
@@ -6,6 +6,8 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  * Templates 4-7: capacity expansion (new for P4-U10).
  */
 
+const EXPLANATION = 'A colon introduces the list after a complete opening, and each bullet follows a consistent punctuation pattern.';
+
 const TEMPLATES = [
   // ─── Legacy parity (indices 0-3) ─────────────────────────────────────────────
   {
@@ -23,11 +25,14 @@ const TEMPLATES = [
         {
           type: 'requiresBulletStemAndItems',
           stem: 'Pack',
-          items: ['pencils', 'rulers', 'glue sticks'],
+          items: ['pencils', 'rulers', 'glue sticks'],    explanation: EXPLANATION,
+
           misconceptionTags: ['structure.bullet_colon_missing', 'structure.bullet_marker_missing', 'structure.bullet_punctuation_inconsistent'],
         },
       ],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.bullet_colon_missing', 'structure.bullet_marker_missing', 'structure.bullet_punctuation_inconsistent'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -46,11 +51,14 @@ const TEMPLATES = [
         {
           type: 'requiresBulletStemAndItems',
           stem: 'Bring',
-          items: ['a coat', 'a torch', 'a notebook'],
+          items: ['a coat', 'a torch', 'a notebook'],    explanation: EXPLANATION,
+
           misconceptionTags: ['structure.bullet_colon_missing', 'structure.bullet_marker_missing', 'structure.bullet_punctuation_inconsistent'],
         },
       ],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.bullet_colon_missing', 'structure.bullet_marker_missing', 'structure.bullet_punctuation_inconsistent'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -69,11 +77,14 @@ const TEMPLATES = [
         {
           type: 'requiresBulletStemAndItems',
           stem: 'Take',
-          items: ['water', 'snacks', 'a hat'],
+          items: ['water', 'snacks', 'a hat'],    explanation: EXPLANATION,
+
           misconceptionTags: ['structure.bullet_colon_missing', 'structure.bullet_marker_missing', 'structure.bullet_punctuation_inconsistent'],
         },
       ],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.bullet_colon_missing', 'structure.bullet_marker_missing', 'structure.bullet_punctuation_inconsistent'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -92,11 +103,14 @@ const TEMPLATES = [
         {
           type: 'requiresBulletStemAndItems',
           stem: 'Check',
-          items: ['doors', 'windows', 'lights'],
+          items: ['doors', 'windows', 'lights'],    explanation: EXPLANATION,
+
           misconceptionTags: ['structure.bullet_colon_missing', 'structure.bullet_marker_missing', 'structure.bullet_punctuation_inconsistent'],
         },
       ],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.bullet_colon_missing', 'structure.bullet_marker_missing', 'structure.bullet_punctuation_inconsistent'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -116,11 +130,14 @@ const TEMPLATES = [
         {
           type: 'requiresBulletStemAndItems',
           stem: 'Collect',
-          items: ['shells', 'feathers', 'pebbles'],
+          items: ['shells', 'feathers', 'pebbles'],    explanation: EXPLANATION,
+
           misconceptionTags: ['structure.bullet_colon_missing', 'structure.bullet_marker_missing', 'structure.bullet_punctuation_inconsistent'],
         },
       ],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.bullet_colon_missing', 'structure.bullet_marker_missing', 'structure.bullet_punctuation_inconsistent'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -139,11 +156,14 @@ const TEMPLATES = [
         {
           type: 'requiresBulletStemAndItems',
           stem: 'Prepare',
-          items: ['flour', 'butter', 'sugar'],
+          items: ['flour', 'butter', 'sugar'],    explanation: EXPLANATION,
+
           misconceptionTags: ['structure.bullet_colon_missing', 'structure.bullet_marker_missing', 'structure.bullet_punctuation_inconsistent'],
         },
       ],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.bullet_colon_missing', 'structure.bullet_marker_missing', 'structure.bullet_punctuation_inconsistent'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -162,11 +182,14 @@ const TEMPLATES = [
         {
           type: 'requiresBulletStemAndItems',
           stem: 'Remember',
-          items: ['keys', 'phone', 'wallet'],
+          items: ['keys', 'phone', 'wallet'],    explanation: EXPLANATION,
+
           misconceptionTags: ['structure.bullet_colon_missing', 'structure.bullet_marker_missing', 'structure.bullet_punctuation_inconsistent'],
         },
       ],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.bullet_colon_missing', 'structure.bullet_marker_missing', 'structure.bullet_punctuation_inconsistent'],
     readiness: ['constrained_transfer', 'transfer', 'misconception', 'negative_test'],
   },
@@ -185,11 +208,14 @@ const TEMPLATES = [
         {
           type: 'requiresBulletStemAndItems',
           stem: 'Buy',
-          items: ['milk', 'bread', 'eggs'],
+          items: ['milk', 'bread', 'eggs'],    explanation: EXPLANATION,
+
           misconceptionTags: ['structure.bullet_colon_missing', 'structure.bullet_marker_missing', 'structure.bullet_punctuation_inconsistent'],
         },
       ],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.bullet_colon_missing', 'structure.bullet_marker_missing', 'structure.bullet_punctuation_inconsistent'],
     readiness: ['constrained_transfer', 'transfer', 'misconception', 'negative_test'],
   },
@@ -214,6 +240,7 @@ export const bulletPointsParagraphDsl = TEMPLATES.map((t, i) =>
       skillIds: t.skillIds,
       clusterId: t.clusterId,
       validator: t.validator,
+      explanation: t.explanation,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/colon-list-combine.js
+++ b/shared/punctuation/dsl-families/colon-list-combine.js
@@ -6,6 +6,8 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  * Templates 4-7: capacity expansion (new for P4-U10).
  */
 
+const EXPLANATION = 'A colon introduces the list after a complete sentence that sets it up.';
+
 const TEMPLATES = [
   // ─── Legacy parity (indices 0-3) ─────────────────────────────────────────────
   {
@@ -17,6 +19,8 @@ const TEMPLATES = [
       opening: 'We needed three tools',
       items: ['a torch', 'a rope', 'a map'],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.colon_missing', 'structure.list_separator_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -29,6 +33,8 @@ const TEMPLATES = [
       opening: 'The kit included three things',
       items: ['a lantern', 'a compass', 'a notebook'],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.colon_missing', 'structure.list_separator_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -41,6 +47,8 @@ const TEMPLATES = [
       opening: 'The drawer held three supplies',
       items: ['pens', 'rulers', 'tape'],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.colon_missing', 'structure.list_separator_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -53,6 +61,8 @@ const TEMPLATES = [
       opening: 'We chose three activities',
       items: ['swimming', 'cycling', 'climbing'],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.colon_missing', 'structure.list_separator_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -66,6 +76,8 @@ const TEMPLATES = [
       opening: 'The garden had three features',
       items: ['a pond', 'a bench', 'a hedge'],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.colon_missing', 'structure.list_separator_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -78,6 +90,8 @@ const TEMPLATES = [
       opening: 'She packed three essentials',
       items: ['water', 'sunscreen', 'a hat'],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.colon_missing', 'structure.list_separator_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -90,6 +104,8 @@ const TEMPLATES = [
       opening: 'The recipe required three spices',
       items: ['cumin', 'paprika', 'turmeric'],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.colon_missing', 'structure.list_separator_missing'],
     readiness: ['constrained_transfer', 'transfer', 'misconception', 'negative_test'],
   },
@@ -102,6 +118,8 @@ const TEMPLATES = [
       opening: 'The team trained in three sports',
       items: ['running', 'rowing', 'tennis'],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.colon_missing', 'structure.list_separator_missing'],
     readiness: ['constrained_transfer', 'transfer', 'misconception', 'negative_test'],
   },
@@ -123,6 +141,7 @@ export const colonListCombineDsl = TEMPLATES.map((t, i) =>
       stem: t.stem,
       model: t.model,
       validator: t.validator,
+      explanation: t.explanation,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/colon-list-insert.js
+++ b/shared/punctuation/dsl-families/colon-list-insert.js
@@ -6,6 +6,8 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  * Templates 4-7: capacity expansion (new for P4-U9).
  */
 
+const EXPLANATION = 'A colon introduces the list after a complete sentence that sets it up.';
+
 const TEMPLATES = [
   // ─── Legacy parity (indices 0-3) ─────────────────────────────────────────────
   {
@@ -17,6 +19,8 @@ const TEMPLATES = [
       opening: 'We needed three tools',
       items: ['a torch', 'a rope', 'a map'],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.colon_missing', 'structure.list_separator_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
   },
@@ -29,6 +33,8 @@ const TEMPLATES = [
       opening: 'The kit included three things',
       items: ['a lantern', 'a compass', 'a notebook'],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.colon_missing', 'structure.list_separator_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
   },
@@ -41,6 +47,8 @@ const TEMPLATES = [
       opening: 'The drawer held three supplies',
       items: ['pens', 'rulers', 'tape'],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.colon_missing', 'structure.list_separator_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
   },
@@ -53,6 +61,8 @@ const TEMPLATES = [
       opening: 'We chose three activities',
       items: ['swimming', 'cycling', 'climbing'],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.colon_missing', 'structure.list_separator_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
   },
@@ -66,6 +76,8 @@ const TEMPLATES = [
       opening: 'The garden had three features',
       items: ['a pond', 'a bench', 'a hedge'],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.colon_missing', 'structure.list_separator_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
   },
@@ -78,6 +90,8 @@ const TEMPLATES = [
       opening: 'She packed three essentials',
       items: ['water', 'sunscreen', 'a hat'],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.colon_missing', 'structure.list_separator_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
   },
@@ -90,6 +104,8 @@ const TEMPLATES = [
       opening: 'The recipe required three spices',
       items: ['cumin', 'paprika', 'turmeric'],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.colon_missing', 'structure.list_separator_missing'],
     readiness: ['insertion', 'transfer', 'misconception', 'negative_test'],
   },
@@ -102,6 +118,8 @@ const TEMPLATES = [
       opening: 'The team trained in three sports',
       items: ['running', 'rowing', 'tennis'],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.colon_missing', 'structure.list_separator_missing'],
     readiness: ['insertion', 'transfer', 'misconception', 'negative_test'],
   },
@@ -123,6 +141,7 @@ export const colonListInsertDsl = TEMPLATES.map((t, i) =>
       stem: t.stem,
       model: t.model,
       validator: t.validator,
+      explanation: t.explanation,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/colon-semicolon-paragraph.js
+++ b/shared/punctuation/dsl-families/colon-semicolon-paragraph.js
@@ -6,6 +6,8 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  * Templates 4-7: capacity expansion (new for P4-U10).
  */
 
+const EXPLANATION = 'A colon introduces a list after a complete sentence, and a semicolon joins two closely related main clauses.';
+
 const TEMPLATES = [
   // ─── Legacy parity (indices 0-3) ─────────────────────────────────────────────
   {
@@ -21,18 +23,22 @@ const TEMPLATES = [
           type: 'requiresColonBeforeList',
           opening: 'We needed three tools',
           items: ['a lantern', 'a compass', 'a notebook'],
-          allowTrailingText: true,
+          allowTrailingText: true,    explanation: EXPLANATION,
+
           misconceptionTags: ['structure.colon_missing', 'structure.list_separator_missing'],
         },
         {
           type: 'requiresBoundaryBetweenClauses',
           mark: ';',
           left: 'The tide rose',
-          right: 'the group moved inland',
+          right: 'the group moved inland',    explanation: EXPLANATION,
+
           misconceptionTags: ['boundary.comma_splice', 'boundary.semicolon_missing'],
         },
       ],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.colon_missing', 'structure.list_separator_missing', 'boundary.comma_splice', 'boundary.semicolon_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -49,18 +55,22 @@ const TEMPLATES = [
           type: 'requiresColonBeforeList',
           opening: 'The kit held three things',
           items: ['a torch', 'a rope', 'a map'],
-          allowTrailingText: true,
+          allowTrailingText: true,    explanation: EXPLANATION,
+
           misconceptionTags: ['structure.colon_missing', 'structure.list_separator_missing'],
         },
         {
           type: 'requiresBoundaryBetweenClauses',
           mark: ';',
           left: 'The rain stopped',
-          right: 'the match continued',
+          right: 'the match continued',    explanation: EXPLANATION,
+
           misconceptionTags: ['boundary.comma_splice', 'boundary.semicolon_missing'],
         },
       ],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.colon_missing', 'structure.list_separator_missing', 'boundary.comma_splice', 'boundary.semicolon_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -77,18 +87,22 @@ const TEMPLATES = [
           type: 'requiresColonBeforeList',
           opening: 'The box contained three items',
           items: ['a scarf', 'a medal', 'a badge'],
-          allowTrailingText: true,
+          allowTrailingText: true,    explanation: EXPLANATION,
+
           misconceptionTags: ['structure.colon_missing', 'structure.list_separator_missing'],
         },
         {
           type: 'requiresBoundaryBetweenClauses',
           mark: ';',
           left: 'The door opened',
-          right: 'the crowd cheered',
+          right: 'the crowd cheered',    explanation: EXPLANATION,
+
           misconceptionTags: ['boundary.comma_splice', 'boundary.semicolon_missing'],
         },
       ],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.colon_missing', 'structure.list_separator_missing', 'boundary.comma_splice', 'boundary.semicolon_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -105,18 +119,22 @@ const TEMPLATES = [
           type: 'requiresColonBeforeList',
           opening: 'Our display needed three labels',
           items: ['rivers', 'mountains', 'coasts'],
-          allowTrailingText: true,
+          allowTrailingText: true,    explanation: EXPLANATION,
+
           misconceptionTags: ['structure.colon_missing', 'structure.list_separator_missing'],
         },
         {
           type: 'requiresBoundaryBetweenClauses',
           mark: ';',
           left: 'The lights dimmed',
-          right: 'the film began',
+          right: 'the film began',    explanation: EXPLANATION,
+
           misconceptionTags: ['boundary.comma_splice', 'boundary.semicolon_missing'],
         },
       ],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.colon_missing', 'structure.list_separator_missing', 'boundary.comma_splice', 'boundary.semicolon_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -134,18 +152,22 @@ const TEMPLATES = [
           type: 'requiresColonBeforeList',
           opening: 'The shed stored three items',
           items: ['a mower', 'a rake', 'a hose'],
-          allowTrailingText: true,
+          allowTrailingText: true,    explanation: EXPLANATION,
+
           misconceptionTags: ['structure.colon_missing', 'structure.list_separator_missing'],
         },
         {
           type: 'requiresBoundaryBetweenClauses',
           mark: ';',
           left: 'The gate creaked',
-          right: 'the dog barked',
+          right: 'the dog barked',    explanation: EXPLANATION,
+
           misconceptionTags: ['boundary.comma_splice', 'boundary.semicolon_missing'],
         },
       ],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.colon_missing', 'structure.list_separator_missing', 'boundary.comma_splice', 'boundary.semicolon_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -162,18 +184,22 @@ const TEMPLATES = [
           type: 'requiresColonBeforeList',
           opening: 'We tried three flavours',
           items: ['mint', 'lemon', 'ginger'],
-          allowTrailingText: true,
+          allowTrailingText: true,    explanation: EXPLANATION,
+
           misconceptionTags: ['structure.colon_missing', 'structure.list_separator_missing'],
         },
         {
           type: 'requiresBoundaryBetweenClauses',
           mark: ';',
           left: 'The queue grew',
-          right: 'the server worked faster',
+          right: 'the server worked faster',    explanation: EXPLANATION,
+
           misconceptionTags: ['boundary.comma_splice', 'boundary.semicolon_missing'],
         },
       ],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.colon_missing', 'structure.list_separator_missing', 'boundary.comma_splice', 'boundary.semicolon_missing'],
     readiness: ['constrained_transfer', 'transfer', 'misconception', 'negative_test'],
   },
@@ -190,18 +216,22 @@ const TEMPLATES = [
           type: 'requiresColonBeforeList',
           opening: 'The park offered three trails',
           items: ['woodland', 'riverside', 'hilltop'],
-          allowTrailingText: true,
+          allowTrailingText: true,    explanation: EXPLANATION,
+
           misconceptionTags: ['structure.colon_missing', 'structure.list_separator_missing'],
         },
         {
           type: 'requiresBoundaryBetweenClauses',
           mark: ';',
           left: 'The fog lifted',
-          right: 'the runners set off',
+          right: 'the runners set off',    explanation: EXPLANATION,
+
           misconceptionTags: ['boundary.comma_splice', 'boundary.semicolon_missing'],
         },
       ],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.colon_missing', 'structure.list_separator_missing', 'boundary.comma_splice', 'boundary.semicolon_missing'],
     readiness: ['constrained_transfer', 'transfer', 'misconception', 'negative_test'],
   },
@@ -218,18 +248,22 @@ const TEMPLATES = [
           type: 'requiresColonBeforeList',
           opening: 'The basket held three fruits',
           items: ['apples', 'pears', 'plums'],
-          allowTrailingText: true,
+          allowTrailingText: true,    explanation: EXPLANATION,
+
           misconceptionTags: ['structure.colon_missing', 'structure.list_separator_missing'],
         },
         {
           type: 'requiresBoundaryBetweenClauses',
           mark: ';',
           left: 'The whistle blew',
-          right: 'the players stopped',
+          right: 'the players stopped',    explanation: EXPLANATION,
+
           misconceptionTags: ['boundary.comma_splice', 'boundary.semicolon_missing'],
         },
       ],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.colon_missing', 'structure.list_separator_missing', 'boundary.comma_splice', 'boundary.semicolon_missing'],
     readiness: ['constrained_transfer', 'transfer', 'misconception', 'negative_test'],
   },
@@ -253,6 +287,7 @@ export const colonSemicolonParagraphDsl = TEMPLATES.map((t, i) =>
       skillIds: t.skillIds,
       clusterId: t.clusterId,
       validator: t.validator,
+      explanation: t.explanation,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/comma-clarity-insert.js
+++ b/shared/punctuation/dsl-families/comma-clarity-insert.js
@@ -4,12 +4,16 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  * DSL definitions for gen_comma_clarity_insert family.
  */
 
+const EXPLANATION = 'A comma after the opening phrase prevents the reader from misreading the start of the main clause.';
+
 const TEMPLATES = [
   {
     prompt: 'Add the comma that makes the meaning clear.',
     stem: 'In the evening the harbour was quiet.',
     model: 'In the evening, the harbour was quiet.',
     validator: { type: 'startsWithPhraseComma', phrase: 'In the evening' },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.clarity_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
   },
@@ -18,6 +22,8 @@ const TEMPLATES = [
     stem: 'When the mist lifted the tower appeared.',
     model: 'When the mist lifted, the tower appeared.',
     validator: { type: 'startsWithPhraseComma', phrase: 'When the mist lifted' },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.clarity_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
   },
@@ -26,6 +32,8 @@ const TEMPLATES = [
     stem: 'Without a map the walkers lost time.',
     model: 'Without a map, the walkers lost time.',
     validator: { type: 'startsWithPhraseComma', phrase: 'Without a map' },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.clarity_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
   },
@@ -34,6 +42,8 @@ const TEMPLATES = [
     stem: 'As the whistle blew the teams lined up.',
     model: 'As the whistle blew, the teams lined up.',
     validator: { type: 'startsWithPhraseComma', phrase: 'As the whistle blew' },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.clarity_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
   },
@@ -42,6 +52,8 @@ const TEMPLATES = [
     stem: 'After the final whistle the crowd cheered.',
     model: 'After the final whistle, the crowd cheered.',
     validator: { type: 'startsWithPhraseComma', phrase: 'After the final whistle' },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.clarity_missing'],
     readiness: ['insertion', 'transfer', 'misconception', 'negative_test'],
   },
@@ -50,6 +62,8 @@ const TEMPLATES = [
     stem: 'If the alarm sounds the class will line up.',
     model: 'If the alarm sounds, the class will line up.',
     validator: { type: 'startsWithPhraseComma', phrase: 'If the alarm sounds' },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.clarity_missing'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
   },
@@ -58,6 +72,8 @@ const TEMPLATES = [
     stem: 'Near the old bridge the lane narrows.',
     model: 'Near the old bridge, the lane narrows.',
     validator: { type: 'startsWithPhraseComma', phrase: 'Near the old bridge' },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.clarity_missing'],
     readiness: ['insertion', 'transfer', 'misconception', 'negative_test'],
   },
@@ -66,6 +82,8 @@ const TEMPLATES = [
     stem: 'Because the path flooded the cyclists turned back.',
     model: 'Because the path flooded, the cyclists turned back.',
     validator: { type: 'startsWithPhraseComma', phrase: 'Because the path flooded' },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.clarity_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
   },
@@ -87,6 +105,7 @@ export const commaClarityInsertDsl = TEMPLATES.map((t, i) =>
       stem: t.stem,
       model: t.model,
       validator: t.validator,
+      explanation: t.explanation,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/dash-clause-combine.js
+++ b/shared/punctuation/dsl-families/dash-clause-combine.js
@@ -4,12 +4,16 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  * DSL definitions for gen_dash_clause_combine family.
  */
 
+const EXPLANATION = 'A dash separates two independent but related ideas, often adding surprise or contrast.';
+
 const TEMPLATES = [
   {
     prompt: 'Combine the two related clauses into one sentence with a dash.',
     stem: 'The gate was stuck.\nWe found another path.',
     model: 'The gate was stuck – we found another path.',
     validator: { type: 'combineBoundaryBetweenClauses', left: 'The gate was stuck', right: 'we found another path', mark: '-' },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['boundary.dash_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -18,6 +22,8 @@ const TEMPLATES = [
     stem: 'The bell rang.\nEveryone hurried inside.',
     model: 'The bell rang – everyone hurried inside.',
     validator: { type: 'combineBoundaryBetweenClauses', left: 'The bell rang', right: 'everyone hurried inside', mark: '-' },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['boundary.dash_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -26,6 +32,8 @@ const TEMPLATES = [
     stem: 'The torch failed.\nWe used the lantern.',
     model: 'The torch failed – we used the lantern.',
     validator: { type: 'combineBoundaryBetweenClauses', left: 'The torch failed', right: 'we used the lantern', mark: '-' },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['boundary.dash_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -34,6 +42,8 @@ const TEMPLATES = [
     stem: 'The bridge was closed.\nThe buses turned back.',
     model: 'The bridge was closed – the buses turned back.',
     validator: { type: 'combineBoundaryBetweenClauses', left: 'The bridge was closed', right: 'the buses turned back', mark: '-' },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['boundary.dash_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -42,6 +52,8 @@ const TEMPLATES = [
     stem: 'The waves grew louder.\nWe stepped back.',
     model: 'The waves grew louder – we stepped back.',
     validator: { type: 'combineBoundaryBetweenClauses', left: 'The waves grew louder', right: 'we stepped back', mark: '-' },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['boundary.dash_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -50,6 +62,8 @@ const TEMPLATES = [
     stem: 'The door opened.\nNobody spoke.',
     model: 'The door opened – nobody spoke.',
     validator: { type: 'combineBoundaryBetweenClauses', left: 'The door opened', right: 'nobody spoke', mark: '-' },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['boundary.dash_missing'],
     readiness: ['constrained_transfer', 'transfer', 'misconception', 'negative_test'],
   },
@@ -58,6 +72,8 @@ const TEMPLATES = [
     stem: 'The signal vanished.\nThe team waited.',
     model: 'The signal vanished – the team waited.',
     validator: { type: 'combineBoundaryBetweenClauses', left: 'The signal vanished', right: 'the team waited', mark: '-' },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['boundary.dash_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -66,6 +82,8 @@ const TEMPLATES = [
     stem: 'The path ended.\nWe climbed over the stile.',
     model: 'The path ended – we climbed over the stile.',
     validator: { type: 'combineBoundaryBetweenClauses', left: 'The path ended', right: 'we climbed over the stile', mark: '-' },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['boundary.dash_missing'],
     readiness: ['constrained_transfer', 'transfer', 'misconception', 'negative_test'],
   },
@@ -87,6 +105,7 @@ export const dashClauseCombineDsl = TEMPLATES.map((t, i) =>
       stem: t.stem,
       model: t.model,
       validator: t.validator,
+      explanation: t.explanation,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/dash-clause-fix.js
+++ b/shared/punctuation/dsl-families/dash-clause-fix.js
@@ -4,12 +4,16 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  * DSL definitions for gen_dash_clause_fix family.
  */
 
+const EXPLANATION = 'A dash separates two independent but related ideas, often adding surprise or contrast.';
+
 const TEMPLATES = [
   {
     prompt: 'Add a dash between the related clauses.',
     stem: 'The gate was stuck we found another path.',
     model: 'The gate was stuck – we found another path.',
     validator: { type: 'requiresBoundaryBetweenClauses', left: 'The gate was stuck', right: 'we found another path', mark: '-' },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['boundary.dash_missing'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
   },
@@ -18,6 +22,8 @@ const TEMPLATES = [
     stem: 'The bell rang everyone hurried inside.',
     model: 'The bell rang – everyone hurried inside.',
     validator: { type: 'requiresBoundaryBetweenClauses', left: 'The bell rang', right: 'everyone hurried inside', mark: '-' },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['boundary.dash_missing'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
   },
@@ -26,6 +32,8 @@ const TEMPLATES = [
     stem: 'The torch failed we used the lantern.',
     model: 'The torch failed – we used the lantern.',
     validator: { type: 'requiresBoundaryBetweenClauses', left: 'The torch failed', right: 'we used the lantern', mark: '-' },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['boundary.dash_missing'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
   },
@@ -34,6 +42,8 @@ const TEMPLATES = [
     stem: 'The bridge was closed the buses turned back.',
     model: 'The bridge was closed – the buses turned back.',
     validator: { type: 'requiresBoundaryBetweenClauses', left: 'The bridge was closed', right: 'the buses turned back', mark: '-' },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['boundary.dash_missing'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
   },
@@ -42,6 +52,8 @@ const TEMPLATES = [
     stem: 'The waves grew louder we stepped back.',
     model: 'The waves grew louder – we stepped back.',
     validator: { type: 'requiresBoundaryBetweenClauses', left: 'The waves grew louder', right: 'we stepped back', mark: '-' },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['boundary.dash_missing'],
     readiness: ['proofreading', 'transfer', 'misconception', 'negative_test'],
   },
@@ -50,6 +62,8 @@ const TEMPLATES = [
     stem: 'The door opened nobody spoke.',
     model: 'The door opened – nobody spoke.',
     validator: { type: 'requiresBoundaryBetweenClauses', left: 'The door opened', right: 'nobody spoke', mark: '-' },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['boundary.dash_missing'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
   },
@@ -58,6 +72,8 @@ const TEMPLATES = [
     stem: 'The signal vanished the team waited.',
     model: 'The signal vanished – the team waited.',
     validator: { type: 'requiresBoundaryBetweenClauses', left: 'The signal vanished', right: 'the team waited', mark: '-' },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['boundary.dash_missing'],
     readiness: ['proofreading', 'transfer', 'misconception', 'negative_test'],
   },
@@ -66,6 +82,8 @@ const TEMPLATES = [
     stem: 'The path ended we climbed over the stile.',
     model: 'The path ended – we climbed over the stile.',
     validator: { type: 'requiresBoundaryBetweenClauses', left: 'The path ended', right: 'we climbed over the stile', mark: '-' },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['boundary.dash_missing'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
   },
@@ -87,6 +105,7 @@ export const dashClauseFixDsl = TEMPLATES.map((t, i) =>
       stem: t.stem,
       model: t.model,
       validator: t.validator,
+      explanation: t.explanation,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/fronted-adverbial-combine.js
+++ b/shared/punctuation/dsl-families/fronted-adverbial-combine.js
@@ -6,6 +6,8 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  * Templates 4-7: capacity expansion (new for P4-U9).
  */
 
+const EXPLANATION = 'A comma separates the opening adverbial phrase from the main clause so the reader knows where the main idea begins.';
+
 const TEMPLATES = [
   // ─── Legacy parity (indices 0-3) ─────────────────────────────────────────────
   {
@@ -17,6 +19,8 @@ const TEMPLATES = [
       phrase: 'Before sunrise',
       mainClause: 'the crew checked the ropes',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.fronted_adverbial_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -29,6 +33,8 @@ const TEMPLATES = [
       phrase: 'After the rehearsal',
       mainClause: 'the cast packed away the props',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.fronted_adverbial_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -41,6 +47,8 @@ const TEMPLATES = [
       phrase: 'During the concert',
       mainClause: 'the hall became silent',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.fronted_adverbial_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -53,6 +61,8 @@ const TEMPLATES = [
       phrase: 'At the edge of the field',
       mainClause: 'the coach waited',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.fronted_adverbial_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -66,6 +76,8 @@ const TEMPLATES = [
       phrase: 'Without warning',
       mainClause: 'the fox darted across the lane',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.fronted_adverbial_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -78,6 +90,8 @@ const TEMPLATES = [
       phrase: 'Behind the shed',
       mainClause: 'the cat hid from the rain',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.fronted_adverbial_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -90,6 +104,8 @@ const TEMPLATES = [
       phrase: 'Throughout the afternoon',
       mainClause: 'the children played outside',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.fronted_adverbial_missing'],
     readiness: ['constrained_transfer', 'transfer', 'misconception', 'negative_test'],
   },
@@ -102,6 +118,8 @@ const TEMPLATES = [
       phrase: 'Near the old bridge',
       mainClause: 'the heron stood perfectly still',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.fronted_adverbial_missing'],
     readiness: ['constrained_transfer', 'transfer', 'misconception', 'negative_test'],
   },
@@ -123,6 +141,7 @@ export const frontedAdverbialCombineDsl = TEMPLATES.map((t, i) =>
       stem: t.stem,
       model: t.model,
       validator: t.validator,
+      explanation: t.explanation,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/fronted-adverbial-fix.js
+++ b/shared/punctuation/dsl-families/fronted-adverbial-fix.js
@@ -6,6 +6,8 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  * Templates 4-7: capacity expansion (new for P4-U9).
  */
 
+const EXPLANATION = 'A comma separates the opening adverbial phrase from the main clause so the reader knows where the main idea begins.';
+
 const TEMPLATES = [
   // ─── Legacy parity (indices 0-3) ─────────────────────────────────────────────
   {
@@ -16,6 +18,8 @@ const TEMPLATES = [
       type: 'startsWithPhraseComma',
       phrase: 'After the storm',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.fronted_adverbial_missing'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
   },
@@ -27,6 +31,8 @@ const TEMPLATES = [
       type: 'startsWithPhraseComma',
       phrase: 'Before sunrise',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.fronted_adverbial_missing'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
   },
@@ -38,6 +44,8 @@ const TEMPLATES = [
       type: 'startsWithPhraseComma',
       phrase: 'During the concert',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.fronted_adverbial_missing'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
   },
@@ -49,6 +57,8 @@ const TEMPLATES = [
       type: 'startsWithPhraseComma',
       phrase: 'At the edge of the field',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.fronted_adverbial_missing'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
   },
@@ -61,6 +71,8 @@ const TEMPLATES = [
       type: 'startsWithPhraseComma',
       phrase: 'Without warning',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.fronted_adverbial_missing'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
   },
@@ -72,6 +84,8 @@ const TEMPLATES = [
       type: 'startsWithPhraseComma',
       phrase: 'Behind the shed',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.fronted_adverbial_missing'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
   },
@@ -83,6 +97,8 @@ const TEMPLATES = [
       type: 'startsWithPhraseComma',
       phrase: 'Throughout the afternoon',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.fronted_adverbial_missing'],
     readiness: ['proofreading', 'transfer', 'misconception', 'negative_test'],
   },
@@ -94,6 +110,8 @@ const TEMPLATES = [
       type: 'startsWithPhraseComma',
       phrase: 'Near the old bridge',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.fronted_adverbial_missing'],
     readiness: ['proofreading', 'transfer', 'misconception', 'negative_test'],
   },
@@ -115,6 +133,7 @@ export const frontedAdverbialFixDsl = TEMPLATES.map((t, i) =>
       stem: t.stem,
       model: t.model,
       validator: t.validator,
+      explanation: t.explanation,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/fronted-speech-paragraph.js
+++ b/shared/punctuation/dsl-families/fronted-speech-paragraph.js
@@ -6,6 +6,8 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  * Templates 4-7: capacity expansion (new for P4-U8).
  */
 
+const EXPLANATION = 'A comma follows the fronted adverbial, and inverted commas wrap the spoken words with their punctuation inside.';
+
 const TEMPLATES = [
   // ─── Legacy parity (indices 0-3) ─────────────────────────────────────────────
   {
@@ -19,17 +21,21 @@ const TEMPLATES = [
       checks: [
         {
           type: 'startsWithPhraseComma',
-          phrase: 'Before lunch',
+          phrase: 'Before lunch',    explanation: EXPLANATION,
+
           misconceptionTags: ['comma.fronted_adverbial_missing'],
         },
         {
           type: 'speechWithWords',
           words: 'can we start now',
-          requiredTerminal: '?',
+          requiredTerminal: '?',    explanation: EXPLANATION,
+
           misconceptionTags: ['speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing'],
         },
       ],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.fronted_adverbial_missing', 'speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -44,17 +50,21 @@ const TEMPLATES = [
       checks: [
         {
           type: 'startsWithPhraseComma',
-          phrase: 'After rehearsal',
+          phrase: 'After rehearsal',    explanation: EXPLANATION,
+
           misconceptionTags: ['comma.fronted_adverbial_missing'],
         },
         {
           type: 'speechWithWords',
           words: 'the props are packed',
-          requiredTerminal: '.',
+          requiredTerminal: '.',    explanation: EXPLANATION,
+
           misconceptionTags: ['speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing'],
         },
       ],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.fronted_adverbial_missing', 'speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -69,17 +79,21 @@ const TEMPLATES = [
       checks: [
         {
           type: 'startsWithPhraseComma',
-          phrase: 'During assembly',
+          phrase: 'During assembly',    explanation: EXPLANATION,
+
           misconceptionTags: ['comma.fronted_adverbial_missing'],
         },
         {
           type: 'speechWithWords',
           words: 'please sit down',
-          requiredTerminal: '.',
+          requiredTerminal: '.',    explanation: EXPLANATION,
+
           misconceptionTags: ['speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing'],
         },
       ],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.fronted_adverbial_missing', 'speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -94,17 +108,21 @@ const TEMPLATES = [
       checks: [
         {
           type: 'startsWithPhraseComma',
-          phrase: 'At the gate',
+          phrase: 'At the gate',    explanation: EXPLANATION,
+
           misconceptionTags: ['comma.fronted_adverbial_missing'],
         },
         {
           type: 'speechWithWords',
           words: 'are we late',
-          requiredTerminal: '?',
+          requiredTerminal: '?',    explanation: EXPLANATION,
+
           misconceptionTags: ['speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing'],
         },
       ],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.fronted_adverbial_missing', 'speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -120,17 +138,21 @@ const TEMPLATES = [
       checks: [
         {
           type: 'startsWithPhraseComma',
-          phrase: 'In the corridor',
+          phrase: 'In the corridor',    explanation: EXPLANATION,
+
           misconceptionTags: ['comma.fronted_adverbial_missing'],
         },
         {
           type: 'speechWithWords',
           words: 'wait for me',
-          requiredTerminal: '!',
+          requiredTerminal: '!',    explanation: EXPLANATION,
+
           misconceptionTags: ['speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing'],
         },
       ],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.fronted_adverbial_missing', 'speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -145,17 +167,21 @@ const TEMPLATES = [
       checks: [
         {
           type: 'startsWithPhraseComma',
-          phrase: 'Near the pond',
+          phrase: 'Near the pond',    explanation: EXPLANATION,
+
           misconceptionTags: ['comma.fronted_adverbial_missing'],
         },
         {
           type: 'speechWithWords',
           words: 'look at the heron',
-          requiredTerminal: '.',
+          requiredTerminal: '.',    explanation: EXPLANATION,
+
           misconceptionTags: ['speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing'],
         },
       ],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.fronted_adverbial_missing', 'speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -170,17 +196,21 @@ const TEMPLATES = [
       checks: [
         {
           type: 'startsWithPhraseComma',
-          phrase: 'Behind the stage',
+          phrase: 'Behind the stage',    explanation: EXPLANATION,
+
           misconceptionTags: ['comma.fronted_adverbial_missing'],
         },
         {
           type: 'speechWithWords',
           words: 'where is my costume',
-          requiredTerminal: '?',
+          requiredTerminal: '?',    explanation: EXPLANATION,
+
           misconceptionTags: ['speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing'],
         },
       ],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.fronted_adverbial_missing', 'speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing'],
     readiness: ['constrained_transfer', 'transfer', 'misconception', 'negative_test'],
   },
@@ -195,17 +225,21 @@ const TEMPLATES = [
       checks: [
         {
           type: 'startsWithPhraseComma',
-          phrase: 'Across the field',
+          phrase: 'Across the field',    explanation: EXPLANATION,
+
           misconceptionTags: ['comma.fronted_adverbial_missing'],
         },
         {
           type: 'speechWithWords',
           words: 'come back here',
-          requiredTerminal: '!',
+          requiredTerminal: '!',    explanation: EXPLANATION,
+
           misconceptionTags: ['speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing'],
         },
       ],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.fronted_adverbial_missing', 'speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing'],
     readiness: ['constrained_transfer', 'transfer', 'misconception', 'negative_test'],
   },
@@ -229,6 +263,7 @@ export const frontedSpeechParagraphDsl = TEMPLATES.map((t, i) =>
       skillIds: t.skillIds,
       clusterId: t.clusterId,
       validator: t.validator,
+      explanation: t.explanation,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/hyphen-insert.js
+++ b/shared/punctuation/dsl-families/hyphen-insert.js
@@ -4,12 +4,16 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  * DSL definitions for gen_hyphen_insert family.
  */
 
+const EXPLANATION = 'The hyphen joins words into a single describing phrase so the reader knows they work together before the noun.';
+
 const TEMPLATES = [
   {
     prompt: 'Add the hyphen that avoids ambiguity.',
     stem: 'The little used path was hidden.',
     model: 'The little-used path was hidden.',
     validator: { type: 'requiresHyphenatedPhrase', phrase: 'little-used path' },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['boundary.hyphen_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
   },
@@ -18,6 +22,8 @@ const TEMPLATES = [
     stem: 'The fast moving tide covered the rocks.',
     model: 'The fast-moving tide covered the rocks.',
     validator: { type: 'requiresHyphenatedPhrase', phrase: 'fast-moving tide' },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['boundary.hyphen_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
   },
@@ -26,6 +32,8 @@ const TEMPLATES = [
     stem: 'The well known guide led us.',
     model: 'The well-known guide led us.',
     validator: { type: 'requiresHyphenatedPhrase', phrase: 'well-known guide' },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['boundary.hyphen_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
   },
@@ -34,6 +42,8 @@ const TEMPLATES = [
     stem: 'The cold blooded reptile rested.',
     model: 'The cold-blooded reptile rested.',
     validator: { type: 'requiresHyphenatedPhrase', phrase: 'cold-blooded reptile' },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['boundary.hyphen_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
   },
@@ -42,6 +52,8 @@ const TEMPLATES = [
     stem: 'The sugar free snack was popular.',
     model: 'The sugar-free snack was popular.',
     validator: { type: 'requiresHyphenatedPhrase', phrase: 'sugar-free snack' },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['boundary.hyphen_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
   },
@@ -50,6 +62,8 @@ const TEMPLATES = [
     stem: 'The ten year old pupil read aloud.',
     model: 'The ten-year-old pupil read aloud.',
     validator: { type: 'requiresHyphenatedPhrase', phrase: 'ten-year-old pupil' },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['boundary.hyphen_missing'],
     readiness: ['insertion', 'transfer', 'misconception', 'negative_test'],
   },
@@ -58,6 +72,8 @@ const TEMPLATES = [
     stem: 'The last minute change surprised us.',
     model: 'The last-minute change surprised us.',
     validator: { type: 'requiresHyphenatedPhrase', phrase: 'last-minute change' },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['boundary.hyphen_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
   },
@@ -66,6 +82,8 @@ const TEMPLATES = [
     stem: 'The short term plan worked.',
     model: 'The short-term plan worked.',
     validator: { type: 'requiresHyphenatedPhrase', phrase: 'short-term plan' },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['boundary.hyphen_missing'],
     readiness: ['proofreading', 'transfer', 'misconception', 'negative_test'],
   },
@@ -87,6 +105,7 @@ export const hyphenInsertDsl = TEMPLATES.map((t, i) =>
       stem: t.stem,
       model: t.model,
       validator: t.validator,
+      explanation: t.explanation,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/list-commas-combine.js
+++ b/shared/punctuation/dsl-families/list-commas-combine.js
@@ -6,6 +6,8 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  * Templates 4-7: capacity expansion (new for P4-U8).
  */
 
+const EXPLANATION = 'Commas separate each item in a list so they are easy to read one by one.';
+
 const TEMPLATES = [
   // ─── Legacy parity (indices 0-3) ─────────────────────────────────────────────
   {
@@ -17,6 +19,8 @@ const TEMPLATES = [
       opening: 'The tray held',
       items: ['shells', 'feathers', 'pebbles'],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.list_separator_missing', 'comma.unnecessary_final_comma'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -29,6 +33,8 @@ const TEMPLATES = [
       opening: 'We collected',
       items: ['leaves', 'twigs', 'acorns'],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.list_separator_missing', 'comma.unnecessary_final_comma'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -41,6 +47,8 @@ const TEMPLATES = [
       opening: 'The bag contained',
       items: ['chalk', 'string', 'tape'],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.list_separator_missing', 'comma.unnecessary_final_comma'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -53,6 +61,8 @@ const TEMPLATES = [
       opening: 'Our lunch included',
       items: ['apples', 'sandwiches', 'juice'],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.list_separator_missing', 'comma.unnecessary_final_comma'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -66,6 +76,8 @@ const TEMPLATES = [
       opening: 'The toolkit included',
       items: ['pliers', 'spanners', 'screws'],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.list_separator_missing', 'comma.unnecessary_final_comma'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -78,6 +90,8 @@ const TEMPLATES = [
       opening: 'We spotted',
       items: ['foxes', 'rabbits', 'deer'],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.list_separator_missing', 'comma.unnecessary_final_comma'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -90,6 +104,8 @@ const TEMPLATES = [
       opening: 'The menu offered',
       items: ['soup', 'salad', 'bread'],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.list_separator_missing', 'comma.unnecessary_final_comma'],
     readiness: ['constrained_transfer', 'transfer', 'misconception', 'negative_test'],
   },
@@ -102,6 +118,8 @@ const TEMPLATES = [
       opening: 'They planted',
       items: ['oaks', 'elms', 'birches'],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.list_separator_missing', 'comma.unnecessary_final_comma'],
     readiness: ['constrained_transfer', 'transfer', 'misconception', 'negative_test'],
   },
@@ -123,6 +141,7 @@ export const listCommasCombineDsl = TEMPLATES.map((t, i) =>
       stem: t.stem,
       model: t.model,
       validator: t.validator,
+      explanation: t.explanation,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/list-commas-insert.js
+++ b/shared/punctuation/dsl-families/list-commas-insert.js
@@ -6,6 +6,8 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  * Templates 4-7: capacity expansion (new for P4-U8).
  */
 
+const EXPLANATION = 'Commas separate each item in a list so they are easy to read one by one.';
+
 const TEMPLATES = [
   // ─── Legacy parity (indices 0-3) ─────────────────────────────────────────────
   {
@@ -16,6 +18,8 @@ const TEMPLATES = [
       type: 'requiresListCommas',
       items: ['ropes', 'maps', 'snacks'],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.list_separator_missing', 'comma.unnecessary_final_comma'],
     readiness: ['insertion', 'misconception', 'negative_test'],
   },
@@ -27,6 +31,8 @@ const TEMPLATES = [
       type: 'requiresListCommas',
       items: ['shells', 'bells', 'chalk'],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.list_separator_missing', 'comma.unnecessary_final_comma'],
     readiness: ['insertion', 'misconception', 'negative_test'],
   },
@@ -38,6 +44,8 @@ const TEMPLATES = [
       type: 'requiresListCommas',
       items: ['paints', 'brushes', 'paper'],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.list_separator_missing', 'comma.unnecessary_final_comma'],
     readiness: ['insertion', 'misconception', 'negative_test'],
   },
@@ -49,6 +57,8 @@ const TEMPLATES = [
       type: 'requiresListCommas',
       items: ['gulls', 'seals', 'dolphins'],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.list_separator_missing', 'comma.unnecessary_final_comma'],
     readiness: ['insertion', 'misconception', 'negative_test'],
   },
@@ -61,6 +71,8 @@ const TEMPLATES = [
       type: 'requiresListCommas',
       items: ['pens', 'rulers', 'notebooks'],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.list_separator_missing', 'comma.unnecessary_final_comma'],
     readiness: ['insertion', 'misconception', 'negative_test'],
   },
@@ -72,6 +84,8 @@ const TEMPLATES = [
       type: 'requiresListCommas',
       items: ['buckets', 'spades', 'nets'],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.list_separator_missing', 'comma.unnecessary_final_comma'],
     readiness: ['insertion', 'misconception', 'negative_test'],
   },
@@ -83,6 +97,8 @@ const TEMPLATES = [
       type: 'requiresListCommas',
       items: ['roses', 'daisies', 'tulips'],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.list_separator_missing', 'comma.unnecessary_final_comma'],
     readiness: ['insertion', 'transfer', 'misconception', 'negative_test'],
   },
@@ -94,6 +110,8 @@ const TEMPLATES = [
       type: 'requiresListCommas',
       items: ['coins', 'stamps', 'keys'],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['comma.list_separator_missing', 'comma.unnecessary_final_comma'],
     readiness: ['insertion', 'transfer', 'misconception', 'negative_test'],
   },
@@ -115,6 +133,7 @@ export const listCommasInsertDsl = TEMPLATES.map((t, i) =>
       stem: t.stem,
       model: t.model,
       validator: t.validator,
+      explanation: t.explanation,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/parenthesis-combine.js
+++ b/shared/punctuation/dsl-families/parenthesis-combine.js
@@ -6,6 +6,8 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  * Templates 4-7: capacity expansion (new for P4-U9).
  */
 
+const EXPLANATION = 'The extra information is set off with punctuation because it can be removed without breaking the sentence.';
+
 const TEMPLATES = [
   // ─── Legacy parity (indices 0-3) ─────────────────────────────────────────────
   {
@@ -18,6 +20,8 @@ const TEMPLATES = [
       phrase: 'an old fishing port',
       after: 'was busy',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -31,6 +35,8 @@ const TEMPLATES = [
       phrase: 'a useful lookout',
       after: 'stood above the bay',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -44,6 +50,8 @@ const TEMPLATES = [
       phrase: 'a quiet room',
       after: 'closed early',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -57,6 +65,8 @@ const TEMPLATES = [
       phrase: 'our maths teacher',
       after: 'smiled proudly',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -71,6 +81,8 @@ const TEMPLATES = [
       phrase: 'a stone crossing',
       after: 'swayed in the wind',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -84,6 +96,8 @@ const TEMPLATES = [
       phrase: 'a narrow waterway',
       after: 'ran beside the park',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -97,6 +111,8 @@ const TEMPLATES = [
       phrase: 'our head teacher',
       after: 'opened the fete',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced'],
     readiness: ['constrained_transfer', 'transfer', 'misconception', 'negative_test'],
   },
@@ -110,6 +126,8 @@ const TEMPLATES = [
       phrase: 'an ancient relic',
       after: 'chimed at noon',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced'],
     readiness: ['constrained_transfer', 'transfer', 'misconception', 'negative_test'],
   },
@@ -131,6 +149,7 @@ export const parenthesisCombineDsl = TEMPLATES.map((t, i) =>
       stem: t.stem,
       model: t.model,
       validator: t.validator,
+      explanation: t.explanation,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/parenthesis-fix.js
+++ b/shared/punctuation/dsl-families/parenthesis-fix.js
@@ -6,6 +6,8 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  * Templates 4-7: capacity expansion (new for P4-U9).
  */
 
+const EXPLANATION = 'The extra information is set off with punctuation because it can be removed without breaking the sentence.';
+
 const TEMPLATES = [
   // ─── Legacy parity (indices 0-3) ─────────────────────────────────────────────
   {
@@ -18,6 +20,8 @@ const TEMPLATES = [
       phrase: 'an old fishing port',
       after: 'was busy',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
   },
@@ -31,6 +35,8 @@ const TEMPLATES = [
       phrase: 'a useful lookout',
       after: 'stood above the bay',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
   },
@@ -44,6 +50,8 @@ const TEMPLATES = [
       phrase: 'a quiet room',
       after: 'closed early',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
   },
@@ -57,6 +65,8 @@ const TEMPLATES = [
       phrase: 'our maths teacher',
       after: 'smiled proudly',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
   },
@@ -71,6 +81,8 @@ const TEMPLATES = [
       phrase: 'a stone crossing',
       after: 'swayed in the wind',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
   },
@@ -84,6 +96,8 @@ const TEMPLATES = [
       phrase: 'a narrow waterway',
       after: 'ran beside the park',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
   },
@@ -97,6 +111,8 @@ const TEMPLATES = [
       phrase: 'our head teacher',
       after: 'opened the fete',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced'],
     readiness: ['proofreading', 'transfer', 'misconception', 'negative_test'],
   },
@@ -110,6 +126,8 @@ const TEMPLATES = [
       phrase: 'an ancient relic',
       after: 'chimed at noon',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced'],
     readiness: ['proofreading', 'transfer', 'misconception', 'negative_test'],
   },
@@ -131,6 +149,7 @@ export const parenthesisFixDsl = TEMPLATES.map((t, i) =>
       stem: t.stem,
       model: t.model,
       validator: t.validator,
+      explanation: t.explanation,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/parenthesis-speech-paragraph.js
+++ b/shared/punctuation/dsl-families/parenthesis-speech-paragraph.js
@@ -6,6 +6,8 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  * Templates 4-7: capacity expansion (new for P4-U9).
  */
 
+const EXPLANATION = 'Parenthetical commas set off removable extra detail, and inverted commas wrap spoken words with their punctuation inside.';
+
 const TEMPLATES = [
   // ─── Legacy parity (indices 0-3) ─────────────────────────────────────────────
   {
@@ -21,17 +23,21 @@ const TEMPLATES = [
           type: 'requiresParentheticalPhrase',
           before: 'The harbour',
           phrase: 'an old fishing port',
-          after: 'was busy',
+          after: 'was busy',    explanation: EXPLANATION,
+
           misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced'],
         },
         {
           type: 'speechWithWords',
           words: 'the bell is ringing',
-          requiredTerminal: '.',
+          requiredTerminal: '.',    explanation: EXPLANATION,
+
           misconceptionTags: ['speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing'],
         },
       ],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced', 'speech.quote_missing', 'speech.reporting_comma_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -48,17 +54,21 @@ const TEMPLATES = [
           type: 'requiresParentheticalPhrase',
           before: 'The tower',
           phrase: 'a useful lookout',
-          after: 'stood above the bay',
+          after: 'stood above the bay',    explanation: EXPLANATION,
+
           misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced'],
         },
         {
           type: 'speechWithWords',
           words: 'where are the boats',
-          requiredTerminal: '?',
+          requiredTerminal: '?',    explanation: EXPLANATION,
+
           misconceptionTags: ['speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing'],
         },
       ],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced', 'speech.quote_missing', 'speech.reporting_comma_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -75,17 +85,21 @@ const TEMPLATES = [
           type: 'requiresParentheticalPhrase',
           before: 'The library',
           phrase: 'a quiet room',
-          after: 'closed early',
+          after: 'closed early',    explanation: EXPLANATION,
+
           misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced'],
         },
         {
           type: 'speechWithWords',
           words: 'we can come back tomorrow',
-          requiredTerminal: '.',
+          requiredTerminal: '.',    explanation: EXPLANATION,
+
           misconceptionTags: ['speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing'],
         },
       ],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced', 'speech.quote_missing', 'speech.reporting_comma_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -102,17 +116,21 @@ const TEMPLATES = [
           type: 'requiresParentheticalPhrase',
           before: 'Mr Patel',
           phrase: 'our maths teacher',
-          after: 'smiled proudly',
+          after: 'smiled proudly',    explanation: EXPLANATION,
+
           misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced'],
         },
         {
           type: 'speechWithWords',
           words: 'did we win',
-          requiredTerminal: '?',
+          requiredTerminal: '?',    explanation: EXPLANATION,
+
           misconceptionTags: ['speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing'],
         },
       ],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced', 'speech.quote_missing', 'speech.reporting_comma_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -130,17 +148,21 @@ const TEMPLATES = [
           type: 'requiresParentheticalPhrase',
           before: 'The bridge',
           phrase: 'a stone crossing',
-          after: 'swayed in the wind',
+          after: 'swayed in the wind',    explanation: EXPLANATION,
+
           misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced'],
         },
         {
           type: 'speechWithWords',
           words: 'hold on tight',
-          requiredTerminal: '!',
+          requiredTerminal: '!',    explanation: EXPLANATION,
+
           misconceptionTags: ['speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing'],
         },
       ],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced', 'speech.quote_missing', 'speech.reporting_comma_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -157,17 +179,21 @@ const TEMPLATES = [
           type: 'requiresParentheticalPhrase',
           before: 'The canal',
           phrase: 'a narrow waterway',
-          after: 'ran beside the park',
+          after: 'ran beside the park',    explanation: EXPLANATION,
+
           misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced'],
         },
         {
           type: 'speechWithWords',
           words: 'the ducks are nesting',
-          requiredTerminal: '.',
+          requiredTerminal: '.',    explanation: EXPLANATION,
+
           misconceptionTags: ['speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing'],
         },
       ],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced', 'speech.quote_missing', 'speech.reporting_comma_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -184,17 +210,21 @@ const TEMPLATES = [
           type: 'requiresParentheticalPhrase',
           before: 'Mrs Khan',
           phrase: 'our head teacher',
-          after: 'opened the fete',
+          after: 'opened the fete',    explanation: EXPLANATION,
+
           misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced'],
         },
         {
           type: 'speechWithWords',
           words: 'can we have another go',
-          requiredTerminal: '?',
+          requiredTerminal: '?',    explanation: EXPLANATION,
+
           misconceptionTags: ['speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing'],
         },
       ],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced', 'speech.quote_missing', 'speech.reporting_comma_missing'],
     readiness: ['constrained_transfer', 'transfer', 'misconception', 'negative_test'],
   },
@@ -211,17 +241,21 @@ const TEMPLATES = [
           type: 'requiresParentheticalPhrase',
           before: 'The clock',
           phrase: 'an ancient relic',
-          after: 'chimed at noon',
+          after: 'chimed at noon',    explanation: EXPLANATION,
+
           misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced'],
         },
         {
           type: 'speechWithWords',
           words: 'it still works',
-          requiredTerminal: '.',
+          requiredTerminal: '.',    explanation: EXPLANATION,
+
           misconceptionTags: ['speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing'],
         },
       ],
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced', 'speech.quote_missing', 'speech.reporting_comma_missing'],
     readiness: ['constrained_transfer', 'transfer', 'misconception', 'negative_test'],
   },
@@ -245,6 +279,7 @@ export const parenthesisSpeechParagraphDsl = TEMPLATES.map((t, i) =>
       skillIds: t.skillIds,
       clusterId: t.clusterId,
       validator: t.validator,
+      explanation: t.explanation,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/semicolon-combine.js
+++ b/shared/punctuation/dsl-families/semicolon-combine.js
@@ -6,6 +6,8 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  * Templates 4-7: capacity expansion (new for P4-U10).
  */
 
+const EXPLANATION = 'A semicolon joins two complete sentences that are closely related in meaning.';
+
 const TEMPLATES = [
   // ─── Legacy parity (indices 0-3) ─────────────────────────────────────────────
   {
@@ -18,6 +20,8 @@ const TEMPLATES = [
       right: 'the boats still waited',
       mark: ';',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['boundary.comma_splice', 'boundary.semicolon_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -31,6 +35,8 @@ const TEMPLATES = [
       right: 'the match could continue',
       mark: ';',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['boundary.comma_splice', 'boundary.semicolon_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -44,6 +50,8 @@ const TEMPLATES = [
       right: 'the class kept working',
       mark: ';',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['boundary.comma_splice', 'boundary.semicolon_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -57,6 +65,8 @@ const TEMPLATES = [
       right: 'the hikers walked slowly',
       mark: ';',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['boundary.comma_splice', 'boundary.semicolon_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -71,6 +81,8 @@ const TEMPLATES = [
       right: 'the shutters rattled loudly',
       mark: ';',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['boundary.comma_splice', 'boundary.semicolon_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -84,6 +96,8 @@ const TEMPLATES = [
       right: 'the bats emerged from the cave',
       mark: ';',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['boundary.comma_splice', 'boundary.semicolon_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
   },
@@ -97,6 +111,8 @@ const TEMPLATES = [
       right: 'the villagers moved to higher ground',
       mark: ';',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['boundary.comma_splice', 'boundary.semicolon_missing'],
     readiness: ['constrained_transfer', 'transfer', 'misconception', 'negative_test'],
   },
@@ -110,6 +126,8 @@ const TEMPLATES = [
       right: 'the children lined up quietly',
       mark: ';',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['boundary.comma_splice', 'boundary.semicolon_missing'],
     readiness: ['constrained_transfer', 'transfer', 'misconception', 'negative_test'],
   },
@@ -131,6 +149,7 @@ export const semicolonCombineDsl = TEMPLATES.map((t, i) =>
       stem: t.stem,
       model: t.model,
       validator: t.validator,
+      explanation: t.explanation,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/semicolon-fix.js
+++ b/shared/punctuation/dsl-families/semicolon-fix.js
@@ -6,6 +6,8 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  * Templates 4-7: capacity expansion (new for P4-U10).
  */
 
+const EXPLANATION = 'A semicolon joins two complete sentences that are closely related in meaning.';
+
 const TEMPLATES = [
   // ─── Legacy parity (indices 0-3) ─────────────────────────────────────────────
   {
@@ -18,6 +20,8 @@ const TEMPLATES = [
       right: 'the boats still waited',
       mark: ';',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['boundary.comma_splice', 'boundary.semicolon_missing'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
   },
@@ -31,6 +35,8 @@ const TEMPLATES = [
       right: 'the match could continue',
       mark: ';',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['boundary.comma_splice', 'boundary.semicolon_missing'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
   },
@@ -44,6 +50,8 @@ const TEMPLATES = [
       right: 'the class kept working',
       mark: ';',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['boundary.comma_splice', 'boundary.semicolon_missing'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
   },
@@ -57,6 +65,8 @@ const TEMPLATES = [
       right: 'the hikers walked slowly',
       mark: ';',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['boundary.comma_splice', 'boundary.semicolon_missing'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
   },
@@ -71,6 +81,8 @@ const TEMPLATES = [
       right: 'the shutters rattled loudly',
       mark: ';',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['boundary.comma_splice', 'boundary.semicolon_missing'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
   },
@@ -84,6 +96,8 @@ const TEMPLATES = [
       right: 'the bats emerged from the cave',
       mark: ';',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['boundary.comma_splice', 'boundary.semicolon_missing'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
   },
@@ -97,6 +111,8 @@ const TEMPLATES = [
       right: 'the villagers moved to higher ground',
       mark: ';',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['boundary.comma_splice', 'boundary.semicolon_missing'],
     readiness: ['proofreading', 'transfer', 'misconception', 'negative_test'],
   },
@@ -110,6 +126,8 @@ const TEMPLATES = [
       right: 'the children lined up quietly',
       mark: ';',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['boundary.comma_splice', 'boundary.semicolon_missing'],
     readiness: ['proofreading', 'transfer', 'misconception', 'negative_test'],
   },
@@ -131,6 +149,7 @@ export const semicolonFixDsl = TEMPLATES.map((t, i) =>
       stem: t.stem,
       model: t.model,
       validator: t.validator,
+      explanation: t.explanation,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/semicolon-list-fix.js
+++ b/shared/punctuation/dsl-families/semicolon-list-fix.js
@@ -4,12 +4,16 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  * DSL definitions for gen_semicolon_list_fix family.
  */
 
+const EXPLANATION = 'Semicolons separate complex list items that already contain commas, keeping each group clear.';
+
 const TEMPLATES = [
   {
     prompt: 'Use semi-colons to separate the complex list items.',
     stem: 'We visited Dover, England, Lyon, France and Porto, Portugal.',
     model: 'We visited Dover, England; Lyon, France; and Porto, Portugal.',
     validator: { type: 'requiresSemicolonList', items: ['Dover, England', 'Lyon, France', 'Porto, Portugal'] },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.semicolon_list_missing'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
   },
@@ -18,6 +22,8 @@ const TEMPLATES = [
     stem: 'The winners were Aria, Year 5, Noah, Year 6 and Sam, Year 4.',
     model: 'The winners were Aria, Year 5; Noah, Year 6; and Sam, Year 4.',
     validator: { type: 'requiresSemicolonList', items: ['Aria, Year 5', 'Noah, Year 6', 'Sam, Year 4'] },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.semicolon_list_missing'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
   },
@@ -26,6 +32,8 @@ const TEMPLATES = [
     stem: 'The stalls sold apples, Kent, pears, Devon and berries, Wales.',
     model: 'The stalls sold apples, Kent; pears, Devon; and berries, Wales.',
     validator: { type: 'requiresSemicolonList', items: ['apples, Kent', 'pears, Devon', 'berries, Wales'] },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.semicolon_list_missing'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
   },
@@ -34,6 +42,8 @@ const TEMPLATES = [
     stem: 'The clubs met in Leeds, Monday, York, Tuesday and Bath, Friday.',
     model: 'The clubs met in Leeds, Monday; York, Tuesday; and Bath, Friday.',
     validator: { type: 'requiresSemicolonList', items: ['Leeds, Monday', 'York, Tuesday', 'Bath, Friday'] },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.semicolon_list_missing'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
   },
@@ -42,6 +52,8 @@ const TEMPLATES = [
     stem: 'The survey covered Cardiff, Wales, Belfast, Northern Ireland and Truro, Cornwall.',
     model: 'The survey covered Cardiff, Wales; Belfast, Northern Ireland; and Truro, Cornwall.',
     validator: { type: 'requiresSemicolonList', items: ['Cardiff, Wales', 'Belfast, Northern Ireland', 'Truro, Cornwall'] },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.semicolon_list_missing'],
     readiness: ['proofreading', 'transfer', 'misconception', 'negative_test'],
   },
@@ -50,6 +62,8 @@ const TEMPLATES = [
     stem: 'The teams were Falcons, Year 5, Otters, Year 6 and Kites, Year 4.',
     model: 'The teams were Falcons, Year 5; Otters, Year 6; and Kites, Year 4.',
     validator: { type: 'requiresSemicolonList', items: ['Falcons, Year 5', 'Otters, Year 6', 'Kites, Year 4'] },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.semicolon_list_missing'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
   },
@@ -58,6 +72,8 @@ const TEMPLATES = [
     stem: 'The boxes contained shells, blue, pebbles, grey and glass, green.',
     model: 'The boxes contained shells, blue; pebbles, grey; and glass, green.',
     validator: { type: 'requiresSemicolonList', items: ['shells, blue', 'pebbles, grey', 'glass, green'] },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.semicolon_list_missing'],
     readiness: ['proofreading', 'transfer', 'misconception', 'negative_test'],
   },
@@ -66,6 +82,8 @@ const TEMPLATES = [
     stem: 'The route stopped at Exeter, station one, Bristol, station two and Reading, station three.',
     model: 'The route stopped at Exeter, station one; Bristol, station two; and Reading, station three.',
     validator: { type: 'requiresSemicolonList', items: ['Exeter, station one', 'Bristol, station two', 'Reading, station three'] },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['structure.semicolon_list_missing'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
   },
@@ -87,6 +105,7 @@ export const semicolonListFixDsl = TEMPLATES.map((t, i) =>
       stem: t.stem,
       model: t.model,
       validator: t.validator,
+      explanation: t.explanation,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/sentence-endings-insert.js
+++ b/shared/punctuation/dsl-families/sentence-endings-insert.js
@@ -5,60 +5,70 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  * Each variant slot maps 1:1 to an existing hand-authored template.
  */
 
+const EXPLANATION = 'Every sentence needs a capital letter at the start and the correct end mark to show whether it is a statement, question, or exclamation.';
+
 const TEMPLATES = [
   {
     prompt: 'Add the capital letter and end punctuation.',
     stem: 'where is the tide bell',
-    model: 'Where is the tide bell?',
+    model: 'Where is the tide bell?',    explanation: EXPLANATION,
+
     misconceptionTags: ['endmarks.question_mark_missing', 'endmarks.capitalisation_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
   },
   {
     prompt: 'Add the capital letter and end punctuation.',
     stem: 'what a bright signal',
-    model: 'What a bright signal!',
+    model: 'What a bright signal!',    explanation: EXPLANATION,
+
     misconceptionTags: ['endmarks.exclamation_mark_missing', 'endmarks.capitalisation_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
   },
   {
     prompt: 'Add the capital letter and end punctuation.',
     stem: 'did the crew check the lanterns',
-    model: 'Did the crew check the lanterns?',
+    model: 'Did the crew check the lanterns?',    explanation: EXPLANATION,
+
     misconceptionTags: ['endmarks.question_mark_missing', 'endmarks.capitalisation_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
   },
   {
     prompt: 'Add the capital letter and end punctuation.',
     stem: 'how quickly the fog cleared',
-    model: 'How quickly the fog cleared!',
+    model: 'How quickly the fog cleared!',    explanation: EXPLANATION,
+
     misconceptionTags: ['endmarks.exclamation_mark_missing', 'endmarks.capitalisation_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
   },
   {
     prompt: 'Rewrite this as a correctly punctuated question.',
     stem: 'can the rescue team hear us',
-    model: 'Can the rescue team hear us?',
+    model: 'Can the rescue team hear us?',    explanation: EXPLANATION,
+
     misconceptionTags: ['endmarks.question_mark_missing', 'endmarks.capitalisation_missing'],
     readiness: ['insertion', 'transfer', 'misconception', 'negative_test'],
   },
   {
     prompt: 'Rewrite the excited sentence with its capital letter and end mark.',
     stem: 'what an amazing view',
-    model: 'What an amazing view!',
+    model: 'What an amazing view!',    explanation: EXPLANATION,
+
     misconceptionTags: ['endmarks.exclamation_mark_missing', 'endmarks.capitalisation_missing'],
     readiness: ['insertion', 'transfer', 'misconception', 'negative_test'],
   },
   {
     prompt: 'Correct the sentence ending and capital letter.',
     stem: 'the lights went out',
-    model: 'The lights went out.',
+    model: 'The lights went out.',    explanation: EXPLANATION,
+
     misconceptionTags: ['endmarks.terminal_missing', 'endmarks.capitalisation_missing'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
   },
   {
     prompt: 'Add the capital letter and the calm command ending.',
     stem: 'please close the safety gate',
-    model: 'Please close the safety gate.',
+    model: 'Please close the safety gate.',    explanation: EXPLANATION,
+
     misconceptionTags: ['endmarks.terminal_missing', 'endmarks.capitalisation_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
   },
@@ -79,6 +89,7 @@ export const sentenceEndingsInsertDsl = TEMPLATES.map((t, i) =>
       prompt: t.prompt,
       stem: t.stem,
       model: t.model,
+      explanation: t.explanation,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/speech-insert.js
+++ b/shared/punctuation/dsl-families/speech-insert.js
@@ -6,6 +6,8 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  * Templates 4-7: capacity expansion (new for P4-U8).
  */
 
+const EXPLANATION = 'Inverted commas wrap the spoken words, and the end punctuation stays inside the closing speech mark.';
+
 const TEMPLATES = [
   // ─── Legacy parity (indices 0-3) ─────────────────────────────────────────────
   {
@@ -18,6 +20,8 @@ const TEMPLATES = [
       spokenWords: 'can we start now',
       requiredTerminal: '?',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
   },
@@ -31,6 +35,8 @@ const TEMPLATES = [
       spokenWords: 'the bell is ringing',
       requiredTerminal: '.',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
   },
@@ -44,6 +50,8 @@ const TEMPLATES = [
       spokenWords: 'keep the gate closed',
       requiredTerminal: '.',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
   },
@@ -57,6 +65,8 @@ const TEMPLATES = [
       spokenWords: 'where did the map go',
       requiredTerminal: '?',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
   },
@@ -71,6 +81,8 @@ const TEMPLATES = [
       spokenWords: 'watch out for the wave',
       requiredTerminal: '!',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
   },
@@ -84,6 +96,8 @@ const TEMPLATES = [
       spokenWords: 'the path is clear',
       requiredTerminal: '.',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
   },
@@ -97,6 +111,8 @@ const TEMPLATES = [
       spokenWords: 'is the door locked',
       requiredTerminal: '?',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing'],
     readiness: ['insertion', 'transfer', 'misconception', 'negative_test'],
   },
@@ -110,6 +126,8 @@ const TEMPLATES = [
       spokenWords: 'stay behind the line',
       requiredTerminal: '.',
     },
+    explanation: EXPLANATION,
+
     misconceptionTags: ['speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing'],
     readiness: ['insertion', 'transfer', 'misconception', 'negative_test'],
   },
@@ -131,6 +149,7 @@ export const speechInsertDsl = TEMPLATES.map((t, i) =>
       stem: t.stem,
       model: t.model,
       rubric: t.rubric,
+      explanation: t.explanation,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/generators.js
+++ b/shared/punctuation/generators.js
@@ -68,6 +68,20 @@ function stableJson(value) {
     .map((key) => [key, stableJson(value[key])]));
 }
 
+/**
+ * Strip `explanation` keys from a validator structure before hashing.
+ * Explanation is a P6 learner-feedback addition that must not alter template identity.
+ */
+function stripExplanationForHash(value) {
+  if (Array.isArray(value)) return value.map(stripExplanationForHash);
+  if (!isPlainObject(value)) return value;
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(([key]) => key !== 'explanation')
+      .map(([key, v]) => [key, stripExplanationForHash(v)]),
+  );
+}
+
 function templateIdFor(familyId, template) {
   const explicit = typeof template?.templateId === 'string' ? template.templateId.trim() : '';
   if (explicit) return explicit;
@@ -80,7 +94,7 @@ function templateIdFor(familyId, template) {
       : [],
     skillIds: uniqueStrings(template.skillIds).sort(),
     clusterId: template.clusterId || '',
-    validator: stableJson(template.validator || {}),
+    validator: stableJson(stripExplanationForHash(template.validator || {})),
     rubric: stableJson(template.rubric || {}),
   };
   return `${familyId}_template_${shortHash(JSON.stringify(stableJson(payload)))}`;

--- a/tests/punctuation-dsl-conversion-parity.test.js
+++ b/tests/punctuation-dsl-conversion-parity.test.js
@@ -14,6 +14,24 @@ import {
 } from '../shared/punctuation/content.js';
 import { markPunctuationAnswer } from '../shared/punctuation/marking.js';
 
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Strip `explanation` keys from a validator structure for baseline comparison.
+ * Explanation is a P6 intentional addition that does not exist in frozen P4 baselines.
+ */
+function stripExplanation(value) {
+  if (Array.isArray(value)) return value.map(stripExplanation);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value)
+        .filter(([key]) => key !== 'explanation')
+        .map(([key, v]) => [key, stripExplanation(v)]),
+    );
+  }
+  return value;
+}
+
 // ─── Fixture loading ──────────────────────────────────────────────────────────
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -312,7 +330,7 @@ test('depth 4 output matches P4 baseline for 18 DSL-converted families', () => {
         stem: i.stem,
         model: i.model,
         validatorType: i.validator?.type || null,
-        validator: i.validator || null,
+        validator: stripExplanation(i.validator) || null,
         rubric: i.rubric || null,
         misconceptionTags: i.misconceptionTags,
         readiness: i.readiness,

--- a/tests/punctuation-explanation-specificity.test.js
+++ b/tests/punctuation-explanation-specificity.test.js
@@ -1,0 +1,130 @@
+/**
+ * Explanation specificity tests for punctuation DSL templates.
+ *
+ * Ensures every generated item carries a rule-specific explanation rather than
+ * the generic fallback, and that explanations are child-readable without
+ * internal identifiers leaking through.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createPunctuationGeneratedItems } from '../shared/punctuation/generators.js';
+
+const GENERIC_FALLBACK = 'This generated item practises the same published punctuation skill.';
+
+// Internal identifier patterns that must never appear in child-facing explanations
+const INTERNAL_PATTERNS = [
+  /dsl_/i,
+  /gen_/i,
+  /v\d+$/,
+  /familyId/i,
+  /templateId/i,
+  /validator/i,
+  /misconceptionTag/i,
+  /clusterId/i,
+  /rewardUnitId/i,
+  /requiresTokens/i,
+  /requiresBoundary/i,
+  /requiresParenthetical/i,
+  /requiresColonBeforeList/i,
+  /requiresHyphenatedPhrase/i,
+  /requiresBulletStemAndItems/i,
+  /requiresApostropheForms/i,
+  /startsWithPhraseComma/i,
+  /combineColonList/i,
+  /combineBoundaryBetweenClauses/i,
+  /combineFrontedAdverbial/i,
+  /combineParentheticalPhrase/i,
+  /combineListSentence/i,
+  /paragraphRepair/i,
+  /speechWithWords/i,
+  /requiresSemicolonList/i,
+  /requiresListCommas/i,
+];
+
+/** Generate items at a given depth and return them. */
+function generateAtDepth(depth) {
+  return createPunctuationGeneratedItems({ depth });
+}
+
+test('explanation specificity: no item uses the generic fallback at depth 4', () => {
+  const items = generateAtDepth(4);
+  assert.ok(items.length > 0, 'depth 4 must produce items');
+  for (const item of items) {
+    assert.notStrictEqual(
+      item.explanation,
+      GENERIC_FALLBACK,
+      `Item ${item.id} (family: ${item.generatorFamilyId}) still has the generic fallback explanation`,
+    );
+  }
+});
+
+test('explanation specificity: no item uses the generic fallback at depth 6', () => {
+  const items = generateAtDepth(6);
+  assert.ok(items.length > 0, 'depth 6 must produce items');
+  for (const item of items) {
+    assert.notStrictEqual(
+      item.explanation,
+      GENERIC_FALLBACK,
+      `Item ${item.id} (family: ${item.generatorFamilyId}) still has the generic fallback explanation`,
+    );
+  }
+});
+
+test('explanation specificity: no item uses the generic fallback at depth 8', () => {
+  const items = generateAtDepth(8);
+  assert.ok(items.length > 0, 'depth 8 must produce items');
+  for (const item of items) {
+    assert.notStrictEqual(
+      item.explanation,
+      GENERIC_FALLBACK,
+      `Item ${item.id} (family: ${item.generatorFamilyId}) still has the generic fallback explanation`,
+    );
+  }
+});
+
+test('explanation length: all explanations are between 10 and 150 characters', () => {
+  const items = generateAtDepth(8);
+  for (const item of items) {
+    const len = item.explanation.length;
+    assert.ok(
+      len >= 10 && len <= 150,
+      `Item ${item.id} explanation length ${len} is outside 10-150 range: "${item.explanation}"`,
+    );
+  }
+});
+
+test('explanation content: no internal IDs or validator names leak into explanations', () => {
+  const items = generateAtDepth(8);
+  for (const item of items) {
+    for (const pattern of INTERNAL_PATTERNS) {
+      assert.ok(
+        !pattern.test(item.explanation),
+        `Item ${item.id} explanation matches forbidden pattern ${pattern}: "${item.explanation}"`,
+      );
+    }
+  }
+});
+
+test('explanation coverage: every generator family produces a specific explanation', () => {
+  const items = generateAtDepth(8);
+  const familyExplanations = new Map();
+  for (const item of items) {
+    if (!familyExplanations.has(item.generatorFamilyId)) {
+      familyExplanations.set(item.generatorFamilyId, new Set());
+    }
+    familyExplanations.get(item.generatorFamilyId).add(item.explanation);
+  }
+  for (const [familyId, explanations] of familyExplanations) {
+    assert.ok(
+      !explanations.has(GENERIC_FALLBACK),
+      `Family ${familyId} still contains the generic fallback explanation`,
+    );
+    for (const exp of explanations) {
+      assert.ok(
+        exp.length >= 10,
+        `Family ${familyId} has a too-short explanation: "${exp}"`,
+      );
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- Adds a child-readable `explanation` field to every template in all 25 DSL family files, replacing the generic fallback
- Each explanation describes WHY the punctuation rule works (e.g. "A comma separates the opening adverbial phrase from the main clause so the reader knows where the main idea begins")
- Adds `tests/punctuation-explanation-specificity.test.js` with 6 assertions: no fallback at depths 4/6/8, length bounds 10-150 chars, no internal IDs leaked

## Test plan
- [x] `node --test tests/punctuation-explanation-specificity.test.js` — 6/6 pass
- [x] `node --test tests/punctuation-golden-marking.test.js` — 3/3 pass (no regression)
- [x] `node --test tests/punctuation-star-projection.test.js` — 81/81 pass (no regression)