### PR TITLE
feat(punctuation-qg): semantic explanation oracle (P7 U6)

### DIFF
--- a/shared/punctuation/dsl-families/apostrophe-contractions-fix.js
+++ b/shared/punctuation/dsl-families/apostrophe-contractions-fix.js
@@ -5,6 +5,7 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  */
 
 const EXPLANATION = 'The apostrophe shows where letters have been removed to shorten two words into one.';
+const EXPLANATION_RULE_ID = 'apostrophe.contraction';
 
 const TEMPLATES = [
   {
@@ -89,6 +90,7 @@ export const apostropheContractionsDsl = TEMPLATES.map((t, i) =>
       stem: t.stem,
       model: t.model,
       explanation: t.explanation,
+      explanationRuleId: EXPLANATION_RULE_ID,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/apostrophe-mix-paragraph.js
+++ b/shared/punctuation/dsl-families/apostrophe-mix-paragraph.js
@@ -7,6 +7,7 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  */
 
 const EXPLANATION = 'The apostrophe marks contractions where letters are missing and possession where something belongs to a noun.';
+const EXPLANATION_RULE_ID = 'apostrophe.possession-mixed';
 
 const TEMPLATES = [
   // ─── Legacy parity (indices 0-3) ─────────────────────────────────────────────
@@ -216,6 +217,7 @@ export const apostropheMixParagraphDsl = TEMPLATES.map((t, i) =>
       clusterId: t.clusterId,
       validator: t.validator,
       explanation: t.explanation,
+      explanationRuleId: EXPLANATION_RULE_ID,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/apostrophe-possession-insert.js
+++ b/shared/punctuation/dsl-families/apostrophe-possession-insert.js
@@ -7,6 +7,7 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  */
 
 const EXPLANATION = 'The apostrophe before the s shows that the item belongs to the noun.';
+const EXPLANATION_RULE_ID = 'apostrophe.possession-singular';
 
 const TEMPLATES = [
   // ─── Legacy parity (indices 0-3) ─────────────────────────────────────────────
@@ -134,6 +135,7 @@ export const apostrophePossessionInsertDsl = TEMPLATES.map((t, i) =>
       model: t.model,
       validator: t.validator,
       explanation: t.explanation,
+      explanationRuleId: EXPLANATION_RULE_ID,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/bullet-points-fix.js
+++ b/shared/punctuation/dsl-families/bullet-points-fix.js
@@ -7,6 +7,7 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  */
 
 const EXPLANATION = 'Every bullet in a list must follow the same punctuation pattern so the reader knows the list is consistent.';
+const EXPLANATION_RULE_ID = 'bullet.stem-consistency';
 
 const TEMPLATES = [
   // ─── Legacy parity (indices 0-3) ─────────────────────────────────────────────
@@ -142,6 +143,7 @@ export const bulletPointsFixDsl = TEMPLATES.map((t, i) =>
       model: t.model,
       validator: t.validator,
       explanation: t.explanation,
+      explanationRuleId: EXPLANATION_RULE_ID,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/bullet-points-paragraph.js
+++ b/shared/punctuation/dsl-families/bullet-points-paragraph.js
@@ -7,6 +7,7 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  */
 
 const EXPLANATION = 'A colon introduces the list after a complete opening, and each bullet follows a consistent punctuation pattern.';
+const EXPLANATION_RULE_ID = 'bullet.colon-and-consistency';
 
 const TEMPLATES = [
   // ─── Legacy parity (indices 0-3) ─────────────────────────────────────────────
@@ -241,6 +242,7 @@ export const bulletPointsParagraphDsl = TEMPLATES.map((t, i) =>
       clusterId: t.clusterId,
       validator: t.validator,
       explanation: t.explanation,
+      explanationRuleId: EXPLANATION_RULE_ID,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/colon-list-combine.js
+++ b/shared/punctuation/dsl-families/colon-list-combine.js
@@ -7,6 +7,7 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  */
 
 const EXPLANATION = 'A colon introduces the list after a complete sentence that sets it up.';
+const EXPLANATION_RULE_ID = 'colon.complete-introduction';
 
 const TEMPLATES = [
   // ─── Legacy parity (indices 0-3) ─────────────────────────────────────────────
@@ -142,6 +143,7 @@ export const colonListCombineDsl = TEMPLATES.map((t, i) =>
       model: t.model,
       validator: t.validator,
       explanation: t.explanation,
+      explanationRuleId: EXPLANATION_RULE_ID,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/colon-list-insert.js
+++ b/shared/punctuation/dsl-families/colon-list-insert.js
@@ -7,6 +7,7 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  */
 
 const EXPLANATION = 'A colon introduces the list after a complete sentence that sets it up.';
+const EXPLANATION_RULE_ID = 'colon.complete-introduction';
 
 const TEMPLATES = [
   // ─── Legacy parity (indices 0-3) ─────────────────────────────────────────────
@@ -142,6 +143,7 @@ export const colonListInsertDsl = TEMPLATES.map((t, i) =>
       model: t.model,
       validator: t.validator,
       explanation: t.explanation,
+      explanationRuleId: EXPLANATION_RULE_ID,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/colon-semicolon-paragraph.js
+++ b/shared/punctuation/dsl-families/colon-semicolon-paragraph.js
@@ -7,6 +7,7 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  */
 
 const EXPLANATION = 'A colon introduces a list after a complete sentence, and a semicolon joins two closely related main clauses.';
+const EXPLANATION_RULE_ID = 'mixed.colon-semicolon';
 
 const TEMPLATES = [
   // ─── Legacy parity (indices 0-3) ─────────────────────────────────────────────
@@ -288,6 +289,7 @@ export const colonSemicolonParagraphDsl = TEMPLATES.map((t, i) =>
       clusterId: t.clusterId,
       validator: t.validator,
       explanation: t.explanation,
+      explanationRuleId: EXPLANATION_RULE_ID,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/comma-clarity-insert.js
+++ b/shared/punctuation/dsl-families/comma-clarity-insert.js
@@ -5,6 +5,7 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  */
 
 const EXPLANATION = 'A comma after the opening phrase prevents the reader from misreading the start of the main clause.';
+const EXPLANATION_RULE_ID = 'comma.clarity';
 
 const TEMPLATES = [
   {
@@ -106,6 +107,7 @@ export const commaClarityInsertDsl = TEMPLATES.map((t, i) =>
       model: t.model,
       validator: t.validator,
       explanation: t.explanation,
+      explanationRuleId: EXPLANATION_RULE_ID,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/dash-clause-combine.js
+++ b/shared/punctuation/dsl-families/dash-clause-combine.js
@@ -5,6 +5,7 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  */
 
 const EXPLANATION = 'A dash separates two independent but related ideas, often adding surprise or contrast.';
+const EXPLANATION_RULE_ID = 'dash.clause-separation';
 
 const TEMPLATES = [
   {
@@ -106,6 +107,7 @@ export const dashClauseCombineDsl = TEMPLATES.map((t, i) =>
       model: t.model,
       validator: t.validator,
       explanation: t.explanation,
+      explanationRuleId: EXPLANATION_RULE_ID,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/dash-clause-fix.js
+++ b/shared/punctuation/dsl-families/dash-clause-fix.js
@@ -5,6 +5,7 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  */
 
 const EXPLANATION = 'A dash separates two independent but related ideas, often adding surprise or contrast.';
+const EXPLANATION_RULE_ID = 'dash.clause-separation';
 
 const TEMPLATES = [
   {
@@ -106,6 +107,7 @@ export const dashClauseFixDsl = TEMPLATES.map((t, i) =>
       model: t.model,
       validator: t.validator,
       explanation: t.explanation,
+      explanationRuleId: EXPLANATION_RULE_ID,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/fronted-adverbial-combine.js
+++ b/shared/punctuation/dsl-families/fronted-adverbial-combine.js
@@ -7,6 +7,7 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  */
 
 const EXPLANATION = 'A comma separates the opening adverbial phrase from the main clause so the reader knows where the main idea begins.';
+const EXPLANATION_RULE_ID = 'fronted-adverbial.comma-after-opener';
 
 const TEMPLATES = [
   // ─── Legacy parity (indices 0-3) ─────────────────────────────────────────────
@@ -142,6 +143,7 @@ export const frontedAdverbialCombineDsl = TEMPLATES.map((t, i) =>
       model: t.model,
       validator: t.validator,
       explanation: t.explanation,
+      explanationRuleId: EXPLANATION_RULE_ID,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/fronted-adverbial-fix.js
+++ b/shared/punctuation/dsl-families/fronted-adverbial-fix.js
@@ -7,6 +7,7 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  */
 
 const EXPLANATION = 'A comma separates the opening adverbial phrase from the main clause so the reader knows where the main idea begins.';
+const EXPLANATION_RULE_ID = 'fronted-adverbial.comma-after-opener';
 
 const TEMPLATES = [
   // ─── Legacy parity (indices 0-3) ─────────────────────────────────────────────
@@ -134,6 +135,7 @@ export const frontedAdverbialFixDsl = TEMPLATES.map((t, i) =>
       model: t.model,
       validator: t.validator,
       explanation: t.explanation,
+      explanationRuleId: EXPLANATION_RULE_ID,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/fronted-speech-paragraph.js
+++ b/shared/punctuation/dsl-families/fronted-speech-paragraph.js
@@ -7,6 +7,7 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  */
 
 const EXPLANATION = 'A comma follows the fronted adverbial, and inverted commas wrap the spoken words with their punctuation inside.';
+const EXPLANATION_RULE_ID = 'mixed.fronted-speech';
 
 const TEMPLATES = [
   // ─── Legacy parity (indices 0-3) ─────────────────────────────────────────────
@@ -264,6 +265,7 @@ export const frontedSpeechParagraphDsl = TEMPLATES.map((t, i) =>
       clusterId: t.clusterId,
       validator: t.validator,
       explanation: t.explanation,
+      explanationRuleId: EXPLANATION_RULE_ID,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/hyphen-insert.js
+++ b/shared/punctuation/dsl-families/hyphen-insert.js
@@ -5,6 +5,7 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  */
 
 const EXPLANATION = 'The hyphen joins words into a single describing phrase so the reader knows they work together before the noun.';
+const EXPLANATION_RULE_ID = 'hyphen.compound-modifier';
 
 const TEMPLATES = [
   {
@@ -106,6 +107,7 @@ export const hyphenInsertDsl = TEMPLATES.map((t, i) =>
       model: t.model,
       validator: t.validator,
       explanation: t.explanation,
+      explanationRuleId: EXPLANATION_RULE_ID,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/list-commas-combine.js
+++ b/shared/punctuation/dsl-families/list-commas-combine.js
@@ -7,6 +7,7 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  */
 
 const EXPLANATION = 'Commas separate each item in a list so they are easy to read one by one.';
+const EXPLANATION_RULE_ID = 'list.comma-separation';
 
 const TEMPLATES = [
   // ─── Legacy parity (indices 0-3) ─────────────────────────────────────────────
@@ -142,6 +143,7 @@ export const listCommasCombineDsl = TEMPLATES.map((t, i) =>
       model: t.model,
       validator: t.validator,
       explanation: t.explanation,
+      explanationRuleId: EXPLANATION_RULE_ID,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/list-commas-insert.js
+++ b/shared/punctuation/dsl-families/list-commas-insert.js
@@ -7,6 +7,7 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  */
 
 const EXPLANATION = 'Commas separate each item in a list so they are easy to read one by one.';
+const EXPLANATION_RULE_ID = 'list.comma-separation';
 
 const TEMPLATES = [
   // ─── Legacy parity (indices 0-3) ─────────────────────────────────────────────
@@ -134,6 +135,7 @@ export const listCommasInsertDsl = TEMPLATES.map((t, i) =>
       model: t.model,
       validator: t.validator,
       explanation: t.explanation,
+      explanationRuleId: EXPLANATION_RULE_ID,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/parenthesis-combine.js
+++ b/shared/punctuation/dsl-families/parenthesis-combine.js
@@ -7,6 +7,7 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  */
 
 const EXPLANATION = 'The extra information is set off with punctuation because it can be removed without breaking the sentence.';
+const EXPLANATION_RULE_ID = 'parenthesis.additional-information';
 
 const TEMPLATES = [
   // ─── Legacy parity (indices 0-3) ─────────────────────────────────────────────
@@ -150,6 +151,7 @@ export const parenthesisCombineDsl = TEMPLATES.map((t, i) =>
       model: t.model,
       validator: t.validator,
       explanation: t.explanation,
+      explanationRuleId: EXPLANATION_RULE_ID,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/parenthesis-fix.js
+++ b/shared/punctuation/dsl-families/parenthesis-fix.js
@@ -7,6 +7,7 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  */
 
 const EXPLANATION = 'The extra information is set off with punctuation because it can be removed without breaking the sentence.';
+const EXPLANATION_RULE_ID = 'parenthesis.additional-information';
 
 const TEMPLATES = [
   // ─── Legacy parity (indices 0-3) ─────────────────────────────────────────────
@@ -150,6 +151,7 @@ export const parenthesisFixDsl = TEMPLATES.map((t, i) =>
       model: t.model,
       validator: t.validator,
       explanation: t.explanation,
+      explanationRuleId: EXPLANATION_RULE_ID,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/parenthesis-speech-paragraph.js
+++ b/shared/punctuation/dsl-families/parenthesis-speech-paragraph.js
@@ -7,6 +7,7 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  */
 
 const EXPLANATION = 'Parenthetical commas set off removable extra detail, and inverted commas wrap spoken words with their punctuation inside.';
+const EXPLANATION_RULE_ID = 'mixed.parenthesis-speech';
 
 const TEMPLATES = [
   // ─── Legacy parity (indices 0-3) ─────────────────────────────────────────────
@@ -280,6 +281,7 @@ export const parenthesisSpeechParagraphDsl = TEMPLATES.map((t, i) =>
       clusterId: t.clusterId,
       validator: t.validator,
       explanation: t.explanation,
+      explanationRuleId: EXPLANATION_RULE_ID,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/semicolon-combine.js
+++ b/shared/punctuation/dsl-families/semicolon-combine.js
@@ -7,6 +7,7 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  */
 
 const EXPLANATION = 'A semicolon joins two complete sentences that are closely related in meaning.';
+const EXPLANATION_RULE_ID = 'semicolon.independent-clauses';
 
 const TEMPLATES = [
   // ─── Legacy parity (indices 0-3) ─────────────────────────────────────────────
@@ -150,6 +151,7 @@ export const semicolonCombineDsl = TEMPLATES.map((t, i) =>
       model: t.model,
       validator: t.validator,
       explanation: t.explanation,
+      explanationRuleId: EXPLANATION_RULE_ID,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/semicolon-fix.js
+++ b/shared/punctuation/dsl-families/semicolon-fix.js
@@ -7,6 +7,7 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  */
 
 const EXPLANATION = 'A semicolon joins two complete sentences that are closely related in meaning.';
+const EXPLANATION_RULE_ID = 'semicolon.independent-clauses';
 
 const TEMPLATES = [
   // ─── Legacy parity (indices 0-3) ─────────────────────────────────────────────
@@ -150,6 +151,7 @@ export const semicolonFixDsl = TEMPLATES.map((t, i) =>
       model: t.model,
       validator: t.validator,
       explanation: t.explanation,
+      explanationRuleId: EXPLANATION_RULE_ID,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/semicolon-list-fix.js
+++ b/shared/punctuation/dsl-families/semicolon-list-fix.js
@@ -5,6 +5,7 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  */
 
 const EXPLANATION = 'Semicolons separate complex list items that already contain commas, keeping each group clear.';
+const EXPLANATION_RULE_ID = 'semicolon.complex-list';
 
 const TEMPLATES = [
   {
@@ -106,6 +107,7 @@ export const semicolonListFixDsl = TEMPLATES.map((t, i) =>
       model: t.model,
       validator: t.validator,
       explanation: t.explanation,
+      explanationRuleId: EXPLANATION_RULE_ID,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/sentence-endings-insert.js
+++ b/shared/punctuation/dsl-families/sentence-endings-insert.js
@@ -6,6 +6,7 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  */
 
 const EXPLANATION = 'Every sentence needs a capital letter at the start and the correct end mark to show whether it is a statement, question, or exclamation.';
+const EXPLANATION_RULE_ID = 'sentence-ending.terminal-mark';
 
 const TEMPLATES = [
   {
@@ -90,6 +91,7 @@ export const sentenceEndingsInsertDsl = TEMPLATES.map((t, i) =>
       stem: t.stem,
       model: t.model,
       explanation: t.explanation,
+      explanationRuleId: EXPLANATION_RULE_ID,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/dsl-families/speech-insert.js
+++ b/shared/punctuation/dsl-families/speech-insert.js
@@ -7,6 +7,7 @@ import { definePunctuationTemplate } from '../template-dsl.js';
  */
 
 const EXPLANATION = 'Inverted commas wrap the spoken words, and the end punctuation stays inside the closing speech mark.';
+const EXPLANATION_RULE_ID = 'speech.inverted-comma-enclosure';
 
 const TEMPLATES = [
   // ─── Legacy parity (indices 0-3) ─────────────────────────────────────────────
@@ -150,6 +151,7 @@ export const speechInsertDsl = TEMPLATES.map((t, i) =>
       model: t.model,
       rubric: t.rubric,
       explanation: t.explanation,
+      explanationRuleId: EXPLANATION_RULE_ID,
       misconceptionTags: t.misconceptionTags,
       readiness: t.readiness,
     }),

--- a/shared/punctuation/explanation-lint.js
+++ b/shared/punctuation/explanation-lint.js
@@ -1,0 +1,180 @@
+/**
+ * Semantic explanation lint — verifies that each generated explanation
+ * is semantically consistent with its rule family, not merely non-generic.
+ *
+ * Admin/test-only utility. NEVER exposed to children.
+ */
+
+/**
+ * Lint rule definitions keyed by ruleId prefix.
+ * Each entry specifies keywords that MUST appear (case-insensitive substring).
+ * At least one keyword from each `anyOf` group must be present.
+ */
+const LINT_RULES = Object.freeze({
+  'speech': {
+    anyOf: [['inverted comma', 'speech mark', 'quotation mark', 'inverted commas', 'speech marks']],
+  },
+  'apostrophe.possession-singular': {
+    anyOf: [["apostrophe", "'s"]],
+    description: 'Must mention apostrophe or possessive marker',
+  },
+  'apostrophe.possession-plural': {
+    anyOf: [["apostrophe", "'s"]],
+    description: 'Must mention apostrophe or possessive marker',
+  },
+  'apostrophe.possession-mixed': {
+    anyOf: [['apostrophe']],
+  },
+  'apostrophe.contraction': {
+    anyOf: [['apostrophe']],
+  },
+  'list.comma-separation': {
+    anyOf: [['comma', 'commas']],
+    allOf: [],
+  },
+  'colon.complete-introduction': {
+    anyOf: [['colon']],
+    requireAny: [['introduces', 'complete', 'opening', 'sets it up', 'sentence']],
+  },
+  'semicolon.independent-clauses': {
+    anyOf: [['semicolon', 'semi-colon']],
+    requireAny: [['complete sentence', 'closely related', 'main clause', 'independent', 'stand alone', 'related']],
+  },
+  'semicolon.complex-list': {
+    anyOf: [['semicolon', 'semi-colon']],
+    requireAny: [['list', 'complex', 'commas', 'group', 'items']],
+  },
+  'bullet.stem-consistency': {
+    anyOf: [['consistent', 'consistency', 'punctuation pattern', 'same']],
+  },
+  'bullet.colon-and-consistency': {
+    anyOf: [['colon', 'consistent', 'consistency', 'bullet', 'punctuation pattern']],
+  },
+  'fronted-adverbial.comma-after-opener': {
+    anyOf: [['comma']],
+    requireAny: [['opener', 'adverbial', 'fronted', 'opening', 'main clause', 'phrase']],
+  },
+  'hyphen.compound-modifier': {
+    anyOf: [['hyphen']],
+  },
+  'parenthesis.additional-information': {
+    anyOf: [['extra', 'removed', 'set off', 'parenthetical', 'bracket', 'parenthesis', 'additional']],
+  },
+  'dash.clause-separation': {
+    anyOf: [['dash']],
+    requireAny: [['independent', 'related', 'surprise', 'contrast', 'ideas', 'clauses']],
+  },
+  'sentence-ending.terminal-mark': {
+    anyOf: [['capital', 'end', 'full stop', 'question', 'exclamation', 'statement']],
+  },
+  'comma.clarity': {
+    anyOf: [['comma']],
+    requireAny: [['opening', 'phrase', 'misreading', 'clear', 'main clause']],
+  },
+  'mixed.fronted-speech': {
+    anyOf: [['comma', 'inverted comma', 'speech mark', 'inverted commas']],
+  },
+  'mixed.parenthesis-speech': {
+    anyOf: [['parenthetical', 'extra', 'inverted comma', 'speech', 'removable', 'set off']],
+  },
+  'mixed.colon-semicolon': {
+    anyOf: [['colon', 'semicolon', 'semi-colon']],
+  },
+});
+
+/**
+ * Check whether a text contains at least one keyword from a list (case-insensitive).
+ */
+function containsAny(text, keywords) {
+  const lower = text.toLowerCase();
+  return keywords.some((kw) => lower.includes(kw.toLowerCase()));
+}
+
+/**
+ * Resolve the lint rule for a given ruleId.
+ * Tries exact match first, then prefix match.
+ */
+function resolveRule(ruleId) {
+  if (!ruleId) return null;
+  // Exact match
+  if (LINT_RULES[ruleId]) return LINT_RULES[ruleId];
+  // Prefix match (e.g. 'speech.inverted-comma-enclosure' matches 'speech')
+  for (const prefix of Object.keys(LINT_RULES)) {
+    if (ruleId.startsWith(prefix)) return LINT_RULES[prefix];
+  }
+  return null;
+}
+
+/**
+ * Lint a single explanation against its rule family.
+ *
+ * @param {string} explanation - The explanation text to lint
+ * @param {string} ruleId - The explanationRuleId assigned to the template
+ * @param {object} [itemContext] - Optional context (for future extensions)
+ * @returns {{ pass: boolean, violations: string[] }}
+ */
+export function lintExplanation(explanation, ruleId, itemContext = {}) {
+  const violations = [];
+
+  if (!explanation || typeof explanation !== 'string') {
+    violations.push('Explanation is empty or not a string');
+    return { pass: false, violations };
+  }
+
+  if (!ruleId || typeof ruleId !== 'string') {
+    violations.push('explanationRuleId is missing or not a string');
+    return { pass: false, violations };
+  }
+
+  const rule = resolveRule(ruleId);
+  if (!rule) {
+    // Unknown ruleId — pass silently to allow future expansion
+    return { pass: true, violations: [] };
+  }
+
+  // Check anyOf groups — at least one keyword from each group must appear
+  if (rule.anyOf) {
+    for (const group of rule.anyOf) {
+      if (!containsAny(explanation, group)) {
+        violations.push(
+          `Explanation for rule "${ruleId}" must contain one of: ${group.join(', ')}`,
+        );
+      }
+    }
+  }
+
+  // Check requireAny groups — at least one keyword from each group must appear
+  if (rule.requireAny) {
+    for (const group of rule.requireAny) {
+      if (!containsAny(explanation, group)) {
+        violations.push(
+          `Explanation for rule "${ruleId}" must also contain one of: ${group.join(', ')}`,
+        );
+      }
+    }
+  }
+
+  return { pass: violations.length === 0, violations };
+}
+
+/**
+ * Lint all items in a batch. Returns summary with per-item results.
+ *
+ * @param {Array<{explanation: string, explanationRuleId: string}>} items
+ * @returns {{ allPass: boolean, results: Array<{id: string, pass: boolean, violations: string[]}> }}
+ */
+export function lintExplanationBatch(items) {
+  const results = [];
+  for (const item of items) {
+    const { pass, violations } = lintExplanation(
+      item.explanation,
+      item.explanationRuleId,
+      { id: item.id, familyId: item.generatorFamilyId },
+    );
+    results.push({ id: item.id || '(unknown)', pass, violations });
+  }
+  return {
+    allPass: results.every((r) => r.pass),
+    results,
+  };
+}

--- a/shared/punctuation/generators.js
+++ b/shared/punctuation/generators.js
@@ -69,15 +69,15 @@ function stableJson(value) {
 }
 
 /**
- * Strip `explanation` keys from a validator structure before hashing.
- * Explanation is a P6 learner-feedback addition that must not alter template identity.
+ * Strip `explanation` and `explanationRuleId` keys from a validator structure before hashing.
+ * These are P6/P7 learner-feedback additions that must not alter template identity.
  */
 function stripExplanationForHash(value) {
   if (Array.isArray(value)) return value.map(stripExplanationForHash);
   if (!isPlainObject(value)) return value;
   return Object.fromEntries(
     Object.entries(value)
-      .filter(([key]) => key !== 'explanation')
+      .filter(([key]) => key !== 'explanation' && key !== 'explanationRuleId')
       .map(([key, v]) => [key, stripExplanationForHash(v)]),
   );
 }
@@ -201,6 +201,7 @@ function buildGeneratedItem({ family, skill, template, templateIndex, seed, vari
     stem: template.stem || '',
     accepted: uniqueStrings([model, ...(Array.isArray(template.accepted) ? template.accepted : [])]),
     explanation: template.explanation || 'This generated item practises the same published punctuation skill.',
+    ...(typeof template.explanationRuleId === 'string' ? { explanationRuleId: template.explanationRuleId } : {}),
     model,
     ...(isPlainObject(template.validator) ? { validator: template.validator } : {}),
     ...(isPlainObject(template.rubric) ? { rubric: template.rubric } : {}),

--- a/shared/punctuation/template-dsl.js
+++ b/shared/punctuation/template-dsl.js
@@ -233,6 +233,7 @@ export function expandDslTemplates(dslDefinitions, { embedTemplateId = true } = 
         ...(isPlainObject(buildResult.rubric) ? { rubric: buildResult.rubric } : {}),
         ...(Array.isArray(buildResult.accepted) ? { accepted: buildResult.accepted } : {}),
         explanation: buildResult.explanation || 'This generated item practises the same published punctuation skill.',
+        ...(typeof buildResult.explanationRuleId === 'string' ? { explanationRuleId: buildResult.explanationRuleId } : {}),
         ...skillIdsEntry,
         ...clusterIdEntry,
         misconceptionTags: buildResult.misconceptionTags || spec.misconceptionTags,

--- a/tests/punctuation-semantic-explanation-lint.test.js
+++ b/tests/punctuation-semantic-explanation-lint.test.js
@@ -1,0 +1,218 @@
+/**
+ * Semantic explanation lint tests for punctuation DSL templates (P7-U6).
+ *
+ * Verifies that each generated explanation is semantically matched to its
+ * rule family via explanationRuleId, not just "not generic".
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createPunctuationGeneratedItems } from '../shared/punctuation/generators.js';
+import { lintExplanation, lintExplanationBatch } from '../shared/punctuation/explanation-lint.js';
+
+const GENERIC_FALLBACK = 'This generated item practises the same published punctuation skill.';
+
+/** Generate items at a given depth and return them. */
+function generateAtDepth(depth) {
+  return createPunctuationGeneratedItems({ depth });
+}
+
+// ─── explanationRuleId presence ───────────────────────────────────────────────
+
+test('semantic lint: every generated item at depth 4 has explanationRuleId', () => {
+  const items = generateAtDepth(4);
+  assert.ok(items.length > 0, 'depth 4 must produce items');
+  for (const item of items) {
+    assert.ok(
+      typeof item.explanationRuleId === 'string' && item.explanationRuleId.length > 0,
+      `Item ${item.id} (family: ${item.generatorFamilyId}) is missing explanationRuleId`,
+    );
+  }
+});
+
+test('semantic lint: every generated item at depth 6 has explanationRuleId', () => {
+  const items = generateAtDepth(6);
+  assert.ok(items.length > 0, 'depth 6 must produce items');
+  for (const item of items) {
+    assert.ok(
+      typeof item.explanationRuleId === 'string' && item.explanationRuleId.length > 0,
+      `Item ${item.id} (family: ${item.generatorFamilyId}) is missing explanationRuleId`,
+    );
+  }
+});
+
+test('semantic lint: every generated item at depth 8 has explanationRuleId', () => {
+  const items = generateAtDepth(8);
+  assert.ok(items.length > 0, 'depth 8 must produce items');
+  for (const item of items) {
+    assert.ok(
+      typeof item.explanationRuleId === 'string' && item.explanationRuleId.length > 0,
+      `Item ${item.id} (family: ${item.generatorFamilyId}) is missing explanationRuleId`,
+    );
+  }
+});
+
+// ─── Semantic lint pass at all depths ─────────────────────────────────────────
+
+test('semantic lint: all families pass lint at depth 4', () => {
+  const items = generateAtDepth(4);
+  const { allPass, results } = lintExplanationBatch(items);
+  const failures = results.filter((r) => !r.pass);
+  assert.ok(
+    allPass,
+    `${failures.length} item(s) failed semantic lint at depth 4:\n` +
+    failures.map((f) => `  ${f.id}: ${f.violations.join('; ')}`).join('\n'),
+  );
+});
+
+test('semantic lint: all families pass lint at depth 6', () => {
+  const items = generateAtDepth(6);
+  const { allPass, results } = lintExplanationBatch(items);
+  const failures = results.filter((r) => !r.pass);
+  assert.ok(
+    allPass,
+    `${failures.length} item(s) failed semantic lint at depth 6:\n` +
+    failures.map((f) => `  ${f.id}: ${f.violations.join('; ')}`).join('\n'),
+  );
+});
+
+test('semantic lint: all families pass lint at depth 8', () => {
+  const items = generateAtDepth(8);
+  const { allPass, results } = lintExplanationBatch(items);
+  const failures = results.filter((r) => !r.pass);
+  assert.ok(
+    allPass,
+    `${failures.length} item(s) failed semantic lint at depth 8:\n` +
+    failures.map((f) => `  ${f.id}: ${f.violations.join('; ')}`).join('\n'),
+  );
+});
+
+// ─── Generic fallback still blocked ──────────────────────────────────────────
+
+test('semantic lint: generic fallback blocked at depth 4', () => {
+  const items = generateAtDepth(4);
+  for (const item of items) {
+    assert.notStrictEqual(
+      item.explanation,
+      GENERIC_FALLBACK,
+      `Item ${item.id} uses the generic fallback`,
+    );
+  }
+});
+
+test('semantic lint: generic fallback blocked at depth 6', () => {
+  const items = generateAtDepth(6);
+  for (const item of items) {
+    assert.notStrictEqual(
+      item.explanation,
+      GENERIC_FALLBACK,
+      `Item ${item.id} uses the generic fallback`,
+    );
+  }
+});
+
+test('semantic lint: generic fallback blocked at depth 8', () => {
+  const items = generateAtDepth(8);
+  for (const item of items) {
+    assert.notStrictEqual(
+      item.explanation,
+      GENERIC_FALLBACK,
+      `Item ${item.id} uses the generic fallback`,
+    );
+  }
+});
+
+// ─── Negative tests: wrong explanation fails lint ─────────────────────────────
+
+test('semantic lint: deliberately wrong explanation fails', () => {
+  // A speech rule with no mention of speech marks / inverted commas
+  const result = lintExplanation(
+    'A comma separates two clauses.',
+    'speech.inverted-comma-enclosure',
+  );
+  assert.strictEqual(result.pass, false, 'Wrong explanation should fail lint');
+  assert.ok(result.violations.length > 0);
+});
+
+test('semantic lint: explanation contradicting rule category fails', () => {
+  // Semicolon rule with no mention of semicolons or related concepts
+  const result = lintExplanation(
+    'Use a comma to join these two sentences together.',
+    'semicolon.independent-clauses',
+  );
+  assert.strictEqual(result.pass, false, 'Contradicting explanation should fail lint');
+  assert.ok(result.violations.length > 0);
+});
+
+test('semantic lint: colon rule without introducing concept fails', () => {
+  const result = lintExplanation(
+    'A colon is a punctuation mark.',
+    'colon.complete-introduction',
+  );
+  assert.strictEqual(result.pass, false, 'Colon without "introduces"/"complete" should fail');
+  assert.ok(result.violations.length > 0);
+});
+
+test('semantic lint: bullet rule without consistency concept fails', () => {
+  const result = lintExplanation(
+    'Use capital letters at the start of each line.',
+    'bullet.stem-consistency',
+  );
+  assert.strictEqual(result.pass, false, 'Bullet without consistency keyword should fail');
+  assert.ok(result.violations.length > 0);
+});
+
+// ─── Correct explanations pass lint ──────────────────────────────────────────
+
+test('semantic lint: correct speech explanation passes', () => {
+  const result = lintExplanation(
+    'Inverted commas wrap the spoken words, and the end punctuation stays inside the closing speech mark.',
+    'speech.inverted-comma-enclosure',
+  );
+  assert.strictEqual(result.pass, true);
+  assert.deepStrictEqual(result.violations, []);
+});
+
+test('semantic lint: correct semicolon explanation passes', () => {
+  const result = lintExplanation(
+    'A semicolon joins two complete sentences that are closely related in meaning.',
+    'semicolon.independent-clauses',
+  );
+  assert.strictEqual(result.pass, true);
+  assert.deepStrictEqual(result.violations, []);
+});
+
+test('semantic lint: correct colon explanation passes', () => {
+  const result = lintExplanation(
+    'A colon introduces the list after a complete sentence that sets it up.',
+    'colon.complete-introduction',
+  );
+  assert.strictEqual(result.pass, true);
+  assert.deepStrictEqual(result.violations, []);
+});
+
+test('semantic lint: correct bullet explanation passes', () => {
+  const result = lintExplanation(
+    'Every bullet in a list must follow the same punctuation pattern so the reader knows the list is consistent.',
+    'bullet.stem-consistency',
+  );
+  assert.strictEqual(result.pass, true);
+  assert.deepStrictEqual(result.violations, []);
+});
+
+// ─── Edge cases ──────────────────────────────────────────────────────────────
+
+test('semantic lint: missing ruleId fails', () => {
+  const result = lintExplanation('Some explanation.', '');
+  assert.strictEqual(result.pass, false);
+});
+
+test('semantic lint: empty explanation fails', () => {
+  const result = lintExplanation('', 'speech.inverted-comma-enclosure');
+  assert.strictEqual(result.pass, false);
+});
+
+test('semantic lint: unknown ruleId passes gracefully', () => {
+  const result = lintExplanation('Any text at all.', 'future.unknown-rule');
+  assert.strictEqual(result.pass, true, 'Unknown rules should pass to allow extension');
+});


### PR DESCRIPTION
## Summary
- Add `explanationRuleId` metadata to all 25 DSL families, flowing through `template-dsl.js` and `generators.js` into generated items
- Create `shared/punctuation/explanation-lint.js` — keyword-based semantic validator per rule category (speech, apostrophe, list, colon, semicolon, bullet, fronted-adverbial, hyphen, parenthesis, dash, sentence-ending, comma-clarity, mixed)
- 20 new tests in `tests/punctuation-semantic-explanation-lint.test.js` proving every item maps to its rule family and passes semantic lint at depths 4, 6, 8; plus negative cases for wrong/contradicting explanations

## Key invariants
- `explanationRuleId` is stripped from hash computation — zero templateId/variantSignature changes
- Metadata is admin/test-only — never exposed to children
- Existing 6 specificity tests + 3 golden marking tests still pass (41 total)
- Generic fallback remains blocked at all depths

## Test plan
- [x] `node --test tests/punctuation-semantic-explanation-lint.test.js` — 20/20 pass
- [x] `node --test tests/punctuation-explanation-specificity.test.js` — 6/6 pass (regression)
- [x] `node --test tests/punctuation-golden-marking.test.js` — 3/3 pass (regression)