### PR TITLE
fix(grammar-qg): P10 U2 target-sentence dedup regression

### DIFF
--- a/tests/grammar-qg-p10-prompt-cue-contract.test.js
+++ b/tests/grammar-qg-p10-prompt-cue-contract.test.js
@@ -204,3 +204,55 @@ describe('P10 U2: focusCue.text is not a whole sentence', () => {
     }
   }
 });
+
+// ---------------------------------------------------------------------------
+// 8. REGRESSION: target-sentence templates must include sentence in promptParts
+// ---------------------------------------------------------------------------
+
+describe('P10 U2 REGRESSION: target-sentence cue produces visible sentence part', () => {
+  it('subordinate_clause_choice seed 1: promptParts contains a sentence part with actual text', () => {
+    const q = generateQuestion('subordinate_clause_choice', 1);
+    assert.ok(q, 'question must be generated');
+    assert.ok(q.promptParts, 'promptParts must be present');
+    const sentencePart = q.promptParts.find(p => p.kind === 'sentence');
+    assert.ok(
+      sentencePart,
+      `promptParts must contain a {kind:'sentence'} part — sentence must be VISIBLE to learner. Got kinds: ${q.promptParts.map(p => p.kind).join(', ')}`
+    );
+    assert.ok(
+      sentencePart.text && sentencePart.text.length > 10,
+      `sentence part text must be substantial (got "${sentencePart.text}")`
+    );
+  });
+
+  it('subject_object_choice seed 1: promptParts text contains the full instruction (not mangled)', () => {
+    const q = generateQuestion('subject_object_choice', 1);
+    assert.ok(q, 'question must be generated');
+    assert.ok(q.promptParts, 'promptParts must be present');
+    const textPart = q.promptParts.find(p => p.kind === 'text');
+    assert.ok(textPart, 'promptParts must contain a text part with instruction');
+    // The instruction must not be empty or trivially short (indicating wrong dedup)
+    assert.ok(
+      textPart.text.length > 5,
+      `instruction text part must not be mangled/empty (got "${textPart.text}")`
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 9. REGRESSION: focusTarget must NOT leak to serialised output (any template)
+// ---------------------------------------------------------------------------
+
+describe('P10 U2 REGRESSION: focusTarget never present on serialised output', () => {
+  for (const template of GRAMMAR_TEMPLATE_METADATA) {
+    it(`${template.id}: focusTarget must not be present`, () => {
+      const q = createGrammarQuestion({ templateId: template.id, seed: 1 });
+      if (!q) return; // Some templates may not generate for certain seeds
+      assert.strictEqual(
+        q.focusTarget,
+        undefined,
+        `focusTarget must be deleted before returning — found "${q.focusTarget}" on ${template.id}`
+      );
+    });
+  }
+});

--- a/worker/src/subjects/grammar/content.js
+++ b/worker/src/subjects/grammar/content.js
@@ -7643,8 +7643,10 @@ function buildPromptParts(plainPrompt, cueType, targetWord, targetSentence) {
   // P10 U2: Determine instruction-only text. If the plainPrompt already contains
   // the target sentence inline (from stripped HTML), extract just the instruction
   // portion to avoid duplicating the sentence content in promptParts.
+  // Guard: only strip if targetSentence is long enough to be a real sentence
+  // (short values like "object" from a wrong <strong> pick must not trigger dedup).
   let instructionText = plainPrompt;
-  if (targetSentence && plainPrompt.includes(targetSentence)) {
+  if (targetSentence && targetSentence.length > 15 && plainPrompt.includes(targetSentence)) {
     // Remove the sentence content from the instruction text
     const idx = plainPrompt.indexOf(targetSentence);
     instructionText = cleanSpaces(plainPrompt.slice(0, idx));
@@ -7678,7 +7680,8 @@ function buildPromptParts(plainPrompt, cueType, targetWord, targetSentence) {
     }
   } else if (cueType === 'target-sentence' && targetSentence) {
     parts.push({ kind: 'text', text: instructionText });
-    if (!plainPrompt.includes(targetSentence)) {
+    if (instructionText !== plainPrompt) {
+      // We DID strip the sentence from instructionText — add it back as structured part
       parts.push({ kind: 'lineBreak', text: '' });
       parts.push({ kind: 'sentence', text: targetSentence });
     }
@@ -7700,7 +7703,11 @@ function enrichPromptCue(question) {
 
   const plainPrompt = stripLegacyHtml(question.stemHtml);
   const cueType = detectCueType(plainPrompt);
-  if (!cueType) return question;
+  if (!cueType) {
+    // Clean up internal-only field even on early return — do not leak to serialised output
+    delete question.focusTarget;
+    return question;
+  }
 
   const underlinedWord = extractUnderlinedWord(question.stemHtml);
   const boldSentence = extractBoldSentence(question.stemHtml);


### PR DESCRIPTION
## Summary
- **HIGH severity hotfix**: `buildPromptParts` deduplication logic made target sentences INVISIBLE to learners for 6 templates using the `target-sentence` cue type
- Fixed the condition from `!plainPrompt.includes(targetSentence)` (always false) to `instructionText !== plainPrompt` (true when stripping occurred)
- Added minimum length guard (>15 chars) to prevent `extractBoldSentence` wrong-match from triggering dedup on short strings like "object"
- Fixed `focusTarget` field leaking on serialised output when `detectCueType()` returns null

## Affected templates
`subordinate_clause_choice`, `identify_words_in_sentence`, `build_noun_phrase`, `subject_object_choice`, `parenthesis_replace_choice`, `proc_semicolon_choice`

## Test plan
- [x] New regression tests (sections 8-9) in `grammar-qg-p10-prompt-cue-contract.test.js`
- [x] `subordinate_clause_choice` seed 1: promptParts contains `{kind:'sentence'}` part with actual sentence text
- [x] `subject_object_choice` seed 1: promptParts text contains full instruction (not mangled)
- [x] All templates: `focusTarget` not present on serialised output
- [x] Full grammar test suite: 5,322 pass / 0 fail
- [x] Spelling test suite: 718 pass / 0 fail
- [x] No new regressions introduced (pre-existing failures in punctuation-combine and capacity unrelated)