### PR TITLE
feat(grammar-qg-p9): U9 — production smoke evidence gate

### DIFF
--- a/scripts/validate-grammar-qg-certification-evidence.mjs
+++ b/scripts/validate-grammar-qg-certification-evidence.mjs
@@ -259,8 +259,85 @@ export function validateReportAgainstManifest(reportContent, manifest) {
 }
 
 /**
- * Validate smoke evidence — checks that smoke evidence files exist when claimed.
- * (Stub for U9 extension — currently checks file existence.)
+ * Required fields in a production smoke evidence JSON file.
+ */
+export const SMOKE_EVIDENCE_REQUIRED_FIELDS = [
+  'releaseId',
+  'deployedUrl',
+  'timestamp',
+  'command',
+  'learnerFixtureType',
+  'itemCreationResult',
+  'answerSubmissionResult',
+  'readModelUpdateResult',
+  'noAnswerLeakAssertion',
+  'failureDetails',
+];
+
+/**
+ * Extract the certification_decision from report frontmatter.
+ * Returns the raw string value or null if not present.
+ */
+export function extractCertificationDecision(reportContent) {
+  const fmBlock = reportContent.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!fmBlock) return null;
+  const match = fmBlock[1].match(/^certification_decision:\s+(.+)$/m);
+  return match ? match[1].trim() : null;
+}
+
+/**
+ * Extract the post_deploy_smoke_evidence value from report frontmatter.
+ * Returns the raw string value or null if not present.
+ */
+export function extractPostDeploySmokeEvidence(reportContent) {
+  const fmBlock = reportContent.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!fmBlock) return null;
+  const match = fmBlock[1].match(/^post_deploy_smoke_evidence:\s+(.+)$/m);
+  return match ? match[1].trim() : null;
+}
+
+/**
+ * Extract the limitations list from report frontmatter.
+ * Returns an array of limitation strings, or empty array if not present.
+ */
+export function extractLimitations(reportContent) {
+  const fmBlock = reportContent.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!fmBlock) return [];
+
+  const lines = fmBlock[1].split(/\r?\n/);
+  const limitations = [];
+  let inLimitations = false;
+
+  for (const line of lines) {
+    if (/^limitations:\s*$/.test(line)) {
+      inLimitations = true;
+      continue;
+    }
+    if (inLimitations) {
+      const itemMatch = line.match(/^\s+-\s+(.+)$/);
+      if (itemMatch) {
+        limitations.push(itemMatch[1].trim());
+      } else if (/^\w/.test(line)) {
+        // New top-level key — stop collecting limitations
+        break;
+      }
+    }
+  }
+  return limitations;
+}
+
+/**
+ * Validate smoke evidence — checks that smoke evidence files exist when required.
+ *
+ * Rules:
+ * - If certification_decision is CERTIFIED_POST_DEPLOY:
+ *   - A valid smoke evidence file MUST exist at reports/grammar/grammar-production-smoke-<releaseId>.json
+ *   - The file must contain all required fields
+ *   - The file's releaseId must match the report's content release ID
+ * - If certification_decision is CERTIFIED_PRE_DEPLOY or CERTIFIED_WITH_LIMITATIONS:
+ *   - No smoke evidence file required (pass without it)
+ * - Legacy behaviour: if no certification_decision in frontmatter, fall back to
+ *   checking text claims of "smoke passed"
  *
  * @param {object} manifest - Parsed certification manifest JSON.
  * @param {string} reportContent - Markdown content of the completion report.
@@ -272,7 +349,86 @@ export function validateSmokeEvidence(manifest, reportContent, opts = {}) {
   const rootDir = opts.rootDir || ROOT_DIR;
   const mismatches = [];
 
-  // Check if report claims smoke passed
+  const certDecision = extractCertificationDecision(reportContent);
+  const postDeploySmokeField = extractPostDeploySmokeEvidence(reportContent);
+
+  // --- CERTIFIED_PRE_DEPLOY: no smoke file required ---
+  if (certDecision && /certified[_-]?pre[_-]?deploy/i.test(certDecision)) {
+    return { pass: true, mismatches: [] };
+  }
+
+  // --- CERTIFIED_WITH_LIMITATIONS: no smoke file required ---
+  if (certDecision && /certified[_-]?with[_-]?limitations/i.test(certDecision)) {
+    return { pass: true, mismatches: [] };
+  }
+
+  // --- CERTIFIED_POST_DEPLOY: smoke file MUST exist and be valid ---
+  if (certDecision && /certified[_-]?post[_-]?deploy/i.test(certDecision)) {
+    const releaseId = manifest.contentReleaseId;
+    if (!releaseId) {
+      mismatches.push({
+        field: 'smokeEvidenceFile',
+        claimed: 'CERTIFIED_POST_DEPLOY',
+        actual: 'no contentReleaseId in manifest',
+        message: 'Cannot validate smoke evidence: manifest has no contentReleaseId',
+      });
+      return { pass: false, mismatches };
+    }
+
+    const evidencePath = path.join(rootDir, 'reports', 'grammar', `grammar-production-smoke-${releaseId}.json`);
+
+    // Check file existence
+    if (!existsSync(evidencePath)) {
+      mismatches.push({
+        field: 'smokeEvidenceFile',
+        claimed: 'CERTIFIED_POST_DEPLOY',
+        actual: `evidence file not found at reports/grammar/grammar-production-smoke-${releaseId}.json`,
+        message: `Report claims CERTIFIED_POST_DEPLOY but smoke evidence file does not exist: reports/grammar/grammar-production-smoke-${releaseId}.json`,
+      });
+      return { pass: false, mismatches };
+    }
+
+    // Parse and validate the evidence file
+    let evidence;
+    try {
+      evidence = JSON.parse(readFileSync(evidencePath, 'utf8'));
+    } catch (err) {
+      mismatches.push({
+        field: 'smokeEvidenceFileSchema',
+        claimed: 'valid JSON',
+        actual: `parse error: ${err.message}`,
+        message: `Smoke evidence file is not valid JSON: ${err.message}`,
+      });
+      return { pass: false, mismatches };
+    }
+
+    // Check required fields — a field is present if it exists in the object (null is valid for failureDetails)
+    for (const field of SMOKE_EVIDENCE_REQUIRED_FIELDS) {
+      if (!(field in evidence)) {
+        mismatches.push({
+          field: 'smokeEvidenceFieldMissing',
+          claimed: `field "${field}" present`,
+          actual: 'missing',
+          message: `Smoke evidence file is missing required field: ${field}`,
+        });
+      }
+    }
+
+    // Validate releaseId matches
+    if (evidence.releaseId && evidence.releaseId !== releaseId) {
+      mismatches.push({
+        field: 'smokeEvidenceReleaseIdMismatch',
+        claimed: releaseId,
+        actual: evidence.releaseId,
+        message: `Smoke evidence releaseId "${evidence.releaseId}" does not match manifest contentReleaseId "${releaseId}"`,
+      });
+    }
+
+    return { pass: mismatches.length === 0, mismatches };
+  }
+
+  // --- Legacy fallback: no certification_decision in frontmatter ---
+  // Check if report claims smoke passed via text
   const smokePassedRegex = /(?:production\s+smoke|repository\s+smoke|post-deploy\s+smoke)\s*[:=]?\s*(passed|pass)/i;
   const claimsSmokePassed = smokePassedRegex.test(reportContent);
 

--- a/scripts/validate-grammar-qg-completion-report.mjs
+++ b/scripts/validate-grammar-qg-completion-report.mjs
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'node:url';
 
 import { buildGrammarQuestionGeneratorAudit } from './audit-grammar-question-generator.mjs';
 import { buildGrammarContentQualityAudit } from './audit-grammar-content-quality.mjs';
-import { validateReportAgainstManifest, validateEvidenceManifest } from './validate-grammar-qg-certification-evidence.mjs';
+import { validateReportAgainstManifest, validateEvidenceManifest, validateSmokeEvidence, extractCertificationDecision, extractPostDeploySmokeEvidence } from './validate-grammar-qg-certification-evidence.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -504,19 +504,34 @@ export function validateGrammarCompletionReport(reportContent, opts = {}) {
     }
   }
 
-  // --- production-smoke evidence file validation ---
-  const claimsPostDeployPassed = smokeStatus.postDeploySmoke &&
-    (smokeStatus.postDeploySmoke.includes('passed') || smokeStatus.postDeploySmoke.includes('pass'));
-  if (claimsPostDeployPassed) {
-    const releaseId = reportedReleaseId || audit.releaseId;
-    const evidencePath = path.join(rootDir, 'reports', 'grammar', `grammar-production-smoke-${releaseId}.json`);
-    if (!existsSync(evidencePath)) {
-      mismatches.push({
-        field: 'productionSmokeEvidence',
-        claimed: 'post-deploy smoke passed',
-        actual: `evidence file not found at ${path.relative(rootDir, evidencePath)}`,
-        message: `Report claims post-deploy smoke passed but evidence file does not exist: ${path.relative(rootDir, evidencePath)}`,
-      });
+  // --- production-smoke evidence file validation (P9-U9 enhanced) ---
+  const certDecision = extractCertificationDecision(reportContent);
+  const postDeploySmokeField = extractPostDeploySmokeEvidence(reportContent);
+
+  // If certification_decision is CERTIFIED_POST_DEPLOY, delegate full validation to validateSmokeEvidence
+  if (certDecision && /certified[_-]?post[_-]?deploy/i.test(certDecision)) {
+    const smokeManifest = { contentReleaseId: reportedReleaseId || audit.releaseId };
+    const smokeResult = validateSmokeEvidence(smokeManifest, reportContent, { rootDir });
+    mismatches.push(...smokeResult.mismatches);
+  } else if (certDecision && /certified[_-]?pre[_-]?deploy/i.test(certDecision)) {
+    // CERTIFIED_PRE_DEPLOY: no smoke file required — skip
+  } else if (certDecision && /certified[_-]?with[_-]?limitations/i.test(certDecision)) {
+    // CERTIFIED_WITH_LIMITATIONS: no smoke file required — skip
+  } else {
+    // Legacy fallback: check text-based smoke claims
+    const claimsPostDeployPassed = smokeStatus.postDeploySmoke &&
+      (smokeStatus.postDeploySmoke.includes('passed') || smokeStatus.postDeploySmoke.includes('pass'));
+    if (claimsPostDeployPassed) {
+      const releaseId = reportedReleaseId || audit.releaseId;
+      const evidencePath = path.join(rootDir, 'reports', 'grammar', `grammar-production-smoke-${releaseId}.json`);
+      if (!existsSync(evidencePath)) {
+        mismatches.push({
+          field: 'productionSmokeEvidence',
+          claimed: 'post-deploy smoke passed',
+          actual: `evidence file not found at ${path.relative(rootDir, evidencePath)}`,
+          message: `Report claims post-deploy smoke passed but evidence file does not exist: ${path.relative(rootDir, evidencePath)}`,
+        });
+      }
     }
   }
 

--- a/tests/grammar-qg-p9-oracle-windows.test.js
+++ b/tests/grammar-qg-p9-oracle-windows.test.js
@@ -8,11 +8,12 @@
  * 4. The total oracle test count is reproducible from manifest windows
  * 5. All oracle families are represented in the manifest
  */
