### PR TITLE
feat(hero-mode): add telemetry probe ops route (pA1 U2)

### DIFF
--- a/tests/hero-pA1-telemetry-probe.test.js
+++ b/tests/hero-pA1-telemetry-probe.test.js
@@ -163,10 +163,8 @@ describe('probeHeroTelemetry', () => {
   });
 
   it('caps limit at 100', async () => {
-    // Verify that an absurd limit is capped — we test via the function's
-    // internal safeLimit logic by checking it does not throw or return more
-    // than the cap. With our mock, the DB returns whatever it has regardless,
-    // but the function should pass a capped limit to the query.
+    // Verify that an absurd limit is capped — the DB must receive 100 as
+    // the bound parameter, not the raw 9999 input.
     const mockRows = [
       {
         id: 'hero-evt-single',
@@ -178,12 +176,28 @@ describe('probeHeroTelemetry', () => {
         created_at: 1714400000000,
       },
     ];
-    const db = createMockDb(mockRows);
+    let capturedBindArg;
+    const db = {
+      prepare() {
+        return {
+          bind(...args) {
+            capturedBindArg = args[0];
+            return {
+              async all() {
+                return { results: mockRows };
+              },
+            };
+          },
+        };
+      },
+    };
     const result = await probeHeroTelemetry({ db, limit: 9999 });
 
     // Function still works — does not blow up with high limit
     assert.equal(result.count, 1);
     assert.equal(typeof result.probedAt, 'string');
+    // The bound parameter must be capped at 100, not the raw 9999
+    assert.equal(capturedBindArg, 100, 'bind() must receive capped limit of 100');
   });
 
   it('defaults limit to 20 when not provided', async () => {

--- a/tests/hero-pA1-telemetry-probe.test.js
+++ b/tests/hero-pA1-telemetry-probe.test.js
@@ -1,0 +1,321 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  probeHeroTelemetry,
+  stripPrivacyFields,
+  PRIVACY_STRIP_FIELDS,
+} from '../worker/src/hero/telemetry-probe.js';
+
+// ── Mock D1 helpers ─────────────────────────────────────────────────
+
+function createMockDb(rows = []) {
+  return {
+    prepare() {
+      return {
+        bind() {
+          return {
+            async all() {
+              return { results: rows };
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+function createThrowingDb(error = new Error('table not found')) {
+  return {
+    prepare() {
+      return {
+        bind() {
+          return {
+            async all() {
+              throw error;
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+// ── probeHeroTelemetry ──────────────────────────────────────────────
+
+describe('probeHeroTelemetry', () => {
+  it('returns structured array from mock D1 data', async () => {
+    const mockRows = [
+      {
+        id: 'hero-evt-req1-hero-task-completed',
+        learner_id: 'learner-1',
+        subject_id: 'grammar',
+        system_id: 'hero-mode',
+        event_type: 'hero.task.completed',
+        event_json: JSON.stringify({ questId: 'q1', taskId: 't1', subjectId: 'grammar' }),
+        created_at: 1714400000000,
+      },
+      {
+        id: 'hero-evt-req2-hero-daily-completed',
+        learner_id: 'learner-1',
+        subject_id: null,
+        system_id: 'hero-mode',
+        event_type: 'hero.daily.completed',
+        event_json: JSON.stringify({ questId: 'q1', dateKey: '2026-04-29' }),
+        created_at: 1714400001000,
+      },
+    ];
+
+    const db = createMockDb(mockRows);
+    const result = await probeHeroTelemetry({ db, limit: 20 });
+
+    assert.equal(result.count, 2);
+    assert.equal(result.events.length, 2);
+    assert.equal(result.events[0].id, 'hero-evt-req1-hero-task-completed');
+    assert.equal(result.events[0].eventType, 'hero.task.completed');
+    assert.equal(result.events[0].systemId, 'hero-mode');
+    assert.deepEqual(result.events[0].data, { questId: 'q1', taskId: 't1', subjectId: 'grammar' });
+    assert.equal(typeof result.probedAt, 'string');
+  });
+
+  it('strips privacy fields from event data', async () => {
+    const mockRows = [
+      {
+        id: 'hero-evt-req3-hero-task-completed',
+        learner_id: 'learner-2',
+        subject_id: 'spelling',
+        system_id: 'hero-mode',
+        event_type: 'hero.task.completed',
+        event_json: JSON.stringify({
+          questId: 'q2',
+          rawAnswer: 'secret child answer',
+          rawPrompt: 'secret prompt',
+          childFreeText: 'free text from child',
+          childInput: 'input from child',
+          answerText: 'answer text',
+          rawText: 'raw text content',
+          childContent: 'child content data',
+          subjectId: 'spelling',
+        }),
+        created_at: 1714400002000,
+      },
+    ];
+
+    const db = createMockDb(mockRows);
+    const result = await probeHeroTelemetry({ db, limit: 20 });
+
+    assert.equal(result.count, 1);
+    const eventData = result.events[0].data;
+
+    // Privacy fields must be stripped
+    for (const field of PRIVACY_STRIP_FIELDS) {
+      assert.equal(field in eventData, false, `field "${field}" should be stripped`);
+    }
+
+    // Non-privacy fields must remain
+    assert.equal(eventData.questId, 'q2');
+    assert.equal(eventData.subjectId, 'spelling');
+  });
+
+  it('returns empty result when db is null/undefined', async () => {
+    const result = await probeHeroTelemetry({ db: null });
+
+    assert.deepEqual(result.events, []);
+    assert.equal(result.count, 0);
+    assert.equal(typeof result.probedAt, 'string');
+  });
+
+  it('returns empty result when db is not provided', async () => {
+    const result = await probeHeroTelemetry({});
+
+    assert.deepEqual(result.events, []);
+    assert.equal(result.count, 0);
+    assert.equal(typeof result.probedAt, 'string');
+  });
+
+  it('returns empty result when db query throws (table missing)', async () => {
+    const db = createThrowingDb(new Error('no such table: event_log'));
+    const result = await probeHeroTelemetry({ db });
+
+    assert.deepEqual(result.events, []);
+    assert.equal(result.count, 0);
+    assert.equal(typeof result.probedAt, 'string');
+  });
+
+  it('respects limit parameter (returns max N events)', async () => {
+    const mockRows = Array.from({ length: 5 }, (_, i) => ({
+      id: `hero-evt-req${i}-hero-task-completed`,
+      learner_id: `learner-${i}`,
+      subject_id: 'grammar',
+      system_id: 'hero-mode',
+      event_type: 'hero.task.completed',
+      event_json: JSON.stringify({ questId: `q${i}` }),
+      created_at: 1714400000000 + i * 1000,
+    }));
+
+    // The mock returns all rows, but the function passes limit to the query.
+    // We simulate that the DB already respected the limit by returning 5 rows.
+    const db = createMockDb(mockRows);
+    const result = await probeHeroTelemetry({ db, limit: 5 });
+
+    assert.equal(result.count, 5);
+    assert.equal(result.events.length, 5);
+  });
+
+  it('caps limit at 100', async () => {
+    // Verify that an absurd limit is capped — we test via the function's
+    // internal safeLimit logic by checking it does not throw or return more
+    // than the cap. With our mock, the DB returns whatever it has regardless,
+    // but the function should pass a capped limit to the query.
+    const mockRows = [
+      {
+        id: 'hero-evt-single',
+        learner_id: 'learner-x',
+        subject_id: null,
+        system_id: 'hero-mode',
+        event_type: 'hero.daily.completed',
+        event_json: JSON.stringify({ dateKey: '2026-04-29' }),
+        created_at: 1714400000000,
+      },
+    ];
+    const db = createMockDb(mockRows);
+    const result = await probeHeroTelemetry({ db, limit: 9999 });
+
+    // Function still works — does not blow up with high limit
+    assert.equal(result.count, 1);
+    assert.equal(typeof result.probedAt, 'string');
+  });
+
+  it('defaults limit to 20 when not provided', async () => {
+    const db = createMockDb([]);
+    const result = await probeHeroTelemetry({ db });
+
+    assert.equal(result.count, 0);
+    assert.equal(typeof result.probedAt, 'string');
+  });
+
+  it('probedAt is a valid ISO 8601 timestamp', async () => {
+    const db = createMockDb([]);
+    const result = await probeHeroTelemetry({ db });
+
+    // ISO 8601: must parse to a valid Date and round-trip
+    const parsed = new Date(result.probedAt);
+    assert.ok(!isNaN(parsed.getTime()), 'probedAt must parse to a valid Date');
+    assert.equal(result.probedAt, parsed.toISOString());
+  });
+
+  it('handles malformed event_json gracefully', async () => {
+    const mockRows = [
+      {
+        id: 'hero-evt-bad-json',
+        learner_id: 'learner-3',
+        subject_id: null,
+        system_id: 'hero-mode',
+        event_type: 'hero.task.completed',
+        event_json: 'not-valid-json{{{',
+        created_at: 1714400003000,
+      },
+    ];
+
+    const db = createMockDb(mockRows);
+    const result = await probeHeroTelemetry({ db });
+
+    assert.equal(result.count, 1);
+    assert.equal(result.events[0].data, null);
+    assert.equal(result.events[0].eventType, 'hero.task.completed');
+  });
+
+  it('handles null event_json gracefully', async () => {
+    const mockRows = [
+      {
+        id: 'hero-evt-null-json',
+        learner_id: 'learner-4',
+        subject_id: 'punctuation',
+        system_id: 'hero-mode',
+        event_type: 'hero.daily.completed',
+        event_json: null,
+        created_at: 1714400004000,
+      },
+    ];
+
+    const db = createMockDb(mockRows);
+    const result = await probeHeroTelemetry({ db });
+
+    assert.equal(result.count, 1);
+    assert.equal(result.events[0].data, null);
+  });
+});
+
+// ── stripPrivacyFields ──────────────────────────────────────────────
+
+describe('stripPrivacyFields', () => {
+  it('strips all defined privacy fields from flat object', () => {
+    const input = {
+      questId: 'q1',
+      rawAnswer: 'secret',
+      rawPrompt: 'prompt',
+      childFreeText: 'text',
+      childInput: 'input',
+      answerText: 'answer',
+      rawText: 'raw',
+      childContent: 'content',
+      subjectId: 'grammar',
+    };
+
+    const result = stripPrivacyFields(input);
+    assert.equal(result.questId, 'q1');
+    assert.equal(result.subjectId, 'grammar');
+    for (const field of PRIVACY_STRIP_FIELDS) {
+      assert.equal(field in result, false);
+    }
+  });
+
+  it('strips privacy fields from nested objects recursively', () => {
+    const input = {
+      data: {
+        rawAnswer: 'nested secret',
+        taskId: 't1',
+        nested: {
+          childFreeText: 'deeply nested',
+          value: 42,
+        },
+      },
+    };
+
+    const result = stripPrivacyFields(input);
+    assert.equal(result.data.taskId, 't1');
+    assert.equal('rawAnswer' in result.data, false);
+    assert.equal(result.data.nested.value, 42);
+    assert.equal('childFreeText' in result.data.nested, false);
+  });
+
+  it('handles arrays correctly', () => {
+    const input = [
+      { rawAnswer: 'a', questId: 'q1' },
+      { childInput: 'b', taskId: 't1' },
+    ];
+
+    const result = stripPrivacyFields(input);
+    assert.ok(Array.isArray(result));
+    assert.equal(result[0].questId, 'q1');
+    assert.equal('rawAnswer' in result[0], false);
+    assert.equal(result[1].taskId, 't1');
+    assert.equal('childInput' in result[1], false);
+  });
+
+  it('returns primitives unchanged', () => {
+    assert.equal(stripPrivacyFields(null), null);
+    assert.equal(stripPrivacyFields(undefined), undefined);
+    assert.equal(stripPrivacyFields(42), 42);
+    assert.equal(stripPrivacyFields('hello'), 'hello');
+    assert.equal(stripPrivacyFields(true), true);
+  });
+
+  it('does not mutate the original object', () => {
+    const input = { rawAnswer: 'secret', questId: 'q1' };
+    const result = stripPrivacyFields(input);
+
+    assert.equal(input.rawAnswer, 'secret'); // original untouched
+    assert.equal('rawAnswer' in result, false);
+  });
+});

--- a/worker/src/app.js
+++ b/worker/src/app.js
@@ -48,6 +48,7 @@ import { handleHeroReadModel } from './hero/routes.js';
 import { resolveHeroStartTaskCommand } from './hero/launch.js';
 import { resolveHeroClaimCommand } from './hero/claim.js';
 import { resolveHeroCampCommand } from './hero/camp.js';
+import { probeHeroTelemetry } from './hero/telemetry-probe.js';
 import {
   initialiseDailyProgress,
   markTaskStarted,
@@ -2655,6 +2656,18 @@ export function createWorkerApp({
           const db = requireDatabase(env);
           const kpiResult = await getBusinessKpis(db);
           return json({ ok: true, ...kpiResult });
+        }
+
+        // pA1 U2: Hero telemetry probe — read-only operational verification
+        // for Ring 2–4 operators. Returns last-N hero events from event_log
+        // with privacy re-validation. Admin/ops gated via assertAdminHubActorForBundle.
+        if (url.pathname === '/api/admin/hero/telemetry-probe' && request.method === 'GET') {
+          requireSameOrigin(request, env);
+          await repository.assertAdminHubActorForBundle(session.accountId);
+          const probeLimit = Number(url.searchParams.get('limit')) || 20;
+          const db = requireDatabase(env);
+          const probeResult = await probeHeroTelemetry({ db, limit: probeLimit });
+          return json({ ok: true, ...probeResult });
         }
 
         // R31: regex dispatch for parameterised admin ops mutations. Placed

--- a/worker/src/app.js
+++ b/worker/src/app.js
@@ -2664,6 +2664,21 @@ export function createWorkerApp({
         if (url.pathname === '/api/admin/hero/telemetry-probe' && request.method === 'GET') {
           requireSameOrigin(request, env);
           await repository.assertAdminHubActorForBundle(session.accountId);
+          const heroProbeRateLimit = await consumeRateLimit(env, {
+            bucket: 'admin-ops-mutation',
+            identifier: session.accountId,
+            limit: 60,
+            windowMs: 60_000,
+          });
+          if (!heroProbeRateLimit.allowed) {
+            return rateLimitResponse({
+              code: 'admin_ops_mutation_rate_limited',
+              retryAfterSeconds: heroProbeRateLimit.retryAfterSeconds,
+              extra: {
+                message: 'Admin-ops reads are rate-limited at 60 per minute per session.',
+              },
+            });
+          }
           const probeLimit = Number(url.searchParams.get('limit')) || 20;
           const db = requireDatabase(env);
           const probeResult = await probeHeroTelemetry({ db, limit: probeLimit });

--- a/worker/src/hero/telemetry-probe.js
+++ b/worker/src/hero/telemetry-probe.js
@@ -1,0 +1,94 @@
+// Pure read-only telemetry probe for Hero Mode pA1 operational verification.
+// Returns last-N events from the event_log D1 table (system_id='hero-mode')
+// with privacy re-validation. No writes, no state mutations.
+
+/**
+ * Privacy-sensitive fields that must be stripped before returning event data
+ * to Ring 2–4 operators. Superset of the metrics-contract FORBIDDEN_FIELDS
+ * plus additional child-content fields that may appear in event_json.
+ */
+const PRIVACY_STRIP_FIELDS = Object.freeze([
+  'rawAnswer',
+  'rawPrompt',
+  'childFreeText',
+  'childInput',
+  'answerText',
+  'rawText',
+  'childContent',
+]);
+
+/**
+ * Recursively strip privacy-sensitive fields from an object.
+ * Returns a new object — never mutates the input.
+ * @param {unknown} obj
+ * @returns {unknown}
+ */
+function stripPrivacyFields(obj) {
+  if (obj === null || obj === undefined) return obj;
+  if (Array.isArray(obj)) return obj.map(stripPrivacyFields);
+  if (typeof obj !== 'object') return obj;
+
+  const result = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (PRIVACY_STRIP_FIELDS.includes(key)) continue;
+    result[key] = stripPrivacyFields(value);
+  }
+  return result;
+}
+
+/**
+ * Probe hero telemetry events from the D1 event_log table.
+ *
+ * @param {Object} params
+ * @param {Object} params.db — D1 database binding (env.DB)
+ * @param {number} [params.limit=20] — max events to return (capped at 100)
+ * @returns {Promise<{ events: Array, count: number, probedAt: string }>}
+ */
+export async function probeHeroTelemetry({ db, limit = 20 } = {}) {
+  const probedAt = new Date().toISOString();
+  const safeLimit = Math.max(1, Math.min(Number(limit) || 20, 100));
+
+  if (!db) {
+    return { events: [], count: 0, probedAt };
+  }
+
+  let rows;
+  try {
+    const result = await db.prepare(`
+      SELECT id, learner_id, subject_id, system_id, event_type, event_json, created_at
+      FROM event_log
+      WHERE system_id = 'hero-mode'
+      ORDER BY created_at DESC, id DESC
+      LIMIT ?
+    `).bind(safeLimit).all();
+    rows = result?.results || [];
+  } catch {
+    // Table may not exist on pre-migration deploys — return empty gracefully
+    return { events: [], count: 0, probedAt };
+  }
+
+  const events = rows.map((row) => {
+    let parsedData = null;
+    try {
+      parsedData = row.event_json ? JSON.parse(row.event_json) : null;
+    } catch {
+      parsedData = null;
+    }
+
+    const event = {
+      id: row.id,
+      learnerId: row.learner_id,
+      subjectId: row.subject_id,
+      systemId: row.system_id,
+      eventType: row.event_type,
+      data: parsedData,
+      createdAt: row.created_at,
+    };
+
+    return stripPrivacyFields(event);
+  });
+
+  return { events, count: events.length, probedAt };
+}
+
+export { PRIVACY_STRIP_FIELDS, stripPrivacyFields };


### PR DESCRIPTION
## Summary
- Adds read-only `/api/admin/hero/telemetry-probe` GET route for Ring 2-4 operators
- Returns last-N Hero events from D1 `event_log` (system_id='hero-mode') with privacy re-validation
- Admin/ops-only auth via `assertAdminHubActorForBundle` + `requireSameOrigin` CSRF protection
- Privacy fields (`rawAnswer`, `rawPrompt`, `childFreeText`, `childInput`, `answerText`, `rawText`, `childContent`) recursively stripped before response

## Test plan
- [x] `node --test tests/hero-pA1-telemetry-probe.test.js` passes (16/16)
- [x] Privacy fields stripped from response even if injected into event data
- [x] Empty/missing DB returns safe empty response `{ events: [], count: 0 }`
- [x] Limit parameter respected and capped at 100
- [x] Malformed JSON in event_log handled gracefully (data: null)
- [x] `probedAt` is valid ISO 8601 timestamp