### PR TITLE
feat(punctuation-qg): depth-6 activation gate (P7 U9)

### DIFF
--- a/shared/punctuation/depth-activation-gate.js
+++ b/shared/punctuation/depth-activation-gate.js
@@ -1,0 +1,224 @@
+/**
+ * Punctuation depth-6 activation gate.
+ *
+ * PURELY EVALUATIVE — reports readiness for depth promotion from 4 to 6.
+ * Does NOT mutate any state. Deterministic: same inputs = same outputs.
+ *
+ * Three possible outcomes:
+ *   - 'keep-depth-4'         : one or more evidence checks fail
+ *   - 'raise-all-to-6'       : all families pass all evidence checks
+ *   - 'raise-selected-to-6'  : reserved for future partial promotion (not yet triggered)
+ *
+ * Depth-8 is NEVER recommended as learner-facing (always capacity-only).
+ *
+ * P7-U9  |  depth-6 activation gate
+ */
+
+import { PRODUCTION_DEPTH } from './generators.js';
+import { BLOCKING_DECISIONS } from './reviewer-decisions.js';
+
+// ─── Evidence checklist ─────────────────────────────────────────────────────
+
+/**
+ * All required evidence items that must be satisfied before depth can be raised.
+ */
+export const DEPTH_ACTIVATION_EVIDENCE = Object.freeze([
+  'reviewer-decisions-populated',
+  'no-blocking-decisions',
+  'no-unresolved-clusters',
+  'speech-oracle-pass',
+  'semantic-lint-pass',
+  'production-gate-pass',
+  'runtime-count-valid',
+  'release-id-change',
+  'star-evidence-scoped',
+]);
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+const EXPECTED_DEPTH_6_RELEASE_ID = 'punctuation-r5-qg-depth-6';
+
+// ─── Gate evaluation ────────────────────────────────────────────────────────
+
+/**
+ * Evaluate whether depth can be raised from 4 to 6.
+ *
+ * @param {object} options
+ * @param {number} options.targetDepth - Target depth (must be 6)
+ * @param {object} options.reviewerDecisions - Loaded reviewer decisions data
+ * @param {string[]} options.candidateItemIds - Item IDs only in depth-6 pool
+ * @param {Array} options.crossModeClusters - Cross-mode overlap clusters
+ * @param {boolean} options.speechOraclePass - Whether speech oracle hardening passes
+ * @param {boolean} options.semanticLintPass - Whether semantic explanation lint passes
+ * @param {boolean} options.productionGatePass - Whether production gate passes
+ * @param {string} options.currentReleaseId - Current release identifier
+ * @param {number} options.expectedRuntimeCount - Expected total items at target depth
+ * @param {number} options.fixedItemCount - Number of fixed (non-generated) items
+ * @param {number} options.familyCount - Number of published generator families
+ * @returns {{ pass: boolean, outcome: string, blockers: Array, evidence: Array }}
+ */
+export function evaluateDepthActivationGate(options) {
+  const {
+    targetDepth,
+    reviewerDecisions,
+    candidateItemIds,
+    crossModeClusters,
+    speechOraclePass,
+    semanticLintPass,
+    productionGatePass,
+    currentReleaseId,
+    expectedRuntimeCount,
+    fixedItemCount,
+    familyCount,
+  } = options;
+
+  // Depth-8 is NEVER learner-facing — reject immediately
+  if (targetDepth > 6) {
+    return {
+      pass: false,
+      outcome: 'keep-depth-4',
+      blockers: [{
+        evidence: 'target-depth-cap',
+        reason: `Depth ${targetDepth} exceeds maximum learner-facing depth (6). Depth-8 is capacity-only.`,
+      }],
+      evidence: [],
+    };
+  }
+
+  const evidence = [];
+  const blockers = [];
+
+  // 1. reviewer-decisions-populated
+  const hasDecisions = reviewerDecisions &&
+    Array.isArray(reviewerDecisions.itemDecisions) &&
+    reviewerDecisions.itemDecisions.length > 0;
+  evidence.push({ id: 'reviewer-decisions-populated', pass: hasDecisions });
+  if (!hasDecisions) {
+    blockers.push({
+      evidence: 'reviewer-decisions-populated',
+      reason: 'Reviewer decisions are empty — depth-6 candidate items have not been reviewed',
+    });
+  }
+
+  // 2. no-blocking-decisions
+  const itemDecisionMap = new Map();
+  if (hasDecisions) {
+    for (const d of reviewerDecisions.itemDecisions) {
+      itemDecisionMap.set(d.itemId, d);
+    }
+  }
+  const blockingCandidates = [];
+  for (const itemId of (candidateItemIds || [])) {
+    const decision = itemDecisionMap.get(itemId);
+    if (decision && BLOCKING_DECISIONS.includes(decision.decision)) {
+      blockingCandidates.push({ itemId, decision: decision.decision });
+    }
+  }
+  const noBlocking = blockingCandidates.length === 0;
+  evidence.push({ id: 'no-blocking-decisions', pass: noBlocking });
+  if (!noBlocking) {
+    blockers.push({
+      evidence: 'no-blocking-decisions',
+      reason: `${blockingCandidates.length} candidate item(s) have blocking decisions`,
+      details: blockingCandidates,
+    });
+  }
+
+  // 3. no-unresolved-clusters
+  const clusterDecisionMap = new Map();
+  if (reviewerDecisions && Array.isArray(reviewerDecisions.clusterDecisions)) {
+    for (const d of reviewerDecisions.clusterDecisions) {
+      clusterDecisionMap.set(d.clusterId, d);
+    }
+  }
+  const unresolvedClusters = [];
+  for (const cluster of (crossModeClusters || [])) {
+    const clusterId = typeof cluster === 'string' ? cluster : cluster.clusterId;
+    const decision = clusterDecisionMap.get(clusterId);
+    if (!decision) {
+      unresolvedClusters.push({ clusterId, reason: 'no decision recorded' });
+    }
+  }
+  const noClustersUnresolved = unresolvedClusters.length === 0;
+  evidence.push({ id: 'no-unresolved-clusters', pass: noClustersUnresolved });
+  if (!noClustersUnresolved) {
+    blockers.push({
+      evidence: 'no-unresolved-clusters',
+      reason: `${unresolvedClusters.length} cross-mode cluster(s) have no reviewer decision`,
+      details: unresolvedClusters,
+    });
+  }
+
+  // 4. speech-oracle-pass
+  const speechPass = speechOraclePass === true;
+  evidence.push({ id: 'speech-oracle-pass', pass: speechPass });
+  if (!speechPass) {
+    blockers.push({
+      evidence: 'speech-oracle-pass',
+      reason: 'Speech oracle hardening has not passed (U1 tests must be green)',
+    });
+  }
+
+  // 5. semantic-lint-pass
+  const lintPass = semanticLintPass === true;
+  evidence.push({ id: 'semantic-lint-pass', pass: lintPass });
+  if (!lintPass) {
+    blockers.push({
+      evidence: 'semantic-lint-pass',
+      reason: 'Semantic explanation lint has not passed (U6 must be green)',
+    });
+  }
+
+  // 6. production-gate-pass
+  const prodPass = productionGatePass === true;
+  evidence.push({ id: 'production-gate-pass', pass: prodPass });
+  if (!prodPass) {
+    blockers.push({
+      evidence: 'production-gate-pass',
+      reason: 'Production gate has not passed — existing depth-4 content is not fully cleared',
+    });
+  }
+
+  // 7. runtime-count-valid
+  // Formula: fixedItemCount + familyCount * targetDepth
+  const computedCount = fixedItemCount + familyCount * targetDepth;
+  const countValid = expectedRuntimeCount === computedCount;
+  evidence.push({ id: 'runtime-count-valid', pass: countValid, expected: computedCount, actual: expectedRuntimeCount });
+  if (!countValid) {
+    blockers.push({
+      evidence: 'runtime-count-valid',
+      reason: `Expected runtime count ${computedCount} (fixed ${fixedItemCount} + ${familyCount} families × depth ${targetDepth}), got ${expectedRuntimeCount}`,
+    });
+  }
+
+  // 8. release-id-change
+  const releaseIdWouldChange = currentReleaseId !== EXPECTED_DEPTH_6_RELEASE_ID;
+  evidence.push({ id: 'release-id-change', pass: releaseIdWouldChange, expectedNewId: EXPECTED_DEPTH_6_RELEASE_ID });
+  if (!releaseIdWouldChange) {
+    blockers.push({
+      evidence: 'release-id-change',
+      reason: `Release ID is already "${EXPECTED_DEPTH_6_RELEASE_ID}" — no promotion needed or ID not updated`,
+    });
+  }
+
+  // 9. star-evidence-scoped — structural guarantee (always true by design)
+  evidence.push({ id: 'star-evidence-scoped', pass: true });
+
+  // ─── Outcome determination ──────────────────────────────────────────────────
+
+  const allPass = blockers.length === 0;
+  let outcome;
+  if (!allPass) {
+    outcome = 'keep-depth-4';
+  } else {
+    // All evidence satisfied — raise all families to target depth
+    outcome = 'raise-all-to-6';
+  }
+
+  return {
+    pass: allPass,
+    outcome,
+    blockers,
+    evidence,
+  };
+}

