### PR TITLE
feat(grammar-qg): P10 U2 — explicit prompt target contract

### DIFF
--- a/scripts/audit-grammar-prompt-cues.mjs
+++ b/scripts/audit-grammar-prompt-cues.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+/**
+ * Grammar QG P10 U2 — Prompt Cue Audit
+ *
+ * For seeds 1..N, generate all templates and check:
+ * 1. No whole-sentence underline when prompt asks for word/phrase
+ * 2. No duplicate content in promptParts
+ * 3. If prompt contains cue language, focusCue must exist (or explicit fallback)
+ *
+ * Usage:
+ *   node scripts/audit-grammar-prompt-cues.mjs --seeds=1..30 --json
+ *   node scripts/audit-grammar-prompt-cues.mjs --seeds=1..5
+ */
+import {
+  createGrammarQuestion,
+  GRAMMAR_TEMPLATE_METADATA,
+} from '../worker/src/subjects/grammar/content.js';
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing
+// ---------------------------------------------------------------------------
+
+const args = process.argv.slice(2);
+let seedStart = 1;
+let seedEnd = 30;
+let jsonOutput = false;
+
+for (const arg of args) {
+  if (arg.startsWith('--seeds=')) {
+    const range = arg.slice('--seeds='.length);
+    const parts = range.split('..');
+    seedStart = parseInt(parts[0], 10) || 1;
+    seedEnd = parseInt(parts[1], 10) || seedStart;
+  }
+  if (arg === '--json') jsonOutput = true;
+}
+
+// ---------------------------------------------------------------------------
+// Audit checks
+// ---------------------------------------------------------------------------
+
+const CUE_LANGUAGE_RE = /underlined|in\s+bold|shown\s+in\s+brackets|sentence\s+below/i;
+const UNDERLINE_WORD_RE = /\bunderlined\s+word\b/i;
+const UNDERLINE_PHRASE_RE = /\bunderlined\s+(noun\s+phrase|group|pair)\b/i;
+
+function wordCount(text) {
+  return text.trim().split(/\s+/).length;
+}
+
+function auditQuestion(templateId, seed) {
+  const failures = [];
+  const q = createGrammarQuestion({ templateId, seed });
+  if (!q) return { templateId, seed, pass: true, failures };
+
+  const plainPrompt = (q.stemHtml || '').replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
+
+  // Check 1: No whole-sentence underline when prompt asks for word/phrase
+  if (q.focusCue && q.focusCue.type === 'underline') {
+    const wc = wordCount(q.focusCue.text);
+    if (UNDERLINE_WORD_RE.test(plainPrompt) && wc > 3) {
+      failures.push({
+        check: 'whole-sentence-underline-word',
+        message: `Prompt asks for "underlined word" but focusCue.text has ${wc} words: "${q.focusCue.text}"`
+      });
+    }
+    if (UNDERLINE_PHRASE_RE.test(plainPrompt) && wc > 8) {
+      failures.push({
+        check: 'whole-sentence-underline-phrase',
+        message: `Prompt asks for "underlined phrase/group" but focusCue.text has ${wc} words: "${q.focusCue.text}"`
+      });
+    }
+  }
+
+  // Check 2: No duplicate content in promptParts
+  if (q.promptParts && q.promptParts.length > 1) {
+    const textPart = q.promptParts.find(p => p.kind === 'text');
+    const sentenceParts = q.promptParts.filter(p =>
+      p.kind === 'sentence' || p.kind === 'underline' || p.kind === 'emphasis'
+    );
+    if (textPart && sentenceParts.length > 0) {
+      const fullSentence = sentenceParts.map(p => p.text).join('').trim();
+      if (fullSentence.length >= 10 && textPart.text.includes(fullSentence)) {
+        failures.push({
+          check: 'duplicate-content',
+          message: `Instruction text duplicates the sentence content: "${fullSentence.substring(0, 60)}..."`
+        });
+      }
+    }
+  }
+
+  // Check 3: If prompt contains cue language, focusCue or promptParts must exist
+  if (CUE_LANGUAGE_RE.test(plainPrompt)) {
+    if (!q.focusCue && !q.promptParts) {
+      failures.push({
+        check: 'missing-cue-data',
+        message: `Prompt contains cue language but no focusCue or promptParts`
+      });
+    }
+  }
+
+  return {
+    templateId,
+    seed,
+    pass: failures.length === 0,
+    failures
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+const results = [];
+let totalPass = 0;
+let totalFail = 0;
+const failedTemplates = new Set();
+
+for (const template of GRAMMAR_TEMPLATE_METADATA) {
+  for (let seed = seedStart; seed <= seedEnd; seed++) {
+    const result = auditQuestion(template.id, seed);
+    results.push(result);
+    if (result.pass) {
+      totalPass++;
+    } else {
+      totalFail++;
+      failedTemplates.add(template.id);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Output
+// ---------------------------------------------------------------------------
+
+const summary = {
+  seeds: `${seedStart}..${seedEnd}`,
+  templates: GRAMMAR_TEMPLATE_METADATA.length,
+  totalChecked: results.length,
+  totalPass,
+  totalFail,
+  failedTemplates: [...failedTemplates].sort(),
+  allPass: totalFail === 0
+};
+
+if (jsonOutput) {
+  const failedResults = results.filter(r => !r.pass);
+  console.log(JSON.stringify({ summary, failures: failedResults }, null, 2));
+} else {
+  console.log('Grammar Prompt Cue Audit');
+  console.log('========================');
+  console.log(`Seeds: ${summary.seeds}`);
+  console.log(`Templates: ${summary.templates}`);
+  console.log(`Checks: ${summary.totalChecked}`);
+  console.log(`Pass: ${summary.totalPass}`);
+  console.log(`Fail: ${summary.totalFail}`);
+  if (summary.failedTemplates.length > 0) {
+    console.log(`\nFailed templates:`);
+    for (const t of summary.failedTemplates) {
+      const tFailures = results.filter(r => r.templateId === t && !r.pass);
+      console.log(`  - ${t} (${tFailures.length} failures)`);
+      for (const f of tFailures.slice(0, 3)) {
+        for (const issue of f.failures) {
+          console.log(`      seed ${f.seed}: [${issue.check}] ${issue.message}`);
+        }
+      }
+      if (tFailures.length > 3) {
+        console.log(`      ... and ${tFailures.length - 3} more`);
+      }
+    }
+  }
+  console.log(`\n${summary.allPass ? 'PASS' : 'FAIL'}`);
+}
+
+process.exit(summary.allPass ? 0 : 1);

--- a/tests/grammar-qg-p10-prompt-cue-contract.test.js
+++ b/tests/grammar-qg-p10-prompt-cue-contract.test.js
@@ -1,0 +1,206 @@
+/**
+ * Grammar QG P10 U2 — Explicit Prompt Target Contract
+ *
+ * Validates that:
+ * - focusCue.text correctly targets the intended word/phrase, never the whole sentence
+ * - promptParts does not duplicate sentence content
+ * - Templates mentioning "underlined" produce valid focusCue or explicit fallback
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  createGrammarQuestion,
+  GRAMMAR_TEMPLATE_METADATA,
+} from '../worker/src/subjects/grammar/content.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function generateQuestion(templateId, seed = 1) {
+  return createGrammarQuestion({ templateId, seed });
+}
+
+function wordCount(text) {
+  return text.trim().split(/\s+/).length;
+}
+
+// ---------------------------------------------------------------------------
+// 1. word_class_underlined_choice: focusCue.text is a single word
+// ---------------------------------------------------------------------------
+
+describe('P10 U2: word_class_underlined_choice — focusCue targets single word', () => {
+  for (let seed = 1; seed <= 5; seed++) {
+    it(`seed ${seed}: focusCue.text is a single word`, () => {
+      const q = generateQuestion('word_class_underlined_choice', seed);
+      assert.ok(q, 'question must be generated');
+      assert.ok(q.focusCue, 'focusCue must be present');
+      assert.strictEqual(q.focusCue.type, 'underline');
+      assert.ok(
+        wordCount(q.focusCue.text) <= 2,
+        `focusCue.text must be 1-2 words (a single word), got ${wordCount(q.focusCue.text)} words: "${q.focusCue.text}"`
+      );
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 2. qg_p4_voice_roles_transfer: focusCue.text is a noun phrase (2-4 words)
+// ---------------------------------------------------------------------------
+
+describe('P10 U2: qg_p4_voice_roles_transfer — focusCue targets noun phrase', () => {
+  for (let seed = 1; seed <= 5; seed++) {
+    it(`seed ${seed}: focusCue.text is a noun phrase (2-4 words, not a full sentence)`, () => {
+      const q = generateQuestion('qg_p4_voice_roles_transfer', seed);
+      assert.ok(q, 'question must be generated');
+      assert.ok(q.focusCue, 'focusCue must be present');
+      assert.strictEqual(q.focusCue.type, 'underline');
+      const wc = wordCount(q.focusCue.text);
+      assert.ok(
+        wc >= 2 && wc <= 4,
+        `focusCue.text must be 2-4 words (noun phrase), got ${wc} words: "${q.focusCue.text}"`
+      );
+      // Must NOT be a full sentence (no verb typically, and shorter than the example)
+      assert.ok(
+        !q.focusCue.text.includes('.'),
+        'focusCue.text must not contain a full stop (not a full sentence)'
+      );
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 3. qg_p4_word_class_noun_phrase_transfer seed 3: focusCue targets the word
+// ---------------------------------------------------------------------------
+
+describe('P10 U2: qg_p4_word_class_noun_phrase_transfer seed 3 — focusCue targets word', () => {
+  it('seed 3: focusCue.text is the specific word, not the whole phrase', () => {
+    const q = generateQuestion('qg_p4_word_class_noun_phrase_transfer', 3);
+    assert.ok(q, 'question must be generated');
+    assert.ok(q.focusCue, 'focusCue must be present');
+    assert.strictEqual(q.focusCue.type, 'underline');
+    assert.strictEqual(q.focusCue.text, 'incredibly');
+    assert.strictEqual(wordCount(q.focusCue.text), 1, 'focusCue.text must be exactly 1 word');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. qg_p3_noun_phrases_explain: underline on noun phrase, not whole sentence
+// ---------------------------------------------------------------------------
+
+describe('P10 U2: qg_p3_noun_phrases_explain — underline on noun phrase', () => {
+  // Seeds 3 and 7 have "underlined group" prompts
+  for (const seed of [3, 7]) {
+    it(`seed ${seed}: focusCue.text is the noun phrase, not the whole sentence`, () => {
+      const q = generateQuestion('qg_p3_noun_phrases_explain', seed);
+      assert.ok(q, 'question must be generated');
+      assert.ok(q.focusCue, `focusCue must be present for seed ${seed}`);
+      assert.strictEqual(q.focusCue.type, 'underline');
+      // The noun phrase should be 4-8 words (a phrase), not a full sentence
+      const wc = wordCount(q.focusCue.text);
+      assert.ok(
+        wc >= 3 && wc <= 8,
+        `focusCue.text must be 3-8 words (noun phrase), got ${wc} words: "${q.focusCue.text}"`
+      );
+      // Must not end with a full stop (sentence indicator)
+      assert.ok(
+        !q.focusCue.text.endsWith('.'),
+        'focusCue.text must not end with full stop — it is a phrase, not a sentence'
+      );
+    });
+  }
+
+  it('seed 1: no "underlined" in prompt, so focusCue may be absent', () => {
+    const q = generateQuestion('qg_p3_noun_phrases_explain', 1);
+    assert.ok(q, 'question must be generated');
+    // Seed 1 prompt is "Why is this an expanded noun phrase?" — no "underlined"
+    const plainPrompt = q.stemHtml.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
+    if (!/underlined/i.test(plainPrompt)) {
+      // No underline reference — focusCue absence is acceptable
+      assert.ok(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. No duplicate sentence content in any promptParts array
+// ---------------------------------------------------------------------------
+
+describe('P10 U2: no duplicate sentence content in promptParts', () => {
+  const cueTemplates = GRAMMAR_TEMPLATE_METADATA.filter(t => {
+    const q = createGrammarQuestion({ templateId: t.id, seed: 1 });
+    return q && q.promptParts && q.promptParts.length > 1;
+  });
+
+  for (const template of cueTemplates) {
+    it(`${template.id}: no sentence text duplicated in instruction part`, () => {
+      const q = createGrammarQuestion({ templateId: template.id, seed: 1 });
+      if (!q || !q.promptParts || q.promptParts.length <= 1) return;
+
+      const textPart = q.promptParts.find(p => p.kind === 'text');
+      const sentenceParts = q.promptParts.filter(p =>
+        p.kind === 'sentence' || p.kind === 'underline' || p.kind === 'emphasis'
+      );
+
+      if (!textPart || sentenceParts.length === 0) return;
+
+      // Reconstruct the sentence from structured parts
+      const fullSentence = sentenceParts.map(p => p.text).join('').trim();
+      if (fullSentence.length < 10) return; // Skip trivially short content
+
+      assert.ok(
+        !textPart.text.includes(fullSentence),
+        `The instruction text part must not contain the full sentence "${fullSentence.substring(0, 50)}..."`
+      );
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 6. Cue consistency: if prompt contains "underlined"/"bold"/etc, enrichment present
+// ---------------------------------------------------------------------------
+
+describe('P10 U2: cue consistency enforcement', () => {
+  const allTemplates = GRAMMAR_TEMPLATE_METADATA.filter(t => {
+    const q = createGrammarQuestion({ templateId: t.id, seed: 1 });
+    if (!q) return false;
+    const plain = q.stemHtml.replace(/<[^>]*>/g, '');
+    return /underlined|in\s+bold|shown\s+in\s+brackets|sentence\s+below/i.test(plain);
+  });
+
+  for (const template of allTemplates) {
+    it(`${template.id}: has focusCue or promptParts when cue language detected`, () => {
+      const q = createGrammarQuestion({ templateId: template.id, seed: 1 });
+      assert.ok(q, 'question must be generated');
+      const hasCue = q.focusCue || q.promptParts;
+      assert.ok(hasCue, `Template ${template.id} has cue language but lacks prompt cue data`);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 7. focusCue.text must not be unreasonably long (whole-sentence detection)
+// ---------------------------------------------------------------------------
+
+describe('P10 U2: focusCue.text is not a whole sentence', () => {
+  const underlinedTemplates = GRAMMAR_TEMPLATE_METADATA.filter(t => {
+    const q = createGrammarQuestion({ templateId: t.id, seed: 1 });
+    if (!q || !q.focusCue) return false;
+    return q.focusCue.type === 'underline';
+  });
+
+  for (const template of underlinedTemplates) {
+    for (let seed = 1; seed <= 3; seed++) {
+      it(`${template.id} seed ${seed}: focusCue.text is not a whole sentence (<=8 words)`, () => {
+        const q = createGrammarQuestion({ templateId: template.id, seed });
+        if (!q || !q.focusCue || q.focusCue.type !== 'underline') return;
+        const wc = wordCount(q.focusCue.text);
+        assert.ok(
+          wc <= 8,
+          `focusCue.text should be a word/phrase, not a sentence. Got ${wc} words: "${q.focusCue.text}"`
+        );
+      });
+    }
+  }
+});

--- a/worker/src/subjects/grammar/content.js
+++ b/worker/src/subjects/grammar/content.js
@@ -6676,6 +6676,7 @@ const P4_MIXED_TRANSFER_CASES = Object.freeze({
     {
       prompt: "Identify the head noun and the word class of the underlined word in this noun phrase.",
       example: "those incredibly brave firefighters",
+      focus: "incredibly",
       fields: [
         { label: "Head noun", correct: "firefighters", options: ["those", "incredibly", "brave", "firefighters"] },
         { label: "Word class of 'incredibly'", correct: "adverb", options: ["adjective", "adverb", "noun", "determiner"] }
@@ -7135,6 +7136,7 @@ const P4_MIXED_TRANSFER_CASES = Object.freeze({
     {
       prompt: "Identify the voice and the grammatical role of the underlined noun phrase.",
       example: "The trophy was awarded to Amir by the head teacher.",
+      focus: "The trophy",
       fields: [
         { label: "Voice of the sentence", correct: "passive", options: ["active", "passive"] },
         { label: "Role of 'the trophy'", correct: "subject", options: ["subject", "object"] }
@@ -7145,6 +7147,7 @@ const P4_MIXED_TRANSFER_CASES = Object.freeze({
     {
       prompt: "Identify the voice and the grammatical role of the underlined noun phrase.",
       example: "The goalkeeper saved the penalty brilliantly.",
+      focus: "the penalty",
       fields: [
         { label: "Voice of the sentence", correct: "active", options: ["active", "passive"] },
         { label: "Role of 'the penalty'", correct: "object", options: ["subject", "object"] }
@@ -7155,6 +7158,7 @@ const P4_MIXED_TRANSFER_CASES = Object.freeze({
     {
       prompt: "Identify the voice and the grammatical role of the underlined noun phrase.",
       example: "The cake was eaten by the children before lunch.",
+      focus: "The cake",
       fields: [
         { label: "Voice of the sentence", correct: "passive", options: ["active", "passive"] },
         { label: "Role of 'the cake'", correct: "subject", options: ["subject", "object"] }
@@ -7165,6 +7169,7 @@ const P4_MIXED_TRANSFER_CASES = Object.freeze({
     {
       prompt: "Identify the voice and the grammatical role of the underlined noun phrase.",
       example: "Lena painted the scenery for the school play.",
+      focus: "the scenery",
       fields: [
         { label: "Voice of the sentence", correct: "active", options: ["active", "passive"] },
         { label: "Role of 'the scenery'", correct: "object", options: ["subject", "object"] }
@@ -7175,6 +7180,7 @@ const P4_MIXED_TRANSFER_CASES = Object.freeze({
     {
       prompt: "Identify the voice and the grammatical role of the underlined noun phrase.",
       example: "The windows were smashed by the hailstones during the storm.",
+      focus: "The windows",
       fields: [
         { label: "Voice of the sentence", correct: "passive", options: ["active", "passive"] },
         { label: "Role of 'the windows'", correct: "subject", options: ["subject", "object"] }
@@ -7185,6 +7191,7 @@ const P4_MIXED_TRANSFER_CASES = Object.freeze({
     {
       prompt: "Identify the voice and the grammatical role of the underlined noun phrase.",
       example: "The librarian shelved the new books carefully.",
+      focus: "the new books",
       fields: [
         { label: "Voice of the sentence", correct: "active", options: ["active", "passive"] },
         { label: "Role of 'the new books'", correct: "object", options: ["subject", "object"] }
@@ -7195,6 +7202,7 @@ const P4_MIXED_TRANSFER_CASES = Object.freeze({
     {
       prompt: "Identify the voice and the grammatical role of the underlined noun phrase.",
       example: "The letter was posted by Grandma yesterday afternoon.",
+      focus: "The letter",
       fields: [
         { label: "Voice of the sentence", correct: "passive", options: ["active", "passive"] },
         { label: "Role of 'the letter'", correct: "subject", options: ["subject", "object"] }
@@ -7205,6 +7213,7 @@ const P4_MIXED_TRANSFER_CASES = Object.freeze({
     {
       prompt: "Identify the voice and the grammatical role of the underlined noun phrase.",
       example: "The children carried the heavy equipment across the field.",
+      focus: "the heavy equipment",
       fields: [
         { label: "Voice of the sentence", correct: "active", options: ["active", "passive"] },
         { label: "Role of 'the heavy equipment'", correct: "object", options: ["subject", "object"] }
@@ -7365,10 +7374,27 @@ function buildP4MixedTransferClassifyQuestion(template, seed, cases) {
     answerText
   });
   const conceptNames = template.skillIds.map(s => s.replace(/_/g, ' ')).join(' and ');
+
+  // P10 U2: Build stemHtml with proper <u> wrapping when focus is specified.
+  // The focus field identifies the exact word/phrase to underline.
+  let stemHtml;
+  if (item.focus) {
+    const escapedExample = escapeHtml(item.example);
+    const escapedFocus = escapeHtml(item.focus);
+    const sentenceWithUnderline = escapedExample.replace(escapedFocus, `<u>${escapedFocus}</u>`);
+    stemHtml = `<p>${escapeHtml(item.prompt)}</p><p><strong>${sentenceWithUnderline}</strong></p>`;
+  } else {
+    stemHtml = `<p>${escapeHtml(item.prompt)}</p><p><strong>${escapeHtml(item.example)}</strong></p>`;
+  }
+
+  // P10 U2: Set focusTarget for enrichment when prompt says "underlined" and focus exists
+  const focusTarget = item.focus || null;
+
   return makeBaseQuestion(template, seed, {
     marks: rows.length,
     answerSpec,
-    stemHtml: `<p>${escapeHtml(item.prompt)}</p><p><strong>${escapeHtml(item.example)}</strong></p>`,
+    stemHtml,
+    focusTarget,
     inputSpec: { type: "table_choice", columns: allColumns, rows: rows.map(r => {
       const rowObj = { key: r.key, label: r.label, ariaLabel: r.label };
       // Include row-specific options when they differ from the global column set
@@ -7398,15 +7424,38 @@ function buildP3ExplanationChoiceQuestion(template, seed, cases) {
     feedbackLong:item.why,
     answerText:correct
   });
+
+  // P10 U2: When the prompt mentions "underlined group/word" and there's a focus
+  // field, wrap the focus phrase in <u> within the example sentence for correct
+  // prompt-cue extraction. This ensures focusCue targets the noun phrase, not
+  // the whole sentence.
+  const promptMentionsUnderline = /underlined/i.test(item.prompt);
   const stemParts = [
     `<p>${escapeHtml(item.prompt)}</p>`
   ];
-  if (item.example) stemParts.push(`<p><strong>${escapeHtml(item.example)}</strong></p>`);
-  if (item.focus) stemParts.push(`<p><strong>Focus:</strong> ${escapeHtml(item.focus)}</p>`);
+  if (item.example) {
+    if (item.focus && promptMentionsUnderline) {
+      // Wrap the focus phrase in <u> within the sentence
+      const escapedExample = escapeHtml(item.example);
+      const escapedFocus = escapeHtml(item.focus);
+      const sentenceWithUnderline = escapedExample.replace(escapedFocus, `<u>${escapedFocus}</u>`);
+      stemParts.push(`<p><strong>${sentenceWithUnderline}</strong></p>`);
+    } else {
+      stemParts.push(`<p><strong>${escapeHtml(item.example)}</strong></p>`);
+    }
+  }
+  if (item.focus && !promptMentionsUnderline) {
+    stemParts.push(`<p><strong>Focus:</strong> ${escapeHtml(item.focus)}</p>`);
+  }
+
+  // P10 U2: Set focusTarget for enrichment when focus exists
+  const focusTarget = item.focus || null;
+
   return makeBaseQuestion(template, seed, {
     marks:1,
     answerSpec,
     stemHtml:stemParts.join(""),
+    focusTarget,
     inputSpec:{ type:"single_choice", label:"Choose one", options:buildChoiceOptions(rng, correct, distractors) },
     solutionLines:[
       "Choose the option that explains the grammar relationship.",
@@ -7591,9 +7640,27 @@ function extractBoldSentence(stemHtml) {
 function buildPromptParts(plainPrompt, cueType, targetWord, targetSentence) {
   const parts = [];
 
+  // P10 U2: Determine instruction-only text. If the plainPrompt already contains
+  // the target sentence inline (from stripped HTML), extract just the instruction
+  // portion to avoid duplicating the sentence content in promptParts.
+  let instructionText = plainPrompt;
+  if (targetSentence && plainPrompt.includes(targetSentence)) {
+    // Remove the sentence content from the instruction text
+    const idx = plainPrompt.indexOf(targetSentence);
+    instructionText = cleanSpaces(plainPrompt.slice(0, idx));
+  } else if (targetWord && !targetSentence && plainPrompt.includes(targetWord)) {
+    // For noun-phrase/word targets with no separate sentence, keep instruction only
+    // if the prompt text extends well beyond the target (e.g. "...in the sentence below? <sentence>")
+    const idx = plainPrompt.lastIndexOf(targetWord);
+    const beforeTarget = plainPrompt.slice(0, idx).trim();
+    // Only strip if there's meaningful instruction text before the target
+    if (beforeTarget.length > 20) {
+      instructionText = cleanSpaces(beforeTarget);
+    }
+  }
+
   if (cueType === 'underline' && targetWord) {
-    // Split prompt into text + cue reference, then append sentence
-    parts.push({ kind: 'text', text: plainPrompt });
+    parts.push({ kind: 'text', text: instructionText });
     if (targetSentence) {
       parts.push({ kind: 'lineBreak', text: '' });
       const sentenceBeforeTarget = targetSentence.split(targetWord);
@@ -7604,15 +7671,19 @@ function buildPromptParts(plainPrompt, cueType, targetWord, targetSentence) {
       } else {
         parts.push({ kind: 'sentence', text: targetSentence });
       }
+    } else {
+      // No separate sentence — target word stands alone (e.g. noun phrase context)
+      parts.push({ kind: 'lineBreak', text: '' });
+      parts.push({ kind: 'underline', text: targetWord });
     }
   } else if (cueType === 'target-sentence' && targetSentence) {
-    parts.push({ kind: 'text', text: plainPrompt });
+    parts.push({ kind: 'text', text: instructionText });
     if (!plainPrompt.includes(targetSentence)) {
       parts.push({ kind: 'lineBreak', text: '' });
       parts.push({ kind: 'sentence', text: targetSentence });
     }
   } else if (cueType === 'bold' && targetWord) {
-    parts.push({ kind: 'text', text: plainPrompt });
+    parts.push({ kind: 'text', text: instructionText });
     if (targetSentence) {
       parts.push({ kind: 'lineBreak', text: '' });
       parts.push({ kind: 'emphasis', text: targetSentence });
@@ -7633,18 +7704,37 @@ function enrichPromptCue(question) {
 
   const underlinedWord = extractUnderlinedWord(question.stemHtml);
   const boldSentence = extractBoldSentence(question.stemHtml);
-  const targetWord = underlinedWord || boldSentence || null;
+
+  // P10 U2: When the prompt says "underlined noun phrase/group/word" but the
+  // stemHtml uses <strong> (not <u>), fall back to the question's focusTarget
+  // field which the template generator sets to the intended underline target.
+  let targetWord;
+  if (cueType === 'underline') {
+    targetWord = underlinedWord || question.focusTarget || boldSentence || null;
+  } else {
+    targetWord = underlinedWord || boldSentence || null;
+  }
   const targetSentence = boldSentence || null;
 
   // Build focusCue
-  if (cueType === 'underline' && underlinedWord) {
-    question.focusCue = { type: 'underline', text: underlinedWord };
+  if (cueType === 'underline' && targetWord) {
+    question.focusCue = { type: 'underline', text: targetWord };
   } else if (cueType === 'bold' && boldSentence) {
     question.focusCue = { type: 'bold', text: boldSentence };
   } else if (cueType === 'quoted-word' && targetWord) {
     question.focusCue = { type: 'quoted-word', text: targetWord };
   } else if (cueType === 'target-sentence' && targetSentence) {
     question.focusCue = { type: 'target-sentence', text: targetSentence };
+  }
+
+  // P10 U2: Cue consistency enforcement — if cueType is 'underline' but we
+  // couldn't resolve any target (no <u> tag, no focusTarget, no bold fallback),
+  // provide minimal promptParts (text-only) without a focusCue. This handles
+  // templates like formality_pairs where "underlined pair" refers to UI-level
+  // formatting rather than a prompt-cue target requiring visual highlighting.
+  if (!question.focusCue && cueType === 'underline') {
+    question.promptParts = [{ kind: 'text', text: plainPrompt }];
+    return question;
   }
 
   // Build promptParts
@@ -7675,6 +7765,9 @@ function enrichPromptCue(question) {
       question.readAloudText = `${plainPrompt} Focus on: ${word}.`;
     }
   }
+
+  // P10 U2: Clean up internal-only field — do not leak focusTarget to serialised output
+  delete question.focusTarget;
 
   return question;
 }


### PR DESCRIPTION
## Summary
- Fix `buildPromptParts` duplication: extract instruction-only text when `plainPrompt` already contains the sentence (from stripped HTML), preventing the sentence appearing twice in `promptParts`
- Fix noun-phrase templates (`qg_p4_voice_roles_transfer`, `qg_p3_noun_phrases_explain`) to underline the target noun phrase (2-4 words) rather than the whole sentence
- Fix `qg_p4_word_class_noun_phrase_transfer` seed 3 to underline the specific word ("incredibly") rather than the entire phrase
- Add `focusTarget` internal field so template generators can explicitly communicate the underline target to the enrichment layer
- Add cue consistency enforcement: templates with "underlined" but no resolvable target get minimal text-only `promptParts` without broken `focusCue`
- New audit script validates 2,340 checks (78 templates x 30 seeds) for correct prompt-cue targeting

## Plan Deviations
- Added `focusTarget` as an internal-only field (deleted before serialisation) rather than modifying `stemHtml` parsing heuristics — cleaner separation between template intent and enrichment logic
- `formality_pairs` template gets text-only `promptParts` (no `focusCue`) because "underlined pair" refers to UI-level formatting in the input area, not a prompt-cue target — this preserves the P9 test contract while avoiding incorrect enrichment

## Test plan
- [x] `node --test tests/grammar-qg-p10-prompt-cue-contract.test.js` passes (31 tests)
- [x] `node --test tests/grammar-qg-p9-learner-surface.test.js` passes (65 tests, zero regression)
- [x] `node scripts/audit-grammar-prompt-cues.mjs --seeds=1..30 --json` passes (2,340 checks)
- [x] `node --test tests/grammar-qg-p10-evidence-truth.test.js` passes (22 tests)