### PR TITLE
feat(punctuation-qg): durable reviewer-decision gate (P7 U4)

### DIFF
--- a/shared/punctuation/reviewer-decisions.js
+++ b/shared/punctuation/reviewer-decisions.js
@@ -1,0 +1,385 @@
+/**
+ * Punctuation reviewer-decision gate.
+ *
+ * Provides schema validation and gate evaluation for production, depth-6,
+ * and cross-mode cluster decisions. Core P7 invariant: empty decisions FAIL.
+ */
+
+import { readFileSync } from 'node:fs';
+
+// ─── Decision states ─────────────────────────────────────────────────────────
+
+const DECISION_STATES = Object.freeze({
+  APPROVED: 'approved',
+  ACCEPTABLE_CROSS_MODE_OVERLAP: 'acceptable-cross-mode-overlap',
+  NEEDS_REWRITE: 'needs-rewrite',
+  NEEDS_MARKING_FIX: 'needs-marking-fix',
+  NEEDS_PROMPT_TIGHTENING: 'needs-prompt-tightening',
+  RETIRE: 'retire',
+  PENDING: 'pending',
+});
+
+const ALL_DECISION_VALUES = Object.freeze(Object.values(DECISION_STATES));
+
+/**
+ * Decisions that block a gate from passing.
+ * Items with these decisions are considered NOT cleared for production/depth-6.
+ */
+const BLOCKING_DECISIONS = Object.freeze([
+  DECISION_STATES.NEEDS_REWRITE,
+  DECISION_STATES.NEEDS_MARKING_FIX,
+  DECISION_STATES.NEEDS_PROMPT_TIGHTENING,
+  DECISION_STATES.RETIRE,
+  DECISION_STATES.PENDING,
+]);
+
+// ─── Schema validation ───────────────────────────────────────────────────────
+
+/**
+ * Validate a single item decision entry.
+ * @param {object} entry
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+function validateItemDecision(entry) {
+  const errors = [];
+
+  if (!entry || typeof entry !== 'object') {
+    return { valid: false, errors: ['Decision entry must be an object'] };
+  }
+
+  if (typeof entry.itemId !== 'string' || !entry.itemId) {
+    errors.push('itemId is required and must be a non-empty string');
+  }
+
+  if (!ALL_DECISION_VALUES.includes(entry.decision)) {
+    errors.push(
+      `decision "${entry.decision}" is invalid. Must be one of: ${ALL_DECISION_VALUES.join(', ')}`,
+    );
+  }
+
+  if (typeof entry.reviewer !== 'string' || !entry.reviewer) {
+    errors.push('reviewer is required and must be a non-empty string');
+  }
+
+  if (typeof entry.reviewedAt !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(entry.reviewedAt)) {
+    errors.push('reviewedAt is required and must be a YYYY-MM-DD string');
+  }
+
+  // Rationale required for specific decision types
+  const rationaleRequired = [
+    DECISION_STATES.ACCEPTABLE_CROSS_MODE_OVERLAP,
+    DECISION_STATES.RETIRE,
+  ];
+  if (rationaleRequired.includes(entry.decision)) {
+    if (typeof entry.rationale !== 'string' || !entry.rationale) {
+      errors.push(`rationale is required for decision "${entry.decision}"`);
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Validate a single cluster decision entry.
+ * @param {object} entry
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+function validateClusterDecision(entry) {
+  const errors = [];
+
+  if (!entry || typeof entry !== 'object') {
+    return { valid: false, errors: ['Cluster decision entry must be an object'] };
+  }
+
+  if (typeof entry.clusterId !== 'string' || !entry.clusterId) {
+    errors.push('clusterId is required and must be a non-empty string');
+  }
+
+  if (!ALL_DECISION_VALUES.includes(entry.decision)) {
+    errors.push(
+      `decision "${entry.decision}" is invalid. Must be one of: ${ALL_DECISION_VALUES.join(', ')}`,
+    );
+  }
+
+  if (typeof entry.reviewer !== 'string' || !entry.reviewer) {
+    errors.push('reviewer is required and must be a non-empty string');
+  }
+
+  if (typeof entry.reviewedAt !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(entry.reviewedAt)) {
+    errors.push('reviewedAt is required and must be a YYYY-MM-DD string');
+  }
+
+  // Cluster decisions for cross-mode overlap require rationale
+  if (entry.decision === DECISION_STATES.ACCEPTABLE_CROSS_MODE_OVERLAP) {
+    if (typeof entry.rationale !== 'string' || !entry.rationale) {
+      errors.push('rationale is required for acceptable-cross-mode-overlap cluster decisions');
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Validate the complete decisions structure.
+ * @param {object} data - The full fixture data with itemDecisions and clusterDecisions arrays
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+function validateDecisionSchema(data) {
+  const errors = [];
+
+  if (!data || typeof data !== 'object') {
+    return { valid: false, errors: ['Decisions data must be an object'] };
+  }
+
+  if (!Array.isArray(data.itemDecisions)) {
+    errors.push('itemDecisions must be an array');
+  } else {
+    for (let i = 0; i < data.itemDecisions.length; i++) {
+      const result = validateItemDecision(data.itemDecisions[i]);
+      if (!result.valid) {
+        errors.push(...result.errors.map((e) => `itemDecisions[${i}]: ${e}`));
+      }
+    }
+  }
+
+  if (!Array.isArray(data.clusterDecisions)) {
+    errors.push('clusterDecisions must be an array');
+  } else {
+    for (let i = 0; i < data.clusterDecisions.length; i++) {
+      const result = validateClusterDecision(data.clusterDecisions[i]);
+      if (!result.valid) {
+        errors.push(...result.errors.map((e) => `clusterDecisions[${i}]: ${e}`));
+      }
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+// ─── Gate evaluation ─────────────────────────────────────────────────────────
+
+/**
+ * Build a lookup map from itemDecisions array.
+ * @param {Array} itemDecisions
+ * @returns {Map<string, object>}
+ */
+function buildItemDecisionMap(itemDecisions) {
+  const map = new Map();
+  for (const d of itemDecisions) {
+    map.set(d.itemId, d);
+  }
+  return map;
+}
+
+/**
+ * Build a lookup map from clusterDecisions array.
+ * @param {Array} clusterDecisions
+ * @returns {Map<string, object>}
+ */
+function buildClusterDecisionMap(clusterDecisions) {
+  const map = new Map();
+  for (const d of clusterDecisions) {
+    map.set(d.clusterId, d);
+  }
+  return map;
+}
+
+/**
+ * Evaluate the production gate.
+ *
+ * FAILS if:
+ * - itemDecisions is empty (core P7 invariant: empty = fail)
+ * - Any production item has a blocking decision
+ * - Any production item has no decision at all
+ *
+ * @param {object} data - The decisions data with itemDecisions array
+ * @param {string[]} productionItemIds - IDs of production items to check
+ * @returns {{ pass: boolean, blockers: Array<{itemId: string, reason: string}>, stats: object }}
+ */
+function evaluateProductionGate(data, productionItemIds) {
+  const stats = { total: productionItemIds.length, approved: 0, blocked: 0, missing: 0, retired: 0 };
+  const blockers = [];
+
+  // Core P7 invariant: empty decisions FAIL
+  if (!Array.isArray(data.itemDecisions) || data.itemDecisions.length === 0) {
+    return {
+      pass: false,
+      blockers: [{ itemId: '*', reason: 'itemDecisions is empty — gate requires populated decisions' }],
+      stats: { ...stats, missing: productionItemIds.length },
+    };
+  }
+
+  const decisionMap = buildItemDecisionMap(data.itemDecisions);
+
+  for (const itemId of productionItemIds) {
+    const decision = decisionMap.get(itemId);
+
+    if (!decision) {
+      stats.missing++;
+      blockers.push({ itemId, reason: 'no decision recorded' });
+      continue;
+    }
+
+    if (BLOCKING_DECISIONS.includes(decision.decision)) {
+      stats.blocked++;
+      if (decision.decision === DECISION_STATES.RETIRE) stats.retired++;
+      blockers.push({ itemId, reason: `decision is "${decision.decision}"` });
+    } else {
+      stats.approved++;
+    }
+  }
+
+  return {
+    pass: blockers.length === 0,
+    blockers,
+    stats,
+  };
+}
+
+/**
+ * Evaluate the depth-6 candidate gate.
+ *
+ * Checks ONLY candidate items (not in production). Fails if any has a blocking decision.
+ * Does NOT affect the production gate.
+ *
+ * @param {object} data - The decisions data with itemDecisions array
+ * @param {string[]} candidateItemIds - IDs of depth-6 candidate items
+ * @returns {{ pass: boolean, blockers: Array<{itemId: string, reason: string}>, stats: object }}
+ */
+function evaluateDepth6Gate(data, candidateItemIds) {
+  const stats = { total: candidateItemIds.length, approved: 0, blocked: 0, missing: 0, retired: 0 };
+  const blockers = [];
+
+  if (!Array.isArray(data.itemDecisions) || data.itemDecisions.length === 0) {
+    // Depth-6 gate with no decisions: treat as "not yet reviewed" — still fails
+    return {
+      pass: false,
+      blockers: [{ itemId: '*', reason: 'itemDecisions is empty — no candidate reviews exist' }],
+      stats: { ...stats, missing: candidateItemIds.length },
+    };
+  }
+
+  const decisionMap = buildItemDecisionMap(data.itemDecisions);
+
+  for (const itemId of candidateItemIds) {
+    const decision = decisionMap.get(itemId);
+
+    if (!decision) {
+      stats.missing++;
+      blockers.push({ itemId, reason: 'no decision recorded' });
+      continue;
+    }
+
+    if (BLOCKING_DECISIONS.includes(decision.decision)) {
+      stats.blocked++;
+      if (decision.decision === DECISION_STATES.RETIRE) stats.retired++;
+      blockers.push({ itemId, reason: `decision is "${decision.decision}"` });
+    } else {
+      stats.approved++;
+    }
+  }
+
+  return {
+    pass: blockers.length === 0,
+    blockers,
+    stats,
+  };
+}
+
+/**
+ * Evaluate the cluster gate for cross-mode overlaps.
+ *
+ * Each cluster must have an `acceptable-cross-mode-overlap` decision with rationale.
+ *
+ * @param {object} data - The decisions data with clusterDecisions array
+ * @param {string[]} crossModeClusterIds - IDs of cross-mode overlap clusters to check
+ * @returns {{ pass: boolean, blockers: Array<{clusterId: string, reason: string}>, stats: object }}
+ */
+function evaluateClusterGate(data, crossModeClusterIds) {
+  const stats = { total: crossModeClusterIds.length, approved: 0, blocked: 0, missing: 0 };
+  const blockers = [];
+
+  if (!Array.isArray(data.clusterDecisions)) {
+    return {
+      pass: crossModeClusterIds.length === 0,
+      blockers: crossModeClusterIds.map((id) => ({ clusterId: id, reason: 'clusterDecisions array missing' })),
+      stats: { ...stats, missing: crossModeClusterIds.length },
+    };
+  }
+
+  const decisionMap = buildClusterDecisionMap(data.clusterDecisions);
+
+  for (const clusterId of crossModeClusterIds) {
+    const decision = decisionMap.get(clusterId);
+
+    if (!decision) {
+      stats.missing++;
+      blockers.push({ clusterId, reason: 'no cluster decision recorded' });
+      continue;
+    }
+
+    if (decision.decision !== DECISION_STATES.ACCEPTABLE_CROSS_MODE_OVERLAP) {
+      stats.blocked++;
+      blockers.push({ clusterId, reason: `decision is "${decision.decision}", expected "acceptable-cross-mode-overlap"` });
+      continue;
+    }
+
+    if (typeof decision.rationale !== 'string' || !decision.rationale) {
+      stats.blocked++;
+      blockers.push({ clusterId, reason: 'acceptable-cross-mode-overlap requires rationale' });
+      continue;
+    }
+
+    stats.approved++;
+  }
+
+  return {
+    pass: blockers.length === 0,
+    blockers,
+    stats,
+  };
+}
+
+// ─── Loader ──────────────────────────────────────────────────────────────────
+
+/**
+ * Load and validate reviewer decisions from a file path or data object.
+ * @param {string|object} fixturePathOrData - File path (string) or parsed data (object)
+ * @returns {{ data: object, valid: boolean, errors: string[] }}
+ */
+function loadReviewerDecisions(fixturePathOrData) {
+  let data;
+
+  if (typeof fixturePathOrData === 'string') {
+    const raw = readFileSync(fixturePathOrData, 'utf8');
+    data = JSON.parse(raw);
+  } else {
+    data = fixturePathOrData;
+  }
+
+  // Support legacy format: if data has 'decisions' object but no 'itemDecisions',
+  // treat as schema v1 (backward compat)
+  if (data && !Array.isArray(data.itemDecisions) && typeof data.decisions === 'object') {
+    data = {
+      ...data,
+      itemDecisions: data.itemDecisions || [],
+      clusterDecisions: data.clusterDecisions || [],
+    };
+  }
+
+  const validation = validateDecisionSchema(data);
+  return { data, valid: validation.valid, errors: validation.errors };
+}
+
+export {
+  DECISION_STATES,
+  ALL_DECISION_VALUES,
+  BLOCKING_DECISIONS,
+  validateItemDecision,
+  validateClusterDecision,
+  validateDecisionSchema,
+  evaluateProductionGate,
+  evaluateDepth6Gate,
+  evaluateClusterGate,
+  loadReviewerDecisions,
+};

