### PR TITLE
refactor(punctuation): sweep dead CSS + consolidate hero rules + reclaim bundle bytes (U7)

### DIFF
--- a/src/subjects/punctuation/components/PunctuationMapScene.jsx
+++ b/src/subjects/punctuation/components/PunctuationMapScene.jsx
@@ -376,7 +376,7 @@ export function PunctuationMapScene({ ui, actions }) {
           (`.hero-backdrop` paints at `position: absolute; inset: 0`), while
           `.punctuation-map-hero-content` sits above via `z-index: 1`. URL
           is the phase-stable `bellstormSceneForPhase('map').src`. */}
-      <section className="punctuation-map-hero" style={{ position: 'relative' }}>
+      <section className="punctuation-map-hero">
         <HeroBackdrop url={scene.src} extraBackdropClassName="punctuation-hero-backdrop" />
         <div className="punctuation-map-hero-content">
           <div className="eyebrow">{PUNCTUATION_DASHBOARD_HERO.eyebrow}</div>

--- a/src/subjects/punctuation/components/PunctuationSummaryScene.jsx
+++ b/src/subjects/punctuation/components/PunctuationSummaryScene.jsx
@@ -694,7 +694,7 @@ export function PunctuationSummaryScene({
           (`.hero-backdrop` is `position: absolute; inset: 0`), while
           `.punctuation-summary-hero-content` sits above via `z-index: 1`. URL
           is the phase-stable `bellstormSceneForPhase('summary').src`. */}
-      <section className="punctuation-summary-hero" style={{ position: 'relative' }}>
+      <section className="punctuation-summary-hero">
         <HeroBackdrop url={scene.src} extraBackdropClassName="punctuation-hero-backdrop" />
         <div className="punctuation-summary-hero-content">
           <div className="eyebrow">Summary</div>

--- a/styles/app.css
+++ b/styles/app.css
@@ -1135,39 +1135,6 @@ textarea:focus-visible {
   overflow: hidden;
 }
 
-.punctuation-hero,
-.punctuation-strip {
-  display: grid;
-  align-items: center;
-  gap: 18px;
-}
-
-.punctuation-hero {
-  grid-template-columns: minmax(220px, 0.95fr) minmax(0, 1.05fr);
-}
-
-.punctuation-strip {
-  grid-template-columns: 168px minmax(0, 1fr);
-}
-
-.punctuation-hero img,
-.punctuation-strip img {
-  display: block;
-  width: 100%;
-  object-fit: cover;
-  border: 1px solid var(--line);
-  border-radius: var(--radius);
-  background: var(--panel-soft);
-}
-
-.punctuation-hero img {
-  aspect-ratio: 16 / 9;
-}
-
-.punctuation-strip img {
-  aspect-ratio: 4 / 3;
-}
-
 .choice-list {
   display: grid;
   gap: 10px;
@@ -1204,16 +1171,6 @@ textarea:focus-visible {
   overflow-wrap: anywhere;
 }
 
-@media (max-width: 760px) {
-  .punctuation-hero,
-  .punctuation-strip {
-    grid-template-columns: 1fr;
-  }
-
-  .punctuation-strip img {
-    aspect-ratio: 16 / 9;
-  }
-}
 .summary-grid { display: grid; gap: 16px; }
 .summary-hero {
   text-align: center;
@@ -10521,99 +10478,43 @@ html { scroll-behavior: smooth; }
   box-shadow: 0 0 0 3px color-mix(in oklab, #B8873F 18%, transparent);
 }
 
-/* --- Legacy hero chrome (dead selectors — kept one release cycle) ------- */
-/* The pre-U4 Punctuation Setup painted its hero via a static `<img
-   srcSet>` inside `.punctuation-dashboard-hero`. U4 moves backdrop
-   painting to the platform `HeroBackdrop` (which uses
-   `background-image` on `.punctuation-hero-backdrop`). The rules below
-   are retained for one release cycle so any external stylesheet /
-   admin-tool selector that targeted the old class does not break
-   mid-rollout. Follow-up PR removes them once Playwright locators
-   and the Admin Debug Bundle have caught up. */
+/* --- U5/U6/U7 (refactor ui-consolidation): Punctuation scene hero chrome */
+/* The three Punctuation scene hero wrappers (`.punctuation-session-hero`,
+   `-summary-hero`, `-map-hero`) are positioning ancestors for the platform
+   `HeroBackdrop`, which paints via `position: absolute; inset: 0`. Without a
+   `position: relative` wrapper the backdrop would escape to the page root.
+   `overflow: hidden` clips the slow pan animation to the card frame;
+   `border-radius: inherit` keeps the painted region inside the rounded card
+   corners (matches `.setup-main` behaviour at app.css:4604-4607).
 
-/* Hero: Bellstorm backdrop + headline + primary CTA */
-.punctuation-dashboard-hero {
-  display: grid;
-  grid-template-columns: minmax(220px, 0.95fr) minmax(0, 1.05fr);
-  align-items: center;
-  gap: 18px;
-}
-.punctuation-dashboard-hero img {
-  display: block;
-  width: 100%;
-  aspect-ratio: 16 / 9;
-  object-fit: cover;
-  border: 1px solid var(--line);
-  border-radius: var(--radius);
-  background: var(--panel-soft);
-}
-.punctuation-dashboard-hero-content {
-  display: grid;
-  gap: 10px;
-}
-.punctuation-dashboard-cta-row {
-  margin-top: 8px;
-}
-@media (max-width: 760px) {
-  .punctuation-dashboard-hero {
-    grid-template-columns: 1fr;
-  }
-}
+   Their `-content` children sit above the absolute-positioned backdrop via
+   `z-index: 1` so the eyebrow / section-title / subtitle render on top, not
+   behind, the painted artwork. The explicit `position: relative` establishes
+   a stacking context that z-index can act on.
 
-/* --- U5 (refactor ui-consolidation): Session-scene hero chrome --------- */
-/* `.punctuation-session-hero` is the positioning ancestor for the
-   platform `HeroBackdrop` which paints via `position: absolute; inset: 0`
-   (app.css:5526-5532). Without a `position: relative` wrapper the backdrop
-   would escape to the page root. `overflow: hidden` clips the slow pan
-   animation to the card frame; `border-radius: inherit` keeps the painted
-   region inside the rounded card corners (matches `.setup-main` behaviour
-   at app.css:4604-4607).
-
-   `.punctuation-session-hero-content` sits above the absolute-positioned
-   backdrop via `z-index: 1` so the eyebrow / section-title / subtitle
-   render on top, not behind, the painted artwork. The explicit
-   `position: relative` establishes a stacking context that z-index can
-   act on. */
-.punctuation-session-hero {
-  position: relative;
-  overflow: hidden;
-  border-radius: inherit;
-  min-height: 160px;
-}
-.punctuation-session-hero-content {
-  position: relative;
-  z-index: 1;
-  padding: 18px 20px;
-  display: grid;
-  gap: 6px;
-}
-
-/* --- U6 (refactor ui-consolidation): Summary + Map scene hero chrome --- */
-/* `.punctuation-summary-hero` and `.punctuation-map-hero` are positioning
-   ancestors for the platform `HeroBackdrop` (paints via
-   `position: absolute; inset: 0`). `overflow: hidden` clips the slow pan
-   animation to the card frame; `border-radius: inherit` keeps the painted
-   region inside the rounded card corners. Their `-content` children sit
-   above the absolute-positioned backdrop via `z-index: 1`. Same idiom as
-   `.punctuation-session-hero` / `-content` above — duplication is
-   intentional for clarity; a U7 sweep may consolidate. */
-.punctuation-summary-hero {
-  position: relative;
-  overflow: hidden;
-  border-radius: inherit;
-}
-.punctuation-summary-hero-content {
-  position: relative;
-  z-index: 1;
-}
+   The Session hero additionally carries a `min-height: 160px` floor and
+   inner padding/grid on its content wrapper — those are applied as a
+   scene-specific extension below the shared rules. */
+.punctuation-session-hero,
+.punctuation-summary-hero,
 .punctuation-map-hero {
   position: relative;
   overflow: hidden;
   border-radius: inherit;
 }
+.punctuation-session-hero-content,
+.punctuation-summary-hero-content,
 .punctuation-map-hero-content {
   position: relative;
   z-index: 1;
+}
+.punctuation-session-hero {
+  min-height: 160px;
+}
+.punctuation-session-hero-content {
+  padding: 18px 20px;
+  display: grid;
+  gap: 6px;
 }
 
 /* Progress row — compact stats strip */

--- a/tests/playwright/shared.mjs
+++ b/tests/playwright/shared.mjs
@@ -64,22 +64,13 @@ const SCREENSHOT_DETERMINISM_CSS = `
 .spelling-hero-backdrop .spelling-hero-layer,
 .grammar-hero picture,
 .grammar-hero > img,
-.punctuation-hero img,
-.punctuation-strip img,
-/* U5 (refactor ui-consolidation) extension — the Punctuation Session
-   scene now paints via platform HeroBackdrop. The legacy `.punctuation-
-   strip img` rule above stays as harmless coverage; the new rule hides
-   the `background-image` paints on HeroBackdrop layers so deterministic
-   screenshot diffs do not see per-phase bellstorm variance. Matches both
-   the Session scene's scoped wrapper (`.punctuation-session-hero`) and
-   the Setup scene's one (`.punctuation-hero-backdrop` — already in place
-   from U4) so both surfaces stay deterministic. */
+/* U5/U6/U7 (refactor ui-consolidation) — the three Punctuation scenes
+   (Setup, Session, Summary, Map) all paint via the platform HeroBackdrop.
+   Hiding the `background-image` paints on HeroBackdrop layers so
+   deterministic screenshot diffs do not see per-phase bellstorm variance.
+   The `data-hero-layer="true"` anchors match every adopter wrapper. */
 .punctuation-hero-backdrop [data-hero-layer="true"],
 .punctuation-session-hero [data-hero-layer="true"],
-/* U6 (refactor ui-consolidation) extension — Summary + Map scenes also paint
-   via platform HeroBackdrop. Belt-and-braces coverage on top of the
-   `.punctuation-hero-backdrop [data-hero-layer="true"]` rule above so any
-   future stylesheet change that repositions the layer still stays pinned. */
 .punctuation-summary-hero [data-hero-layer="true"],
 .punctuation-map-hero [data-hero-layer="true"],
 .monster-celebration-overlay,
@@ -368,24 +359,16 @@ export function defaultMasks(page) {
     // the DOM — removing the phantom selectors so the default-mask
     // audit (NIT-2) shows every entry resolves to ≥1 element.
     page.locator('[data-punctuation-session-source]'),
-    // U5 (refactor ui-consolidation): the Session scene header moved
-    // from `.punctuation-strip .section-title` to
-    // `.punctuation-session-hero-content .section-title` when the scene
-    // adopted the platform `HeroBackdrop`. The legacy selector stays as
-    // belt-and-braces so baselines captured against pre-U5 DOM remain
-    // masked during rollout; the new anchor is authoritative going
-    // forward.
+    // U5/U6 (refactor ui-consolidation): the Session / Summary / Map scene
+    // headers moved from the legacy `.punctuation-strip .section-title` /
+    // `.punctuation-hero .section-title` anchors onto the scene-specific
+    // `.punctuation-{session,summary,map}-hero-content .section-title`
+    // wrappers when each adopted the platform `HeroBackdrop`. U7 drops the
+    // legacy belt-and-braces entries now that no production JSX renders
+    // those class names.
     page.locator('.punctuation-session-hero-content .section-title'),
-    page.locator('.punctuation-strip .section-title'),
-    // U6 (refactor ui-consolidation): the Summary scene header moved from
-    // `.punctuation-strip .section-title` to
-    // `.punctuation-summary-hero-content .section-title`, and the Map scene
-    // header moved from `.punctuation-hero .section-title` to
-    // `.punctuation-map-hero-content .section-title`, when each adopted the
-    // platform `HeroBackdrop`. Legacy selectors stay as belt-and-braces.
     page.locator('.punctuation-summary-hero-content .section-title'),
     page.locator('.punctuation-map-hero-content .section-title'),
-    page.locator('.punctuation-hero .section-title'),
   ];
 }
 

--- a/tests/playwright/visual-baselines.playwright.test.mjs
+++ b/tests/playwright/visual-baselines.playwright.test.mjs
@@ -261,20 +261,16 @@ async function injectFixedPromptContent(page) {
       '.prompt-sentence',
       '.cloze',
       '.grammar-prompt',
-      // U5 (refactor ui-consolidation): the Session-scene prompt moved
-      // from `.punctuation-strip .section-title` to
-      // `.punctuation-session-hero-content .section-title` when the
-      // scene adopted the platform `HeroBackdrop`. Both selectors are
-      // kept so this helper still stabilises text content on pre-U5
-      // baselines AND post-U5 DOM.
+      // U5/U6/U7 (refactor ui-consolidation): the Session / Summary / Map
+      // scene prompts now render inside the platform HeroBackdrop-adopting
+      // wrappers `.punctuation-{session,summary,map}-hero-content`. The
+      // legacy `.punctuation-strip .section-title` /
+      // `.punctuation-hero .section-title` belt-and-braces entries were
+      // dropped in U7 because no production JSX still renders those class
+      // names.
       '.punctuation-session-hero-content .section-title',
-      '.punctuation-strip .section-title',
-      // U6 (refactor ui-consolidation): Summary + Map scenes also carry
-      // platform HeroBackdrop wrappers; mirror the U5 selector additions
-      // so baseline capture still stabilises text across all three scenes.
       '.punctuation-summary-hero-content .section-title',
       '.punctuation-map-hero-content .section-title',
-      '.punctuation-hero .section-title',
       '[data-punctuation-session-source]',
     ];
     for (const selector of selectors) {


### PR DESCRIPTION
## Summary
- **Dead CSS removed** from `styles/app.css`: the legacy `.punctuation-strip` + `.punctuation-hero` + `.punctuation-dashboard-hero` blocks (+ their media-query variants + `.punctuation-dashboard-hero-content` + `.punctuation-dashboard-cta-row`). Verified zero production JSX and zero tests reference these class names. ~99 lines of raw CSS reclaimed.
- **Consolidated** the three near-identical `.punctuation-{session,summary,map}-hero` positioning blocks added by U5+U6 into one selector list + Session-specific extension. The explanatory comment merges U5's and U6's commentary into a single unified rationale.
- **Inline-style cleanup**: dropped the redundant `style={{ position: 'relative' }}` on the Map + Summary scene `<section>` wrappers. The consolidated CSS rule now owns positioning.
- **Playwright cleanup**: `defaultMasks()`, `SCREENSHOT_DETERMINISM_CSS`, and `injectFixedPromptContent()` all drop the `.punctuation-strip` / `.punctuation-hero` legacy anchors. No production JSX renders those class names, so the belt-and-braces entries are now dead. The `data-hero-layer="true"` scoped anchors already cover every adopter.

## Bundle delta
- `app.bundle.js` gzip: **226,908 B → 226,884 B** (-24 B).
- `styles/app.css`: 13,338 → 13,239 lines (-99 lines, ~890 B raw).
- `bundle-byte-budget.test.js` still passes under the 227,000 ceiling (116 B headroom).

## Test plan
- [x] `node --test` full U7 slice: 506/506 passing (platform-length-picker, platform-hero-copy, platform-setup-side-panel, punctuation-setup-hero-backdrop, punctuation-session-hero-backdrop, punctuation-summary-hero-backdrop, punctuation-map-hero-backdrop, react-punctuation-scene, punctuation-view-model, react-punctuation-assets, react-grammar-surface, react-spelling-surface, bundle-byte-budget, client-bundle-audit).
- [x] Post-consolidation render sanity: the four scene backdrop tests (Setup + Session + Summary + Map) all green — hero positioning unchanged.
- [x] Grep confirms no production code or test references the dropped selectors except in migration comments.