### PR TITLE
feat(grammar): P10 U3 — read-aloud and accessibility alignment

### DIFF
--- a/src/subjects/grammar/speech.js
+++ b/src/subjects/grammar/speech.js
@@ -52,14 +52,33 @@ function inputSpecSpeechParts(inputSpec = {}) {
   }
 
   if (inputSpec.type === 'table_choice') {
-    const rows = (Array.isArray(inputSpec.rows) ? inputSpec.rows : [])
-      .map((row) => cleanSpeechText(row?.label, 180))
-      .filter(Boolean);
+    const rows = Array.isArray(inputSpec.rows) ? inputSpec.rows : [];
     const columns = (Array.isArray(inputSpec.columns) ? inputSpec.columns : [])
       .map((column) => cleanSpeechText(column, 80))
       .filter(Boolean);
-    if (rows.length) parts.push(`Rows: ${rows.join('. ')}`);
-    if (columns.length) parts.push(`Choices: ${columns.join(', ')}`);
+    const isHeterogeneous = rows.some(
+      (r) => Array.isArray(r?.options) && r.options.length > 0
+    );
+    if (isHeterogeneous) {
+      for (const row of rows) {
+        const label = cleanSpeechText(row?.label, 180);
+        if (!label) continue;
+        const rowOpts = (Array.isArray(row?.options) ? row.options : [])
+          .map((opt) => cleanSpeechText(opt, 80))
+          .filter(Boolean);
+        if (rowOpts.length) {
+          parts.push(`Row ${label}: choices ${rowOpts.join(', ')}`);
+        } else {
+          parts.push(`Row ${label}`);
+        }
+      }
+    } else {
+      const rowLabels = rows
+        .map((row) => cleanSpeechText(row?.label, 180))
+        .filter(Boolean);
+      if (rowLabels.length) parts.push(`Rows: ${rowLabels.join('. ')}`);
+      if (columns.length) parts.push(`Choices: ${columns.join(', ')}`);
+    }
     return parts;
   }
 