--- a/tests/fixtures/punctuation-reviewer-decisions.json
+++ b/tests/fixtures/punctuation-reviewer-decisions.json
@@ -1,4 +1,6 @@
 {
-  "_meta": { "generated": "2026-04-29", "items_reviewed": 192 },
-  "decisions": {}
+  "_meta": { "generated": "2026-04-29", "schema_version": 2, "items_reviewed": 192 },
+  "decisions": {},
+  "itemDecisions": [],
+  "clusterDecisions": []
 }

--- a/tests/punctuation-reviewer-decision-gate.test.js
+++ b/tests/punctuation-reviewer-decision-gate.test.js
@@ -1,0 +1,447 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import {
+  DECISION_STATES,
+  ALL_DECISION_VALUES,
+  BLOCKING_DECISIONS,
+  validateItemDecision,
+  validateClusterDecision,
+  validateDecisionSchema,
+  evaluateProductionGate,
+  evaluateDepth6Gate,
+  evaluateClusterGate,
+  loadReviewerDecisions,
+} from '../shared/punctuation/reviewer-decisions.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DECISIONS_PATH = join(__dirname, 'fixtures', 'punctuation-reviewer-decisions.json');
+
+// ─── Helper factories ────────────────────────────────────────────────────────
+
+function makeItemDecision(overrides = {}) {
+  return {
+    itemId: 'test-item-001',
+    decision: DECISION_STATES.APPROVED,
+    reviewer: 'james',
+    reviewedAt: '2026-04-29',
+    ...overrides,
+  };
+}
+
+function makeClusterDecision(overrides = {}) {
+  return {
+    clusterId: 'cluster-001',
+    decision: DECISION_STATES.ACCEPTABLE_CROSS_MODE_OVERLAP,
+    reviewer: 'james',
+    reviewedAt: '2026-04-29',
+    rationale: 'Same sentence used in fix and combine modes — intentional pedagogical reuse',
+    ...overrides,
+  };
+}
+
+function makeDecisionsData(itemDecisions = [], clusterDecisions = []) {
+  return { itemDecisions, clusterDecisions };
+}
+
+// ─── Core P7 invariant: empty decisions FAIL ─────────────────────────────────
+
+test('production gate: empty itemDecisions FAILS (core P7 invariant)', () => {
+  const data = makeDecisionsData([], []);
+  const result = evaluateProductionGate(data, ['item-1', 'item-2', 'item-3']);
+
+  assert.equal(result.pass, false, 'empty decisions must fail');
+  assert.ok(result.blockers.length > 0, 'must report blockers');
+  assert.equal(result.blockers[0].itemId, '*');
+  assert.ok(result.blockers[0].reason.includes('empty'), 'reason mentions empty');
+});
+
+test('production gate: fixture file with empty itemDecisions FAILS', () => {
+  const raw = readFileSync(DECISIONS_PATH, 'utf8');
+  const parsed = JSON.parse(raw);
+  const result = evaluateProductionGate(parsed, ['any-item-id']);
+
+  assert.equal(result.pass, false, 'fixture with empty itemDecisions must fail');
+});
+
+// ─── Production gate: populated decisions ────────────────────────────────────
+
+test('production gate: all items approved PASSES', () => {
+  const productionIds = ['item-1', 'item-2', 'item-3'];
+  const data = makeDecisionsData(
+    productionIds.map((id) => makeItemDecision({ itemId: id })),
+    [],
+  );
+
+  const result = evaluateProductionGate(data, productionIds);
+
+  assert.equal(result.pass, true);
+  assert.equal(result.blockers.length, 0);
+  assert.equal(result.stats.approved, 3);
+  assert.equal(result.stats.blocked, 0);
+  assert.equal(result.stats.missing, 0);
+});
+
+test('production gate: one item with needs-rewrite FAILS', () => {
+  const productionIds = ['item-1', 'item-2', 'item-3'];
+  const data = makeDecisionsData([
+    makeItemDecision({ itemId: 'item-1' }),
+    makeItemDecision({ itemId: 'item-2', decision: DECISION_STATES.NEEDS_REWRITE }),
+    makeItemDecision({ itemId: 'item-3' }),
+  ], []);
+
+  const result = evaluateProductionGate(data, productionIds);
+
+  assert.equal(result.pass, false);
+  assert.equal(result.blockers.length, 1);
+  assert.equal(result.blockers[0].itemId, 'item-2');
+  assert.ok(result.blockers[0].reason.includes('needs-rewrite'));
+});
+
+test('production gate: one item with pending FAILS', () => {
+  const productionIds = ['item-1', 'item-2'];
+  const data = makeDecisionsData([
+    makeItemDecision({ itemId: 'item-1' }),
+    makeItemDecision({ itemId: 'item-2', decision: DECISION_STATES.PENDING }),
+  ], []);
+
+  const result = evaluateProductionGate(data, productionIds);
+
+  assert.equal(result.pass, false);
+  assert.equal(result.blockers.length, 1);
+  assert.equal(result.blockers[0].itemId, 'item-2');
+  assert.ok(result.blockers[0].reason.includes('pending'));
+});
+
+test('production gate: one item with needs-marking-fix FAILS', () => {
+  const productionIds = ['item-1'];
+  const data = makeDecisionsData([
+    makeItemDecision({ itemId: 'item-1', decision: DECISION_STATES.NEEDS_MARKING_FIX }),
+  ], []);
+
+  const result = evaluateProductionGate(data, productionIds);
+
+  assert.equal(result.pass, false);
+  assert.equal(result.stats.blocked, 1);
+});
+
+test('production gate: one item with needs-prompt-tightening FAILS', () => {
+  const productionIds = ['item-1'];
+  const data = makeDecisionsData([
+    makeItemDecision({ itemId: 'item-1', decision: DECISION_STATES.NEEDS_PROMPT_TIGHTENING }),
+  ], []);
+
+  const result = evaluateProductionGate(data, productionIds);
+
+  assert.equal(result.pass, false);
+  assert.equal(result.stats.blocked, 1);
+});
+
+test('production gate: one item with retire FAILS', () => {
+  const productionIds = ['item-1'];
+  const data = makeDecisionsData([
+    makeItemDecision({
+      itemId: 'item-1',
+      decision: DECISION_STATES.RETIRE,
+      rationale: 'Ambiguous stem — learner confusion in trials',
+    }),
+  ], []);
+
+  const result = evaluateProductionGate(data, productionIds);
+
+  assert.equal(result.pass, false);
+  assert.equal(result.stats.retired, 1);
+});
+
+test('production gate: missing item (no decision recorded) FAILS', () => {
+  const productionIds = ['item-1', 'item-2'];
+  const data = makeDecisionsData([
+    makeItemDecision({ itemId: 'item-1' }),
+    // item-2 has no decision
+  ], []);
+
+  const result = evaluateProductionGate(data, productionIds);
+
+  assert.equal(result.pass, false);
+  assert.equal(result.stats.missing, 1);
+  assert.ok(result.blockers.some((b) => b.itemId === 'item-2'));
+});
+
+test('production gate: acceptable-cross-mode-overlap counts as approved for items', () => {
+  const productionIds = ['item-1'];
+  const data = makeDecisionsData([
+    makeItemDecision({
+      itemId: 'item-1',
+      decision: DECISION_STATES.ACCEPTABLE_CROSS_MODE_OVERLAP,
+      rationale: 'Intentional cross-mode reuse for pedagogical coverage',
+    }),
+  ], []);
+
+  const result = evaluateProductionGate(data, productionIds);
+
+  assert.equal(result.pass, true, 'acceptable-cross-mode-overlap is not blocking');
+  assert.equal(result.stats.approved, 1);
+});
+
+// ─── Depth-6 gate: candidate isolation ───────────────────────────────────────
+
+test('depth-6 gate: candidate with blocking decision fails depth-6 but NOT production', () => {
+  const productionIds = ['prod-1', 'prod-2'];
+  const candidateIds = ['candidate-1', 'candidate-2'];
+
+  const data = makeDecisionsData([
+    makeItemDecision({ itemId: 'prod-1' }),
+    makeItemDecision({ itemId: 'prod-2' }),
+    makeItemDecision({ itemId: 'candidate-1', decision: DECISION_STATES.NEEDS_REWRITE }),
+    makeItemDecision({ itemId: 'candidate-2' }),
+  ], []);
+
+  // Depth-6 gate fails
+  const depth6Result = evaluateDepth6Gate(data, candidateIds);
+  assert.equal(depth6Result.pass, false, 'depth-6 gate fails for candidate with blocking decision');
+  assert.equal(depth6Result.blockers.length, 1);
+  assert.equal(depth6Result.blockers[0].itemId, 'candidate-1');
+
+  // Production gate passes (only checks production items)
+  const prodResult = evaluateProductionGate(data, productionIds);
+  assert.equal(prodResult.pass, true, 'production gate unaffected by candidate blocking decision');
+});
+
+test('depth-6 gate: all candidates approved PASSES', () => {
+  const candidateIds = ['c-1', 'c-2', 'c-3'];
+  const data = makeDecisionsData(
+    candidateIds.map((id) => makeItemDecision({ itemId: id })),
+    [],
+  );
+
+  const result = evaluateDepth6Gate(data, candidateIds);
+
+  assert.equal(result.pass, true);
+  assert.equal(result.stats.approved, 3);
+});
+
+test('depth-6 gate: empty decisions FAILS', () => {
+  const result = evaluateDepth6Gate(makeDecisionsData([], []), ['c-1']);
+
+  assert.equal(result.pass, false);
+});
+
+// ─── Cluster gate: cross-mode overlap ────────────────────────────────────────
+
+test('cluster gate: cluster without acceptable-cross-mode-overlap FAILS', () => {
+  const clusterIds = ['cluster-A'];
+  const data = makeDecisionsData([], []);
+
+  const result = evaluateClusterGate(data, clusterIds);
+
+  assert.equal(result.pass, false);
+  assert.equal(result.stats.missing, 1);
+});
+
+test('cluster gate: cluster with decision but no rationale FAILS', () => {
+  const clusterIds = ['cluster-A'];
+  const data = makeDecisionsData([], [
+    {
+      clusterId: 'cluster-A',
+      decision: DECISION_STATES.ACCEPTABLE_CROSS_MODE_OVERLAP,
+      reviewer: 'james',
+      reviewedAt: '2026-04-29',
+      rationale: '', // Empty rationale
+    },
+  ]);
+
+  const result = evaluateClusterGate(data, clusterIds);
+
+  assert.equal(result.pass, false);
+  assert.ok(result.blockers[0].reason.includes('rationale'));
+});
+
+test('cluster gate: cluster with wrong decision type FAILS', () => {
+  const clusterIds = ['cluster-A'];
+  const data = makeDecisionsData([], [
+    makeClusterDecision({ clusterId: 'cluster-A', decision: DECISION_STATES.APPROVED, rationale: undefined }),
+  ]);
+
+  const result = evaluateClusterGate(data, clusterIds);
+
+  assert.equal(result.pass, false);
+  assert.ok(result.blockers[0].reason.includes('expected "acceptable-cross-mode-overlap"'));
+});
+
+test('cluster gate: cluster with valid acceptable-cross-mode-overlap and rationale PASSES', () => {
+  const clusterIds = ['cluster-A', 'cluster-B'];
+  const data = makeDecisionsData([], [
+    makeClusterDecision({ clusterId: 'cluster-A' }),
+    makeClusterDecision({ clusterId: 'cluster-B', rationale: 'Fix-mode adds pedagogical contrast' }),
+  ]);
+
+  const result = evaluateClusterGate(data, clusterIds);
+
+  assert.equal(result.pass, true);
+  assert.equal(result.stats.approved, 2);
+});
+
+test('cluster gate: no clusters to check passes vacuously', () => {
+  const result = evaluateClusterGate(makeDecisionsData([], []), []);
+  assert.equal(result.pass, true);
+});
+
+// ─── Schema validation ───────────────────────────────────────────────────────
+
+test('schema validation: rejects invalid decision states', () => {
+  const entry = makeItemDecision({ decision: 'invalid-state' });
+  const result = validateItemDecision(entry);
+
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some((e) => e.includes('invalid')));
+});
+
+test('schema validation: rejects missing itemId', () => {
+  const entry = makeItemDecision({ itemId: '' });
+  const result = validateItemDecision(entry);
+
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some((e) => e.includes('itemId')));
+});
+
+test('schema validation: rejects missing reviewer', () => {
+  const entry = makeItemDecision({ reviewer: '' });
+  const result = validateItemDecision(entry);
+
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some((e) => e.includes('reviewer')));
+});
+
+test('schema validation: rejects invalid reviewedAt format', () => {
+  const entry = makeItemDecision({ reviewedAt: '29-04-2026' });
+  const result = validateItemDecision(entry);
+
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some((e) => e.includes('reviewedAt')));
+});
+
+test('schema validation: requires rationale for retire decision', () => {
+  const entry = makeItemDecision({ decision: DECISION_STATES.RETIRE });
+  const result = validateItemDecision(entry);
+
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some((e) => e.includes('rationale')));
+});
+
+test('schema validation: requires rationale for acceptable-cross-mode-overlap', () => {
+  const entry = makeItemDecision({ decision: DECISION_STATES.ACCEPTABLE_CROSS_MODE_OVERLAP });
+  const result = validateItemDecision(entry);
+
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some((e) => e.includes('rationale')));
+});
+
+test('schema validation: accepts valid approved entry', () => {
+  const entry = makeItemDecision();
+  const result = validateItemDecision(entry);
+
+  assert.equal(result.valid, true);
+  assert.equal(result.errors.length, 0);
+});
+
+test('schema validation: accepts valid retire entry with rationale', () => {
+  const entry = makeItemDecision({
+    decision: DECISION_STATES.RETIRE,
+    rationale: 'Stem is ambiguous post-curriculum update',
+  });
+  const result = validateItemDecision(entry);
+
+  assert.equal(result.valid, true);
+});
+
+test('schema validation: validates full decisions data', () => {
+  const data = makeDecisionsData(
+    [makeItemDecision()],
+    [makeClusterDecision()],
+  );
+  const result = validateDecisionSchema(data);
+
+  assert.equal(result.valid, true);
+  assert.equal(result.errors.length, 0);
+});
+
+test('schema validation: reports errors from both arrays', () => {
+  const data = makeDecisionsData(
+    [makeItemDecision({ decision: 'bogus' })],
+    [{ clusterId: '', decision: 'invalid' }],
+  );
+  const result = validateDecisionSchema(data);
+
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.length >= 2, `expected multiple errors, got ${result.errors.length}`);
+});
+
+// ─── Stats reporting ─────────────────────────────────────────────────────────
+
+test('gate reports exact counts (approved, blocked, missing, retired)', () => {
+  const productionIds = ['p1', 'p2', 'p3', 'p4', 'p5'];
+  const data = makeDecisionsData([
+    makeItemDecision({ itemId: 'p1' }),
+    makeItemDecision({ itemId: 'p2' }),
+    makeItemDecision({ itemId: 'p3', decision: DECISION_STATES.NEEDS_REWRITE }),
+    makeItemDecision({
+      itemId: 'p4',
+      decision: DECISION_STATES.RETIRE,
+      rationale: 'Obsolete after curriculum revision',
+    }),
+    // p5 has no decision
+  ], []);
+
+  const result = evaluateProductionGate(data, productionIds);
+
+  assert.equal(result.stats.total, 5);
+  assert.equal(result.stats.approved, 2);
+  assert.equal(result.stats.blocked, 2); // needs-rewrite + retire
+  assert.equal(result.stats.missing, 1); // p5
+  assert.equal(result.stats.retired, 1); // p4
+  assert.equal(result.pass, false);
+});
+
+// ─── Loader ──────────────────────────────────────────────────────────────────
+
+test('loadReviewerDecisions: loads fixture file and returns valid structure', () => {
+  const { data, valid, errors } = loadReviewerDecisions(DECISIONS_PATH);
+
+  assert.ok(data !== null);
+  assert.ok(Array.isArray(data.itemDecisions));
+  assert.ok(Array.isArray(data.clusterDecisions));
+  // Empty arrays are valid schema (but fail gate — that is the point)
+  assert.equal(valid, true);
+  assert.equal(errors.length, 0);
+});
+
+test('loadReviewerDecisions: handles data object directly', () => {
+  const input = makeDecisionsData([makeItemDecision()], [makeClusterDecision()]);
+  const { data, valid } = loadReviewerDecisions(input);
+
+  assert.equal(valid, true);
+  assert.equal(data.itemDecisions.length, 1);
+});
+
+// ─── Decision state coverage ─────────────────────────────────────────────────
+
+test('BLOCKING_DECISIONS includes exactly the expected states', () => {
+  assert.deepEqual(
+    [...BLOCKING_DECISIONS].sort(),
+    ['needs-marking-fix', 'needs-prompt-tightening', 'needs-rewrite', 'pending', 'retire'].sort(),
+  );
+});
+
+test('ALL_DECISION_VALUES covers all 7 states', () => {
+  assert.equal(ALL_DECISION_VALUES.length, 7);
+  assert.ok(ALL_DECISION_VALUES.includes('approved'));
+  assert.ok(ALL_DECISION_VALUES.includes('acceptable-cross-mode-overlap'));
+  assert.ok(ALL_DECISION_VALUES.includes('needs-rewrite'));
+  assert.ok(ALL_DECISION_VALUES.includes('needs-marking-fix'));
+  assert.ok(ALL_DECISION_VALUES.includes('needs-prompt-tightening'));
+  assert.ok(ALL_DECISION_VALUES.includes('retire'));
+  assert.ok(ALL_DECISION_VALUES.includes('pending'));
+});


### PR DESCRIPTION
## Summary
- Adds `shared/punctuation/reviewer-decisions.js` — schema validation + gate evaluation for production, depth-6, and cluster reviewer decisions
- Core P7 invariant enforced: empty `decisions` explicitly FAILS the gate (not treated as approval)
- Updates fixture to schema v2 with `itemDecisions`/`clusterDecisions` arrays; retains legacy `decisions` key for backward compat with perceived-variety tests
- 33 tests covering all 7 decision states, blocking logic, gate isolation, rationale requirements, and stats reporting

## Test plan
- [x] `node --test tests/punctuation-reviewer-decision-gate.test.js` — 33/33 pass
- [x] `node --test tests/punctuation-perceived-variety.test.js` — 7/7 pass (no regression)
- [x] Empty fixture fails production gate (core invariant proven)
- [x] Depth-6 candidate blocking does NOT fail production gate (isolation proven)