### PR TITLE
feat(hero-mode): per-account flag override for Ring 4 (pA1 U8)

### DIFF
--- a/shared/hero/account-override.js
+++ b/shared/hero/account-override.js
@@ -1,0 +1,52 @@
+// Resolve Hero flag overrides for internal team accounts.
+// Pure function — no side effects, no DB access.
+//
+// When HERO_INTERNAL_ACCOUNTS (JSON secret) lists an accountId, all 6 Hero
+// flags are force-enabled. Additive-only: non-listed accounts are unchanged.
+
+const HERO_FLAG_KEYS = Object.freeze([
+  'HERO_MODE_SHADOW_ENABLED',
+  'HERO_MODE_LAUNCH_ENABLED',
+  'HERO_MODE_CHILD_UI_ENABLED',
+  'HERO_MODE_PROGRESS_ENABLED',
+  'HERO_MODE_ECONOMY_ENABLED',
+  'HERO_MODE_CAMP_ENABLED',
+]);
+
+/**
+ * Resolve Hero flag overrides for internal team accounts.
+ *
+ * @param {Object} params
+ * @param {Object} params.env — Worker environment bindings
+ * @param {string} params.accountId — caller account ID
+ * @returns {Object} env-like object with Hero flags force-enabled for listed accounts
+ */
+export function resolveHeroFlagsWithOverride({ env, accountId }) {
+  const safeEnv = env || {};
+
+  // Parse the secret — must be a valid JSON array of strings
+  const raw = safeEnv.HERO_INTERNAL_ACCOUNTS;
+  if (raw == null || raw === '') return safeEnv;
+
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return safeEnv;
+  }
+
+  if (!Array.isArray(parsed)) return safeEnv;
+
+  // Check membership — only override for listed accounts
+  if (!accountId || !parsed.includes(accountId)) return safeEnv;
+
+  // Force all 6 Hero flags on (additive — preserves all other bindings)
+  const overrides = {};
+  for (const key of HERO_FLAG_KEYS) {
+    overrides[key] = 'true';
+  }
+
+  return { ...safeEnv, ...overrides };
+}
+
+export { HERO_FLAG_KEYS };

