### PR TITLE
feat(grammar-qg-p9): U10 — template blocklist and scheduler safety

### DIFF
--- a/reports/grammar/grammar-qg-p9-certification-status-map.json
+++ b/reports/grammar/grammar-qg-p9-certification-status-map.json
@@ -1,0 +1,626 @@
+{
+  "sentence_type_table": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "question_mark_select": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "word_class_underlined_choice": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "identify_words_in_sentence": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "expanded_noun_phrase_choice": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "build_noun_phrase": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "fronted_adverbial_choose": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "fix_fronted_adverbial": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "subordinate_clause_choice": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "combine_clauses_rewrite": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "relative_clause_identify": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "relative_clause_complete": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "tense_form_choice": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "tense_rewrite": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "standard_english_pairs": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "pronoun_cohesion_choice": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "formality_pairs": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "active_passive_rewrite": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "subject_object_choice": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "modal_verb_choice": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "parenthesis_replace_choice": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "parenthesis_fix_sentence": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "speech_punctuation_fix": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "apostrophe_possession_choice": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "explain_reason_choice": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "standard_fix_sentence": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "proc_fronted_adverbial_fix": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "proc_semicolon_choice": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "proc_colon_list_fix": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "proc_dash_boundary_fix": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "proc_hyphen_ambiguity_choice": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "proc_speech_punctuation_fix": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "proc_apostrophe_possession_choice": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "proc2_standard_english_choice": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "proc2_standard_english_fix": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "proc2_tense_aspect_choice": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "proc2_modal_choice": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "proc2_formality_choice": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "proc2_pronoun_cohesion_choice": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "proc2_subject_object_identify": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "proc2_passive_to_active": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "proc2_relative_clause_choice": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "proc2_fronted_adverbial_build": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "proc2_boundary_punctuation_explain": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "proc3_sentence_function_choice": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "proc3_word_class_contrast_choice": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "proc3_noun_phrase_build": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "proc3_clause_join_rewrite": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "proc3_parenthesis_commas_fix": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "proc3_hyphen_fix_meaning": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "qg_active_passive_choice": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "qg_subject_object_classify_table": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "qg_pronoun_referent_identify": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "qg_formality_classify_table": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "qg_modal_verb_explain": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "qg_hyphen_ambiguity_explain": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "qg_p3_sentence_functions_explain": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "qg_p3_word_classes_explain": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "qg_p3_noun_phrases_explain": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "qg_p3_clauses_explain": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "qg_p3_relative_clauses_explain": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "qg_p3_tense_aspect_explain": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "qg_p3_pronouns_cohesion_explain": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "qg_p3_formality_explain": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "qg_p3_active_passive_explain": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "qg_p3_subject_object_explain": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "qg_p3_parenthesis_commas_explain": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "qg_p3_speech_punctuation_explain": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "qg_p3_apostrophe_possession_explain": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "proc3_apostrophe_rewrite": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "qg_p4_sentence_speech_transfer": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "qg_p4_word_class_noun_phrase_transfer": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "qg_p4_adverbial_clause_boundary_transfer": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "qg_p4_relative_parenthesis_transfer": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "qg_p4_verb_form_register_transfer": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "qg_p4_cohesion_formality_transfer": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "qg_p4_voice_roles_transfer": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  },
+  "qg_p4_possession_hyphen_clarity_transfer": {
+    "status": "approved",
+    "evidence": [
+      "oracle",
+      "review",
+      "prompt-cue-render"
+    ]
+  }
+}

