### PR TITLE
ci(github): skip heavy jobs for docs-only PRs

### DIFF
--- a/.github/actions/classify-docs-only/action.yml
+++ b/.github/actions/classify-docs-only/action.yml
@@ -1,0 +1,21 @@
+name: Classify docs-only changes
+description: Emits docs_only=true when every changed file is documentation.
+inputs:
+  base-sha:
+    description: Base commit SHA for the pull request diff.
+    required: false
+    default: ''
+  head-sha:
+    description: Head commit SHA for the pull request diff.
+    required: false
+    default: ''
+outputs:
+  docs_only:
+    description: Whether the change set contains only documentation files.
+    value: ${{ steps.classify.outputs.docs_only }}
+runs:
+  using: composite
+  steps:
+    - id: classify
+      shell: bash
+      run: node scripts/ci-docs-only.mjs "${{ inputs.base-sha }}" "${{ inputs.head-sha }}"

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -88,12 +88,31 @@ Default PR gates are therefore:
 
 - `npm test + npm run check`
 - `npm run audit:client`
+- `npm run audit:punctuation-content`
 
 Browser evidence remains expected for browser-facing changes, but the
 owner of that slice should run the targeted local Playwright command and
 include the command/result in the PR body. Use the `run-playwright` label
 when a reviewer wants GitHub-hosted confirmation before merge. The full
 matrix remains covered by `playwright-nightly.yml`.
+
+## Documentation-only pull requests
+
+PR workflows classify the pull request diff before running heavy CI. If every
+changed path is under `docs/` or ends in `.md`, the PR is treated as
+documentation-only and these heavy jobs are skipped at job level:
+
+- `npm test + npm run check`
+- `npm run audit:client`
+- `npm run audit:punctuation-content`
+- `Chromium + mobile-390 golden paths`
+
+The classifier lives in `scripts/ci-docs-only.mjs`, is wrapped by
+`.github/actions/classify-docs-only/action.yml`, and is covered by
+`tests/ci-docs-only.test.js`. Keep this as a job-level condition rather than
+an `on.pull_request.paths-ignore` filter: GitHub reports conditionally skipped
+jobs as successful for required-check purposes, while a skipped workflow can
+leave a required check pending.
 
 ## Current workflows
 
@@ -103,6 +122,7 @@ matrix remains covered by `playwright-nightly.yml`.
 | `playwright-nightly.yml` | `schedule` (03:07 UTC) | Full 5-viewport Playwright matrix. |
 | `node-test.yml` | `pull_request` | `npm test` + `npm run check` (schema-drift canary). |
 | `audit.yml` | `pull_request` | `npm run audit:client`. |
+| `punctuation-content-audit.yml` | `pull_request` | `npm run audit:punctuation-content`. |
 | `mega-invariant-nightly.yml` | `schedule` (02:37 UTC) | Variable-seed Mega invariant probe. |
 
 ## Temporary non-blocking status: `audit.yml` (SH2-U11)

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -28,8 +28,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Classify changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.classify.outputs.docs_only }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Classify docs-only changes
+        id: classify
+        uses: ./.github/actions/classify-docs-only
+        with:
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          head-sha: ${{ github.sha }}
+
   audit:
     name: npm run audit:client
+    needs: changes
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.docs_only != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -37,8 +37,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Classify changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.classify.outputs.docs_only }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Classify docs-only changes
+        id: classify
+        uses: ./.github/actions/classify-docs-only
+        with:
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          head-sha: ${{ github.sha }}
+
   test:
     name: npm test + npm run check
+    needs: changes
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.docs_only != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -55,13 +55,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Classify changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.classify.outputs.docs_only }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Classify docs-only changes
+        id: classify
+        uses: ./.github/actions/classify-docs-only
+        with:
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          head-sha: ${{ github.sha }}
+
   playwright:
     name: Chromium + mobile-390 golden paths
+    needs: changes
     runs-on: ubuntu-latest
     # Keep this as a job-level condition, not a workflow/path filter.
     # A skipped job reports success for required-check purposes; a
     # skipped workflow can remain pending and block merges.
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-playwright')) }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && needs.changes.outputs.docs_only != 'true' && contains(github.event.pull_request.labels.*.name, 'run-playwright')) }}
     timeout-minutes: 20
     steps:
       - name: Checkout

--- a/.github/workflows/punctuation-content-audit.yml
+++ b/.github/workflows/punctuation-content-audit.yml
@@ -25,8 +25,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Classify changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.classify.outputs.docs_only }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Classify docs-only changes
+        id: classify
+        uses: ./.github/actions/classify-docs-only
+        with:
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          head-sha: ${{ github.sha }}
+
   audit:
     name: npm run audit:punctuation-content