--- a/tests/hero-pA1-account-override.test.js
+++ b/tests/hero-pA1-account-override.test.js
@@ -1,0 +1,191 @@
+// Hero Mode pA1 U8 — Per-Account Flag Override.
+//
+// Verifies:
+// 1. Listed accounts get all 6 Hero flags force-enabled
+// 2. Non-listed accounts see original env unchanged
+// 3. Graceful handling of missing/empty/malformed HERO_INTERNAL_ACCOUNTS
+// 4. Additive-only: non-Hero env vars preserved
+// 5. Integration: buildHeroShadowReadModel produces enabled UI for override accounts
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { resolveHeroFlagsWithOverride, HERO_FLAG_KEYS } from '../shared/hero/account-override.js';
+import { buildHeroShadowReadModel } from '../worker/src/hero/read-model.js';
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+const TEAM_ACCOUNT = 'acc-team-001';
+const OTHER_ACCOUNT = 'acc-public-999';
+
+function baseEnv(overrides = {}) {
+  return {
+    HERO_MODE_SHADOW_ENABLED: 'false',
+    HERO_MODE_LAUNCH_ENABLED: 'false',
+    HERO_MODE_CHILD_UI_ENABLED: 'false',
+    HERO_MODE_PROGRESS_ENABLED: 'false',
+    HERO_MODE_ECONOMY_ENABLED: 'false',
+    HERO_MODE_CAMP_ENABLED: 'false',
+    APP_NAME: 'KS2 Mastery',
+    DB: 'mock-db-binding',
+    ...overrides,
+  };
+}
+
+function envWithTeamList(accounts = [TEAM_ACCOUNT]) {
+  return baseEnv({ HERO_INTERNAL_ACCOUNTS: JSON.stringify(accounts) });
+}
+
+// ── Unit: resolveHeroFlagsWithOverride ──────────────────────────────
+
+test('account in list → all 6 flags resolved as enabled', () => {
+  const env = envWithTeamList([TEAM_ACCOUNT, 'acc-other']);
+  const result = resolveHeroFlagsWithOverride({ env, accountId: TEAM_ACCOUNT });
+
+  for (const key of HERO_FLAG_KEYS) {
+    assert.equal(result[key], 'true', `${key} must be 'true' for listed account`);
+  }
+});
+
+test('account NOT in list → flags from env unchanged (all false)', () => {
+  const env = envWithTeamList([TEAM_ACCOUNT]);
+  const result = resolveHeroFlagsWithOverride({ env, accountId: OTHER_ACCOUNT });
+
+  for (const key of HERO_FLAG_KEYS) {
+    assert.equal(result[key], 'false', `${key} must remain 'false' for non-listed account`);
+  }
+});
+
+test('HERO_INTERNAL_ACCOUNTS is empty string → no override', () => {
+  const env = baseEnv({ HERO_INTERNAL_ACCOUNTS: '' });
+  const result = resolveHeroFlagsWithOverride({ env, accountId: TEAM_ACCOUNT });
+
+  for (const key of HERO_FLAG_KEYS) {
+    assert.equal(result[key], 'false');
+  }
+});
+
+test('HERO_INTERNAL_ACCOUNTS is missing/undefined → no override', () => {
+  const env = baseEnv();
+  // No HERO_INTERNAL_ACCOUNTS key at all
+  const result = resolveHeroFlagsWithOverride({ env, accountId: TEAM_ACCOUNT });
+
+  for (const key of HERO_FLAG_KEYS) {
+    assert.equal(result[key], 'false');
+  }
+});
+
+test('HERO_INTERNAL_ACCOUNTS is malformed JSON → no override (graceful)', () => {
+  const env = baseEnv({ HERO_INTERNAL_ACCOUNTS: '{not valid json[' });
+  const result = resolveHeroFlagsWithOverride({ env, accountId: TEAM_ACCOUNT });
+
+  for (const key of HERO_FLAG_KEYS) {
+    assert.equal(result[key], 'false');
+  }
+});
+
+test('HERO_INTERNAL_ACCOUNTS is valid JSON but not an array → no override', () => {
+  const env = baseEnv({ HERO_INTERNAL_ACCOUNTS: '{"id": "acc-team-001"}' });
+  const result = resolveHeroFlagsWithOverride({ env, accountId: TEAM_ACCOUNT });
+
+  for (const key of HERO_FLAG_KEYS) {
+    assert.equal(result[key], 'false');
+  }
+});
+
+test('override is additive-only: non-Hero env vars are preserved unchanged', () => {
+  const env = envWithTeamList([TEAM_ACCOUNT]);
+  const result = resolveHeroFlagsWithOverride({ env, accountId: TEAM_ACCOUNT });
+
+  assert.equal(result.APP_NAME, 'KS2 Mastery');
+  assert.equal(result.DB, 'mock-db-binding');
+  assert.equal(result.HERO_INTERNAL_ACCOUNTS, JSON.stringify([TEAM_ACCOUNT]));
+});
+
+test('env is null → returns empty object without throwing', () => {
+  const result = resolveHeroFlagsWithOverride({ env: null, accountId: TEAM_ACCOUNT });
+  assert.deepEqual(result, {});
+});
+
+test('accountId is empty string → no override applied', () => {
+  const env = envWithTeamList([TEAM_ACCOUNT]);
+  const result = resolveHeroFlagsWithOverride({ env, accountId: '' });
+
+  for (const key of HERO_FLAG_KEYS) {
+    assert.equal(result[key], 'false');
+  }
+});
+
+test('accountId is undefined → no override applied', () => {
+  const env = envWithTeamList([TEAM_ACCOUNT]);
+  const result = resolveHeroFlagsWithOverride({ env, accountId: undefined });
+
+  for (const key of HERO_FLAG_KEYS) {
+    assert.equal(result[key], 'false');
+  }
+});
+
+// ── Integration: buildHeroShadowReadModel with override ─────────────
+
+test('integration: buildHeroShadowReadModel with override produces enabled UI for listed account', () => {
+  const env = envWithTeamList([TEAM_ACCOUNT]);
+
+  // Minimal subject read models for eligibility (spelling provider needs data)
+  const subjectReadModels = {
+    spelling: {
+      data: {
+        megaStatus: 'not-started',
+        units: [
+          { id: 'unit-1', status: 'mastered', score: 100, starCount: 3 },
+          { id: 'unit-2', status: 'in-progress', score: 60, starCount: 1 },
+        ],
+      },
+      ui: {},
+    },
+  };
+
+  const result = buildHeroShadowReadModel({
+    learnerId: 'learner-test-1',
+    accountId: TEAM_ACCOUNT,
+    subjectReadModels,
+    now: Date.now(),
+    env,
+  });
+
+  // Override forces all flags on → ui.enabled should be true (assuming launchable tasks)
+  assert.equal(result.childVisible, true, 'childVisible must be true for overridden account');
+
+  // The ui.reason tells us what happened — if no launchable tasks it could be
+  // 'no-launchable-tasks', but the shadow/launch/childUi gates must pass
+  assert.notEqual(result.ui.reason, 'shadow-disabled');
+  assert.notEqual(result.ui.reason, 'launch-disabled');
+  assert.notEqual(result.ui.reason, 'child-ui-disabled');
+});
+
+test('integration: buildHeroShadowReadModel without override keeps flags from env', () => {
+  const env = envWithTeamList([TEAM_ACCOUNT]);
+
+  const subjectReadModels = {
+    spelling: {
+      data: {
+        megaStatus: 'not-started',
+        units: [
+          { id: 'unit-1', status: 'mastered', score: 100, starCount: 3 },
+        ],
+      },
+      ui: {},
+    },
+  };
+
+  const result = buildHeroShadowReadModel({
+    learnerId: 'learner-test-2',
+    accountId: OTHER_ACCOUNT,
+    subjectReadModels,
+    now: Date.now(),
+    env,
+  });
+
+  // Non-listed account → all flags off → shadow-disabled
+  assert.equal(result.ui.reason, 'shadow-disabled');
+  assert.equal(result.childVisible, false);
+});