--- a/tests/grammar-qg-p9-blocklist-scheduler.test.js
+++ b/tests/grammar-qg-p9-blocklist-scheduler.test.js
@@ -1,0 +1,197 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import fs from 'node:fs';
+
+import {
+  buildGrammarMiniPack,
+  buildGrammarPracticeQueue,
+} from '../worker/src/subjects/grammar/selection.js';
+import {
+  GRAMMAR_TEMPLATE_METADATA,
+} from '../worker/src/subjects/grammar/content.js';
+import {
+  isTemplateBlocked,
+  CERTIFICATION_STATUS_MAP,
+  _testBlockOverride,
+} from '../worker/src/subjects/grammar/certification-status.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT_DIR = path.resolve(__dirname, '..');
+const STATUS_MAP_PATH = path.resolve(ROOT_DIR, 'reports', 'grammar', 'grammar-qg-p9-certification-status-map.json');
+
+const statusMapJson = JSON.parse(fs.readFileSync(STATUS_MAP_PATH, 'utf8'));
+
+// --- Status map structural tests ---
+
+describe('P9 Certification Status Map: completeness', () => {
+  it('has entries for all 78 templates', () => {
+    assert.equal(Object.keys(statusMapJson).length, 78);
+  });
+
+  it('every GRAMMAR_TEMPLATE_METADATA template exists in the status map', () => {
+    const mapKeys = new Set(Object.keys(statusMapJson));
+    for (const template of GRAMMAR_TEMPLATE_METADATA) {
+      assert.ok(mapKeys.has(template.id), `Missing template in status map: ${template.id}`);
+    }
+  });
+
+  it('has no entries with status pending or unknown', () => {
+    for (const [id, entry] of Object.entries(statusMapJson)) {
+      assert.notEqual(entry.status, 'pending', `Template ${id} has forbidden status "pending"`);
+      assert.notEqual(entry.status, 'unknown', `Template ${id} has forbidden status "unknown"`);
+    }
+  });
+
+  it('all entries have a valid status value', () => {
+    const validStatuses = new Set(['approved', 'blocked', 'watchlist']);
+    for (const [id, entry] of Object.entries(statusMapJson)) {
+      assert.ok(validStatuses.has(entry.status), `Template ${id} has invalid status: ${entry.status}`);
+    }
+  });
+
+  it('all entries have a non-empty evidence array', () => {
+    for (const [id, entry] of Object.entries(statusMapJson)) {
+      assert.ok(Array.isArray(entry.evidence), `Template ${id} evidence is not an array`);
+      assert.ok(entry.evidence.length > 0, `Template ${id} has empty evidence array`);
+    }
+  });
+});
+
+describe('P9 Certification Status Map: module parity with JSON artefact', () => {
+  it('CERTIFICATION_STATUS_MAP has all 78 template keys', () => {
+    assert.equal(Object.keys(CERTIFICATION_STATUS_MAP).length, 78);
+  });
+
+  it('module map matches JSON artefact status for every template', () => {
+    for (const template of GRAMMAR_TEMPLATE_METADATA) {
+      const jsonEntry = statusMapJson[template.id];
+      const moduleEntry = CERTIFICATION_STATUS_MAP[template.id];
+      assert.ok(moduleEntry, `Module missing template: ${template.id}`);
+      assert.equal(moduleEntry.status, jsonEntry.status, `Status mismatch for ${template.id}`);
+    }
+  });
+});
+
+// --- isTemplateBlocked helper tests ---
+
+describe('P9 isTemplateBlocked helper', () => {
+  it('returns false for an approved template', () => {
+    assert.equal(isTemplateBlocked('sentence_type_table'), false);
+  });
+
+  it('returns true for an unknown templateId (fail-closed)', () => {
+    assert.equal(isTemplateBlocked('nonexistent_template_xyz'), true);
+  });
+});
+
+// --- Scheduler blocklist integration tests ---
+
+describe('P9 Blocklist: buildGrammarMiniPack with all approved', () => {
+  it('returns results when all templates are approved', () => {
+    const pack = buildGrammarMiniPack({ seed: 42, size: 8 });
+    assert.equal(pack.length, 8);
+  });
+
+  it('behaves identically to P8 (selection returns results with default options)', () => {
+    const pack = buildGrammarMiniPack({ seed: 123, size: 6 });
+    assert.equal(pack.length, 6);
+    for (const entry of pack) {
+      assert.ok(entry.templateId, 'each entry has a templateId');
+      assert.ok(Array.isArray(entry.skillIds), 'each entry has skillIds');
+    }
+  });
+});
+
+describe('P9 Blocklist: buildGrammarPracticeQueue with all approved', () => {
+  it('returns results when all templates are approved', () => {
+    const queue = buildGrammarPracticeQueue({ seed: 42, size: 5 });
+    assert.equal(queue.length, 5);
+  });
+
+  it('behaves identically to P8 (selection returns results with default options)', () => {
+    const queue = buildGrammarPracticeQueue({ seed: 99, size: 3 });
+    assert.equal(queue.length, 3);
+    for (const entry of queue) {
+      assert.ok(entry.templateId, 'each entry has a templateId');
+      assert.ok(Array.isArray(entry.skillIds), 'each entry has skillIds');
+    }
+  });
+});
+
+// --- Blocked template exclusion tests ---
+// These tests use the _testBlockOverride set exported from certification-status.js
+// to simulate a blocked template without needing to mutate frozen objects.
+
+describe('P9 Blocklist: blocked template exclusion in miniPack', () => {
+  // Pick a template that is satsFriendly so it would normally appear in mini-pack
+  const blockedId = GRAMMAR_TEMPLATE_METADATA.find((t) => t.satsFriendly)?.id || GRAMMAR_TEMPLATE_METADATA[0].id;
+
+  it('blocked template never appears in mini-pack across many seeds', () => {
+    _testBlockOverride.add(blockedId);
+    try {
+      for (let s = 1; s <= 50; s++) {
+        const pack = buildGrammarMiniPack({ seed: s, size: 8 });
+        const ids = pack.map((e) => e.templateId);
+        assert.ok(!ids.includes(blockedId), `Blocked template ${blockedId} appeared in mini-pack with seed ${s}`);
+      }
+    } finally {
+      _testBlockOverride.delete(blockedId);
+    }
+  });
+
+  it('blocked template CAN appear with includeBlocked: true', () => {
+    _testBlockOverride.add(blockedId);
+    try {
+      // With includeBlocked, the template is eligible. Run enough seeds to verify
+      // it appears at least once (probabilistic but with 200 packs of 8, this is
+      // near-certain for any template in the pool).
+      let appeared = false;
+      for (let s = 1; s <= 200; s++) {
+        const pack = buildGrammarMiniPack({ seed: s, size: 8, includeBlocked: true });
+        if (pack.some((e) => e.templateId === blockedId)) {
+          appeared = true;
+          break;
+        }
+      }
+      assert.ok(appeared, `Blocked template ${blockedId} never appeared even with includeBlocked: true`);
+    } finally {
+      _testBlockOverride.delete(blockedId);
+    }
+  });
+});
+
+describe('P9 Blocklist: blocked template exclusion in practiceQueue', () => {
+  const blockedId = GRAMMAR_TEMPLATE_METADATA.find((t) => t.satsFriendly)?.id || GRAMMAR_TEMPLATE_METADATA[0].id;
+
+  it('blocked template never appears in practice queue across many seeds', () => {
+    _testBlockOverride.add(blockedId);
+    try {
+      for (let s = 1; s <= 50; s++) {
+        const queue = buildGrammarPracticeQueue({ seed: s, size: 5 });
+        const ids = queue.map((e) => e.templateId);
+        assert.ok(!ids.includes(blockedId), `Blocked template ${blockedId} appeared in practice queue with seed ${s}`);
+      }
+    } finally {
+      _testBlockOverride.delete(blockedId);
+    }
+  });
+
+  it('blocked template CAN appear in practice queue with includeBlocked: true', () => {
+    _testBlockOverride.add(blockedId);
+    try {
+      let appeared = false;
+      for (let s = 1; s <= 200; s++) {
+        const queue = buildGrammarPracticeQueue({ seed: s, size: 5, includeBlocked: true });
+        if (queue.some((e) => e.templateId === blockedId)) {
+          appeared = true;
+          break;
+        }
+      }
+      assert.ok(appeared, `Blocked template ${blockedId} never appeared even with includeBlocked: true`);
+    } finally {
+      _testBlockOverride.delete(blockedId);
+    }
+  });
+});

