### PR TITLE
feat(grammar-qg-p9): U3 — learner-visible prompt cue contract

### DIFF
--- a/docs/plans/james/grammar/grammar-content-expansion-audit.md
+++ b/docs/plans/james/grammar/grammar-content-expansion-audit.md
@@ -5,7 +5,7 @@ status: p5-updated
 date: 2026-04-28
 plan: docs/plans/2026-04-26-001-feat-grammar-phase4-learning-hardening-plan.md
 unit: U12
-contentReleaseId: grammar-qg-p8-2026-04-29
+contentReleaseId: grammar-qg-p9-2026-04-29
 contentReleaseBump: yes
 ---
 

--- a/src/subjects/grammar/components/GrammarSessionScene.jsx
+++ b/src/subjects/grammar/components/GrammarSessionScene.jsx
@@ -670,7 +670,21 @@ export function GrammarSessionScene({ grammar, actions, runtimeReadOnly }) {
             answerFormId={answerFormId}
           />
         ) : null}
-        <p className="grammar-prompt">{item.promptText || 'Loading the next Grammar item...'}</p>
+        {item.promptParts ? (
+          <p className="grammar-prompt" aria-label={item.screenReaderPromptText || undefined}>
+            {item.promptParts.map((part, i) => {
+              switch (part.kind) {
+                case 'emphasis': return <em key={i}>{part.text}</em>;
+                case 'underline': return <span key={i} className="prompt-underline">{part.text}</span>;
+                case 'lineBreak': return <br key={i} />;
+                case 'sentence': return <span key={i} className="prompt-sentence">{part.text}</span>;
+                default: return <span key={i}>{part.text}</span>;
+              }
+            })}
+          </p>
+        ) : (
+          <p className="grammar-prompt">{item.promptText || 'Loading the next Grammar item...'}</p>
+        )}
         {item.checkLine ? <p className="grammar-check-line">{item.checkLine}</p> : null}
         <ReadAloudControls grammar={grammar} />
         {!isMiniTest ? <GuidancePanel support={session.supportGuidance} /> : null}

--- a/styles/app.css
+++ b/styles/app.css
@@ -7928,6 +7928,16 @@ textarea:focus-visible {
   letter-spacing: 0;
 }
 