@@ -134,7 +153,23 @@ export function buildGrammarSpeechText(grammar = {}) {
   const item = miniItem || session.currentItem || {};
   const parts = [];
   pushText(parts, item.templateLabel, 180);
-  pushText(parts, item.promptText, 520);
+
+  // P10 U3 preference chain: readAloudText > screenReaderPromptText > promptText
+  const readAloud = typeof item.readAloudText === 'string' && item.readAloudText.trim()
+    ? item.readAloudText
+    : '';
+  const srPrompt = typeof item.screenReaderPromptText === 'string' && item.screenReaderPromptText.trim()
+    ? item.screenReaderPromptText
+    : '';
+
+  if (readAloud) {
+    pushText(parts, readAloud, 520);
+  } else if (srPrompt) {
+    pushText(parts, srPrompt, 520);
+  } else {
+    pushText(parts, item.promptText, 520);
+  }
+
   pushText(parts, item.checkLine, 360);
   parts.push(...inputSpecSpeechParts(item.inputSpec || {}));
 

--- a/tests/grammar-qg-p10-read-aloud-alignment.test.js
+++ b/tests/grammar-qg-p10-read-aloud-alignment.test.js
@@ -1,0 +1,262 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildGrammarSpeechText } from '../src/subjects/grammar/speech.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeGrammar(item, overrides = {}) {
+  return {
+    phase: 'session',
+    session: {
+      type: 'practice',
+      currentItem: item,
+      ...overrides,
+    },
+    feedback: null,
+  };
+}
+
+function makeMiniTestGrammar(item) {
+  return {
+    phase: 'session',
+    session: {
+      type: 'mini-set',
+      currentItem: { promptText: 'This fallback must not appear.' },
+      miniTest: {
+        currentIndex: 0,
+        finished: false,
+        questions: [{
+          current: true,
+          item,
+        }],
+      },
+    },
+    feedback: null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 1. word_class_underlined_choice with readAloudText mentions underlined word
+// ---------------------------------------------------------------------------
+
+test('readAloudText preference: word_class_underlined_choice mentions the underlined word', () => {
+  const item = {
+    templateLabel: 'Identify the word class',
+    promptText: 'What word class is the underlined word?',
+    readAloudText: 'What word class is the underlined word? The underlined word is: beautiful.',
+    screenReaderPromptText: 'What word class is the underlined word? Target word: beautiful',
+    checkLine: 'Think about what the word describes.',
+    inputSpec: {
+      type: 'single_choice',
+      options: [
+        { value: 'adjective', label: 'adjective' },
+        { value: 'adverb', label: 'adverb' },
+        { value: 'noun', label: 'noun' },
+      ],
+    },
+  };
+
+  const text = buildGrammarSpeechText(makeGrammar(item));
+
+  assert.match(text, /The underlined word is: beautiful/,
+    'readAloudText must be used as primary prompt');
+  assert.match(text, /adjective/, 'inputSpec options must still be appended');
+  // Must NOT duplicate promptText alongside readAloudText
+  const underlinedCount = (text.match(/underlined word/g) || []).length;
+  assert.ok(underlinedCount <= 2,
+    'readAloudText should not cause duplication of prompt content');
+});
+
+// ---------------------------------------------------------------------------
+// 2. qg_p4_voice_roles_transfer item mentions the noun phrase
+// ---------------------------------------------------------------------------
+
+test('readAloudText preference: voice_roles_transfer item mentions the noun phrase', () => {
+  const item = {
+    templateLabel: 'Voice roles transfer',
+    promptText: 'What is the function of the underlined noun phrase?',
+    readAloudText: 'What is the function of the underlined noun phrase? The underlined word is: the old cat.',
+    screenReaderPromptText: 'What is the function of the underlined noun phrase? Target word: the old cat',
+    checkLine: 'Consider subject, object, or complement.',
+    inputSpec: {
+      type: 'single_choice',
+      options: [
+        { value: 'subject', label: 'subject' },
+        { value: 'object', label: 'object' },
+      ],
+    },
+  };
+
+  const text = buildGrammarSpeechText(makeGrammar(item));
+
+  assert.match(text, /the old cat/, 'must mention the noun phrase from readAloudText');
+  assert.match(text, /subject/, 'options must still appear');
+});
+
+// ---------------------------------------------------------------------------
+// 3. Row-specific table_choice speech lists per-row choices
+// ---------------------------------------------------------------------------
+
+test('table_choice with row-specific options lists per-row choices', () => {
+  const item = {
+    templateLabel: 'Sort the words',
+    promptText: 'Sort each word into the correct column.',
+    inputSpec: {
+      type: 'table_choice',
+      rows: [
+        { label: 'quickly', options: ['adverb', 'adjective'] },
+        { label: 'bright', options: ['adverb', 'adjective'] },
+        { label: 'carefully', options: ['adverb', 'adjective', 'noun'] },
+      ],
+      columns: ['adverb', 'adjective'],
+    },
+  };
+
+  const text = buildGrammarSpeechText(makeGrammar(item));
+
+  assert.match(text, /Row quickly: choices adverb, adjective/,
+    'row-specific options must be announced per row');
+  assert.match(text, /Row bright: choices adverb, adjective/,
+    'each row must have its own announcement');
+  assert.match(text, /Row carefully: choices adverb, adjective, noun/,
+    'heterogeneous row must list all its options');
+});
+
+// ---------------------------------------------------------------------------
+// 4. Homogeneous table_choice still uses global column fallback
+// ---------------------------------------------------------------------------
+
+test('table_choice without row-specific options uses global columns', () => {
+  const item = {
+    templateLabel: 'Classify sentences',
+    promptText: 'Sort each sentence by type.',
+    inputSpec: {
+      type: 'table_choice',
+      rows: [
+        { label: 'The cat sat.' },
+        { label: 'Did the cat sit?' },
+      ],
+      columns: ['statement', 'question', 'command'],
+    },
+  };
+
+  const text = buildGrammarSpeechText(makeGrammar(item));
+
+  assert.match(text, /Rows: The cat sat/,
+    'homogeneous table must list row labels');
+  assert.match(text, /Choices: statement, question, command/,
+    'homogeneous table must list global columns');
+  assert.doesNotMatch(text, /Row The cat sat: choices/,
+    'must NOT use per-row format for homogeneous tables');
+});
+
+// ---------------------------------------------------------------------------
+// 5. Empty readAloudText falls back to screenReaderPromptText
+// ---------------------------------------------------------------------------
+
+test('empty readAloudText falls back to screenReaderPromptText', () => {
+  const item = {
+    templateLabel: 'Word class',
+    promptText: 'Select the word class.',
+    readAloudText: '',
+    screenReaderPromptText: 'Select the word class. Target word: running',
+    inputSpec: { type: 'single_choice', options: [{ value: 'verb', label: 'verb' }] },
+  };
+
+  const text = buildGrammarSpeechText(makeGrammar(item));
+
+  assert.match(text, /Target word: running/,
+    'screenReaderPromptText must be used when readAloudText is empty');
+  assert.doesNotMatch(text, /^.*Select the word class\. Select the word class/,
+    'must not duplicate the prompt text');
+});
+
+// ---------------------------------------------------------------------------
+// 6. Item with neither readAloudText nor screenReaderPromptText falls back to promptText
+// ---------------------------------------------------------------------------
+
+test('item without readAloudText or screenReaderPromptText falls back to promptText', () => {
+  const item = {
+    templateLabel: 'Spot the adverbial',
+    promptText: 'Choose the sentence with a fronted adverbial.',
+    checkLine: 'Look for the opener.',
+    inputSpec: {
+      type: 'single_choice',
+      options: [
+        { value: 'a', label: 'After lunch, we played.' },
+        { value: 'b', label: 'We played after lunch.' },
+      ],
+    },
+  };
+
+  const text = buildGrammarSpeechText(makeGrammar(item));
+
+  assert.match(text, /Choose the sentence with a fronted adverbial/,
+    'promptText must be used as fallback');
+  assert.match(text, /After lunch, we played/, 'options must still appear');
+});
+
+// ---------------------------------------------------------------------------
+// 7. Mini-test mode uses current item's readAloudText
+// ---------------------------------------------------------------------------
+
+test('mini-test mode uses current item readAloudText', () => {
+  const item = {
+    templateLabel: 'Mini word class',
+    promptText: 'What word class is the underlined word?',
+    readAloudText: 'What word class is the underlined word? The underlined word is: slowly.',
+    inputSpec: {
+      type: 'single_choice',
+      options: [{ value: 'adverb', label: 'adverb' }],
+    },
+  };
+
+  const text = buildGrammarSpeechText(makeMiniTestGrammar(item));
+
+  assert.match(text, /The underlined word is: slowly/,
+    'mini-test must use readAloudText from the current item');
+  assert.doesNotMatch(text, /This fallback must not appear/,
+    'must use mini-test item not session.currentItem');
+});
+
+// ---------------------------------------------------------------------------
+// 8. readAloudText does NOT also push promptText (no duplication)
+// ---------------------------------------------------------------------------
+
+test('readAloudText prevents promptText duplication', () => {
+  const item = {
+    templateLabel: 'Determiner',
+    promptText: 'Choose the determiner.',
+    readAloudText: 'Choose the determiner. The underlined word is: the.',
+    inputSpec: { type: 'single_choice', options: [{ value: 'the', label: 'the' }] },
+  };
+
+  const text = buildGrammarSpeechText(makeGrammar(item));
+
+  // "Choose the determiner" should appear exactly once (inside readAloudText)
+  const matches = text.match(/Choose the determiner/g) || [];
+  assert.equal(matches.length, 1,
+    'promptText must not be pushed separately when readAloudText is used');
+});
+
+// ---------------------------------------------------------------------------
+// 9. Whitespace-only readAloudText treated as empty (falls through)
+// ---------------------------------------------------------------------------
+
+test('whitespace-only readAloudText is treated as empty', () => {
+  const item = {
+    templateLabel: 'Conjunction',
+    promptText: 'Select the conjunction.',
+    readAloudText: '   ',
+    screenReaderPromptText: 'Select the conjunction. Target word: and',
+    inputSpec: { type: 'single_choice', options: [{ value: 'and', label: 'and' }] },
+  };
+
+  const text = buildGrammarSpeechText(makeGrammar(item));
+
+  assert.match(text, /Target word: and/,
+    'whitespace-only readAloudText must fall through to screenReaderPromptText');
+});


### PR DESCRIPTION
## Summary
- Add preference chain to `buildGrammarSpeechText()`: `readAloudText` > `screenReaderPromptText` > `promptText` fallback. When `readAloudText` is used, `promptText` is not separately pushed (prevents duplication).
- Fix `table_choice` row-specific speech in `inputSpecSpeechParts()`: heterogeneous tables (rows with `row.options`) now announce each row individually as "Row [label]: choices [opt1], [opt2]" instead of only listing global columns. Homogeneous tables retain existing behaviour.
- 9 new tests in `tests/grammar-qg-p10-read-aloud-alignment.test.js` covering all paths.

## Test plan
- [x] `node --test tests/grammar-speech.test.js` — 4/4 pass (zero regression)
- [x] `node --test tests/grammar-qg-p10-read-aloud-alignment.test.js` — 9/9 pass
- [ ] CI green