--- a/worker/src/subjects/grammar/certification-status.js
+++ b/worker/src/subjects/grammar/certification-status.js
@@ -1,0 +1,44 @@
+/**
+ * Grammar QG P9 — Template certification status.
+ *
+ * Exports the certification status map and a helper to determine whether a
+ * template is blocked from learner-facing scheduling.  The underlying data
+ * lives in reports/grammar/grammar-qg-p9-certification-status-map.json (the
+ * evidence artefact) but is inlined here as a JS module so static import in
+ * Cloudflare Workers works without JSON import assertions.
+ */
+
+import { GRAMMAR_TEMPLATE_METADATA } from './content.js';
+
+// Build the certification map at module load time from GRAMMAR_TEMPLATE_METADATA.
+// All 78 templates are approved as of P9 certification — this matches the JSON
+// artefact committed to reports/grammar/.  If a future phase needs to block a
+// template, change the status here AND in the JSON artefact.
+const CERTIFICATION_STATUS_MAP = Object.freeze(
+  Object.fromEntries(
+    GRAMMAR_TEMPLATE_METADATA.map((t) => [
+      t.id,
+      Object.freeze({ status: 'approved', evidence: Object.freeze(['oracle', 'review', 'prompt-cue-render']) }),
+    ]),
+  ),
+);
+
+/**
+ * Test-only override set.  When a templateId is present in this set,
+ * isTemplateBlocked returns true regardless of the certification map.
+ * Production code never touches this — only test harnesses add/clear entries.
+ */
+export const _testBlockOverride = new Set();
+
+/**
+ * Returns true if the given templateId has status 'blocked' in the
+ * certification map.  Unknown template IDs are treated as blocked (fail-closed).
+ */
+export function isTemplateBlocked(templateId) {
+  if (_testBlockOverride.has(templateId)) return true;
+  const entry = CERTIFICATION_STATUS_MAP[templateId];
+  if (!entry) return true; // fail-closed: unknown templates are blocked
+  return entry.status === 'blocked';
+}
+
+export { CERTIFICATION_STATUS_MAP };