+.grammar-prompt .prompt-underline {
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+  text-underline-offset: 3px;
+}
+
+.grammar-prompt .prompt-sentence {
+  font-weight: 600;
+}
+
 .grammar-check-line {
   margin: -4px 0 0;
   color: var(--ink-2);

--- a/tests/fixtures/grammar-legacy-oracle/grammar-qg-p6-baseline.json
+++ b/tests/fixtures/grammar-legacy-oracle/grammar-qg-p6-baseline.json
@@ -1,5 +1,5 @@
 {
-  "releaseId": "grammar-qg-p8-2026-04-29",
+  "releaseId": "grammar-qg-p9-2026-04-29",
   "conceptCount": 18,
   "templateCount": 78,
   "selectedResponseCount": 58,

--- a/tests/grammar-qg-p7-production-evidence.test.js
+++ b/tests/grammar-qg-p7-production-evidence.test.js
@@ -272,16 +272,16 @@ describe('Grammar QG P7 — Smoke artefact schema enforcement', () => {
     assert.ok(missing.includes('timestamp'));
   });
 
-  it('P8 bumps the content release ID for production content fix', async () => {
-    // P8 fixes speech_punctuation_fix content defect and bumps the release ID
+  it('P9 bumps the content release ID for prompt cue contract', async () => {
+    // P9 adds structured prompt cues and bumps the release ID
     const { GRAMMAR_CONTENT_RELEASE_ID } = await import('../worker/src/subjects/grammar/content.js');
-    assert.equal(GRAMMAR_CONTENT_RELEASE_ID, 'grammar-qg-p8-2026-04-29',
-      'P8 must use new content release ID since it fixes production content');
+    assert.equal(GRAMMAR_CONTENT_RELEASE_ID, 'grammar-qg-p9-2026-04-29',
+      'P9 must use new content release ID since it adds learner-visible serialisation fields');
   });
 
   it('smoke evidence file path uses current content release ID', () => {
-    const contentReleaseId = 'grammar-qg-p8-2026-04-29';
+    const contentReleaseId = 'grammar-qg-p9-2026-04-29';
     const expectedFileName = `grammar-production-smoke-${contentReleaseId}.json`;
-    assert.equal(expectedFileName, 'grammar-production-smoke-grammar-qg-p8-2026-04-29.json');
+    assert.equal(expectedFileName, 'grammar-production-smoke-grammar-qg-p9-2026-04-29.json');
   });
 });

--- a/tests/grammar-qg-p9-learner-surface.test.js
+++ b/tests/grammar-qg-p9-learner-surface.test.js
@@ -1,0 +1,222 @@
+/**
+ * Grammar QG P9 — Learner-visible Prompt Cue Contract
+ *
+ * Structural checks proving that templates with visual-cue language
+ * (underlined, bold, sentence below) produce structured prompt metadata
+ * for safe client-side rendering without dangerouslySetInnerHTML.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  createGrammarQuestion,
+  serialiseGrammarQuestion,
+  GRAMMAR_CONTENT_RELEASE_ID,
+  GRAMMAR_TEMPLATE_METADATA,
+} from '../worker/src/subjects/grammar/content.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function generateQuestion(templateId, seed = 1) {
+  return createGrammarQuestion({ templateId, seed });
+}
+
+function serialiseQuestion(templateId, seed = 1) {
+  const q = generateQuestion(templateId, seed);
+  return q ? serialiseGrammarQuestion(q) : null;
+}
+
+// ---------------------------------------------------------------------------
+// 1. word_class_underlined_choice has focusCue with type 'underline'
+// ---------------------------------------------------------------------------
+
+describe('P9 prompt cue: word_class_underlined_choice', () => {
+  it('question has focusCue with type underline', () => {
+    const q = generateQuestion('word_class_underlined_choice', 1);
+    assert.ok(q, 'question must be generated');
+    assert.ok(q.focusCue, 'focusCue must be present');
+    assert.strictEqual(q.focusCue.type, 'underline');
+    assert.ok(q.focusCue.text.length > 0, 'focusCue.text must be non-empty');
+  });
+
+  it('question has promptParts array', () => {
+    const q = generateQuestion('word_class_underlined_choice', 2);
+    assert.ok(q, 'question must be generated');
+    assert.ok(Array.isArray(q.promptParts), 'promptParts must be an array');
+    assert.ok(q.promptParts.length > 0, 'promptParts must not be empty');
+    // Must contain an underline part matching the focusCue word
+    const underlinePart = q.promptParts.find(p => p.kind === 'underline');
+    assert.ok(underlinePart, 'must have an underline part');
+    assert.strictEqual(underlinePart.text, q.focusCue.text);
+  });
+
+  it('screenReaderPromptText mentions the target word', () => {
+    const q = generateQuestion('word_class_underlined_choice', 3);
+    assert.ok(q, 'question must be generated');
+    assert.ok(q.screenReaderPromptText, 'screenReaderPromptText must exist');
+    assert.ok(
+      q.screenReaderPromptText.includes(q.focusCue.text),
+      `screenReaderPromptText must mention '${q.focusCue.text}'`
+    );
+    assert.ok(
+      q.screenReaderPromptText.includes('Target word:'),
+      'screenReaderPromptText must include "Target word:" prefix'
+    );
+  });
+
+  it('readAloudText includes the cue context', () => {
+    const q = generateQuestion('word_class_underlined_choice', 4);
+    assert.ok(q, 'question must be generated');
+    assert.ok(q.readAloudText, 'readAloudText must exist');
+    assert.ok(
+      q.readAloudText.includes(q.focusCue.text),
+      'readAloudText must mention the underlined word'
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Serialised question includes promptParts when present
+// ---------------------------------------------------------------------------
+
+describe('P9 prompt cue: serialisation includes structured fields', () => {
+  it('serialised word_class_underlined_choice includes promptParts', () => {
+    const s = serialiseQuestion('word_class_underlined_choice', 1);
+    assert.ok(s, 'serialised question must exist');
+    assert.ok(Array.isArray(s.promptParts), 'promptParts must be in serialised output');
+    assert.ok(s.focusCue, 'focusCue must be in serialised output');
+    assert.strictEqual(s.focusCue.type, 'underline');
+    assert.ok(s.screenReaderPromptText, 'screenReaderPromptText must be in serialised output');
+    assert.ok(s.readAloudText, 'readAloudText must be in serialised output');
+  });
+
+  it('serialised question still has promptText (backwards compat)', () => {
+    const s = serialiseQuestion('word_class_underlined_choice', 2);
+    assert.ok(s, 'serialised question must exist');
+    assert.ok(s.promptText, 'promptText must still be present');
+    assert.ok(s.promptText.length > 0, 'promptText must be non-empty');
+  });
+
+  it('contentReleaseId reflects P9', () => {
+    const s = serialiseQuestion('word_class_underlined_choice', 1);
+    assert.ok(s, 'serialised question must exist');
+    assert.strictEqual(s.contentReleaseId, 'grammar-qg-p9-2026-04-29');
+    assert.strictEqual(GRAMMAR_CONTENT_RELEASE_ID, 'grammar-qg-p9-2026-04-29');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Questions WITHOUT visual cues still have promptText, no promptParts
+// ---------------------------------------------------------------------------
+
+describe('P9 prompt cue: backwards compat for non-cue templates', () => {
+  // Find a template that does NOT use underlined/bold/sentence-below in its prompt
+  const nonCueTemplate = GRAMMAR_TEMPLATE_METADATA.find(t => {
+    const q = createGrammarQuestion({ templateId: t.id, seed: 1 });
+    return q && !q.promptParts;
+  });
+
+  it('non-cue template exists in corpus', () => {
+    assert.ok(nonCueTemplate, 'at least one template must lack promptParts');
+  });
+
+  it('non-cue template has promptText in serialised output', () => {
+    if (!nonCueTemplate) return;
+    const s = serialiseQuestion(nonCueTemplate.id, 1);
+    assert.ok(s, 'serialised question must exist');
+    assert.ok(s.promptText, 'promptText must still be present');
+    assert.strictEqual(s.promptParts, undefined, 'promptParts must be absent');
+    assert.strictEqual(s.focusCue, undefined, 'focusCue must be absent');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Prompt containing "underlined" has corresponding focusCue or promptParts
+// ---------------------------------------------------------------------------
+
+describe('P9 prompt cue: all "underlined" prompts get enriched', () => {
+  const underlinedTemplates = GRAMMAR_TEMPLATE_METADATA.filter(t => {
+    const q = createGrammarQuestion({ templateId: t.id, seed: 1 });
+    if (!q) return false;
+    const plain = String(q.stemHtml || '');
+    return /underlined/i.test(plain);
+  });
+
+  it('at least word_class_underlined_choice is in the set', () => {
+    const ids = underlinedTemplates.map(t => t.id);
+    assert.ok(ids.includes('word_class_underlined_choice'));
+  });
+
+  for (const template of underlinedTemplates) {
+    it(`${template.id} has focusCue or promptParts when "underlined" in stemHtml`, () => {
+      const q = createGrammarQuestion({ templateId: template.id, seed: 1 });
+      assert.ok(q, 'question must be generated');
+      const hasCue = q.focusCue || q.promptParts;
+      assert.ok(hasCue, `Template ${template.id} mentions "underlined" but lacks prompt cue data`);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 5. Serialised question does NOT leak answerSpec
+// ---------------------------------------------------------------------------
+
+describe('P9 prompt cue: no answer leaks in serialised output', () => {
+  const BANNED_KEYS = ['evaluate', 'golden', 'nearMiss', 'accepted', 'answerSpec', 'correct'];
+
+  for (const template of GRAMMAR_TEMPLATE_METADATA.slice(0, 10)) {
+    it(`${template.id}: serialised output has no answer-leaking keys`, () => {
+      const s = serialiseQuestion(template.id, 1);
+      if (!s) return; // skip templates that fail to generate
+      for (const banned of BANNED_KEYS) {
+        assert.ok(
+          !(banned in s),
+          `serialised output contains banned key '${banned}'`
+        );
+      }
+      // Also check promptParts / focusCue don't contain answer data
+      if (s.promptParts) {
+        for (const part of s.promptParts) {
+          assert.ok(
+            !('correct' in part) && !('golden' in part),
+            'promptParts must not contain answer data'
+          );
+        }
+      }
+      if (s.focusCue) {
+        assert.ok(
+          !('correct' in s.focusCue) && !('golden' in s.focusCue),
+          'focusCue must not contain answer data'
+        );
+      }
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 6. screenReaderPromptText mentions target word when focusCue exists
+// ---------------------------------------------------------------------------
+
+describe('P9 prompt cue: screenReaderPromptText mentions target', () => {
+  const cueTemplates = GRAMMAR_TEMPLATE_METADATA.filter(t => {
+    const q = createGrammarQuestion({ templateId: t.id, seed: 1 });
+    return q && q.focusCue;
+  });
+
+  it('at least one template has focusCue', () => {
+    assert.ok(cueTemplates.length > 0, 'no templates produced focusCue');
+  });
+
+  for (const template of cueTemplates) {
+    it(`${template.id}: screenReaderPromptText mentions focusCue.text`, () => {
+      const q = createGrammarQuestion({ templateId: template.id, seed: 1 });
+      assert.ok(q.screenReaderPromptText, 'screenReaderPromptText must exist');
+      assert.ok(
+        q.screenReaderPromptText.includes(q.focusCue.text),
+        `screenReaderPromptText must mention '${q.focusCue.text}'`
+      );
+    });
+  }
+});

--- a/worker/src/subjects/grammar/content.js
+++ b/worker/src/subjects/grammar/content.js
@@ -7526,7 +7526,7 @@ function markStringAnswer(respText, acceptedList, opts = {}) {
 }
 
 function makeBaseQuestion(template, seed, data) {
-  return Object.assign({
+  const question = Object.assign({
     templateId: template.id,
     templateLabel: template.label,
     domain: template.domain,
@@ -7540,6 +7540,134 @@ function makeBaseQuestion(template, seed, data) {
     checkLine: "",
     contrastHtml: ""
   }, data || {});
+  return enrichPromptCue(question);
+}
+
+// ---------------------------------------------------------------------------
+// Prompt-cue enrichment — P9 U3
+// Adds structured `promptParts`, `focusCue`, `screenReaderPromptText`, and
+// `readAloudText` when the stemHtml contains visual-cue language. The React
+// renderer uses these to show underlines/bold safely without dangerouslySetInnerHTML.
+// ---------------------------------------------------------------------------
+
+const CUE_PATTERNS = [
+  { regex: /\bunderlined\s+word/i, type: 'underline' },
+  { regex: /\bunderlined\s+pair/i, type: 'underline' },
+  { regex: /\bunderlined\s+group/i, type: 'underline' },
+  { regex: /\bunderlined\s+noun\s+phrase/i, type: 'underline' },
+  { regex: /\bin\s+bold\b/i, type: 'bold' },
+  { regex: /\bshown\s+in\s+brackets/i, type: 'quoted-word' },
+  { regex: /\bsentence\s+below/i, type: 'target-sentence' },
+];
+
+function detectCueType(plainPrompt) {
+  for (const { regex, type } of CUE_PATTERNS) {
+    if (regex.test(plainPrompt)) return type;
+  }
+  return null;
+}
+
+function extractUnderlinedWord(stemHtml) {
+  const match = stemHtml.match(/<u>([^<]+)<\/u>/);
+  return match ? match[1] : null;
+}
+
+function extractBoldSentence(stemHtml) {
+  const match = stemHtml.match(/<strong>(.*?)<\/strong>/);
+  if (!match) return null;
+  // Strip inner HTML tags to get the plain sentence
+  return match[1].replace(/<[^>]*>/g, '').trim();
+}
+
+function buildPromptParts(plainPrompt, cueType, targetWord, targetSentence) {
+  const parts = [];
+
+  if (cueType === 'underline' && targetWord) {
+    // Split prompt into text + cue reference, then append sentence
+    parts.push({ kind: 'text', text: plainPrompt });
+    if (targetSentence) {
+      parts.push({ kind: 'lineBreak', text: '' });
+      const sentenceBeforeTarget = targetSentence.split(targetWord);
+      if (sentenceBeforeTarget.length >= 2) {
+        parts.push({ kind: 'sentence', text: sentenceBeforeTarget[0] });
+        parts.push({ kind: 'underline', text: targetWord });
+        parts.push({ kind: 'sentence', text: sentenceBeforeTarget.slice(1).join(targetWord) });
+      } else {
+        parts.push({ kind: 'sentence', text: targetSentence });
+      }
+    }
+  } else if (cueType === 'target-sentence' && targetSentence) {
+    parts.push({ kind: 'text', text: plainPrompt });
+    if (!plainPrompt.includes(targetSentence)) {
+      parts.push({ kind: 'lineBreak', text: '' });
+      parts.push({ kind: 'sentence', text: targetSentence });
+    }
+  } else if (cueType === 'bold' && targetWord) {
+    parts.push({ kind: 'text', text: plainPrompt });
+    if (targetSentence) {
+      parts.push({ kind: 'lineBreak', text: '' });
+      parts.push({ kind: 'emphasis', text: targetSentence });
+    }
+  } else {
+    parts.push({ kind: 'text', text: plainPrompt });
+  }
+
+  return parts;
+}
+
+function enrichPromptCue(question) {
+  if (!question || !question.stemHtml) return question;
+
+  const plainPrompt = stripLegacyHtml(question.stemHtml);
+  const cueType = detectCueType(plainPrompt);
+  if (!cueType) return question;
+
+  const underlinedWord = extractUnderlinedWord(question.stemHtml);
+  const boldSentence = extractBoldSentence(question.stemHtml);
+  const targetWord = underlinedWord || boldSentence || null;
+  const targetSentence = boldSentence || null;
+
+  // Build focusCue
+  if (cueType === 'underline' && underlinedWord) {
+    question.focusCue = { type: 'underline', text: underlinedWord };
+  } else if (cueType === 'bold' && boldSentence) {
+    question.focusCue = { type: 'bold', text: boldSentence };
+  } else if (cueType === 'quoted-word' && targetWord) {
+    question.focusCue = { type: 'quoted-word', text: targetWord };
+  } else if (cueType === 'target-sentence' && targetSentence) {
+    question.focusCue = { type: 'target-sentence', text: targetSentence };
+  }
+
+  // Build promptParts
+  question.promptParts = buildPromptParts(plainPrompt, cueType, targetWord, targetSentence);
+
+  // screenReaderPromptText — mentions the target word clearly
+  if (question.focusCue) {
+    const word = question.focusCue.text;
+    if (cueType === 'underline') {
+      question.screenReaderPromptText = `${plainPrompt} Target word: ${word}`;
+    } else if (cueType === 'bold') {
+      question.screenReaderPromptText = `${plainPrompt} Focus: ${word}`;
+    } else if (cueType === 'target-sentence') {
+      question.screenReaderPromptText = `${plainPrompt} Sentence: ${word}`;
+    } else {
+      question.screenReaderPromptText = `${plainPrompt} Target: ${word}`;
+    }
+  }
+
+  // readAloudText — full spoken form including cue
+  if (question.focusCue) {
+    const word = question.focusCue.text;
+    if (cueType === 'underline') {
+      question.readAloudText = `${plainPrompt} The underlined word is: ${word}.`;
+    } else if (cueType === 'target-sentence') {
+      question.readAloudText = `${plainPrompt} The sentence is: ${word}.`;
+    } else {
+      question.readAloudText = `${plainPrompt} Focus on: ${word}.`;
+    }
+  }
+
+  return question;
 }
 
 function capFirst(text) {
@@ -7960,7 +8088,7 @@ export function grammarQuestionVariantSignature(question) {
   return `grammar-v1:${stableStringHash(JSON.stringify(payload))}`;
 }
 
-export const GRAMMAR_CONTENT_RELEASE_ID = 'grammar-qg-p8-2026-04-29';
+export const GRAMMAR_CONTENT_RELEASE_ID = 'grammar-qg-p9-2026-04-29';
 export const GRAMMAR_MISCONCEPTIONS = Object.freeze(MISCONCEPTIONS);
 export const GRAMMAR_MINIMAL_HINTS = Object.freeze(MINIMAL_HINTS);
 export const GRAMMAR_QUESTION_TYPES = Object.freeze(QUESTION_TYPES);
@@ -8019,7 +8147,7 @@ export function evaluateGrammarQuestion(question, response = {}) {
 
 export function serialiseGrammarQuestion(question) {
   if (!question || typeof question !== 'object' || Array.isArray(question)) return null;
-  return {
+  const serialised = {
     contentReleaseId: GRAMMAR_CONTENT_RELEASE_ID,
     templateId: question.templateId,
     templateLabel: question.templateLabel,
@@ -8043,4 +8171,12 @@ export function serialiseGrammarQuestion(question) {
       questionType: question.questionType,
     },
   };
+
+  // P9 U3: structured prompt cue fields (prompt-level, no answer leaks)
+  if (question.promptParts) serialised.promptParts = question.promptParts;
+  if (question.focusCue) serialised.focusCue = question.focusCue;
+  if (question.screenReaderPromptText) serialised.screenReaderPromptText = question.screenReaderPromptText;
+  if (question.readAloudText) serialised.readAloudText = question.readAloudText;
+
+  return serialised;
 }


### PR DESCRIPTION
## Summary
- Adds structured prompt cue representation (`promptParts`, `focusCue`, `screenReaderPromptText`, `readAloudText`) to grammar questions whose stemHtml contains visual-cue language (underlined, bold, sentence below)
- React renderer in GrammarSessionScene uses `promptParts` for safe semantic markup (no dangerouslySetInnerHTML), falling back to plain `promptText` for backwards compat
- Bumps `GRAMMAR_CONTENT_RELEASE_ID` to `grammar-qg-p9-2026-04-29` since this is a learner-visible serialisation change

## Key implementation details
- `enrichPromptCue()` helper in content.js runs at question creation time via `makeBaseQuestion`
- Templates affected: `word_class_underlined_choice`, `formality_pairs`, `qg_p4_voice_roles_transfer`, plus all templates with "sentence below" in their prompt
- Serialisation includes cue fields only when present (additive, non-breaking)
- CSS classes `.prompt-underline` and `.prompt-sentence` added to `styles/app.css`

## Test plan
- [x] 31 new tests in `grammar-qg-p9-learner-surface.test.js` covering cue generation, serialisation, backwards compat, no-leak invariants, and screenReaderPromptText
- [x] 601 existing P8 UX support tests pass (zero regression)
- [x] 23 existing P7 production evidence tests pass (release ID updated)
- [x] 10 content expansion audit tests pass (frontmatter updated)
- [x] Total: 665 tests pass, 0 failures