### PR TITLE
feat(punctuation): reviewer QA pack and perceived-variety report (P6-U6/U7)

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "verify:grammar-qg-p8": "npm run verify:grammar-qg-p7 && node --test tests/grammar-qg-p8-question-quality.test.js tests/grammar-qg-p8-governance.test.js tests/grammar-qg-p8-oracles.test.js tests/grammar-qg-p8-review-register.test.js tests/grammar-qg-p8-ux-support.test.js",
     "grammar:qg:calibrate": "node scripts/grammar-qg-calibrate.mjs",
     "verify:punctuation-qg": "node scripts/verify-punctuation-qg.mjs",
-    "verify:punctuation-qg:p5": "node scripts/verify-punctuation-qg-p5.mjs"
+    "verify:punctuation-qg:p5": "node scripts/verify-punctuation-qg-p5.mjs",
+    "review:punctuation-questions": "node scripts/review-punctuation-questions.mjs"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",

--- a/scripts/review-punctuation-questions.mjs
+++ b/scripts/review-punctuation-questions.mjs
@@ -1,0 +1,326 @@
+#!/usr/bin/env node
+
+/**
+ * Reviewer QA pack for punctuation questions.
+ *
+ * Produces a comprehensive human-readable markdown report (stdout) and/or
+ * a JSON file for programmatic consumption.
+ *
+ * Usage:
+ *   node scripts/review-punctuation-questions.mjs              # markdown to stdout
+ *   node scripts/review-punctuation-questions.mjs --json       # JSON to stdout
+ *   node scripts/review-punctuation-questions.mjs --out qa.json  # JSON to file
+ */
+
+import { writeFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+import {
+  PUNCTUATION_CONTENT_MANIFEST,
+  createPunctuationContentIndexes,
+} from '../shared/punctuation/content.js';
+import {
+  createPunctuationGeneratedItems,
+  PRODUCTION_DEPTH,
+} from '../shared/punctuation/generators.js';
+import { markPunctuationAnswer } from '../shared/punctuation/marking.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function normaliseForVariety(value) {
+  return String(value ?? '')
+    .replace(/ /g, ' ')
+    .replace(/[""]/g, '"')
+    .replace(/['']/g, "'")
+    .replace(/[–—]/g, '-')
+    .replace(/[^a-z0-9\s]/gi, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+}
+
+function validatorSummary(item) {
+  if (!item.validator && !item.rubric) return '(none)';
+  const parts = [];
+  if (item.validator) {
+    const type = item.validator.type || 'unknown';
+    const facets = Array.isArray(item.validator.facets)
+      ? item.validator.facets.map((f) => f.id || f.type || '?').join(', ')
+      : '';
+    parts.push(`validator: ${type}${facets ? ` [${facets}]` : ''}`);
+  }
+  if (item.rubric) {
+    const type = item.rubric.type || 'unknown';
+    parts.push(`rubric: ${type}`);
+  }
+  return parts.join('; ');
+}
+
+function markingResultSummary(result) {
+  if (!result) return '(no result)';
+  const parts = [`correct: ${result.correct}`];
+  if (result.score != null) parts.push(`score: ${result.score}`);
+  if (Array.isArray(result.facetResults) && result.facetResults.length) {
+    const passed = result.facetResults.filter((f) => f.pass).length;
+    parts.push(`facets: ${passed}/${result.facetResults.length} passed`);
+  }
+  if (Array.isArray(result.misconceptionTags) && result.misconceptionTags.length) {
+    parts.push(`misconceptions: ${result.misconceptionTags.join(', ')}`);
+  }
+  return parts.join(' | ');
+}
+
+// ─── Build pool ──────────────────────────────────────────────────────────────
+
+function buildProductionPool() {
+  const indexes = createPunctuationContentIndexes(PUNCTUATION_CONTENT_MANIFEST);
+  const fixedItems = indexes.items.map((item) => ({ ...item, _source: 'fixed' }));
+
+  const generatedItems = createPunctuationGeneratedItems({
+    manifest: PUNCTUATION_CONTENT_MANIFEST,
+    seed: PUNCTUATION_CONTENT_MANIFEST.releaseId || 'punctuation',
+    perFamily: PRODUCTION_DEPTH,
+  }).map((item) => ({ ...item, _source: 'generated' }));
+
+  return [...fixedItems, ...generatedItems];
+}
+
+// ─── Per-item QA entry ────────────────────────────────────────────────────────
+
+function buildItemEntry(item) {
+  const answer = item.mode === 'choose'
+    ? { choiceIndex: item.correctIndex }
+    : { typed: item.model || '' };
+
+  let markingResult = null;
+  try {
+    markingResult = markPunctuationAnswer({ item, answer });
+  } catch {
+    markingResult = { correct: false, error: 'marking threw' };
+  }
+
+  return {
+    id: item.id,
+    source: item._source,
+    skillIds: item.skillIds || [],
+    rewardUnitId: item.rewardUnitId || '',
+    mode: item.mode || '',
+    prompt: item.prompt || '',
+    stem: item.stem || '',
+    model: item.model || '',
+    accepted: item.accepted || [],
+    explanation: item.explanation || '',
+    validatorSummary: validatorSummary(item),
+    misconceptionTags: item.misconceptionTags || [],
+    markingResult,
+    markingResultSummary: markingResultSummary(markingResult),
+    ...(item._source === 'generated' ? {
+      templateId: item.templateId || '',
+      variantSignature: item.variantSignature || '',
+      generatorFamilyId: item.generatorFamilyId || '',
+    } : {}),
+  };
+}
+
+// ─── Perceived-variety analysis ───────────────────────────────────────────────
+
+function buildVarietyClusters(pool) {
+  const stemGroups = new Map();
+  const modelGroups = new Map();
+
+  for (const item of pool) {
+    const normStem = normaliseForVariety(item.stem);
+    const normModel = normaliseForVariety(item.model);
+
+    if (normStem) {
+      if (!stemGroups.has(normStem)) stemGroups.set(normStem, []);
+      stemGroups.get(normStem).push(item);
+    }
+    if (normModel) {
+      if (!modelGroups.has(normModel)) modelGroups.set(normModel, []);
+      modelGroups.get(normModel).push(item);
+    }
+  }
+
+  const clusters = [];
+
+  for (const [normText, items] of stemGroups) {
+    if (items.length < 2) continue;
+    const modes = [...new Set(items.map((i) => i.mode))].sort();
+    const isSameMode = modes.length === 1 && items.length > 1;
+    const isCrossMode = modes.length > 1;
+    clusters.push({
+      type: 'stem',
+      normalisedText: normText,
+      modes,
+      itemIds: items.map((i) => i.id).sort(),
+      count: items.length,
+      classification: isSameMode ? 'SAME-MODE-DUPLICATE' : 'CROSS-MODE-OVERLAP',
+      sampleStem: items[0].stem || '',
+    });
+  }
+
+  for (const [normText, items] of modelGroups) {
+    if (items.length < 2) continue;
+    const modes = [...new Set(items.map((i) => i.mode))].sort();
+    const isSameMode = modes.length === 1 && items.length > 1;
+    clusters.push({
+      type: 'model',
+      normalisedText: normText,
+      modes,
+      itemIds: items.map((i) => i.id).sort(),
+      count: items.length,
+      classification: isSameMode ? 'SAME-MODE-DUPLICATE' : 'CROSS-MODE-OVERLAP',
+      sampleModel: items[0].model || '',
+    });
+  }
+
+  clusters.sort((a, b) => b.count - a.count || a.normalisedText.localeCompare(b.normalisedText));
+  return clusters;
+}
+
+// ─── Markdown formatting ──────────────────────────────────────────────────────
+
+function formatMarkdown(entries, clusters, meta) {
+  const lines = [];
+
+  lines.push('# Punctuation Reviewer QA Pack');
+  lines.push('');
+  lines.push(`Generated: ${meta.date}`);
+  lines.push(`Production depth: ${meta.depth}`);
+  lines.push(`Total items: ${meta.totalItems} (fixed: ${meta.fixedCount}, generated: ${meta.generatedCount})`);
+  lines.push('');
+
+  // ─── Per-item catalogue ─────────────────────────────────────────────────────
+  lines.push('## Item Catalogue');
+  lines.push('');
+
+  for (const entry of entries) {
+    lines.push(`### ${entry.id}`);
+    lines.push('');
+    lines.push(`- **Source:** ${entry.source}`);
+    lines.push(`- **Mode:** ${entry.mode}`);
+    lines.push(`- **Skills:** ${entry.skillIds.join(', ')}`);
+    lines.push(`- **Reward unit:** ${entry.rewardUnitId}`);
+    lines.push(`- **Prompt:** ${entry.prompt}`);
+    if (entry.stem) lines.push(`- **Stem:** ${entry.stem}`);
+    lines.push(`- **Model answer:** ${entry.model}`);
+    if (entry.accepted.length > 1) {
+      lines.push(`- **Accepted alternatives:** ${entry.accepted.filter((a) => a !== entry.model).join(' | ')}`);
+    }
+    lines.push(`- **Explanation:** ${entry.explanation}`);
+    lines.push(`- **Validator/rubric:** ${entry.validatorSummary}`);
+    if (entry.misconceptionTags.length) {
+      lines.push(`- **Misconception tags:** ${entry.misconceptionTags.join(', ')}`);
+    }
+    lines.push(`- **Marking result:** ${entry.markingResultSummary}`);
+    if (entry.templateId) {
+      lines.push(`- **Template ID:** ${entry.templateId}`);
+      lines.push(`- **Variant signature:** ${entry.variantSignature}`);
+      lines.push(`- **Generator family:** ${entry.generatorFamilyId}`);
+    }
+    lines.push('');
+  }
+
+  // ─── Perceived-variety report ───────────────────────────────────────────────
+  lines.push('## Perceived-Variety Report');
+  lines.push('');
+
+  const sameModeClusters = clusters.filter((c) => c.classification === 'SAME-MODE-DUPLICATE');
+  const crossModeClusters = clusters.filter((c) => c.classification === 'CROSS-MODE-OVERLAP');
+
+  lines.push(`Same-mode duplicate clusters: ${sameModeClusters.length}`);
+  lines.push(`Cross-mode overlap clusters: ${crossModeClusters.length}`);
+  lines.push('');
+
+  if (sameModeClusters.length) {
+    lines.push('### Same-Mode Duplicates (potential bugs)');
+    lines.push('');
+    for (const cluster of sameModeClusters) {
+      const sample = cluster.sampleStem || cluster.sampleModel || cluster.normalisedText;
+      lines.push(`- **[${cluster.type}]** "${sample}" (mode=${cluster.modes[0]}, ${cluster.count} items)`);
+      lines.push(`  Items: ${cluster.itemIds.join(', ')}`);
+    }
+    lines.push('');
+  }
+
+  if (crossModeClusters.length) {
+    lines.push('### Cross-Mode Overlaps (reviewer decision)');
+    lines.push('');
+    for (const cluster of crossModeClusters) {
+      const sample = cluster.sampleStem || cluster.sampleModel || cluster.normalisedText;
+      lines.push(`- **[${cluster.type}]** "${sample}" (modes=${cluster.modes.join(',')}, ${cluster.count} items)`);
+      lines.push(`  Items: ${cluster.itemIds.join(', ')}`);
+    }
+    lines.push('');
+  }
+
+  if (!sameModeClusters.length && !crossModeClusters.length) {
+    lines.push('No variety clusters detected — all items have unique stems and models.');
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+// ─── JSON output ──────────────────────────────────────────────────────────────
+
+function buildJsonOutput(entries, clusters, meta) {
+  return {
+    _meta: meta,
+    items: entries,
+    perceivedVariety: {
+      totalClusters: clusters.length,
+      sameModeCount: clusters.filter((c) => c.classification === 'SAME-MODE-DUPLICATE').length,
+      crossModeCount: clusters.filter((c) => c.classification === 'CROSS-MODE-OVERLAP').length,
+      clusters,
+    },
+  };
+}
+
+// ─── CLI ──────────────────────────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const args = new Set(argv);
+  const outIndex = argv.indexOf('--out');
+  const outPath = outIndex >= 0 && outIndex + 1 < argv.length ? argv[outIndex + 1] : null;
+  return {
+    json: args.has('--json'),
+    outPath,
+  };
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const pool = buildProductionPool();
+  const entries = pool.map(buildItemEntry);
+  const clusters = buildVarietyClusters(pool);
+
+  const meta = {
+    generated: new Date().toISOString().slice(0, 10),
+    date: new Date().toISOString().slice(0, 10),
+    depth: PRODUCTION_DEPTH,
+    totalItems: pool.length,
+    fixedCount: pool.filter((i) => i._source === 'fixed').length,
+    generatedCount: pool.filter((i) => i._source === 'generated').length,
+    items_reviewed: pool.length,
+  };
+
+  if (args.json || args.outPath) {
+    const json = JSON.stringify(buildJsonOutput(entries, clusters, meta), null, 2);
+    if (args.outPath) {
+      writeFileSync(args.outPath, json + '\n', 'utf8');
+      process.stderr.write(`QA pack written to ${args.outPath}\n`);
+    } else {
+      process.stdout.write(json + '\n');
+    }
+  } else {
+    process.stdout.write(formatMarkdown(entries, clusters, meta));
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}
+
+export { buildProductionPool, buildItemEntry, buildVarietyClusters, normaliseForVariety };

--- a/tests/fixtures/punctuation-reviewer-decisions.json
+++ b/tests/fixtures/punctuation-reviewer-decisions.json
@@ -1,0 +1,4 @@
+{
+  "_meta": { "generated": "2026-04-29", "items_reviewed": 192 },
+  "decisions": {}
+}

--- a/tests/punctuation-perceived-variety.test.js
+++ b/tests/punctuation-perceived-variety.test.js
@@ -1,0 +1,129 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import {
+  buildProductionPool,
+  buildVarietyClusters,
+  normaliseForVariety,
+} from '../scripts/review-punctuation-questions.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DECISIONS_PATH = join(__dirname, 'fixtures', 'punctuation-reviewer-decisions.json');
+
+// ─── Perceived-variety invariants ─────────────────────────────────────────────
+
+test('perceived-variety: no SAME-MODE duplicate stem clusters in production pool', () => {
+  const pool = buildProductionPool();
+  const clusters = buildVarietyClusters(pool);
+  const sameModeStemClusters = clusters.filter(
+    (c) => c.type === 'stem' && c.classification === 'SAME-MODE-DUPLICATE',
+  );
+
+  if (sameModeStemClusters.length > 0) {
+    const detail = sameModeStemClusters
+      .map((c) => `  stem="${c.normalisedText}" mode=${c.modes[0]} items=[${c.itemIds.join(', ')}]`)
+      .join('\n');
+    assert.fail(
+      `Found ${sameModeStemClusters.length} same-mode duplicate stem cluster(s):\n${detail}`,
+    );
+  }
+});
+
+test('perceived-variety: cross-mode overlaps are counted and reported', () => {
+  const pool = buildProductionPool();
+  const clusters = buildVarietyClusters(pool);
+  const crossModeClusters = clusters.filter(
+    (c) => c.classification === 'CROSS-MODE-OVERLAP',
+  );
+
+  // Informational — this test documents how many cross-mode overlaps exist
+  // without failing. The count is available for reviewer inspection.
+  assert.ok(
+    typeof crossModeClusters.length === 'number',
+    'cross-mode overlap count is a number',
+  );
+
+  // Log for informational purposes during test run
+  if (crossModeClusters.length > 0) {
+    process.stderr.write(
+      `[info] ${crossModeClusters.length} cross-mode overlap cluster(s) detected (not a failure)\n`,
+    );
+  }
+});
+
+test('perceived-variety: normaliseForVariety strips punctuation and lowercases', () => {
+  assert.equal(normaliseForVariety('Hello, World!'), 'hello world');
+  assert.equal(normaliseForVariety('"Why?" she asked.'), 'why she asked');
+  assert.equal(normaliseForVariety('  Extra   spaces  '), 'extra spaces');
+  assert.equal(normaliseForVariety('It’s a dash—test'), 'its a dashtest');
+});
+
+// ─── Reviewer decisions fixture schema ────────────────────────────────────────
+
+test('reviewer decisions fixture: is valid JSON with expected schema', () => {
+  const raw = readFileSync(DECISIONS_PATH, 'utf8');
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    assert.fail(`punctuation-reviewer-decisions.json is not valid JSON: ${err.message}`);
+  }
+
+  assert.equal(typeof parsed, 'object');
+  assert.ok(parsed !== null, 'fixture is not null');
+  assert.ok('_meta' in parsed, 'fixture has _meta key');
+  assert.ok('decisions' in parsed, 'fixture has decisions key');
+
+  // _meta shape
+  assert.equal(typeof parsed._meta, 'object');
+  assert.equal(typeof parsed._meta.generated, 'string');
+  assert.equal(typeof parsed._meta.items_reviewed, 'number');
+
+  // decisions is an object (may be empty)
+  assert.equal(typeof parsed.decisions, 'object');
+  assert.ok(!Array.isArray(parsed.decisions), 'decisions is not an array');
+});
+
+test('reviewer decisions fixture: decision values are valid strings if present', () => {
+  const parsed = JSON.parse(readFileSync(DECISIONS_PATH, 'utf8'));
+  const VALID_DECISIONS = new Set([
+    'approved',
+    'needs-rewrite',
+    'acceptable-cross-mode-overlap',
+    'pending',
+  ]);
+
+  for (const [key, value] of Object.entries(parsed.decisions || {})) {
+    assert.ok(
+      typeof value === 'string' && VALID_DECISIONS.has(value),
+      `Decision for "${key}" has invalid value "${value}". Expected one of: ${[...VALID_DECISIONS].join(', ')}`,
+    );
+  }
+});
+
+// ─── Production pool sanity ───────────────────────────────────────────────────
+
+test('production pool: contains both fixed and generated items', () => {
+  const pool = buildProductionPool();
+  const fixedCount = pool.filter((i) => i._source === 'fixed').length;
+  const generatedCount = pool.filter((i) => i._source === 'generated').length;
+
+  assert.ok(fixedCount > 0, `Expected fixed items, got ${fixedCount}`);
+  assert.ok(generatedCount > 0, `Expected generated items, got ${generatedCount}`);
+  assert.ok(pool.length > 50, `Expected pool > 50, got ${pool.length}`);
+});
+
+test('production pool: every item has required fields', () => {
+  const pool = buildProductionPool();
+  for (const item of pool) {
+    assert.ok(item.id, `Item missing id`);
+    assert.ok(item.mode, `Item ${item.id} missing mode`);
+    assert.ok(
+      Array.isArray(item.skillIds) && item.skillIds.length > 0,
+      `Item ${item.id} missing skillIds`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

- Adds `npm run review:punctuation-questions` which builds the full production pool (92 fixed + 100 generated at depth 4) and outputs a per-question QA pack for human reviewer inspection
- Includes perceived-variety analysis: groups items by normalised stem/model overlap, classifying same-mode duplicates (bugs) vs cross-mode overlaps (reviewer decisions)
- Creates the reviewer decisions fixture (`tests/fixtures/punctuation-reviewer-decisions.json`) as the CI gate structure for future item reviews

## Test plan

- [x] `node --test tests/punctuation-perceived-variety.test.js` — 7/7 passing
- [x] `node scripts/review-punctuation-questions.mjs` — markdown output verified (192 items)
- [x] `node scripts/review-punctuation-questions.mjs --json` — JSON output verified
- [x] `node scripts/review-punctuation-questions.mjs --out file.json` — file write verified
- [x] Zero same-mode duplicate stem clusters (invariant holds)
- [x] 47 cross-mode overlap clusters reported (informational, not failing)