### PR TITLE
feat(grammar-qg): P10 U0 — evidence truth reset

### DIFF
--- a/docs/plans/james/grammar/grammar-content-expansion-audit.md
+++ b/docs/plans/james/grammar/grammar-content-expansion-audit.md
@@ -5,7 +5,7 @@ status: p5-updated
 date: 2026-04-28
 plan: docs/plans/2026-04-26-001-feat-grammar-phase4-learning-hardening-plan.md
 unit: U12
-contentReleaseId: grammar-qg-p9-2026-04-29
+contentReleaseId: grammar-qg-p10-2026-04-29
 contentReleaseBump: yes
 ---
 

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "verify:grammar-qg-p7": "npm run verify:grammar-qg-p6 && node --test tests/grammar-qg-p7-governance.test.js tests/grammar-qg-p7-elapsed-timing.test.js tests/grammar-qg-p7-event-expansion.test.js tests/grammar-qg-p7-health-report.test.js tests/grammar-qg-p7-action-candidates.test.js tests/grammar-qg-p7-production-evidence.test.js tests/grammar-qg-p7-analytics-view.test.js",
     "verify:grammar-qg-p8": "npm run verify:grammar-qg-p7 && node --test tests/grammar-qg-p8-question-quality.test.js tests/grammar-qg-p8-governance.test.js tests/grammar-qg-p8-oracles.test.js tests/grammar-qg-p8-review-register.test.js tests/grammar-qg-p8-ux-support.test.js",
     "verify:grammar-qg-p9": "npm run verify:grammar-qg-p8 && node --test tests/grammar-qg-p9-report-evidence-lock.test.js tests/grammar-qg-p9-inventory-manifest.test.js tests/grammar-qg-p9-review-evidence.test.js tests/grammar-qg-p9-learner-surface.test.js tests/grammar-qg-p9-table-choice-contract.test.js tests/grammar-qg-p9-event-expansion-real-tags.test.js tests/grammar-qg-p9-oracle-windows.test.js tests/grammar-qg-p9-blocklist-scheduler.test.js",
+    "verify:grammar-qg-p10": "npm run verify:grammar-qg-p9 && node --test tests/grammar-qg-p10-evidence-truth.test.js",
     "grammar:qg:calibrate": "node scripts/grammar-qg-calibrate.mjs",
     "verify:punctuation-qg": "node scripts/verify-punctuation-qg.mjs",
     "verify:punctuation-qg:p5": "node scripts/verify-punctuation-qg-p5.mjs",

--- a/reports/grammar/grammar-qg-p10-certification-manifest.json
+++ b/reports/grammar/grammar-qg-p10-certification-manifest.json
@@ -1,0 +1,25 @@
+{
+  "contentReleaseId": "grammar-qg-p10-2026-04-29",
+  "templateDenominator": 78,
+  "seedWindow": {
+    "certification": "1..30"
+  },
+  "seedWindowPerEvidenceType": {
+    "selected-response-oracle": "1..15",
+    "constructed-response-oracle": "1..10",
+    "manual-review-oracle": "1..5",
+    "redaction-oracle": "1..30",
+    "content-quality-audit": "1..30"
+  },
+  "expectedItemCount": 2340,
+  "expectedOutputPaths": [
+    "reports/grammar/grammar-qg-p10-question-inventory.json",
+    "reports/grammar/grammar-qg-p10-question-inventory-redacted.md"
+  ],
+  "generatorScript": "scripts/generate-grammar-qg-quality-inventory.mjs",
+  "generatorScriptHash": "82b0bf220b9bd6b6d0190dbd5bb64bc98777f191b0ea4e2adaa471ec140535c8",
+  "generationCommand": "node scripts/generate-grammar-qg-quality-inventory.mjs --seeds=1..30 --release=p10",
+  "generatedAt": "2026-04-29T22:26:53.702Z",
+  "answerInternalsIncluded": true,
+  "answerInternalsRedacted": true
+}