--- a/tests/punctuation-depth-activation-gate.test.js
+++ b/tests/punctuation-depth-activation-gate.test.js
@@ -1,0 +1,325 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  DEPTH_ACTIVATION_EVIDENCE,
+  evaluateDepthActivationGate,
+} from '../shared/punctuation/depth-activation-gate.js';
+import { PRODUCTION_DEPTH } from '../shared/punctuation/generators.js';
+import { BLOCKING_DECISIONS, DECISION_STATES } from '../shared/punctuation/reviewer-decisions.js';
+
+// ─── Test helpers ───────────────────────────────────────────────────────────
+
+const FIXED_ITEM_COUNT = 92;
+const FAMILY_COUNT = 25;
+
+function makePassingOptions(overrides = {}) {
+  const candidateItemIds = ['d6-item-1', 'd6-item-2', 'd6-item-3'];
+  return {
+    targetDepth: 6,
+    reviewerDecisions: {
+      itemDecisions: candidateItemIds.map((itemId) => ({
+        itemId,
+        decision: DECISION_STATES.APPROVED,
+        reviewer: 'james',
+        reviewedAt: '2026-04-29',
+      })),
+      clusterDecisions: [
+        {
+          clusterId: 'cluster-A',
+          decision: DECISION_STATES.ACCEPTABLE_CROSS_MODE_OVERLAP,
+          reviewer: 'james',
+          reviewedAt: '2026-04-29',
+          rationale: 'Intentional cross-mode reuse for pedagogical coverage',
+        },
+      ],
+    },
+    candidateItemIds,
+    crossModeClusters: [{ clusterId: 'cluster-A' }],
+    speechOraclePass: true,
+    semanticLintPass: true,
+    productionGatePass: true,
+    currentReleaseId: 'punctuation-r4-full-14-skill-structure',
+    expectedRuntimeCount: FIXED_ITEM_COUNT + FAMILY_COUNT * 6,
+    fixedItemCount: FIXED_ITEM_COUNT,
+    familyCount: FAMILY_COUNT,
+    ...overrides,
+  };
+}
+
+// ─── Full pass scenario ─────────────────────────────────────────────────────
+
+test('all evidence satisfied → gate passes with outcome "raise-all-to-6"', () => {
+  const result = evaluateDepthActivationGate(makePassingOptions());
+
+  assert.equal(result.pass, true);
+  assert.equal(result.outcome, 'raise-all-to-6');
+  assert.equal(result.blockers.length, 0);
+  assert.equal(result.evidence.length, DEPTH_ACTIVATION_EVIDENCE.length);
+  for (const item of result.evidence) {
+    assert.equal(item.pass, true, `evidence "${item.id}" should pass`);
+  }
+});
+
+// ─── Individual evidence failures ───────────────────────────────────────────
+
+test('missing reviewer decisions → gate fails with specific blocker', () => {
+  const result = evaluateDepthActivationGate(makePassingOptions({
+    reviewerDecisions: { itemDecisions: [], clusterDecisions: [] },
+  }));
+
+  assert.equal(result.pass, false);
+  assert.equal(result.outcome, 'keep-depth-4');
+  assert.ok(result.blockers.some((b) => b.evidence === 'reviewer-decisions-populated'));
+});
+
+test('blocking decision on candidate item → gate fails', () => {
+  const candidateItemIds = ['d6-item-1', 'd6-item-2'];
+  const result = evaluateDepthActivationGate(makePassingOptions({
+    candidateItemIds,
+    reviewerDecisions: {
+      itemDecisions: [
+        { itemId: 'd6-item-1', decision: DECISION_STATES.APPROVED, reviewer: 'james', reviewedAt: '2026-04-29' },
+        { itemId: 'd6-item-2', decision: DECISION_STATES.NEEDS_REWRITE, reviewer: 'james', reviewedAt: '2026-04-29' },
+      ],
+      clusterDecisions: [
+        { clusterId: 'cluster-A', decision: DECISION_STATES.ACCEPTABLE_CROSS_MODE_OVERLAP, reviewer: 'james', reviewedAt: '2026-04-29', rationale: 'OK' },
+      ],
+    },
+  }));
+
+  assert.equal(result.pass, false);
+  assert.equal(result.outcome, 'keep-depth-4');
+  const blocker = result.blockers.find((b) => b.evidence === 'no-blocking-decisions');
+  assert.ok(blocker, 'must report no-blocking-decisions blocker');
+  assert.ok(blocker.details.some((d) => d.itemId === 'd6-item-2'));
+});
+
+test('unresolved cluster → gate fails', () => {
+  const result = evaluateDepthActivationGate(makePassingOptions({
+    crossModeClusters: [{ clusterId: 'cluster-A' }, { clusterId: 'cluster-B' }],
+    reviewerDecisions: {
+      itemDecisions: [
+        { itemId: 'd6-item-1', decision: DECISION_STATES.APPROVED, reviewer: 'james', reviewedAt: '2026-04-29' },
+        { itemId: 'd6-item-2', decision: DECISION_STATES.APPROVED, reviewer: 'james', reviewedAt: '2026-04-29' },
+        { itemId: 'd6-item-3', decision: DECISION_STATES.APPROVED, reviewer: 'james', reviewedAt: '2026-04-29' },
+      ],
+      clusterDecisions: [
+        { clusterId: 'cluster-A', decision: DECISION_STATES.ACCEPTABLE_CROSS_MODE_OVERLAP, reviewer: 'james', reviewedAt: '2026-04-29', rationale: 'OK' },
+        // cluster-B has no decision
+      ],
+    },
+  }));
+
+  assert.equal(result.pass, false);
+  assert.equal(result.outcome, 'keep-depth-4');
+  const blocker = result.blockers.find((b) => b.evidence === 'no-unresolved-clusters');
+  assert.ok(blocker, 'must report no-unresolved-clusters blocker');
+  assert.ok(blocker.details.some((d) => d.clusterId === 'cluster-B'));
+});
+
+test('speech oracle not passing → gate fails', () => {
+  const result = evaluateDepthActivationGate(makePassingOptions({
+    speechOraclePass: false,
+  }));
+
+  assert.equal(result.pass, false);
+  assert.equal(result.outcome, 'keep-depth-4');
+  assert.ok(result.blockers.some((b) => b.evidence === 'speech-oracle-pass'));
+});
+
+test('semantic lint failing → gate fails', () => {
+  const result = evaluateDepthActivationGate(makePassingOptions({
+    semanticLintPass: false,
+  }));
+
+  assert.equal(result.pass, false);
+  assert.equal(result.outcome, 'keep-depth-4');
+  assert.ok(result.blockers.some((b) => b.evidence === 'semantic-lint-pass'));
+});
+
+test('production gate failing → gate fails', () => {
+  const result = evaluateDepthActivationGate(makePassingOptions({
+    productionGatePass: false,
+  }));
+
+  assert.equal(result.pass, false);
+  assert.equal(result.outcome, 'keep-depth-4');
+  assert.ok(result.blockers.some((b) => b.evidence === 'production-gate-pass'));
+});
+
+test('runtime count mismatch → gate fails', () => {
+  const result = evaluateDepthActivationGate(makePassingOptions({
+    expectedRuntimeCount: 999,
+  }));
+
+  assert.equal(result.pass, false);
+  assert.equal(result.outcome, 'keep-depth-4');
+  const blocker = result.blockers.find((b) => b.evidence === 'runtime-count-valid');
+  assert.ok(blocker, 'must report runtime-count-valid blocker');
+  assert.ok(blocker.reason.includes('999'));
+});
+
+// ─── Multiple blockers simultaneously ───────────────────────────────────────
+
+test('multiple blockers reported simultaneously', () => {
+  const result = evaluateDepthActivationGate(makePassingOptions({
+    speechOraclePass: false,
+    semanticLintPass: false,
+    productionGatePass: false,
+  }));
+
+  assert.equal(result.pass, false);
+  assert.equal(result.outcome, 'keep-depth-4');
+  assert.ok(result.blockers.length >= 3, `expected at least 3 blockers, got ${result.blockers.length}`);
+  assert.ok(result.blockers.some((b) => b.evidence === 'speech-oracle-pass'));
+  assert.ok(result.blockers.some((b) => b.evidence === 'semantic-lint-pass'));
+  assert.ok(result.blockers.some((b) => b.evidence === 'production-gate-pass'));
+});
+
+// ─── Purity and determinism ─────────────────────────────────────────────────
+
+test('gate does not mutate input (pure function)', () => {
+  const options = makePassingOptions();
+  const originalDecisions = JSON.parse(JSON.stringify(options.reviewerDecisions));
+  const originalCandidates = [...options.candidateItemIds];
+  const originalClusters = JSON.parse(JSON.stringify(options.crossModeClusters));
+
+  evaluateDepthActivationGate(options);
+
+  assert.deepEqual(options.reviewerDecisions, originalDecisions, 'reviewerDecisions mutated');
+  assert.deepEqual(options.candidateItemIds, originalCandidates, 'candidateItemIds mutated');
+  assert.deepEqual(options.crossModeClusters, originalClusters, 'crossModeClusters mutated');
+});
+
+test('gate is deterministic — same inputs produce same outputs', () => {
+  const options = makePassingOptions();
+  const result1 = evaluateDepthActivationGate(options);
+  const result2 = evaluateDepthActivationGate(options);
+
+  assert.deepEqual(result1, result2);
+});
+
+// ─── Depth-8 never learner-facing ──────────────────────────────────────────
+
+test('depth-8 is never recommended as learner-facing', () => {
+  const result = evaluateDepthActivationGate(makePassingOptions({
+    targetDepth: 8,
+    expectedRuntimeCount: FIXED_ITEM_COUNT + FAMILY_COUNT * 8,
+  }));
+
+  assert.equal(result.pass, false, 'depth-8 must never pass as learner-facing');
+  assert.equal(result.outcome, 'keep-depth-4');
+  assert.ok(
+    result.blockers.some((b) => b.reason.includes('capacity-only')),
+    'must explain depth-8 is capacity-only',
+  );
+});
+
+test('depth-10 is also rejected (cap at 6 for learner-facing)', () => {
+  const result = evaluateDepthActivationGate(makePassingOptions({
+    targetDepth: 10,
+    expectedRuntimeCount: FIXED_ITEM_COUNT + FAMILY_COUNT * 10,
+  }));
+
+  assert.equal(result.pass, false);
+  assert.equal(result.outcome, 'keep-depth-4');
+});
+
+// ─── Output structure ───────────────────────────────────────────────────────
+
+test('output lists exact blockers by item/cluster/family ID', () => {
+  const candidateItemIds = ['item-X', 'item-Y', 'item-Z'];
+  const result = evaluateDepthActivationGate(makePassingOptions({
+    candidateItemIds,
+    crossModeClusters: [{ clusterId: 'overlap-1' }, { clusterId: 'overlap-2' }],
+    reviewerDecisions: {
+      itemDecisions: [
+        { itemId: 'item-X', decision: DECISION_STATES.APPROVED, reviewer: 'james', reviewedAt: '2026-04-29' },
+        { itemId: 'item-Y', decision: DECISION_STATES.NEEDS_MARKING_FIX, reviewer: 'james', reviewedAt: '2026-04-29' },
+        { itemId: 'item-Z', decision: DECISION_STATES.RETIRE, reviewer: 'james', reviewedAt: '2026-04-29', rationale: 'Confusing' },
+      ],
+      clusterDecisions: [
+        // overlap-1 has decision, overlap-2 does not
+        { clusterId: 'overlap-1', decision: DECISION_STATES.ACCEPTABLE_CROSS_MODE_OVERLAP, reviewer: 'james', reviewedAt: '2026-04-29', rationale: 'OK' },
+      ],
+    },
+  }));
+
+  assert.equal(result.pass, false);
+
+  // Check blocking decisions details include exact item IDs
+  const blockingBlocker = result.blockers.find((b) => b.evidence === 'no-blocking-decisions');
+  assert.ok(blockingBlocker);
+  assert.ok(blockingBlocker.details.some((d) => d.itemId === 'item-Y'));
+  assert.ok(blockingBlocker.details.some((d) => d.itemId === 'item-Z'));
+
+  // Check unresolved clusters details include exact cluster ID
+  const clusterBlocker = result.blockers.find((b) => b.evidence === 'no-unresolved-clusters');
+  assert.ok(clusterBlocker);
+  assert.ok(clusterBlocker.details.some((d) => d.clusterId === 'overlap-2'));
+});
+
+// ─── Evidence constant coverage ─────────────────────────────────────────────
+
+test('DEPTH_ACTIVATION_EVIDENCE contains exactly 9 items', () => {
+  assert.equal(DEPTH_ACTIVATION_EVIDENCE.length, 9);
+});
+
+test('all evidence items are checked in a passing gate result', () => {
+  const result = evaluateDepthActivationGate(makePassingOptions());
+  const evidenceIds = result.evidence.map((e) => e.id);
+
+  for (const expected of DEPTH_ACTIVATION_EVIDENCE) {
+    assert.ok(evidenceIds.includes(expected), `evidence "${expected}" missing from gate output`);
+  }
+});
+
+// ─── Release ID check ───────────────────────────────────────────────────────
+
+test('release ID already at depth-6 value → gate fails (no promotion needed)', () => {
+  const result = evaluateDepthActivationGate(makePassingOptions({
+    currentReleaseId: 'punctuation-r5-qg-depth-6',
+  }));
+
+  assert.equal(result.pass, false);
+  assert.equal(result.outcome, 'keep-depth-4');
+  assert.ok(result.blockers.some((b) => b.evidence === 'release-id-change'));
+});
+
+// ─── Star evidence is structural guarantee ──────────────────────────────────
+
+test('star-evidence-scoped always passes (structural guarantee)', () => {
+  const result = evaluateDepthActivationGate(makePassingOptions());
+  const starEvidence = result.evidence.find((e) => e.id === 'star-evidence-scoped');
+
+  assert.ok(starEvidence);
+  assert.equal(starEvidence.pass, true);
+});
+
+// ─── PRODUCTION_DEPTH import verification ───────────────────────────────────
+
+test('PRODUCTION_DEPTH is imported and used as baseline (currently 4)', () => {
+  assert.equal(PRODUCTION_DEPTH, 4);
+});
+
+// ─── Cross-mode clusters accept string or object format ─────────────────────
+
+test('crossModeClusters accepts string array format', () => {
+  const result = evaluateDepthActivationGate(makePassingOptions({
+    crossModeClusters: ['cluster-A'],
+    reviewerDecisions: {
+      itemDecisions: [
+        { itemId: 'd6-item-1', decision: DECISION_STATES.APPROVED, reviewer: 'james', reviewedAt: '2026-04-29' },
+        { itemId: 'd6-item-2', decision: DECISION_STATES.APPROVED, reviewer: 'james', reviewedAt: '2026-04-29' },
+        { itemId: 'd6-item-3', decision: DECISION_STATES.APPROVED, reviewer: 'james', reviewedAt: '2026-04-29' },
+      ],
+      clusterDecisions: [
+        { clusterId: 'cluster-A', decision: DECISION_STATES.ACCEPTABLE_CROSS_MODE_OVERLAP, reviewer: 'james', reviewedAt: '2026-04-29', rationale: 'OK' },
+      ],
+    },
+  }));
+
+  assert.equal(result.pass, true);
+  assert.equal(result.outcome, 'raise-all-to-6');
+});


### PR DESCRIPTION
## Summary
- Adds `shared/punctuation/depth-activation-gate.js` — purely evaluative gate that checks 9 evidence items before depth can be raised from 4 to 6
- Gate returns structured `{ pass, outcome, blockers[], evidence[] }` — deterministic, no state mutation
- Depth-8 is hard-capped as capacity-only (never learner-facing)
- 20 tests covering: full pass, individual evidence failures, multiple simultaneous blockers, purity, determinism, depth-8 rejection, output structure

## Test plan
- [x] `node --test tests/punctuation-depth-activation-gate.test.js` — 20/20 pass
- [x] `node --test tests/punctuation-reviewer-decision-gate.test.js` — 33/33 pass (no conflict)