### PR TITLE
feat(grammar): prompt cue audit alignment check + cueNotRequiredReason (P10 R-U7)

### DIFF
--- a/scripts/audit-grammar-prompt-cues.mjs
+++ b/scripts/audit-grammar-prompt-cues.mjs
@@ -6,6 +6,8 @@
  * 1. No whole-sentence underline when prompt asks for word/phrase
  * 2. No duplicate content in promptParts
  * 3. If prompt contains cue language, focusCue must exist (or explicit fallback)
+ * 4. Screen-reader/read-aloud alignment — both mention focusCue.text
+ * 5. cueNotRequiredReason present when promptParts exist without focusCue
  *
  * Usage:
  *   node scripts/audit-grammar-prompt-cues.mjs --seeds=1..30 --json
@@ -94,6 +96,33 @@ function auditQuestion(templateId, seed) {
       failures.push({
         check: 'missing-cue-data',
         message: `Prompt contains cue language but no focusCue or promptParts`
+      });
+    }
+  }
+
+  // Check 4: Screen-reader/read-aloud alignment — both must mention focusCue.text
+  if (q.focusCue && q.focusCue.text) {
+    const cueTextLower = q.focusCue.text.toLowerCase();
+    if (q.screenReaderPromptText && !q.screenReaderPromptText.toLowerCase().includes(cueTextLower)) {
+      failures.push({
+        check: 'screen-reader-misaligned',
+        message: `screenReaderPromptText does not mention focusCue.text "${q.focusCue.text}"`
+      });
+    }
+    if (q.readAloudText && !q.readAloudText.toLowerCase().includes(cueTextLower)) {
+      failures.push({
+        check: 'read-aloud-misaligned',
+        message: `readAloudText does not mention focusCue.text "${q.focusCue.text}"`
+      });
+    }
+  }
+
+  // Check 5: cueNotRequiredReason for promptParts without focusCue
+  if (q.promptParts && q.promptParts.length > 0 && !q.focusCue) {
+    if (!q.cueNotRequiredReason || typeof q.cueNotRequiredReason !== 'string' || q.cueNotRequiredReason.trim() === '') {
+      failures.push({
+        check: 'missing-cue-not-required-reason',
+        message: `Has promptParts but no focusCue and missing cueNotRequiredReason`
       });
     }
   }

--- a/tests/grammar-qg-p10-prompt-cue-contract.test.js
+++ b/tests/grammar-qg-p10-prompt-cue-contract.test.js
@@ -240,7 +240,58 @@ describe('P10 U2 REGRESSION: target-sentence cue produces visible sentence part'
 });
 
 // ---------------------------------------------------------------------------
-// 9. REGRESSION: focusTarget must NOT leak to serialised output (any template)
+// 9. P10 U7: screenReaderPromptText includes focusCue.text
+// ---------------------------------------------------------------------------
+
+describe('P10 U7: screenReaderPromptText includes focusCue.text', () => {
+  it('word_class_underlined_choice seed 1: screenReaderPromptText mentions focusCue.text', () => {
+    const q = generateQuestion('word_class_underlined_choice', 1);
+    assert.ok(q, 'question must be generated');
+    assert.ok(q.focusCue, 'focusCue must be present');
+    assert.ok(q.screenReaderPromptText, 'screenReaderPromptText must be present');
+    assert.ok(
+      q.screenReaderPromptText.toLowerCase().includes(q.focusCue.text.toLowerCase()),
+      `screenReaderPromptText must contain focusCue.text "${q.focusCue.text}" — got "${q.screenReaderPromptText}"`
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 10. P10 U7: readAloudText includes focusCue.text
+// ---------------------------------------------------------------------------
+
+describe('P10 U7: readAloudText includes focusCue.text', () => {
+  it('word_class_underlined_choice seed 1: readAloudText mentions focusCue.text', () => {
+    const q = generateQuestion('word_class_underlined_choice', 1);
+    assert.ok(q, 'question must be generated');
+    assert.ok(q.focusCue, 'focusCue must be present');
+    assert.ok(q.readAloudText, 'readAloudText must be present');
+    assert.ok(
+      q.readAloudText.toLowerCase().includes(q.focusCue.text.toLowerCase()),
+      `readAloudText must contain focusCue.text "${q.focusCue.text}" — got "${q.readAloudText}"`
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 11. P10 U7: cueNotRequiredReason present when promptParts exist without focusCue
+// ---------------------------------------------------------------------------
+
+describe('P10 U7: cueNotRequiredReason present when promptParts exist without focusCue', () => {
+  it('formality_pairs seed 1: has cueNotRequiredReason when promptParts exist without focusCue', () => {
+    const q = generateQuestion('formality_pairs', 1);
+    assert.ok(q, 'question must be generated');
+    assert.ok(q.promptParts, 'promptParts must be present');
+    assert.strictEqual(q.focusCue, undefined, 'focusCue must NOT be present for this template');
+    assert.ok(
+      q.cueNotRequiredReason && typeof q.cueNotRequiredReason === 'string' && q.cueNotRequiredReason.trim().length > 0,
+      `cueNotRequiredReason must be a non-empty string — got "${q.cueNotRequiredReason}"`
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 12. REGRESSION: focusTarget must NOT leak to serialised output (any template)
 // ---------------------------------------------------------------------------
 
 describe('P10 U2 REGRESSION: focusTarget never present on serialised output', () => {

--- a/worker/src/subjects/grammar/content.js
+++ b/worker/src/subjects/grammar/content.js
@@ -7706,6 +7706,10 @@ function enrichPromptCue(question) {
   if (!cueType) {
     // Clean up internal-only field even on early return — do not leak to serialised output
     delete question.focusTarget;
+    // P10 U7: If promptParts exist but no cue language detected, explain why focusCue is absent
+    if (question.promptParts) {
+      question.cueNotRequiredReason = 'no-cue-language-in-prompt';
+    }
     return question;
   }
 
@@ -7741,6 +7745,10 @@ function enrichPromptCue(question) {
   // formatting rather than a prompt-cue target requiring visual highlighting.
   if (!question.focusCue && cueType === 'underline') {
     question.promptParts = [{ kind: 'text', text: plainPrompt }];
+    // P10 U7: Explain why focusCue is absent despite promptParts being present
+    question.cueNotRequiredReason = 'unresolvable-underline-target';
+    // Clean up internal-only field
+    delete question.focusTarget;
     return question;
   }
 


### PR DESCRIPTION
## Summary
- Add Check 4 to `scripts/audit-grammar-prompt-cues.mjs`: verifies `screenReaderPromptText` and `readAloudText` both mention `focusCue.text` (case-insensitive) when focusCue is present
- Add Check 5: verifies `cueNotRequiredReason` exists as a non-empty string when `promptParts` are present but `focusCue` is null
- `enrichPromptCue` now sets `cueNotRequiredReason` on both early-return paths (`no-cue-language-in-prompt` and `unresolvable-underline-target`)
- Three new contract tests validate the alignment and reason fields

## Test plan
- [x] `node --test tests/grammar-qg-p10-prompt-cue-contract.test.js` — 118 pass, 0 fail
- [x] `node scripts/audit-grammar-prompt-cues.mjs --seeds=1..30 --json` — 2,340 checks, 0 violations
- [ ] CI green