--- a/worker/src/hero/launch.js
+++ b/worker/src/hero/launch.js
@@ -9,6 +9,8 @@ import {
   HERO_READY_SUBJECT_IDS,
 } from '../../../shared/hero/constants.js';
 
+import { resolveHeroFlagsWithOverride } from '../../../shared/hero/account-override.js';
+
 function envFlagEnabled(value) {
   return ['1', 'true', 'yes', 'on'].includes(String(value || '').trim().toLowerCase());
 }
@@ -105,8 +107,9 @@ export async function resolveHeroStartTaskCommand({ body, repository, env, now, 
     });
   }
 
-  const safeEnv = env || {};
-  const childUiEnabled = envFlagEnabled(safeEnv.HERO_MODE_CHILD_UI_ENABLED);
+  // Per-account override: team accounts in HERO_INTERNAL_ACCOUNTS get all flags on
+  const resolvedEnv = resolveHeroFlagsWithOverride({ env, accountId: callerAccountId });
+  const childUiEnabled = envFlagEnabled(resolvedEnv.HERO_MODE_CHILD_UI_ENABLED);
 
   // Quest fingerprint validation: required when child UI is enabled
   if (childUiEnabled) {

--- a/worker/src/hero/read-model.js
+++ b/worker/src/hero/read-model.js
@@ -25,6 +25,8 @@ import {
   HERO_READY_SUBJECT_IDS,
 } from '../../../shared/hero/constants.js';
 
+import { resolveHeroFlagsWithOverride } from '../../../shared/hero/account-override.js';
+
 import { resolveEligibility } from '../../../shared/hero/eligibility.js';
 import { generateHeroSeed, deriveDateKey } from '../../../shared/hero/seed.js';
 import { scheduleShadowQuest } from '../../../shared/hero/scheduler.js';
@@ -142,12 +144,14 @@ export function buildHeroShadowReadModel({
   campEnabled = false,
 } = {}) {
   const dateKey = deriveDateKey(now, HERO_DEFAULT_TIMEZONE);
-  const safeEnv = env || {};
+
+  // Per-account override: team accounts in HERO_INTERNAL_ACCOUNTS get all flags on
+  const resolvedEnv = resolveHeroFlagsWithOverride({ env, accountId });
 
   // Feature flag hierarchy
-  const shadowEnabled = envFlagEnabled(safeEnv.HERO_MODE_SHADOW_ENABLED);
-  const launchEnabled = envFlagEnabled(safeEnv.HERO_MODE_LAUNCH_ENABLED);
-  const childUiEnabled = envFlagEnabled(safeEnv.HERO_MODE_CHILD_UI_ENABLED);
+  const shadowEnabled = envFlagEnabled(resolvedEnv.HERO_MODE_SHADOW_ENABLED);
+  const launchEnabled = envFlagEnabled(resolvedEnv.HERO_MODE_LAUNCH_ENABLED);
+  const childUiEnabled = envFlagEnabled(resolvedEnv.HERO_MODE_CHILD_UI_ENABLED);
 
   // 1. Run each provider via the provider registry.
   //    subjectReadModels is keyed by subjectId. Each value is either:

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -48,6 +48,11 @@
     "HERO_MODE_PROGRESS_ENABLED": "false",
     "HERO_MODE_ECONOMY_ENABLED": "false",
     "HERO_MODE_CAMP_ENABLED": "false"
+    // Secret: HERO_INTERNAL_ACCOUNTS — JSON array of account IDs for Ring 4
+    // internal production override. Listed accounts get all 6 Hero flags
+    // force-enabled regardless of the vars above. Set via:
+    //   npx wrangler secret put HERO_INTERNAL_ACCOUNTS
+    // Value: '["account-id-1","account-id-2"]'
   },
   "d1_databases": [
     {


### PR DESCRIPTION
## Summary
- Adds `shared/hero/account-override.js` — pure flag resolution with team account list from `HERO_INTERNAL_ACCOUNTS` secret
- Integrates into read-model and launch command so listed accounts get all 6 Hero flags force-enabled
- Additive-only: listed accounts get flags on, non-listed accounts unchanged, non-Hero env vars preserved
- Production remains default-off for all non-team accounts (vars unchanged in wrangler.jsonc)

## Test plan
- [x] node --test tests/hero-pA1-account-override.test.js (12/12 pass)
- [x] node --test tests/hero-p6-rollback.test.js (17/17 pass, no regression)
- [x] node --test tests/hero-pA1-flag-ladder.test.js (31/31 pass, no regression)