--- a/scripts/generate-grammar-qg-certification-manifest.mjs
+++ b/scripts/generate-grammar-qg-certification-manifest.mjs
@@ -26,6 +26,10 @@ async function main() {
   const seedCount = 30;
   const expectedItemCount = templateDenominator * seedCount;
 
+  // Derive phase label from the content release ID (e.g. "grammar-qg-p10-2026-04-29" → "p10")
+  const phaseMatch = GRAMMAR_CONTENT_RELEASE_ID.match(/grammar-qg-(p\d+)-/);
+  const phase = phaseMatch ? phaseMatch[1] : 'p10';
+
   const manifest = {
     contentReleaseId: GRAMMAR_CONTENT_RELEASE_ID,
     templateDenominator,
@@ -39,22 +43,22 @@ async function main() {
     },
     expectedItemCount,
     expectedOutputPaths: [
-      'reports/grammar/grammar-qg-p9-question-inventory.json',
-      'reports/grammar/grammar-qg-p9-question-inventory-redacted.md',
+      `reports/grammar/grammar-qg-${phase}-question-inventory.json`,
+      `reports/grammar/grammar-qg-${phase}-question-inventory-redacted.md`,
     ],
     generatorScript: 'scripts/generate-grammar-qg-quality-inventory.mjs',
     generatorScriptHash,
-    generationCommand: 'node scripts/generate-grammar-qg-quality-inventory.mjs --seeds=1..30 --release=p9',
+    generationCommand: `node scripts/generate-grammar-qg-quality-inventory.mjs --seeds=1..30 --release=${phase}`,
     generatedAt: new Date().toISOString(),
     answerInternalsIncluded: true,
     answerInternalsRedacted: true,
   };
 
   await fs.mkdir(REPORTS_DIR, { recursive: true });
-  const manifestPath = path.join(REPORTS_DIR, 'grammar-qg-p9-certification-manifest.json');
+  const manifestPath = path.join(REPORTS_DIR, `grammar-qg-${phase}-certification-manifest.json`);
   await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2) + '\n', 'utf8');
 
-  console.log('Grammar QG P9 Certification Manifest generated:');
+  console.log(`Grammar QG ${phase.toUpperCase()} Certification Manifest generated:`);
   console.log(`  Content Release: ${manifest.contentReleaseId}`);
   console.log(`  Template Denominator: ${manifest.templateDenominator}`);
   console.log(`  Expected Item Count: ${manifest.expectedItemCount}`);

--- a/scripts/validate-grammar-qg-certification-evidence.mjs
+++ b/scripts/validate-grammar-qg-certification-evidence.mjs
@@ -19,6 +19,8 @@ import { existsSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { GRAMMAR_CONTENT_RELEASE_ID } from '../worker/src/subjects/grammar/content.js';
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const ROOT_DIR = path.resolve(__dirname, '..');
@@ -442,6 +444,43 @@ export function validateSmokeEvidence(manifest, reportContent, opts = {}) {
         message: `Report claims smoke passed but evidence file does not exist: ${path.relative(rootDir, evidencePath)}`,
       });
     }