--- a/worker/src/subjects/grammar/selection.js
+++ b/worker/src/subjects/grammar/selection.js
@@ -5,6 +5,7 @@ import {
   grammarQuestionVariantSignature,
   grammarTemplateGeneratorFamilyId,
 } from './content.js';
+import { isTemplateBlocked } from './certification-status.js';
 
 export const SELECTION_WEIGHTS = Object.freeze({
   due: 3.0,
@@ -396,11 +397,13 @@ export function buildGrammarPracticeQueue({
   seed = 1,
   size = 1,
   now = Date.now(),
+  includeBlocked = false,
 } = {}) {
   const safeSize = Math.max(0, Math.floor(Number(size) || 0));
   if (safeSize === 0) return [];
   const normalisedFocus = normaliseFocus(focusConceptId);
-  const pool = focusAwarePool(mode, normalisedFocus, safeSize);
+  const unfilteredPool = focusAwarePool(mode, normalisedFocus, safeSize);
+  const pool = includeBlocked ? unfilteredPool : unfilteredPool.filter((t) => !isTemplateBlocked(t.id));
   const nowTs = Number(now) || Date.now();
   const rng = seededRandom(Number(seed) || 1);
   const workingRecent = Array.isArray(recentAttempts) ? recentAttempts.slice() : [];
@@ -476,6 +479,7 @@ export function buildGrammarMiniPack({
   recentAttempts = [],
   seed = 1,
   now = Date.now(),
+  includeBlocked = false,
 } = {}) {
   // Contract parity with buildGrammarPracticeQueue: size=0 returns an empty
   // array rather than silently coercing to a single-item pack. Surfaced by
@@ -484,7 +488,8 @@ export function buildGrammarMiniPack({
   if (requestedSize <= 0) return [];
   const safeSize = Math.max(1, requestedSize);
   const normalisedFocus = normaliseFocus(focusConceptId);
-  const pool = focusAwarePool('satsset', normalisedFocus, safeSize);
+  const unfilteredPool = focusAwarePool('satsset', normalisedFocus, safeSize);
+  const pool = includeBlocked ? unfilteredPool : unfilteredPool.filter((t) => !isTemplateBlocked(t.id));
   const nowTs = Number(now) || Date.now();
   const rng = seededRandom(Number(seed) || 1);
   const workingRecent = Array.isArray(recentAttempts) ? recentAttempts.slice() : [];


### PR DESCRIPTION
## Summary
- Adds `reports/grammar/grammar-qg-p9-certification-status-map.json` — evidence artefact recording approved/blocked/watchlist state for all 78 grammar templates (all approved at P9 baseline)
- Adds `worker/src/subjects/grammar/certification-status.js` — module exporting `isTemplateBlocked(templateId)` with fail-closed semantics (unknown IDs are blocked)
- Updates `selection.js`: both `buildGrammarMiniPack` and `buildGrammarPracticeQueue` filter blocked templates from the candidate pool before selection, with an `includeBlocked: true` escape hatch for debug/review mode
- No changes to selection weights or existing algorithm logic

## Test plan
- [x] 17 new tests in `tests/grammar-qg-p9-blocklist-scheduler.test.js`
- [x] Status map completeness: all 78 templates present, no pending/unknown status
- [x] Module parity: JS module matches JSON artefact
- [x] Blocked exclusion: blocked template never appears across 50 seeds (mini-pack + practice queue)
- [x] `includeBlocked: true` bypass: blocked template CAN appear
- [x] Existing 20 grammar-selection tests pass (no regression)