-import { describe, it } from 'node:test';
+import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import fs from 'node:fs';
+import os from 'node:os';
 
 import {
   parseSeedWindow,
@@ -20,6 +21,10 @@ import {
   validateEvidenceManifest,
   validateReportAgainstManifest,
   validateSmokeEvidence,
+  extractCertificationDecision,
+  extractPostDeploySmokeEvidence,
+  extractLimitations,
+  SMOKE_EVIDENCE_REQUIRED_FIELDS,
 } from '../scripts/validate-grammar-qg-certification-evidence.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -380,5 +385,209 @@ describe('P9 Oracle Windows: completion report validator integration', () => {
     const module = await import('../scripts/validate-grammar-qg-completion-report.mjs');
     assert.ok(typeof module.validateGrammarCompletionReport === 'function');
     assert.ok(typeof module.validateReleaseFrontmatter === 'function');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 10. Production smoke evidence gate (P9-U9)
+// ---------------------------------------------------------------------------
+
+describe('P9 Production Smoke Evidence Gate', () => {
+  let tmpDir;
+
+  before(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'grammar-smoke-test-'));
+    fs.mkdirSync(path.join(tmpDir, 'reports', 'grammar'), { recursive: true });
+  });
+
+  after(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function buildFrontmatterReport(opts = {}) {
+    const {
+      certDecision = 'CERTIFIED_POST_DEPLOY',
+      postDeploySmokeEvidence = null,
+      limitations = null,
+      releaseId = 'grammar-qg-p8-2026-04-29',
+    } = opts;
+    const lines = ['---'];
+    lines.push(`certification_decision: ${certDecision}`);
+    if (postDeploySmokeEvidence) {
+      lines.push(`post_deploy_smoke_evidence: ${postDeploySmokeEvidence}`);
+    }
+    if (limitations) {
+      lines.push('limitations:');
+      for (const lim of limitations) {
+        lines.push(`  - ${lim}`);
+      }
+    }
+    lines.push('---');
+    lines.push('');
+    lines.push('# Grammar QG Completion Report');
+    lines.push('');
+    lines.push(`Content release id: ${releaseId}`);
+    return lines.join('\n');
+  }
+
+  function writeValidSmokeFile(releaseId) {
+    const evidence = {
+      releaseId,
+      deployedUrl: 'https://ks2-mastery.example.com',
+      timestamp: '2026-04-29T18:00:00.000Z',
+      command: 'node scripts/production-smoke.mjs --release=p8',
+      learnerFixtureType: 'fresh-learner',
+      itemCreationResult: { status: 'pass', itemCount: 3 },
+      answerSubmissionResult: { status: 'pass', correctCount: 3 },
+      readModelUpdateResult: { status: 'pass', starsUpdated: true },
+      noAnswerLeakAssertion: { status: 'pass', leakedFields: [] },
+      failureDetails: null,
+    };
+    const filePath = path.join(tmpDir, 'reports', 'grammar', `grammar-production-smoke-${releaseId}.json`);
+    fs.writeFileSync(filePath, JSON.stringify(evidence, null, 2));
+    return filePath;
+  }
+
+  // --- Test: CERTIFIED_POST_DEPLOY without smoke file → fails ---
+  it('fails when report claims CERTIFIED_POST_DEPLOY but smoke file is absent', () => {
+    const releaseId = 'grammar-qg-test-missing-2026-04-29';
+    const report = buildFrontmatterReport({ certDecision: 'CERTIFIED_POST_DEPLOY', releaseId });
+    const testManifest = { contentReleaseId: releaseId };
+
+    const result = validateSmokeEvidence(testManifest, report, { rootDir: tmpDir });
+    assert.equal(result.pass, false, 'Should fail without smoke evidence file');
+    const err = result.mismatches.find((m) => m.field === 'smokeEvidenceFile');
+    assert.ok(err, 'Expected smokeEvidenceFile mismatch');
+    assert.match(err.message, /CERTIFIED_POST_DEPLOY/);
+  });
+
+  // --- Test: CERTIFIED_PRE_DEPLOY with smoke="not-run" → passes ---
+  it('passes when report claims CERTIFIED_PRE_DEPLOY with smoke not-run', () => {
+    const releaseId = 'grammar-qg-test-predeploy-2026-04-29';
+    const report = buildFrontmatterReport({
+      certDecision: 'CERTIFIED_PRE_DEPLOY',
+      postDeploySmokeEvidence: 'not-run',
+      releaseId,
+    });
+    const testManifest = { contentReleaseId: releaseId };
+
+    const result = validateSmokeEvidence(testManifest, report, { rootDir: tmpDir });
+    assert.equal(result.pass, true, `Expected pass but got: ${JSON.stringify(result.mismatches)}`);
+  });
+
+  // --- Test: CERTIFIED_POST_DEPLOY with valid smoke file → passes ---
+  it('passes when report claims CERTIFIED_POST_DEPLOY with valid smoke file', () => {
+    const releaseId = 'grammar-qg-test-valid-2026-04-29';
+    writeValidSmokeFile(releaseId);
+    const report = buildFrontmatterReport({ certDecision: 'CERTIFIED_POST_DEPLOY', releaseId });
+    const testManifest = { contentReleaseId: releaseId };
+
+    const result = validateSmokeEvidence(testManifest, report, { rootDir: tmpDir });
+    assert.equal(result.pass, true, `Expected pass but got: ${JSON.stringify(result.mismatches)}`);
+  });
+
+  // --- Test: smoke evidence file with wrong releaseId → fails ---
+  it('fails when smoke evidence file has mismatched releaseId', () => {
+    const manifestReleaseId = 'grammar-qg-test-mismatch-2026-04-29';
+    const wrongReleaseId = 'grammar-qg-WRONG-release';
+    // Write file at the expected path but with wrong internal releaseId
+    const evidence = {
+      releaseId: wrongReleaseId,
+      deployedUrl: 'https://ks2-mastery.example.com',
+      timestamp: '2026-04-29T18:00:00.000Z',
+      command: 'node scripts/production-smoke.mjs',
+      learnerFixtureType: 'fresh-learner',
+      itemCreationResult: { status: 'pass' },
+      answerSubmissionResult: { status: 'pass' },
+      readModelUpdateResult: { status: 'pass' },
+      noAnswerLeakAssertion: { status: 'pass' },
+      failureDetails: null,
+    };
+    const filePath = path.join(tmpDir, 'reports', 'grammar', `grammar-production-smoke-${manifestReleaseId}.json`);
+    fs.writeFileSync(filePath, JSON.stringify(evidence, null, 2));
+
+    const report = buildFrontmatterReport({ certDecision: 'CERTIFIED_POST_DEPLOY', releaseId: manifestReleaseId });
+    const testManifest = { contentReleaseId: manifestReleaseId };
+
+    const result = validateSmokeEvidence(testManifest, report, { rootDir: tmpDir });
+    assert.equal(result.pass, false, 'Should fail with mismatched releaseId');
+    const err = result.mismatches.find((m) => m.field === 'smokeEvidenceReleaseIdMismatch');
+    assert.ok(err, 'Expected smokeEvidenceReleaseIdMismatch');
+    assert.match(err.message, /does not match/);
+  });
+
+  // --- Test: smoke evidence file missing required fields → fails ---
+  it('fails when smoke evidence file is missing required fields', () => {
+    const releaseId = 'grammar-qg-test-incomplete-2026-04-29';
+    // Write file with only some fields
+    const incompleteEvidence = {
+      releaseId,
+      deployedUrl: 'https://ks2-mastery.example.com',
+      // Missing: timestamp, command, learnerFixtureType, itemCreationResult,
+      //          answerSubmissionResult, readModelUpdateResult, noAnswerLeakAssertion, failureDetails
+    };
+    const filePath = path.join(tmpDir, 'reports', 'grammar', `grammar-production-smoke-${releaseId}.json`);
+    fs.writeFileSync(filePath, JSON.stringify(incompleteEvidence, null, 2));
+
+    const report = buildFrontmatterReport({ certDecision: 'CERTIFIED_POST_DEPLOY', releaseId });
+    const testManifest = { contentReleaseId: releaseId };
+
+    const result = validateSmokeEvidence(testManifest, report, { rootDir: tmpDir });
+    assert.equal(result.pass, false, 'Should fail with missing fields');
+    const fieldErrs = result.mismatches.filter((m) => m.field === 'smokeEvidenceFieldMissing');
+    assert.ok(fieldErrs.length > 0, 'Expected smokeEvidenceFieldMissing errors');
+    // Should report exactly the missing fields
+    const missingFieldNames = fieldErrs.map((e) => e.claimed.match(/"(.+)"/)[1]);
+    assert.ok(missingFieldNames.includes('timestamp'));
+    assert.ok(missingFieldNames.includes('command'));
+    assert.ok(missingFieldNames.includes('learnerFixtureType'));
+  });
+
+  // --- Test: CERTIFIED_WITH_LIMITATIONS with "post-deploy not run" → passes ---
+  it('passes when report claims CERTIFIED_WITH_LIMITATIONS with limitation "post-deploy not run"', () => {
+    const releaseId = 'grammar-qg-test-limited-2026-04-29';
+    const report = buildFrontmatterReport({
+      certDecision: 'CERTIFIED_WITH_LIMITATIONS',
+      limitations: ['post-deploy not run'],
+      releaseId,
+    });
+    const testManifest = { contentReleaseId: releaseId };
+
+    const result = validateSmokeEvidence(testManifest, report, { rootDir: tmpDir });
+    assert.equal(result.pass, true, `Expected pass but got: ${JSON.stringify(result.mismatches)}`);
+  });
+
+  // --- Test: extractCertificationDecision ---
+  it('extractCertificationDecision extracts from frontmatter', () => {
+    const report = '---\ncertification_decision: CERTIFIED_POST_DEPLOY\n---\n# Report';
+    assert.equal(extractCertificationDecision(report), 'CERTIFIED_POST_DEPLOY');
+  });
+
+  it('extractCertificationDecision returns null when absent', () => {
+    const report = '---\ntitle: Report\n---\n# Report';
+    assert.equal(extractCertificationDecision(report), null);
+  });
+
+  // --- Test: extractPostDeploySmokeEvidence ---
+  it('extractPostDeploySmokeEvidence extracts "not-run"', () => {
+    const report = '---\npost_deploy_smoke_evidence: not-run\n---\n# Report';
+    assert.equal(extractPostDeploySmokeEvidence(report), 'not-run');
+  });
+
+  // --- Test: extractLimitations ---
+  it('extractLimitations extracts limitation list', () => {
+    const report = '---\nlimitations:\n  - post-deploy not run\n  - staging only\n---\n# Report';
+    const lims = extractLimitations(report);
+    assert.deepEqual(lims, ['post-deploy not run', 'staging only']);
+  });
+
+  // --- Test: SMOKE_EVIDENCE_REQUIRED_FIELDS is complete ---
+  it('SMOKE_EVIDENCE_REQUIRED_FIELDS contains all expected fields', () => {
+    const expected = [
+      'releaseId', 'deployedUrl', 'timestamp', 'command', 'learnerFixtureType',
+      'itemCreationResult', 'answerSubmissionResult', 'readModelUpdateResult',
+      'noAnswerLeakAssertion', 'failureDetails',
+    ];
+    assert.deepEqual(SMOKE_EVIDENCE_REQUIRED_FIELDS, expected);
   });
 });


### PR DESCRIPTION
## Summary
- Extends `validateSmokeEvidence` to enforce structured evidence validation when a report claims `CERTIFIED_POST_DEPLOY`: file existence, 10 required schema fields, and releaseId consistency
- Updates completion report validator to route certification decisions through the smoke gate (`CERTIFIED_PRE_DEPLOY` and `CERTIFIED_WITH_LIMITATIONS` bypass without a smoke file)
- Adds 11 new tests covering all six gate scenarios (missing file, valid file, wrong releaseId, incomplete schema, pre-deploy pass-through, limitations pass-through)

## Test plan
- [x] All 54 tests in `grammar-qg-p9-oracle-windows.test.js` pass
- [x] All 25 tests in `grammar-qg-p9-report-evidence-lock.test.js` pass
- [x] No regressions in existing smoke evidence or oracle window validation