+  }
+
+  return { pass: mismatches.length === 0, mismatches };
+}
+
+// ---------------------------------------------------------------------------
+// Cross-check: manifest ↔ code ↔ report release ID consistency (P10-U0)
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate that the manifest contentReleaseId matches the code-exported
+ * GRAMMAR_CONTENT_RELEASE_ID, and optionally that a report's release ID
+ * also matches.
+ *
+ * @param {object} manifest - Parsed certification manifest JSON.
+ * @param {string} [reportReleaseId] - Release ID extracted from a completion report (optional).
+ * @returns {{ pass: boolean, mismatches: Array<{ field: string, claimed: any, actual: any, message: string }> }}
+ */
+export function validateReleaseIdConsistency(manifest, reportReleaseId) {
+  const mismatches = [];
+
+  if (manifest.contentReleaseId !== GRAMMAR_CONTENT_RELEASE_ID) {
+    mismatches.push({
+      field: 'manifestVsCodeReleaseId',
+      claimed: manifest.contentReleaseId,
+      actual: GRAMMAR_CONTENT_RELEASE_ID,
+      message: `Manifest contentReleaseId "${manifest.contentReleaseId}" does not match code GRAMMAR_CONTENT_RELEASE_ID "${GRAMMAR_CONTENT_RELEASE_ID}"`,
+    });
+  }
+
+  if (reportReleaseId != null && reportReleaseId !== manifest.contentReleaseId) {
+    mismatches.push({
+      field: 'reportVsManifestReleaseId',
+      claimed: reportReleaseId,
+      actual: manifest.contentReleaseId,
+      message: `Report release ID "${reportReleaseId}" does not match manifest contentReleaseId "${manifest.contentReleaseId}"`,
+    });
   }
 
   return { pass: mismatches.length === 0, mismatches };

--- a/scripts/validate-grammar-qg-completion-report.mjs
+++ b/scripts/validate-grammar-qg-completion-report.mjs
@@ -102,6 +102,15 @@ function extractFrontmatter(reportContent) {
   let currentList = null;
 
   for (const line of lines) {
+    // Inline empty array: `key: []`
+    const inlineEmptyArrayMatch = line.match(/^(\w[\w_]*):\s+\[\]\s*$/);
+    if (inlineEmptyArrayMatch) {
+      if (currentKey && currentList) fm[currentKey] = currentList;
+      currentKey = inlineEmptyArrayMatch[1];
+      currentList = null;
+      fm[currentKey] = [];
+      continue;
+    }
     const scalarMatch = line.match(/^(\w[\w_]*):\s+(.+)$/);
     if (scalarMatch) {
       if (currentKey && currentList) fm[currentKey] = currentList;

--- a/tests/admin-production-evidence.test.js
+++ b/tests/admin-production-evidence.test.js
@@ -310,7 +310,7 @@ test('buildEvidencePanelModel surfaces threshold violations from P5 30-learner f
         certifying: false,
         dryRun: false,
         learners: 30,
-        finishedAt: '2026-04-28T21:33:08.171Z',
+        finishedAt: freshDate,
         commit: '1c56e06',
         failures: ['maxBootstrapP95Ms'],
         thresholdViolations: [

--- a/tests/fixtures/grammar-legacy-oracle/grammar-qg-p6-baseline.json
+++ b/tests/fixtures/grammar-legacy-oracle/grammar-qg-p6-baseline.json
@@ -1,5 +1,5 @@
 {
-  "releaseId": "grammar-qg-p9-2026-04-29",
+  "releaseId": "grammar-qg-p10-2026-04-29",
   "conceptCount": 18,
   "templateCount": 78,
   "selectedResponseCount": 58,

--- a/tests/grammar-qg-p10-evidence-truth.test.js
+++ b/tests/grammar-qg-p10-evidence-truth.test.js
@@ -1,0 +1,298 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { GRAMMAR_CONTENT_RELEASE_ID } from '../worker/src/subjects/grammar/content.js';
+import {
+  validateReleaseIdConsistency,
+  validateEvidenceManifest,
+} from '../scripts/validate-grammar-qg-certification-evidence.mjs';
+import {
+  validateReleaseFrontmatter,
+} from '../scripts/validate-grammar-qg-completion-report.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT_DIR = path.resolve(__dirname, '..');
+const REPORTS_DIR = path.resolve(ROOT_DIR, 'reports', 'grammar');
+
+// ---------------------------------------------------------------------------
+// 1. P10 manifest has correct release ID matching code
+// ---------------------------------------------------------------------------
+
+describe('P10 Evidence Truth: manifest-to-code consistency', () => {
+  const p10ManifestPath = path.join(REPORTS_DIR, 'grammar-qg-p10-certification-manifest.json');
+
+  it('P10 manifest file exists', () => {
+    assert.ok(fs.existsSync(p10ManifestPath), 'P10 manifest must exist');
+  });
+
+  it('P10 manifest contentReleaseId matches GRAMMAR_CONTENT_RELEASE_ID', () => {
+    const manifest = JSON.parse(fs.readFileSync(p10ManifestPath, 'utf8'));
+    assert.equal(manifest.contentReleaseId, GRAMMAR_CONTENT_RELEASE_ID);
+    assert.equal(manifest.contentReleaseId, 'grammar-qg-p10-2026-04-29');
+  });
+
+  it('validateReleaseIdConsistency passes for P10 manifest', () => {
+    const manifest = JSON.parse(fs.readFileSync(p10ManifestPath, 'utf8'));
+    const result = validateReleaseIdConsistency(manifest);
+    assert.equal(result.pass, true, `Expected pass but got: ${JSON.stringify(result.mismatches)}`);
+  });
+
+  it('P10 manifest passes schema validation', () => {
+    const result = validateEvidenceManifest(p10ManifestPath);
+    assert.equal(result.valid, true, `Schema errors: ${JSON.stringify(result.errors)}`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Stale P8 release ID in a manifest fails validation
+// ---------------------------------------------------------------------------
+
+describe('P10 Evidence Truth: stale release ID detection', () => {
+  it('manifest with P8 release ID fails cross-check against code', () => {
+    const staleManifest = {
+      contentReleaseId: 'grammar-qg-p8-2026-04-29',
+      templateDenominator: 78,
+      seedWindow: { certification: '1..30' },
+      seedWindowPerEvidenceType: {
+        'selected-response-oracle': '1..15',
+        'constructed-response-oracle': '1..10',
+        'manual-review-oracle': '1..5',
+        'redaction-oracle': '1..30',
+        'content-quality-audit': '1..30',
+      },
+      expectedItemCount: 2340,
+    };
+    const result = validateReleaseIdConsistency(staleManifest);
+    assert.equal(result.pass, false);
+    assert.equal(result.mismatches.length, 1);
+    assert.match(result.mismatches[0].message, /grammar-qg-p8/);
+  });
+
+  it('manifest with P9 release ID also fails (stale after P10 bump)', () => {
+    const staleManifest = { contentReleaseId: 'grammar-qg-p9-2026-04-29' };
+    const result = validateReleaseIdConsistency(staleManifest);
+    assert.equal(result.pass, false);
+    assert.match(result.mismatches[0].message, /grammar-qg-p9/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. pending-this-commit in frontmatter fails validation
+// ---------------------------------------------------------------------------
+
+describe('P10 Evidence Truth: placeholder rejection', () => {
+  function buildReport(fields = {}) {
+    const defaults = {
+      implementation_prs: ['#650'],
+      final_content_release_commit: 'a1b2c3d4e5f6g7h8',
+      post_merge_fix_commits: [],
+      final_report_commit: 'b2c3d4e5f6a7b8c9',
+    };
+    const merged = { ...defaults, ...fields };
+    const lines = ['---'];
+    for (const [key, value] of Object.entries(merged)) {
+      if (Array.isArray(value)) {
+        if (value.length === 0) {
+          lines.push(`${key}: []`);
+        } else {
+          lines.push(`${key}:`);
+          for (const item of value) lines.push(`  - ${item}`);
+        }
+      } else {
+        lines.push(`${key}: ${value}`);
+      }
+    }
+    lines.push('---');
+    lines.push('');
+    lines.push('# Completion Report');
+    return lines.join('\n');
+  }
+
+  it('rejects "pending-this-commit" in final_report_commit', () => {
+    const report = buildReport({ final_report_commit: 'pending-this-commit' });
+    const result = validateReleaseFrontmatter(report);
+    assert.equal(result.valid, false);
+    const err = result.errors.find((e) => e.field === 'final_report_commit');
+    assert.ok(err, 'Expected error for final_report_commit');
+    assert.match(err.message, /placeholder/i);
+  });
+
+  it('rejects "pending-report-commit" as compound placeholder', () => {
+    const report = buildReport({ final_report_commit: 'pending-report-commit' });
+    const result = validateReleaseFrontmatter(report);
+    assert.equal(result.valid, false);
+    const err = result.errors.find((e) => e.field === 'final_report_commit');
+    assert.ok(err);
+  });
+
+  it('rejects "todo-sha" as compound placeholder', () => {
+    const report = buildReport({ final_content_release_commit: 'todo-sha-value' });
+    const result = validateReleaseFrontmatter(report);
+    assert.equal(result.valid, false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Inline [] YAML parses correctly as empty array
+// ---------------------------------------------------------------------------
+
+describe('P10 Evidence Truth: inline YAML empty array', () => {
+  it('post_merge_fix_commits: [] parses as empty array and passes validation', () => {
+    const report = [
+      '---',
+      'implementation_prs:',
+      '  - "#650"',
+      'final_content_release_commit: a1b2c3d4e5f6g7h8',
+      'post_merge_fix_commits: []',
+      'final_report_commit: b2c3d4e5f6a7b8c9',
+      '---',
+      '',
+      '# Report',
+    ].join('\n');
+    const result = validateReleaseFrontmatter(report);
+    assert.equal(result.valid, true, `Expected valid but got: ${JSON.stringify(result.errors)}`);
+  });
+
+  it('post_merge_fix_commits: [] does not produce "Must be a list" error', () => {
+    const report = [
+      '---',
+      'implementation_prs:',
+      '  - "#650"',
+      'final_content_release_commit: a1b2c3d4e5f6g7h8',
+      'post_merge_fix_commits: []',
+      'final_report_commit: b2c3d4e5f6a7b8c9',
+      '---',
+      '',
+      '# Report',
+    ].join('\n');
+    const result = validateReleaseFrontmatter(report);
+    const listErr = result.errors.find((e) => e.field === 'post_merge_fix_commits');
+    assert.equal(listErr, undefined, 'Should not error on inline []');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Compound placeholders rejected
+// ---------------------------------------------------------------------------
+
+describe('P10 Evidence Truth: compound placeholder variants', () => {
+  function buildReport(overrides) {
+    const defaults = {
+      implementation_prs: ['#650'],
+      final_content_release_commit: 'a1b2c3d4e5f6g7h8',
+      post_merge_fix_commits: [],
+      final_report_commit: 'b2c3d4e5f6a7b8c9',
+    };
+    const merged = { ...defaults, ...overrides };
+    const lines = ['---'];
+    for (const [key, value] of Object.entries(merged)) {
+      if (Array.isArray(value)) {
+        if (value.length === 0) {
+          lines.push(`${key}: []`);
+        } else {
+          lines.push(`${key}:`);
+          for (const item of value) lines.push(`  - ${item}`);
+        }
+      } else {
+        lines.push(`${key}: ${value}`);
+      }
+    }
+    lines.push('---');
+    lines.push('');
+    lines.push('# Report');
+    return lines.join('\n');
+  }
+
+  const compoundPlaceholders = [
+    'pending-report-commit',
+    'tbd-release-sha',
+    'unknown-final-commit',
+    'tbc-after-merge',
+    'commit-pending',
+    'sha-unknown',
+  ];
+
+  for (const token of compoundPlaceholders) {
+    it(`rejects compound placeholder "${token}" in final_report_commit`, () => {
+      const report = buildReport({ final_report_commit: token });
+      const result = validateReleaseFrontmatter(report);
+      assert.equal(result.valid, false, `Should reject "${token}"`);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 6. Valid hex SHAs containing "pending" substring pass
+// ---------------------------------------------------------------------------
+
+describe('P10 Evidence Truth: hex SHAs with placeholder substrings pass', () => {
+  function buildReport(overrides) {
+    const defaults = {
+      implementation_prs: ['#650'],
+      final_content_release_commit: 'a1b2c3d4e5f6g7h8',
+      post_merge_fix_commits: [],
+      final_report_commit: 'b2c3d4e5f6a7b8c9',
+    };
+    const merged = { ...defaults, ...overrides };
+    const lines = ['---'];
+    for (const [key, value] of Object.entries(merged)) {
+      if (Array.isArray(value)) {
+        if (value.length === 0) {
+          lines.push(`${key}: []`);
+        } else {
+          lines.push(`${key}:`);
+          for (const item of value) lines.push(`  - ${item}`);
+        }
+      } else {
+        lines.push(`${key}: ${value}`);
+      }
+    }
+    lines.push('---');
+    lines.push('');
+    lines.push('# Report');
+    return lines.join('\n');
+  }
+
+  it('"7pendinga3f" passes — digits mixed in means it is not a pure-alpha compound', () => {
+    const report = buildReport({ final_report_commit: '7pendinga3f' });
+    const result = validateReleaseFrontmatter(report);
+    const err = result.errors.find((e) => e.field === 'final_report_commit' && /placeholder/i.test(e.message));
+    assert.equal(err, undefined, '"7pendinga3f" must not be flagged as a placeholder');
+  });
+
+  it('"a0pending1b2c3d4" passes — hex-like value containing "pending" substring', () => {
+    const report = buildReport({ final_content_release_commit: 'a0pending1b2c3d4' });
+    const result = validateReleaseFrontmatter(report);
+    const err = result.errors.find((e) => e.field === 'final_content_release_commit' && /placeholder/i.test(e.message));
+    assert.equal(err, undefined, 'Hex-like value must not be flagged as a placeholder');
+  });
+
+  it('"deadbeef01234567" passes — pure hex SHA', () => {
+    const report = buildReport({ final_report_commit: 'deadbeef01234567' });
+    const result = validateReleaseFrontmatter(report);
+    assert.equal(result.valid, true, `Expected valid but got: ${JSON.stringify(result.errors)}`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. Report release ID vs manifest cross-check
+// ---------------------------------------------------------------------------
+
+describe('P10 Evidence Truth: report-vs-manifest release ID', () => {
+  it('mismatched report release ID fails', () => {
+    const manifest = { contentReleaseId: 'grammar-qg-p10-2026-04-29' };
+    const result = validateReleaseIdConsistency(manifest, 'grammar-qg-p9-2026-04-29');
+    assert.equal(result.pass, false);
+    assert.equal(result.mismatches.length, 1);
+    assert.match(result.mismatches[0].field, /reportVsManifest/);
+  });
+
+  it('matching report release ID passes', () => {
+    const manifest = { contentReleaseId: GRAMMAR_CONTENT_RELEASE_ID };
+    const result = validateReleaseIdConsistency(manifest, GRAMMAR_CONTENT_RELEASE_ID);
+    assert.equal(result.pass, true);
+  });
+});

--- a/tests/grammar-qg-p7-production-evidence.test.js
+++ b/tests/grammar-qg-p7-production-evidence.test.js
@@ -272,16 +272,15 @@ describe('Grammar QG P7 — Smoke artefact schema enforcement', () => {
     assert.ok(missing.includes('timestamp'));
   });
 
-  it('P9 bumps the content release ID for prompt cue contract', async () => {
-    // P9 adds structured prompt cues and bumps the release ID
+  it('content release ID follows expected grammar-qg-pN pattern', async () => {
     const { GRAMMAR_CONTENT_RELEASE_ID } = await import('../worker/src/subjects/grammar/content.js');
-    assert.equal(GRAMMAR_CONTENT_RELEASE_ID, 'grammar-qg-p9-2026-04-29',
-      'P9 must use new content release ID since it adds learner-visible serialisation fields');
+    assert.match(GRAMMAR_CONTENT_RELEASE_ID, /^grammar-qg-p\d+-\d{4}-\d{2}-\d{2}$/,
+      'Release ID must follow grammar-qg-pN-YYYY-MM-DD pattern');
   });
 
-  it('smoke evidence file path uses current content release ID', () => {
-    const contentReleaseId = 'grammar-qg-p9-2026-04-29';
-    const expectedFileName = `grammar-production-smoke-${contentReleaseId}.json`;
-    assert.equal(expectedFileName, 'grammar-production-smoke-grammar-qg-p9-2026-04-29.json');
+  it('smoke evidence file path uses current content release ID', async () => {
+    const { GRAMMAR_CONTENT_RELEASE_ID } = await import('../worker/src/subjects/grammar/content.js');
+    const expectedFileName = `grammar-production-smoke-${GRAMMAR_CONTENT_RELEASE_ID}.json`;
+    assert.match(expectedFileName, /^grammar-production-smoke-grammar-qg-p\d+-\d{4}-\d{2}-\d{2}\.json$/);
   });
 });

--- a/tests/grammar-qg-p9-learner-surface.test.js
+++ b/tests/grammar-qg-p9-learner-surface.test.js
@@ -101,11 +101,11 @@ describe('P9 prompt cue: serialisation includes structured fields', () => {
     assert.ok(s.promptText.length > 0, 'promptText must be non-empty');
   });
 
-  it('contentReleaseId reflects P9', () => {
+  it('contentReleaseId matches current code export', () => {
     const s = serialiseQuestion('word_class_underlined_choice', 1);
     assert.ok(s, 'serialised question must exist');
-    assert.strictEqual(s.contentReleaseId, 'grammar-qg-p9-2026-04-29');
-    assert.strictEqual(GRAMMAR_CONTENT_RELEASE_ID, 'grammar-qg-p9-2026-04-29');
+    assert.strictEqual(s.contentReleaseId, GRAMMAR_CONTENT_RELEASE_ID);
+    assert.match(GRAMMAR_CONTENT_RELEASE_ID, /^grammar-qg-p\d+-\d{4}-\d{2}-\d{2}$/);
   });
 });
 

--- a/worker/src/subjects/grammar/content.js
+++ b/worker/src/subjects/grammar/content.js
@@ -8097,7 +8097,7 @@ export function grammarQuestionVariantSignature(question) {
   return `grammar-v1:${stableStringHash(JSON.stringify(payload))}`;
 }
 
-export const GRAMMAR_CONTENT_RELEASE_ID = 'grammar-qg-p9-2026-04-29';
+export const GRAMMAR_CONTENT_RELEASE_ID = 'grammar-qg-p10-2026-04-29';
 export const GRAMMAR_MISCONCEPTIONS = Object.freeze(MISCONCEPTIONS);
 export const GRAMMAR_MINIMAL_HINTS = Object.freeze(MINIMAL_HINTS);
 export const GRAMMAR_QUESTION_TYPES = Object.freeze(QUESTION_TYPES);


### PR DESCRIPTION
## Summary
- Bump `GRAMMAR_CONTENT_RELEASE_ID` from `grammar-qg-p9-2026-04-29` to `grammar-qg-p10-2026-04-29`
- Generate P10 certification manifest (`reports/grammar/grammar-qg-p10-certification-manifest.json`) with correct release ID; P9 manifest preserved unchanged
- Add `validateReleaseIdConsistency()` to the evidence validator — cross-checks manifest `contentReleaseId` against code export and optional report release ID
- Harden completion report frontmatter parser to correctly handle inline `[]` YAML as empty array
- 22 new tests covering all six scenarios: manifest-code match, stale ID rejection, placeholder rejection, inline YAML parsing, compound placeholder variants, hex SHA false-positive avoidance, and report-vs-manifest cross-check

## Plan Deviations
- None

## Test plan
- [x] `node --test tests/grammar-qg-p10-evidence-truth.test.js` — 22/22 pass
- [x] Full P7-P10 test suite (3,803 tests) — zero failures
- [x] `grammar-engine.test.js` — 48/48 pass
- [x] `grammar-functionality-completeness.test.js` — 24/24 pass
- [x] P9 tests updated to use pattern-based assertions instead of hardcoded P9 release string