### PR TITLE
fix(test): hero-pA1 fixture date drifts past 2026-04-29

### DIFF
--- a/tests/fixtures/hero-pA1-seeded-learners.js
+++ b/tests/fixtures/hero-pA1-seeded-learners.js
@@ -8,6 +8,7 @@
 
 import { HERO_POOL_ROSTER_VERSION } from '../../shared/hero/hero-pool.js';
 import { HERO_ECONOMY_VERSION } from '../../shared/hero/economy.js';
+import { deriveDateKey } from '../../shared/hero/seed.js';
 
 // ── Subject read-model fixtures ─────────────────────────────────────
 
@@ -61,7 +62,10 @@ export function lockedPlaceholders() {
 // ── Hero progress state fixtures ─────────────────────────────────────
 
 const NOW = Date.now();
-const DATE_KEY = '2026-04-29';
+// Derived from NOW so the fixture tracks today's London date — keeps the
+// flag-ladder D2 reconciliation in sync with the read-model's
+// progressDateMatch check (which compares against deriveDateKey(now)).
+const DATE_KEY = deriveDateKey(NOW);
 
 /**
  * Learner who has completed today's quest (all tasks completed, daily complete).


### PR DESCRIPTION
## Summary

The `hero-pA1-seeded-learners` fixture hardcoded `DATE_KEY = '2026-04-29'`, but the read-model derives `dateKey` from `Date.now()` via `deriveDateKey(now, HERO_DEFAULT_TIMEZONE)`. From **2026-04-30** onwards this caused `progressDateMatch === false` at `worker/src/hero/read-model.js:350`, which zeroed every merged task's `effortCompleted` and broke `D2: Enable all, start quest, claim task → disable → re-enable → completed tasks preserved` (expected 6, actual 0).

Switching `DATE_KEY` to `deriveDateKey(NOW)` keeps the fixture aligned with today's London date, so the flag-ladder reconciliation keeps proving rather than rotting on the calendar boundary. Same import already exists in `worker/src/hero/read-model.js`.

## Why this is a one-line root-cause fix, not a workaround

The mismatch isn't between the fixture and the test — the fixture controls both the input state's `dateKey` and the assertions' expectations. The mismatch is between the fixture's hardcoded date and **the time the test runs**. Reproducing the bug only required waiting one day. The right fix is to make the fixture self-dating, mirroring how production code derives `dateKey` from `now()`.

## Verification

- Before: `node --test tests/hero-pA1-flag-ladder.test.js` → 30 pass / 1 fail (D2)
- After: `node --test tests/hero-pA1-flag-ladder.test.js` → **31 pass / 0 fail**

## Blast radius

- One file touched: `tests/fixtures/hero-pA1-seeded-learners.js`
- One added import: `deriveDateKey` from `shared/hero/seed.js` (production module)
- No production code change
- Unblocks every PR currently red on `npm test + npm run check` due to this single failure

## Test plan

- [x] `node --test tests/hero-pA1-flag-ladder.test.js` passes locally on Node 22.16.0
- [x] No production source change → no bundle / audit / build impact
- [x] Other fixture exports unaffected — they all already used `DATE_KEY` so they migrate together

🤖 Generated with [Claude Code](https://claude.com/claude-code)