+    needs: changes
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.docs_only != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/scripts/ci-docs-only.mjs
+++ b/scripts/ci-docs-only.mjs
@@ -1,0 +1,67 @@
+import { execFileSync } from 'node:child_process';
+import { appendFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export function normaliseChangedFiles(output) {
+  return String(output || '')
+    .split(/\r?\n/)
+    .map((filePath) => filePath.trim())
+    .filter(Boolean);
+}
+
+export function isDocumentationPath(filePath) {
+  const normalised = String(filePath || '').replace(/\\/g, '/');
+  return normalised.startsWith('docs/') || normalised.endsWith('.md');
+}
+
+export function isDocsOnlyChange(files) {
+  const changedFiles = files.filter(Boolean);
+  return changedFiles.length > 0 && changedFiles.every(isDocumentationPath);
+}
+
+export function collectChangedFiles(baseSha, headSha) {
+  return normaliseChangedFiles(
+    execFileSync('git', ['diff', '--name-only', baseSha, headSha], {
+      encoding: 'utf8',
+    }),
+  );
+}
+
+export function writeGithubOutput(docsOnly) {
+  const output = `docs_only=${docsOnly ? 'true' : 'false'}\n`;
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(process.env.GITHUB_OUTPUT, output);
+    return;
+  }
+  process.stdout.write(output);
+}
+
+export function run(argv = process.argv.slice(2)) {
+  const [baseSha, headSha] = argv;
+  if (!baseSha || !headSha) {
+    console.log('Missing base/head SHA; treating change set as non-docs-only.');
+    writeGithubOutput(false);
+    return false;
+  }
+
+  const changedFiles = collectChangedFiles(baseSha, headSha);
+  const docsOnly = isDocsOnlyChange(changedFiles);
+
+  console.log(`Changed files: ${changedFiles.length}`);
+  console.log(`Docs-only change set: ${docsOnly ? 'yes' : 'no'}`);
+  writeGithubOutput(docsOnly);
+  return docsOnly;
+}
+
+const isDirectInvocation = (() => {
+  try {
+    return fileURLToPath(import.meta.url) === path.resolve(process.argv[1] || '');
+  } catch {
+    return false;
+  }
+})();
+
+if (isDirectInvocation) {
+  run();
+}

--- a/tests/ci-docs-only.test.js
+++ b/tests/ci-docs-only.test.js
@@ -1,0 +1,48 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  isDocsOnlyChange,
+  isDocumentationPath,
+  normaliseChangedFiles,
+} from '../scripts/ci-docs-only.mjs';
+
+test('normaliseChangedFiles removes empty lines and whitespace', () => {
+  assert.deepEqual(
+    normaliseChangedFiles('docs/a.md\n\n src/app.jsx \r\n'),
+    ['docs/a.md', 'src/app.jsx'],
+  );
+});
+
+test('isDocumentationPath accepts docs directory files and Markdown files', () => {
+  assert.equal(isDocumentationPath('docs/operations/capacity.md'), true);
+  assert.equal(isDocumentationPath('docs/evidence/report.json'), true);
+  assert.equal(isDocumentationPath('README.md'), true);
+  assert.equal(isDocumentationPath('.github/workflows/README.md'), true);
+});
+
+test('isDocumentationPath rejects runtime, CI config, and public index files', () => {
+  assert.equal(isDocumentationPath('src/app.jsx'), false);
+  assert.equal(isDocumentationPath('.github/workflows/node-test.yml'), false);
+  assert.equal(isDocumentationPath('llms.txt'), false);
+  assert.equal(isDocumentationPath('public/sitemap.xml'), false);
+});
+
+test('isDocsOnlyChange requires a non-empty all-documentation change set', () => {
+  assert.equal(isDocsOnlyChange([]), false);
+  assert.equal(
+    isDocsOnlyChange([
+      'docs/operations/capacity.md',
+      'docs/evidence/report.json',
+      'README.md',
+    ]),
+    true,
+  );
+  assert.equal(
+    isDocsOnlyChange([
+      'docs/operations/capacity.md',
+      'src/app.jsx',
+    ]),
+    false,
+  );
+});


### PR DESCRIPTION
## Summary
- Adds a reusable docs-only classifier for PR diffs.
- Skips heavy GitHub Actions jobs at job level when every changed file is under `docs/` or ends in `.md`.
- Documents the policy and covers the classifier with node tests.

## Verification
- `npm test -- tests/ci-docs-only.test.js`
- `ruby -e 'require "yaml"; ARGV.each { |file| YAML.load_file(file); puts "ok #{file}" }' .github/workflows/node-test.yml .github/workflows/audit.yml .github/workflows/punctuation-content-audit.yml .github/workflows/playwright.yml .github/actions/classify-docs-only/action.yml`
- `git diff --check`
- Earlier before the final rebase: full `npm test` passed with 12082 tests, 12076 passed, 6 skipped.