### PR TITLE
feat(grammar-qg): P10 R-U6 render inventory enrichment

### DIFF
--- a/reports/grammar/grammar-qg-p10-render-inventory-redacted.md
+++ b/reports/grammar/grammar-qg-p10-render-inventory-redacted.md
@@ -4,7 +4,7 @@ Content Release: grammar-qg-p10-2026-04-29
 Total Items: 2340
 Templates: 78
 Seed Range: 1..30
-Generated: 2026-04-29T23:40:39.022Z
+Generated: 2026-04-30T00:25:06.658Z
 
 _Answer internals stripped from this report._
 

--- a/reports/grammar/grammar-qg-p10-render-inventory.md
+++ b/reports/grammar/grammar-qg-p10-render-inventory.md
@@ -1,0 +1,2352 @@
+# Grammar QG P10 Render Inventory
+
+Content Release: grammar-qg-p10-2026-04-29
+Total Items: 2340
+Templates: 78
+Seed Range: 1..30
+Generated: 2026-04-30T00:25:06.658Z
+
+_This report includes answer internals and is for adult review only._
+
+| templateId | seed | inputType | visibleOptions (summary) | speechOutput (truncated) | feedbackLong |
+| --- | --- | --- | --- | --- | --- |
+| sentence_type_table | 1 | table_choice | 4 rows/fields | Classify sentence functions. Tick one box in each  | How loudly the drums were beating! → exclamation \| Why is th |
+| sentence_type_table | 2 | table_choice | 4 rows/fields | Classify sentence functions. Tick one box in each  | Can we finish the poster tomorrow? → question \| How loudly t |
+| sentence_type_table | 3 | table_choice | 4 rows/fields | Classify sentence functions. Tick one box in each  | Where did you put the compass? → question \| How loudly the d |
+| sentence_type_table | 4 | table_choice | 4 rows/fields | Classify sentence functions. Tick one box in each  | Where did you put the compass? → question \| Close the gate b |
+| sentence_type_table | 5 | table_choice | 4 rows/fields | Classify sentence functions. Tick one box in each  | Can we finish the poster tomorrow? → question \| The lantern  |
+| sentence_type_table | 6 | table_choice | 4 rows/fields | Classify sentence functions. Tick one box in each  | What a huge shadow that tree casts! → exclamation \| Can we f |
+| sentence_type_table | 7 | table_choice | 4 rows/fields | Classify sentence functions. Tick one box in each  | Wait by the hall doors. → command \| Can we finish the poster |
+| sentence_type_table | 8 | table_choice | 4 rows/fields | Classify sentence functions. Tick one box in each  | Wait by the hall doors. → command \| What an icy wind this is |
+| sentence_type_table | 9 | table_choice | 4 rows/fields | Classify sentence functions. Tick one box in each  | Why is the gate still open? → question \| What an icy wind th |
+| sentence_type_table | 10 | table_choice | 4 rows/fields | Classify sentence functions. Tick one box in each  | The river flowed past the old bridge. → statement \| Have the |
+| sentence_type_table | 11 | table_choice | 4 rows/fields | Classify sentence functions. Tick one box in each  | Mia tucked the map into her coat pocket. → statement \| How l |
+| sentence_type_table | 12 | table_choice | 4 rows/fields | Classify sentence functions. Tick one box in each  | Please fold the letter neatly. → command \| What a huge shado |
+| sentence_type_table | 13 | table_choice | 4 rows/fields | Classify sentence functions. Tick one box in each  | What a huge shadow that tree casts! → exclamation \| The lant |
+| sentence_type_table | 14 | table_choice | 4 rows/fields | Classify sentence functions. Tick one box in each  | Our coach arrives at half past nine. → statement \| Close the |
+| sentence_type_table | 15 | table_choice | 4 rows/fields | Classify sentence functions. Tick one box in each  | Bring your reading record tomorrow. → command \| What a huge  |
+| sentence_type_table | 16 | table_choice | 4 rows/fields | Classify sentence functions. Tick one box in each  | How quickly the rabbit ran! → exclamation \| Have the tickets |
+| sentence_type_table | 17 | table_choice | 4 rows/fields | Classify sentence functions. Tick one box in each  | What a huge shadow that tree casts! → exclamation \| Where di |
+| sentence_type_table | 18 | table_choice | 4 rows/fields | Classify sentence functions. Tick one box in each  | The lantern swung in the wind. → statement \| Please fold the |
+| sentence_type_table | 19 | table_choice | 4 rows/fields | Classify sentence functions. Tick one box in each  | Why is the gate still open? → question \| Please fold the let |
+| sentence_type_table | 20 | table_choice | 4 rows/fields | Classify sentence functions. Tick one box in each  | Our coach arrives at half past nine. → statement \| Bring you |
+| sentence_type_table | 21 | table_choice | 4 rows/fields | Classify sentence functions. Tick one box in each  | Bring your reading record tomorrow. → command \| Our coach ar |
+| sentence_type_table | 22 | table_choice | 4 rows/fields | Classify sentence functions. Tick one box in each  | Where did you put the compass? → question \| How quickly the  |
+| sentence_type_table | 23 | table_choice | 4 rows/fields | Classify sentence functions. Tick one box in each  | Bring your reading record tomorrow. → command \| Have the tic |
+| sentence_type_table | 24 | table_choice | 4 rows/fields | Classify sentence functions. Tick one box in each  | What a huge shadow that tree casts! → exclamation \| Mia tuck |
+| sentence_type_table | 25 | table_choice | 4 rows/fields | Classify sentence functions. Tick one box in each  | Mia tucked the map into her coat pocket. → statement \| Have  |
+| sentence_type_table | 26 | table_choice | 4 rows/fields | Classify sentence functions. Tick one box in each  | The lantern swung in the wind. → statement \| Why is the gate |
+| sentence_type_table | 27 | table_choice | 4 rows/fields | Classify sentence functions. Tick one box in each  | What a huge shadow that tree casts! → exclamation \| Please f |
+| sentence_type_table | 28 | table_choice | 4 rows/fields | Classify sentence functions. Tick one box in each  | Mia tucked the map into her coat pocket. → statement \| How q |
+| sentence_type_table | 29 | table_choice | 4 rows/fields | Classify sentence functions. Tick one box in each  | Where did you put the compass? → question \| Bring your readi |
+| sentence_type_table | 30 | table_choice | 4 rows/fields | Classify sentence functions. Tick one box in each  | Where did you put the compass? → question \| The lantern swun |
+| question_mark_select | 1 | checkbox_list | What a long journey this has been, Can y | Find the real questions. Tick all the sentences th | The sentences needing question marks are: Can you help me ca |
+| question_mark_select | 2 | checkbox_list | What a long journey this has been, Can y | Find the real questions. Tick all the sentences th | The sentences needing question marks are: Can you help me ca |
+| question_mark_select | 3 | checkbox_list | What a long journey this has been, Can y | Find the real questions. Tick all the sentences th | The sentences needing question marks are: Can you help me ca |
+| question_mark_select | 4 | checkbox_list | What a long journey this has been, Can y | Find the real questions. Tick all the sentences th | The sentences needing question marks are: Can you help me ca |
+| question_mark_select | 5 | checkbox_list | What a long journey this has been, Can y | Find the real questions. Tick all the sentences th | The sentences needing question marks are: Can you help me ca |
+| question_mark_select | 6 | checkbox_list | What a long journey this has been, Can y | Find the real questions. Tick all the sentences th | The sentences needing question marks are: Can you help me ca |
+| question_mark_select | 7 | checkbox_list | How good it would be if Jay could come,  | Find the real questions. Tick all the sentences th | The sentences needing question marks are: Is Jay going to co |
+| question_mark_select | 8 | checkbox_list | How good it would be if Jay could come,  | Find the real questions. Tick all the sentences th | The sentences needing question marks are: Is Jay going to co |
+| question_mark_select | 9 | checkbox_list | How good it would be if Jay could come,  | Find the real questions. Tick all the sentences th | The sentences needing question marks are: Is Jay going to co |
+| question_mark_select | 10 | checkbox_list | What a long journey this has been, Can y | Find the real questions. Tick all the sentences th | The sentences needing question marks are: Can you help me ca |
+| question_mark_select | 11 | checkbox_list | What a long journey this has been, Can y | Find the real questions. Tick all the sentences th | The sentences needing question marks are: Can you help me ca |
+| question_mark_select | 12 | checkbox_list | How good it would be if Jay could come,  | Find the real questions. Tick all the sentences th | The sentences needing question marks are: Is Jay going to co |
+| question_mark_select | 13 | checkbox_list | What a long journey this has been, Can y | Find the real questions. Tick all the sentences th | The sentences needing question marks are: Can you help me ca |
+| question_mark_select | 14 | checkbox_list | How good it would be if Jay could come,  | Find the real questions. Tick all the sentences th | The sentences needing question marks are: Is Jay going to co |
+| question_mark_select | 15 | checkbox_list | How good it would be if Jay could come,  | Find the real questions. Tick all the sentences th | The sentences needing question marks are: Is Jay going to co |
+| question_mark_select | 16 | checkbox_list | What a long journey this has been, Can y | Find the real questions. Tick all the sentences th | The sentences needing question marks are: Can you help me ca |
+| question_mark_select | 17 | checkbox_list | What a long journey this has been, Can y | Find the real questions. Tick all the sentences th | The sentences needing question marks are: Can you help me ca |
+| question_mark_select | 18 | checkbox_list | How good it would be if Jay could come,  | Find the real questions. Tick all the sentences th | The sentences needing question marks are: Is Jay going to co |
+| question_mark_select | 19 | checkbox_list | How good it would be if Jay could come,  | Find the real questions. Tick all the sentences th | The sentences needing question marks are: Is Jay going to co |
+| question_mark_select | 20 | checkbox_list | What a long journey this has been, Can y | Find the real questions. Tick all the sentences th | The sentences needing question marks are: Can you help me ca |
+| question_mark_select | 21 | checkbox_list | How good it would be if Jay could come,  | Find the real questions. Tick all the sentences th | The sentences needing question marks are: Is Jay going to co |
+| question_mark_select | 22 | checkbox_list | What a long journey this has been, Can y | Find the real questions. Tick all the sentences th | The sentences needing question marks are: Can you help me ca |
+| question_mark_select | 23 | checkbox_list | How good it would be if Jay could come,  | Find the real questions. Tick all the sentences th | The sentences needing question marks are: Is Jay going to co |
+| question_mark_select | 24 | checkbox_list | How good it would be if Jay could come,  | Find the real questions. Tick all the sentences th | The sentences needing question marks are: Is Jay going to co |
+| question_mark_select | 25 | checkbox_list | What a long journey this has been, Can y | Find the real questions. Tick all the sentences th | The sentences needing question marks are: Can you help me ca |
+| question_mark_select | 26 | checkbox_list | What a long journey this has been, Can y | Find the real questions. Tick all the sentences th | The sentences needing question marks are: Can you help me ca |
+| question_mark_select | 27 | checkbox_list | How good it would be if Jay could come,  | Find the real questions. Tick all the sentences th | The sentences needing question marks are: Is Jay going to co |
+| question_mark_select | 28 | checkbox_list | How good it would be if Jay could come,  | Find the real questions. Tick all the sentences th | The sentences needing question marks are: Is Jay going to co |
+| question_mark_select | 29 | checkbox_list | How good it would be if Jay could come,  | Find the real questions. Tick all the sentences th | The sentences needing question marks are: Is Jay going to co |
+| question_mark_select | 30 | checkbox_list | What a long journey this has been, Can y | Find the real questions. Tick all the sentences th | The sentences needing question marks are: Can you help me ca |
+| word_class_underlined_choice | 1 | single_choice | pronoun, determiner, adjective, preposit | Which word class is the underlined word in the sen | The underlined word is pronoun. |
+| word_class_underlined_choice | 2 | single_choice | pronoun, determiner, adjective, preposit | Which word class is the underlined word in the sen | The underlined word is pronoun. |
+| word_class_underlined_choice | 3 | single_choice | pronoun, determiner, adjective, preposit | Which word class is the underlined word in the sen | The underlined word is pronoun. |
+| word_class_underlined_choice | 4 | single_choice | verb, adjective, noun, preposition | Which word class is the underlined word in the sen | The underlined word is verb. |
+| word_class_underlined_choice | 5 | single_choice | pronoun, determiner, adjective, preposit | Which word class is the underlined word in the sen | The underlined word is pronoun. |
+| word_class_underlined_choice | 6 | single_choice | adjective, noun, adverb, verb | Which word class is the underlined word in the sen | The underlined word is adjective. |
+| word_class_underlined_choice | 7 | single_choice | adverb, conjunction, adjective, determin | Which word class is the underlined word in the sen | The underlined word is adverb. |
+| word_class_underlined_choice | 8 | single_choice | preposition, adverb, verb, noun | Which word class is the underlined word in the sen | The underlined word is preposition. |
+| word_class_underlined_choice | 9 | single_choice | preposition, adverb, verb, noun | Which word class is the underlined word in the sen | The underlined word is preposition. |
+| word_class_underlined_choice | 10 | single_choice | adjective, noun, adverb, verb | Which word class is the underlined word in the sen | The underlined word is adjective. |
+| word_class_underlined_choice | 11 | single_choice | adjective, noun, adverb, verb | Which word class is the underlined word in the sen | The underlined word is adjective. |
+| word_class_underlined_choice | 12 | single_choice | pronoun, determiner, adjective, conjunct | Which word class is the underlined word in the sen | The underlined word is determiner. |
+| word_class_underlined_choice | 13 | single_choice | adjective, noun, adverb, verb | Which word class is the underlined word in the sen | The underlined word is adjective. |
+| word_class_underlined_choice | 14 | single_choice | preposition, adverb, conjunction, verb | Which word class is the underlined word in the sen | The underlined word is conjunction. |
+| word_class_underlined_choice | 15 | single_choice | preposition, adverb, verb, noun | Which word class is the underlined word in the sen | The underlined word is preposition. |
+| word_class_underlined_choice | 16 | single_choice | pronoun, determiner, adjective, preposit | Which word class is the underlined word in the sen | The underlined word is pronoun. |
+| word_class_underlined_choice | 17 | single_choice | pronoun, determiner, adjective, preposit | Which word class is the underlined word in the sen | The underlined word is pronoun. |
+| word_class_underlined_choice | 18 | single_choice | preposition, adverb, conjunction, verb | Which word class is the underlined word in the sen | The underlined word is conjunction. |
+| word_class_underlined_choice | 19 | single_choice | adverb, conjunction, adjective, determin | Which word class is the underlined word in the sen | The underlined word is adverb. |
+| word_class_underlined_choice | 20 | single_choice | noun, verb, adverb, conjunction | Which word class is the underlined word in the sen | The underlined word is noun. |
+| word_class_underlined_choice | 21 | single_choice | preposition, adverb, conjunction, verb | Which word class is the underlined word in the sen | The underlined word is conjunction. |
+| word_class_underlined_choice | 22 | single_choice | adjective, noun, adverb, verb | Which word class is the underlined word in the sen | The underlined word is adjective. |
+| word_class_underlined_choice | 23 | single_choice | adverb, conjunction, adjective, determin | Which word class is the underlined word in the sen | The underlined word is adverb. |
+| word_class_underlined_choice | 24 | single_choice | pronoun, determiner, adjective, conjunct | Which word class is the underlined word in the sen | The underlined word is determiner. |
+| word_class_underlined_choice | 25 | single_choice | adjective, noun, adverb, verb | Which word class is the underlined word in the sen | The underlined word is adjective. |
+| word_class_underlined_choice | 26 | single_choice | adjective, noun, adverb, verb | Which word class is the underlined word in the sen | The underlined word is adjective. |
+| word_class_underlined_choice | 27 | single_choice | preposition, adverb, conjunction, verb | Which word class is the underlined word in the sen | The underlined word is conjunction. |
+| word_class_underlined_choice | 28 | single_choice | preposition, adverb, conjunction, verb | Which word class is the underlined word in the sen | The underlined word is conjunction. |
+| word_class_underlined_choice | 29 | single_choice | preposition, adverb, verb, noun | Which word class is the underlined word in the sen | The underlined word is preposition. |
+| word_class_underlined_choice | 30 | single_choice | noun, verb, adverb, conjunction | Which word class is the underlined word in the sen | The underlined word is noun. |
+| identify_words_in_sentence | 1 | checkbox_list | Nina, carefully, and, quietly | Select all the adverbs in the sentence below. Nina | The correct words are: carefully, quietly. |
+| identify_words_in_sentence | 2 | checkbox_list | Nina, carefully, and, quietly | Select all the adverbs in the sentence below. Nina | The correct words are: carefully, quietly. |
+| identify_words_in_sentence | 3 | checkbox_list | Nina, carefully, and, quietly | Select all the adverbs in the sentence below. Nina | The correct words are: carefully, quietly. |
+| identify_words_in_sentence | 4 | checkbox_list | She, handed, it, to | Select all the pronouns in the sentence below. She | The correct words are: She, it, them, they. |
+| identify_words_in_sentence | 5 | checkbox_list | Nina, carefully, and, quietly | Select all the adverbs in the sentence below. Nina | The correct words are: carefully, quietly. |
+| identify_words_in_sentence | 6 | checkbox_list | Nina, carefully, and, quietly | Select all the adverbs in the sentence below. Nina | The correct words are: carefully, quietly. |
+| identify_words_in_sentence | 7 | checkbox_list | Luca, laughed, because, Maya | Select all the conjunctions in the sentence below. | The correct words are: because, and. |
+| identify_words_in_sentence | 8 | checkbox_list | Luca, laughed, because, Maya | Select all the conjunctions in the sentence below. | The correct words are: because, and. |
+| identify_words_in_sentence | 9 | checkbox_list | Luca, laughed, because, Maya | Select all the conjunctions in the sentence below. | The correct words are: because, and. |
+| identify_words_in_sentence | 10 | checkbox_list | Nina, carefully, and, quietly | Select all the adverbs in the sentence below. Nina | The correct words are: carefully, quietly. |
+| identify_words_in_sentence | 11 | checkbox_list | Nina, carefully, and, quietly | Select all the adverbs in the sentence below. Nina | The correct words are: carefully, quietly. |
+| identify_words_in_sentence | 12 | checkbox_list | Those, small, birds, built | Select all the determiners in the sentence below.  | The correct words are: Those, a, the. |
+| identify_words_in_sentence | 13 | checkbox_list | Nina, carefully, and, quietly | Select all the adverbs in the sentence below. Nina | The correct words are: carefully, quietly. |
+| identify_words_in_sentence | 14 | checkbox_list | Those, small, birds, built | Select all the determiners in the sentence below.  | The correct words are: Those, a, the. |
+| identify_words_in_sentence | 15 | checkbox_list | Luca, laughed, because, Maya | Select all the conjunctions in the sentence below. | The correct words are: because, and. |
+| identify_words_in_sentence | 16 | checkbox_list | Nina, carefully, and, quietly | Select all the adverbs in the sentence below. Nina | The correct words are: carefully, quietly. |
+| identify_words_in_sentence | 17 | checkbox_list | Nina, carefully, and, quietly | Select all the adverbs in the sentence below. Nina | The correct words are: carefully, quietly. |
+| identify_words_in_sentence | 18 | checkbox_list | Those, small, birds, built | Select all the determiners in the sentence below.  | The correct words are: Those, a, the. |
+| identify_words_in_sentence | 19 | checkbox_list | Luca, laughed, because, Maya | Select all the conjunctions in the sentence below. | The correct words are: because, and. |
+| identify_words_in_sentence | 20 | checkbox_list | She, handed, it, to | Select all the pronouns in the sentence below. She | The correct words are: She, it, them, they. |
+| identify_words_in_sentence | 21 | checkbox_list | Those, small, birds, built | Select all the determiners in the sentence below.  | The correct words are: Those, a, the. |
+| identify_words_in_sentence | 22 | checkbox_list | Nina, carefully, and, quietly | Select all the adverbs in the sentence below. Nina | The correct words are: carefully, quietly. |
+| identify_words_in_sentence | 23 | checkbox_list | Luca, laughed, because, Maya | Select all the conjunctions in the sentence below. | The correct words are: because, and. |
+| identify_words_in_sentence | 24 | checkbox_list | Those, small, birds, built | Select all the determiners in the sentence below.  | The correct words are: Those, a, the. |
+| identify_words_in_sentence | 25 | checkbox_list | Nina, carefully, and, quietly | Select all the adverbs in the sentence below. Nina | The correct words are: carefully, quietly. |
+| identify_words_in_sentence | 26 | checkbox_list | Nina, carefully, and, quietly | Select all the adverbs in the sentence below. Nina | The correct words are: carefully, quietly. |
+| identify_words_in_sentence | 27 | checkbox_list | Those, small, birds, built | Select all the determiners in the sentence below.  | The correct words are: Those, a, the. |
+| identify_words_in_sentence | 28 | checkbox_list | Those, small, birds, built | Select all the determiners in the sentence below.  | The correct words are: Those, a, the. |
+| identify_words_in_sentence | 29 | checkbox_list | Luca, laughed, because, Maya | Select all the conjunctions in the sentence below. | The correct words are: because, and. |
+| identify_words_in_sentence | 30 | checkbox_list | She, handed, it, to | Select all the pronouns in the sentence below. She | The correct words are: She, it, them, they. |
+| expanded_noun_phrase_choice | 1 | single_choice | the silver key under the mat, jumped ove | Spot the expanded noun phrase. Which option is an  | The correct answer is: the silver key under the mat. |
+| expanded_noun_phrase_choice | 2 | single_choice | The tired explorers climbed the hill., A | Spot the expanded noun phrase. Which sentence cont | The correct answer is: The tired explorers climbed the hill. |
+| expanded_noun_phrase_choice | 3 | single_choice | The tired explorers climbed the hill., A | Spot the expanded noun phrase. Which sentence cont | The correct answer is: The tired explorers climbed the hill. |
+| expanded_noun_phrase_choice | 4 | single_choice | The tired explorers climbed the hill., A | Spot the expanded noun phrase. Which sentence cont | The correct answer is: The tired explorers climbed the hill. |
+| expanded_noun_phrase_choice | 5 | single_choice | The tired explorers climbed the hill., A | Spot the expanded noun phrase. Which sentence cont | The correct answer is: The tired explorers climbed the hill. |
+| expanded_noun_phrase_choice | 6 | single_choice | the silver key under the mat, jumped ove | Spot the expanded noun phrase. Which option is an  | The correct answer is: the silver key under the mat. |
+| expanded_noun_phrase_choice | 7 | single_choice | the tall boy with muddy boots, ran acros | Spot the expanded noun phrase. Which option is an  | The correct answer is: the tall boy with muddy boots. |
+| expanded_noun_phrase_choice | 8 | single_choice | the tall boy with muddy boots, ran acros | Spot the expanded noun phrase. Which option is an  | The correct answer is: the tall boy with muddy boots. |
+| expanded_noun_phrase_choice | 9 | single_choice | the tall boy with muddy boots, ran acros | Spot the expanded noun phrase. Which option is an  | The correct answer is: the tall boy with muddy boots. |
+| expanded_noun_phrase_choice | 10 | single_choice | the silver key under the mat, jumped ove | Spot the expanded noun phrase. Which option is an  | The correct answer is: the silver key under the mat. |
+| expanded_noun_phrase_choice | 11 | single_choice | the silver key under the mat, jumped ove | Spot the expanded noun phrase. Which option is an  | The correct answer is: the silver key under the mat. |
+| expanded_noun_phrase_choice | 12 | single_choice | the tall boy with muddy boots, ran acros | Spot the expanded noun phrase. Which option is an  | The correct answer is: the tall boy with muddy boots. |
+| expanded_noun_phrase_choice | 13 | single_choice | the silver key under the mat, jumped ove | Spot the expanded noun phrase. Which option is an  | The correct answer is: the silver key under the mat. |
+| expanded_noun_phrase_choice | 14 | single_choice | the silver key under the mat, jumped ove | Spot the expanded noun phrase. Which option is an  | The correct answer is: the silver key under the mat. |
+| expanded_noun_phrase_choice | 15 | single_choice | the tall boy with muddy boots, ran acros | Spot the expanded noun phrase. Which option is an  | The correct answer is: the tall boy with muddy boots. |
+| expanded_noun_phrase_choice | 16 | single_choice | the silver key under the mat, jumped ove | Spot the expanded noun phrase. Which option is an  | The correct answer is: the silver key under the mat. |
+| expanded_noun_phrase_choice | 17 | single_choice | The tired explorers climbed the hill., A | Spot the expanded noun phrase. Which sentence cont | The correct answer is: The tired explorers climbed the hill. |
+| expanded_noun_phrase_choice | 18 | single_choice | the silver key under the mat, jumped ove | Spot the expanded noun phrase. Which option is an  | The correct answer is: the silver key under the mat. |
+| expanded_noun_phrase_choice | 19 | single_choice | the tall boy with muddy boots, ran acros | Spot the expanded noun phrase. Which option is an  | The correct answer is: the tall boy with muddy boots. |
+| expanded_noun_phrase_choice | 20 | single_choice | The tired explorers climbed the hill., A | Spot the expanded noun phrase. Which sentence cont | The correct answer is: The tired explorers climbed the hill. |
+| expanded_noun_phrase_choice | 21 | single_choice | the silver key under the mat, jumped ove | Spot the expanded noun phrase. Which option is an  | The correct answer is: the silver key under the mat. |
+| expanded_noun_phrase_choice | 22 | single_choice | the silver key under the mat, jumped ove | Spot the expanded noun phrase. Which option is an  | The correct answer is: the silver key under the mat. |
+| expanded_noun_phrase_choice | 23 | single_choice | the tall boy with muddy boots, ran acros | Spot the expanded noun phrase. Which option is an  | The correct answer is: the tall boy with muddy boots. |
+| expanded_noun_phrase_choice | 24 | single_choice | the tall boy with muddy boots, ran acros | Spot the expanded noun phrase. Which option is an  | The correct answer is: the tall boy with muddy boots. |
+| expanded_noun_phrase_choice | 25 | single_choice | the silver key under the mat, jumped ove | Spot the expanded noun phrase. Which option is an  | The correct answer is: the silver key under the mat. |
+| expanded_noun_phrase_choice | 26 | single_choice | the silver key under the mat, jumped ove | Spot the expanded noun phrase. Which option is an  | The correct answer is: the silver key under the mat. |
+| expanded_noun_phrase_choice | 27 | single_choice | the silver key under the mat, jumped ove | Spot the expanded noun phrase. Which option is an  | The correct answer is: the silver key under the mat. |
+| expanded_noun_phrase_choice | 28 | single_choice | the silver key under the mat, jumped ove | Spot the expanded noun phrase. Which option is an  | The correct answer is: the silver key under the mat. |
+| expanded_noun_phrase_choice | 29 | single_choice | the tall boy with muddy boots, ran acros | Spot the expanded noun phrase. Which option is an  | The correct answer is: the tall boy with muddy boots. |
+| expanded_noun_phrase_choice | 30 | single_choice | The tired explorers climbed the hill., A | Spot the expanded noun phrase. Which sentence cont | The correct answer is: The tired explorers climbed the hill. |
+| build_noun_phrase | 1 | multi | 3 rows/fields | Build a noun phrase of at least three words to com | Your noun phrase has been saved for review. It is not auto-m |
+| build_noun_phrase | 2 | multi | 3 rows/fields | Build a noun phrase of at least three words to com | Your noun phrase has been saved for review. It is not auto-m |
+| build_noun_phrase | 3 | multi | 3 rows/fields | Build a noun phrase of at least three words to com | Your noun phrase has been saved for review. It is not auto-m |
+| build_noun_phrase | 4 | multi | 3 rows/fields | Build a noun phrase of at least three words to com | Your noun phrase has been saved for review. It is not auto-m |
+| build_noun_phrase | 5 | multi | 3 rows/fields | Build a noun phrase of at least three words to com | Your noun phrase has been saved for review. It is not auto-m |
+| build_noun_phrase | 6 | multi | 3 rows/fields | Build a noun phrase of at least three words to com | Your noun phrase has been saved for review. It is not auto-m |
+| build_noun_phrase | 7 | multi | 3 rows/fields | Build a noun phrase of at least three words to com | Your noun phrase has been saved for review. It is not auto-m |
+| build_noun_phrase | 8 | multi | 3 rows/fields | Build a noun phrase of at least three words to com | Your noun phrase has been saved for review. It is not auto-m |
+| build_noun_phrase | 9 | multi | 3 rows/fields | Build a noun phrase of at least three words to com | Your noun phrase has been saved for review. It is not auto-m |
+| build_noun_phrase | 10 | multi | 3 rows/fields | Build a noun phrase of at least three words to com | Your noun phrase has been saved for review. It is not auto-m |
+| build_noun_phrase | 11 | multi | 3 rows/fields | Build a noun phrase of at least three words to com | Your noun phrase has been saved for review. It is not auto-m |
+| build_noun_phrase | 12 | multi | 3 rows/fields | Build a noun phrase of at least three words to com | Your noun phrase has been saved for review. It is not auto-m |
+| build_noun_phrase | 13 | multi | 3 rows/fields | Build a noun phrase of at least three words to com | Your noun phrase has been saved for review. It is not auto-m |
+| build_noun_phrase | 14 | multi | 3 rows/fields | Build a noun phrase of at least three words to com | Your noun phrase has been saved for review. It is not auto-m |
+| build_noun_phrase | 15 | multi | 3 rows/fields | Build a noun phrase of at least three words to com | Your noun phrase has been saved for review. It is not auto-m |
+| build_noun_phrase | 16 | multi | 3 rows/fields | Build a noun phrase of at least three words to com | Your noun phrase has been saved for review. It is not auto-m |
+| build_noun_phrase | 17 | multi | 3 rows/fields | Build a noun phrase of at least three words to com | Your noun phrase has been saved for review. It is not auto-m |
+| build_noun_phrase | 18 | multi | 3 rows/fields | Build a noun phrase of at least three words to com | Your noun phrase has been saved for review. It is not auto-m |
+| build_noun_phrase | 19 | multi | 3 rows/fields | Build a noun phrase of at least three words to com | Your noun phrase has been saved for review. It is not auto-m |
+| build_noun_phrase | 20 | multi | 3 rows/fields | Build a noun phrase of at least three words to com | Your noun phrase has been saved for review. It is not auto-m |
+| build_noun_phrase | 21 | multi | 3 rows/fields | Build a noun phrase of at least three words to com | Your noun phrase has been saved for review. It is not auto-m |
+| build_noun_phrase | 22 | multi | 3 rows/fields | Build a noun phrase of at least three words to com | Your noun phrase has been saved for review. It is not auto-m |
+| build_noun_phrase | 23 | multi | 3 rows/fields | Build a noun phrase of at least three words to com | Your noun phrase has been saved for review. It is not auto-m |
+| build_noun_phrase | 24 | multi | 3 rows/fields | Build a noun phrase of at least three words to com | Your noun phrase has been saved for review. It is not auto-m |
+| build_noun_phrase | 25 | multi | 3 rows/fields | Build a noun phrase of at least three words to com | Your noun phrase has been saved for review. It is not auto-m |
+| build_noun_phrase | 26 | multi | 3 rows/fields | Build a noun phrase of at least three words to com | Your noun phrase has been saved for review. It is not auto-m |
+| build_noun_phrase | 27 | multi | 3 rows/fields | Build a noun phrase of at least three words to com | Your noun phrase has been saved for review. It is not auto-m |
+| build_noun_phrase | 28 | multi | 3 rows/fields | Build a noun phrase of at least three words to com | Your noun phrase has been saved for review. It is not auto-m |
+| build_noun_phrase | 29 | multi | 3 rows/fields | Build a noun phrase of at least three words to com | Your noun phrase has been saved for review. It is not auto-m |
+| build_noun_phrase | 30 | multi | 3 rows/fields | Build a noun phrase of at least three words to com | Your noun phrase has been saved for review. It is not auto-m |
+| fronted_adverbial_choose | 1 | single_choice | In the morning, the market opens early., | Spot the fronted adverbial. Which sentence starts  | The correct answer is: In the morning, the market opens earl |
+| fronted_adverbial_choose | 2 | single_choice | She is feeling tired, so Kal is going to | Spot the fronted adverbial. Which sentence starts  | The correct answer is: After dinner, Kal is going to her roo |
+| fronted_adverbial_choose | 3 | single_choice | In the morning, the market opens early., | Spot the fronted adverbial. Which sentence starts  | The correct answer is: In the morning, the market opens earl |
+| fronted_adverbial_choose | 4 | single_choice | She is feeling tired, so Kal is going to | Spot the fronted adverbial. Which sentence starts  | The correct answer is: After dinner, Kal is going to her roo |
+| fronted_adverbial_choose | 5 | single_choice | In the morning, the market opens early., | Spot the fronted adverbial. Which sentence starts  | The correct answer is: In the morning, the market opens earl |
+| fronted_adverbial_choose | 6 | single_choice | She is feeling tired, so Kal is going to | Spot the fronted adverbial. Which sentence starts  | The correct answer is: After dinner, Kal is going to her roo |
+| fronted_adverbial_choose | 7 | single_choice | In the morning, the market opens early., | Spot the fronted adverbial. Which sentence starts  | The correct answer is: In the morning, the market opens earl |
+| fronted_adverbial_choose | 8 | single_choice | She is feeling tired, so Kal is going to | Spot the fronted adverbial. Which sentence starts  | The correct answer is: After dinner, Kal is going to her roo |
+| fronted_adverbial_choose | 9 | single_choice | In the morning, the market opens early., | Spot the fronted adverbial. Which sentence starts  | The correct answer is: In the morning, the market opens earl |
+| fronted_adverbial_choose | 10 | single_choice | She is feeling tired, so Kal is going to | Spot the fronted adverbial. Which sentence starts  | The correct answer is: After dinner, Kal is going to her roo |
+| fronted_adverbial_choose | 11 | single_choice | In the morning, the market opens early., | Spot the fronted adverbial. Which sentence starts  | The correct answer is: In the morning, the market opens earl |
+| fronted_adverbial_choose | 12 | single_choice | She is feeling tired, so Kal is going to | Spot the fronted adverbial. Which sentence starts  | The correct answer is: After dinner, Kal is going to her roo |
+| fronted_adverbial_choose | 13 | single_choice | In the morning, the market opens early., | Spot the fronted adverbial. Which sentence starts  | The correct answer is: In the morning, the market opens earl |
+| fronted_adverbial_choose | 14 | single_choice | She is feeling tired, so Kal is going to | Spot the fronted adverbial. Which sentence starts  | The correct answer is: After dinner, Kal is going to her roo |
+| fronted_adverbial_choose | 15 | single_choice | In the morning, the market opens early., | Spot the fronted adverbial. Which sentence starts  | The correct answer is: In the morning, the market opens earl |
+| fronted_adverbial_choose | 16 | single_choice | She is feeling tired, so Kal is going to | Spot the fronted adverbial. Which sentence starts  | The correct answer is: After dinner, Kal is going to her roo |
+| fronted_adverbial_choose | 17 | single_choice | In the morning, the market opens early., | Spot the fronted adverbial. Which sentence starts  | The correct answer is: In the morning, the market opens earl |
+| fronted_adverbial_choose | 18 | single_choice | She is feeling tired, so Kal is going to | Spot the fronted adverbial. Which sentence starts  | The correct answer is: After dinner, Kal is going to her roo |
+| fronted_adverbial_choose | 19 | single_choice | In the morning, the market opens early., | Spot the fronted adverbial. Which sentence starts  | The correct answer is: In the morning, the market opens earl |
+| fronted_adverbial_choose | 20 | single_choice | She is feeling tired, so Kal is going to | Spot the fronted adverbial. Which sentence starts  | The correct answer is: After dinner, Kal is going to her roo |
+| fronted_adverbial_choose | 21 | single_choice | In the morning, the market opens early., | Spot the fronted adverbial. Which sentence starts  | The correct answer is: In the morning, the market opens earl |
+| fronted_adverbial_choose | 22 | single_choice | She is feeling tired, so Kal is going to | Spot the fronted adverbial. Which sentence starts  | The correct answer is: After dinner, Kal is going to her roo |
+| fronted_adverbial_choose | 23 | single_choice | In the morning, the market opens early., | Spot the fronted adverbial. Which sentence starts  | The correct answer is: In the morning, the market opens earl |
+| fronted_adverbial_choose | 24 | single_choice | She is feeling tired, so Kal is going to | Spot the fronted adverbial. Which sentence starts  | The correct answer is: After dinner, Kal is going to her roo |
+| fronted_adverbial_choose | 25 | single_choice | In the morning, the market opens early., | Spot the fronted adverbial. Which sentence starts  | The correct answer is: In the morning, the market opens earl |
+| fronted_adverbial_choose | 26 | single_choice | She is feeling tired, so Kal is going to | Spot the fronted adverbial. Which sentence starts  | The correct answer is: After dinner, Kal is going to her roo |
+| fronted_adverbial_choose | 27 | single_choice | In the morning, the market opens early., | Spot the fronted adverbial. Which sentence starts  | The correct answer is: In the morning, the market opens earl |
+| fronted_adverbial_choose | 28 | single_choice | She is feeling tired, so Kal is going to | Spot the fronted adverbial. Which sentence starts  | The correct answer is: After dinner, Kal is going to her roo |
+| fronted_adverbial_choose | 29 | single_choice | In the morning, the market opens early., | Spot the fronted adverbial. Which sentence starts  | The correct answer is: In the morning, the market opens earl |
+| fronted_adverbial_choose | 30 | single_choice | She is feeling tired, so Kal is going to | Spot the fronted adverbial. Which sentence starts  | The correct answer is: After dinner, Kal is going to her roo |
+| fix_fronted_adverbial | 1 | textarea | placeholder: Type the corrected sentence | Add the comma after a fronted adverbial. Copy the  | The correct sentence is: After the concert, the audience che |
+| fix_fronted_adverbial | 2 | textarea | placeholder: Type the corrected sentence | Add the comma after a fronted adverbial. Copy the  | The correct sentence is: Later that afternoon, our team fina |
+| fix_fronted_adverbial | 3 | textarea | placeholder: Type the corrected sentence | Add the comma after a fronted adverbial. Copy the  | The correct sentence is: Before sunrise, the campers packed  |
+| fix_fronted_adverbial | 4 | textarea | placeholder: Type the corrected sentence | Add the comma after a fronted adverbial. Copy the  | The correct sentence is: After the concert, the audience che |
+| fix_fronted_adverbial | 5 | textarea | placeholder: Type the corrected sentence | Add the comma after a fronted adverbial. Copy the  | The correct sentence is: Later that afternoon, our team fina |
+| fix_fronted_adverbial | 6 | textarea | placeholder: Type the corrected sentence | Add the comma after a fronted adverbial. Copy the  | The correct sentence is: Before sunrise, the campers packed  |
+| fix_fronted_adverbial | 7 | textarea | placeholder: Type the corrected sentence | Add the comma after a fronted adverbial. Copy the  | The correct sentence is: After the concert, the audience che |
+| fix_fronted_adverbial | 8 | textarea | placeholder: Type the corrected sentence | Add the comma after a fronted adverbial. Copy the  | The correct sentence is: Later that afternoon, our team fina |
+| fix_fronted_adverbial | 9 | textarea | placeholder: Type the corrected sentence | Add the comma after a fronted adverbial. Copy the  | The correct sentence is: Before sunrise, the campers packed  |
+| fix_fronted_adverbial | 10 | textarea | placeholder: Type the corrected sentence | Add the comma after a fronted adverbial. Copy the  | The correct sentence is: After the concert, the audience che |
+| fix_fronted_adverbial | 11 | textarea | placeholder: Type the corrected sentence | Add the comma after a fronted adverbial. Copy the  | The correct sentence is: Later that afternoon, our team fina |
+| fix_fronted_adverbial | 12 | textarea | placeholder: Type the corrected sentence | Add the comma after a fronted adverbial. Copy the  | The correct sentence is: Before sunrise, the campers packed  |
+| fix_fronted_adverbial | 13 | textarea | placeholder: Type the corrected sentence | Add the comma after a fronted adverbial. Copy the  | The correct sentence is: After the concert, the audience che |
+| fix_fronted_adverbial | 14 | textarea | placeholder: Type the corrected sentence | Add the comma after a fronted adverbial. Copy the  | The correct sentence is: Later that afternoon, our team fina |
+| fix_fronted_adverbial | 15 | textarea | placeholder: Type the corrected sentence | Add the comma after a fronted adverbial. Copy the  | The correct sentence is: Before sunrise, the campers packed  |
+| fix_fronted_adverbial | 16 | textarea | placeholder: Type the corrected sentence | Add the comma after a fronted adverbial. Copy the  | The correct sentence is: After the concert, the audience che |
+| fix_fronted_adverbial | 17 | textarea | placeholder: Type the corrected sentence | Add the comma after a fronted adverbial. Copy the  | The correct sentence is: Later that afternoon, our team fina |
+| fix_fronted_adverbial | 18 | textarea | placeholder: Type the corrected sentence | Add the comma after a fronted adverbial. Copy the  | The correct sentence is: Before sunrise, the campers packed  |
+| fix_fronted_adverbial | 19 | textarea | placeholder: Type the corrected sentence | Add the comma after a fronted adverbial. Copy the  | The correct sentence is: After the concert, the audience che |
+| fix_fronted_adverbial | 20 | textarea | placeholder: Type the corrected sentence | Add the comma after a fronted adverbial. Copy the  | The correct sentence is: Later that afternoon, our team fina |
+| fix_fronted_adverbial | 21 | textarea | placeholder: Type the corrected sentence | Add the comma after a fronted adverbial. Copy the  | The correct sentence is: Before sunrise, the campers packed  |
+| fix_fronted_adverbial | 22 | textarea | placeholder: Type the corrected sentence | Add the comma after a fronted adverbial. Copy the  | The correct sentence is: After the concert, the audience che |
+| fix_fronted_adverbial | 23 | textarea | placeholder: Type the corrected sentence | Add the comma after a fronted adverbial. Copy the  | The correct sentence is: Later that afternoon, our team fina |
+| fix_fronted_adverbial | 24 | textarea | placeholder: Type the corrected sentence | Add the comma after a fronted adverbial. Copy the  | The correct sentence is: Before sunrise, the campers packed  |
+| fix_fronted_adverbial | 25 | textarea | placeholder: Type the corrected sentence | Add the comma after a fronted adverbial. Copy the  | The correct sentence is: After the concert, the audience che |
+| fix_fronted_adverbial | 26 | textarea | placeholder: Type the corrected sentence | Add the comma after a fronted adverbial. Copy the  | The correct sentence is: Later that afternoon, our team fina |
+| fix_fronted_adverbial | 27 | textarea | placeholder: Type the corrected sentence | Add the comma after a fronted adverbial. Copy the  | The correct sentence is: Before sunrise, the campers packed  |
+| fix_fronted_adverbial | 28 | textarea | placeholder: Type the corrected sentence | Add the comma after a fronted adverbial. Copy the  | The correct sentence is: After the concert, the audience che |
+| fix_fronted_adverbial | 29 | textarea | placeholder: Type the corrected sentence | Add the comma after a fronted adverbial. Copy the  | The correct sentence is: Later that afternoon, our team fina |
+| fix_fronted_adverbial | 30 | textarea | placeholder: Type the corrected sentence | Add the comma after a fronted adverbial. Copy the  | The correct sentence is: Before sunrise, the campers packed  |
+| subordinate_clause_choice | 1 | single_choice | the pupils lined up quietly, When the be | Which option is the subordinate clause in the sent | The subordinate clause is: When the bell rang. |
+| subordinate_clause_choice | 2 | single_choice | wear your boots, If the path is icy, the | Which option is the subordinate clause in the sent | The subordinate clause is: If the path is icy. |
+| subordinate_clause_choice | 3 | single_choice | Although the wind was strong, the boat r | Which option is the subordinate clause in the sent | The subordinate clause is: Although the wind was strong. |
+| subordinate_clause_choice | 4 | single_choice | the pupils lined up quietly, When the be | Which option is the subordinate clause in the sent | The subordinate clause is: When the bell rang. |
+| subordinate_clause_choice | 5 | single_choice | wear your boots, If the path is icy, the | Which option is the subordinate clause in the sent | The subordinate clause is: If the path is icy. |
+| subordinate_clause_choice | 6 | single_choice | Although the wind was strong, the boat r | Which option is the subordinate clause in the sent | The subordinate clause is: Although the wind was strong. |
+| subordinate_clause_choice | 7 | single_choice | the pupils lined up quietly, When the be | Which option is the subordinate clause in the sent | The subordinate clause is: When the bell rang. |
+| subordinate_clause_choice | 8 | single_choice | wear your boots, If the path is icy, the | Which option is the subordinate clause in the sent | The subordinate clause is: If the path is icy. |
+| subordinate_clause_choice | 9 | single_choice | Although the wind was strong, the boat r | Which option is the subordinate clause in the sent | The subordinate clause is: Although the wind was strong. |
+| subordinate_clause_choice | 10 | single_choice | the pupils lined up quietly, When the be | Which option is the subordinate clause in the sent | The subordinate clause is: When the bell rang. |
+| subordinate_clause_choice | 11 | single_choice | wear your boots, If the path is icy, the | Which option is the subordinate clause in the sent | The subordinate clause is: If the path is icy. |
+| subordinate_clause_choice | 12 | single_choice | Although the wind was strong, the boat r | Which option is the subordinate clause in the sent | The subordinate clause is: Although the wind was strong. |
+| subordinate_clause_choice | 13 | single_choice | the pupils lined up quietly, When the be | Which option is the subordinate clause in the sent | The subordinate clause is: When the bell rang. |
+| subordinate_clause_choice | 14 | single_choice | wear your boots, If the path is icy, the | Which option is the subordinate clause in the sent | The subordinate clause is: If the path is icy. |
+| subordinate_clause_choice | 15 | single_choice | Although the wind was strong, the boat r | Which option is the subordinate clause in the sent | The subordinate clause is: Although the wind was strong. |
+| subordinate_clause_choice | 16 | single_choice | the pupils lined up quietly, When the be | Which option is the subordinate clause in the sent | The subordinate clause is: When the bell rang. |
+| subordinate_clause_choice | 17 | single_choice | wear your boots, If the path is icy, the | Which option is the subordinate clause in the sent | The subordinate clause is: If the path is icy. |
+| subordinate_clause_choice | 18 | single_choice | Although the wind was strong, the boat r | Which option is the subordinate clause in the sent | The subordinate clause is: Although the wind was strong. |
+| subordinate_clause_choice | 19 | single_choice | the pupils lined up quietly, When the be | Which option is the subordinate clause in the sent | The subordinate clause is: When the bell rang. |
+| subordinate_clause_choice | 20 | single_choice | wear your boots, If the path is icy, the | Which option is the subordinate clause in the sent | The subordinate clause is: If the path is icy. |
+| subordinate_clause_choice | 21 | single_choice | Although the wind was strong, the boat r | Which option is the subordinate clause in the sent | The subordinate clause is: Although the wind was strong. |
+| subordinate_clause_choice | 22 | single_choice | the pupils lined up quietly, When the be | Which option is the subordinate clause in the sent | The subordinate clause is: When the bell rang. |
+| subordinate_clause_choice | 23 | single_choice | wear your boots, If the path is icy, the | Which option is the subordinate clause in the sent | The subordinate clause is: If the path is icy. |
+| subordinate_clause_choice | 24 | single_choice | Although the wind was strong, the boat r | Which option is the subordinate clause in the sent | The subordinate clause is: Although the wind was strong. |
+| subordinate_clause_choice | 25 | single_choice | the pupils lined up quietly, When the be | Which option is the subordinate clause in the sent | The subordinate clause is: When the bell rang. |
+| subordinate_clause_choice | 26 | single_choice | wear your boots, If the path is icy, the | Which option is the subordinate clause in the sent | The subordinate clause is: If the path is icy. |
+| subordinate_clause_choice | 27 | single_choice | Although the wind was strong, the boat r | Which option is the subordinate clause in the sent | The subordinate clause is: Although the wind was strong. |
+| subordinate_clause_choice | 28 | single_choice | the pupils lined up quietly, When the be | Which option is the subordinate clause in the sent | The subordinate clause is: When the bell rang. |
+| subordinate_clause_choice | 29 | single_choice | wear your boots, If the path is icy, the | Which option is the subordinate clause in the sent | The subordinate clause is: If the path is icy. |
+| subordinate_clause_choice | 30 | single_choice | Although the wind was strong, the boat r | Which option is the subordinate clause in the sent | The subordinate clause is: Although the wind was strong. |
+| combine_clauses_rewrite | 1 | textarea | placeholder: Write one complete sentence | Combine ideas into one sentence. Combine the ideas | A correct answer is: Sam wore gloves because it was cold. |
+| combine_clauses_rewrite | 2 | textarea | placeholder: Write one complete sentence | Combine ideas into one sentence. Combine the ideas | A correct answer is: When the bell rang, the pupils lined up |
+| combine_clauses_rewrite | 3 | textarea | placeholder: Write one complete sentence | Combine ideas into one sentence. Combine the ideas | A correct answer is: Although Mia was tired, she finished th |
+| combine_clauses_rewrite | 4 | textarea | placeholder: Write one complete sentence | Combine ideas into one sentence. Combine the ideas | A correct answer is: Sam wore gloves because it was cold. |
+| combine_clauses_rewrite | 5 | textarea | placeholder: Write one complete sentence | Combine ideas into one sentence. Combine the ideas | A correct answer is: When the bell rang, the pupils lined up |
+| combine_clauses_rewrite | 6 | textarea | placeholder: Write one complete sentence | Combine ideas into one sentence. Combine the ideas | A correct answer is: Although Mia was tired, she finished th |
+| combine_clauses_rewrite | 7 | textarea | placeholder: Write one complete sentence | Combine ideas into one sentence. Combine the ideas | A correct answer is: Sam wore gloves because it was cold. |
+| combine_clauses_rewrite | 8 | textarea | placeholder: Write one complete sentence | Combine ideas into one sentence. Combine the ideas | A correct answer is: When the bell rang, the pupils lined up |
+| combine_clauses_rewrite | 9 | textarea | placeholder: Write one complete sentence | Combine ideas into one sentence. Combine the ideas | A correct answer is: Although Mia was tired, she finished th |
+| combine_clauses_rewrite | 10 | textarea | placeholder: Write one complete sentence | Combine ideas into one sentence. Combine the ideas | A correct answer is: Sam wore gloves because it was cold. |
+| combine_clauses_rewrite | 11 | textarea | placeholder: Write one complete sentence | Combine ideas into one sentence. Combine the ideas | A correct answer is: When the bell rang, the pupils lined up |
+| combine_clauses_rewrite | 12 | textarea | placeholder: Write one complete sentence | Combine ideas into one sentence. Combine the ideas | A correct answer is: Although Mia was tired, she finished th |
+| combine_clauses_rewrite | 13 | textarea | placeholder: Write one complete sentence | Combine ideas into one sentence. Combine the ideas | A correct answer is: Sam wore gloves because it was cold. |
+| combine_clauses_rewrite | 14 | textarea | placeholder: Write one complete sentence | Combine ideas into one sentence. Combine the ideas | A correct answer is: When the bell rang, the pupils lined up |
+| combine_clauses_rewrite | 15 | textarea | placeholder: Write one complete sentence | Combine ideas into one sentence. Combine the ideas | A correct answer is: Although Mia was tired, she finished th |
+| combine_clauses_rewrite | 16 | textarea | placeholder: Write one complete sentence | Combine ideas into one sentence. Combine the ideas | A correct answer is: Sam wore gloves because it was cold. |
+| combine_clauses_rewrite | 17 | textarea | placeholder: Write one complete sentence | Combine ideas into one sentence. Combine the ideas | A correct answer is: When the bell rang, the pupils lined up |
+| combine_clauses_rewrite | 18 | textarea | placeholder: Write one complete sentence | Combine ideas into one sentence. Combine the ideas | A correct answer is: Although Mia was tired, she finished th |
+| combine_clauses_rewrite | 19 | textarea | placeholder: Write one complete sentence | Combine ideas into one sentence. Combine the ideas | A correct answer is: Sam wore gloves because it was cold. |
+| combine_clauses_rewrite | 20 | textarea | placeholder: Write one complete sentence | Combine ideas into one sentence. Combine the ideas | A correct answer is: When the bell rang, the pupils lined up |
+| combine_clauses_rewrite | 21 | textarea | placeholder: Write one complete sentence | Combine ideas into one sentence. Combine the ideas | A correct answer is: Although Mia was tired, she finished th |
+| combine_clauses_rewrite | 22 | textarea | placeholder: Write one complete sentence | Combine ideas into one sentence. Combine the ideas | A correct answer is: Sam wore gloves because it was cold. |
+| combine_clauses_rewrite | 23 | textarea | placeholder: Write one complete sentence | Combine ideas into one sentence. Combine the ideas | A correct answer is: When the bell rang, the pupils lined up |
+| combine_clauses_rewrite | 24 | textarea | placeholder: Write one complete sentence | Combine ideas into one sentence. Combine the ideas | A correct answer is: Although Mia was tired, she finished th |
+| combine_clauses_rewrite | 25 | textarea | placeholder: Write one complete sentence | Combine ideas into one sentence. Combine the ideas | A correct answer is: Sam wore gloves because it was cold. |
+| combine_clauses_rewrite | 26 | textarea | placeholder: Write one complete sentence | Combine ideas into one sentence. Combine the ideas | A correct answer is: When the bell rang, the pupils lined up |
+| combine_clauses_rewrite | 27 | textarea | placeholder: Write one complete sentence | Combine ideas into one sentence. Combine the ideas | A correct answer is: Although Mia was tired, she finished th |
+| combine_clauses_rewrite | 28 | textarea | placeholder: Write one complete sentence | Combine ideas into one sentence. Combine the ideas | A correct answer is: Sam wore gloves because it was cold. |
+| combine_clauses_rewrite | 29 | textarea | placeholder: Write one complete sentence | Combine ideas into one sentence. Combine the ideas | A correct answer is: When the bell rang, the pupils lined up |
+| combine_clauses_rewrite | 30 | textarea | placeholder: Write one complete sentence | Combine ideas into one sentence. Combine the ideas | A correct answer is: Although Mia was tired, she finished th |
+| relative_clause_identify | 1 | single_choice | The book that I borrowed was brilliant., | Spot the relative clause. Which sentence contains  | The correct sentence is: The book that I borrowed was brilli |
+| relative_clause_identify | 2 | single_choice | The village, which sits by the sea, is v | Spot the relative clause. Which sentence contains  | The correct sentence is: The village, which sits by the sea, |
+| relative_clause_identify | 3 | single_choice | The boy who dropped his hat waved to us. | Spot the relative clause. Which sentence contains  | The correct sentence is: The boy who dropped his hat waved t |
+| relative_clause_identify | 4 | single_choice | The book that I borrowed was brilliant., | Spot the relative clause. Which sentence contains  | The correct sentence is: The book that I borrowed was brilli |
+| relative_clause_identify | 5 | single_choice | The village, which sits by the sea, is v | Spot the relative clause. Which sentence contains  | The correct sentence is: The village, which sits by the sea, |
+| relative_clause_identify | 6 | single_choice | The boy who dropped his hat waved to us. | Spot the relative clause. Which sentence contains  | The correct sentence is: The boy who dropped his hat waved t |
+| relative_clause_identify | 7 | single_choice | The book that I borrowed was brilliant., | Spot the relative clause. Which sentence contains  | The correct sentence is: The book that I borrowed was brilli |
+| relative_clause_identify | 8 | single_choice | The village, which sits by the sea, is v | Spot the relative clause. Which sentence contains  | The correct sentence is: The village, which sits by the sea, |
+| relative_clause_identify | 9 | single_choice | The boy who dropped his hat waved to us. | Spot the relative clause. Which sentence contains  | The correct sentence is: The boy who dropped his hat waved t |
+| relative_clause_identify | 10 | single_choice | The book that I borrowed was brilliant., | Spot the relative clause. Which sentence contains  | The correct sentence is: The book that I borrowed was brilli |
+| relative_clause_identify | 11 | single_choice | The village, which sits by the sea, is v | Spot the relative clause. Which sentence contains  | The correct sentence is: The village, which sits by the sea, |
+| relative_clause_identify | 12 | single_choice | The boy who dropped his hat waved to us. | Spot the relative clause. Which sentence contains  | The correct sentence is: The boy who dropped his hat waved t |
+| relative_clause_identify | 13 | single_choice | The book that I borrowed was brilliant., | Spot the relative clause. Which sentence contains  | The correct sentence is: The book that I borrowed was brilli |
+| relative_clause_identify | 14 | single_choice | The village, which sits by the sea, is v | Spot the relative clause. Which sentence contains  | The correct sentence is: The village, which sits by the sea, |
+| relative_clause_identify | 15 | single_choice | The boy who dropped his hat waved to us. | Spot the relative clause. Which sentence contains  | The correct sentence is: The boy who dropped his hat waved t |
+| relative_clause_identify | 16 | single_choice | The book that I borrowed was brilliant., | Spot the relative clause. Which sentence contains  | The correct sentence is: The book that I borrowed was brilli |
+| relative_clause_identify | 17 | single_choice | The village, which sits by the sea, is v | Spot the relative clause. Which sentence contains  | The correct sentence is: The village, which sits by the sea, |
+| relative_clause_identify | 18 | single_choice | The boy who dropped his hat waved to us. | Spot the relative clause. Which sentence contains  | The correct sentence is: The boy who dropped his hat waved t |
+| relative_clause_identify | 19 | single_choice | The book that I borrowed was brilliant., | Spot the relative clause. Which sentence contains  | The correct sentence is: The book that I borrowed was brilli |
+| relative_clause_identify | 20 | single_choice | The village, which sits by the sea, is v | Spot the relative clause. Which sentence contains  | The correct sentence is: The village, which sits by the sea, |
+| relative_clause_identify | 21 | single_choice | The boy who dropped his hat waved to us. | Spot the relative clause. Which sentence contains  | The correct sentence is: The boy who dropped his hat waved t |
+| relative_clause_identify | 22 | single_choice | The book that I borrowed was brilliant., | Spot the relative clause. Which sentence contains  | The correct sentence is: The book that I borrowed was brilli |
+| relative_clause_identify | 23 | single_choice | The village, which sits by the sea, is v | Spot the relative clause. Which sentence contains  | The correct sentence is: The village, which sits by the sea, |
+| relative_clause_identify | 24 | single_choice | The boy who dropped his hat waved to us. | Spot the relative clause. Which sentence contains  | The correct sentence is: The boy who dropped his hat waved t |
+| relative_clause_identify | 25 | single_choice | The book that I borrowed was brilliant., | Spot the relative clause. Which sentence contains  | The correct sentence is: The book that I borrowed was brilli |
+| relative_clause_identify | 26 | single_choice | The village, which sits by the sea, is v | Spot the relative clause. Which sentence contains  | The correct sentence is: The village, which sits by the sea, |
+| relative_clause_identify | 27 | single_choice | The boy who dropped his hat waved to us. | Spot the relative clause. Which sentence contains  | The correct sentence is: The boy who dropped his hat waved t |
+| relative_clause_identify | 28 | single_choice | The book that I borrowed was brilliant., | Spot the relative clause. Which sentence contains  | The correct sentence is: The book that I borrowed was brilli |
+| relative_clause_identify | 29 | single_choice | The village, which sits by the sea, is v | Spot the relative clause. Which sentence contains  | The correct sentence is: The village, which sits by the sea, |
+| relative_clause_identify | 30 | single_choice | The boy who dropped his hat waved to us. | Spot the relative clause. Which sentence contains  | The correct sentence is: The boy who dropped his hat waved t |
+| relative_clause_complete | 1 | single_choice | who had visited Egypt, because she visit | Complete with a relative clause. Complete the sent | The best completion is: who had visited Egypt. |
+| relative_clause_complete | 2 | single_choice | that was locked outside, because it was  | Complete with a relative clause. Complete the sent | The best completion is: that was locked outside. |
+| relative_clause_complete | 3 | single_choice | who had visited Egypt, because she visit | Complete with a relative clause. Complete the sent | The best completion is: who had visited Egypt. |
+| relative_clause_complete | 4 | single_choice | that was locked outside, because it was  | Complete with a relative clause. Complete the sent | The best completion is: that was locked outside. |
+| relative_clause_complete | 5 | single_choice | who had visited Egypt, because she visit | Complete with a relative clause. Complete the sent | The best completion is: who had visited Egypt. |
+| relative_clause_complete | 6 | single_choice | that was locked outside, because it was  | Complete with a relative clause. Complete the sent | The best completion is: that was locked outside. |
+| relative_clause_complete | 7 | single_choice | who had visited Egypt, because she visit | Complete with a relative clause. Complete the sent | The best completion is: who had visited Egypt. |
+| relative_clause_complete | 8 | single_choice | that was locked outside, because it was  | Complete with a relative clause. Complete the sent | The best completion is: that was locked outside. |
+| relative_clause_complete | 9 | single_choice | who had visited Egypt, because she visit | Complete with a relative clause. Complete the sent | The best completion is: who had visited Egypt. |
+| relative_clause_complete | 10 | single_choice | that was locked outside, because it was  | Complete with a relative clause. Complete the sent | The best completion is: that was locked outside. |
+| relative_clause_complete | 11 | single_choice | who had visited Egypt, because she visit | Complete with a relative clause. Complete the sent | The best completion is: who had visited Egypt. |
+| relative_clause_complete | 12 | single_choice | that was locked outside, because it was  | Complete with a relative clause. Complete the sent | The best completion is: that was locked outside. |
+| relative_clause_complete | 13 | single_choice | who had visited Egypt, because she visit | Complete with a relative clause. Complete the sent | The best completion is: who had visited Egypt. |
+| relative_clause_complete | 14 | single_choice | that was locked outside, because it was  | Complete with a relative clause. Complete the sent | The best completion is: that was locked outside. |
+| relative_clause_complete | 15 | single_choice | who had visited Egypt, because she visit | Complete with a relative clause. Complete the sent | The best completion is: who had visited Egypt. |
+| relative_clause_complete | 16 | single_choice | that was locked outside, because it was  | Complete with a relative clause. Complete the sent | The best completion is: that was locked outside. |
+| relative_clause_complete | 17 | single_choice | who had visited Egypt, because she visit | Complete with a relative clause. Complete the sent | The best completion is: who had visited Egypt. |
+| relative_clause_complete | 18 | single_choice | that was locked outside, because it was  | Complete with a relative clause. Complete the sent | The best completion is: that was locked outside. |
+| relative_clause_complete | 19 | single_choice | who had visited Egypt, because she visit | Complete with a relative clause. Complete the sent | The best completion is: who had visited Egypt. |
+| relative_clause_complete | 20 | single_choice | that was locked outside, because it was  | Complete with a relative clause. Complete the sent | The best completion is: that was locked outside. |
+| relative_clause_complete | 21 | single_choice | who had visited Egypt, because she visit | Complete with a relative clause. Complete the sent | The best completion is: who had visited Egypt. |
+| relative_clause_complete | 22 | single_choice | that was locked outside, because it was  | Complete with a relative clause. Complete the sent | The best completion is: that was locked outside. |
+| relative_clause_complete | 23 | single_choice | who had visited Egypt, because she visit | Complete with a relative clause. Complete the sent | The best completion is: who had visited Egypt. |
+| relative_clause_complete | 24 | single_choice | that was locked outside, because it was  | Complete with a relative clause. Complete the sent | The best completion is: that was locked outside. |
+| relative_clause_complete | 25 | single_choice | who had visited Egypt, because she visit | Complete with a relative clause. Complete the sent | The best completion is: who had visited Egypt. |
+| relative_clause_complete | 26 | single_choice | that was locked outside, because it was  | Complete with a relative clause. Complete the sent | The best completion is: that was locked outside. |
+| relative_clause_complete | 27 | single_choice | who had visited Egypt, because she visit | Complete with a relative clause. Complete the sent | The best completion is: who had visited Egypt. |
+| relative_clause_complete | 28 | single_choice | that was locked outside, because it was  | Complete with a relative clause. Complete the sent | The best completion is: that was locked outside. |
+| relative_clause_complete | 29 | single_choice | who had visited Egypt, because she visit | Complete with a relative clause. Complete the sent | The best completion is: who had visited Egypt. |
+| relative_clause_complete | 30 | single_choice | that was locked outside, because it was  | Complete with a relative clause. Complete the sent | The best completion is: that was locked outside. |
+| tense_form_choice | 1 | single_choice | talked, have talked, were talking, had t | Choose the correct verb form. Choose the best verb | The correct form is: were talking. |
+| tense_form_choice | 2 | single_choice | has twisted, twisted yesterday, was twis | Choose the correct verb form. Choose the best verb | The correct form is: has twisted. |
+| tense_form_choice | 3 | single_choice | had / started, has / started, was / star | Choose the correct verb form. Choose the best verb | The correct form is: had / started. |
+| tense_form_choice | 4 | single_choice | talked, have talked, were talking, had t | Choose the correct verb form. Choose the best verb | The correct form is: were talking. |
+| tense_form_choice | 5 | single_choice | has twisted, twisted yesterday, was twis | Choose the correct verb form. Choose the best verb | The correct form is: has twisted. |
+| tense_form_choice | 6 | single_choice | had / started, has / started, was / star | Choose the correct verb form. Choose the best verb | The correct form is: had / started. |
+| tense_form_choice | 7 | single_choice | talked, have talked, were talking, had t | Choose the correct verb form. Choose the best verb | The correct form is: were talking. |
+| tense_form_choice | 8 | single_choice | has twisted, twisted yesterday, was twis | Choose the correct verb form. Choose the best verb | The correct form is: has twisted. |
+| tense_form_choice | 9 | single_choice | had / started, has / started, was / star | Choose the correct verb form. Choose the best verb | The correct form is: had / started. |
+| tense_form_choice | 10 | single_choice | talked, have talked, were talking, had t | Choose the correct verb form. Choose the best verb | The correct form is: were talking. |
+| tense_form_choice | 11 | single_choice | has twisted, twisted yesterday, was twis | Choose the correct verb form. Choose the best verb | The correct form is: has twisted. |
+| tense_form_choice | 12 | single_choice | had / started, has / started, was / star | Choose the correct verb form. Choose the best verb | The correct form is: had / started. |
+| tense_form_choice | 13 | single_choice | talked, have talked, were talking, had t | Choose the correct verb form. Choose the best verb | The correct form is: were talking. |
+| tense_form_choice | 14 | single_choice | has twisted, twisted yesterday, was twis | Choose the correct verb form. Choose the best verb | The correct form is: has twisted. |
+| tense_form_choice | 15 | single_choice | had / started, has / started, was / star | Choose the correct verb form. Choose the best verb | The correct form is: had / started. |
+| tense_form_choice | 16 | single_choice | talked, have talked, were talking, had t | Choose the correct verb form. Choose the best verb | The correct form is: were talking. |
+| tense_form_choice | 17 | single_choice | has twisted, twisted yesterday, was twis | Choose the correct verb form. Choose the best verb | The correct form is: has twisted. |
+| tense_form_choice | 18 | single_choice | had / started, has / started, was / star | Choose the correct verb form. Choose the best verb | The correct form is: had / started. |
+| tense_form_choice | 19 | single_choice | talked, have talked, were talking, had t | Choose the correct verb form. Choose the best verb | The correct form is: were talking. |
+| tense_form_choice | 20 | single_choice | has twisted, twisted yesterday, was twis | Choose the correct verb form. Choose the best verb | The correct form is: has twisted. |
+| tense_form_choice | 21 | single_choice | had / started, has / started, was / star | Choose the correct verb form. Choose the best verb | The correct form is: had / started. |
+| tense_form_choice | 22 | single_choice | talked, have talked, were talking, had t | Choose the correct verb form. Choose the best verb | The correct form is: were talking. |
+| tense_form_choice | 23 | single_choice | has twisted, twisted yesterday, was twis | Choose the correct verb form. Choose the best verb | The correct form is: has twisted. |
+| tense_form_choice | 24 | single_choice | had / started, has / started, was / star | Choose the correct verb form. Choose the best verb | The correct form is: had / started. |
+| tense_form_choice | 25 | single_choice | talked, have talked, were talking, had t | Choose the correct verb form. Choose the best verb | The correct form is: were talking. |
+| tense_form_choice | 26 | single_choice | has twisted, twisted yesterday, was twis | Choose the correct verb form. Choose the best verb | The correct form is: has twisted. |
+| tense_form_choice | 27 | single_choice | had / started, has / started, was / star | Choose the correct verb form. Choose the best verb | The correct form is: had / started. |
+| tense_form_choice | 28 | single_choice | talked, have talked, were talking, had t | Choose the correct verb form. Choose the best verb | The correct form is: were talking. |
+| tense_form_choice | 29 | single_choice | has twisted, twisted yesterday, was twis | Choose the correct verb form. Choose the best verb | The correct form is: has twisted. |
+| tense_form_choice | 30 | single_choice | had / started, has / started, was / star | Choose the correct verb form. Choose the best verb | The correct form is: had / started. |
+| tense_rewrite | 1 | textarea | placeholder: Write the full sentence. | Rewrite in a different tense. Rewrite the sentence | A correct answer is: I have finished my homework. |
+| tense_rewrite | 2 | textarea | placeholder: Write the full sentence. | Rewrite in a different tense. Rewrite the sentence | A correct answer is: She had packed her bag before the trip. |
+| tense_rewrite | 3 | textarea | placeholder: Write the full sentence. | Rewrite in a different tense. Rewrite the sentence | A correct answer is: The dog was chasing the cat. |
+| tense_rewrite | 4 | textarea | placeholder: Write the full sentence. | Rewrite in a different tense. Rewrite the sentence | A correct answer is: I have finished my homework. |
+| tense_rewrite | 5 | textarea | placeholder: Write the full sentence. | Rewrite in a different tense. Rewrite the sentence | A correct answer is: She had packed her bag before the trip. |
+| tense_rewrite | 6 | textarea | placeholder: Write the full sentence. | Rewrite in a different tense. Rewrite the sentence | A correct answer is: The dog was chasing the cat. |
+| tense_rewrite | 7 | textarea | placeholder: Write the full sentence. | Rewrite in a different tense. Rewrite the sentence | A correct answer is: I have finished my homework. |
+| tense_rewrite | 8 | textarea | placeholder: Write the full sentence. | Rewrite in a different tense. Rewrite the sentence | A correct answer is: She had packed her bag before the trip. |
+| tense_rewrite | 9 | textarea | placeholder: Write the full sentence. | Rewrite in a different tense. Rewrite the sentence | A correct answer is: The dog was chasing the cat. |
+| tense_rewrite | 10 | textarea | placeholder: Write the full sentence. | Rewrite in a different tense. Rewrite the sentence | A correct answer is: I have finished my homework. |
+| tense_rewrite | 11 | textarea | placeholder: Write the full sentence. | Rewrite in a different tense. Rewrite the sentence | A correct answer is: She had packed her bag before the trip. |
+| tense_rewrite | 12 | textarea | placeholder: Write the full sentence. | Rewrite in a different tense. Rewrite the sentence | A correct answer is: The dog was chasing the cat. |
+| tense_rewrite | 13 | textarea | placeholder: Write the full sentence. | Rewrite in a different tense. Rewrite the sentence | A correct answer is: I have finished my homework. |
+| tense_rewrite | 14 | textarea | placeholder: Write the full sentence. | Rewrite in a different tense. Rewrite the sentence | A correct answer is: She had packed her bag before the trip. |
+| tense_rewrite | 15 | textarea | placeholder: Write the full sentence. | Rewrite in a different tense. Rewrite the sentence | A correct answer is: The dog was chasing the cat. |
+| tense_rewrite | 16 | textarea | placeholder: Write the full sentence. | Rewrite in a different tense. Rewrite the sentence | A correct answer is: I have finished my homework. |
+| tense_rewrite | 17 | textarea | placeholder: Write the full sentence. | Rewrite in a different tense. Rewrite the sentence | A correct answer is: She had packed her bag before the trip. |
+| tense_rewrite | 18 | textarea | placeholder: Write the full sentence. | Rewrite in a different tense. Rewrite the sentence | A correct answer is: The dog was chasing the cat. |
+| tense_rewrite | 19 | textarea | placeholder: Write the full sentence. | Rewrite in a different tense. Rewrite the sentence | A correct answer is: I have finished my homework. |
+| tense_rewrite | 20 | textarea | placeholder: Write the full sentence. | Rewrite in a different tense. Rewrite the sentence | A correct answer is: She had packed her bag before the trip. |
+| tense_rewrite | 21 | textarea | placeholder: Write the full sentence. | Rewrite in a different tense. Rewrite the sentence | A correct answer is: The dog was chasing the cat. |
+| tense_rewrite | 22 | textarea | placeholder: Write the full sentence. | Rewrite in a different tense. Rewrite the sentence | A correct answer is: I have finished my homework. |
+| tense_rewrite | 23 | textarea | placeholder: Write the full sentence. | Rewrite in a different tense. Rewrite the sentence | A correct answer is: She had packed her bag before the trip. |
+| tense_rewrite | 24 | textarea | placeholder: Write the full sentence. | Rewrite in a different tense. Rewrite the sentence | A correct answer is: The dog was chasing the cat. |
+| tense_rewrite | 25 | textarea | placeholder: Write the full sentence. | Rewrite in a different tense. Rewrite the sentence | A correct answer is: I have finished my homework. |
+| tense_rewrite | 26 | textarea | placeholder: Write the full sentence. | Rewrite in a different tense. Rewrite the sentence | A correct answer is: She had packed her bag before the trip. |
+| tense_rewrite | 27 | textarea | placeholder: Write the full sentence. | Rewrite in a different tense. Rewrite the sentence | A correct answer is: The dog was chasing the cat. |
+| tense_rewrite | 28 | textarea | placeholder: Write the full sentence. | Rewrite in a different tense. Rewrite the sentence | A correct answer is: I have finished my homework. |
+| tense_rewrite | 29 | textarea | placeholder: Write the full sentence. | Rewrite in a different tense. Rewrite the sentence | A correct answer is: She had packed her bag before the trip. |
+| tense_rewrite | 30 | textarea | placeholder: Write the full sentence. | Rewrite in a different tense. Rewrite the sentence | A correct answer is: The dog was chasing the cat. |
+| standard_english_pairs | 1 | multi | 2 rows/fields | Choose the Standard English forms. Choose the corr | Correct choices: saw; did. |
+| standard_english_pairs | 2 | multi | 2 rows/fields | Choose the Standard English forms. Choose the corr | Correct choices: were; did. |
+| standard_english_pairs | 3 | multi | 2 rows/fields | Choose the Standard English forms. Choose the corr | Correct choices: saw; did. |
+| standard_english_pairs | 4 | multi | 2 rows/fields | Choose the Standard English forms. Choose the corr | Correct choices: were; did. |
+| standard_english_pairs | 5 | multi | 2 rows/fields | Choose the Standard English forms. Choose the corr | Correct choices: saw; did. |
+| standard_english_pairs | 6 | multi | 2 rows/fields | Choose the Standard English forms. Choose the corr | Correct choices: were; did. |
+| standard_english_pairs | 7 | multi | 2 rows/fields | Choose the Standard English forms. Choose the corr | Correct choices: saw; did. |
+| standard_english_pairs | 8 | multi | 2 rows/fields | Choose the Standard English forms. Choose the corr | Correct choices: were; did. |
+| standard_english_pairs | 9 | multi | 2 rows/fields | Choose the Standard English forms. Choose the corr | Correct choices: saw; did. |
+| standard_english_pairs | 10 | multi | 2 rows/fields | Choose the Standard English forms. Choose the corr | Correct choices: were; did. |
+| standard_english_pairs | 11 | multi | 2 rows/fields | Choose the Standard English forms. Choose the corr | Correct choices: saw; did. |
+| standard_english_pairs | 12 | multi | 2 rows/fields | Choose the Standard English forms. Choose the corr | Correct choices: were; did. |
+| standard_english_pairs | 13 | multi | 2 rows/fields | Choose the Standard English forms. Choose the corr | Correct choices: saw; did. |
+| standard_english_pairs | 14 | multi | 2 rows/fields | Choose the Standard English forms. Choose the corr | Correct choices: were; did. |
+| standard_english_pairs | 15 | multi | 2 rows/fields | Choose the Standard English forms. Choose the corr | Correct choices: saw; did. |
+| standard_english_pairs | 16 | multi | 2 rows/fields | Choose the Standard English forms. Choose the corr | Correct choices: were; did. |
+| standard_english_pairs | 17 | multi | 2 rows/fields | Choose the Standard English forms. Choose the corr | Correct choices: saw; did. |
+| standard_english_pairs | 18 | multi | 2 rows/fields | Choose the Standard English forms. Choose the corr | Correct choices: were; did. |
+| standard_english_pairs | 19 | multi | 2 rows/fields | Choose the Standard English forms. Choose the corr | Correct choices: saw; did. |
+| standard_english_pairs | 20 | multi | 2 rows/fields | Choose the Standard English forms. Choose the corr | Correct choices: were; did. |
+| standard_english_pairs | 21 | multi | 2 rows/fields | Choose the Standard English forms. Choose the corr | Correct choices: saw; did. |
+| standard_english_pairs | 22 | multi | 2 rows/fields | Choose the Standard English forms. Choose the corr | Correct choices: were; did. |
+| standard_english_pairs | 23 | multi | 2 rows/fields | Choose the Standard English forms. Choose the corr | Correct choices: saw; did. |
+| standard_english_pairs | 24 | multi | 2 rows/fields | Choose the Standard English forms. Choose the corr | Correct choices: were; did. |
+| standard_english_pairs | 25 | multi | 2 rows/fields | Choose the Standard English forms. Choose the corr | Correct choices: saw; did. |
+| standard_english_pairs | 26 | multi | 2 rows/fields | Choose the Standard English forms. Choose the corr | Correct choices: were; did. |
+| standard_english_pairs | 27 | multi | 2 rows/fields | Choose the Standard English forms. Choose the corr | Correct choices: saw; did. |
+| standard_english_pairs | 28 | multi | 2 rows/fields | Choose the Standard English forms. Choose the corr | Correct choices: were; did. |
+| standard_english_pairs | 29 | multi | 2 rows/fields | Choose the Standard English forms. Choose the corr | Correct choices: saw; did. |
+| standard_english_pairs | 30 | multi | 2 rows/fields | Choose the Standard English forms. Choose the corr | Correct choices: were; did. |
+| pronoun_cohesion_choice | 1 | single_choice | Arjun gave Arjun's book to Arjun's siste | Choose the clearest cohesive version. Which versio | The clearest version is: Arjun gave his book to his sister b |
+| pronoun_cohesion_choice | 2 | single_choice | Mila put Mila's coat on the chair before | Choose the clearest cohesive version. Which versio | The clearest version is: Mila put her coat on the chair befo |
+| pronoun_cohesion_choice | 3 | single_choice | Arjun gave Arjun's book to Arjun's siste | Choose the clearest cohesive version. Which versio | The clearest version is: Arjun gave his book to his sister b |
+| pronoun_cohesion_choice | 4 | single_choice | Mila put Mila's coat on the chair before | Choose the clearest cohesive version. Which versio | The clearest version is: Mila put her coat on the chair befo |
+| pronoun_cohesion_choice | 5 | single_choice | Arjun gave Arjun's book to Arjun's siste | Choose the clearest cohesive version. Which versio | The clearest version is: Arjun gave his book to his sister b |
+| pronoun_cohesion_choice | 6 | single_choice | Mila put Mila's coat on the chair before | Choose the clearest cohesive version. Which versio | The clearest version is: Mila put her coat on the chair befo |
+| pronoun_cohesion_choice | 7 | single_choice | Arjun gave Arjun's book to Arjun's siste | Choose the clearest cohesive version. Which versio | The clearest version is: Arjun gave his book to his sister b |
+| pronoun_cohesion_choice | 8 | single_choice | Mila put Mila's coat on the chair before | Choose the clearest cohesive version. Which versio | The clearest version is: Mila put her coat on the chair befo |
+| pronoun_cohesion_choice | 9 | single_choice | Arjun gave Arjun's book to Arjun's siste | Choose the clearest cohesive version. Which versio | The clearest version is: Arjun gave his book to his sister b |
+| pronoun_cohesion_choice | 10 | single_choice | Mila put Mila's coat on the chair before | Choose the clearest cohesive version. Which versio | The clearest version is: Mila put her coat on the chair befo |
+| pronoun_cohesion_choice | 11 | single_choice | Arjun gave Arjun's book to Arjun's siste | Choose the clearest cohesive version. Which versio | The clearest version is: Arjun gave his book to his sister b |
+| pronoun_cohesion_choice | 12 | single_choice | Mila put Mila's coat on the chair before | Choose the clearest cohesive version. Which versio | The clearest version is: Mila put her coat on the chair befo |
+| pronoun_cohesion_choice | 13 | single_choice | Arjun gave Arjun's book to Arjun's siste | Choose the clearest cohesive version. Which versio | The clearest version is: Arjun gave his book to his sister b |
+| pronoun_cohesion_choice | 14 | single_choice | Mila put Mila's coat on the chair before | Choose the clearest cohesive version. Which versio | The clearest version is: Mila put her coat on the chair befo |
+| pronoun_cohesion_choice | 15 | single_choice | Arjun gave Arjun's book to Arjun's siste | Choose the clearest cohesive version. Which versio | The clearest version is: Arjun gave his book to his sister b |
+| pronoun_cohesion_choice | 16 | single_choice | Mila put Mila's coat on the chair before | Choose the clearest cohesive version. Which versio | The clearest version is: Mila put her coat on the chair befo |
+| pronoun_cohesion_choice | 17 | single_choice | Arjun gave Arjun's book to Arjun's siste | Choose the clearest cohesive version. Which versio | The clearest version is: Arjun gave his book to his sister b |
+| pronoun_cohesion_choice | 18 | single_choice | Mila put Mila's coat on the chair before | Choose the clearest cohesive version. Which versio | The clearest version is: Mila put her coat on the chair befo |
+| pronoun_cohesion_choice | 19 | single_choice | Arjun gave Arjun's book to Arjun's siste | Choose the clearest cohesive version. Which versio | The clearest version is: Arjun gave his book to his sister b |
+| pronoun_cohesion_choice | 20 | single_choice | Mila put Mila's coat on the chair before | Choose the clearest cohesive version. Which versio | The clearest version is: Mila put her coat on the chair befo |
+| pronoun_cohesion_choice | 21 | single_choice | Arjun gave Arjun's book to Arjun's siste | Choose the clearest cohesive version. Which versio | The clearest version is: Arjun gave his book to his sister b |
+| pronoun_cohesion_choice | 22 | single_choice | Mila put Mila's coat on the chair before | Choose the clearest cohesive version. Which versio | The clearest version is: Mila put her coat on the chair befo |
+| pronoun_cohesion_choice | 23 | single_choice | Arjun gave Arjun's book to Arjun's siste | Choose the clearest cohesive version. Which versio | The clearest version is: Arjun gave his book to his sister b |
+| pronoun_cohesion_choice | 24 | single_choice | Mila put Mila's coat on the chair before | Choose the clearest cohesive version. Which versio | The clearest version is: Mila put her coat on the chair befo |
+| pronoun_cohesion_choice | 25 | single_choice | Arjun gave Arjun's book to Arjun's siste | Choose the clearest cohesive version. Which versio | The clearest version is: Arjun gave his book to his sister b |
+| pronoun_cohesion_choice | 26 | single_choice | Mila put Mila's coat on the chair before | Choose the clearest cohesive version. Which versio | The clearest version is: Mila put her coat on the chair befo |
+| pronoun_cohesion_choice | 27 | single_choice | Arjun gave Arjun's book to Arjun's siste | Choose the clearest cohesive version. Which versio | The clearest version is: Arjun gave his book to his sister b |
+| pronoun_cohesion_choice | 28 | single_choice | Mila put Mila's coat on the chair before | Choose the clearest cohesive version. Which versio | The clearest version is: Mila put her coat on the chair befo |
+| pronoun_cohesion_choice | 29 | single_choice | Arjun gave Arjun's book to Arjun's siste | Choose the clearest cohesive version. Which versio | The clearest version is: Arjun gave his book to his sister b |
+| pronoun_cohesion_choice | 30 | single_choice | Mila put Mila's coat on the chair before | Choose the clearest cohesive version. Which versio | The clearest version is: Mila put her coat on the chair befo |
+| formality_pairs | 1 | multi | 3 rows/fields | Choose the more formal option. Circle the most for | Correct formal choices: discover; enter; request. |
+| formality_pairs | 2 | multi | 3 rows/fields | Choose the more formal option. Circle the most for | Correct formal choices: established; requested; compete. |
+| formality_pairs | 3 | multi | 3 rows/fields | Choose the more formal option. Circle the most for | Correct formal choices: discover; enter; request. |
+| formality_pairs | 4 | multi | 3 rows/fields | Choose the more formal option. Circle the most for | Correct formal choices: established; requested; compete. |
+| formality_pairs | 5 | multi | 3 rows/fields | Choose the more formal option. Circle the most for | Correct formal choices: discover; enter; request. |
+| formality_pairs | 6 | multi | 3 rows/fields | Choose the more formal option. Circle the most for | Correct formal choices: established; requested; compete. |
+| formality_pairs | 7 | multi | 3 rows/fields | Choose the more formal option. Circle the most for | Correct formal choices: discover; enter; request. |
+| formality_pairs | 8 | multi | 3 rows/fields | Choose the more formal option. Circle the most for | Correct formal choices: established; requested; compete. |
+| formality_pairs | 9 | multi | 3 rows/fields | Choose the more formal option. Circle the most for | Correct formal choices: discover; enter; request. |
+| formality_pairs | 10 | multi | 3 rows/fields | Choose the more formal option. Circle the most for | Correct formal choices: established; requested; compete. |
+| formality_pairs | 11 | multi | 3 rows/fields | Choose the more formal option. Circle the most for | Correct formal choices: discover; enter; request. |
+| formality_pairs | 12 | multi | 3 rows/fields | Choose the more formal option. Circle the most for | Correct formal choices: established; requested; compete. |
+| formality_pairs | 13 | multi | 3 rows/fields | Choose the more formal option. Circle the most for | Correct formal choices: discover; enter; request. |
+| formality_pairs | 14 | multi | 3 rows/fields | Choose the more formal option. Circle the most for | Correct formal choices: established; requested; compete. |
+| formality_pairs | 15 | multi | 3 rows/fields | Choose the more formal option. Circle the most for | Correct formal choices: discover; enter; request. |
+| formality_pairs | 16 | multi | 3 rows/fields | Choose the more formal option. Circle the most for | Correct formal choices: established; requested; compete. |
+| formality_pairs | 17 | multi | 3 rows/fields | Choose the more formal option. Circle the most for | Correct formal choices: discover; enter; request. |
+| formality_pairs | 18 | multi | 3 rows/fields | Choose the more formal option. Circle the most for | Correct formal choices: established; requested; compete. |
+| formality_pairs | 19 | multi | 3 rows/fields | Choose the more formal option. Circle the most for | Correct formal choices: discover; enter; request. |
+| formality_pairs | 20 | multi | 3 rows/fields | Choose the more formal option. Circle the most for | Correct formal choices: established; requested; compete. |
+| formality_pairs | 21 | multi | 3 rows/fields | Choose the more formal option. Circle the most for | Correct formal choices: discover; enter; request. |
+| formality_pairs | 22 | multi | 3 rows/fields | Choose the more formal option. Circle the most for | Correct formal choices: established; requested; compete. |
+| formality_pairs | 23 | multi | 3 rows/fields | Choose the more formal option. Circle the most for | Correct formal choices: discover; enter; request. |
+| formality_pairs | 24 | multi | 3 rows/fields | Choose the more formal option. Circle the most for | Correct formal choices: established; requested; compete. |
+| formality_pairs | 25 | multi | 3 rows/fields | Choose the more formal option. Circle the most for | Correct formal choices: discover; enter; request. |
+| formality_pairs | 26 | multi | 3 rows/fields | Choose the more formal option. Circle the most for | Correct formal choices: established; requested; compete. |
+| formality_pairs | 27 | multi | 3 rows/fields | Choose the more formal option. Circle the most for | Correct formal choices: discover; enter; request. |
+| formality_pairs | 28 | multi | 3 rows/fields | Choose the more formal option. Circle the most for | Correct formal choices: established; requested; compete. |
+| formality_pairs | 29 | multi | 3 rows/fields | Choose the more formal option. Circle the most for | Correct formal choices: discover; enter; request. |
+| formality_pairs | 30 | multi | 3 rows/fields | Choose the more formal option. Circle the most for | Correct formal choices: established; requested; compete. |
+| active_passive_rewrite | 1 | textarea | placeholder: Write the full transformed  | Transform active and passive voice. Rewrite the se | A correct answer is: The bread was baked by the chef. |
+| active_passive_rewrite | 2 | textarea | placeholder: Write the full transformed  | Transform active and passive voice. Rewrite the se | A correct answer is: The trophy will be collected by the tea |
+| active_passive_rewrite | 3 | textarea | placeholder: Write the full transformed  | Transform active and passive voice. Rewrite the se | A correct answer is: The council maintains the local park. |
+| active_passive_rewrite | 4 | textarea | placeholder: Write the full transformed  | Transform active and passive voice. Rewrite the se | A correct answer is: The bread was baked by the chef. |
+| active_passive_rewrite | 5 | textarea | placeholder: Write the full transformed  | Transform active and passive voice. Rewrite the se | A correct answer is: The trophy will be collected by the tea |
+| active_passive_rewrite | 6 | textarea | placeholder: Write the full transformed  | Transform active and passive voice. Rewrite the se | A correct answer is: The council maintains the local park. |
+| active_passive_rewrite | 7 | textarea | placeholder: Write the full transformed  | Transform active and passive voice. Rewrite the se | A correct answer is: The bread was baked by the chef. |
+| active_passive_rewrite | 8 | textarea | placeholder: Write the full transformed  | Transform active and passive voice. Rewrite the se | A correct answer is: The trophy will be collected by the tea |
+| active_passive_rewrite | 9 | textarea | placeholder: Write the full transformed  | Transform active and passive voice. Rewrite the se | A correct answer is: The council maintains the local park. |
+| active_passive_rewrite | 10 | textarea | placeholder: Write the full transformed  | Transform active and passive voice. Rewrite the se | A correct answer is: The bread was baked by the chef. |
+| active_passive_rewrite | 11 | textarea | placeholder: Write the full transformed  | Transform active and passive voice. Rewrite the se | A correct answer is: The trophy will be collected by the tea |
+| active_passive_rewrite | 12 | textarea | placeholder: Write the full transformed  | Transform active and passive voice. Rewrite the se | A correct answer is: The council maintains the local park. |
+| active_passive_rewrite | 13 | textarea | placeholder: Write the full transformed  | Transform active and passive voice. Rewrite the se | A correct answer is: The bread was baked by the chef. |
+| active_passive_rewrite | 14 | textarea | placeholder: Write the full transformed  | Transform active and passive voice. Rewrite the se | A correct answer is: The trophy will be collected by the tea |
+| active_passive_rewrite | 15 | textarea | placeholder: Write the full transformed  | Transform active and passive voice. Rewrite the se | A correct answer is: The council maintains the local park. |
+| active_passive_rewrite | 16 | textarea | placeholder: Write the full transformed  | Transform active and passive voice. Rewrite the se | A correct answer is: The bread was baked by the chef. |
+| active_passive_rewrite | 17 | textarea | placeholder: Write the full transformed  | Transform active and passive voice. Rewrite the se | A correct answer is: The trophy will be collected by the tea |
+| active_passive_rewrite | 18 | textarea | placeholder: Write the full transformed  | Transform active and passive voice. Rewrite the se | A correct answer is: The council maintains the local park. |
+| active_passive_rewrite | 19 | textarea | placeholder: Write the full transformed  | Transform active and passive voice. Rewrite the se | A correct answer is: The bread was baked by the chef. |
+| active_passive_rewrite | 20 | textarea | placeholder: Write the full transformed  | Transform active and passive voice. Rewrite the se | A correct answer is: The trophy will be collected by the tea |
+| active_passive_rewrite | 21 | textarea | placeholder: Write the full transformed  | Transform active and passive voice. Rewrite the se | A correct answer is: The council maintains the local park. |
+| active_passive_rewrite | 22 | textarea | placeholder: Write the full transformed  | Transform active and passive voice. Rewrite the se | A correct answer is: The bread was baked by the chef. |
+| active_passive_rewrite | 23 | textarea | placeholder: Write the full transformed  | Transform active and passive voice. Rewrite the se | A correct answer is: The trophy will be collected by the tea |
+| active_passive_rewrite | 24 | textarea | placeholder: Write the full transformed  | Transform active and passive voice. Rewrite the se | A correct answer is: The council maintains the local park. |
+| active_passive_rewrite | 25 | textarea | placeholder: Write the full transformed  | Transform active and passive voice. Rewrite the se | A correct answer is: The bread was baked by the chef. |
+| active_passive_rewrite | 26 | textarea | placeholder: Write the full transformed  | Transform active and passive voice. Rewrite the se | A correct answer is: The trophy will be collected by the tea |
+| active_passive_rewrite | 27 | textarea | placeholder: Write the full transformed  | Transform active and passive voice. Rewrite the se | A correct answer is: The council maintains the local park. |
+| active_passive_rewrite | 28 | textarea | placeholder: Write the full transformed  | Transform active and passive voice. Rewrite the se | A correct answer is: The bread was baked by the chef. |
+| active_passive_rewrite | 29 | textarea | placeholder: Write the full transformed  | Transform active and passive voice. Rewrite the se | A correct answer is: The trophy will be collected by the tea |
+| active_passive_rewrite | 30 | textarea | placeholder: Write the full transformed  | Transform active and passive voice. Rewrite the se | A correct answer is: The council maintains the local park. |
+| subject_object_choice | 1 | single_choice | The noisy gull, stole, the sandwich, fro | In the sentence below, what is the object? The noi | The object is: the sandwich. |
+| subject_object_choice | 2 | single_choice | On Friday morning, our science club, vis | In the sentence below, what is the subject? On Fri | The subject is: our science club. |
+| subject_object_choice | 3 | single_choice | After lunch, the tired goalkeeper, caugh | In the sentence below, what is the subject? After  | The subject is: the tired goalkeeper. |
+| subject_object_choice | 4 | single_choice | The noisy gull, stole, the sandwich, fro | In the sentence below, what is the object? The noi | The object is: the sandwich. |
+| subject_object_choice | 5 | single_choice | On Friday morning, our science club, vis | In the sentence below, what is the subject? On Fri | The subject is: our science club. |
+| subject_object_choice | 6 | single_choice | After lunch, the tired goalkeeper, caugh | In the sentence below, what is the subject? After  | The subject is: the tired goalkeeper. |
+| subject_object_choice | 7 | single_choice | The noisy gull, stole, the sandwich, fro | In the sentence below, what is the object? The noi | The object is: the sandwich. |
+| subject_object_choice | 8 | single_choice | On Friday morning, our science club, vis | In the sentence below, what is the subject? On Fri | The subject is: our science club. |
+| subject_object_choice | 9 | single_choice | After lunch, the tired goalkeeper, caugh | In the sentence below, what is the subject? After  | The subject is: the tired goalkeeper. |
+| subject_object_choice | 10 | single_choice | The noisy gull, stole, the sandwich, fro | In the sentence below, what is the object? The noi | The object is: the sandwich. |
+| subject_object_choice | 11 | single_choice | On Friday morning, our science club, vis | In the sentence below, what is the subject? On Fri | The subject is: our science club. |
+| subject_object_choice | 12 | single_choice | After lunch, the tired goalkeeper, caugh | In the sentence below, what is the subject? After  | The subject is: the tired goalkeeper. |
+| subject_object_choice | 13 | single_choice | The noisy gull, stole, the sandwich, fro | In the sentence below, what is the object? The noi | The object is: the sandwich. |
+| subject_object_choice | 14 | single_choice | On Friday morning, our science club, vis | In the sentence below, what is the subject? On Fri | The subject is: our science club. |
+| subject_object_choice | 15 | single_choice | After lunch, the tired goalkeeper, caugh | In the sentence below, what is the subject? After  | The subject is: the tired goalkeeper. |
+| subject_object_choice | 16 | single_choice | The noisy gull, stole, the sandwich, fro | In the sentence below, what is the object? The noi | The object is: the sandwich. |
+| subject_object_choice | 17 | single_choice | On Friday morning, our science club, vis | In the sentence below, what is the subject? On Fri | The subject is: our science club. |
+| subject_object_choice | 18 | single_choice | After lunch, the tired goalkeeper, caugh | In the sentence below, what is the subject? After  | The subject is: the tired goalkeeper. |
+| subject_object_choice | 19 | single_choice | The noisy gull, stole, the sandwich, fro | In the sentence below, what is the object? The noi | The object is: the sandwich. |
+| subject_object_choice | 20 | single_choice | On Friday morning, our science club, vis | In the sentence below, what is the subject? On Fri | The subject is: our science club. |
+| subject_object_choice | 21 | single_choice | After lunch, the tired goalkeeper, caugh | In the sentence below, what is the subject? After  | The subject is: the tired goalkeeper. |
+| subject_object_choice | 22 | single_choice | The noisy gull, stole, the sandwich, fro | In the sentence below, what is the object? The noi | The object is: the sandwich. |
+| subject_object_choice | 23 | single_choice | On Friday morning, our science club, vis | In the sentence below, what is the subject? On Fri | The subject is: our science club. |
+| subject_object_choice | 24 | single_choice | After lunch, the tired goalkeeper, caugh | In the sentence below, what is the subject? After  | The subject is: the tired goalkeeper. |
+| subject_object_choice | 25 | single_choice | The noisy gull, stole, the sandwich, fro | In the sentence below, what is the object? The noi | The object is: the sandwich. |
+| subject_object_choice | 26 | single_choice | On Friday morning, our science club, vis | In the sentence below, what is the subject? On Fri | The subject is: our science club. |
+| subject_object_choice | 27 | single_choice | After lunch, the tired goalkeeper, caugh | In the sentence below, what is the subject? After  | The subject is: the tired goalkeeper. |
+| subject_object_choice | 28 | single_choice | The noisy gull, stole, the sandwich, fro | In the sentence below, what is the object? The noi | The object is: the sandwich. |
+| subject_object_choice | 29 | single_choice | On Friday morning, our science club, vis | In the sentence below, what is the subject? On Fri | The subject is: our science club. |
+| subject_object_choice | 30 | single_choice | After lunch, the tired goalkeeper, caugh | In the sentence below, what is the subject? After  | The subject is: the tired goalkeeper. |
+| modal_verb_choice | 1 | single_choice | might, could, should, will | Choose the best modal meaning. Which modal verb be | The correct answer is: should. |
+| modal_verb_choice | 2 | single_choice | It might snow tonight., It should snow t | Choose the best modal meaning. Which sentence soun | The correct answer is: It will snow tonight.. |
+| modal_verb_choice | 3 | single_choice | The team must win., The team will win.,  | Choose the best modal meaning. Which sentence show | The correct answer is: The team might win.. |
+| modal_verb_choice | 4 | single_choice | might, could, should, will | Choose the best modal meaning. Which modal verb be | The correct answer is: should. |
+| modal_verb_choice | 5 | single_choice | It might snow tonight., It should snow t | Choose the best modal meaning. Which sentence soun | The correct answer is: It will snow tonight.. |
+| modal_verb_choice | 6 | single_choice | The team must win., The team will win.,  | Choose the best modal meaning. Which sentence show | The correct answer is: The team might win.. |
+| modal_verb_choice | 7 | single_choice | might, could, should, will | Choose the best modal meaning. Which modal verb be | The correct answer is: should. |
+| modal_verb_choice | 8 | single_choice | It might snow tonight., It should snow t | Choose the best modal meaning. Which sentence soun | The correct answer is: It will snow tonight.. |
+| modal_verb_choice | 9 | single_choice | The team must win., The team will win.,  | Choose the best modal meaning. Which sentence show | The correct answer is: The team might win.. |
+| modal_verb_choice | 10 | single_choice | might, could, should, will | Choose the best modal meaning. Which modal verb be | The correct answer is: should. |
+| modal_verb_choice | 11 | single_choice | It might snow tonight., It should snow t | Choose the best modal meaning. Which sentence soun | The correct answer is: It will snow tonight.. |
+| modal_verb_choice | 12 | single_choice | The team must win., The team will win.,  | Choose the best modal meaning. Which sentence show | The correct answer is: The team might win.. |
+| modal_verb_choice | 13 | single_choice | might, could, should, will | Choose the best modal meaning. Which modal verb be | The correct answer is: should. |
+| modal_verb_choice | 14 | single_choice | It might snow tonight., It should snow t | Choose the best modal meaning. Which sentence soun | The correct answer is: It will snow tonight.. |
+| modal_verb_choice | 15 | single_choice | The team must win., The team will win.,  | Choose the best modal meaning. Which sentence show | The correct answer is: The team might win.. |
+| modal_verb_choice | 16 | single_choice | might, could, should, will | Choose the best modal meaning. Which modal verb be | The correct answer is: should. |
+| modal_verb_choice | 17 | single_choice | It might snow tonight., It should snow t | Choose the best modal meaning. Which sentence soun | The correct answer is: It will snow tonight.. |
+| modal_verb_choice | 18 | single_choice | The team must win., The team will win.,  | Choose the best modal meaning. Which sentence show | The correct answer is: The team might win.. |
+| modal_verb_choice | 19 | single_choice | might, could, should, will | Choose the best modal meaning. Which modal verb be | The correct answer is: should. |
+| modal_verb_choice | 20 | single_choice | It might snow tonight., It should snow t | Choose the best modal meaning. Which sentence soun | The correct answer is: It will snow tonight.. |
+| modal_verb_choice | 21 | single_choice | The team must win., The team will win.,  | Choose the best modal meaning. Which sentence show | The correct answer is: The team might win.. |
+| modal_verb_choice | 22 | single_choice | might, could, should, will | Choose the best modal meaning. Which modal verb be | The correct answer is: should. |
+| modal_verb_choice | 23 | single_choice | It might snow tonight., It should snow t | Choose the best modal meaning. Which sentence soun | The correct answer is: It will snow tonight.. |
+| modal_verb_choice | 24 | single_choice | The team must win., The team will win.,  | Choose the best modal meaning. Which sentence show | The correct answer is: The team might win.. |
+| modal_verb_choice | 25 | single_choice | might, could, should, will | Choose the best modal meaning. Which modal verb be | The correct answer is: should. |
+| modal_verb_choice | 26 | single_choice | It might snow tonight., It should snow t | Choose the best modal meaning. Which sentence soun | The correct answer is: It will snow tonight.. |
+| modal_verb_choice | 27 | single_choice | The team must win., The team will win.,  | Choose the best modal meaning. Which sentence show | The correct answer is: The team might win.. |
+| modal_verb_choice | 28 | single_choice | might, could, should, will | Choose the best modal meaning. Which modal verb be | The correct answer is: should. |
+| modal_verb_choice | 29 | single_choice | It might snow tonight., It should snow t | Choose the best modal meaning. Which sentence soun | The correct answer is: It will snow tonight.. |
+| modal_verb_choice | 30 | single_choice | The team must win., The team will win.,  | Choose the best modal meaning. Which sentence show | The correct answer is: The team might win.. |
+| parenthesis_replace_choice | 1 | single_choice | semi-colons, dashes, colons, question ma | What punctuation could be used instead of brackets | The correct answer is: dashes. |
+| parenthesis_replace_choice | 2 | single_choice | hyphens, colons, semi-colons, dashes | What punctuation could be used instead of brackets | The correct answer is: dashes. |
+| parenthesis_replace_choice | 3 | single_choice | semi-colons, dashes, colons, question ma | What punctuation could be used instead of brackets | The correct answer is: dashes. |
+| parenthesis_replace_choice | 4 | single_choice | hyphens, colons, semi-colons, dashes | What punctuation could be used instead of brackets | The correct answer is: dashes. |
+| parenthesis_replace_choice | 5 | single_choice | semi-colons, dashes, colons, question ma | What punctuation could be used instead of brackets | The correct answer is: dashes. |
+| parenthesis_replace_choice | 6 | single_choice | hyphens, colons, semi-colons, dashes | What punctuation could be used instead of brackets | The correct answer is: dashes. |
+| parenthesis_replace_choice | 7 | single_choice | semi-colons, dashes, colons, question ma | What punctuation could be used instead of brackets | The correct answer is: dashes. |
+| parenthesis_replace_choice | 8 | single_choice | hyphens, colons, semi-colons, dashes | What punctuation could be used instead of brackets | The correct answer is: dashes. |
+| parenthesis_replace_choice | 9 | single_choice | semi-colons, dashes, colons, question ma | What punctuation could be used instead of brackets | The correct answer is: dashes. |
+| parenthesis_replace_choice | 10 | single_choice | hyphens, colons, semi-colons, dashes | What punctuation could be used instead of brackets | The correct answer is: dashes. |
+| parenthesis_replace_choice | 11 | single_choice | semi-colons, dashes, colons, question ma | What punctuation could be used instead of brackets | The correct answer is: dashes. |
+| parenthesis_replace_choice | 12 | single_choice | hyphens, colons, semi-colons, dashes | What punctuation could be used instead of brackets | The correct answer is: dashes. |
+| parenthesis_replace_choice | 13 | single_choice | semi-colons, dashes, colons, question ma | What punctuation could be used instead of brackets | The correct answer is: dashes. |
+| parenthesis_replace_choice | 14 | single_choice | hyphens, colons, semi-colons, dashes | What punctuation could be used instead of brackets | The correct answer is: dashes. |
+| parenthesis_replace_choice | 15 | single_choice | semi-colons, dashes, colons, question ma | What punctuation could be used instead of brackets | The correct answer is: dashes. |
+| parenthesis_replace_choice | 16 | single_choice | hyphens, colons, semi-colons, dashes | What punctuation could be used instead of brackets | The correct answer is: dashes. |
+| parenthesis_replace_choice | 17 | single_choice | semi-colons, dashes, colons, question ma | What punctuation could be used instead of brackets | The correct answer is: dashes. |
+| parenthesis_replace_choice | 18 | single_choice | hyphens, colons, semi-colons, dashes | What punctuation could be used instead of brackets | The correct answer is: dashes. |
+| parenthesis_replace_choice | 19 | single_choice | semi-colons, dashes, colons, question ma | What punctuation could be used instead of brackets | The correct answer is: dashes. |
+| parenthesis_replace_choice | 20 | single_choice | hyphens, colons, semi-colons, dashes | What punctuation could be used instead of brackets | The correct answer is: dashes. |
+| parenthesis_replace_choice | 21 | single_choice | semi-colons, dashes, colons, question ma | What punctuation could be used instead of brackets | The correct answer is: dashes. |
+| parenthesis_replace_choice | 22 | single_choice | hyphens, colons, semi-colons, dashes | What punctuation could be used instead of brackets | The correct answer is: dashes. |
+| parenthesis_replace_choice | 23 | single_choice | semi-colons, dashes, colons, question ma | What punctuation could be used instead of brackets | The correct answer is: dashes. |
+| parenthesis_replace_choice | 24 | single_choice | hyphens, colons, semi-colons, dashes | What punctuation could be used instead of brackets | The correct answer is: dashes. |
+| parenthesis_replace_choice | 25 | single_choice | semi-colons, dashes, colons, question ma | What punctuation could be used instead of brackets | The correct answer is: dashes. |
+| parenthesis_replace_choice | 26 | single_choice | hyphens, colons, semi-colons, dashes | What punctuation could be used instead of brackets | The correct answer is: dashes. |
+| parenthesis_replace_choice | 27 | single_choice | semi-colons, dashes, colons, question ma | What punctuation could be used instead of brackets | The correct answer is: dashes. |
+| parenthesis_replace_choice | 28 | single_choice | hyphens, colons, semi-colons, dashes | What punctuation could be used instead of brackets | The correct answer is: dashes. |
+| parenthesis_replace_choice | 29 | single_choice | semi-colons, dashes, colons, question ma | What punctuation could be used instead of brackets | The correct answer is: dashes. |
+| parenthesis_replace_choice | 30 | single_choice | hyphens, colons, semi-colons, dashes | What punctuation could be used instead of brackets | The correct answer is: dashes. |
+| parenthesis_fix_sentence | 1 | textarea | placeholder: Type the corrected sentence | Insert brackets for parenthesis. Insert a pair of  | A correct answer is: My cousin (the youngest in the family)  |
+| parenthesis_fix_sentence | 2 | textarea | placeholder: Type the corrected sentence | Insert brackets for parenthesis. Insert a pair of  | A correct answer is: Our class visited a castle (the oldest  |
+| parenthesis_fix_sentence | 3 | textarea | placeholder: Type the corrected sentence | Insert brackets for parenthesis. Insert a pair of  | A correct answer is: My cousin (the youngest in the family)  |
+| parenthesis_fix_sentence | 4 | textarea | placeholder: Type the corrected sentence | Insert brackets for parenthesis. Insert a pair of  | A correct answer is: Our class visited a castle (the oldest  |
+| parenthesis_fix_sentence | 5 | textarea | placeholder: Type the corrected sentence | Insert brackets for parenthesis. Insert a pair of  | A correct answer is: My cousin (the youngest in the family)  |
+| parenthesis_fix_sentence | 6 | textarea | placeholder: Type the corrected sentence | Insert brackets for parenthesis. Insert a pair of  | A correct answer is: Our class visited a castle (the oldest  |
+| parenthesis_fix_sentence | 7 | textarea | placeholder: Type the corrected sentence | Insert brackets for parenthesis. Insert a pair of  | A correct answer is: My cousin (the youngest in the family)  |
+| parenthesis_fix_sentence | 8 | textarea | placeholder: Type the corrected sentence | Insert brackets for parenthesis. Insert a pair of  | A correct answer is: Our class visited a castle (the oldest  |
+| parenthesis_fix_sentence | 9 | textarea | placeholder: Type the corrected sentence | Insert brackets for parenthesis. Insert a pair of  | A correct answer is: My cousin (the youngest in the family)  |
+| parenthesis_fix_sentence | 10 | textarea | placeholder: Type the corrected sentence | Insert brackets for parenthesis. Insert a pair of  | A correct answer is: Our class visited a castle (the oldest  |
+| parenthesis_fix_sentence | 11 | textarea | placeholder: Type the corrected sentence | Insert brackets for parenthesis. Insert a pair of  | A correct answer is: My cousin (the youngest in the family)  |
+| parenthesis_fix_sentence | 12 | textarea | placeholder: Type the corrected sentence | Insert brackets for parenthesis. Insert a pair of  | A correct answer is: Our class visited a castle (the oldest  |
+| parenthesis_fix_sentence | 13 | textarea | placeholder: Type the corrected sentence | Insert brackets for parenthesis. Insert a pair of  | A correct answer is: My cousin (the youngest in the family)  |
+| parenthesis_fix_sentence | 14 | textarea | placeholder: Type the corrected sentence | Insert brackets for parenthesis. Insert a pair of  | A correct answer is: Our class visited a castle (the oldest  |
+| parenthesis_fix_sentence | 15 | textarea | placeholder: Type the corrected sentence | Insert brackets for parenthesis. Insert a pair of  | A correct answer is: My cousin (the youngest in the family)  |
+| parenthesis_fix_sentence | 16 | textarea | placeholder: Type the corrected sentence | Insert brackets for parenthesis. Insert a pair of  | A correct answer is: Our class visited a castle (the oldest  |
+| parenthesis_fix_sentence | 17 | textarea | placeholder: Type the corrected sentence | Insert brackets for parenthesis. Insert a pair of  | A correct answer is: My cousin (the youngest in the family)  |
+| parenthesis_fix_sentence | 18 | textarea | placeholder: Type the corrected sentence | Insert brackets for parenthesis. Insert a pair of  | A correct answer is: Our class visited a castle (the oldest  |
+| parenthesis_fix_sentence | 19 | textarea | placeholder: Type the corrected sentence | Insert brackets for parenthesis. Insert a pair of  | A correct answer is: My cousin (the youngest in the family)  |
+| parenthesis_fix_sentence | 20 | textarea | placeholder: Type the corrected sentence | Insert brackets for parenthesis. Insert a pair of  | A correct answer is: Our class visited a castle (the oldest  |
+| parenthesis_fix_sentence | 21 | textarea | placeholder: Type the corrected sentence | Insert brackets for parenthesis. Insert a pair of  | A correct answer is: My cousin (the youngest in the family)  |
+| parenthesis_fix_sentence | 22 | textarea | placeholder: Type the corrected sentence | Insert brackets for parenthesis. Insert a pair of  | A correct answer is: Our class visited a castle (the oldest  |
+| parenthesis_fix_sentence | 23 | textarea | placeholder: Type the corrected sentence | Insert brackets for parenthesis. Insert a pair of  | A correct answer is: My cousin (the youngest in the family)  |
+| parenthesis_fix_sentence | 24 | textarea | placeholder: Type the corrected sentence | Insert brackets for parenthesis. Insert a pair of  | A correct answer is: Our class visited a castle (the oldest  |
+| parenthesis_fix_sentence | 25 | textarea | placeholder: Type the corrected sentence | Insert brackets for parenthesis. Insert a pair of  | A correct answer is: My cousin (the youngest in the family)  |
+| parenthesis_fix_sentence | 26 | textarea | placeholder: Type the corrected sentence | Insert brackets for parenthesis. Insert a pair of  | A correct answer is: Our class visited a castle (the oldest  |
+| parenthesis_fix_sentence | 27 | textarea | placeholder: Type the corrected sentence | Insert brackets for parenthesis. Insert a pair of  | A correct answer is: My cousin (the youngest in the family)  |
+| parenthesis_fix_sentence | 28 | textarea | placeholder: Type the corrected sentence | Insert brackets for parenthesis. Insert a pair of  | A correct answer is: Our class visited a castle (the oldest  |
+| parenthesis_fix_sentence | 29 | textarea | placeholder: Type the corrected sentence | Insert brackets for parenthesis. Insert a pair of  | A correct answer is: My cousin (the youngest in the family)  |
+| parenthesis_fix_sentence | 30 | textarea | placeholder: Type the corrected sentence | Insert brackets for parenthesis. Insert a pair of  | A correct answer is: Our class visited a castle (the oldest  |
+| speech_punctuation_fix | 1 | textarea | placeholder: Type the corrected sentence | Punctuate direct speech. Punctuate the direct spee | A correct answer is: Dad shouted, “Run inside!” |
+| speech_punctuation_fix | 2 | textarea | placeholder: Type the corrected sentence | Punctuate direct speech. Punctuate the direct spee | A correct answer is: “Sit down!” said the coach. |
+| speech_punctuation_fix | 3 | textarea | placeholder: Type the corrected sentence | Punctuate direct speech. Punctuate the direct spee | A correct answer is: “Where are you going?” asked Mum. |
+| speech_punctuation_fix | 4 | textarea | placeholder: Type the corrected sentence | Punctuate direct speech. Punctuate the direct spee | A correct answer is: Dad shouted, “Run inside!” |
+| speech_punctuation_fix | 5 | textarea | placeholder: Type the corrected sentence | Punctuate direct speech. Punctuate the direct spee | A correct answer is: “Sit down!” said the coach. |
+| speech_punctuation_fix | 6 | textarea | placeholder: Type the corrected sentence | Punctuate direct speech. Punctuate the direct spee | A correct answer is: “Where are you going?” asked Mum. |
+| speech_punctuation_fix | 7 | textarea | placeholder: Type the corrected sentence | Punctuate direct speech. Punctuate the direct spee | A correct answer is: Dad shouted, “Run inside!” |
+| speech_punctuation_fix | 8 | textarea | placeholder: Type the corrected sentence | Punctuate direct speech. Punctuate the direct spee | A correct answer is: “Sit down!” said the coach. |
+| speech_punctuation_fix | 9 | textarea | placeholder: Type the corrected sentence | Punctuate direct speech. Punctuate the direct spee | A correct answer is: “Where are you going?” asked Mum. |
+| speech_punctuation_fix | 10 | textarea | placeholder: Type the corrected sentence | Punctuate direct speech. Punctuate the direct spee | A correct answer is: Dad shouted, “Run inside!” |
+| speech_punctuation_fix | 11 | textarea | placeholder: Type the corrected sentence | Punctuate direct speech. Punctuate the direct spee | A correct answer is: “Sit down!” said the coach. |
+| speech_punctuation_fix | 12 | textarea | placeholder: Type the corrected sentence | Punctuate direct speech. Punctuate the direct spee | A correct answer is: “Where are you going?” asked Mum. |
+| speech_punctuation_fix | 13 | textarea | placeholder: Type the corrected sentence | Punctuate direct speech. Punctuate the direct spee | A correct answer is: Dad shouted, “Run inside!” |
+| speech_punctuation_fix | 14 | textarea | placeholder: Type the corrected sentence | Punctuate direct speech. Punctuate the direct spee | A correct answer is: “Sit down!” said the coach. |
+| speech_punctuation_fix | 15 | textarea | placeholder: Type the corrected sentence | Punctuate direct speech. Punctuate the direct spee | A correct answer is: “Where are you going?” asked Mum. |
+| speech_punctuation_fix | 16 | textarea | placeholder: Type the corrected sentence | Punctuate direct speech. Punctuate the direct spee | A correct answer is: Dad shouted, “Run inside!” |
+| speech_punctuation_fix | 17 | textarea | placeholder: Type the corrected sentence | Punctuate direct speech. Punctuate the direct spee | A correct answer is: “Sit down!” said the coach. |
+| speech_punctuation_fix | 18 | textarea | placeholder: Type the corrected sentence | Punctuate direct speech. Punctuate the direct spee | A correct answer is: “Where are you going?” asked Mum. |
+| speech_punctuation_fix | 19 | textarea | placeholder: Type the corrected sentence | Punctuate direct speech. Punctuate the direct spee | A correct answer is: Dad shouted, “Run inside!” |
+| speech_punctuation_fix | 20 | textarea | placeholder: Type the corrected sentence | Punctuate direct speech. Punctuate the direct spee | A correct answer is: “Sit down!” said the coach. |
+| speech_punctuation_fix | 21 | textarea | placeholder: Type the corrected sentence | Punctuate direct speech. Punctuate the direct spee | A correct answer is: “Where are you going?” asked Mum. |
+| speech_punctuation_fix | 22 | textarea | placeholder: Type the corrected sentence | Punctuate direct speech. Punctuate the direct spee | A correct answer is: Dad shouted, “Run inside!” |
+| speech_punctuation_fix | 23 | textarea | placeholder: Type the corrected sentence | Punctuate direct speech. Punctuate the direct spee | A correct answer is: “Sit down!” said the coach. |
+| speech_punctuation_fix | 24 | textarea | placeholder: Type the corrected sentence | Punctuate direct speech. Punctuate the direct spee | A correct answer is: “Where are you going?” asked Mum. |
+| speech_punctuation_fix | 25 | textarea | placeholder: Type the corrected sentence | Punctuate direct speech. Punctuate the direct spee | A correct answer is: Dad shouted, “Run inside!” |
+| speech_punctuation_fix | 26 | textarea | placeholder: Type the corrected sentence | Punctuate direct speech. Punctuate the direct spee | A correct answer is: “Sit down!” said the coach. |
+| speech_punctuation_fix | 27 | textarea | placeholder: Type the corrected sentence | Punctuate direct speech. Punctuate the direct spee | A correct answer is: “Where are you going?” asked Mum. |
+| speech_punctuation_fix | 28 | textarea | placeholder: Type the corrected sentence | Punctuate direct speech. Punctuate the direct spee | A correct answer is: Dad shouted, “Run inside!” |
+| speech_punctuation_fix | 29 | textarea | placeholder: Type the corrected sentence | Punctuate direct speech. Punctuate the direct spee | A correct answer is: “Sit down!” said the coach. |
+| speech_punctuation_fix | 30 | textarea | placeholder: Type the corrected sentence | Punctuate direct speech. Punctuate the direct spee | A correct answer is: “Where are you going?” asked Mum. |
+| apostrophe_possession_choice | 1 | single_choice | dogs, dog's, dogs', dogs's | Choose the correct possessive apostrophe. Choose t | The correct answer is: dog's. |
+| apostrophe_possession_choice | 2 | single_choice | children's, childrens', childrens, child | Choose the correct possessive apostrophe. Choose t | The correct answer is: children's. |
+| apostrophe_possession_choice | 3 | single_choice | girls, girl's, girls', girls's | Choose the correct possessive apostrophe. Choose t | The correct answer is: girls'. |
+| apostrophe_possession_choice | 4 | single_choice | dogs, dog's, dogs', dogs's | Choose the correct possessive apostrophe. Choose t | The correct answer is: dog's. |
+| apostrophe_possession_choice | 5 | single_choice | children's, childrens', childrens, child | Choose the correct possessive apostrophe. Choose t | The correct answer is: children's. |
+| apostrophe_possession_choice | 6 | single_choice | girls, girl's, girls', girls's | Choose the correct possessive apostrophe. Choose t | The correct answer is: girls'. |
+| apostrophe_possession_choice | 7 | single_choice | dogs, dog's, dogs', dogs's | Choose the correct possessive apostrophe. Choose t | The correct answer is: dog's. |
+| apostrophe_possession_choice | 8 | single_choice | children's, childrens', childrens, child | Choose the correct possessive apostrophe. Choose t | The correct answer is: children's. |
+| apostrophe_possession_choice | 9 | single_choice | girls, girl's, girls', girls's | Choose the correct possessive apostrophe. Choose t | The correct answer is: girls'. |
+| apostrophe_possession_choice | 10 | single_choice | dogs, dog's, dogs', dogs's | Choose the correct possessive apostrophe. Choose t | The correct answer is: dog's. |
+| apostrophe_possession_choice | 11 | single_choice | children's, childrens', childrens, child | Choose the correct possessive apostrophe. Choose t | The correct answer is: children's. |
+| apostrophe_possession_choice | 12 | single_choice | girls, girl's, girls', girls's | Choose the correct possessive apostrophe. Choose t | The correct answer is: girls'. |
+| apostrophe_possession_choice | 13 | single_choice | dogs, dog's, dogs', dogs's | Choose the correct possessive apostrophe. Choose t | The correct answer is: dog's. |
+| apostrophe_possession_choice | 14 | single_choice | children's, childrens', childrens, child | Choose the correct possessive apostrophe. Choose t | The correct answer is: children's. |
+| apostrophe_possession_choice | 15 | single_choice | girls, girl's, girls', girls's | Choose the correct possessive apostrophe. Choose t | The correct answer is: girls'. |
+| apostrophe_possession_choice | 16 | single_choice | dogs, dog's, dogs', dogs's | Choose the correct possessive apostrophe. Choose t | The correct answer is: dog's. |
+| apostrophe_possession_choice | 17 | single_choice | children's, childrens', childrens, child | Choose the correct possessive apostrophe. Choose t | The correct answer is: children's. |
+| apostrophe_possession_choice | 18 | single_choice | girls, girl's, girls', girls's | Choose the correct possessive apostrophe. Choose t | The correct answer is: girls'. |
+| apostrophe_possession_choice | 19 | single_choice | dogs, dog's, dogs', dogs's | Choose the correct possessive apostrophe. Choose t | The correct answer is: dog's. |
+| apostrophe_possession_choice | 20 | single_choice | children's, childrens', childrens, child | Choose the correct possessive apostrophe. Choose t | The correct answer is: children's. |
+| apostrophe_possession_choice | 21 | single_choice | girls, girl's, girls', girls's | Choose the correct possessive apostrophe. Choose t | The correct answer is: girls'. |
+| apostrophe_possession_choice | 22 | single_choice | dogs, dog's, dogs', dogs's | Choose the correct possessive apostrophe. Choose t | The correct answer is: dog's. |
+| apostrophe_possession_choice | 23 | single_choice | children's, childrens', childrens, child | Choose the correct possessive apostrophe. Choose t | The correct answer is: children's. |
+| apostrophe_possession_choice | 24 | single_choice | girls, girl's, girls', girls's | Choose the correct possessive apostrophe. Choose t | The correct answer is: girls'. |
+| apostrophe_possession_choice | 25 | single_choice | dogs, dog's, dogs', dogs's | Choose the correct possessive apostrophe. Choose t | The correct answer is: dog's. |
+| apostrophe_possession_choice | 26 | single_choice | children's, childrens', childrens, child | Choose the correct possessive apostrophe. Choose t | The correct answer is: children's. |
+| apostrophe_possession_choice | 27 | single_choice | girls, girl's, girls', girls's | Choose the correct possessive apostrophe. Choose t | The correct answer is: girls'. |
+| apostrophe_possession_choice | 28 | single_choice | dogs, dog's, dogs', dogs's | Choose the correct possessive apostrophe. Choose t | The correct answer is: dog's. |
+| apostrophe_possession_choice | 29 | single_choice | children's, childrens', childrens, child | Choose the correct possessive apostrophe. Choose t | The correct answer is: children's. |
+| apostrophe_possession_choice | 30 | single_choice | girls, girl's, girls', girls's | Choose the correct possessive apostrophe. Choose t | The correct answer is: girls'. |
+| explain_reason_choice | 1 | single_choice | Because Standard English uses ‘did’, not | Explain why. Why is 'I done my homework' wrong in  | The best explanation is: Because Standard English uses ‘did’ |
+| explain_reason_choice | 2 | single_choice | Because the opening words are a fronted  | Explain why. Why is there a comma after the openin | The best explanation is: Because the opening words are a fro |
+| explain_reason_choice | 3 | single_choice | Because Standard English uses ‘did’, not | Explain why. Why is 'I done my homework' wrong in  | The best explanation is: Because Standard English uses ‘did’ |
+| explain_reason_choice | 4 | single_choice | Because the opening words are a fronted  | Explain why. Why is there a comma after the openin | The best explanation is: Because the opening words are a fro |
+| explain_reason_choice | 5 | single_choice | Because Standard English uses ‘did’, not | Explain why. Why is 'I done my homework' wrong in  | The best explanation is: Because Standard English uses ‘did’ |
+| explain_reason_choice | 6 | single_choice | Because the opening words are a fronted  | Explain why. Why is there a comma after the openin | The best explanation is: Because the opening words are a fro |
+| explain_reason_choice | 7 | single_choice | Because Standard English uses ‘did’, not | Explain why. Why is 'I done my homework' wrong in  | The best explanation is: Because Standard English uses ‘did’ |
+| explain_reason_choice | 8 | single_choice | Because the opening words are a fronted  | Explain why. Why is there a comma after the openin | The best explanation is: Because the opening words are a fro |
+| explain_reason_choice | 9 | single_choice | Because Standard English uses ‘did’, not | Explain why. Why is 'I done my homework' wrong in  | The best explanation is: Because Standard English uses ‘did’ |
+| explain_reason_choice | 10 | single_choice | Because the opening words are a fronted  | Explain why. Why is there a comma after the openin | The best explanation is: Because the opening words are a fro |
+| explain_reason_choice | 11 | single_choice | Because Standard English uses ‘did’, not | Explain why. Why is 'I done my homework' wrong in  | The best explanation is: Because Standard English uses ‘did’ |
+| explain_reason_choice | 12 | single_choice | Because the opening words are a fronted  | Explain why. Why is there a comma after the openin | The best explanation is: Because the opening words are a fro |
+| explain_reason_choice | 13 | single_choice | Because Standard English uses ‘did’, not | Explain why. Why is 'I done my homework' wrong in  | The best explanation is: Because Standard English uses ‘did’ |
+| explain_reason_choice | 14 | single_choice | Because the opening words are a fronted  | Explain why. Why is there a comma after the openin | The best explanation is: Because the opening words are a fro |
+| explain_reason_choice | 15 | single_choice | Because Standard English uses ‘did’, not | Explain why. Why is 'I done my homework' wrong in  | The best explanation is: Because Standard English uses ‘did’ |
+| explain_reason_choice | 16 | single_choice | Because the opening words are a fronted  | Explain why. Why is there a comma after the openin | The best explanation is: Because the opening words are a fro |
+| explain_reason_choice | 17 | single_choice | Because Standard English uses ‘did’, not | Explain why. Why is 'I done my homework' wrong in  | The best explanation is: Because Standard English uses ‘did’ |
+| explain_reason_choice | 18 | single_choice | Because the opening words are a fronted  | Explain why. Why is there a comma after the openin | The best explanation is: Because the opening words are a fro |
+| explain_reason_choice | 19 | single_choice | Because Standard English uses ‘did’, not | Explain why. Why is 'I done my homework' wrong in  | The best explanation is: Because Standard English uses ‘did’ |
+| explain_reason_choice | 20 | single_choice | Because the opening words are a fronted  | Explain why. Why is there a comma after the openin | The best explanation is: Because the opening words are a fro |
+| explain_reason_choice | 21 | single_choice | Because Standard English uses ‘did’, not | Explain why. Why is 'I done my homework' wrong in  | The best explanation is: Because Standard English uses ‘did’ |
+| explain_reason_choice | 22 | single_choice | Because the opening words are a fronted  | Explain why. Why is there a comma after the openin | The best explanation is: Because the opening words are a fro |
+| explain_reason_choice | 23 | single_choice | Because Standard English uses ‘did’, not | Explain why. Why is 'I done my homework' wrong in  | The best explanation is: Because Standard English uses ‘did’ |
+| explain_reason_choice | 24 | single_choice | Because the opening words are a fronted  | Explain why. Why is there a comma after the openin | The best explanation is: Because the opening words are a fro |
+| explain_reason_choice | 25 | single_choice | Because Standard English uses ‘did’, not | Explain why. Why is 'I done my homework' wrong in  | The best explanation is: Because Standard English uses ‘did’ |
+| explain_reason_choice | 26 | single_choice | Because the opening words are a fronted  | Explain why. Why is there a comma after the openin | The best explanation is: Because the opening words are a fro |
+| explain_reason_choice | 27 | single_choice | Because Standard English uses ‘did’, not | Explain why. Why is 'I done my homework' wrong in  | The best explanation is: Because Standard English uses ‘did’ |
+| explain_reason_choice | 28 | single_choice | Because the opening words are a fronted  | Explain why. Why is there a comma after the openin | The best explanation is: Because the opening words are a fro |
+| explain_reason_choice | 29 | single_choice | Because Standard English uses ‘did’, not | Explain why. Why is 'I done my homework' wrong in  | The best explanation is: Because Standard English uses ‘did’ |
+| explain_reason_choice | 30 | single_choice | Because the opening words are a fronted  | Explain why. Why is there a comma after the openin | The best explanation is: Because the opening words are a fro |
+| standard_fix_sentence | 1 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | Your Standard English rewrite has been saved for review. It  |
+| standard_fix_sentence | 2 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | Your Standard English rewrite has been saved for review. It  |
+| standard_fix_sentence | 3 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | Your Standard English rewrite has been saved for review. It  |
+| standard_fix_sentence | 4 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | Your Standard English rewrite has been saved for review. It  |
+| standard_fix_sentence | 5 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | Your Standard English rewrite has been saved for review. It  |
+| standard_fix_sentence | 6 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | Your Standard English rewrite has been saved for review. It  |
+| standard_fix_sentence | 7 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | Your Standard English rewrite has been saved for review. It  |
+| standard_fix_sentence | 8 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | Your Standard English rewrite has been saved for review. It  |
+| standard_fix_sentence | 9 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | Your Standard English rewrite has been saved for review. It  |
+| standard_fix_sentence | 10 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | Your Standard English rewrite has been saved for review. It  |
+| standard_fix_sentence | 11 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | Your Standard English rewrite has been saved for review. It  |
+| standard_fix_sentence | 12 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | Your Standard English rewrite has been saved for review. It  |
+| standard_fix_sentence | 13 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | Your Standard English rewrite has been saved for review. It  |
+| standard_fix_sentence | 14 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | Your Standard English rewrite has been saved for review. It  |
+| standard_fix_sentence | 15 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | Your Standard English rewrite has been saved for review. It  |
+| standard_fix_sentence | 16 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | Your Standard English rewrite has been saved for review. It  |
+| standard_fix_sentence | 17 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | Your Standard English rewrite has been saved for review. It  |
+| standard_fix_sentence | 18 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | Your Standard English rewrite has been saved for review. It  |
+| standard_fix_sentence | 19 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | Your Standard English rewrite has been saved for review. It  |
+| standard_fix_sentence | 20 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | Your Standard English rewrite has been saved for review. It  |
+| standard_fix_sentence | 21 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | Your Standard English rewrite has been saved for review. It  |
+| standard_fix_sentence | 22 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | Your Standard English rewrite has been saved for review. It  |
+| standard_fix_sentence | 23 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | Your Standard English rewrite has been saved for review. It  |
+| standard_fix_sentence | 24 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | Your Standard English rewrite has been saved for review. It  |
+| standard_fix_sentence | 25 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | Your Standard English rewrite has been saved for review. It  |
+| standard_fix_sentence | 26 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | Your Standard English rewrite has been saved for review. It  |
+| standard_fix_sentence | 27 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | Your Standard English rewrite has been saved for review. It  |
+| standard_fix_sentence | 28 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | Your Standard English rewrite has been saved for review. It  |
+| standard_fix_sentence | 29 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | Your Standard English rewrite has been saved for review. It  |
+| standard_fix_sentence | 30 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | Your Standard English rewrite has been saved for review. It  |
+| proc_fronted_adverbial_fix | 1 | textarea | placeholder: Write the corrected sentenc | Fix comma after fronted adverbial. Rewrite the sen | A correct answer is: With great care, Ava locked the window. |
+| proc_fronted_adverbial_fix | 2 | textarea | placeholder: Write the corrected sentenc | Fix comma after fronted adverbial. Rewrite the sen | A correct answer is: With great care, Noah found the map. |
+| proc_fronted_adverbial_fix | 3 | textarea | placeholder: Write the corrected sentenc | Fix comma after fronted adverbial. Rewrite the sen | A correct answer is: With great care, Ava carried the trophy |
+| proc_fronted_adverbial_fix | 4 | textarea | placeholder: Write the corrected sentenc | Fix comma after fronted adverbial. Rewrite the sen | A correct answer is: After the final whistle, Noah carried t |
+| proc_fronted_adverbial_fix | 5 | textarea | placeholder: Write the corrected sentenc | Fix comma after fronted adverbial. Rewrite the sen | A correct answer is: With great care, Nora found the gate. |
+| proc_fronted_adverbial_fix | 6 | textarea | placeholder: Write the corrected sentenc | Fix comma after fronted adverbial. Rewrite the sen | A correct answer is: Without warning, Ava opened the rucksac |
+| proc_fronted_adverbial_fix | 7 | textarea | placeholder: Write the corrected sentenc | Fix comma after fronted adverbial. Rewrite the sen | A correct answer is: Before sunrise, Ava lifted the sketchbo |
+| proc_fronted_adverbial_fix | 8 | textarea | placeholder: Write the corrected sentenc | Fix comma after fronted adverbial. Rewrite the sen | A correct answer is: After lunch, Amira lifted the map. |
+| proc_fronted_adverbial_fix | 9 | textarea | placeholder: Write the corrected sentenc | Fix comma after fronted adverbial. Rewrite the sen | A correct answer is: After lunch, Sam cleaned the gate. |
+| proc_fronted_adverbial_fix | 10 | textarea | placeholder: Write the corrected sentenc | Fix comma after fronted adverbial. Rewrite the sen | A correct answer is: Without warning, Ruby cleaned the rucks |
+| proc_fronted_adverbial_fix | 11 | textarea | placeholder: Write the corrected sentenc | Fix comma after fronted adverbial. Rewrite the sen | A correct answer is: Without warning, Luca found the window. |
+| proc_fronted_adverbial_fix | 12 | textarea | placeholder: Write the corrected sentenc | Fix comma after fronted adverbial. Rewrite the sen | A correct answer is: Later that day, Ava locked the window. |
+| proc_fronted_adverbial_fix | 13 | textarea | placeholder: Write the corrected sentenc | Fix comma after fronted adverbial. Rewrite the sen | A correct answer is: Without warning, Elsie carried the lant |
+| proc_fronted_adverbial_fix | 14 | textarea | placeholder: Write the corrected sentenc | Fix comma after fronted adverbial. Rewrite the sen | A correct answer is: At the edge of the field, Zac packed th |
+| proc_fronted_adverbial_fix | 15 | textarea | placeholder: Write the corrected sentenc | Fix comma after fronted adverbial. Rewrite the sen | A correct answer is: After lunch, Elsie dropped the trophy. |
+| proc_fronted_adverbial_fix | 16 | textarea | placeholder: Write the corrected sentenc | Fix comma after fronted adverbial. Rewrite the sen | A correct answer is: With great care, Ben dropped the picnic |
+| proc_fronted_adverbial_fix | 17 | textarea | placeholder: Write the corrected sentenc | Fix comma after fronted adverbial. Rewrite the sen | A correct answer is: With great care, Mia opened the window. |
+| proc_fronted_adverbial_fix | 18 | textarea | placeholder: Write the corrected sentenc | Fix comma after fronted adverbial. Rewrite the sen | A correct answer is: At the edge of the field, Amira opened  |
+| proc_fronted_adverbial_fix | 19 | textarea | placeholder: Write the corrected sentenc | Fix comma after fronted adverbial. Rewrite the sen | A correct answer is: Before sunrise, Noah cleaned the trophy |
+| proc_fronted_adverbial_fix | 20 | textarea | placeholder: Write the corrected sentenc | Fix comma after fronted adverbial. Rewrite the sen | A correct answer is: On Friday morning, Elsie packed the win |
+| proc_fronted_adverbial_fix | 21 | textarea | placeholder: Write the corrected sentenc | Fix comma after fronted adverbial. Rewrite the sen | A correct answer is: At the edge of the field, Zac dropped t |
+| proc_fronted_adverbial_fix | 22 | textarea | placeholder: Write the corrected sentenc | Fix comma after fronted adverbial. Rewrite the sen | A correct answer is: Without warning, Mia opened the gate. |
+| proc_fronted_adverbial_fix | 23 | textarea | placeholder: Write the corrected sentenc | Fix comma after fronted adverbial. Rewrite the sen | A correct answer is: Before sunrise, Ava packed the rucksack |
+| proc_fronted_adverbial_fix | 24 | textarea | placeholder: Write the corrected sentenc | Fix comma after fronted adverbial. Rewrite the sen | A correct answer is: Later that day, Ruby carried the map. |
+| proc_fronted_adverbial_fix | 25 | textarea | placeholder: Write the corrected sentenc | Fix comma after fronted adverbial. Rewrite the sen | A correct answer is: Without warning, Nora lifted the window |
+| proc_fronted_adverbial_fix | 26 | textarea | placeholder: Write the corrected sentenc | Fix comma after fronted adverbial. Rewrite the sen | A correct answer is: Without warning, Jay carried the window |
+| proc_fronted_adverbial_fix | 27 | textarea | placeholder: Write the corrected sentenc | Fix comma after fronted adverbial. Rewrite the sen | A correct answer is: At the edge of the field, Ava opened th |
+| proc_fronted_adverbial_fix | 28 | textarea | placeholder: Write the corrected sentenc | Fix comma after fronted adverbial. Rewrite the sen | A correct answer is: At the edge of the field, Jay lifted th |
+| proc_fronted_adverbial_fix | 29 | textarea | placeholder: Write the corrected sentenc | Fix comma after fronted adverbial. Rewrite the sen | A correct answer is: After lunch, Ben opened the map. |
+| proc_fronted_adverbial_fix | 30 | textarea | placeholder: Write the corrected sentenc | Fix comma after fronted adverbial. Rewrite the sen | A correct answer is: On Friday morning, Sam opened the troph |
+| proc_semicolon_choice | 1 | single_choice | ;, :, ,, ? | Which punctuation mark best completes the sentence | The best answer is: The rain stopped; the playground began t |
+| proc_semicolon_choice | 2 | single_choice | ;, :, ,, ? | Which punctuation mark best completes the sentence | The best answer is: The lights went out; the hall fell silen |
+| proc_semicolon_choice | 3 | single_choice | ;, :, ,, ? | Which punctuation mark best completes the sentence | The best answer is: The bell rang; the pupils hurried inside |
+| proc_semicolon_choice | 4 | single_choice | ;, :, ,, ? | Which punctuation mark best completes the sentence | The best answer is: The wind strengthened; the tent flapped  |
+| proc_semicolon_choice | 5 | single_choice | ;, :, ,, ? | Which punctuation mark best completes the sentence | The best answer is: The bus arrived; everyone grabbed their  |
+| proc_semicolon_choice | 6 | single_choice | ;, :, ,, ? | Which punctuation mark best completes the sentence | The best answer is: The sun broke through the clouds; the ic |
+| proc_semicolon_choice | 7 | single_choice | ;, :, ,, ? | Which punctuation mark best completes the sentence | The best answer is: The tide was rising quickly; the fisherm |
+| proc_semicolon_choice | 8 | single_choice | ;, :, ,, ? | Which punctuation mark best completes the sentence | The best answer is: The whistle blew; the runners set off do |
+| proc_semicolon_choice | 9 | single_choice | ;, :, ,, ? | Which punctuation mark best completes the sentence | The best answer is: The audience clapped loudly; the choir t |
+| proc_semicolon_choice | 10 | single_choice | ;, :, ,, ? | Which punctuation mark best completes the sentence | The best answer is: The rain stopped; the playground began t |
+| proc_semicolon_choice | 11 | single_choice | ;, :, ,, ? | Which punctuation mark best completes the sentence | The best answer is: The lights went out; the hall fell silen |
+| proc_semicolon_choice | 12 | single_choice | ;, :, ,, ? | Which punctuation mark best completes the sentence | The best answer is: The bell rang; the pupils hurried inside |
+| proc_semicolon_choice | 13 | single_choice | ;, :, ,, ? | Which punctuation mark best completes the sentence | The best answer is: The wind strengthened; the tent flapped  |
+| proc_semicolon_choice | 14 | single_choice | ;, :, ,, ? | Which punctuation mark best completes the sentence | The best answer is: The bus arrived; everyone grabbed their  |
+| proc_semicolon_choice | 15 | single_choice | ;, :, ,, ? | Which punctuation mark best completes the sentence | The best answer is: The sun broke through the clouds; the ic |
+| proc_semicolon_choice | 16 | single_choice | ;, :, ,, ? | Which punctuation mark best completes the sentence | The best answer is: The tide was rising quickly; the fisherm |
+| proc_semicolon_choice | 17 | single_choice | ;, :, ,, ? | Which punctuation mark best completes the sentence | The best answer is: The whistle blew; the runners set off do |
+| proc_semicolon_choice | 18 | single_choice | ;, :, ,, ? | Which punctuation mark best completes the sentence | The best answer is: The audience clapped loudly; the choir t |
+| proc_semicolon_choice | 19 | single_choice | ;, :, ,, ? | Which punctuation mark best completes the sentence | The best answer is: The rain stopped; the playground began t |
+| proc_semicolon_choice | 20 | single_choice | ;, :, ,, ? | Which punctuation mark best completes the sentence | The best answer is: The lights went out; the hall fell silen |
+| proc_semicolon_choice | 21 | single_choice | ;, :, ,, ? | Which punctuation mark best completes the sentence | The best answer is: The bell rang; the pupils hurried inside |
+| proc_semicolon_choice | 22 | single_choice | ;, :, ,, ? | Which punctuation mark best completes the sentence | The best answer is: The wind strengthened; the tent flapped  |
+| proc_semicolon_choice | 23 | single_choice | ;, :, ,, ? | Which punctuation mark best completes the sentence | The best answer is: The bus arrived; everyone grabbed their  |
+| proc_semicolon_choice | 24 | single_choice | ;, :, ,, ? | Which punctuation mark best completes the sentence | The best answer is: The sun broke through the clouds; the ic |
+| proc_semicolon_choice | 25 | single_choice | ;, :, ,, ? | Which punctuation mark best completes the sentence | The best answer is: The tide was rising quickly; the fisherm |
+| proc_semicolon_choice | 26 | single_choice | ;, :, ,, ? | Which punctuation mark best completes the sentence | The best answer is: The whistle blew; the runners set off do |
+| proc_semicolon_choice | 27 | single_choice | ;, :, ,, ? | Which punctuation mark best completes the sentence | The best answer is: The audience clapped loudly; the choir t |
+| proc_semicolon_choice | 28 | single_choice | ;, :, ,, ? | Which punctuation mark best completes the sentence | The best answer is: The rain stopped; the playground began t |
+| proc_semicolon_choice | 29 | single_choice | ;, :, ,, ? | Which punctuation mark best completes the sentence | The best answer is: The lights went out; the hall fell silen |
+| proc_semicolon_choice | 30 | single_choice | ;, :, ,, ? | Which punctuation mark best completes the sentence | The best answer is: The bell rang; the pupils hurried inside |
+| proc_colon_list_fix | 1 | textarea | placeholder: Write the corrected sentenc | Insert a colon for a list. Rewrite the sentence wi | A correct answer is: For the picnic we packed three things:  |
+| proc_colon_list_fix | 2 | textarea | placeholder: Write the corrected sentenc | Insert a colon for a list. Rewrite the sentence wi | A correct answer is: The museum displayed four objects: a he |
+| proc_colon_list_fix | 3 | textarea | placeholder: Write the corrected sentenc | Insert a colon for a list. Rewrite the sentence wi | A correct answer is: We still needed two items for camp: a t |
+| proc_colon_list_fix | 4 | textarea | placeholder: Write the corrected sentenc | Insert a colon for a list. Rewrite the sentence wi | A correct answer is: The club offered three prizes: a medal, |
+| proc_colon_list_fix | 5 | textarea | placeholder: Write the corrected sentenc | Insert a colon for a list. Rewrite the sentence wi | A correct answer is: The recipe called for five ingredients: |
+| proc_colon_list_fix | 6 | textarea | placeholder: Write the corrected sentenc | Insert a colon for a list. Rewrite the sentence wi | A correct answer is: Three countries were represented at the |
+| proc_colon_list_fix | 7 | textarea | placeholder: Write the corrected sentenc | Insert a colon for a list. Rewrite the sentence wi | A correct answer is: The explorer carried four essential sup |
+| proc_colon_list_fix | 8 | textarea | placeholder: Write the corrected sentenc | Insert a colon for a list. Rewrite the sentence wi | A correct answer is: The school banned three items from the  |
+| proc_colon_list_fix | 9 | textarea | placeholder: Write the corrected sentenc | Insert a colon for a list. Rewrite the sentence wi | A correct answer is: The gardener planted four types of vege |
+| proc_colon_list_fix | 10 | textarea | placeholder: Write the corrected sentenc | Insert a colon for a list. Rewrite the sentence wi | A correct answer is: For the picnic we packed three things:  |
+| proc_colon_list_fix | 11 | textarea | placeholder: Write the corrected sentenc | Insert a colon for a list. Rewrite the sentence wi | A correct answer is: The museum displayed four objects: a he |
+| proc_colon_list_fix | 12 | textarea | placeholder: Write the corrected sentenc | Insert a colon for a list. Rewrite the sentence wi | A correct answer is: We still needed two items for camp: a t |
+| proc_colon_list_fix | 13 | textarea | placeholder: Write the corrected sentenc | Insert a colon for a list. Rewrite the sentence wi | A correct answer is: The club offered three prizes: a medal, |
+| proc_colon_list_fix | 14 | textarea | placeholder: Write the corrected sentenc | Insert a colon for a list. Rewrite the sentence wi | A correct answer is: The recipe called for five ingredients: |
+| proc_colon_list_fix | 15 | textarea | placeholder: Write the corrected sentenc | Insert a colon for a list. Rewrite the sentence wi | A correct answer is: Three countries were represented at the |
+| proc_colon_list_fix | 16 | textarea | placeholder: Write the corrected sentenc | Insert a colon for a list. Rewrite the sentence wi | A correct answer is: The explorer carried four essential sup |
+| proc_colon_list_fix | 17 | textarea | placeholder: Write the corrected sentenc | Insert a colon for a list. Rewrite the sentence wi | A correct answer is: The school banned three items from the  |
+| proc_colon_list_fix | 18 | textarea | placeholder: Write the corrected sentenc | Insert a colon for a list. Rewrite the sentence wi | A correct answer is: The gardener planted four types of vege |
+| proc_colon_list_fix | 19 | textarea | placeholder: Write the corrected sentenc | Insert a colon for a list. Rewrite the sentence wi | A correct answer is: For the picnic we packed three things:  |
+| proc_colon_list_fix | 20 | textarea | placeholder: Write the corrected sentenc | Insert a colon for a list. Rewrite the sentence wi | A correct answer is: The museum displayed four objects: a he |
+| proc_colon_list_fix | 21 | textarea | placeholder: Write the corrected sentenc | Insert a colon for a list. Rewrite the sentence wi | A correct answer is: We still needed two items for camp: a t |
+| proc_colon_list_fix | 22 | textarea | placeholder: Write the corrected sentenc | Insert a colon for a list. Rewrite the sentence wi | A correct answer is: The club offered three prizes: a medal, |
+| proc_colon_list_fix | 23 | textarea | placeholder: Write the corrected sentenc | Insert a colon for a list. Rewrite the sentence wi | A correct answer is: The recipe called for five ingredients: |
+| proc_colon_list_fix | 24 | textarea | placeholder: Write the corrected sentenc | Insert a colon for a list. Rewrite the sentence wi | A correct answer is: Three countries were represented at the |
+| proc_colon_list_fix | 25 | textarea | placeholder: Write the corrected sentenc | Insert a colon for a list. Rewrite the sentence wi | A correct answer is: The explorer carried four essential sup |
+| proc_colon_list_fix | 26 | textarea | placeholder: Write the corrected sentenc | Insert a colon for a list. Rewrite the sentence wi | A correct answer is: The school banned three items from the  |
+| proc_colon_list_fix | 27 | textarea | placeholder: Write the corrected sentenc | Insert a colon for a list. Rewrite the sentence wi | A correct answer is: The gardener planted four types of vege |
+| proc_colon_list_fix | 28 | textarea | placeholder: Write the corrected sentenc | Insert a colon for a list. Rewrite the sentence wi | A correct answer is: For the picnic we packed three things:  |
+| proc_colon_list_fix | 29 | textarea | placeholder: Write the corrected sentenc | Insert a colon for a list. Rewrite the sentence wi | A correct answer is: The museum displayed four objects: a he |
+| proc_colon_list_fix | 30 | textarea | placeholder: Write the corrected sentenc | Insert a colon for a list. Rewrite the sentence wi | A correct answer is: We still needed two items for camp: a t |
+| proc_dash_boundary_fix | 1 | textarea | placeholder: Write the corrected sentenc | Insert a dash to mark a strong break. Rewrite the  | A correct answer is: I had one worry – the batteries were fl |
+| proc_dash_boundary_fix | 2 | textarea | placeholder: Write the corrected sentenc | Insert a dash to mark a strong break. Rewrite the  | A correct answer is: The plan was simple – follow the red ar |
+| proc_dash_boundary_fix | 3 | textarea | placeholder: Write the corrected sentenc | Insert a dash to mark a strong break. Rewrite the  | A correct answer is: There was only one answer – turn back a |
+| proc_dash_boundary_fix | 4 | textarea | placeholder: Write the corrected sentenc | Insert a dash to mark a strong break. Rewrite the  | A correct answer is: One thought filled my mind – where had  |
+| proc_dash_boundary_fix | 5 | textarea | placeholder: Write the corrected sentenc | Insert a dash to mark a strong break. Rewrite the  | A correct answer is: She had made her decision – the letter  |
+| proc_dash_boundary_fix | 6 | textarea | placeholder: Write the corrected sentenc | Insert a dash to mark a strong break. Rewrite the  | A correct answer is: The message was clear – everyone must l |
+| proc_dash_boundary_fix | 7 | textarea | placeholder: Write the corrected sentenc | Insert a dash to mark a strong break. Rewrite the  | A correct answer is: He remembered just one rule – never ope |
+| proc_dash_boundary_fix | 8 | textarea | placeholder: Write the corrected sentenc | Insert a dash to mark a strong break. Rewrite the  | A correct answer is: The result surprised us all – the young |
+| proc_dash_boundary_fix | 9 | textarea | placeholder: Write the corrected sentenc | Insert a dash to mark a strong break. Rewrite the  | A correct answer is: Only one thing could save us – the map  |
+| proc_dash_boundary_fix | 10 | textarea | placeholder: Write the corrected sentenc | Insert a dash to mark a strong break. Rewrite the  | A correct answer is: I had one worry – the batteries were fl |
+| proc_dash_boundary_fix | 11 | textarea | placeholder: Write the corrected sentenc | Insert a dash to mark a strong break. Rewrite the  | A correct answer is: The plan was simple – follow the red ar |
+| proc_dash_boundary_fix | 12 | textarea | placeholder: Write the corrected sentenc | Insert a dash to mark a strong break. Rewrite the  | A correct answer is: There was only one answer – turn back a |
+| proc_dash_boundary_fix | 13 | textarea | placeholder: Write the corrected sentenc | Insert a dash to mark a strong break. Rewrite the  | A correct answer is: One thought filled my mind – where had  |
+| proc_dash_boundary_fix | 14 | textarea | placeholder: Write the corrected sentenc | Insert a dash to mark a strong break. Rewrite the  | A correct answer is: She had made her decision – the letter  |
+| proc_dash_boundary_fix | 15 | textarea | placeholder: Write the corrected sentenc | Insert a dash to mark a strong break. Rewrite the  | A correct answer is: The message was clear – everyone must l |
+| proc_dash_boundary_fix | 16 | textarea | placeholder: Write the corrected sentenc | Insert a dash to mark a strong break. Rewrite the  | A correct answer is: He remembered just one rule – never ope |
+| proc_dash_boundary_fix | 17 | textarea | placeholder: Write the corrected sentenc | Insert a dash to mark a strong break. Rewrite the  | A correct answer is: The result surprised us all – the young |
+| proc_dash_boundary_fix | 18 | textarea | placeholder: Write the corrected sentenc | Insert a dash to mark a strong break. Rewrite the  | A correct answer is: Only one thing could save us – the map  |
+| proc_dash_boundary_fix | 19 | textarea | placeholder: Write the corrected sentenc | Insert a dash to mark a strong break. Rewrite the  | A correct answer is: I had one worry – the batteries were fl |
+| proc_dash_boundary_fix | 20 | textarea | placeholder: Write the corrected sentenc | Insert a dash to mark a strong break. Rewrite the  | A correct answer is: The plan was simple – follow the red ar |
+| proc_dash_boundary_fix | 21 | textarea | placeholder: Write the corrected sentenc | Insert a dash to mark a strong break. Rewrite the  | A correct answer is: There was only one answer – turn back a |
+| proc_dash_boundary_fix | 22 | textarea | placeholder: Write the corrected sentenc | Insert a dash to mark a strong break. Rewrite the  | A correct answer is: One thought filled my mind – where had  |
+| proc_dash_boundary_fix | 23 | textarea | placeholder: Write the corrected sentenc | Insert a dash to mark a strong break. Rewrite the  | A correct answer is: She had made her decision – the letter  |
+| proc_dash_boundary_fix | 24 | textarea | placeholder: Write the corrected sentenc | Insert a dash to mark a strong break. Rewrite the  | A correct answer is: The message was clear – everyone must l |
+| proc_dash_boundary_fix | 25 | textarea | placeholder: Write the corrected sentenc | Insert a dash to mark a strong break. Rewrite the  | A correct answer is: He remembered just one rule – never ope |
+| proc_dash_boundary_fix | 26 | textarea | placeholder: Write the corrected sentenc | Insert a dash to mark a strong break. Rewrite the  | A correct answer is: The result surprised us all – the young |
+| proc_dash_boundary_fix | 27 | textarea | placeholder: Write the corrected sentenc | Insert a dash to mark a strong break. Rewrite the  | A correct answer is: Only one thing could save us – the map  |
+| proc_dash_boundary_fix | 28 | textarea | placeholder: Write the corrected sentenc | Insert a dash to mark a strong break. Rewrite the  | A correct answer is: I had one worry – the batteries were fl |
+| proc_dash_boundary_fix | 29 | textarea | placeholder: Write the corrected sentenc | Insert a dash to mark a strong break. Rewrite the  | A correct answer is: The plan was simple – follow the red ar |
+| proc_dash_boundary_fix | 30 | textarea | placeholder: Write the corrected sentenc | Insert a dash to mark a strong break. Rewrite the  | A correct answer is: There was only one answer – turn back a |
+| proc_hyphen_ambiguity_choice | 1 | single_choice | We saw a man-eating shark near the rocks | Choose the clearer hyphenated sentence. Which sent | The clearer answer is: We saw a man-eating shark near the ro |
+| proc_hyphen_ambiguity_choice | 2 | single_choice | We visited the small-animal hospital aft | Choose the clearer hyphenated sentence. Which sent | The clearer answer is: We visited the small-animal hospital  |
+| proc_hyphen_ambiguity_choice | 3 | single_choice | Dad opened the clothes-drying cabinet in | Choose the clearer hyphenated sentence. Which sent | The clearer answer is: Dad opened the clothes-drying cabinet |
+| proc_hyphen_ambiguity_choice | 4 | single_choice | The teacher set a well-known test for th | Choose the clearer hyphenated sentence. Which sent | The clearer answer is: The teacher set a well-known test for |
+| proc_hyphen_ambiguity_choice | 5 | single_choice | We looked up at the ten-storey building. | Choose the clearer hyphenated sentence. Which sent | The clearer answer is: We looked up at the ten-storey buildi |
+| proc_hyphen_ambiguity_choice | 6 | single_choice | Sam ran in the three-mile race on Saturd | Choose the clearer hyphenated sentence. Which sent | The clearer answer is: Sam ran in the three-mile race on Sat |
+| proc_hyphen_ambiguity_choice | 7 | single_choice | Mum found a bargain at the second-hand s | Choose the clearer hyphenated sentence. Which sent | The clearer answer is: Mum found a bargain at the second-han |
+| proc_hyphen_ambiguity_choice | 8 | single_choice | The six-year-old child ran across the pa | Choose the clearer hyphenated sentence. Which sent | The clearer answer is: The six-year-old child ran across the |
+| proc_hyphen_ambiguity_choice | 9 | single_choice | Jay chose the sugar-free ice cream from  | Choose the clearer hyphenated sentence. Which sent | The clearer answer is: Jay chose the sugar-free ice cream fr |
+| proc_hyphen_ambiguity_choice | 10 | single_choice | We saw a man-eating shark near the rocks | Choose the clearer hyphenated sentence. Which sent | The clearer answer is: We saw a man-eating shark near the ro |
+| proc_hyphen_ambiguity_choice | 11 | single_choice | We visited the small-animal hospital aft | Choose the clearer hyphenated sentence. Which sent | The clearer answer is: We visited the small-animal hospital  |
+| proc_hyphen_ambiguity_choice | 12 | single_choice | Dad opened the clothes-drying cabinet in | Choose the clearer hyphenated sentence. Which sent | The clearer answer is: Dad opened the clothes-drying cabinet |
+| proc_hyphen_ambiguity_choice | 13 | single_choice | The teacher set a well-known test for th | Choose the clearer hyphenated sentence. Which sent | The clearer answer is: The teacher set a well-known test for |
+| proc_hyphen_ambiguity_choice | 14 | single_choice | We looked up at the ten-storey building. | Choose the clearer hyphenated sentence. Which sent | The clearer answer is: We looked up at the ten-storey buildi |
+| proc_hyphen_ambiguity_choice | 15 | single_choice | Sam ran in the three-mile race on Saturd | Choose the clearer hyphenated sentence. Which sent | The clearer answer is: Sam ran in the three-mile race on Sat |
+| proc_hyphen_ambiguity_choice | 16 | single_choice | Mum found a bargain at the second-hand s | Choose the clearer hyphenated sentence. Which sent | The clearer answer is: Mum found a bargain at the second-han |
+| proc_hyphen_ambiguity_choice | 17 | single_choice | The six-year-old child ran across the pa | Choose the clearer hyphenated sentence. Which sent | The clearer answer is: The six-year-old child ran across the |
+| proc_hyphen_ambiguity_choice | 18 | single_choice | Jay chose the sugar-free ice cream from  | Choose the clearer hyphenated sentence. Which sent | The clearer answer is: Jay chose the sugar-free ice cream fr |
+| proc_hyphen_ambiguity_choice | 19 | single_choice | We saw a man-eating shark near the rocks | Choose the clearer hyphenated sentence. Which sent | The clearer answer is: We saw a man-eating shark near the ro |
+| proc_hyphen_ambiguity_choice | 20 | single_choice | We visited the small-animal hospital aft | Choose the clearer hyphenated sentence. Which sent | The clearer answer is: We visited the small-animal hospital  |
+| proc_hyphen_ambiguity_choice | 21 | single_choice | Dad opened the clothes-drying cabinet in | Choose the clearer hyphenated sentence. Which sent | The clearer answer is: Dad opened the clothes-drying cabinet |
+| proc_hyphen_ambiguity_choice | 22 | single_choice | The teacher set a well-known test for th | Choose the clearer hyphenated sentence. Which sent | The clearer answer is: The teacher set a well-known test for |
+| proc_hyphen_ambiguity_choice | 23 | single_choice | We looked up at the ten-storey building. | Choose the clearer hyphenated sentence. Which sent | The clearer answer is: We looked up at the ten-storey buildi |
+| proc_hyphen_ambiguity_choice | 24 | single_choice | Sam ran in the three-mile race on Saturd | Choose the clearer hyphenated sentence. Which sent | The clearer answer is: Sam ran in the three-mile race on Sat |
+| proc_hyphen_ambiguity_choice | 25 | single_choice | Mum found a bargain at the second-hand s | Choose the clearer hyphenated sentence. Which sent | The clearer answer is: Mum found a bargain at the second-han |
+| proc_hyphen_ambiguity_choice | 26 | single_choice | The six-year-old child ran across the pa | Choose the clearer hyphenated sentence. Which sent | The clearer answer is: The six-year-old child ran across the |
+| proc_hyphen_ambiguity_choice | 27 | single_choice | Jay chose the sugar-free ice cream from  | Choose the clearer hyphenated sentence. Which sent | The clearer answer is: Jay chose the sugar-free ice cream fr |
+| proc_hyphen_ambiguity_choice | 28 | single_choice | We saw a man-eating shark near the rocks | Choose the clearer hyphenated sentence. Which sent | The clearer answer is: We saw a man-eating shark near the ro |
+| proc_hyphen_ambiguity_choice | 29 | single_choice | We visited the small-animal hospital aft | Choose the clearer hyphenated sentence. Which sent | The clearer answer is: We visited the small-animal hospital  |
+| proc_hyphen_ambiguity_choice | 30 | single_choice | Dad opened the clothes-drying cabinet in | Choose the clearer hyphenated sentence. Which sent | The clearer answer is: Dad opened the clothes-drying cabinet |
+| proc_speech_punctuation_fix | 1 | textarea | placeholder: Type the corrected sentence | Fix speech punctuation. Punctuate the direct speec | A correct answer is: Ben said, "Shut the gate behind you!" |
+| proc_speech_punctuation_fix | 2 | textarea | placeholder: Type the corrected sentence | Fix speech punctuation. Punctuate the direct speec | A correct answer is: "What a huge wave that was!" asked Ava. |
+| proc_speech_punctuation_fix | 3 | textarea | placeholder: Type the corrected sentence | Fix speech punctuation. Punctuate the direct speec | A correct answer is: "Why are your boots muddy?" said Ava. |
+| proc_speech_punctuation_fix | 4 | textarea | placeholder: Type the corrected sentence | Fix speech punctuation. Punctuate the direct speec | A correct answer is: the guide asked, "Bring the torch with  |
+| proc_speech_punctuation_fix | 5 | textarea | placeholder: Type the corrected sentence | Fix speech punctuation. Punctuate the direct speec | A correct answer is: "What a huge wave that was!" whispered  |
+| proc_speech_punctuation_fix | 6 | textarea | placeholder: Type the corrected sentence | Fix speech punctuation. Punctuate the direct speec | A correct answer is: "Have you packed the torch?" said Miss  |
+| proc_speech_punctuation_fix | 7 | textarea | placeholder: Type the corrected sentence | Fix speech punctuation. Punctuate the direct speec | A correct answer is: Mum said, "Hold the ladder steady!" |
+| proc_speech_punctuation_fix | 8 | textarea | placeholder: Type the corrected sentence | Fix speech punctuation. Punctuate the direct speec | A correct answer is: "What a huge wave that was!" whispered  |
+| proc_speech_punctuation_fix | 9 | textarea | placeholder: Type the corrected sentence | Fix speech punctuation. Punctuate the direct speec | A correct answer is: "Where is the spare key?" called Dad. |
+| proc_speech_punctuation_fix | 10 | textarea | placeholder: Type the corrected sentence | Fix speech punctuation. Punctuate the direct speec | A correct answer is: Miss Patel called, "Shut the gate behin |
+| proc_speech_punctuation_fix | 11 | textarea | placeholder: Type the corrected sentence | Fix speech punctuation. Punctuate the direct speec | A correct answer is: "Look out for the puddle!" shouted Miss |
+| proc_speech_punctuation_fix | 12 | textarea | placeholder: Type the corrected sentence | Fix speech punctuation. Punctuate the direct speec | A correct answer is: "Have you packed the torch?" said the c |
+| proc_speech_punctuation_fix | 13 | textarea | placeholder: Type the corrected sentence | Fix speech punctuation. Punctuate the direct speec | A correct answer is: Miss Patel asked, "Bring the torch with |
+| proc_speech_punctuation_fix | 14 | textarea | placeholder: Type the corrected sentence | Fix speech punctuation. Punctuate the direct speec | A correct answer is: "Look out for the puddle!" shouted Miss |
+| proc_speech_punctuation_fix | 15 | textarea | placeholder: Type the corrected sentence | Fix speech punctuation. Punctuate the direct speec | A correct answer is: "Why are your boots muddy?" shouted Dad |
+| proc_speech_punctuation_fix | 16 | textarea | placeholder: Type the corrected sentence | Fix speech punctuation. Punctuate the direct speec | A correct answer is: Ben said, "Hold the ladder steady!" |
+| proc_speech_punctuation_fix | 17 | textarea | placeholder: Type the corrected sentence | Fix speech punctuation. Punctuate the direct speec | A correct answer is: "Look out for the puddle!" said Ben. |
+| proc_speech_punctuation_fix | 18 | textarea | placeholder: Type the corrected sentence | Fix speech punctuation. Punctuate the direct speec | A correct answer is: "Have you packed the torch?" whispered  |
+| proc_speech_punctuation_fix | 19 | textarea | placeholder: Type the corrected sentence | Fix speech punctuation. Punctuate the direct speec | A correct answer is: Mum asked, "Wait by the hall doors!" |
+| proc_speech_punctuation_fix | 20 | textarea | placeholder: Type the corrected sentence | Fix speech punctuation. Punctuate the direct speec | A correct answer is: "Look out for the puddle!" asked Ava. |
+| proc_speech_punctuation_fix | 21 | textarea | placeholder: Type the corrected sentence | Fix speech punctuation. Punctuate the direct speec | A correct answer is: "Why are your boots muddy?" shouted Mis |
+| proc_speech_punctuation_fix | 22 | textarea | placeholder: Type the corrected sentence | Fix speech punctuation. Punctuate the direct speec | A correct answer is: Ben asked, "Bring the torch with you!" |
+| proc_speech_punctuation_fix | 23 | textarea | placeholder: Type the corrected sentence | Fix speech punctuation. Punctuate the direct speec | A correct answer is: "Look out for the puddle!" said Mum. |
+| proc_speech_punctuation_fix | 24 | textarea | placeholder: Type the corrected sentence | Fix speech punctuation. Punctuate the direct speec | A correct answer is: "Why are your boots muddy?" called the  |
+| proc_speech_punctuation_fix | 25 | textarea | placeholder: Type the corrected sentence | Fix speech punctuation. Punctuate the direct speec | A correct answer is: Ben called, "Shut the gate behind you!" |
+| proc_speech_punctuation_fix | 26 | textarea | placeholder: Type the corrected sentence | Fix speech punctuation. Punctuate the direct speec | A correct answer is: "Look out for the puddle!" whispered Mi |
+| proc_speech_punctuation_fix | 27 | textarea | placeholder: Type the corrected sentence | Fix speech punctuation. Punctuate the direct speec | A correct answer is: "Where is the spare key?" said the coac |
+| proc_speech_punctuation_fix | 28 | textarea | placeholder: Type the corrected sentence | Fix speech punctuation. Punctuate the direct speec | A correct answer is: the coach whispered, "Shut the gate beh |
+| proc_speech_punctuation_fix | 29 | textarea | placeholder: Type the corrected sentence | Fix speech punctuation. Punctuate the direct speec | A correct answer is: "What a huge wave that was!" said Dad. |
+| proc_speech_punctuation_fix | 30 | textarea | placeholder: Type the corrected sentence | Fix speech punctuation. Punctuate the direct speec | A correct answer is: "Why are your boots muddy?" called the  |
+| proc_apostrophe_possession_choice | 1 | single_choice | the girl's coats, the girls' coats, the  | Choose the correct possessive apostrophe. Choose t | The correct answer is: the girls' coats |
+| proc_apostrophe_possession_choice | 2 | single_choice | the peoples tickets, the people's ticket | Choose the correct possessive apostrophe. Choose t | The correct answer is: the people's tickets |
+| proc_apostrophe_possession_choice | 3 | single_choice | the dogs tickets, the dog's tickets, the | Choose the correct possessive apostrophe. Choose t | The correct answer is: the dog's tickets |
+| proc_apostrophe_possession_choice | 4 | single_choice | the boy's lunchboxes, the boys' lunchbox | Choose the correct possessive apostrophe. Choose t | The correct answer is: the boys' lunchboxes |
+| proc_apostrophe_possession_choice | 5 | single_choice | the womens coats, the women's coats, the | Choose the correct possessive apostrophe. Choose t | The correct answer is: the women's coats |
+| proc_apostrophe_possession_choice | 6 | single_choice | the dogs bags, the dog's bags, the dogs' | Choose the correct possessive apostrophe. Choose t | The correct answer is: the dog's bags |
+| proc_apostrophe_possession_choice | 7 | single_choice | the girl's boots, the girls' boots, the  | Choose the correct possessive apostrophe. Choose t | The correct answer is: the girls' boots |
+| proc_apostrophe_possession_choice | 8 | single_choice | the mens books, the men's books, the men | Choose the correct possessive apostrophe. Choose t | The correct answer is: the men's books |
+| proc_apostrophe_possession_choice | 9 | single_choice | the farmers books, the farmer's books, t | Choose the correct possessive apostrophe. Choose t | The correct answer is: the farmer's books |
+| proc_apostrophe_possession_choice | 10 | single_choice | the farmer's bags, the farmers' bags, th | Choose the correct possessive apostrophe. Choose t | The correct answer is: the farmers' bags |
+| proc_apostrophe_possession_choice | 11 | single_choice | the mens bags, the men's bags, the men'  | Choose the correct possessive apostrophe. Choose t | The correct answer is: the men's bags |
+| proc_apostrophe_possession_choice | 12 | single_choice | the dogs bikes, the dog's bikes, the dog | Choose the correct possessive apostrophe. Choose t | The correct answer is: the dog's bikes |
+| proc_apostrophe_possession_choice | 13 | single_choice | the player's bags, the players' bags, th | Choose the correct possessive apostrophe. Choose t | The correct answer is: the players' bags |
+| proc_apostrophe_possession_choice | 14 | single_choice | the peoples bags, the people's bags, the | Choose the correct possessive apostrophe. Choose t | The correct answer is: the people's bags |
+| proc_apostrophe_possession_choice | 15 | single_choice | the teachers books, the teacher's books, | Choose the correct possessive apostrophe. Choose t | The correct answer is: the teacher's books |
+| proc_apostrophe_possession_choice | 16 | single_choice | the girl's coats, the girls' coats, the  | Choose the correct possessive apostrophe. Choose t | The correct answer is: the girls' coats |
+| proc_apostrophe_possession_choice | 17 | single_choice | the childrens coats, the children's coat | Choose the correct possessive apostrophe. Choose t | The correct answer is: the children's coats |
+| proc_apostrophe_possession_choice | 18 | single_choice | the players bikes, the player's bikes, t | Choose the correct possessive apostrophe. Choose t | The correct answer is: the player's bikes |
+| proc_apostrophe_possession_choice | 19 | single_choice | the boy's boots, the boys' boots, the bo | Choose the correct possessive apostrophe. Choose t | The correct answer is: the boys' boots |
+| proc_apostrophe_possession_choice | 20 | single_choice | the peoples tickets, the people's ticket | Choose the correct possessive apostrophe. Choose t | The correct answer is: the people's tickets |
+| proc_apostrophe_possession_choice | 21 | single_choice | the teachers bags, the teacher's bags, t | Choose the correct possessive apostrophe. Choose t | The correct answer is: the teacher's bags |
+| proc_apostrophe_possession_choice | 22 | single_choice | the boy's coats, the boys' coats, the bo | Choose the correct possessive apostrophe. Choose t | The correct answer is: the boys' coats |
+| proc_apostrophe_possession_choice | 23 | single_choice | the childrens boots, the children's boot | Choose the correct possessive apostrophe. Choose t | The correct answer is: the children's boots |
+| proc_apostrophe_possession_choice | 24 | single_choice | the farmers bikes, the farmer's bikes, t | Choose the correct possessive apostrophe. Choose t | The correct answer is: the farmer's bikes |
+| proc_apostrophe_possession_choice | 25 | single_choice | the visitor's coats, the visitors' coats | Choose the correct possessive apostrophe. Choose t | The correct answer is: the visitors' coats |
+| proc_apostrophe_possession_choice | 26 | single_choice | the mens bags, the men's bags, the men'  | Choose the correct possessive apostrophe. Choose t | The correct answer is: the men's bags |
+| proc_apostrophe_possession_choice | 27 | single_choice | the dogs bikes, the dog's bikes, the dog | Choose the correct possessive apostrophe. Choose t | The correct answer is: the dog's bikes |
+| proc_apostrophe_possession_choice | 28 | single_choice | the visitor's bikes, the visitors' bikes | Choose the correct possessive apostrophe. Choose t | The correct answer is: the visitors' bikes |
+| proc_apostrophe_possession_choice | 29 | single_choice | the childrens books, the children's book | Choose the correct possessive apostrophe. Choose t | The correct answer is: the children's books |
+| proc_apostrophe_possession_choice | 30 | single_choice | the farmers lunchboxes, the farmer's lun | Choose the correct possessive apostrophe. Choose t | The correct answer is: the farmer's lunchboxes |
+| proc2_standard_english_choice | 1 | single_choice | Ava don't know why the gate is locked.,  | Choose Standard English. Which sentence is written | The correct answer is: Ava doesn't know why the gate is lock |
+| proc2_standard_english_choice | 2 | single_choice | Noah doesn't know where the hall is., No | Choose Standard English. Which sentence is written | The correct answer is: Noah doesn't know where the hall is. |
+| proc2_standard_english_choice | 3 | single_choice | Ava don't know where the hall is., Ava n | Choose Standard English. Which sentence is written | The correct answer is: Ava doesn't know where the hall is. |
+| proc2_standard_english_choice | 4 | single_choice | Noah has saw the comet last night., Noah | Choose Standard English. Which sentence is written | The correct answer is: Noah saw the comet last night. |
+| proc2_standard_english_choice | 5 | single_choice | Nora not know the answer yet., Nora don' | Choose Standard English. Which sentence is written | The correct answer is: Nora doesn't know the answer yet. |
+| proc2_standard_english_choice | 6 | single_choice | Ava didn't know why the gate is locked., | Choose Standard English. Which sentence is written | The correct answer is: Ava doesn't know why the gate is lock |
+| proc2_standard_english_choice | 7 | single_choice | The visitors be waiting by the gate., Th | Choose Standard English. Which sentence is written | The correct answer is: The visitors were waiting by the gate |
+| proc2_standard_english_choice | 8 | single_choice | They be standing near the hall., They we | Choose Standard English. Which sentence is written | The correct answer is: They were standing near the hall. |
+| proc2_standard_english_choice | 9 | single_choice | We were ready for the start., We was rea | Choose Standard English. Which sentence is written | The correct answer is: We were ready for the start. |
+| proc2_standard_english_choice | 10 | single_choice | Ruby didn't know why the gate is locked. | Choose Standard English. Which sentence is written | The correct answer is: Ruby doesn't know why the gate is loc |
+| proc2_standard_english_choice | 11 | single_choice | Luca doesn't know why the gate is locked | Choose Standard English. Which sentence is written | The correct answer is: Luca doesn't know why the gate is loc |
+| proc2_standard_english_choice | 12 | single_choice | I done my homework before tea., I did my | Choose Standard English. Which sentence is written | The correct answer is: I did my homework before tea. |
+| proc2_standard_english_choice | 13 | single_choice | Elsie don't know the answer yet., Elsie  | Choose Standard English. Which sentence is written | The correct answer is: Elsie doesn't know the answer yet. |
+| proc2_standard_english_choice | 14 | single_choice | I have did the poster before tea., I did | Choose Standard English. Which sentence is written | The correct answer is: I did the poster before tea. |
+| proc2_standard_english_choice | 15 | single_choice | They is walking home after lunch., They  | Choose Standard English. Which sentence is written | The correct answer is: They were walking home after lunch. |
+| proc2_standard_english_choice | 16 | single_choice | Ben didn't know how to fold the map., Be | Choose Standard English. Which sentence is written | The correct answer is: Ben doesn't know how to fold the map. |
+| proc2_standard_english_choice | 17 | single_choice | Mia didn't know why the gate is locked., | Choose Standard English. Which sentence is written | The correct answer is: Mia doesn't know why the gate is lock |
+| proc2_standard_english_choice | 18 | single_choice | I have did my reading record before tea. | Choose Standard English. Which sentence is written | The correct answer is: I did my reading record before tea. |
+| proc2_standard_english_choice | 19 | single_choice | They was walking home after lunch., They | Choose Standard English. Which sentence is written | The correct answer is: They were walking home after lunch. |
+| proc2_standard_english_choice | 20 | single_choice | Elsie has saw the trophy yesterday., Els | Choose Standard English. Which sentence is written | The correct answer is: Elsie saw the trophy yesterday. |
+| proc2_standard_english_choice | 21 | single_choice | I do the poster before tea., I did the p | Choose Standard English. Which sentence is written | The correct answer is: I did the poster before tea. |
+| proc2_standard_english_choice | 22 | single_choice | Mia not know the answer yet., Mia didn't | Choose Standard English. Which sentence is written | The correct answer is: Mia doesn't know the answer yet. |
+| proc2_standard_english_choice | 23 | single_choice | The players be waiting by the gate., The | Choose Standard English. Which sentence is written | The correct answer is: The players were waiting by the gate. |
+| proc2_standard_english_choice | 24 | single_choice | I do the map work before tea., I have di | Choose Standard English. Which sentence is written | The correct answer is: I did the map work before tea. |
+| proc2_standard_english_choice | 25 | single_choice | Nora don't know why the gate is locked., | Choose Standard English. Which sentence is written | The correct answer is: Nora doesn't know why the gate is loc |
+| proc2_standard_english_choice | 26 | single_choice | Jay not know why the gate is locked., Ja | Choose Standard English. Which sentence is written | The correct answer is: Jay doesn't know why the gate is lock |
+| proc2_standard_english_choice | 27 | single_choice | I do my homework before tea., I done my  | Choose Standard English. Which sentence is written | The correct answer is: I did my homework before tea. |
+| proc2_standard_english_choice | 28 | single_choice | I done my reading record before tea., I  | Choose Standard English. Which sentence is written | The correct answer is: I did my reading record before tea. |
+| proc2_standard_english_choice | 29 | single_choice | They is waiting by the gate., They be wa | Choose Standard English. Which sentence is written | The correct answer is: They were waiting by the gate. |
+| proc2_standard_english_choice | 30 | single_choice | Sam see the notice last night., Sam has  | Choose Standard English. Which sentence is written | The correct answer is: Sam saw the notice last night. |
+| proc2_standard_english_fix | 1 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | A correct answer is: Ava doesn't know why the gate is locked |
+| proc2_standard_english_fix | 2 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | A correct answer is: Noah doesn't know where the hall is. |
+| proc2_standard_english_fix | 3 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | A correct answer is: Ava doesn't know where the hall is. |
+| proc2_standard_english_fix | 4 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | A correct answer is: Noah saw the comet last night. |
+| proc2_standard_english_fix | 5 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | A correct answer is: Nora doesn't know the answer yet. |
+| proc2_standard_english_fix | 6 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | A correct answer is: Ava doesn't know why the gate is locked |
+| proc2_standard_english_fix | 7 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | A correct answer is: The visitors were waiting by the gate. |
+| proc2_standard_english_fix | 8 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | A correct answer is: They were standing near the hall. |
+| proc2_standard_english_fix | 9 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | A correct answer is: We were ready for the start. |
+| proc2_standard_english_fix | 10 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | A correct answer is: Ruby doesn't know why the gate is locke |
+| proc2_standard_english_fix | 11 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | A correct answer is: Luca doesn't know why the gate is locke |
+| proc2_standard_english_fix | 12 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | A correct answer is: I did my homework before tea. |
+| proc2_standard_english_fix | 13 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | A correct answer is: Elsie doesn't know the answer yet. |
+| proc2_standard_english_fix | 14 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | A correct answer is: I did the poster before tea. |
+| proc2_standard_english_fix | 15 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | A correct answer is: They were walking home after lunch. |
+| proc2_standard_english_fix | 16 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | A correct answer is: Ben doesn't know how to fold the map. |
+| proc2_standard_english_fix | 17 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | A correct answer is: Mia doesn't know why the gate is locked |
+| proc2_standard_english_fix | 18 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | A correct answer is: I did my reading record before tea. |
+| proc2_standard_english_fix | 19 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | A correct answer is: They were walking home after lunch. |
+| proc2_standard_english_fix | 20 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | A correct answer is: Elsie saw the trophy yesterday. |
+| proc2_standard_english_fix | 21 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | A correct answer is: I did the poster before tea. |
+| proc2_standard_english_fix | 22 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | A correct answer is: Mia doesn't know the answer yet. |
+| proc2_standard_english_fix | 23 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | A correct answer is: The players were waiting by the gate. |
+| proc2_standard_english_fix | 24 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | A correct answer is: I did the map work before tea. |
+| proc2_standard_english_fix | 25 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | A correct answer is: Nora doesn't know why the gate is locke |
+| proc2_standard_english_fix | 26 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | A correct answer is: Jay doesn't know why the gate is locked |
+| proc2_standard_english_fix | 27 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | A correct answer is: I did my homework before tea. |
+| proc2_standard_english_fix | 28 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | A correct answer is: I did my reading record before tea. |
+| proc2_standard_english_fix | 29 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | A correct answer is: They were waiting by the gate. |
+| proc2_standard_english_fix | 30 | textarea | placeholder: Write the corrected sentenc | Rewrite in Standard English. Rewrite the sentence  | A correct answer is: Sam saw the notice last night. |
+| proc2_tense_aspect_choice | 1 | single_choice | finished, had finished, are finishing, h | Choose the correct tense or aspect. Choose the ver | By the time the coach arrived, The pupils had finished the p |
+| proc2_tense_aspect_choice | 2 | single_choice | is starting, started, had started, has s | Choose the correct tense or aspect. Choose the ver | Last night, He started the bag. |
+| proc2_tense_aspect_choice | 3 | single_choice | had started, has started, is starting, s | Choose the correct tense or aspect. Choose the ver | Last night, He started the project. |
+| proc2_tense_aspect_choice | 4 | single_choice | visited, had visited, has visited, is vi | Choose the correct tense or aspect. Choose the ver | Yesterday, Ava visited the bag. |
+| proc2_tense_aspect_choice | 5 | single_choice | is starting, started, had started, has s | Choose the correct tense or aspect. Choose the ver | On Monday, Amira started the display. |
+| proc2_tense_aspect_choice | 6 | single_choice | are cleaning, have cleaned, had cleaned, | Choose the correct tense or aspect. Choose the ver | Yesterday, They cleaned the project. |
+| proc2_tense_aspect_choice | 7 | single_choice | had opened, are opening, opened, have op | Choose the correct tense or aspect. Choose the ver | Last night, The pupils opened the project. |
+| proc2_tense_aspect_choice | 8 | single_choice | had packed, is packing, has packed, pack | Choose the correct tense or aspect. Choose the ver | Before lunch yesterday, She packed the display. |
+| proc2_tense_aspect_choice | 9 | single_choice | has packed, packed, had packed, is packi | Choose the correct tense or aspect. Choose the ver | By the time the coach arrived, He had packed the plan. |
+| proc2_tense_aspect_choice | 10 | single_choice | have cleaned, had cleaned, are cleaning, | Choose the correct tense or aspect. Choose the ver | Last night, The pupils cleaned the plan. |
+| proc2_tense_aspect_choice | 11 | single_choice | are cleaning, have cleaned, cleaned, had | Choose the correct tense or aspect. Choose the ver | By the time the rain started, We had cleaned the poster. |
+| proc2_tense_aspect_choice | 12 | single_choice | have lifted, are lifting, lifted, had li | Choose the correct tense or aspect. Choose the ver | The pupils have lifted the project already. |
+| proc2_tense_aspect_choice | 13 | single_choice | has finished, had finished, is finishing | Choose the correct tense or aspect. Choose the ver | Ava has finished the bag already. |
+| proc2_tense_aspect_choice | 14 | single_choice | are cleaning, cleaned, have cleaned, had | Choose the correct tense or aspect. Choose the ver | We have cleaned the poster just. |
+| proc2_tense_aspect_choice | 15 | single_choice | is lifting, had lifted, lifted, has lift | Choose the correct tense or aspect. Choose the ver | Before lunch yesterday, Zac lifted the poster. |
+| proc2_tense_aspect_choice | 16 | single_choice | had finished, finished, have finished, a | Choose the correct tense or aspect. Choose the ver | Yesterday, We finished the project. |
+| proc2_tense_aspect_choice | 17 | single_choice | had started, have started, are starting, | Choose the correct tense or aspect. Choose the ver | They have started the project today. |
+| proc2_tense_aspect_choice | 18 | single_choice | painted, are painting, had painted, have | Choose the correct tense or aspect. Choose the ver | By the time the rain started, They had painted the display. |
+| proc2_tense_aspect_choice | 19 | single_choice | has opened, is opening, opened, had open | Choose the correct tense or aspect. Choose the ver | He has opened the bag just. |
+| proc2_tense_aspect_choice | 20 | single_choice | have started, started, are starting, had | Choose the correct tense or aspect. Choose the ver | Yesterday, They started the bag. |
+| proc2_tense_aspect_choice | 21 | single_choice | had painted, has painted, is painting, p | Choose the correct tense or aspect. Choose the ver | By the time the lesson began, She had painted the poster. |
+| proc2_tense_aspect_choice | 22 | single_choice | finished, had finished, is finishing, ha | Choose the correct tense or aspect. Choose the ver | By the time the coach arrived, She had finished the bag. |
+| proc2_tense_aspect_choice | 23 | single_choice | have opened, opened, are opening, had op | Choose the correct tense or aspect. Choose the ver | They have opened the project already. |
+| proc2_tense_aspect_choice | 24 | single_choice | has lifted, is lifting, had lifted, lift | Choose the correct tense or aspect. Choose the ver | She has lifted the plan already. |
+| proc2_tense_aspect_choice | 25 | single_choice | had finished, have finished, are finishi | Choose the correct tense or aspect. Choose the ver | The pupils have finished the plan already. |
+| proc2_tense_aspect_choice | 26 | single_choice | had cleaned, cleaned, have cleaned, are  | Choose the correct tense or aspect. Choose the ver | By the time the rain started, They had cleaned the display. |
+| proc2_tense_aspect_choice | 27 | single_choice | is painting, had painted, painted, has p | Choose the correct tense or aspect. Choose the ver | He has painted the project already. |
+| proc2_tense_aspect_choice | 28 | single_choice | had painted, are painting, have painted, | Choose the correct tense or aspect. Choose the ver | The pupils have painted the display already. |
+| proc2_tense_aspect_choice | 29 | single_choice | is packing, had packed, packed, has pack | Choose the correct tense or aspect. Choose the ver | Last night, She packed the project. |
+| proc2_tense_aspect_choice | 30 | single_choice | is washing, washed, had washed, has wash | Choose the correct tense or aspect. Choose the ver | Before lunch yesterday, Mia washed the plan. |
+| proc2_modal_choice | 1 | single_choice | should, might, must, could | Choose the modal verb. Choose the modal verb that  | The correct answer is: must. ‘Must’ shows strongest obligati |
+| proc2_modal_choice | 2 | single_choice | must, will, might, should | Choose the modal verb. Choose the modal verb that  | The correct answer is: might. ‘Might’ shows possibility, not |
+| proc2_modal_choice | 3 | single_choice | must, will, should, might | Choose the modal verb. Choose the modal verb that  | The correct answer is: should. ‘Should’ is the modal of advi |
+| proc2_modal_choice | 4 | single_choice | might, should, will, must | Choose the modal verb. Choose the modal verb that  | The correct answer is: will. ‘Will’ fits a definite future e |
+| proc2_modal_choice | 5 | single_choice | must, may, might, will | Choose the modal verb. Choose the modal verb that  | The correct answer is: may. ‘May’ is the modal of permission |
+| proc2_modal_choice | 6 | single_choice | will, must, could, should | Choose the modal verb. Choose the modal verb that  | The correct answer is: could. ‘Could’ expresses ability or c |
+| proc2_modal_choice | 7 | single_choice | could, might, would, must | Choose the modal verb. Choose the modal verb that  | The correct answer is: must. ‘Must not’ expresses a strong p |
+| proc2_modal_choice | 8 | single_choice | might, could, must, should | Choose the modal verb. Choose the modal verb that  | The correct answer is: should. ‘Should’ expresses a reasonab |
+| proc2_modal_choice | 9 | single_choice | must, shall, will, might | Choose the modal verb. Choose the modal verb that  | The correct answer is: might. ‘Might’ shows an uncertain pos |
+| proc2_modal_choice | 10 | single_choice | must, might, should, could | Choose the modal verb. Choose the modal verb that  | The correct answer is: must. ‘Must’ shows strongest obligati |
+| proc2_modal_choice | 11 | single_choice | might, will, must, should | Choose the modal verb. Choose the modal verb that  | The correct answer is: might. ‘Might’ shows possibility, not |
+| proc2_modal_choice | 12 | single_choice | might, will, should, must | Choose the modal verb. Choose the modal verb that  | The correct answer is: should. ‘Should’ is the modal of advi |
+| proc2_modal_choice | 13 | single_choice | must, will, might, should | Choose the modal verb. Choose the modal verb that  | The correct answer is: will. ‘Will’ fits a definite future e |
+| proc2_modal_choice | 14 | single_choice | may, will, might, must | Choose the modal verb. Choose the modal verb that  | The correct answer is: may. ‘May’ is the modal of permission |
+| proc2_modal_choice | 15 | single_choice | should, will, must, could | Choose the modal verb. Choose the modal verb that  | The correct answer is: could. ‘Could’ expresses ability or c |
+| proc2_modal_choice | 16 | single_choice | would, might, must, could | Choose the modal verb. Choose the modal verb that  | The correct answer is: must. ‘Must not’ expresses a strong p |
+| proc2_modal_choice | 17 | single_choice | could, must, should, might | Choose the modal verb. Choose the modal verb that  | The correct answer is: should. ‘Should’ expresses a reasonab |
+| proc2_modal_choice | 18 | single_choice | might, will, shall, must | Choose the modal verb. Choose the modal verb that  | The correct answer is: might. ‘Might’ shows an uncertain pos |
+| proc2_modal_choice | 19 | single_choice | might, could, should, must | Choose the modal verb. Choose the modal verb that  | The correct answer is: must. ‘Must’ shows strongest obligati |
+| proc2_modal_choice | 20 | single_choice | might, should, must, will | Choose the modal verb. Choose the modal verb that  | The correct answer is: might. ‘Might’ shows possibility, not |
+| proc2_modal_choice | 21 | single_choice | might, should, will, must | Choose the modal verb. Choose the modal verb that  | The correct answer is: should. ‘Should’ is the modal of advi |
+| proc2_modal_choice | 22 | single_choice | might, must, will, should | Choose the modal verb. Choose the modal verb that  | The correct answer is: will. ‘Will’ fits a definite future e |
+| proc2_modal_choice | 23 | single_choice | will, must, might, may | Choose the modal verb. Choose the modal verb that  | The correct answer is: may. ‘May’ is the modal of permission |
+| proc2_modal_choice | 24 | single_choice | will, could, should, must | Choose the modal verb. Choose the modal verb that  | The correct answer is: could. ‘Could’ expresses ability or c |
+| proc2_modal_choice | 25 | single_choice | must, might, would, could | Choose the modal verb. Choose the modal verb that  | The correct answer is: must. ‘Must not’ expresses a strong p |
+| proc2_modal_choice | 26 | single_choice | should, must, could, might | Choose the modal verb. Choose the modal verb that  | The correct answer is: should. ‘Should’ expresses a reasonab |
+| proc2_modal_choice | 27 | single_choice | shall, will, might, must | Choose the modal verb. Choose the modal verb that  | The correct answer is: might. ‘Might’ shows an uncertain pos |
+| proc2_modal_choice | 28 | single_choice | must, should, could, might | Choose the modal verb. Choose the modal verb that  | The correct answer is: must. ‘Must’ shows strongest obligati |
+| proc2_modal_choice | 29 | single_choice | must, should, will, might | Choose the modal verb. Choose the modal verb that  | The correct answer is: might. ‘Might’ shows possibility, not |
+| proc2_modal_choice | 30 | single_choice | must, should, might, will | Choose the modal verb. Choose the modal verb that  | The correct answer is: should. ‘Should’ is the modal of advi |
+| proc2_formality_choice | 1 | single_choice | I just wanted to ask if we could maybe h | Choose the more formal sentence. Which sentence wo | The correct answer is: I am writing to request two extra cha |
+| proc2_formality_choice | 2 | single_choice | The club got set up last year., Last yea | Choose the more formal sentence. Which sentence so | The correct answer is: The club was established last year. |
+| proc2_formality_choice | 3 | single_choice | A few pupils were off for the visit., Qu | Choose the more formal sentence. Choose the senten | The correct answer is: Several pupils were absent from the v |
+| proc2_formality_choice | 4 | single_choice | We're so excited about the new library o | Choose the more formal sentence. Which sentence is | The correct answer is: We are delighted to announce the open |
+| proc2_formality_choice | 5 | single_choice | Can everyone turn up by half six?, Guest | Choose the more formal sentence. Choose the senten | The correct answer is: Guests are kindly requested to arrive |
+| proc2_formality_choice | 6 | single_choice | We tried the experiment and it sort of w | Choose the more formal sentence. Which sentence wo | The correct answer is: The experiment was conducted under co |
+| proc2_formality_choice | 7 | single_choice | Your service was awful and I'm not happy | Choose the more formal sentence. Which sentence is | The correct answer is: I wish to draw your attention to the  |
+| proc2_formality_choice | 8 | single_choice | Here's the person who's going to talk to | Choose the more formal sentence. Which sentence fi | The correct answer is: It is with great pleasure that I intr |
+| proc2_formality_choice | 9 | single_choice | Thanks so much for the cash you gave us. | Choose the more formal sentence. Which sentence is | The correct answer is: I am writing to express my gratitude  |
+| proc2_formality_choice | 10 | single_choice | I am writing to request two extra chairs | Choose the more formal sentence. Which sentence wo | The correct answer is: I am writing to request two extra cha |
+| proc2_formality_choice | 11 | single_choice | The club was established last year., Las | Choose the more formal sentence. Which sentence so | The correct answer is: The club was established last year. |
+| proc2_formality_choice | 12 | single_choice | Some pupils didn't come on the trip., Qu | Choose the more formal sentence. Choose the senten | The correct answer is: Several pupils were absent from the v |
+| proc2_formality_choice | 13 | single_choice | Guess what – there's a new library start | Choose the more formal sentence. Which sentence is | The correct answer is: We are delighted to announce the open |
+| proc2_formality_choice | 14 | single_choice | Guests are kindly requested to arrive by | Choose the more formal sentence. Choose the senten | The correct answer is: Guests are kindly requested to arrive |
+| proc2_formality_choice | 15 | single_choice | The experiment happened and everything w | Choose the more formal sentence. Which sentence wo | The correct answer is: The experiment was conducted under co |
+| proc2_formality_choice | 16 | single_choice | Just so you know, the service was really | Choose the more formal sentence. Which sentence is | The correct answer is: I wish to draw your attention to the  |
+| proc2_formality_choice | 17 | single_choice | So yeah, this is the speaker we got in t | Choose the more formal sentence. Which sentence fi | The correct answer is: It is with great pleasure that I intr |
+| proc2_formality_choice | 18 | single_choice | I am writing to express my gratitude for | Choose the more formal sentence. Which sentence is | The correct answer is: I am writing to express my gratitude  |
+| proc2_formality_choice | 19 | single_choice | Can we get a couple more chairs for the  | Choose the more formal sentence. Which sentence wo | The correct answer is: I am writing to request two extra cha |
+| proc2_formality_choice | 20 | single_choice | The club was established last year., The | Choose the more formal sentence. Which sentence so | The correct answer is: The club was established last year. |
+| proc2_formality_choice | 21 | single_choice | Some pupils didn't come on the trip., Se | Choose the more formal sentence. Choose the senten | The correct answer is: Several pupils were absent from the v |
+| proc2_formality_choice | 22 | single_choice | We're so excited about the new library o | Choose the more formal sentence. Which sentence is | The correct answer is: We are delighted to announce the open |
+| proc2_formality_choice | 23 | single_choice | Please try to get there by about six-thi | Choose the more formal sentence. Choose the senten | The correct answer is: Guests are kindly requested to arrive |
+| proc2_formality_choice | 24 | single_choice | We tried the experiment and it sort of w | Choose the more formal sentence. Which sentence wo | The correct answer is: The experiment was conducted under co |
+| proc2_formality_choice | 25 | single_choice | I wish to draw your attention to the uns | Choose the more formal sentence. Which sentence is | The correct answer is: I wish to draw your attention to the  |
+| proc2_formality_choice | 26 | single_choice | It is with great pleasure that I introdu | Choose the more formal sentence. Which sentence fi | The correct answer is: It is with great pleasure that I intr |
+| proc2_formality_choice | 27 | single_choice | Just wanted to say thanks for giving us  | Choose the more formal sentence. Which sentence is | The correct answer is: I am writing to express my gratitude  |
+| proc2_formality_choice | 28 | single_choice | I am writing to request two extra chairs | Choose the more formal sentence. Which sentence wo | The correct answer is: I am writing to request two extra cha |
+| proc2_formality_choice | 29 | single_choice | The club got set up last year., The club | Choose the more formal sentence. Which sentence so | The correct answer is: The club was established last year. |
+| proc2_formality_choice | 30 | single_choice | A few pupils were off for the visit., Se | Choose the more formal sentence. Choose the senten | The correct answer is: Several pupils were absent from the v |
+| proc2_pronoun_cohesion_choice | 1 | single_choice | Amira gave Ava it because Amira was carr | Choose the clearer cohesive version. Which version | The clearest answer is: Amira gave Ava the ticket because Am |
+| proc2_pronoun_cohesion_choice | 2 | single_choice | Jay gave Noah it because Noah needed it  | Choose the clearer cohesive version. Which version | The clearest answer is: Jay gave Noah the torch because Noah |
+| proc2_pronoun_cohesion_choice | 3 | single_choice | Jay gave Ava it because Ava was leaving  | Choose the clearer cohesive version. Which version | The clearest answer is: Jay gave Ava the ticket because Ava  |
+| proc2_pronoun_cohesion_choice | 4 | single_choice | Ruby gave Noah it because Noah was leavi | Choose the clearer cohesive version. Which version | The clearest answer is: Ruby gave Noah the torch because Noa |
+| proc2_pronoun_cohesion_choice | 5 | single_choice | Jay gave the torch to her because Nora n | Choose the clearer cohesive version. Which version | The clearest answer is: Jay gave Nora the torch because Nora |
+| proc2_pronoun_cohesion_choice | 6 | single_choice | Luca gave Ava the glove because she was  | Choose the clearer cohesive version. Which version | The clearest answer is: Luca gave Ava the glove because Ava  |
+| proc2_pronoun_cohesion_choice | 7 | single_choice | Ava gave the note to her because Ben nee | Choose the clearer cohesive version. Which version | The clearest answer is: Ava gave Ben the note because Ben ne |
+| proc2_pronoun_cohesion_choice | 8 | single_choice | Ben gave Amira the torch because Amira n | Choose the clearer cohesive version. Which version | The clearest answer is: Ben gave Amira the torch because Ami |
+| proc2_pronoun_cohesion_choice | 9 | single_choice | Mia gave Sam the map because she was car | Choose the clearer cohesive version. Which version | The clearest answer is: Mia gave Sam the map because Mia was |
+| proc2_pronoun_cohesion_choice | 10 | single_choice | Luca gave Ruby it because Luca was carry | Choose the clearer cohesive version. Which version | The clearest answer is: Luca gave Ruby the glove because Luc |
+| proc2_pronoun_cohesion_choice | 11 | single_choice | Luca gave Zac it because Zac needed it f | Choose the clearer cohesive version. Which version | The clearest answer is: Luca gave Zac the glove because Zac  |
+| proc2_pronoun_cohesion_choice | 12 | single_choice | Noah gave Ava it because Noah was carryi | Choose the clearer cohesive version. Which version | The clearest answer is: Noah gave Ava the ticket because Noa |
+| proc2_pronoun_cohesion_choice | 13 | single_choice | Luca gave Noah the map because she was l | Choose the clearer cohesive version. Which version | The clearest answer is: Luca gave Noah the map because Noah  |
+| proc2_pronoun_cohesion_choice | 14 | single_choice | Zac gave the ticket to Elsie because she | Choose the clearer cohesive version. Which version | The clearest answer is: Zac gave Elsie the ticket because Za |
+| proc2_pronoun_cohesion_choice | 15 | single_choice | Mia gave the ticket to Zac because she h | Choose the clearer cohesive version. Which version | The clearest answer is: Mia gave Zac the ticket because Mia  |
+| proc2_pronoun_cohesion_choice | 16 | single_choice | Amira gave Ben it because Amira had foun | Choose the clearer cohesive version. Which version | The clearest answer is: Amira gave Ben the glove because Ami |
+| proc2_pronoun_cohesion_choice | 17 | single_choice | Jay gave Mia the ticket because she was  | Choose the clearer cohesive version. Which version | The clearest answer is: Jay gave Mia the ticket because Mia  |
+| proc2_pronoun_cohesion_choice | 18 | single_choice | Elsie gave Amira the ticket because Amir | Choose the clearer cohesive version. Which version | The clearest answer is: Elsie gave Amira the ticket because  |
+| proc2_pronoun_cohesion_choice | 19 | single_choice | Ava gave Elsie it because Ava was carryi | Choose the clearer cohesive version. Which version | The clearest answer is: Ava gave Elsie the ticket because Av |
+| proc2_pronoun_cohesion_choice | 20 | single_choice | Nora gave Elsie it because Nora had foun | Choose the clearer cohesive version. Which version | The clearest answer is: Nora gave Elsie the ticket because N |
+| proc2_pronoun_cohesion_choice | 21 | single_choice | Zac gave Elsie the torch because Zac had | Choose the clearer cohesive version. Which version | The clearest answer is: Zac gave Elsie the torch because Zac |
+| proc2_pronoun_cohesion_choice | 22 | single_choice | Amira gave the torch to her because Mia  | Choose the clearer cohesive version. Which version | The clearest answer is: Amira gave Mia the torch because Mia |
+| proc2_pronoun_cohesion_choice | 23 | single_choice | Ben gave Ava it because Ben had found it | Choose the clearer cohesive version. Which version | The clearest answer is: Ben gave Ava the glove because Ben h |
+| proc2_pronoun_cohesion_choice | 24 | single_choice | Noah gave Ruby the torch because she was | Choose the clearer cohesive version. Which version | The clearest answer is: Noah gave Ruby the torch because Rub |
+| proc2_pronoun_cohesion_choice | 25 | single_choice | Amira gave the ticket to her because Sam | Choose the clearer cohesive version. Which version | The clearest answer is: Amira gave Sam the ticket because Sa |
+| proc2_pronoun_cohesion_choice | 26 | single_choice | Luca gave Nora the ticket because Nora w | Choose the clearer cohesive version. Which version | The clearest answer is: Luca gave Nora the ticket because No |
+| proc2_pronoun_cohesion_choice | 27 | single_choice | Elsie gave Ava the map because she was l | Choose the clearer cohesive version. Which version | The clearest answer is: Elsie gave Ava the map because Ava w |
+| proc2_pronoun_cohesion_choice | 28 | single_choice | Zac gave the glove to her because Jay ne | Choose the clearer cohesive version. Which version | The clearest answer is: Zac gave Jay the glove because Jay n |
+| proc2_pronoun_cohesion_choice | 29 | single_choice | Mia gave Ben it because Ben was leaving  | Choose the clearer cohesive version. Which version | The clearest answer is: Mia gave Ben the torch because Ben w |
+| proc2_pronoun_cohesion_choice | 30 | single_choice | Sam gave the ticket to her because Nora  | Choose the clearer cohesive version. Which version | The clearest answer is: Sam gave Nora the ticket because Nor |
+| proc2_subject_object_identify | 1 | single_choice | Ava, the sketchbook, into the hall, With | Identify subject or object. Which words are the ob | The correct answer is: the sketchbook |
+| proc2_subject_object_identify | 2 | single_choice | Noah, With great care, into the hall, th | Identify subject or object. Which word or words ar | The correct answer is: Noah |
+| proc2_subject_object_identify | 3 | single_choice | into the hall, With great care, the lant | Identify subject or object. Which words are the ob | The correct answer is: the lantern |
+| proc2_subject_object_identify | 4 | single_choice | across the yard, the lantern, After the  | Identify subject or object. Which word or words ar | The correct answer is: Noah |
+| proc2_subject_object_identify | 5 | single_choice | Nora, across the yard, the window, With  | Identify subject or object. Which word or words ar | The correct answer is: Nora |
+| proc2_subject_object_identify | 6 | single_choice | after the bell, Ava, Without warning, th | Identify subject or object. Which words are the ob | The correct answer is: the gate |
+| proc2_subject_object_identify | 7 | single_choice | Before sunrise, after the bell, the ruck | Identify subject or object. Which words are the ob | The correct answer is: the rucksack |
+| proc2_subject_object_identify | 8 | single_choice | After lunch, Amira, the rucksack, after  | Identify subject or object. Which words are the ob | The correct answer is: the rucksack |
+| proc2_subject_object_identify | 9 | single_choice | after the bell, Sam, After lunch, the pi | Identify subject or object. Which word or words ar | The correct answer is: Sam |
+| proc2_subject_object_identify | 10 | single_choice | Ruby, Without warning, before the lesson | Identify subject or object. Which words are the ob | The correct answer is: the picnic basket |
+| proc2_subject_object_identify | 11 | single_choice | into the hall, Without warning, the wind | Identify subject or object. Which word or words ar | The correct answer is: Luca |
+| proc2_subject_object_identify | 12 | single_choice | the sketchbook, across the yard, Ava, La | Identify subject or object. Which words are the ob | The correct answer is: the sketchbook |
+| proc2_subject_object_identify | 13 | single_choice | across the yard, Without warning, Elsie, | Identify subject or object. Which words are the ob | The correct answer is: the lantern |
+| proc2_subject_object_identify | 14 | single_choice | across the yard, Zac, the map, At the ed | Identify subject or object. Which words are the ob | The correct answer is: the map |
+| proc2_subject_object_identify | 15 | single_choice | the trophy, After lunch, Elsie, across t | Identify subject or object. Which word or words ar | The correct answer is: Elsie |
+| proc2_subject_object_identify | 16 | single_choice | With great care, the trophy, Ben, before | Identify subject or object. Which words are the ob | The correct answer is: the trophy |
+| proc2_subject_object_identify | 17 | single_choice | With great care, Mia, across the yard, t | Identify subject or object. Which word or words ar | The correct answer is: Mia |
+| proc2_subject_object_identify | 18 | single_choice | the gate, into the hall, Amira, At the e | Identify subject or object. Which word or words ar | The correct answer is: Amira |
+| proc2_subject_object_identify | 19 | single_choice | the picnic basket, into the hall, Noah,  | Identify subject or object. Which words are the ob | The correct answer is: the picnic basket |
+| proc2_subject_object_identify | 20 | single_choice | Elsie, the map, before the lesson, On Fr | Identify subject or object. Which words are the ob | The correct answer is: the map |
+| proc2_subject_object_identify | 21 | single_choice | At the edge of the field, Zac, the troph | Identify subject or object. Which word or words ar | The correct answer is: Zac |
+| proc2_subject_object_identify | 22 | single_choice | Mia, before the lesson, Without warning, | Identify subject or object. Which word or words ar | The correct answer is: Mia |
+| proc2_subject_object_identify | 23 | single_choice | the map, Ava, before the lesson, Before  | Identify subject or object. Which words are the ob | The correct answer is: the map |
+| proc2_subject_object_identify | 24 | single_choice | the lantern, Later that day, after the b | Identify subject or object. Which words are the ob | The correct answer is: the lantern |
+| proc2_subject_object_identify | 25 | single_choice | Without warning, the rucksack, before th | Identify subject or object. Which words are the ob | The correct answer is: the rucksack |
+| proc2_subject_object_identify | 26 | single_choice | Jay, the lantern, Without warning, into  | Identify subject or object. Which word or words ar | The correct answer is: Jay |
+| proc2_subject_object_identify | 27 | single_choice | into the hall, At the edge of the field, | Identify subject or object. Which words are the ob | The correct answer is: the gate |
+| proc2_subject_object_identify | 28 | single_choice | At the edge of the field, before the les | Identify subject or object. Which words are the ob | The correct answer is: the rucksack |
+| proc2_subject_object_identify | 29 | single_choice | before the lesson, After lunch, the gate | Identify subject or object. Which words are the ob | The correct answer is: the gate |
+| proc2_subject_object_identify | 30 | single_choice | the gate, On Friday morning, Sam, across | Identify subject or object. Which words are the ob | The correct answer is: the gate |
+| proc2_passive_to_active | 1 | textarea | placeholder: Write the full sentence. | Rewrite passive as active. Rewrite the sentence in | A correct answer is: Amira lifts the lantern this morning. |
+| proc2_passive_to_active | 2 | textarea | placeholder: Write the full sentence. | Rewrite passive as active. Rewrite the sentence in | A correct answer is: Jay packs the map after the match. |
+| proc2_passive_to_active | 3 | textarea | placeholder: Write the full sentence. | Rewrite passive as active. Rewrite the sentence in | A correct answer is: Jay lifts the lantern. |
+| proc2_passive_to_active | 4 | textarea | placeholder: Write the full sentence. | Rewrite passive as active. Rewrite the sentence in | A correct answer is: Ruby packed the map. |
+| proc2_passive_to_active | 5 | textarea | placeholder: Write the full sentence. | Rewrite passive as active. Rewrite the sentence in | A correct answer is: Jay packed the picnic basket after the  |
+| proc2_passive_to_active | 6 | textarea | placeholder: Write the full sentence. | Rewrite passive as active. Rewrite the sentence in | A correct answer is: Luca paints the lantern. |
+| proc2_passive_to_active | 7 | textarea | placeholder: Write the full sentence. | Rewrite passive as active. Rewrite the sentence in | A correct answer is: Ava washes the lantern after the match. |
+| proc2_passive_to_active | 8 | textarea | placeholder: Write the full sentence. | Rewrite passive as active. Rewrite the sentence in | A correct answer is: Ben carries the rucksack after the matc |
+| proc2_passive_to_active | 9 | textarea | placeholder: Write the full sentence. | Rewrite passive as active. Rewrite the sentence in | A correct answer is: Mia opens the picnic basket this mornin |
+| proc2_passive_to_active | 10 | textarea | placeholder: Write the full sentence. | Rewrite passive as active. Rewrite the sentence in | A correct answer is: Luca painted the sketchbook this mornin |
+| proc2_passive_to_active | 11 | textarea | placeholder: Write the full sentence. | Rewrite passive as active. Rewrite the sentence in | A correct answer is: Luca paints the window after the match. |
+| proc2_passive_to_active | 12 | textarea | placeholder: Write the full sentence. | Rewrite passive as active. Rewrite the sentence in | A correct answer is: Noah painted the lantern this morning. |
+| proc2_passive_to_active | 13 | textarea | placeholder: Write the full sentence. | Rewrite passive as active. Rewrite the sentence in | A correct answer is: Luca opened the map. |
+| proc2_passive_to_active | 14 | textarea | placeholder: Write the full sentence. | Rewrite passive as active. Rewrite the sentence in | A correct answer is: Zac lifted the trophy before lunch. |
+| proc2_passive_to_active | 15 | textarea | placeholder: Write the full sentence. | Rewrite passive as active. Rewrite the sentence in | A correct answer is: Mia carried the trophy before lunch. |
+| proc2_passive_to_active | 16 | textarea | placeholder: Write the full sentence. | Rewrite passive as active. Rewrite the sentence in | A correct answer is: Amira cleaned the gate before lunch. |
+| proc2_passive_to_active | 17 | textarea | placeholder: Write the full sentence. | Rewrite passive as active. Rewrite the sentence in | A correct answer is: Jay lifted the gate. |
+| proc2_passive_to_active | 18 | textarea | placeholder: Write the full sentence. | Rewrite passive as active. Rewrite the sentence in | A correct answer is: Elsie lifts the window. |
+| proc2_passive_to_active | 19 | textarea | placeholder: Write the full sentence. | Rewrite passive as active. Rewrite the sentence in | A correct answer is: Ava lifts the map this morning. |
+| proc2_passive_to_active | 20 | textarea | placeholder: Write the full sentence. | Rewrite passive as active. Rewrite the sentence in | A correct answer is: Nora painted the trophy before lunch. |
+| proc2_passive_to_active | 21 | textarea | placeholder: Write the full sentence. | Rewrite passive as active. Rewrite the sentence in | A correct answer is: Zac packed the trophy before lunch. |
+| proc2_passive_to_active | 22 | textarea | placeholder: Write the full sentence. | Rewrite passive as active. Rewrite the sentence in | A correct answer is: Amira packed the gate. |
+| proc2_passive_to_active | 23 | textarea | placeholder: Write the full sentence. | Rewrite passive as active. Rewrite the sentence in | A correct answer is: Ben painted the lantern before lunch. |
+| proc2_passive_to_active | 24 | textarea | placeholder: Write the full sentence. | Rewrite passive as active. Rewrite the sentence in | A correct answer is: Noah carries the sketchbook. |
+| proc2_passive_to_active | 25 | textarea | placeholder: Write the full sentence. | Rewrite passive as active. Rewrite the sentence in | A correct answer is: Amira painted the picnic basket after t |
+| proc2_passive_to_active | 26 | textarea | placeholder: Write the full sentence. | Rewrite passive as active. Rewrite the sentence in | A correct answer is: Luca lifts the rucksack. |
+| proc2_passive_to_active | 27 | textarea | placeholder: Write the full sentence. | Rewrite passive as active. Rewrite the sentence in | A correct answer is: Elsie opens the lantern. |
+| proc2_passive_to_active | 28 | textarea | placeholder: Write the full sentence. | Rewrite passive as active. Rewrite the sentence in | A correct answer is: Zac cleaned the rucksack after the matc |
+| proc2_passive_to_active | 29 | textarea | placeholder: Write the full sentence. | Rewrite passive as active. Rewrite the sentence in | A correct answer is: Mia carried the gate. |
+| proc2_passive_to_active | 30 | textarea | placeholder: Write the full sentence. | Rewrite passive as active. Rewrite the sentence in | A correct answer is: Sam lifted the picnic basket. |
+| proc2_relative_clause_choice | 1 | single_choice | When everyone wanted the book, it was ea | Choose the sentence with a relative clause. Which  | The correct answer is: The book that belonged to the club wa |
+| proc2_relative_clause_choice | 2 | single_choice | The bag which Ben packed carefully was e | Choose the sentence with a relative clause. Which  | The correct answer is: The bag which Ben packed carefully wa |
+| proc2_relative_clause_choice | 3 | single_choice | When everyone wanted the book, it was ea | Choose the sentence with a relative clause. Which  | The correct answer is: The book which Ben packed carefully w |
+| proc2_relative_clause_choice | 4 | single_choice | The club bag was easy to spot., When eve | Choose the sentence with a relative clause. Which  | The correct answer is: The bag that everyone wanted was easy |
+| proc2_relative_clause_choice | 5 | single_choice | The coat was easy to spot outside., When | Choose the sentence with a relative clause. Which  | The correct answer is: The coat that everyone wanted was eas |
+| proc2_relative_clause_choice | 6 | single_choice | The club book was easy to spot., The boo | Choose the sentence with a relative clause. Which  | The correct answer is: The book that belonged to the club wa |
+| proc2_relative_clause_choice | 7 | single_choice | The runner waved to the crowd quickly.,  | Choose the sentence with a relative clause. Which  | The correct answer is: The runner who carried the flag waved |
+| proc2_relative_clause_choice | 8 | single_choice | The boy waved to the crowd quickly., The | Choose the sentence with a relative clause. Which  | The correct answer is: The boy who was first in line waved t |
+| proc2_relative_clause_choice | 9 | single_choice | The girl who wore a blue cap waved to th | Choose the sentence with a relative clause. Which  | The correct answer is: The girl who wore a blue cap waved to |
+| proc2_relative_clause_choice | 10 | single_choice | The club coat was easy to spot., The coa | Choose the sentence with a relative clause. Which  | The correct answer is: The coat that belonged to the club wa |
+| proc2_relative_clause_choice | 11 | single_choice | The tent that belonged to the club was e | Choose the sentence with a relative clause. Which  | The correct answer is: The tent that belonged to the club wa |
+| proc2_relative_clause_choice | 12 | single_choice | When the runner wore a blue cap, the cro | Choose the sentence with a relative clause. Which  | The correct answer is: The runner who had lost a glove waved |
+| proc2_relative_clause_choice | 13 | single_choice | When everyone wanted the bag, it was eas | Choose the sentence with a relative clause. Which  | The correct answer is: The bag that everyone wanted was easy |
+| proc2_relative_clause_choice | 14 | single_choice | The teacher waved to the crowd quickly., | Choose the sentence with a relative clause. Which  | The correct answer is: The teacher who had lost a glove wave |
+| proc2_relative_clause_choice | 15 | single_choice | The teacher in a blue cap waved to the c | Choose the sentence with a relative clause. Which  | The correct answer is: The teacher who was first in line wav |
+| proc2_relative_clause_choice | 16 | single_choice | The club book was easy to spot., The boo | Choose the sentence with a relative clause. Which  | The correct answer is: The book which stood by the window wa |
+| proc2_relative_clause_choice | 17 | single_choice | The club book was easy to spot., When ev | Choose the sentence with a relative clause. Which  | The correct answer is: The book that belonged to the club wa |
+| proc2_relative_clause_choice | 18 | single_choice | The boy waved to the crowd quickly., Whe | Choose the sentence with a relative clause. Which  | The correct answer is: The boy who had lost a glove waved to |
+| proc2_relative_clause_choice | 19 | single_choice | When the teacher wore a blue cap, the cr | Choose the sentence with a relative clause. Which  | The correct answer is: The teacher who was first in line wav |
+| proc2_relative_clause_choice | 20 | single_choice | The club bag was easy to spot., The bag  | Choose the sentence with a relative clause. Which  | The correct answer is: The bag that belonged to the club was |
+| proc2_relative_clause_choice | 21 | single_choice | The teacher who was first in line waved  | Choose the sentence with a relative clause. Which  | The correct answer is: The teacher who was first in line wav |
+| proc2_relative_clause_choice | 22 | single_choice | The book was easy to spot outside., The  | Choose the sentence with a relative clause. Which  | The correct answer is: The book that everyone wanted was eas |
+| proc2_relative_clause_choice | 23 | single_choice | The runner waved to the crowd quickly.,  | Choose the sentence with a relative clause. Which  | The correct answer is: The runner who had lost a glove waved |
+| proc2_relative_clause_choice | 24 | single_choice | The girl in a blue cap waved to the crow | Choose the sentence with a relative clause. Which  | The correct answer is: The girl who was first in line waved  |
+| proc2_relative_clause_choice | 25 | single_choice | When everyone wanted the coat, it was ea | Choose the sentence with a relative clause. Which  | The correct answer is: The coat that belonged to the club wa |
+| proc2_relative_clause_choice | 26 | single_choice | The tent was easy to spot outside., When | Choose the sentence with a relative clause. Which  | The correct answer is: The tent that belonged to the club wa |
+| proc2_relative_clause_choice | 27 | single_choice | When the runner wore a blue cap, the cro | Choose the sentence with a relative clause. Which  | The correct answer is: The runner who wore a blue cap waved  |
+| proc2_relative_clause_choice | 28 | single_choice | When the boy wore a blue cap, the crowd  | Choose the sentence with a relative clause. Which  | The correct answer is: The boy who had lost a glove waved to |
+| proc2_relative_clause_choice | 29 | single_choice | The runner in a blue cap waved to the cr | Choose the sentence with a relative clause. Which  | The correct answer is: The runner who was first in line wave |
+| proc2_relative_clause_choice | 30 | single_choice | When everyone wanted the coat, it was ea | Choose the sentence with a relative clause. Which  | The correct answer is: The coat which Ben packed carefully w |
+| proc2_fronted_adverbial_build | 1 | textarea | placeholder: Write one complete sentence | Build a sentence with a fronted adverbial. Use thi | Your fronted-adverbial sentence has been saved for review. I |
+| proc2_fronted_adverbial_build | 2 | textarea | placeholder: Write one complete sentence | Build a sentence with a fronted adverbial. Use thi | Your fronted-adverbial sentence has been saved for review. I |
+| proc2_fronted_adverbial_build | 3 | textarea | placeholder: Write one complete sentence | Build a sentence with a fronted adverbial. Use thi | Your fronted-adverbial sentence has been saved for review. I |
+| proc2_fronted_adverbial_build | 4 | textarea | placeholder: Write one complete sentence | Build a sentence with a fronted adverbial. Use thi | Your fronted-adverbial sentence has been saved for review. I |
+| proc2_fronted_adverbial_build | 5 | textarea | placeholder: Write one complete sentence | Build a sentence with a fronted adverbial. Use thi | Your fronted-adverbial sentence has been saved for review. I |
+| proc2_fronted_adverbial_build | 6 | textarea | placeholder: Write one complete sentence | Build a sentence with a fronted adverbial. Use thi | Your fronted-adverbial sentence has been saved for review. I |
+| proc2_fronted_adverbial_build | 7 | textarea | placeholder: Write one complete sentence | Build a sentence with a fronted adverbial. Use thi | Your fronted-adverbial sentence has been saved for review. I |
+| proc2_fronted_adverbial_build | 8 | textarea | placeholder: Write one complete sentence | Build a sentence with a fronted adverbial. Use thi | Your fronted-adverbial sentence has been saved for review. I |
+| proc2_fronted_adverbial_build | 9 | textarea | placeholder: Write one complete sentence | Build a sentence with a fronted adverbial. Use thi | Your fronted-adverbial sentence has been saved for review. I |
+| proc2_fronted_adverbial_build | 10 | textarea | placeholder: Write one complete sentence | Build a sentence with a fronted adverbial. Use thi | Your fronted-adverbial sentence has been saved for review. I |
+| proc2_fronted_adverbial_build | 11 | textarea | placeholder: Write one complete sentence | Build a sentence with a fronted adverbial. Use thi | Your fronted-adverbial sentence has been saved for review. I |
+| proc2_fronted_adverbial_build | 12 | textarea | placeholder: Write one complete sentence | Build a sentence with a fronted adverbial. Use thi | Your fronted-adverbial sentence has been saved for review. I |
+| proc2_fronted_adverbial_build | 13 | textarea | placeholder: Write one complete sentence | Build a sentence with a fronted adverbial. Use thi | Your fronted-adverbial sentence has been saved for review. I |
+| proc2_fronted_adverbial_build | 14 | textarea | placeholder: Write one complete sentence | Build a sentence with a fronted adverbial. Use thi | Your fronted-adverbial sentence has been saved for review. I |
+| proc2_fronted_adverbial_build | 15 | textarea | placeholder: Write one complete sentence | Build a sentence with a fronted adverbial. Use thi | Your fronted-adverbial sentence has been saved for review. I |
+| proc2_fronted_adverbial_build | 16 | textarea | placeholder: Write one complete sentence | Build a sentence with a fronted adverbial. Use thi | Your fronted-adverbial sentence has been saved for review. I |
+| proc2_fronted_adverbial_build | 17 | textarea | placeholder: Write one complete sentence | Build a sentence with a fronted adverbial. Use thi | Your fronted-adverbial sentence has been saved for review. I |
+| proc2_fronted_adverbial_build | 18 | textarea | placeholder: Write one complete sentence | Build a sentence with a fronted adverbial. Use thi | Your fronted-adverbial sentence has been saved for review. I |
+| proc2_fronted_adverbial_build | 19 | textarea | placeholder: Write one complete sentence | Build a sentence with a fronted adverbial. Use thi | Your fronted-adverbial sentence has been saved for review. I |
+| proc2_fronted_adverbial_build | 20 | textarea | placeholder: Write one complete sentence | Build a sentence with a fronted adverbial. Use thi | Your fronted-adverbial sentence has been saved for review. I |
+| proc2_fronted_adverbial_build | 21 | textarea | placeholder: Write one complete sentence | Build a sentence with a fronted adverbial. Use thi | Your fronted-adverbial sentence has been saved for review. I |
+| proc2_fronted_adverbial_build | 22 | textarea | placeholder: Write one complete sentence | Build a sentence with a fronted adverbial. Use thi | Your fronted-adverbial sentence has been saved for review. I |
+| proc2_fronted_adverbial_build | 23 | textarea | placeholder: Write one complete sentence | Build a sentence with a fronted adverbial. Use thi | Your fronted-adverbial sentence has been saved for review. I |
+| proc2_fronted_adverbial_build | 24 | textarea | placeholder: Write one complete sentence | Build a sentence with a fronted adverbial. Use thi | Your fronted-adverbial sentence has been saved for review. I |
+| proc2_fronted_adverbial_build | 25 | textarea | placeholder: Write one complete sentence | Build a sentence with a fronted adverbial. Use thi | Your fronted-adverbial sentence has been saved for review. I |
+| proc2_fronted_adverbial_build | 26 | textarea | placeholder: Write one complete sentence | Build a sentence with a fronted adverbial. Use thi | Your fronted-adverbial sentence has been saved for review. I |
+| proc2_fronted_adverbial_build | 27 | textarea | placeholder: Write one complete sentence | Build a sentence with a fronted adverbial. Use thi | Your fronted-adverbial sentence has been saved for review. I |
+| proc2_fronted_adverbial_build | 28 | textarea | placeholder: Write one complete sentence | Build a sentence with a fronted adverbial. Use thi | Your fronted-adverbial sentence has been saved for review. I |
+| proc2_fronted_adverbial_build | 29 | textarea | placeholder: Write one complete sentence | Build a sentence with a fronted adverbial. Use thi | Your fronted-adverbial sentence has been saved for review. I |
+| proc2_fronted_adverbial_build | 30 | textarea | placeholder: Write one complete sentence | Build a sentence with a fronted adverbial. Use thi | Your fronted-adverbial sentence has been saved for review. I |
+| proc2_boundary_punctuation_explain | 1 | single_choice | The colon replaces speech marks., The co | Explain boundary punctuation. Why is the punctuati | The best explanation is: The words before the colon make a c |
+| proc2_boundary_punctuation_explain | 2 | single_choice | The dash turns the sentence into a quest | Explain boundary punctuation. Why is the punctuati | The best explanation is: The dash creates a strong break bef |
+| proc2_boundary_punctuation_explain | 3 | single_choice | A semi-colon marks a fronted adverbial., | Explain boundary punctuation. Why is the punctuati | The best explanation is: A semi-colon can join two closely r |
+| proc2_boundary_punctuation_explain | 4 | single_choice | The colon replaces speech marks., The co | Explain boundary punctuation. Why is the punctuati | The best explanation is: The words before the colon make a c |
+| proc2_boundary_punctuation_explain | 5 | single_choice | The dash turns the sentence into a quest | Explain boundary punctuation. Why is the punctuati | The best explanation is: The dash creates a strong break bef |
+| proc2_boundary_punctuation_explain | 6 | single_choice | A semi-colon marks a fronted adverbial., | Explain boundary punctuation. Why is the punctuati | The best explanation is: A semi-colon can join two closely r |
+| proc2_boundary_punctuation_explain | 7 | single_choice | The colon replaces speech marks., The co | Explain boundary punctuation. Why is the punctuati | The best explanation is: The words before the colon make a c |
+| proc2_boundary_punctuation_explain | 8 | single_choice | The dash marks a direct speech tag., The | Explain boundary punctuation. Why is the punctuati | The best explanation is: The dash creates a strong break bef |
+| proc2_boundary_punctuation_explain | 9 | single_choice | A semi-colon marks a fronted adverbial., | Explain boundary punctuation. Why is the punctuati | The best explanation is: A semi-colon can join two closely r |
+| proc2_boundary_punctuation_explain | 10 | single_choice | The words before the colon make a comple | Explain boundary punctuation. Why is the punctuati | The best explanation is: The words before the colon make a c |
+| proc2_boundary_punctuation_explain | 11 | single_choice | The dash creates a strong break before a | Explain boundary punctuation. Why is the punctuati | The best explanation is: The dash creates a strong break bef |
+| proc2_boundary_punctuation_explain | 12 | single_choice | A semi-colon shows possession., A semi-c | Explain boundary punctuation. Why is the punctuati | The best explanation is: A semi-colon can join two closely r |
+| proc2_boundary_punctuation_explain | 13 | single_choice | The colon replaces speech marks., The co | Explain boundary punctuation. Why is the punctuati | The best explanation is: The words before the colon make a c |
+| proc2_boundary_punctuation_explain | 14 | single_choice | The dash turns the sentence into a quest | Explain boundary punctuation. Why is the punctuati | The best explanation is: The dash creates a strong break bef |
+| proc2_boundary_punctuation_explain | 15 | single_choice | A semi-colon marks a fronted adverbial., | Explain boundary punctuation. Why is the punctuati | The best explanation is: A semi-colon can join two closely r |
+| proc2_boundary_punctuation_explain | 16 | single_choice | The colon marks possession., The colon r | Explain boundary punctuation. Why is the punctuati | The best explanation is: The words before the colon make a c |
+| proc2_boundary_punctuation_explain | 17 | single_choice | The dash turns the sentence into a quest | Explain boundary punctuation. Why is the punctuati | The best explanation is: The dash creates a strong break bef |
+| proc2_boundary_punctuation_explain | 18 | single_choice | A semi-colon shows possession., A semi-c | Explain boundary punctuation. Why is the punctuati | The best explanation is: A semi-colon can join two closely r |
+| proc2_boundary_punctuation_explain | 19 | single_choice | The words before the colon make a comple | Explain boundary punctuation. Why is the punctuati | The best explanation is: The words before the colon make a c |
+| proc2_boundary_punctuation_explain | 20 | single_choice | The dash turns the sentence into a quest | Explain boundary punctuation. Why is the punctuati | The best explanation is: The dash creates a strong break bef |
+| proc2_boundary_punctuation_explain | 21 | single_choice | A semi-colon shows possession., A semi-c | Explain boundary punctuation. Why is the punctuati | The best explanation is: A semi-colon can join two closely r |
+| proc2_boundary_punctuation_explain | 22 | single_choice | The colon marks possession., The colon s | Explain boundary punctuation. Why is the punctuati | The best explanation is: The words before the colon make a c |
+| proc2_boundary_punctuation_explain | 23 | single_choice | The dash turns the sentence into a quest | Explain boundary punctuation. Why is the punctuati | The best explanation is: The dash creates a strong break bef |
+| proc2_boundary_punctuation_explain | 24 | single_choice | A semi-colon introduces direct speech.,  | Explain boundary punctuation. Why is the punctuati | The best explanation is: A semi-colon can join two closely r |
+| proc2_boundary_punctuation_explain | 25 | single_choice | The words before the colon make a comple | Explain boundary punctuation. Why is the punctuati | The best explanation is: The words before the colon make a c |
+| proc2_boundary_punctuation_explain | 26 | single_choice | The dash marks a direct speech tag., The | Explain boundary punctuation. Why is the punctuati | The best explanation is: The dash creates a strong break bef |
+| proc2_boundary_punctuation_explain | 27 | single_choice | A semi-colon introduces direct speech.,  | Explain boundary punctuation. Why is the punctuati | The best explanation is: A semi-colon can join two closely r |
+| proc2_boundary_punctuation_explain | 28 | single_choice | The words before the colon make a comple | Explain boundary punctuation. Why is the punctuati | The best explanation is: The words before the colon make a c |
+| proc2_boundary_punctuation_explain | 29 | single_choice | The dash shows plural possession., The d | Explain boundary punctuation. Why is the punctuati | The best explanation is: The dash creates a strong break bef |
+| proc2_boundary_punctuation_explain | 30 | single_choice | A semi-colon marks a fronted adverbial., | Explain boundary punctuation. Why is the punctuati | The best explanation is: A semi-colon can join two closely r |
+| proc3_sentence_function_choice | 1 | single_choice | Close the gate before the dog runs out., | Choose the sentence function. Which sentence is a  | The correct sentence is: Close the gate before the dog runs  |
+| proc3_sentence_function_choice | 2 | single_choice | The choir begins at nine o'clock., Bring | Choose the sentence function. Which sentence is a  | The correct sentence is: Bring the blue folder to the hall. |
+| proc3_sentence_function_choice | 3 | single_choice | The choir begins at nine o'clock., How b | Choose the sentence function. Which sentence is a  | The correct sentence is: Close the gate before the dog runs  |
+| proc3_sentence_function_choice | 4 | single_choice | How quickly the clouds moved!, Wait by t | Choose the sentence function. Which sentence is a  | The correct sentence is: How quickly the clouds moved! |
+| proc3_sentence_function_choice | 5 | single_choice | The path beside the stream was muddy., P | Choose the sentence function. Which sentence is a  | The correct sentence is: Put the wet boots on the mat. |
+| proc3_sentence_function_choice | 6 | single_choice | What an enormous splash that was!, Close | Choose the sentence function. Which sentence is a  | The correct sentence is: Close the gate before the dog runs  |
+| proc3_sentence_function_choice | 7 | single_choice | How quickly the clouds moved!, Bring the | Choose the sentence function. Which sentence is a  | The correct sentence is: The lantern was still on the bench. |
+| proc3_sentence_function_choice | 8 | single_choice | Bring the blue folder to the hall., Who  | Choose the sentence function. Which sentence is a  | The correct sentence is: The path beside the stream was mudd |
+| proc3_sentence_function_choice | 9 | single_choice | Wait by the door for the coach., What an | Choose the sentence function. Which sentence is a  | The correct sentence is: Our team practised in the hall toda |
+| proc3_sentence_function_choice | 10 | single_choice | When does the match begin?, The choir be | Choose the sentence function. Which sentence is a  | The correct sentence is: Put the wet boots on the mat. |
+| proc3_sentence_function_choice | 11 | single_choice | Where is the missing torch?, Wait by the | Choose the sentence function. Which sentence is a  | The correct sentence is: Wait by the door for the coach. |
+| proc3_sentence_function_choice | 12 | single_choice | Where is the missing torch?, Wait by the | Choose the sentence function. Which sentence is a  | The correct sentence is: Where is the missing torch? |
+| proc3_sentence_function_choice | 13 | single_choice | Bring the blue folder to the hall., What | Choose the sentence function. Which sentence is a  | The correct sentence is: Bring the blue folder to the hall. |
+| proc3_sentence_function_choice | 14 | single_choice | Wait by the door for the coach., What a  | Choose the sentence function. Which sentence is a  | The correct sentence is: When does the match begin? |
+| proc3_sentence_function_choice | 15 | single_choice | Put the wet boots on the mat., Why is th | Choose the sentence function. Which sentence is a  | The correct sentence is: The choir begins at nine o'clock. |
+| proc3_sentence_function_choice | 16 | single_choice | How bright the lantern looked!, When doe | Choose the sentence function. Which sentence is a  | The correct sentence is: Close the gate before the dog runs  |
+| proc3_sentence_function_choice | 17 | single_choice | When does the match begin?, What a noisy | Choose the sentence function. Which sentence is a  | The correct sentence is: Close the gate before the dog runs  |
+| proc3_sentence_function_choice | 18 | single_choice | The path beside the stream was muddy., H | Choose the sentence function. Which sentence is a  | The correct sentence is: Why is the gate still open? |
+| proc3_sentence_function_choice | 19 | single_choice | The choir begins at nine o'clock., Wait  | Choose the sentence function. Which sentence is a  | The correct sentence is: The choir begins at nine o'clock. |
+| proc3_sentence_function_choice | 20 | single_choice | How quickly the clouds moved!, The lante | Choose the sentence function. Which sentence is a  | The correct sentence is: How quickly the clouds moved! |
+| proc3_sentence_function_choice | 21 | single_choice | When does the match begin?, How bright t | Choose the sentence function. Which sentence is a  | The correct sentence is: When does the match begin? |
+| proc3_sentence_function_choice | 22 | single_choice | When does the match begin?, Close the ga | Choose the sentence function. Which sentence is a  | The correct sentence is: Close the gate before the dog runs  |
+| proc3_sentence_function_choice | 23 | single_choice | How quickly the clouds moved!, The lante | Choose the sentence function. Which sentence is a  | The correct sentence is: The lantern was still on the bench. |
+| proc3_sentence_function_choice | 24 | single_choice | Who packed the blue folder?, The choir b | Choose the sentence function. Which sentence is a  | The correct sentence is: Who packed the blue folder? |
+| proc3_sentence_function_choice | 25 | single_choice | What a noisy drum that is!, Put the wet  | Choose the sentence function. Which sentence is a  | The correct sentence is: Put the wet boots on the mat. |
+| proc3_sentence_function_choice | 26 | single_choice | Wait by the door for the coach., How bri | Choose the sentence function. Which sentence is a  | The correct sentence is: Wait by the door for the coach. |
+| proc3_sentence_function_choice | 27 | single_choice | The choir begins at nine o'clock., What  | Choose the sentence function. Which sentence is a  | The correct sentence is: Where is the missing torch? |
+| proc3_sentence_function_choice | 28 | single_choice | The choir begins at nine o'clock., How q | Choose the sentence function. Which sentence is a  | The correct sentence is: Why is the gate still open? |
+| proc3_sentence_function_choice | 29 | single_choice | When does the match begin?, How quickly  | Choose the sentence function. Which sentence is a  | The correct sentence is: The lantern was still on the bench. |
+| proc3_sentence_function_choice | 30 | single_choice | Who packed the blue folder?, How bright  | Choose the sentence function. Which sentence is a  | The correct sentence is: How bright the lantern looked! |
+| proc3_word_class_contrast_choice | 1 | single_choice | determiner, preposition, adverb, conjunc | Choose the correct word class. In the sentence Aft | ‘Afterwards’ tells us when Ben hurried, so it is an adverb. |
+| proc3_word_class_contrast_choice | 2 | single_choice | pronoun, preposition, determiner, adverb | Choose the correct word class. In the sentence The | ‘The’ introduces the noun phrase ‘the muddy boots’, so it is |
+| proc3_word_class_contrast_choice | 3 | single_choice | determiner, conjunction, pronoun, adject | Choose the correct word class. In the sentence Tho | ‘Those’ stands in place of a noun, so it is a pronoun here. |
+| proc3_word_class_contrast_choice | 4 | single_choice | preposition, adverb, conjunction, determ | Choose the correct word class. In the sentence We  | ‘Because’ introduces a subordinate clause, so it is a conjun |
+| proc3_word_class_contrast_choice | 5 | single_choice | conjunction, preposition, pronoun, adver | Choose the correct word class. In the sentence We  | ‘During’ introduces the phrase ‘during the storm’, so it is  |
+| proc3_word_class_contrast_choice | 6 | single_choice | preposition, adjective, adverb, verb | Choose the correct word class. In the sentence The | ‘Loudly’ tells us how the bridge creaked, so it is an adverb |
+| proc3_word_class_contrast_choice | 7 | single_choice | adverb, preposition, pronoun, conjunctio | Choose the correct word class. In the sentence She | ‘And’ joins two clauses together, so it is a conjunction. |
+| proc3_word_class_contrast_choice | 8 | single_choice | pronoun, adverb, adjective, determiner | Choose the correct word class. In the sentence Sev | ‘Several’ tells us how many children, working as a determine |
+| proc3_word_class_contrast_choice | 9 | single_choice | adverb, determiner, conjunction, preposi | Choose the correct word class. In the sentence Aft | ‘After’ introduces the phrase ‘after lunch’, so it is a prep |
+| proc3_word_class_contrast_choice | 10 | single_choice | adverb, preposition, determiner, conjunc | Choose the correct word class. In the sentence Aft | ‘Afterwards’ tells us when Ben hurried, so it is an adverb. |
+| proc3_word_class_contrast_choice | 11 | single_choice | determiner, preposition, pronoun, adverb | Choose the correct word class. In the sentence The | ‘The’ introduces the noun phrase ‘the muddy boots’, so it is |
+| proc3_word_class_contrast_choice | 12 | single_choice | adjective, conjunction, pronoun, determi | Choose the correct word class. In the sentence Tho | ‘Those’ stands in place of a noun, so it is a pronoun here. |
+| proc3_word_class_contrast_choice | 13 | single_choice | determiner, conjunction, preposition, ad | Choose the correct word class. In the sentence We  | ‘Because’ introduces a subordinate clause, so it is a conjun |
+| proc3_word_class_contrast_choice | 14 | single_choice | preposition, adverb, pronoun, conjunctio | Choose the correct word class. In the sentence We  | ‘During’ introduces the phrase ‘during the storm’, so it is  |
+| proc3_word_class_contrast_choice | 15 | single_choice | verb, preposition, adjective, adverb | Choose the correct word class. In the sentence The | ‘Loudly’ tells us how the bridge creaked, so it is an adverb |
+| proc3_word_class_contrast_choice | 16 | single_choice | pronoun, preposition, conjunction, adver | Choose the correct word class. In the sentence She | ‘And’ joins two clauses together, so it is a conjunction. |
+| proc3_word_class_contrast_choice | 17 | single_choice | adverb, adjective, determiner, pronoun | Choose the correct word class. In the sentence Sev | ‘Several’ tells us how many children, working as a determine |
+| proc3_word_class_contrast_choice | 18 | single_choice | preposition, conjunction, determiner, ad | Choose the correct word class. In the sentence Aft | ‘After’ introduces the phrase ‘after lunch’, so it is a prep |
+| proc3_word_class_contrast_choice | 19 | single_choice | preposition, conjunction, determiner, ad | Choose the correct word class. In the sentence Aft | ‘Afterwards’ tells us when Ben hurried, so it is an adverb. |
+| proc3_word_class_contrast_choice | 20 | single_choice | determiner, adverb, pronoun, preposition | Choose the correct word class. In the sentence The | ‘The’ introduces the noun phrase ‘the muddy boots’, so it is |
+| proc3_word_class_contrast_choice | 21 | single_choice | adjective, pronoun, conjunction, determi | Choose the correct word class. In the sentence Tho | ‘Those’ stands in place of a noun, so it is a pronoun here. |
+| proc3_word_class_contrast_choice | 22 | single_choice | preposition, determiner, conjunction, ad | Choose the correct word class. In the sentence We  | ‘Because’ introduces a subordinate clause, so it is a conjun |
+| proc3_word_class_contrast_choice | 23 | single_choice | adverb, conjunction, pronoun, prepositio | Choose the correct word class. In the sentence We  | ‘During’ introduces the phrase ‘during the storm’, so it is  |
+| proc3_word_class_contrast_choice | 24 | single_choice | preposition, adverb, verb, adjective | Choose the correct word class. In the sentence The | ‘Loudly’ tells us how the bridge creaked, so it is an adverb |
+| proc3_word_class_contrast_choice | 25 | single_choice | conjunction, preposition, pronoun, adver | Choose the correct word class. In the sentence She | ‘And’ joins two clauses together, so it is a conjunction. |
+| proc3_word_class_contrast_choice | 26 | single_choice | determiner, adjective, adverb, pronoun | Choose the correct word class. In the sentence Sev | ‘Several’ tells us how many children, working as a determine |
+| proc3_word_class_contrast_choice | 27 | single_choice | determiner, conjunction, preposition, ad | Choose the correct word class. In the sentence Aft | ‘After’ introduces the phrase ‘after lunch’, so it is a prep |
+| proc3_word_class_contrast_choice | 28 | single_choice | adverb, determiner, conjunction, preposi | Choose the correct word class. In the sentence Aft | ‘Afterwards’ tells us when Ben hurried, so it is an adverb. |
+| proc3_word_class_contrast_choice | 29 | single_choice | pronoun, adverb, preposition, determiner | Choose the correct word class. In the sentence The | ‘The’ introduces the noun phrase ‘the muddy boots’, so it is |
+| proc3_word_class_contrast_choice | 30 | single_choice | determiner, pronoun, adjective, conjunct | Choose the correct word class. In the sentence Tho | ‘Those’ stands in place of a noun, so it is a pronoun here. |
+| proc3_noun_phrase_build | 1 | text | placeholder: Type the noun phrase. | Build an expanded noun phrase. Use all the words t | Your expanded noun phrase has been saved for review. It is n |
+| proc3_noun_phrase_build | 2 | text | placeholder: Type the noun phrase. | Build an expanded noun phrase. Use all the words t | Your expanded noun phrase has been saved for review. It is n |
+| proc3_noun_phrase_build | 3 | text | placeholder: Type the noun phrase. | Build an expanded noun phrase. Use all the words t | Your expanded noun phrase has been saved for review. It is n |
+| proc3_noun_phrase_build | 4 | text | placeholder: Type the noun phrase. | Build an expanded noun phrase. Use all the words t | Your expanded noun phrase has been saved for review. It is n |
+| proc3_noun_phrase_build | 5 | text | placeholder: Type the noun phrase. | Build an expanded noun phrase. Use all the words t | Your expanded noun phrase has been saved for review. It is n |
+| proc3_noun_phrase_build | 6 | text | placeholder: Type the noun phrase. | Build an expanded noun phrase. Use all the words t | Your expanded noun phrase has been saved for review. It is n |
+| proc3_noun_phrase_build | 7 | text | placeholder: Type the noun phrase. | Build an expanded noun phrase. Use all the words t | Your expanded noun phrase has been saved for review. It is n |
+| proc3_noun_phrase_build | 8 | text | placeholder: Type the noun phrase. | Build an expanded noun phrase. Use all the words t | Your expanded noun phrase has been saved for review. It is n |
+| proc3_noun_phrase_build | 9 | text | placeholder: Type the noun phrase. | Build an expanded noun phrase. Use all the words t | Your expanded noun phrase has been saved for review. It is n |
+| proc3_noun_phrase_build | 10 | text | placeholder: Type the noun phrase. | Build an expanded noun phrase. Use all the words t | Your expanded noun phrase has been saved for review. It is n |
+| proc3_noun_phrase_build | 11 | text | placeholder: Type the noun phrase. | Build an expanded noun phrase. Use all the words t | Your expanded noun phrase has been saved for review. It is n |
+| proc3_noun_phrase_build | 12 | text | placeholder: Type the noun phrase. | Build an expanded noun phrase. Use all the words t | Your expanded noun phrase has been saved for review. It is n |
+| proc3_noun_phrase_build | 13 | text | placeholder: Type the noun phrase. | Build an expanded noun phrase. Use all the words t | Your expanded noun phrase has been saved for review. It is n |
+| proc3_noun_phrase_build | 14 | text | placeholder: Type the noun phrase. | Build an expanded noun phrase. Use all the words t | Your expanded noun phrase has been saved for review. It is n |
+| proc3_noun_phrase_build | 15 | text | placeholder: Type the noun phrase. | Build an expanded noun phrase. Use all the words t | Your expanded noun phrase has been saved for review. It is n |
+| proc3_noun_phrase_build | 16 | text | placeholder: Type the noun phrase. | Build an expanded noun phrase. Use all the words t | Your expanded noun phrase has been saved for review. It is n |
+| proc3_noun_phrase_build | 17 | text | placeholder: Type the noun phrase. | Build an expanded noun phrase. Use all the words t | Your expanded noun phrase has been saved for review. It is n |
+| proc3_noun_phrase_build | 18 | text | placeholder: Type the noun phrase. | Build an expanded noun phrase. Use all the words t | Your expanded noun phrase has been saved for review. It is n |
+| proc3_noun_phrase_build | 19 | text | placeholder: Type the noun phrase. | Build an expanded noun phrase. Use all the words t | Your expanded noun phrase has been saved for review. It is n |
+| proc3_noun_phrase_build | 20 | text | placeholder: Type the noun phrase. | Build an expanded noun phrase. Use all the words t | Your expanded noun phrase has been saved for review. It is n |
+| proc3_noun_phrase_build | 21 | text | placeholder: Type the noun phrase. | Build an expanded noun phrase. Use all the words t | Your expanded noun phrase has been saved for review. It is n |
+| proc3_noun_phrase_build | 22 | text | placeholder: Type the noun phrase. | Build an expanded noun phrase. Use all the words t | Your expanded noun phrase has been saved for review. It is n |
+| proc3_noun_phrase_build | 23 | text | placeholder: Type the noun phrase. | Build an expanded noun phrase. Use all the words t | Your expanded noun phrase has been saved for review. It is n |
+| proc3_noun_phrase_build | 24 | text | placeholder: Type the noun phrase. | Build an expanded noun phrase. Use all the words t | Your expanded noun phrase has been saved for review. It is n |
+| proc3_noun_phrase_build | 25 | text | placeholder: Type the noun phrase. | Build an expanded noun phrase. Use all the words t | Your expanded noun phrase has been saved for review. It is n |
+| proc3_noun_phrase_build | 26 | text | placeholder: Type the noun phrase. | Build an expanded noun phrase. Use all the words t | Your expanded noun phrase has been saved for review. It is n |
+| proc3_noun_phrase_build | 27 | text | placeholder: Type the noun phrase. | Build an expanded noun phrase. Use all the words t | Your expanded noun phrase has been saved for review. It is n |
+| proc3_noun_phrase_build | 28 | text | placeholder: Type the noun phrase. | Build an expanded noun phrase. Use all the words t | Your expanded noun phrase has been saved for review. It is n |
+| proc3_noun_phrase_build | 29 | text | placeholder: Type the noun phrase. | Build an expanded noun phrase. Use all the words t | Your expanded noun phrase has been saved for review. It is n |
+| proc3_noun_phrase_build | 30 | text | placeholder: Type the noun phrase. | Build an expanded noun phrase. Use all the words t | Your expanded noun phrase has been saved for review. It is n |
+| proc3_clause_join_rewrite | 1 | textarea | placeholder: Write one combined sentence | Join clauses with a conjunction. Combine these ide | A correct answer is: We stayed inside because it was raining |
+| proc3_clause_join_rewrite | 2 | textarea | placeholder: Write one combined sentence | Join clauses with a conjunction. Combine these ide | A correct answer is: Ben hurried home because he had forgott |
+| proc3_clause_join_rewrite | 3 | textarea | placeholder: Write one combined sentence | Join clauses with a conjunction. Combine these ide | A correct answer is: Mia smiled because she had found the mi |
+| proc3_clause_join_rewrite | 4 | textarea | placeholder: Write one combined sentence | Join clauses with a conjunction. Combine these ide | A correct answer is: Although Mia was tired, she finished th |
+| proc3_clause_join_rewrite | 5 | textarea | placeholder: Write one combined sentence | Join clauses with a conjunction. Combine these ide | A correct answer is: Although the path was muddy, the walker |
+| proc3_clause_join_rewrite | 6 | textarea | placeholder: Write one combined sentence | Join clauses with a conjunction. Combine these ide | A correct answer is: Although the room was noisy, Jay carrie |
+| proc3_clause_join_rewrite | 7 | textarea | placeholder: Write one combined sentence | Join clauses with a conjunction. Combine these ide | A correct answer is: When the bell rang, the pupils lined up |
+| proc3_clause_join_rewrite | 8 | textarea | placeholder: Write one combined sentence | Join clauses with a conjunction. Combine these ide | A correct answer is: When the gate opened, the crowd cheered |
+| proc3_clause_join_rewrite | 9 | textarea | placeholder: Write one combined sentence | Join clauses with a conjunction. Combine these ide | A correct answer is: When the lights went out, everyone fell |
+| proc3_clause_join_rewrite | 10 | textarea | placeholder: Write one combined sentence | Join clauses with a conjunction. Combine these ide | A correct answer is: If you need help, call the office. |
+| proc3_clause_join_rewrite | 11 | textarea | placeholder: Write one combined sentence | Join clauses with a conjunction. Combine these ide | A correct answer is: If the rain starts, go inside the tent. |
+| proc3_clause_join_rewrite | 12 | textarea | placeholder: Write one combined sentence | Join clauses with a conjunction. Combine these ide | A correct answer is: If the torch stops working, fetch the s |
+| proc3_clause_join_rewrite | 13 | textarea | placeholder: Write one combined sentence | Join clauses with a conjunction. Combine these ide | A correct answer is: We stayed inside because it was raining |
+| proc3_clause_join_rewrite | 14 | textarea | placeholder: Write one combined sentence | Join clauses with a conjunction. Combine these ide | A correct answer is: Ben hurried home because he had forgott |
+| proc3_clause_join_rewrite | 15 | textarea | placeholder: Write one combined sentence | Join clauses with a conjunction. Combine these ide | A correct answer is: Mia smiled because she had found the mi |
+| proc3_clause_join_rewrite | 16 | textarea | placeholder: Write one combined sentence | Join clauses with a conjunction. Combine these ide | A correct answer is: Although Mia was tired, she finished th |
+| proc3_clause_join_rewrite | 17 | textarea | placeholder: Write one combined sentence | Join clauses with a conjunction. Combine these ide | A correct answer is: Although the path was muddy, the walker |
+| proc3_clause_join_rewrite | 18 | textarea | placeholder: Write one combined sentence | Join clauses with a conjunction. Combine these ide | A correct answer is: Although the room was noisy, Jay carrie |
+| proc3_clause_join_rewrite | 19 | textarea | placeholder: Write one combined sentence | Join clauses with a conjunction. Combine these ide | A correct answer is: When the bell rang, the pupils lined up |
+| proc3_clause_join_rewrite | 20 | textarea | placeholder: Write one combined sentence | Join clauses with a conjunction. Combine these ide | A correct answer is: When the gate opened, the crowd cheered |
+| proc3_clause_join_rewrite | 21 | textarea | placeholder: Write one combined sentence | Join clauses with a conjunction. Combine these ide | A correct answer is: When the lights went out, everyone fell |
+| proc3_clause_join_rewrite | 22 | textarea | placeholder: Write one combined sentence | Join clauses with a conjunction. Combine these ide | A correct answer is: If you need help, call the office. |
+| proc3_clause_join_rewrite | 23 | textarea | placeholder: Write one combined sentence | Join clauses with a conjunction. Combine these ide | A correct answer is: If the rain starts, go inside the tent. |
+| proc3_clause_join_rewrite | 24 | textarea | placeholder: Write one combined sentence | Join clauses with a conjunction. Combine these ide | A correct answer is: If the torch stops working, fetch the s |
+| proc3_clause_join_rewrite | 25 | textarea | placeholder: Write one combined sentence | Join clauses with a conjunction. Combine these ide | A correct answer is: We stayed inside because it was raining |
+| proc3_clause_join_rewrite | 26 | textarea | placeholder: Write one combined sentence | Join clauses with a conjunction. Combine these ide | A correct answer is: Ben hurried home because he had forgott |
+| proc3_clause_join_rewrite | 27 | textarea | placeholder: Write one combined sentence | Join clauses with a conjunction. Combine these ide | A correct answer is: Mia smiled because she had found the mi |
+| proc3_clause_join_rewrite | 28 | textarea | placeholder: Write one combined sentence | Join clauses with a conjunction. Combine these ide | A correct answer is: Although Mia was tired, she finished th |
+| proc3_clause_join_rewrite | 29 | textarea | placeholder: Write one combined sentence | Join clauses with a conjunction. Combine these ide | A correct answer is: Although the path was muddy, the walker |
+| proc3_clause_join_rewrite | 30 | textarea | placeholder: Write one combined sentence | Join clauses with a conjunction. Combine these ide | A correct answer is: Although the room was noisy, Jay carrie |
+| proc3_parenthesis_commas_fix | 1 | textarea | placeholder: Type the corrected sentence | Add commas for parenthesis. Add commas to show the | A correct answer is: The map, in my opinion, needs replacing |
+| proc3_parenthesis_commas_fix | 2 | textarea | placeholder: Type the corrected sentence | Add commas for parenthesis. Add commas to show the | A correct answer is: Our new puppy, to my surprise, slept th |
+| proc3_parenthesis_commas_fix | 3 | textarea | placeholder: Type the corrected sentence | Add commas for parenthesis. Add commas to show the | A correct answer is: The coach, without any warning, changed |
+| proc3_parenthesis_commas_fix | 4 | textarea | placeholder: Type the corrected sentence | Add commas for parenthesis. Add commas to show the | A correct answer is: The old bridge, as everyone knew, was u |
+| proc3_parenthesis_commas_fix | 5 | textarea | placeholder: Type the corrected sentence | Add commas for parenthesis. Add commas to show the | A correct answer is: The visitors, despite the rain, stayed  |
+| proc3_parenthesis_commas_fix | 6 | textarea | placeholder: Type the corrected sentence | Add commas for parenthesis. Add commas to show the | A correct answer is: Her answer, I think, was correct. |
+| proc3_parenthesis_commas_fix | 7 | textarea | placeholder: Type the corrected sentence | Add commas for parenthesis. Add commas to show the | A correct answer is: The new path, believe it or not, was fi |
+| proc3_parenthesis_commas_fix | 8 | textarea | placeholder: Type the corrected sentence | Add commas for parenthesis. Add commas to show the | A correct answer is: The hall, to be honest, needed a new co |
+| proc3_parenthesis_commas_fix | 9 | textarea | placeholder: Type the corrected sentence | Add commas for parenthesis. Add commas to show the | A correct answer is: Ben, after a short pause, opened the ga |
+| proc3_parenthesis_commas_fix | 10 | textarea | placeholder: Type the corrected sentence | Add commas for parenthesis. Add commas to show the | A correct answer is: The map, in my opinion, needs replacing |
+| proc3_parenthesis_commas_fix | 11 | textarea | placeholder: Type the corrected sentence | Add commas for parenthesis. Add commas to show the | A correct answer is: Our new puppy, to my surprise, slept th |
+| proc3_parenthesis_commas_fix | 12 | textarea | placeholder: Type the corrected sentence | Add commas for parenthesis. Add commas to show the | A correct answer is: The coach, without any warning, changed |
+| proc3_parenthesis_commas_fix | 13 | textarea | placeholder: Type the corrected sentence | Add commas for parenthesis. Add commas to show the | A correct answer is: The old bridge, as everyone knew, was u |
+| proc3_parenthesis_commas_fix | 14 | textarea | placeholder: Type the corrected sentence | Add commas for parenthesis. Add commas to show the | A correct answer is: The visitors, despite the rain, stayed  |
+| proc3_parenthesis_commas_fix | 15 | textarea | placeholder: Type the corrected sentence | Add commas for parenthesis. Add commas to show the | A correct answer is: Her answer, I think, was correct. |
+| proc3_parenthesis_commas_fix | 16 | textarea | placeholder: Type the corrected sentence | Add commas for parenthesis. Add commas to show the | A correct answer is: The new path, believe it or not, was fi |
+| proc3_parenthesis_commas_fix | 17 | textarea | placeholder: Type the corrected sentence | Add commas for parenthesis. Add commas to show the | A correct answer is: The hall, to be honest, needed a new co |
+| proc3_parenthesis_commas_fix | 18 | textarea | placeholder: Type the corrected sentence | Add commas for parenthesis. Add commas to show the | A correct answer is: Ben, after a short pause, opened the ga |
+| proc3_parenthesis_commas_fix | 19 | textarea | placeholder: Type the corrected sentence | Add commas for parenthesis. Add commas to show the | A correct answer is: The map, in my opinion, needs replacing |
+| proc3_parenthesis_commas_fix | 20 | textarea | placeholder: Type the corrected sentence | Add commas for parenthesis. Add commas to show the | A correct answer is: Our new puppy, to my surprise, slept th |
+| proc3_parenthesis_commas_fix | 21 | textarea | placeholder: Type the corrected sentence | Add commas for parenthesis. Add commas to show the | A correct answer is: The coach, without any warning, changed |
+| proc3_parenthesis_commas_fix | 22 | textarea | placeholder: Type the corrected sentence | Add commas for parenthesis. Add commas to show the | A correct answer is: The old bridge, as everyone knew, was u |
+| proc3_parenthesis_commas_fix | 23 | textarea | placeholder: Type the corrected sentence | Add commas for parenthesis. Add commas to show the | A correct answer is: The visitors, despite the rain, stayed  |
+| proc3_parenthesis_commas_fix | 24 | textarea | placeholder: Type the corrected sentence | Add commas for parenthesis. Add commas to show the | A correct answer is: Her answer, I think, was correct. |
+| proc3_parenthesis_commas_fix | 25 | textarea | placeholder: Type the corrected sentence | Add commas for parenthesis. Add commas to show the | A correct answer is: The new path, believe it or not, was fi |
+| proc3_parenthesis_commas_fix | 26 | textarea | placeholder: Type the corrected sentence | Add commas for parenthesis. Add commas to show the | A correct answer is: The hall, to be honest, needed a new co |
+| proc3_parenthesis_commas_fix | 27 | textarea | placeholder: Type the corrected sentence | Add commas for parenthesis. Add commas to show the | A correct answer is: Ben, after a short pause, opened the ga |
+| proc3_parenthesis_commas_fix | 28 | textarea | placeholder: Type the corrected sentence | Add commas for parenthesis. Add commas to show the | A correct answer is: The map, in my opinion, needs replacing |
+| proc3_parenthesis_commas_fix | 29 | textarea | placeholder: Type the corrected sentence | Add commas for parenthesis. Add commas to show the | A correct answer is: Our new puppy, to my surprise, slept th |
+| proc3_parenthesis_commas_fix | 30 | textarea | placeholder: Type the corrected sentence | Add commas for parenthesis. Add commas to show the | A correct answer is: The coach, without any warning, changed |
+| proc3_hyphen_fix_meaning | 1 | textarea | placeholder: Type the corrected sentence | Use a hyphen to make the meaning clear. Rewrite th | A correct answer is: We saw a man-eating shark near the rock |
+| proc3_hyphen_fix_meaning | 2 | textarea | placeholder: Type the corrected sentence | Use a hyphen to make the meaning clear. Rewrite th | A correct answer is: The class made a last-minute poster for |
+| proc3_hyphen_fix_meaning | 3 | textarea | placeholder: Type the corrected sentence | Use a hyphen to make the meaning clear. Rewrite th | A correct answer is: She bought a sugar-free drink for the j |
+| proc3_hyphen_fix_meaning | 4 | textarea | placeholder: Type the corrected sentence | Use a hyphen to make the meaning clear. Rewrite th | A correct answer is: The team needed a well-earned break aft |
+| proc3_hyphen_fix_meaning | 5 | textarea | placeholder: Type the corrected sentence | Use a hyphen to make the meaning clear. Rewrite th | A correct answer is: Ben wore his brand-new trainers to the  |
+| proc3_hyphen_fix_meaning | 6 | textarea | placeholder: Type the corrected sentence | Use a hyphen to make the meaning clear. Rewrite th | A correct answer is: We crossed the narrow, fast-flowing str |
+| proc3_hyphen_fix_meaning | 7 | textarea | placeholder: Type the corrected sentence | Use a hyphen to make the meaning clear. Rewrite th | A correct answer is: The school held a fun-filled sports day |
+| proc3_hyphen_fix_meaning | 8 | textarea | placeholder: Type the corrected sentence | Use a hyphen to make the meaning clear. Rewrite th | A correct answer is: Mia drew a life-size portrait of her br |
+| proc3_hyphen_fix_meaning | 9 | textarea | placeholder: Type the corrected sentence | Use a hyphen to make the meaning clear. Rewrite th | A correct answer is: We visited the small-animal hospital af |
+| proc3_hyphen_fix_meaning | 10 | textarea | placeholder: Type the corrected sentence | Use a hyphen to make the meaning clear. Rewrite th | A correct answer is: We saw a man-eating shark near the rock |
+| proc3_hyphen_fix_meaning | 11 | textarea | placeholder: Type the corrected sentence | Use a hyphen to make the meaning clear. Rewrite th | A correct answer is: The class made a last-minute poster for |
+| proc3_hyphen_fix_meaning | 12 | textarea | placeholder: Type the corrected sentence | Use a hyphen to make the meaning clear. Rewrite th | A correct answer is: She bought a sugar-free drink for the j |
+| proc3_hyphen_fix_meaning | 13 | textarea | placeholder: Type the corrected sentence | Use a hyphen to make the meaning clear. Rewrite th | A correct answer is: The team needed a well-earned break aft |
+| proc3_hyphen_fix_meaning | 14 | textarea | placeholder: Type the corrected sentence | Use a hyphen to make the meaning clear. Rewrite th | A correct answer is: Ben wore his brand-new trainers to the  |
+| proc3_hyphen_fix_meaning | 15 | textarea | placeholder: Type the corrected sentence | Use a hyphen to make the meaning clear. Rewrite th | A correct answer is: We crossed the narrow, fast-flowing str |
+| proc3_hyphen_fix_meaning | 16 | textarea | placeholder: Type the corrected sentence | Use a hyphen to make the meaning clear. Rewrite th | A correct answer is: The school held a fun-filled sports day |
+| proc3_hyphen_fix_meaning | 17 | textarea | placeholder: Type the corrected sentence | Use a hyphen to make the meaning clear. Rewrite th | A correct answer is: Mia drew a life-size portrait of her br |
+| proc3_hyphen_fix_meaning | 18 | textarea | placeholder: Type the corrected sentence | Use a hyphen to make the meaning clear. Rewrite th | A correct answer is: We visited the small-animal hospital af |
+| proc3_hyphen_fix_meaning | 19 | textarea | placeholder: Type the corrected sentence | Use a hyphen to make the meaning clear. Rewrite th | A correct answer is: We saw a man-eating shark near the rock |
+| proc3_hyphen_fix_meaning | 20 | textarea | placeholder: Type the corrected sentence | Use a hyphen to make the meaning clear. Rewrite th | A correct answer is: The class made a last-minute poster for |
+| proc3_hyphen_fix_meaning | 21 | textarea | placeholder: Type the corrected sentence | Use a hyphen to make the meaning clear. Rewrite th | A correct answer is: She bought a sugar-free drink for the j |
+| proc3_hyphen_fix_meaning | 22 | textarea | placeholder: Type the corrected sentence | Use a hyphen to make the meaning clear. Rewrite th | A correct answer is: The team needed a well-earned break aft |
+| proc3_hyphen_fix_meaning | 23 | textarea | placeholder: Type the corrected sentence | Use a hyphen to make the meaning clear. Rewrite th | A correct answer is: Ben wore his brand-new trainers to the  |
+| proc3_hyphen_fix_meaning | 24 | textarea | placeholder: Type the corrected sentence | Use a hyphen to make the meaning clear. Rewrite th | A correct answer is: We crossed the narrow, fast-flowing str |
+| proc3_hyphen_fix_meaning | 25 | textarea | placeholder: Type the corrected sentence | Use a hyphen to make the meaning clear. Rewrite th | A correct answer is: The school held a fun-filled sports day |
+| proc3_hyphen_fix_meaning | 26 | textarea | placeholder: Type the corrected sentence | Use a hyphen to make the meaning clear. Rewrite th | A correct answer is: Mia drew a life-size portrait of her br |
+| proc3_hyphen_fix_meaning | 27 | textarea | placeholder: Type the corrected sentence | Use a hyphen to make the meaning clear. Rewrite th | A correct answer is: We visited the small-animal hospital af |
+| proc3_hyphen_fix_meaning | 28 | textarea | placeholder: Type the corrected sentence | Use a hyphen to make the meaning clear. Rewrite th | A correct answer is: We saw a man-eating shark near the rock |
+| proc3_hyphen_fix_meaning | 29 | textarea | placeholder: Type the corrected sentence | Use a hyphen to make the meaning clear. Rewrite th | A correct answer is: The class made a last-minute poster for |
+| proc3_hyphen_fix_meaning | 30 | textarea | placeholder: Type the corrected sentence | Use a hyphen to make the meaning clear. Rewrite th | A correct answer is: She bought a sugar-free drink for the j |
+| qg_active_passive_choice | 1 | single_choice | Before assembly, the caretaker locked th | Choose active or passive voice. Which sentence is  | The hall receives the action, so it comes first in the passi |
+| qg_active_passive_choice | 2 | single_choice | Aisha painted the scenery for the play., | Choose active or passive voice. Which sentence is  | The passive voice focuses on the scenery rather than the per |
+| qg_active_passive_choice | 3 | single_choice | The gardener trimmed the hedges on Monda | Choose active or passive voice. Which sentence is  | The hedges receive the action and come first in the passive  |
+| qg_active_passive_choice | 4 | single_choice | Noah carried the boxes to the office., N | Choose active or passive voice. Which sentence is  | In the passive, the boxes are placed before the doer. |
+| qg_active_passive_choice | 5 | single_choice | The chef prepared the meal before noon., | Choose active or passive voice. Which sentence is  | The passive puts the thing affected (the meal) into the subj |
+| qg_active_passive_choice | 6 | single_choice | For the fair, Lena designed the poster., | Choose active or passive voice. Which sentence is  | The poster receives the action and appears first in the pass |
+| qg_active_passive_choice | 7 | single_choice | The librarian was sorting the returned b | Choose active or passive voice. Which sentence is  | In the passive, the books are the grammatical subject and th |
+| qg_active_passive_choice | 8 | single_choice | Sam was repairing the puncture during br | Choose active or passive voice. Which sentence is  | The passive moves the thing affected into the subject positi |
+| qg_active_passive_choice | 9 | single_choice | Maya opened the heavy gate after lunch., | Choose active or passive voice. Which sentence is  | The passive sentence puts the thing affected first and uses  |
+| qg_active_passive_choice | 10 | single_choice | The hall was locked by the caretaker bef | Choose active or passive voice. Which sentence is  | The hall receives the action, so it comes first in the passi |
+| qg_active_passive_choice | 11 | single_choice | The scenery was painted by Aisha for the | Choose active or passive voice. Which sentence is  | The passive voice focuses on the scenery rather than the per |
+| qg_active_passive_choice | 12 | single_choice | The gardener was trimming the hedges on  | Choose active or passive voice. Which sentence is  | The hedges receive the action and come first in the passive  |
+| qg_active_passive_choice | 13 | single_choice | To the office, Noah carried the boxes.,  | Choose active or passive voice. Which sentence is  | In the passive, the boxes are placed before the doer. |
+| qg_active_passive_choice | 14 | single_choice | The meal was prepared by the chef before | Choose active or passive voice. Which sentence is  | The passive puts the thing affected (the meal) into the subj |
+| qg_active_passive_choice | 15 | single_choice | Lena was designing the poster for the fa | Choose active or passive voice. Which sentence is  | The poster receives the action and appears first in the pass |
+| qg_active_passive_choice | 16 | single_choice | The returned books needed sorting by the | Choose active or passive voice. Which sentence is  | In the passive, the books are the grammatical subject and th |
+| qg_active_passive_choice | 17 | single_choice | During break, Sam repaired the puncture. | Choose active or passive voice. Which sentence is  | The passive moves the thing affected into the subject positi |
+| qg_active_passive_choice | 18 | single_choice | The heavy gate was opened by Maya after  | Choose active or passive voice. Which sentence is  | The passive sentence puts the thing affected first and uses  |
+| qg_active_passive_choice | 19 | single_choice | The caretaker locked the hall before ass | Choose active or passive voice. Which sentence is  | The hall receives the action, so it comes first in the passi |
+| qg_active_passive_choice | 20 | single_choice | The scenery was painted by Aisha for the | Choose active or passive voice. Which sentence is  | The passive voice focuses on the scenery rather than the per |
+| qg_active_passive_choice | 21 | single_choice | The gardener was trimming the hedges on  | Choose active or passive voice. Which sentence is  | The hedges receive the action and come first in the passive  |
+| qg_active_passive_choice | 22 | single_choice | Noah carried the boxes to the office., T | Choose active or passive voice. Which sentence is  | In the passive, the boxes are placed before the doer. |
+| qg_active_passive_choice | 23 | single_choice | The chef was preparing the meal before n | Choose active or passive voice. Which sentence is  | The passive puts the thing affected (the meal) into the subj |
+| qg_active_passive_choice | 24 | single_choice | For the fair, Lena designed the poster., | Choose active or passive voice. Which sentence is  | The poster receives the action and appears first in the pass |
+| qg_active_passive_choice | 25 | single_choice | The returned books were sorted by the li | Choose active or passive voice. Which sentence is  | In the passive, the books are the grammatical subject and th |
+| qg_active_passive_choice | 26 | single_choice | The puncture was repaired by Sam during  | Choose active or passive voice. Which sentence is  | The passive moves the thing affected into the subject positi |
+| qg_active_passive_choice | 27 | single_choice | After lunch, Maya opened the heavy gate. | Choose active or passive voice. Which sentence is  | The passive sentence puts the thing affected first and uses  |
+| qg_active_passive_choice | 28 | single_choice | The hall was locked by the caretaker bef | Choose active or passive voice. Which sentence is  | The hall receives the action, so it comes first in the passi |
+| qg_active_passive_choice | 29 | single_choice | Aisha painted the scenery for the play., | Choose active or passive voice. Which sentence is  | The passive voice focuses on the scenery rather than the per |
+| qg_active_passive_choice | 30 | single_choice | The gardener trimmed the hedges on Monda | Choose active or passive voice. Which sentence is  | The hedges receive the action and come first in the passive  |
+| qg_subject_object_classify_table | 1 | table_choice | 2 rows/fields | Classify subject and object roles. Classify each n | The subject does the action; the object receives it. |
+| qg_subject_object_classify_table | 2 | table_choice | 2 rows/fields | Classify subject and object roles. Classify each n | The subject does the action; the object receives it. |
+| qg_subject_object_classify_table | 3 | table_choice | 2 rows/fields | Classify subject and object roles. Classify each n | The subject does the action; the object receives it. |
+| qg_subject_object_classify_table | 4 | table_choice | 2 rows/fields | Classify subject and object roles. Classify each n | The subject does the action; the object receives it. |
+| qg_subject_object_classify_table | 5 | table_choice | 2 rows/fields | Classify subject and object roles. Classify each n | The subject does the action; the object receives it. |
+| qg_subject_object_classify_table | 6 | table_choice | 2 rows/fields | Classify subject and object roles. Classify each n | The subject does the action; the object receives it. |
+| qg_subject_object_classify_table | 7 | table_choice | 2 rows/fields | Classify subject and object roles. Classify each n | The subject does the action; the object receives it. |
+| qg_subject_object_classify_table | 8 | table_choice | 2 rows/fields | Classify subject and object roles. Classify each n | The subject does the action; the object receives it. |
+| qg_subject_object_classify_table | 9 | table_choice | 2 rows/fields | Classify subject and object roles. Classify each n | The subject does the action; the object receives it. |
+| qg_subject_object_classify_table | 10 | table_choice | 2 rows/fields | Classify subject and object roles. Classify each n | The subject does the action; the object receives it. |
+| qg_subject_object_classify_table | 11 | table_choice | 2 rows/fields | Classify subject and object roles. Classify each n | The subject does the action; the object receives it. |
+| qg_subject_object_classify_table | 12 | table_choice | 2 rows/fields | Classify subject and object roles. Classify each n | The subject does the action; the object receives it. |
+| qg_subject_object_classify_table | 13 | table_choice | 2 rows/fields | Classify subject and object roles. Classify each n | The subject does the action; the object receives it. |
+| qg_subject_object_classify_table | 14 | table_choice | 2 rows/fields | Classify subject and object roles. Classify each n | The subject does the action; the object receives it. |
+| qg_subject_object_classify_table | 15 | table_choice | 2 rows/fields | Classify subject and object roles. Classify each n | The subject does the action; the object receives it. |
+| qg_subject_object_classify_table | 16 | table_choice | 2 rows/fields | Classify subject and object roles. Classify each n | The subject does the action; the object receives it. |
+| qg_subject_object_classify_table | 17 | table_choice | 2 rows/fields | Classify subject and object roles. Classify each n | The subject does the action; the object receives it. |
+| qg_subject_object_classify_table | 18 | table_choice | 2 rows/fields | Classify subject and object roles. Classify each n | The subject does the action; the object receives it. |
+| qg_subject_object_classify_table | 19 | table_choice | 2 rows/fields | Classify subject and object roles. Classify each n | The subject does the action; the object receives it. |
+| qg_subject_object_classify_table | 20 | table_choice | 2 rows/fields | Classify subject and object roles. Classify each n | The subject does the action; the object receives it. |
+| qg_subject_object_classify_table | 21 | table_choice | 2 rows/fields | Classify subject and object roles. Classify each n | The subject does the action; the object receives it. |
+| qg_subject_object_classify_table | 22 | table_choice | 2 rows/fields | Classify subject and object roles. Classify each n | The subject does the action; the object receives it. |
+| qg_subject_object_classify_table | 23 | table_choice | 2 rows/fields | Classify subject and object roles. Classify each n | The subject does the action; the object receives it. |
+| qg_subject_object_classify_table | 24 | table_choice | 2 rows/fields | Classify subject and object roles. Classify each n | The subject does the action; the object receives it. |
+| qg_subject_object_classify_table | 25 | table_choice | 2 rows/fields | Classify subject and object roles. Classify each n | The subject does the action; the object receives it. |
+| qg_subject_object_classify_table | 26 | table_choice | 2 rows/fields | Classify subject and object roles. Classify each n | The subject does the action; the object receives it. |
+| qg_subject_object_classify_table | 27 | table_choice | 2 rows/fields | Classify subject and object roles. Classify each n | The subject does the action; the object receives it. |
+| qg_subject_object_classify_table | 28 | table_choice | 2 rows/fields | Classify subject and object roles. Classify each n | The subject does the action; the object receives it. |
+| qg_subject_object_classify_table | 29 | table_choice | 2 rows/fields | Classify subject and object roles. Classify each n | The subject does the action; the object receives it. |
+| qg_subject_object_classify_table | 30 | table_choice | 2 rows/fields | Classify subject and object roles. Classify each n | The subject does the action; the object receives it. |
+| qg_pronoun_referent_identify | 1 | single_choice | the library, Sam, Oliver, the library bo | Identify a pronoun referent. In this sentence, wha | The pronoun 'he' refers to Oliver because Oliver returned th |
+| qg_pronoun_referent_identify | 2 | single_choice | the benches, the hall, The pupils, lunch | Identify a pronoun referent. In this sentence, wha | The pronoun 'they' refers to the pupils because the pupils f |
+| qg_pronoun_referent_identify | 3 | single_choice | Mia, the race, Ava, the trophy | Identify a pronoun referent. In this sentence, wha | The pronoun 'she' refers to Ava because Ava won the race and |
+| qg_pronoun_referent_identify | 4 | single_choice | the dog, the fence, the cat, the garden | Identify a pronoun referent. In this sentence, wha | The pronoun 'it' refers to the cat because the cat escaped b |
+| qg_pronoun_referent_identify | 5 | single_choice | Jay, Noah, the teacher, the project | Identify a pronoun referent. In this sentence, wha | The pronoun 'he' refers to Noah because Jay is giving the in |
+| qg_pronoun_referent_identify | 6 | single_choice | the hall, The teachers, the choir, the a | Identify a pronoun referent. In this sentence, wha | The pronoun 'they' refers to the choir because the choir per |
+| qg_pronoun_referent_identify | 7 | single_choice | Elsie, the lamp, the table, the book | Identify a pronoun referent. In this sentence, wha | The pronoun 'it' refers to the book because the book is desc |
+| qg_pronoun_referent_identify | 8 | single_choice | the compass, the teacher, Zac, Ben | Identify a pronoun referent. In this sentence, wha | The pronoun 'he' refers to Ben because Ben is the one making |
+| qg_pronoun_referent_identify | 9 | single_choice | the torch, her pocket, Lena, the map | Identify a pronoun referent. In this sentence, wha | The pronoun 'it' refers to the map because the map is descri |
+| qg_pronoun_referent_identify | 10 | single_choice | Oliver, Sam, the library, the library bo | Identify a pronoun referent. In this sentence, wha | The pronoun 'he' refers to Oliver because Oliver returned th |
+| qg_pronoun_referent_identify | 11 | single_choice | The pupils, the hall, the benches, lunch | Identify a pronoun referent. In this sentence, wha | The pronoun 'they' refers to the pupils because the pupils f |
+| qg_pronoun_referent_identify | 12 | single_choice | the trophy, the race, Ava, Mia | Identify a pronoun referent. In this sentence, wha | The pronoun 'she' refers to Ava because Ava won the race and |
+| qg_pronoun_referent_identify | 13 | single_choice | the garden, the cat, the dog, the fence | Identify a pronoun referent. In this sentence, wha | The pronoun 'it' refers to the cat because the cat escaped b |
+| qg_pronoun_referent_identify | 14 | single_choice | Noah, the project, the teacher, Jay | Identify a pronoun referent. In this sentence, wha | The pronoun 'he' refers to Noah because Jay is giving the in |
+| qg_pronoun_referent_identify | 15 | single_choice | the audience, the hall, The teachers, th | Identify a pronoun referent. In this sentence, wha | The pronoun 'they' refers to the choir because the choir per |
+| qg_pronoun_referent_identify | 16 | single_choice | the table, the lamp, the book, Elsie | Identify a pronoun referent. In this sentence, wha | The pronoun 'it' refers to the book because the book is desc |
+| qg_pronoun_referent_identify | 17 | single_choice | the teacher, Zac, Ben, the compass | Identify a pronoun referent. In this sentence, wha | The pronoun 'he' refers to Ben because Ben is the one making |
+| qg_pronoun_referent_identify | 18 | single_choice | the map, Lena, her pocket, the torch | Identify a pronoun referent. In this sentence, wha | The pronoun 'it' refers to the map because the map is descri |
+| qg_pronoun_referent_identify | 19 | single_choice | Sam, the library book, the library, Oliv | Identify a pronoun referent. In this sentence, wha | The pronoun 'he' refers to Oliver because Oliver returned th |
+| qg_pronoun_referent_identify | 20 | single_choice | The pupils, lunch, the benches, the hall | Identify a pronoun referent. In this sentence, wha | The pronoun 'they' refers to the pupils because the pupils f |
+| qg_pronoun_referent_identify | 21 | single_choice | the trophy, Ava, the race, Mia | Identify a pronoun referent. In this sentence, wha | The pronoun 'she' refers to Ava because Ava won the race and |
+| qg_pronoun_referent_identify | 22 | single_choice | the dog, the garden, the cat, the fence | Identify a pronoun referent. In this sentence, wha | The pronoun 'it' refers to the cat because the cat escaped b |
+| qg_pronoun_referent_identify | 23 | single_choice | the project, Jay, the teacher, Noah | Identify a pronoun referent. In this sentence, wha | The pronoun 'he' refers to Noah because Jay is giving the in |
+| qg_pronoun_referent_identify | 24 | single_choice | the hall, the choir, the audience, The t | Identify a pronoun referent. In this sentence, wha | The pronoun 'they' refers to the choir because the choir per |
+| qg_pronoun_referent_identify | 25 | single_choice | the book, the lamp, the table, Elsie | Identify a pronoun referent. In this sentence, wha | The pronoun 'it' refers to the book because the book is desc |
+| qg_pronoun_referent_identify | 26 | single_choice | Ben, Zac, the teacher, the compass | Identify a pronoun referent. In this sentence, wha | The pronoun 'he' refers to Ben because Ben is the one making |
+| qg_pronoun_referent_identify | 27 | single_choice | her pocket, Lena, the map, the torch | Identify a pronoun referent. In this sentence, wha | The pronoun 'it' refers to the map because the map is descri |
+| qg_pronoun_referent_identify | 28 | single_choice | Oliver, the library, the library book, S | Identify a pronoun referent. In this sentence, wha | The pronoun 'he' refers to Oliver because Oliver returned th |
+| qg_pronoun_referent_identify | 29 | single_choice | the benches, lunch, the hall, The pupils | Identify a pronoun referent. In this sentence, wha | The pronoun 'they' refers to the pupils because the pupils f |
+| qg_pronoun_referent_identify | 30 | single_choice | Mia, Ava, the trophy, the race | Identify a pronoun referent. In this sentence, wha | The pronoun 'she' refers to Ava because Ava won the race and |
+| qg_formality_classify_table | 1 | table_choice | 2 rows/fields | Classify formal and informal register. Classify ea | Formal writing avoids chatty phrasing and uses precise vocab |
+| qg_formality_classify_table | 2 | table_choice | 2 rows/fields | Classify formal and informal register. Classify ea | Formal writing avoids chatty phrasing and uses precise vocab |
+| qg_formality_classify_table | 3 | table_choice | 2 rows/fields | Classify formal and informal register. Classify ea | Formal writing avoids chatty phrasing and uses precise vocab |
+| qg_formality_classify_table | 4 | table_choice | 2 rows/fields | Classify formal and informal register. Classify ea | Formal writing avoids chatty phrasing and uses precise vocab |
+| qg_formality_classify_table | 5 | table_choice | 2 rows/fields | Classify formal and informal register. Classify ea | Formal writing avoids chatty phrasing and uses precise vocab |
+| qg_formality_classify_table | 6 | table_choice | 2 rows/fields | Classify formal and informal register. Classify ea | Formal writing avoids chatty phrasing and uses precise vocab |
+| qg_formality_classify_table | 7 | table_choice | 2 rows/fields | Classify formal and informal register. Classify ea | Formal writing avoids chatty phrasing and uses precise vocab |
+| qg_formality_classify_table | 8 | table_choice | 2 rows/fields | Classify formal and informal register. Classify ea | Formal writing avoids chatty phrasing and uses precise vocab |
+| qg_formality_classify_table | 9 | table_choice | 2 rows/fields | Classify formal and informal register. Classify ea | Formal writing avoids chatty phrasing and uses precise vocab |
+| qg_formality_classify_table | 10 | table_choice | 2 rows/fields | Classify formal and informal register. Classify ea | Formal writing avoids chatty phrasing and uses precise vocab |
+| qg_formality_classify_table | 11 | table_choice | 2 rows/fields | Classify formal and informal register. Classify ea | Formal writing avoids chatty phrasing and uses precise vocab |
+| qg_formality_classify_table | 12 | table_choice | 2 rows/fields | Classify formal and informal register. Classify ea | Formal writing avoids chatty phrasing and uses precise vocab |
+| qg_formality_classify_table | 13 | table_choice | 2 rows/fields | Classify formal and informal register. Classify ea | Formal writing avoids chatty phrasing and uses precise vocab |
+| qg_formality_classify_table | 14 | table_choice | 2 rows/fields | Classify formal and informal register. Classify ea | Formal writing avoids chatty phrasing and uses precise vocab |
+| qg_formality_classify_table | 15 | table_choice | 2 rows/fields | Classify formal and informal register. Classify ea | Formal writing avoids chatty phrasing and uses precise vocab |
+| qg_formality_classify_table | 16 | table_choice | 2 rows/fields | Classify formal and informal register. Classify ea | Formal writing avoids chatty phrasing and uses precise vocab |
+| qg_formality_classify_table | 17 | table_choice | 2 rows/fields | Classify formal and informal register. Classify ea | Formal writing avoids chatty phrasing and uses precise vocab |
+| qg_formality_classify_table | 18 | table_choice | 2 rows/fields | Classify formal and informal register. Classify ea | Formal writing avoids chatty phrasing and uses precise vocab |
+| qg_formality_classify_table | 19 | table_choice | 2 rows/fields | Classify formal and informal register. Classify ea | Formal writing avoids chatty phrasing and uses precise vocab |
+| qg_formality_classify_table | 20 | table_choice | 2 rows/fields | Classify formal and informal register. Classify ea | Formal writing avoids chatty phrasing and uses precise vocab |
+| qg_formality_classify_table | 21 | table_choice | 2 rows/fields | Classify formal and informal register. Classify ea | Formal writing avoids chatty phrasing and uses precise vocab |
+| qg_formality_classify_table | 22 | table_choice | 2 rows/fields | Classify formal and informal register. Classify ea | Formal writing avoids chatty phrasing and uses precise vocab |
+| qg_formality_classify_table | 23 | table_choice | 2 rows/fields | Classify formal and informal register. Classify ea | Formal writing avoids chatty phrasing and uses precise vocab |
+| qg_formality_classify_table | 24 | table_choice | 2 rows/fields | Classify formal and informal register. Classify ea | Formal writing avoids chatty phrasing and uses precise vocab |
+| qg_formality_classify_table | 25 | table_choice | 2 rows/fields | Classify formal and informal register. Classify ea | Formal writing avoids chatty phrasing and uses precise vocab |
+| qg_formality_classify_table | 26 | table_choice | 2 rows/fields | Classify formal and informal register. Classify ea | Formal writing avoids chatty phrasing and uses precise vocab |
+| qg_formality_classify_table | 27 | table_choice | 2 rows/fields | Classify formal and informal register. Classify ea | Formal writing avoids chatty phrasing and uses precise vocab |
+| qg_formality_classify_table | 28 | table_choice | 2 rows/fields | Classify formal and informal register. Classify ea | Formal writing avoids chatty phrasing and uses precise vocab |
+| qg_formality_classify_table | 29 | table_choice | 2 rows/fields | Classify formal and informal register. Classify ea | Formal writing avoids chatty phrasing and uses precise vocab |
+| qg_formality_classify_table | 30 | table_choice | 2 rows/fields | Classify formal and informal register. Classify ea | Formal writing avoids chatty phrasing and uses precise vocab |
+| qg_modal_verb_explain | 1 | single_choice | It names the person doing the action., I | Explain modal verb meaning. In this sentence, what | 'Might' shows that rain is possible but not certain. |
+| qg_modal_verb_explain | 2 | single_choice | It shows something is impossible., It tu | Explain modal verb meaning. In this sentence, what | 'Should' commonly gives advice or a recommendation. |
+| qg_modal_verb_explain | 3 | single_choice | It shows that the action is certain to h | Explain modal verb meaning. In this sentence, what | 'May' can ask for or grant permission. |
+| qg_modal_verb_explain | 4 | single_choice | It shows a future obligation., It makes  | Explain modal verb meaning. In this sentence, what | 'Could' often shows that someone had the ability to do somet |
+| qg_modal_verb_explain | 5 | single_choice | It shows that the action is only a weak  | Explain modal verb meaning. In this sentence, what | 'Will' is commonly used for future certainty or prediction. |
+| qg_modal_verb_explain | 6 | single_choice | It places the action in the past., It sh | Explain modal verb meaning. In this sentence, what | 'Shall' can express rules, obligations, or formal determinat |
+| qg_modal_verb_explain | 7 | single_choice | It gives a command to check the answer., | Explain modal verb meaning. In this sentence, what | 'Could' can also show possibility when the meaning is about  |
+| qg_modal_verb_explain | 8 | single_choice | It makes the sentence a question., It sh | Explain modal verb meaning. In this sentence, what | 'Must' is used here for a rule or strong obligation. |
+| qg_modal_verb_explain | 9 | single_choice | It shows a fixed rule., It names the per | Explain modal verb meaning. In this sentence, what | 'Might' shows that rain is possible but not certain. |
+| qg_modal_verb_explain | 10 | single_choice | It gives advice., It shows something is  | Explain modal verb meaning. In this sentence, what | 'Should' commonly gives advice or a recommendation. |
+| qg_modal_verb_explain | 11 | single_choice | It asks for permission politely., It sho | Explain modal verb meaning. In this sentence, what | 'May' can ask for or grant permission. |
+| qg_modal_verb_explain | 12 | single_choice | It makes the sentence passive., It repla | Explain modal verb meaning. In this sentence, what | 'Could' often shows that someone had the ability to do somet |
+| qg_modal_verb_explain | 13 | single_choice | It turns the sentence into a command., I | Explain modal verb meaning. In this sentence, what | 'Will' is commonly used for future certainty or prediction. |
+| qg_modal_verb_explain | 14 | single_choice | It expresses a rule or prohibition., It  | Explain modal verb meaning. In this sentence, what | 'Shall' can express rules, obligations, or formal determinat |
+| qg_modal_verb_explain | 15 | single_choice | It gives a command to check the answer., | Explain modal verb meaning. In this sentence, what | 'Could' can also show possibility when the meaning is about  |
+| qg_modal_verb_explain | 16 | single_choice | It shows the action happened yesterday., | Explain modal verb meaning. In this sentence, what | 'Must' is used here for a rule or strong obligation. |
+| qg_modal_verb_explain | 17 | single_choice | It names the person doing the action., I | Explain modal verb meaning. In this sentence, what | 'Might' shows that rain is possible but not certain. |
+| qg_modal_verb_explain | 18 | single_choice | It gives advice., It marks direct speech | Explain modal verb meaning. In this sentence, what | 'Should' commonly gives advice or a recommendation. |
+| qg_modal_verb_explain | 19 | single_choice | It shows that the action is certain to h | Explain modal verb meaning. In this sentence, what | 'May' can ask for or grant permission. |
+| qg_modal_verb_explain | 20 | single_choice | It shows past ability., It makes the sen | Explain modal verb meaning. In this sentence, what | 'Could' often shows that someone had the ability to do somet |
+| qg_modal_verb_explain | 21 | single_choice | It gives advice about what to do., It sh | Explain modal verb meaning. In this sentence, what | 'Will' is commonly used for future certainty or prediction. |
+| qg_modal_verb_explain | 22 | single_choice | It shows a weak possibility., It places  | Explain modal verb meaning. In this sentence, what | 'Shall' can express rules, obligations, or formal determinat |
+| qg_modal_verb_explain | 23 | single_choice | It gives a command to check the answer., | Explain modal verb meaning. In this sentence, what | 'Could' can also show possibility when the meaning is about  |
+| qg_modal_verb_explain | 24 | single_choice | It shows the action happened yesterday., | Explain modal verb meaning. In this sentence, what | 'Must' is used here for a rule or strong obligation. |
+| qg_modal_verb_explain | 25 | single_choice | It shows possibility, not certainty., It | Explain modal verb meaning. In this sentence, what | 'Might' shows that rain is possible but not certain. |
+| qg_modal_verb_explain | 26 | single_choice | It gives advice., It shows something is  | Explain modal verb meaning. In this sentence, what | 'Should' commonly gives advice or a recommendation. |
+| qg_modal_verb_explain | 27 | single_choice | It shows that the scissors belong to the | Explain modal verb meaning. In this sentence, what | 'May' can ask for or grant permission. |
+| qg_modal_verb_explain | 28 | single_choice | It shows past ability., It replaces the  | Explain modal verb meaning. In this sentence, what | 'Could' often shows that someone had the ability to do somet |
+| qg_modal_verb_explain | 29 | single_choice | It shows that the action is only a weak  | Explain modal verb meaning. In this sentence, what | 'Will' is commonly used for future certainty or prediction. |
+| qg_modal_verb_explain | 30 | single_choice | It shows a weak possibility., It express | Explain modal verb meaning. In this sentence, what | 'Shall' can express rules, obligations, or formal determinat |
+| qg_hyphen_ambiguity_explain | 1 | single_choice | The hyphen shows a missing letter., The  | Explain how a hyphen changes meaning. Why does the | The hyphen joins 'small' and 'animal' so they work together  |
+| qg_hyphen_ambiguity_explain | 2 | single_choice | The hyphen shows that the poster is the  | Explain how a hyphen changes meaning. Why does the | The compound adjective comes before the noun, so the hyphen  |
+| qg_hyphen_ambiguity_explain | 3 | single_choice | The hyphen shows the author owns a well. | Explain how a hyphen changes meaning. Why does the | Compound adjectives before a noun use a hyphen to show they  |
+| qg_hyphen_ambiguity_explain | 4 | single_choice | The hyphen separates two different group | Explain how a hyphen changes meaning. Why does the | Compound numbers from twenty-one to ninety-nine use a hyphen |
+| qg_hyphen_ambiguity_explain | 5 | single_choice | The hyphen shows that the book belongs t | Explain how a hyphen changes meaning. Why does the | A hyphen after 're' can prevent confusion with a different w |
+| qg_hyphen_ambiguity_explain | 6 | single_choice | The hyphen shows possession by the clock | Explain how a hyphen changes meaning. Why does the | Without the hyphen, 'old' could be read as describing 'fashi |
+| qg_hyphen_ambiguity_explain | 7 | single_choice | The hyphen makes the phrase a question., | Explain how a hyphen changes meaning. Why does the | The compound adjective modifies the noun as a unit, and the  |
+| qg_hyphen_ambiguity_explain | 8 | single_choice | The hyphen turns the phrase into direct  | Explain how a hyphen changes meaning. Why does the | The hyphen joins 'man' and 'eating' into one describing idea |
+| qg_hyphen_ambiguity_explain | 9 | single_choice | The hyphen shows that the hospital build | Explain how a hyphen changes meaning. Why does the | The hyphen joins 'small' and 'animal' so they work together  |
+| qg_hyphen_ambiguity_explain | 10 | single_choice | The hyphen shows that 'last-minute' is o | Explain how a hyphen changes meaning. Why does the | The compound adjective comes before the noun, so the hyphen  |
+| qg_hyphen_ambiguity_explain | 11 | single_choice | The hyphen shows that 'well-known' is on | Explain how a hyphen changes meaning. Why does the | Compound adjectives before a noun use a hyphen to show they  |
+| qg_hyphen_ambiguity_explain | 12 | single_choice | The hyphen shows possession by the numbe | Explain how a hyphen changes meaning. Why does the | Compound numbers from twenty-one to ninety-nine use a hyphen |
+| qg_hyphen_ambiguity_explain | 13 | single_choice | The hyphen means the same as a comma her | Explain how a hyphen changes meaning. Why does the | A hyphen after 're' can prevent confusion with a different w |
+| qg_hyphen_ambiguity_explain | 14 | single_choice | The hyphen shows that 'old-fashioned' is | Explain how a hyphen changes meaning. Why does the | Without the hyphen, 'old' could be read as describing 'fashi |
+| qg_hyphen_ambiguity_explain | 15 | single_choice | The hyphen makes the phrase a question., | Explain how a hyphen changes meaning. Why does the | The compound adjective modifies the noun as a unit, and the  |
+| qg_hyphen_ambiguity_explain | 16 | single_choice | The hyphen shows plural possession., The | Explain how a hyphen changes meaning. Why does the | The hyphen joins 'man' and 'eating' into one describing idea |
+| qg_hyphen_ambiguity_explain | 17 | single_choice | The hyphen shows a missing letter., The  | Explain how a hyphen changes meaning. Why does the | The hyphen joins 'small' and 'animal' so they work together  |
+| qg_hyphen_ambiguity_explain | 18 | single_choice | The hyphen shows that 'last-minute' is o | Explain how a hyphen changes meaning. Why does the | The compound adjective comes before the noun, so the hyphen  |
+| qg_hyphen_ambiguity_explain | 19 | single_choice | The hyphen shows the author owns a well. | Explain how a hyphen changes meaning. Why does the | Compound adjectives before a noun use a hyphen to show they  |
+| qg_hyphen_ambiguity_explain | 20 | single_choice | The hyphen links twenty and four as a si | Explain how a hyphen changes meaning. Why does the | Compound numbers from twenty-one to ninety-nine use a hyphen |
+| qg_hyphen_ambiguity_explain | 21 | single_choice | The hyphen marks a subordinate clause.,  | Explain how a hyphen changes meaning. Why does the | A hyphen after 're' can prevent confusion with a different w |
+| qg_hyphen_ambiguity_explain | 22 | single_choice | The hyphen shows that the clock is old a | Explain how a hyphen changes meaning. Why does the | Without the hyphen, 'old' could be read as describing 'fashi |
+| qg_hyphen_ambiguity_explain | 23 | single_choice | The hyphen makes the phrase a question., | Explain how a hyphen changes meaning. Why does the | The compound adjective modifies the noun as a unit, and the  |
+| qg_hyphen_ambiguity_explain | 24 | single_choice | The hyphen shows plural possession., The | Explain how a hyphen changes meaning. Why does the | The hyphen joins 'man' and 'eating' into one describing idea |
+| qg_hyphen_ambiguity_explain | 25 | single_choice | The hyphen shows that the hospital is fo | Explain how a hyphen changes meaning. Why does the | The hyphen joins 'small' and 'animal' so they work together  |
+| qg_hyphen_ambiguity_explain | 26 | single_choice | The hyphen shows that 'last-minute' is o | Explain how a hyphen changes meaning. Why does the | The compound adjective comes before the noun, so the hyphen  |
+| qg_hyphen_ambiguity_explain | 27 | single_choice | The hyphen separates two independent cla | Explain how a hyphen changes meaning. Why does the | Compound adjectives before a noun use a hyphen to show they  |
+| qg_hyphen_ambiguity_explain | 28 | single_choice | The hyphen links twenty and four as a si | Explain how a hyphen changes meaning. Why does the | Compound numbers from twenty-one to ninety-nine use a hyphen |
+| qg_hyphen_ambiguity_explain | 29 | single_choice | The hyphen shows that the book belongs t | Explain how a hyphen changes meaning. Why does the | A hyphen after 're' can prevent confusion with a different w |
+| qg_hyphen_ambiguity_explain | 30 | single_choice | The hyphen shows that the clock is old a | Explain how a hyphen changes meaning. Why does the | Without the hyphen, 'old' could be read as describing 'fashi |
+| qg_p3_sentence_functions_explain | 1 | single_choice | It is a grammatical exclamation because  | Explain a sentence function. Why is this sentence  | A question asks something directly; the question mark suppor |
+| qg_p3_sentence_functions_explain | 2 | single_choice | It asks where the keys are., It begins w | Explain a sentence function. Why is this sentence  | A statement tells the reader something and does not ask, ord |
+| qg_p3_sentence_functions_explain | 3 | single_choice | It is a question because it uses the wor | Explain a sentence function. Why is this a grammat | KS2 grammatical exclamations often begin with What or How an |
+| qg_p3_sentence_functions_explain | 4 | single_choice | It is a question because it contains the | Explain a sentence function. Why is this a stateme | A reported question can be part of a statement if the whole  |
+| qg_p3_sentence_functions_explain | 5 | single_choice | Any sentence with an exclamation mark is | Explain a sentence function. Why is this not a gra | In KS2 grammar, an exclamation mark alone does not make the  |
+| qg_p3_sentence_functions_explain | 6 | single_choice | It is an exclamation because the speaker | Explain a sentence function. Why is this sentence  | A command instructs someone to act; politeness markers do no |
+| qg_p3_sentence_functions_explain | 7 | single_choice | It is a command because it tells the fox | Explain a sentence function. Why is this sentence  | Grammatical exclamations at KS2 begin with What or How and e |
+| qg_p3_sentence_functions_explain | 8 | single_choice | It gives information without an instruct | Explain a sentence function. Why is this sentence  | A command gives an instruction or request, often with an imp |
+| qg_p3_sentence_functions_explain | 9 | single_choice | It tells the caretaker to leave the keys | Explain a sentence function. Why is this sentence  | A question asks something directly; the question mark suppor |
+| qg_p3_sentence_functions_explain | 10 | single_choice | It gives information, so it is a stateme | Explain a sentence function. Why is this sentence  | A statement tells the reader something and does not ask, ord |
+| qg_p3_sentence_functions_explain | 11 | single_choice | It begins with What and expresses strong | Explain a sentence function. Why is this a grammat | KS2 grammatical exclamations often begin with What or How an |
+| qg_p3_sentence_functions_explain | 12 | single_choice | It is a command because it tells the rea | Explain a sentence function. Why is this a stateme | A reported question can be part of a statement if the whole  |
+| qg_p3_sentence_functions_explain | 13 | single_choice | It is a question because it ends with st | Explain a sentence function. Why is this not a gra | In KS2 grammar, an exclamation mark alone does not make the  |
+| qg_p3_sentence_functions_explain | 14 | single_choice | It tells someone to do something; the po | Explain a sentence function. Why is this sentence  | A command instructs someone to act; politeness markers do no |
+| qg_p3_sentence_functions_explain | 15 | single_choice | It is a command because it tells the fox | Explain a sentence function. Why is this sentence  | Grammatical exclamations at KS2 begin with What or How and e |
+| qg_p3_sentence_functions_explain | 16 | single_choice | It begins with What or How and shows str | Explain a sentence function. Why is this sentence  | A command gives an instruction or request, often with an imp |
+| qg_p3_sentence_functions_explain | 17 | single_choice | It is a grammatical exclamation because  | Explain a sentence function. Why is this sentence  | A question asks something directly; the question mark suppor |
+| qg_p3_sentence_functions_explain | 18 | single_choice | It gives information, so it is a stateme | Explain a sentence function. Why is this sentence  | A statement tells the reader something and does not ask, ord |
+| qg_p3_sentence_functions_explain | 19 | single_choice | It is a question because it uses the wor | Explain a sentence function. Why is this a grammat | KS2 grammatical exclamations often begin with What or How an |
+| qg_p3_sentence_functions_explain | 20 | single_choice | It reports someone wondering; it does no | Explain a sentence function. Why is this a stateme | A reported question can be part of a statement if the whole  |
+| qg_p3_sentence_functions_explain | 21 | single_choice | It is a command because the drums are ma | Explain a sentence function. Why is this not a gra | In KS2 grammar, an exclamation mark alone does not make the  |
+| qg_p3_sentence_functions_explain | 22 | single_choice | It is a question because it uses the wor | Explain a sentence function. Why is this sentence  | A command instructs someone to act; politeness markers do no |
+| qg_p3_sentence_functions_explain | 23 | single_choice | It is a command because it tells the fox | Explain a sentence function. Why is this sentence  | Grammatical exclamations at KS2 begin with What or How and e |
+| qg_p3_sentence_functions_explain | 24 | single_choice | It begins with What or How and shows str | Explain a sentence function. Why is this sentence  | A command gives an instruction or request, often with an imp |
+| qg_p3_sentence_functions_explain | 25 | single_choice | It asks for information directly, so it  | Explain a sentence function. Why is this sentence  | A question asks something directly; the question mark suppor |
+| qg_p3_sentence_functions_explain | 26 | single_choice | It gives information, so it is a stateme | Explain a sentence function. Why is this sentence  | A statement tells the reader something and does not ask, ord |
+| qg_p3_sentence_functions_explain | 27 | single_choice | It is a statement because it gives calm  | Explain a sentence function. Why is this a grammat | KS2 grammatical exclamations often begin with What or How an |
+| qg_p3_sentence_functions_explain | 28 | single_choice | It reports someone wondering; it does no | Explain a sentence function. Why is this a stateme | A reported question can be part of a statement if the whole  |
+| qg_p3_sentence_functions_explain | 29 | single_choice | Any sentence with an exclamation mark is | Explain a sentence function. Why is this not a gra | In KS2 grammar, an exclamation mark alone does not make the  |
+| qg_p3_sentence_functions_explain | 30 | single_choice | It is a question because it uses the wor | Explain a sentence function. Why is this sentence  | A command instructs someone to act; politeness markers do no |
+| qg_p3_word_classes_explain | 1 | single_choice | It joins the two parts of the sentence., | Explain a word class in context. Why is the word ' | Adverbs can modify verbs by telling how, when, where, or how |
+| qg_p3_word_classes_explain | 2 | single_choice | It replaces the noun pupils., It names t | Explain a word class in context. Why is the word ' | A preposition usually links a noun phrase to the rest of the |
+| qg_p3_word_classes_explain | 3 | single_choice | It describes the noun baby., It replaces | Explain a word class in context. Why is the word ' | A conjunction can join clauses and show the relationship bet |
+| qg_p3_word_classes_explain | 4 | single_choice | It tells how the birds nested., It names | Explain a word class in context. Why is the word ' | Determiners come before nouns and help specify them. |
+| qg_p3_word_classes_explain | 5 | single_choice | It describes the compass., It replaces t | Explain a word class in context. Why is the word ' | Pronouns stand in for nouns or noun phrases when the referen |
+| qg_p3_word_classes_explain | 6 | single_choice | It joins two clauses together., It names | Explain a word class in context. Why is the word ' | Adverbs can modify verbs by explaining the manner of the act |
+| qg_p3_word_classes_explain | 7 | single_choice | It replaces the noun children., It descr | Explain a word class in context. Why is the word ' | A preposition links a noun phrase to the rest of the sentenc |
+| qg_p3_word_classes_explain | 8 | single_choice | It joins two clauses together., It repla | Explain a word class in context. Why is the word ' | An adjective gives more information about a noun. |
+| qg_p3_word_classes_explain | 9 | single_choice | It names the person doing the folding.,  | Explain a word class in context. Why is the word ' | Adverbs can modify verbs by telling how, when, where, or how |
+| qg_p3_word_classes_explain | 10 | single_choice | It begins the phrase before assembly and | Explain a word class in context. Why is the word ' | A preposition usually links a noun phrase to the rest of the |
+| qg_p3_word_classes_explain | 11 | single_choice | It joins the reason clause to the main c | Explain a word class in context. Why is the word ' | A conjunction can join clauses and show the relationship bet |
+| qg_p3_word_classes_explain | 12 | single_choice | It names the action in the sentence., It | Explain a word class in context. Why is the word ' | Determiners come before nouns and help specify them. |
+| qg_p3_word_classes_explain | 13 | single_choice | It joins the two clauses because it mean | Explain a word class in context. Why is the word ' | Pronouns stand in for nouns or noun phrases when the referen |
+| qg_p3_word_classes_explain | 14 | single_choice | It modifies the verb flowed by telling h | Explain a word class in context. Why is the word ' | Adverbs can modify verbs by explaining the manner of the act |
+| qg_p3_word_classes_explain | 15 | single_choice | It replaces the noun children., It is a  | Explain a word class in context. Why is the word ' | A preposition links a noun phrase to the rest of the sentenc |
+| qg_p3_word_classes_explain | 16 | single_choice | It replaces a noun phrase to avoid repet | Explain a word class in context. Why is the word ' | An adjective gives more information about a noun. |
+| qg_p3_word_classes_explain | 17 | single_choice | It joins the two parts of the sentence., | Explain a word class in context. Why is the word ' | Adverbs can modify verbs by telling how, when, where, or how |
+| qg_p3_word_classes_explain | 18 | single_choice | It begins the phrase before assembly and | Explain a word class in context. Why is the word ' | A preposition usually links a noun phrase to the rest of the |
+| qg_p3_word_classes_explain | 19 | single_choice | It describes the noun baby., It shows wh | Explain a word class in context. Why is the word ' | A conjunction can join clauses and show the relationship bet |
+| qg_p3_word_classes_explain | 20 | single_choice | It comes before the noun birds and helps | Explain a word class in context. Why is the word ' | Determiners come before nouns and help specify them. |
+| qg_p3_word_classes_explain | 21 | single_choice | It shows the time of the action., It rep | Explain a word class in context. Why is the word ' | Pronouns stand in for nouns or noun phrases when the referen |
+| qg_p3_word_classes_explain | 22 | single_choice | It names the bridge., It joins two claus | Explain a word class in context. Why is the word ' | Adverbs can modify verbs by explaining the manner of the act |
+| qg_p3_word_classes_explain | 23 | single_choice | It replaces the noun children., It descr | Explain a word class in context. Why is the word ' | A preposition links a noun phrase to the rest of the sentenc |
+| qg_p3_word_classes_explain | 24 | single_choice | It replaces a noun phrase to avoid repet | Explain a word class in context. Why is the word ' | An adjective gives more information about a noun. |
+| qg_p3_word_classes_explain | 25 | single_choice | It modifies the verb folded by saying ho | Explain a word class in context. Why is the word ' | Adverbs can modify verbs by telling how, when, where, or how |
+| qg_p3_word_classes_explain | 26 | single_choice | It begins the phrase before assembly and | Explain a word class in context. Why is the word ' | A preposition usually links a noun phrase to the rest of the |
+| qg_p3_word_classes_explain | 27 | single_choice | It replaces the name Luca., It shows whe | Explain a word class in context. Why is the word ' | A conjunction can join clauses and show the relationship bet |
+| qg_p3_word_classes_explain | 28 | single_choice | It comes before the noun birds and helps | Explain a word class in context. Why is the word ' | Determiners come before nouns and help specify them. |
+| qg_p3_word_classes_explain | 29 | single_choice | It describes the compass., It shows the  | Explain a word class in context. Why is the word ' | Pronouns stand in for nouns or noun phrases when the referen |
+| qg_p3_word_classes_explain | 30 | single_choice | It names the bridge., It modifies the ve | Explain a word class in context. Why is the word ' | Adverbs can modify verbs by explaining the manner of the act |
+| qg_p3_noun_phrases_explain | 1 | single_choice | It is direct speech because it names an  | Explain an expanded noun phrase. Why is this an ex | A preposition phrase can expand a noun phrase by adding deta |
+| qg_p3_noun_phrases_explain | 2 | single_choice | It is a noun phrase because it has four  | Explain an expanded noun phrase. Why is this not a | Length is not enough: a noun phrase must centre on a noun, n |
+| qg_p3_noun_phrases_explain | 3 | single_choice | The whole group is the verb phrase., It  | Why is the underlined group a noun phrase? The ner | Extra words before and after the noun can belong inside the  |
+| qg_p3_noun_phrases_explain | 4 | single_choice | It is a clause because every phrase with | Explain an expanded noun phrase. Why is this an ex | A clause normally has a verb; this group names and expands a |
+| qg_p3_noun_phrases_explain | 5 | single_choice | Old oak is the full noun phrase because  | Explain an expanded noun phrase. Why is this not t | A noun phrase needs its head noun; adjectives alone do not m |
+| qg_p3_noun_phrases_explain | 6 | single_choice | It is a conjunction linking two ideas.,  | Explain an expanded noun phrase. Why is this an ex | Adjectives and prepositional phrases can both expand a noun  |
+| qg_p3_noun_phrases_explain | 7 | single_choice | It is an adverbial because it tells wher | Why is the underlined group a noun phrase? The sma | Modifiers before and after the head noun can all belong insi |
+| qg_p3_noun_phrases_explain | 8 | single_choice | It is an adverbial because it tells when | Explain an expanded noun phrase. Why is this an ex | A noun phrase has a noun at its heart; expansion adds detail |
+| qg_p3_noun_phrases_explain | 9 | single_choice | It is a sentence because it has a subjec | Explain an expanded noun phrase. Why is this an ex | A preposition phrase can expand a noun phrase by adding deta |
+| qg_p3_noun_phrases_explain | 10 | single_choice | It contains a verb phrase, so it is part | Explain an expanded noun phrase. Why is this not a | Length is not enough: a noun phrase must centre on a noun, n |
+| qg_p3_noun_phrases_explain | 11 | single_choice | The whole group is centred on the noun g | Why is the underlined group a noun phrase? The ner | Extra words before and after the noun can belong inside the  |
+| qg_p3_noun_phrases_explain | 12 | single_choice | It is a clause because cliff is a subjec | Explain an expanded noun phrase. Why is this an ex | A clause normally has a verb; this group names and expands a |
+| qg_p3_noun_phrases_explain | 13 | single_choice | Old oak is the object because it comes b | Explain an expanded noun phrase. Why is this not t | A noun phrase needs its head noun; adjectives alone do not m |
+| qg_p3_noun_phrases_explain | 14 | single_choice | It is centred on the noun bicycle and ex | Explain an expanded noun phrase. Why is this an ex | Adjectives and prepositional phrases can both expand a noun  |
+| qg_p3_noun_phrases_explain | 15 | single_choice | It is an adverbial because it tells wher | Why is the underlined group a noun phrase? The sma | Modifiers before and after the head noun can all belong insi |
+| qg_p3_noun_phrases_explain | 16 | single_choice | It is a conjunction because it joins ide | Explain an expanded noun phrase. Why is this an ex | A noun phrase has a noun at its heart; expansion adds detail |
+| qg_p3_noun_phrases_explain | 17 | single_choice | It is direct speech because it names an  | Explain an expanded noun phrase. Why is this an ex | A preposition phrase can expand a noun phrase by adding deta |
+| qg_p3_noun_phrases_explain | 18 | single_choice | It contains a verb phrase, so it is part | Explain an expanded noun phrase. Why is this not a | Length is not enough: a noun phrase must centre on a noun, n |
+| qg_p3_noun_phrases_explain | 19 | single_choice | The whole group is the verb phrase., It  | Why is the underlined group a noun phrase? The ner | Extra words before and after the noun can belong inside the  |
+| qg_p3_noun_phrases_explain | 20 | single_choice | It has no verb; it is a noun phrase cent | Explain an expanded noun phrase. Why is this an ex | A clause normally has a verb; this group names and expands a |
+| qg_p3_noun_phrases_explain | 21 | single_choice | Old oak is a clause because it has two w | Explain an expanded noun phrase. Why is this not t | A noun phrase needs its head noun; adjectives alone do not m |
+| qg_p3_noun_phrases_explain | 22 | single_choice | It is a clause because it has a hidden v | Explain an expanded noun phrase. Why is this an ex | Adjectives and prepositional phrases can both expand a noun  |
+| qg_p3_noun_phrases_explain | 23 | single_choice | It is an adverbial because it tells wher | Why is the underlined group a noun phrase? The sma | Modifiers before and after the head noun can all belong insi |
+| qg_p3_noun_phrases_explain | 24 | single_choice | It is a conjunction because it joins ide | Explain an expanded noun phrase. Why is this an ex | A noun phrase has a noun at its heart; expansion adds detail |
+| qg_p3_noun_phrases_explain | 25 | single_choice | It is centred on the noun book and expan | Explain an expanded noun phrase. Why is this an ex | A preposition phrase can expand a noun phrase by adding deta |
+| qg_p3_noun_phrases_explain | 26 | single_choice | It contains a verb phrase, so it is part | Explain an expanded noun phrase. Why is this not a | Length is not enough: a noun phrase must centre on a noun, n |
+| qg_p3_noun_phrases_explain | 27 | single_choice | It is an adverbial because it tells wher | Why is the underlined group a noun phrase? The ner | Extra words before and after the noun can belong inside the  |
+| qg_p3_noun_phrases_explain | 28 | single_choice | It has no verb; it is a noun phrase cent | Explain an expanded noun phrase. Why is this an ex | A clause normally has a verb; this group names and expands a |
+| qg_p3_noun_phrases_explain | 29 | single_choice | Old oak is the full noun phrase because  | Explain an expanded noun phrase. Why is this not t | A noun phrase needs its head noun; adjectives alone do not m |
+| qg_p3_noun_phrases_explain | 30 | single_choice | It is a clause because it has a hidden v | Explain an expanded noun phrase. Why is this an ex | Adjectives and prepositional phrases can both expand a noun  |
+| qg_p3_clauses_explain | 1 | single_choice | It shows that the two clauses mean exact | Explain a clause relationship. Why does the conjun | Although links a contrasting subordinate clause to a main cl |
+| qg_p3_clauses_explain | 2 | single_choice | It is main because it begins with when., | Explain a clause relationship. Why is this a main  | The main clause carries the core meaning and can usually sta |
+| qg_p3_clauses_explain | 3 | single_choice | It is subordinate because it is a questi | Explain a clause relationship. Why is the clause b | Conditional clauses beginning with if often depend on a main |
+| qg_p3_clauses_explain | 4 | single_choice | It makes the second clause subordinate., | Explain a clause relationship. Why does 'and' join | Coordinating conjunctions such as and can join main clauses. |
+| qg_p3_clauses_explain | 5 | single_choice | It is complete because it starts with Wh | Explain a clause relationship. Why is this not a c | A subordinate clause may contain a subject and verb but stil |
+| qg_p3_clauses_explain | 6 | single_choice | It introduces direct speech because a gr | Explain a clause relationship. Why does 'while' in | While is a subordinating conjunction that signals a time rel |
+| qg_p3_clauses_explain | 7 | single_choice | The first clause is subordinate because  | Explain a clause relationship. Why are both clause | Coordinating conjunctions join clauses of equal grammatical  |
+| qg_p3_clauses_explain | 8 | single_choice | It is subordinate because it contains th | Explain a clause relationship. Why is the first cl | A subordinate clause often begins with a subordinating conju |
+| qg_p3_clauses_explain | 9 | single_choice | It joins two noun phrases in a list., It | Explain a clause relationship. Why does the conjun | Although links a contrasting subordinate clause to a main cl |
+| qg_p3_clauses_explain | 10 | single_choice | It can stand alone as a complete clause  | Explain a clause relationship. Why is this a main  | The main clause carries the core meaning and can usually sta |
+| qg_p3_clauses_explain | 11 | single_choice | It gives a condition and needs the main  | Explain a clause relationship. Why is the clause b | Conditional clauses beginning with if often depend on a main |
+| qg_p3_clauses_explain | 12 | single_choice | It introduces a relative clause about be | Explain a clause relationship. Why does 'and' join | Coordinating conjunctions such as and can join main clauses. |
+| qg_p3_clauses_explain | 13 | single_choice | It is complete because coach is a noun., | Explain a clause relationship. Why is this not a c | A subordinate clause may contain a subject and verb but stil |
+| qg_p3_clauses_explain | 14 | single_choice | It introduces a time clause that depends | Explain a clause relationship. Why does 'while' in | While is a subordinating conjunction that signals a time rel |
+| qg_p3_clauses_explain | 15 | single_choice | The first clause is subordinate because  | Explain a clause relationship. Why are both clause | Coordinating conjunctions join clauses of equal grammatical  |
+| qg_p3_clauses_explain | 16 | single_choice | It is subordinate because it can stand a | Explain a clause relationship. Why is the first cl | A subordinate clause often begins with a subordinating conju |
+| qg_p3_clauses_explain | 17 | single_choice | It shows that the two clauses mean exact | Explain a clause relationship. Why does the conjun | Although links a contrasting subordinate clause to a main cl |
+| qg_p3_clauses_explain | 18 | single_choice | It can stand alone as a complete clause  | Explain a clause relationship. Why is this a main  | The main clause carries the core meaning and can usually sta |
+| qg_p3_clauses_explain | 19 | single_choice | It is subordinate because it is a questi | Explain a clause relationship. Why is the clause b | Conditional clauses beginning with if often depend on a main |
+| qg_p3_clauses_explain | 20 | single_choice | It links two related main clauses of equ | Explain a clause relationship. Why does 'and' join | Coordinating conjunctions such as and can join main clauses. |
+| qg_p3_clauses_explain | 21 | single_choice | It is complete because it has no conjunc | Explain a clause relationship. Why is this not a c | A subordinate clause may contain a subject and verb but stil |
+| qg_p3_clauses_explain | 22 | single_choice | It introduces a main clause because it n | Explain a clause relationship. Why does 'while' in | While is a subordinating conjunction that signals a time rel |
+| qg_p3_clauses_explain | 23 | single_choice | The first clause is subordinate because  | Explain a clause relationship. Why are both clause | Coordinating conjunctions join clauses of equal grammatical  |
+| qg_p3_clauses_explain | 24 | single_choice | It is subordinate because it can stand a | Explain a clause relationship. Why is the first cl | A subordinate clause often begins with a subordinating conju |
+| qg_p3_clauses_explain | 25 | single_choice | It introduces a subordinate clause showi | Explain a clause relationship. Why does the conjun | Although links a contrasting subordinate clause to a main cl |
+| qg_p3_clauses_explain | 26 | single_choice | It can stand alone as a complete clause  | Explain a clause relationship. Why is this a main  | The main clause carries the core meaning and can usually sta |
+| qg_p3_clauses_explain | 27 | single_choice | It is subordinate because it has no subj | Explain a clause relationship. Why is the clause b | Conditional clauses beginning with if often depend on a main |
+| qg_p3_clauses_explain | 28 | single_choice | It links two related main clauses of equ | Explain a clause relationship. Why does 'and' join | Coordinating conjunctions such as and can join main clauses. |
+| qg_p3_clauses_explain | 29 | single_choice | It is complete because it starts with Wh | Explain a clause relationship. Why is this not a c | A subordinate clause may contain a subject and verb but stil |
+| qg_p3_clauses_explain | 30 | single_choice | It introduces a main clause because it n | Explain a clause relationship. Why does 'while' in | While is a subordinating conjunction that signals a time rel |
+| qg_p3_relative_clauses_explain | 1 | single_choice | It is an adverbial telling how the plant | Explain a relative clause. Why is the clause 'whic | Which can introduce a relative clause that gives more detail |
+| qg_p3_relative_clauses_explain | 2 | single_choice | It gives the time when the book was on t | Explain a relative clause. Why is the clause 'that | Relative clauses can define or identify the noun they follow |
+| qg_p3_relative_clauses_explain | 3 | single_choice | It is relative because every clause at t | Explain a relative clause. Why is this not a relat | A relative clause attaches to a noun; a when-clause here tel |
+| qg_p3_relative_clauses_explain | 4 | single_choice | Whose introduces a direct question here. | Explain a relative clause. Why does 'whose' introd | Whose can link a relative clause to a noun by showing posses |
+| qg_p3_relative_clauses_explain | 5 | single_choice | The commas show a list of teachers., The | Explain a relative clause. Why does this relative  | Non-essential relative clauses can be marked as parenthesis  |
+| qg_p3_relative_clauses_explain | 6 | single_choice | It marks a fronted adverbial., It introd | Explain a relative clause. Why is 'where' introduc | Where can introduce a relative clause that tells more about  |
+| qg_p3_relative_clauses_explain | 7 | single_choice | It is not a relative clause because it t | Explain a relative clause. Why is this a defining  | Defining relative clauses are essential for identifying the  |
+| qg_p3_relative_clauses_explain | 8 | single_choice | It joins two unrelated main clauses., It | Explain a relative clause. Why is the clause 'who  | Relative clauses add information about a noun, often using w |
+| qg_p3_relative_clauses_explain | 9 | single_choice | It is a question because it starts with  | Explain a relative clause. Why is the clause 'whic | Which can introduce a relative clause that gives more detail |
+| qg_p3_relative_clauses_explain | 10 | single_choice | It identifies the noun book more precise | Explain a relative clause. Why is the clause 'that | Relative clauses can define or identify the noun they follow |
+| qg_p3_relative_clauses_explain | 11 | single_choice | When the show ended is a time clause, no | Explain a relative clause. Why is this not a relat | A relative clause attaches to a noun; a when-clause here tel |
+| qg_p3_relative_clauses_explain | 12 | single_choice | The clause tells where the girl waited., | Explain a relative clause. Why does 'whose' introd | Whose can link a relative clause to a noun by showing posses |
+| qg_p3_relative_clauses_explain | 13 | single_choice | The commas mark possession by the chess  | Explain a relative clause. Why does this relative  | Non-essential relative clauses can be marked as parenthesis  |
+| qg_p3_relative_clauses_explain | 14 | single_choice | The clause gives more information about  | Explain a relative clause. Why is 'where' introduc | Where can introduce a relative clause that tells more about  |
+| qg_p3_relative_clauses_explain | 15 | single_choice | It is not a relative clause because it t | Explain a relative clause. Why is this a defining  | Defining relative clauses are essential for identifying the  |
+| qg_p3_relative_clauses_explain | 16 | single_choice | It is direct speech by the pupil., It te | Explain a relative clause. Why is the clause 'who  | Relative clauses add information about a noun, often using w |
+| qg_p3_relative_clauses_explain | 17 | single_choice | It is an adverbial telling how the plant | Explain a relative clause. Why is the clause 'whic | Which can introduce a relative clause that gives more detail |
+| qg_p3_relative_clauses_explain | 18 | single_choice | It identifies the noun book more precise | Explain a relative clause. Why is the clause 'that | Relative clauses can define or identify the noun they follow |
+| qg_p3_relative_clauses_explain | 19 | single_choice | It is relative because every clause at t | Explain a relative clause. Why is this not a relat | A relative clause attaches to a noun; a when-clause here tel |
+| qg_p3_relative_clauses_explain | 20 | single_choice | The clause adds information about the gi | Explain a relative clause. Why does 'whose' introd | Whose can link a relative clause to a noun by showing posses |
+| qg_p3_relative_clauses_explain | 21 | single_choice | The commas show that the sentence is a q | Explain a relative clause. Why does this relative  | Non-essential relative clauses can be marked as parenthesis  |
+| qg_p3_relative_clauses_explain | 22 | single_choice | It introduces a question about direction | Explain a relative clause. Why is 'where' introduc | Where can introduce a relative clause that tells more about  |
+| qg_p3_relative_clauses_explain | 23 | single_choice | It is not a relative clause because it t | Explain a relative clause. Why is this a defining  | Defining relative clauses are essential for identifying the  |
+| qg_p3_relative_clauses_explain | 24 | single_choice | It is direct speech by the pupil., It ad | Explain a relative clause. Why is the clause 'who  | Relative clauses add information about a noun, often using w |
+| qg_p3_relative_clauses_explain | 25 | single_choice | It adds information about the noun plant | Explain a relative clause. Why is the clause 'whic | Which can introduce a relative clause that gives more detail |
+| qg_p3_relative_clauses_explain | 26 | single_choice | It identifies the noun book more precise | Explain a relative clause. Why is the clause 'that | Relative clauses can define or identify the noun they follow |
+| qg_p3_relative_clauses_explain | 27 | single_choice | It is relative because it tells who bowe | Explain a relative clause. Why is this not a relat | A relative clause attaches to a noun; a when-clause here tel |
+| qg_p3_relative_clauses_explain | 28 | single_choice | The clause adds information about the gi | Explain a relative clause. Why does 'whose' introd | Whose can link a relative clause to a noun by showing posses |
+| qg_p3_relative_clauses_explain | 29 | single_choice | The commas show a list of teachers., The | Explain a relative clause. Why does this relative  | Non-essential relative clauses can be marked as parenthesis  |
+| qg_p3_relative_clauses_explain | 30 | single_choice | It introduces a question about direction | Explain a relative clause. Why is 'where' introduc | Where can introduce a relative clause that tells more about  |
+| qg_p3_tense_aspect_explain | 1 | single_choice | It is simple past because had is always  | Explain tense and aspect. Why is 'had packed' past | Past perfect uses had plus a past participle to show an earl |
+| qg_p3_tense_aspect_explain | 2 | single_choice | It shows an action completed before anot | Explain tense and aspect. Why is 'was reading' pas | Progressive forms use a form of be plus an -ing verb to show |
+| qg_p3_tense_aspect_explain | 3 | single_choice | It shows an action finished yesterday.,  | Explain tense and aspect. Why is 'are building' pr | Present progressive uses am, is, or are with an -ing verb. |
+| qg_p3_tense_aspect_explain | 4 | single_choice | It is present perfect because it happene | Explain tense and aspect. Why is 'walked' simple p | A finished time word such as yesterday often fits the simple |
+| qg_p3_tense_aspect_explain | 5 | single_choice | It is simple present because the action  | Explain tense and aspect. Why is 'have been practi | The form have been plus an -ing verb combines perfect and pr |
+| qg_p3_tense_aspect_explain | 6 | single_choice | It is progressive because arrival takes  | Explain tense and aspect. Why is 'will arrive' sim | Will plus a base verb places the action in the future. |
+| qg_p3_tense_aspect_explain | 7 | single_choice | It is simple past because the doors open | Explain tense and aspect. Why is 'had been waiting | Had been plus an -ing verb shows an ongoing action that prec |
+| qg_p3_tense_aspect_explain | 8 | single_choice | It is progressive because the action is  | Explain tense and aspect. Why is 'has finished' pr | The present perfect often uses has or have plus a past parti |
+| qg_p3_tense_aspect_explain | 9 | single_choice | It is present perfect because it uses ha | Explain tense and aspect. Why is 'had packed' past | Past perfect uses had plus a past participle to show an earl |
+| qg_p3_tense_aspect_explain | 10 | single_choice | It shows an action that was in progress  | Explain tense and aspect. Why is 'was reading' pas | Progressive forms use a form of be plus an -ing verb to show |
+| qg_p3_tense_aspect_explain | 11 | single_choice | It shows an action in progress now using | Explain tense and aspect. Why is 'are building' pr | Present progressive uses am, is, or are with an -ing verb. |
+| qg_p3_tense_aspect_explain | 12 | single_choice | It is progressive because the team kept  | Explain tense and aspect. Why is 'walked' simple p | A finished time word such as yesterday often fits the simple |
+| qg_p3_tense_aspect_explain | 13 | single_choice | It is simple past because all week is al | Explain tense and aspect. Why is 'have been practi | The form have been plus an -ing verb combines perfect and pr |
+| qg_p3_tense_aspect_explain | 14 | single_choice | It uses will plus a base verb to refer t | Explain tense and aspect. Why is 'will arrive' sim | Will plus a base verb places the action in the future. |
+| qg_p3_tense_aspect_explain | 15 | single_choice | It is simple past because the doors open | Explain tense and aspect. Why is 'had been waiting | Had been plus an -ing verb shows an ongoing action that prec |
+| qg_p3_tense_aspect_explain | 16 | single_choice | It is passive because the poster comes a | Explain tense and aspect. Why is 'has finished' pr | The present perfect often uses has or have plus a past parti |
+| qg_p3_tense_aspect_explain | 17 | single_choice | It is simple past because had is always  | Explain tense and aspect. Why is 'had packed' past | Past perfect uses had plus a past participle to show an earl |
+| qg_p3_tense_aspect_explain | 18 | single_choice | It shows an action that was in progress  | Explain tense and aspect. Why is 'was reading' pas | Progressive forms use a form of be plus an -ing verb to show |
+| qg_p3_tense_aspect_explain | 19 | single_choice | It shows an action finished yesterday.,  | Explain tense and aspect. Why is 'are building' pr | Present progressive uses am, is, or are with an -ing verb. |
+| qg_p3_tense_aspect_explain | 20 | single_choice | It uses a past verb form for a finished  | Explain tense and aspect. Why is 'walked' simple p | A finished time word such as yesterday often fits the simple |
+| qg_p3_tense_aspect_explain | 21 | single_choice | It is passive because it uses been., It  | Explain tense and aspect. Why is 'have been practi | The form have been plus an -ing verb combines perfect and pr |
+| qg_p3_tense_aspect_explain | 22 | single_choice | It is present tense because will is in t | Explain tense and aspect. Why is 'will arrive' sim | Will plus a base verb places the action in the future. |
+| qg_p3_tense_aspect_explain | 23 | single_choice | It is simple past because the doors open | Explain tense and aspect. Why is 'had been waiting | Had been plus an -ing verb shows an ongoing action that prec |
+| qg_p3_tense_aspect_explain | 24 | single_choice | It is passive because the poster comes a | Explain tense and aspect. Why is 'has finished' pr | The present perfect often uses has or have plus a past parti |
+| qg_p3_tense_aspect_explain | 25 | single_choice | It shows one past action completed befor | Explain tense and aspect. Why is 'had packed' past | Past perfect uses had plus a past participle to show an earl |
+| qg_p3_tense_aspect_explain | 26 | single_choice | It shows an action that was in progress  | Explain tense and aspect. Why is 'was reading' pas | Progressive forms use a form of be plus an -ing verb to show |
+| qg_p3_tense_aspect_explain | 27 | single_choice | It is a modal verb phrase showing obliga | Explain tense and aspect. Why is 'are building' pr | Present progressive uses am, is, or are with an -ing verb. |
+| qg_p3_tense_aspect_explain | 28 | single_choice | It uses a past verb form for a finished  | Explain tense and aspect. Why is 'walked' simple p | A finished time word such as yesterday often fits the simple |
+| qg_p3_tense_aspect_explain | 29 | single_choice | It is simple present because the action  | Explain tense and aspect. Why is 'have been practi | The form have been plus an -ing verb combines perfect and pr |
+| qg_p3_tense_aspect_explain | 30 | single_choice | It is present tense because will is in t | Explain tense and aspect. Why is 'will arrive' sim | Will plus a base verb places the action in the future. |
+| qg_p3_pronouns_cohesion_explain | 1 | single_choice | She is unclear because it is an adjectiv | Explain pronoun cohesion. Why is the pronoun 'she' | Pronouns should make links clear; ambiguity weakens cohesion |
+| qg_p3_pronouns_cohesion_explain | 2 | single_choice | Repeating the noun always makes writing  | Explain pronoun cohesion. Why is repeating 'the tr | Sometimes repeating a noun is better than using a pronoun wi |
+| qg_p3_pronouns_cohesion_explain | 3 | single_choice | They refers to the benches because bench | Explain pronoun cohesion. Why does 'they' work in  | A plural pronoun should point clearly to a plural noun phras |
+| qg_p3_pronouns_cohesion_explain | 4 | single_choice | This can only refer to a person., This r | Explain pronoun cohesion. Why is 'this' cohesive h | Some pronouns can refer back to a whole idea, not just one n |
+| qg_p3_pronouns_cohesion_explain | 5 | single_choice | Him refers to the baton because it recei | Explain pronoun cohesion. Why is the pronoun 'him' | Object pronouns still need a clear noun phrase to refer back |
+| qg_p3_pronouns_cohesion_explain | 6 | single_choice | Their changes the sentence into a questi | Explain pronoun cohesion. Why does 'their' improve | Possessive pronouns help cohesion when the owner is clear fr |
+| qg_p3_pronouns_cohesion_explain | 7 | single_choice | It must refer to hutch because hutch is  | Explain pronoun cohesion. Why should 'it' be repla | When two possible referents exist, replacing the pronoun wit |
+| qg_p3_pronouns_cohesion_explain | 8 | single_choice | It is unclear because there is no noun b | Explain pronoun cohesion. Why does the pronoun 'it | A pronoun supports cohesion when its referent is clear. |
+| qg_p3_pronouns_cohesion_explain | 9 | single_choice | She clearly refers to the note., She is  | Explain pronoun cohesion. Why is the pronoun 'she' | Pronouns should make links clear; ambiguity weakens cohesion |
+| qg_p3_pronouns_cohesion_explain | 10 | single_choice | Repeating the trophy avoids confusing it | Explain pronoun cohesion. Why is repeating 'the tr | Sometimes repeating a noun is better than using a pronoun wi |
+| qg_p3_pronouns_cohesion_explain | 11 | single_choice | They clearly refers to the pupils, the g | Explain pronoun cohesion. Why does 'they' work in  | A plural pronoun should point clearly to a plural noun phras |
+| qg_p3_pronouns_cohesion_explain | 12 | single_choice | This refers forward to the match only.,  | Explain pronoun cohesion. Why is 'this' cohesive h | Some pronouns can refer back to a whole idea, not just one n |
+| qg_p3_pronouns_cohesion_explain | 13 | single_choice | Him is unclear because it is plural., Hi | Explain pronoun cohesion. Why is the pronoun 'him' | Object pronouns still need a clear noun phrase to refer back |
+| qg_p3_pronouns_cohesion_explain | 14 | single_choice | Their links clearly to the team, keeping | Explain pronoun cohesion. Why does 'their' improve | Possessive pronouns help cohesion when the owner is clear fr |
+| qg_p3_pronouns_cohesion_explain | 15 | single_choice | It must refer to hutch because hutch is  | Explain pronoun cohesion. Why should 'it' be repla | When two possible referents exist, replacing the pronoun wit |
+| qg_p3_pronouns_cohesion_explain | 16 | single_choice | It changes the sentence into passive voi | Explain pronoun cohesion. Why does the pronoun 'it | A pronoun supports cohesion when its referent is clear. |
+| qg_p3_pronouns_cohesion_explain | 17 | single_choice | She is unclear because it is an adjectiv | Explain pronoun cohesion. Why is the pronoun 'she' | Pronouns should make links clear; ambiguity weakens cohesion |
+| qg_p3_pronouns_cohesion_explain | 18 | single_choice | Repeating the trophy avoids confusing it | Explain pronoun cohesion. Why is repeating 'the tr | Sometimes repeating a noun is better than using a pronoun wi |
+| qg_p3_pronouns_cohesion_explain | 19 | single_choice | They refers to the benches because bench | Explain pronoun cohesion. Why does 'they' work in  | A plural pronoun should point clearly to a plural noun phras |
+| qg_p3_pronouns_cohesion_explain | 20 | single_choice | This refers back to the whole situation  | Explain pronoun cohesion. Why is 'this' cohesive h | Some pronouns can refer back to a whole idea, not just one n |
+| qg_p3_pronouns_cohesion_explain | 21 | single_choice | Him refers to Sam because Sam is nearest | Explain pronoun cohesion. Why is the pronoun 'him' | Object pronouns still need a clear noun phrase to refer back |
+| qg_p3_pronouns_cohesion_explain | 22 | single_choice | Their replaces the shed., Their changes  | Explain pronoun cohesion. Why does 'their' improve | Possessive pronouns help cohesion when the owner is clear fr |
+| qg_p3_pronouns_cohesion_explain | 23 | single_choice | It must refer to hutch because hutch is  | Explain pronoun cohesion. Why should 'it' be repla | When two possible referents exist, replacing the pronoun wit |
+| qg_p3_pronouns_cohesion_explain | 24 | single_choice | It changes the sentence into passive voi | Explain pronoun cohesion. Why does the pronoun 'it | A pronoun supports cohesion when its referent is clear. |
+| qg_p3_pronouns_cohesion_explain | 25 | single_choice | She could refer to Maya or Priya, so the | Explain pronoun cohesion. Why is the pronoun 'she' | Pronouns should make links clear; ambiguity weakens cohesion |
+| qg_p3_pronouns_cohesion_explain | 26 | single_choice | Repeating the trophy avoids confusing it | Explain pronoun cohesion. Why is repeating 'the tr | Sometimes repeating a noun is better than using a pronoun wi |
+| qg_p3_pronouns_cohesion_explain | 27 | single_choice | They makes the sentence a direct questio | Explain pronoun cohesion. Why does 'they' work in  | A plural pronoun should point clearly to a plural noun phras |
+| qg_p3_pronouns_cohesion_explain | 28 | single_choice | This refers back to the whole situation  | Explain pronoun cohesion. Why is 'this' cohesive h | Some pronouns can refer back to a whole idea, not just one n |
+| qg_p3_pronouns_cohesion_explain | 29 | single_choice | Him refers to the baton because it recei | Explain pronoun cohesion. Why is the pronoun 'him' | Object pronouns still need a clear noun phrase to refer back |
+| qg_p3_pronouns_cohesion_explain | 30 | single_choice | Their replaces the shed., Their links cl | Explain pronoun cohesion. Why does 'their' improve | Possessive pronouns help cohesion when the owner is clear fr |
+| qg_p3_formality_explain | 1 | single_choice | It is informal because it contains a nou | Explain formal and informal register. Why is this  | Informal register often sounds conversational and relaxed. |
+| qg_p3_formality_explain | 2 | single_choice | Request is more formal because it is a m | Explain formal and informal register. Why is 'requ | Formal vocabulary often chooses precise words that fit the a |
+| qg_p3_formality_explain | 3 | single_choice | It is more formal because passive voice  | Explain formal and informal register. Why is this  | Formal writing can use impersonal structures when the action |
+| qg_p3_formality_explain | 4 | single_choice | OK is too formal for any letter., The se | Explain formal and informal register. Why is this  | Formal writing avoids conversational tags such as OK? at the |
+| qg_p3_formality_explain | 5 | single_choice | It is formal because every past-tense se | Explain formal and informal register. Why is this  | Register depends on vocabulary and structure, not only on wh |
+| qg_p3_formality_explain | 6 | single_choice | It is informal because it is in the pres | Explain formal and informal register. Why is this  | Slang and contractions like 'gonna' lower the formality belo |
+| qg_p3_formality_explain | 7 | single_choice | It is formal because mobile devices is a | Explain formal and informal register. Why does the | Impersonal passive structures suit formal contexts where the |
+| qg_p3_formality_explain | 8 | single_choice | It is formal because it asks a direct qu | Explain formal and informal register. Why is this  | Formal writing is suited to public or official contexts and  |
+| qg_p3_formality_explain | 9 | single_choice | It is informal because it uses Standard  | Explain formal and informal register. Why is this  | Informal register often sounds conversational and relaxed. |
+| qg_p3_formality_explain | 10 | single_choice | Request is more precise and formal than  | Explain formal and informal register. Why is 'requ | Formal vocabulary often chooses precise words that fit the a |
+| qg_p3_formality_explain | 11 | single_choice | It uses impersonal, precise wording inst | Explain formal and informal register. Why is this  | Formal writing can use impersonal structures when the action |
+| qg_p3_formality_explain | 12 | single_choice | The sentence is informal because Friday  | Explain formal and informal register. Why is this  | Formal writing avoids conversational tags such as OK? at the |
+| qg_p3_formality_explain | 13 | single_choice | It is formal because got is always the m | Explain formal and informal register. Why is this  | Register depends on vocabulary and structure, not only on wh |
+| qg_p3_formality_explain | 14 | single_choice | It uses slang ('loads of kids', 'gonna') | Explain formal and informal register. Why is this  | Slang and contractions like 'gonna' lower the formality belo |
+| qg_p3_formality_explain | 15 | single_choice | It is formal because mobile devices is a | Explain formal and informal register. Why does the | Impersonal passive structures suit formal contexts where the |
+| qg_p3_formality_explain | 16 | single_choice | It is formal because it avoids all verbs | Explain formal and informal register. Why is this  | Formal writing is suited to public or official contexts and  |
+| qg_p3_formality_explain | 17 | single_choice | It is informal because it contains a nou | Explain formal and informal register. Why is this  | Informal register often sounds conversational and relaxed. |
+| qg_p3_formality_explain | 18 | single_choice | Request is more precise and formal than  | Explain formal and informal register. Why is 'requ | Formal vocabulary often chooses precise words that fit the a |
+| qg_p3_formality_explain | 19 | single_choice | It is more formal because passive voice  | Explain formal and informal register. Why is this  | Formal writing can use impersonal structures when the action |
+| qg_p3_formality_explain | 20 | single_choice | OK is a chatty tag that does not suit an | Explain formal and informal register. Why is this  | Formal writing avoids conversational tags such as OK? at the |
+| qg_p3_formality_explain | 21 | single_choice | It is formal because club is a noun., Go | Explain formal and informal register. Why is this  | Register depends on vocabulary and structure, not only on wh |
+| qg_p3_formality_explain | 22 | single_choice | It is informal because it mentions child | Explain formal and informal register. Why is this  | Slang and contractions like 'gonna' lower the formality belo |
+| qg_p3_formality_explain | 23 | single_choice | It is formal because mobile devices is a | Explain formal and informal register. Why does the | Impersonal passive structures suit formal contexts where the |
+| qg_p3_formality_explain | 24 | single_choice | It is formal because it avoids all verbs | Explain formal and informal register. Why is this  | Formal writing is suited to public or official contexts and  |
+| qg_p3_formality_explain | 25 | single_choice | It uses chatty wording that suits speech | Explain formal and informal register. Why is this  | Informal register often sounds conversational and relaxed. |
+| qg_p3_formality_explain | 26 | single_choice | Request is more precise and formal than  | Explain formal and informal register. Why is 'requ | Formal vocabulary often chooses precise words that fit the a |
+| qg_p3_formality_explain | 27 | single_choice | It is more formal because it uses the wo | Explain formal and informal register. Why is this  | Formal writing can use impersonal structures when the action |
+| qg_p3_formality_explain | 28 | single_choice | OK is a chatty tag that does not suit an | Explain formal and informal register. Why is this  | Formal writing avoids conversational tags such as OK? at the |
+| qg_p3_formality_explain | 29 | single_choice | It is formal because every past-tense se | Explain formal and informal register. Why is this  | Register depends on vocabulary and structure, not only on wh |
+| qg_p3_formality_explain | 30 | single_choice | It is informal because it mentions child | Explain formal and informal register. Why is this  | Slang and contractions like 'gonna' lower the formality belo |
+| qg_p3_active_passive_explain | 1 | single_choice | It is active because it hides who did th | Explain active and passive voice. Why is this sent | In active voice, the doer normally comes before the verb as  |
+| qg_p3_active_passive_explain | 2 | single_choice | It proves that the action is still happe | Explain active and passive voice. Why might a writ | Passive voice can focus attention on the thing affected or l |
+| qg_p3_active_passive_explain | 3 | single_choice | It is passive because every sentence wit | Explain active and passive voice. Why is this not  | A form of be alone is not enough for passive voice; check th |
+| qg_p3_active_passive_explain | 4 | single_choice | The scenery becomes the person doing the | Explain active and passive voice. Why does this pa | Active and passive can keep the same basic event while chang |
+| qg_p3_active_passive_explain | 5 | single_choice | The medals must be the doers because the | Explain active and passive voice. Why is this pass | A passive sentence does not have to include the doer. |
+| qg_p3_active_passive_explain | 6 | single_choice | It is passive because storms are natural | Explain active and passive voice. Why is this sent | Any noun phrase that does the verb can be the subject in act |
+| qg_p3_active_passive_explain | 7 | single_choice | The sentence becomes a question when mad | Explain active and passive voice. Why does changin | Passive voice shifts attention to the thing affected, not th |
+| qg_p3_active_passive_explain | 8 | single_choice | It is passive because the caretaker is d | Explain active and passive voice. Why is this sent | Passive voice often uses a form of be plus a past participle |
+| qg_p3_active_passive_explain | 9 | single_choice | It is active because the hall comes firs | Explain active and passive voice. Why is this sent | In active voice, the doer normally comes before the verb as  |
+| qg_p3_active_passive_explain | 10 | single_choice | It foregrounds the broken window and doe | Explain active and passive voice. Why might a writ | Passive voice can focus attention on the thing affected or l |
+| qg_p3_active_passive_explain | 11 | single_choice | Was carrying is progressive; Maya is sti | Explain active and passive voice. Why is this not  | A form of be alone is not enough for passive voice; check th |
+| qg_p3_active_passive_explain | 12 | single_choice | The tense changes from past to future.,  | Explain active and passive voice. Why does this pa | Active and passive can keep the same basic event while chang |
+| qg_p3_active_passive_explain | 13 | single_choice | The sentence is informal because the doe | Explain active and passive voice. Why is this pass | A passive sentence does not have to include the doer. |
+| qg_p3_active_passive_explain | 14 | single_choice | The storm is the subject that does the a | Explain active and passive voice. Why is this sent | Any noun phrase that does the verb can be the subject in act |
+| qg_p3_active_passive_explain | 15 | single_choice | The sentence becomes a question when mad | Explain active and passive voice. Why does changin | Passive voice shifts attention to the thing affected, not th |
+| qg_p3_active_passive_explain | 16 | single_choice | It is passive because it asks a question | Explain active and passive voice. Why is this sent | Passive voice often uses a form of be plus a past participle |
+| qg_p3_active_passive_explain | 17 | single_choice | It is active because it hides who did th | Explain active and passive voice. Why is this sent | In active voice, the doer normally comes before the verb as  |
+| qg_p3_active_passive_explain | 18 | single_choice | It foregrounds the broken window and doe | Explain active and passive voice. Why might a writ | Passive voice can focus attention on the thing affected or l |
+| qg_p3_active_passive_explain | 19 | single_choice | It is passive because every sentence wit | Explain active and passive voice. Why is this not  | A form of be alone is not enough for passive voice; check th |
+| qg_p3_active_passive_explain | 20 | single_choice | Aisha is still the doer, but the scenery | Explain active and passive voice. Why does this pa | Active and passive can keep the same basic event while chang |
+| qg_p3_active_passive_explain | 21 | single_choice | The sentence is active because no by-phr | Explain active and passive voice. Why is this pass | A passive sentence does not have to include the doer. |
+| qg_p3_active_passive_explain | 22 | single_choice | Only people can be the subject in active | Explain active and passive voice. Why is this sent | Any noun phrase that does the verb can be the subject in act |
+| qg_p3_active_passive_explain | 23 | single_choice | The sentence becomes a question when mad | Explain active and passive voice. Why does changin | Passive voice shifts attention to the thing affected, not th |
+| qg_p3_active_passive_explain | 24 | single_choice | It is passive because it asks a question | Explain active and passive voice. Why is this sent | Passive voice often uses a form of be plus a past participle |
+| qg_p3_active_passive_explain | 25 | single_choice | The doer, the caretaker, is the subject  | Explain active and passive voice. Why is this sent | In active voice, the doer normally comes before the verb as  |
+| qg_p3_active_passive_explain | 26 | single_choice | It foregrounds the broken window and doe | Explain active and passive voice. Why might a writ | Passive voice can focus attention on the thing affected or l |
+| qg_p3_active_passive_explain | 27 | single_choice | It is passive because the action happene | Explain active and passive voice. Why is this not  | A form of be alone is not enough for passive voice; check th |
+| qg_p3_active_passive_explain | 28 | single_choice | Aisha is still the doer, but the scenery | Explain active and passive voice. Why does this pa | Active and passive can keep the same basic event while chang |
+| qg_p3_active_passive_explain | 29 | single_choice | The medals must be the doers because the | Explain active and passive voice. Why is this pass | A passive sentence does not have to include the doer. |
+| qg_p3_active_passive_explain | 30 | single_choice | Only people can be the subject in active | Explain active and passive voice. Why is this sent | Any noun phrase that does the verb can be the subject in act |
+| qg_p3_subject_object_explain | 1 | single_choice | The soup is an adverbial because it tell | Explain subject and object roles. Why is 'the soup | The object is often the noun phrase that the action is done  |
+| qg_p3_subject_object_explain | 2 | single_choice | Before lunch is the subject because it c | Explain subject and object roles. Why is 'Before l | A fronted adverbial can come first, but the subject is still |
+| qg_p3_subject_object_explain | 3 | single_choice | Only red gloves can be the subject., The | Explain subject and object roles. Why is the expan | A subject can be an expanded noun phrase, not just a single  |
+| qg_p3_subject_object_explain | 4 | single_choice | Aisha must be the subject because she is | Explain subject and object roles. Why is 'the trop | In passive voice, the grammatical subject can be the thing a |
+| qg_p3_subject_object_explain | 5 | single_choice | The letters are the subject because they | Explain subject and object roles. Why is 'the lett | Ask who or what receives the verb to find the object. |
+| qg_p3_subject_object_explain | 6 | single_choice | Their seats is the subject because it re | Explain subject and object roles. Why is 'the audi | A fronted adverbial does not change which noun phrase is the |
+| qg_p3_subject_object_explain | 7 | single_choice | The baby is both subject and object here | Explain subject and object roles. Why does this se | Some verbs are intransitive and do not require an object. |
+| qg_p3_subject_object_explain | 8 | single_choice | The chef comes after the verb., The chef | Explain subject and object roles. Why is 'The chef | In a simple active sentence, the subject usually does the ve |
+| qg_p3_subject_object_explain | 9 | single_choice | The soup does the action., The soup is a | Explain subject and object roles. Why is 'the soup | The object is often the noun phrase that the action is done  |
+| qg_p3_subject_object_explain | 10 | single_choice | Before lunch is an adverbial; Aisha does | Explain subject and object roles. Why is 'Before l | A fronted adverbial can come first, but the subject is still |
+| qg_p3_subject_object_explain | 11 | single_choice | The whole noun phrase names who did the  | Explain subject and object roles. Why is the expan | A subject can be an expanded noun phrase, not just a single  |
+| qg_p3_subject_object_explain | 12 | single_choice | The trophy is the object because every a | Explain subject and object roles. Why is 'the trop | In passive voice, the grammatical subject can be the thing a |
+| qg_p3_subject_object_explain | 13 | single_choice | The letters are the verb because sorting | Explain subject and object roles. Why is 'the lett | Ask who or what receives the verb to find the object. |
+| qg_p3_subject_object_explain | 14 | single_choice | The audience performs the action of retu | Explain subject and object roles. Why is 'the audi | A fronted adverbial does not change which noun phrase is the |
+| qg_p3_subject_object_explain | 15 | single_choice | The baby is both subject and object here | Explain subject and object roles. Why does this se | Some verbs are intransitive and do not require an object. |
+| qg_p3_subject_object_explain | 16 | single_choice | The chef is the object because it is a n | Explain subject and object roles. Why is 'The chef | In a simple active sentence, the subject usually does the ve |
+| qg_p3_subject_object_explain | 17 | single_choice | The soup is an adverbial because it tell | Explain subject and object roles. Why is 'the soup | The object is often the noun phrase that the action is done  |
+| qg_p3_subject_object_explain | 18 | single_choice | Before lunch is an adverbial; Aisha does | Explain subject and object roles. Why is 'Before l | A fronted adverbial can come first, but the subject is still |
+| qg_p3_subject_object_explain | 19 | single_choice | Only red gloves can be the subject., The | Explain subject and object roles. Why is the expan | A subject can be an expanded noun phrase, not just a single  |
+| qg_p3_subject_object_explain | 20 | single_choice | The trophy is before the verb phrase and | Explain subject and object roles. Why is 'the trop | In passive voice, the grammatical subject can be the thing a |
+| qg_p3_subject_object_explain | 21 | single_choice | The letters are an adverbial because the | Explain subject and object roles. Why is 'the lett | Ask who or what receives the verb to find the object. |
+| qg_p3_subject_object_explain | 22 | single_choice | The audience is the object because it co | Explain subject and object roles. Why is 'the audi | A fronted adverbial does not change which noun phrase is the |
+| qg_p3_subject_object_explain | 23 | single_choice | The baby is both subject and object here | Explain subject and object roles. Why does this se | Some verbs are intransitive and do not require an object. |
+| qg_p3_subject_object_explain | 24 | single_choice | The chef is the object because it is a n | Explain subject and object roles. Why is 'The chef | In a simple active sentence, the subject usually does the ve |
+| qg_p3_subject_object_explain | 25 | single_choice | The soup receives the action of tasting. | Explain subject and object roles. Why is 'the soup | The object is often the noun phrase that the action is done  |
+| qg_p3_subject_object_explain | 26 | single_choice | Before lunch is an adverbial; Aisha does | Explain subject and object roles. Why is 'Before l | A fronted adverbial can come first, but the subject is still |
+| qg_p3_subject_object_explain | 27 | single_choice | The ball is the subject because it is af | Explain subject and object roles. Why is the expan | A subject can be an expanded noun phrase, not just a single  |
+| qg_p3_subject_object_explain | 28 | single_choice | The trophy is before the verb phrase and | Explain subject and object roles. Why is 'the trop | In passive voice, the grammatical subject can be the thing a |
+| qg_p3_subject_object_explain | 29 | single_choice | The letters are the subject because they | Explain subject and object roles. Why is 'the lett | Ask who or what receives the verb to find the object. |
+| qg_p3_subject_object_explain | 30 | single_choice | The audience is the object because it co | Explain subject and object roles. Why is 'the audi | A fronted adverbial does not change which noun phrase is the |
+| qg_p3_parenthesis_commas_explain | 1 | single_choice | The dashes introduce a list after a comp | Explain parenthesis punctuation. Why do the dashes | Dashes can mark parenthesis when they enclose removable extr |
+| qg_p3_parenthesis_commas_explain | 2 | single_choice | The brackets show direct speech., The br | Explain parenthesis punctuation. Why do the bracke | Brackets can mark parenthetical information that is not esse |
+| qg_p3_parenthesis_commas_explain | 3 | single_choice | They mark a relative clause about pencil | Explain parenthesis punctuation. Why are these com | List commas separate items; parenthesis commas enclose extra |
+| qg_p3_parenthesis_commas_explain | 4 | single_choice | Only one comma is needed after museum be | Explain parenthesis punctuation. Why is a pair of  | When parenthesis interrupts the middle of a sentence, paired |
+| qg_p3_parenthesis_commas_explain | 5 | single_choice | It is parenthesis because every comma ma | Explain parenthesis punctuation. Why is the phrase | A fronted adverbial comma has a different job from parenthes |
+| qg_p3_parenthesis_commas_explain | 6 | single_choice | Dashes show that the headteacher owns so | Explain parenthesis punctuation. Why do dashes wor | Dashes, commas, and brackets can all mark parenthesis, but d |
+| qg_p3_parenthesis_commas_explain | 7 | single_choice | The brackets mark direct speech., Every  | Explain parenthesis punctuation. Why can the brack | Parenthetical information is additional and removable withou |
+| qg_p3_parenthesis_commas_explain | 8 | single_choice | The commas show where direct speech begi | Explain parenthesis punctuation. Why do the commas | Parenthesis adds extra information without breaking the main |
+| qg_p3_parenthesis_commas_explain | 9 | single_choice | The dashes join two equal main clauses., | Explain parenthesis punctuation. Why do the dashes | Dashes can mark parenthesis when they enclose removable extr |
+| qg_p3_parenthesis_commas_explain | 10 | single_choice | The bracketed clause adds extra informat | Explain parenthesis punctuation. Why do the bracke | Brackets can mark parenthetical information that is not esse |
+| qg_p3_parenthesis_commas_explain | 11 | single_choice | The commas separate items in a list, not | Explain parenthesis punctuation. Why are these com | List commas separate items; parenthesis commas enclose extra |
+| qg_p3_parenthesis_commas_explain | 12 | single_choice | The commas show that the museum owns the | Explain parenthesis punctuation. Why is a pair of  | When parenthesis interrupts the middle of a sentence, paired |
+| qg_p3_parenthesis_commas_explain | 13 | single_choice | It is direct speech because the comma co | Explain parenthesis punctuation. Why is the phrase | A fronted adverbial comma has a different job from parenthes |
+| qg_p3_parenthesis_commas_explain | 14 | single_choice | Dashes give a stronger visual break for  | Explain parenthesis punctuation. Why do dashes wor | Dashes, commas, and brackets can all mark parenthesis, but d |
+| qg_p3_parenthesis_commas_explain | 15 | single_choice | The brackets mark direct speech., The br | Explain parenthesis punctuation. Why can the brack | Parenthetical information is additional and removable withou |
+| qg_p3_parenthesis_commas_explain | 16 | single_choice | The commas mark a fronted adverbial at t | Explain parenthesis punctuation. Why do the commas | Parenthesis adds extra information without breaking the main |
+| qg_p3_parenthesis_commas_explain | 17 | single_choice | The dashes introduce a list after a comp | Explain parenthesis punctuation. Why do the dashes | Dashes can mark parenthesis when they enclose removable extr |
+| qg_p3_parenthesis_commas_explain | 18 | single_choice | The bracketed clause adds extra informat | Explain parenthesis punctuation. Why do the bracke | Brackets can mark parenthetical information that is not esse |
+| qg_p3_parenthesis_commas_explain | 19 | single_choice | They mark a relative clause about pencil | Explain parenthesis punctuation. Why are these com | List commas separate items; parenthesis commas enclose extra |
+| qg_p3_parenthesis_commas_explain | 20 | single_choice | The parenthetical relative clause sits i | Explain parenthesis punctuation. Why is a pair of  | When parenthesis interrupts the middle of a sentence, paired |
+| qg_p3_parenthesis_commas_explain | 21 | single_choice | It is parenthesis because storm is a nou | Explain parenthesis punctuation. Why is the phrase | A fronted adverbial comma has a different job from parenthes |
+| qg_p3_parenthesis_commas_explain | 22 | single_choice | Dashes are the only punctuation that can | Explain parenthesis punctuation. Why do dashes wor | Dashes, commas, and brackets can all mark parenthesis, but d |
+| qg_p3_parenthesis_commas_explain | 23 | single_choice | The brackets mark direct speech., Every  | Explain parenthesis punctuation. Why can the brack | Parenthetical information is additional and removable withou |
+| qg_p3_parenthesis_commas_explain | 24 | single_choice | The commas mark a fronted adverbial at t | Explain parenthesis punctuation. Why do the commas | Parenthesis adds extra information without breaking the main |
+| qg_p3_parenthesis_commas_explain | 25 | single_choice | Usually quiet is extra information inser | Explain parenthesis punctuation. Why do the dashes | Dashes can mark parenthesis when they enclose removable extr |
+| qg_p3_parenthesis_commas_explain | 26 | single_choice | The bracketed clause adds extra informat | Explain parenthesis punctuation. Why do the bracke | Brackets can mark parenthetical information that is not esse |
+| qg_p3_parenthesis_commas_explain | 27 | single_choice | They show that the nouns own the card.,  | Explain parenthesis punctuation. Why are these com | List commas separate items; parenthesis commas enclose extra |
+| qg_p3_parenthesis_commas_explain | 28 | single_choice | The parenthetical relative clause sits i | Explain parenthesis punctuation. Why is a pair of  | When parenthesis interrupts the middle of a sentence, paired |
+| qg_p3_parenthesis_commas_explain | 29 | single_choice | It is parenthesis because every comma ma | Explain parenthesis punctuation. Why is the phrase | A fronted adverbial comma has a different job from parenthes |
+| qg_p3_parenthesis_commas_explain | 30 | single_choice | Dashes are the only punctuation that can | Explain parenthesis punctuation. Why do dashes wor | Dashes, commas, and brackets can all mark parenthesis, but d |
+| qg_p3_speech_punctuation_explain | 1 | single_choice | The comma marks a list of speakers., The | Explain direct speech punctuation. Why is there a  | When a reporting clause follows a statement in direct speech |
+| qg_p3_speech_punctuation_explain | 2 | single_choice | The comma shows that Priya is in a list. | Explain direct speech punctuation. Why is there a  | A comma often separates a reporting clause from the direct s |
+| qg_p3_speech_punctuation_explain | 3 | single_choice | The exclamation mark belongs after shout | Explain direct speech punctuation. Why is the excl | Punctuation that belongs to the spoken words is placed insid |
+| qg_p3_speech_punctuation_explain | 4 | single_choice | Every word after a comma must have a cap | Explain direct speech punctuation. Why does the sp | Direct speech keeps the normal capital letter at the start o |
+| qg_p3_speech_punctuation_explain | 5 | single_choice | The full stop belongs outside because sp | Explain direct speech punctuation. Why is the full | The punctuation that ends the direct speech is part of the q |
+| qg_p3_speech_punctuation_explain | 6 | single_choice | The lower case turns the sentence into a | Explain direct speech punctuation. Why does the re | After a comma inside speech marks, the reporting clause does |
+| qg_p3_speech_punctuation_explain | 7 | single_choice | The question mark shows possession, not  | Explain direct speech punctuation. Why is there no | One end-of-speech punctuation mark is enough; a question mar |
+| qg_p3_speech_punctuation_explain | 8 | single_choice | The question mark shows possession by th | Explain direct speech punctuation. Why does the qu | End punctuation for the spoken words sits inside the speech  |
+| qg_p3_speech_punctuation_explain | 9 | single_choice | The comma shows that map is plural., The | Explain direct speech punctuation. Why is there a  | When a reporting clause follows a statement in direct speech |
+| qg_p3_speech_punctuation_explain | 10 | single_choice | The comma introduces the direct speech a | Explain direct speech punctuation. Why is there a  | A comma often separates a reporting clause from the direct s |
+| qg_p3_speech_punctuation_explain | 11 | single_choice | The spoken words are an exclamation or w | Explain direct speech punctuation. Why is the excl | Punctuation that belongs to the spoken words is placed insid |
+| qg_p3_speech_punctuation_explain | 12 | single_choice | Are is capitalised because it is a noun. | Explain direct speech punctuation. Why does the sp | Direct speech keeps the normal capital letter at the start o |
+| qg_p3_speech_punctuation_explain | 13 | single_choice | The full stop should be replaced by an a | Explain direct speech punctuation. Why is the full | The punctuation that ends the direct speech is part of the q |
+| qg_p3_speech_punctuation_explain | 14 | single_choice | The reporting clause continues the same  | Explain direct speech punctuation. Why does the re | After a comma inside speech marks, the reporting clause does |
+| qg_p3_speech_punctuation_explain | 15 | single_choice | The question mark shows possession, not  | Explain direct speech punctuation. Why is there no | One end-of-speech punctuation mark is enough; a question mar |
+| qg_p3_speech_punctuation_explain | 16 | single_choice | The question mark replaces the closing s | Explain direct speech punctuation. Why does the qu | End punctuation for the spoken words sits inside the speech  |
+| qg_p3_speech_punctuation_explain | 17 | single_choice | The comma marks a list of speakers., The | Explain direct speech punctuation. Why is there a  | When a reporting clause follows a statement in direct speech |
+| qg_p3_speech_punctuation_explain | 18 | single_choice | The comma introduces the direct speech a | Explain direct speech punctuation. Why is there a  | A comma often separates a reporting clause from the direct s |
+| qg_p3_speech_punctuation_explain | 19 | single_choice | The exclamation mark belongs after shout | Explain direct speech punctuation. Why is the excl | Punctuation that belongs to the spoken words is placed insid |
+| qg_p3_speech_punctuation_explain | 20 | single_choice | The direct speech starts a new spoken se | Explain direct speech punctuation. Why does the sp | Direct speech keeps the normal capital letter at the start o |
+| qg_p3_speech_punctuation_explain | 21 | single_choice | The full stop belongs before the opening | Explain direct speech punctuation. Why is the full | The punctuation that ends the direct speech is part of the q |
+| qg_p3_speech_punctuation_explain | 22 | single_choice | Whispered always has a lower-case letter | Explain direct speech punctuation. Why does the re | After a comma inside speech marks, the reporting clause does |
+| qg_p3_speech_punctuation_explain | 23 | single_choice | The question mark shows possession, not  | Explain direct speech punctuation. Why is there no | One end-of-speech punctuation mark is enough; a question mar |
+| qg_p3_speech_punctuation_explain | 24 | single_choice | The question mark replaces the closing s | Explain direct speech punctuation. Why does the qu | End punctuation for the spoken words sits inside the speech  |
+| qg_p3_speech_punctuation_explain | 25 | single_choice | The comma separates the spoken words fro | Explain direct speech punctuation. Why is there a  | When a reporting clause follows a statement in direct speech |
+| qg_p3_speech_punctuation_explain | 26 | single_choice | The comma introduces the direct speech a | Explain direct speech punctuation. Why is there a  | A comma often separates a reporting clause from the direct s |
+| qg_p3_speech_punctuation_explain | 27 | single_choice | The exclamation mark shows that Sam owns | Explain direct speech punctuation. Why is the excl | Punctuation that belongs to the spoken words is placed insid |
+| qg_p3_speech_punctuation_explain | 28 | single_choice | The direct speech starts a new spoken se | Explain direct speech punctuation. Why does the sp | Direct speech keeps the normal capital letter at the start o |
+| qg_p3_speech_punctuation_explain | 29 | single_choice | The full stop belongs outside because sp | Explain direct speech punctuation. Why is the full | The punctuation that ends the direct speech is part of the q |
+| qg_p3_speech_punctuation_explain | 30 | single_choice | Whispered always has a lower-case letter | Explain direct speech punctuation. Why does the re | After a comma inside speech marks, the reporting clause does |
+| qg_p3_apostrophe_possession_explain | 1 | single_choice | The apostrophe turns bags into a verb.,  | Explain possessive apostrophes. Why is the apostro | For a regular plural owner ending in s, the apostrophe usual |
+| qg_p3_apostrophe_possession_explain | 2 | single_choice | Children is singular, so only one child  | Explain possessive apostrophes. Why is this apostr | Irregular plural owners that do not end in s usually use apo |
+| qg_p3_apostrophe_possession_explain | 3 | single_choice | The apostrophe replaces letters from tea | Explain possessive apostrophes. Why does this phra | Possessive apostrophes show ownership; contraction apostroph |
+| qg_p3_apostrophe_possession_explain | 4 | single_choice | The room belongs to one boy, so the apos | Explain possessive apostrophes. Why is 'the boys'  | The apostrophe position changes the owner number, not the nu |
+| qg_p3_apostrophe_possession_explain | 5 | single_choice | More than one dog owns one bowl, so the  | Explain possessive apostrophes. Why is 'the dog's  | Look at the owner, not only the owned noun, when placing the |
+| qg_p3_apostrophe_possession_explain | 6 | single_choice | The extra s turns James into a verb., Th | Explain possessive apostrophes. Why does 'James's' | For singular proper nouns ending in s, apostrophe + s is acc |
+| qg_p3_apostrophe_possession_explain | 7 | single_choice | The apostrophe shows the tables own the  | Explain possessive apostrophes. Why is the apostro | Plural nouns do not need an apostrophe unless they are showi |
+| qg_p3_apostrophe_possession_explain | 8 | single_choice | The apostrophe shows a missing letter fr | Explain possessive apostrophes. Why is the apostro | For one regular singular owner, the apostrophe usually comes |
+| qg_p3_apostrophe_possession_explain | 9 | single_choice | One girl owns the bags, so the apostroph | Explain possessive apostrophes. Why is the apostro | For a regular plural owner ending in s, the apostrophe usual |
+| qg_p3_apostrophe_possession_explain | 10 | single_choice | Children is an irregular plural that doe | Explain possessive apostrophes. Why is this apostr | Irregular plural owners that do not end in s usually use apo |
+| qg_p3_apostrophe_possession_explain | 11 | single_choice | The apostrophe shows the desk belongs to | Explain possessive apostrophes. Why does this phra | Possessive apostrophes show ownership; contraction apostroph |
+| qg_p3_apostrophe_possession_explain | 12 | single_choice | The apostrophe shows that changing is mi | Explain possessive apostrophes. Why is 'the boys'  | The apostrophe position changes the owner number, not the nu |
+| qg_p3_apostrophe_possession_explain | 13 | single_choice | The apostrophe shows dog is a verb., One | Explain possessive apostrophes. Why is 'the dog's  | Look at the owner, not only the owned noun, when placing the |
+| qg_p3_apostrophe_possession_explain | 14 | single_choice | Names ending in s can take apostrophe +  | Explain possessive apostrophes. Why does 'James's' | For singular proper nouns ending in s, apostrophe + s is acc |
+| qg_p3_apostrophe_possession_explain | 15 | single_choice | The apostrophe shows the tables own the  | Explain possessive apostrophes. Why is the apostro | Plural nouns do not need an apostrophe unless they are showi |
+| qg_p3_apostrophe_possession_explain | 16 | single_choice | The apostrophe makes the noun plural., M | Explain possessive apostrophes. Why is the apostro | For one regular singular owner, the apostrophe usually comes |
+| qg_p3_apostrophe_possession_explain | 17 | single_choice | The apostrophe turns bags into a verb.,  | Explain possessive apostrophes. Why is the apostro | For a regular plural owner ending in s, the apostrophe usual |
+| qg_p3_apostrophe_possession_explain | 18 | single_choice | Children is an irregular plural that doe | Explain possessive apostrophes. Why is this apostr | Irregular plural owners that do not end in s usually use apo |
+| qg_p3_apostrophe_possession_explain | 19 | single_choice | The apostrophe replaces letters from tea | Explain possessive apostrophes. Why does this phra | Possessive apostrophes show ownership; contraction apostroph |
+| qg_p3_apostrophe_possession_explain | 20 | single_choice | The room belongs to more than one boy, s | Explain possessive apostrophes. Why is 'the boys'  | The apostrophe position changes the owner number, not the nu |
+| qg_p3_apostrophe_possession_explain | 21 | single_choice | The apostrophe belongs after bowls becau | Explain possessive apostrophes. Why is 'the dog's  | Look at the owner, not only the owned noun, when placing the |
+| qg_p3_apostrophe_possession_explain | 22 | single_choice | The extra s shows there are two people c | Explain possessive apostrophes. Why does 'James's' | For singular proper nouns ending in s, apostrophe + s is acc |
+| qg_p3_apostrophe_possession_explain | 23 | single_choice | The apostrophe shows the tables own the  | Explain possessive apostrophes. Why is the apostro | Plural nouns do not need an apostrophe unless they are showi |
+| qg_p3_apostrophe_possession_explain | 24 | single_choice | The apostrophe makes the noun plural., O | Explain possessive apostrophes. Why is the apostro | For one regular singular owner, the apostrophe usually comes |
+| qg_p3_apostrophe_possession_explain | 25 | single_choice | More than one girl owns the bags, and gi | Explain possessive apostrophes. Why is the apostro | For a regular plural owner ending in s, the apostrophe usual |
+| qg_p3_apostrophe_possession_explain | 26 | single_choice | Children is an irregular plural that doe | Explain possessive apostrophes. Why is this apostr | Irregular plural owners that do not end in s usually use apo |
+| qg_p3_apostrophe_possession_explain | 27 | single_choice | The apostrophe marks a direct speech bre | Explain possessive apostrophes. Why does this phra | Possessive apostrophes show ownership; contraction apostroph |
+| qg_p3_apostrophe_possession_explain | 28 | single_choice | The room belongs to more than one boy, s | Explain possessive apostrophes. Why is 'the boys'  | The apostrophe position changes the owner number, not the nu |
+| qg_p3_apostrophe_possession_explain | 29 | single_choice | More than one dog owns one bowl, so the  | Explain possessive apostrophes. Why is 'the dog's  | Look at the owner, not only the owned noun, when placing the |
+| qg_p3_apostrophe_possession_explain | 30 | single_choice | The extra s shows there are two people c | Explain possessive apostrophes. Why does 'James's' | For singular proper nouns ending in s, apostrophe + s is acc |
+| proc3_apostrophe_rewrite | 1 | text | placeholder: Type the rewritten phrase. | Rewrite with a possessive apostrophe. Rewrite this | A correct answer is: Luca's coats |
+| proc3_apostrophe_rewrite | 2 | text | placeholder: Type the rewritten phrase. | Rewrite with a possessive apostrophe. Rewrite this | A correct answer is: Noah's tickets |
+| proc3_apostrophe_rewrite | 3 | text | placeholder: Type the rewritten phrase. | Rewrite with a possessive apostrophe. Rewrite this | A correct answer is: Zac's tickets |
+| proc3_apostrophe_rewrite | 4 | text | placeholder: Type the rewritten phrase. | Rewrite with a possessive apostrophe. Rewrite this | A correct answer is: Mia's lunchboxes |
+| proc3_apostrophe_rewrite | 5 | text | placeholder: Type the rewritten phrase. | Rewrite with a possessive apostrophe. Rewrite this | A correct answer is: the children's coats |
+| proc3_apostrophe_rewrite | 6 | text | placeholder: Type the rewritten phrase. | Rewrite with a possessive apostrophe. Rewrite this | A correct answer is: Amira's bags |
+| proc3_apostrophe_rewrite | 7 | text | placeholder: Type the rewritten phrase. | Rewrite with a possessive apostrophe. Rewrite this | A correct answer is: Ruby's boots |
+| proc3_apostrophe_rewrite | 8 | text | placeholder: Type the rewritten phrase. | Rewrite with a possessive apostrophe. Rewrite this | A correct answer is: the boys' books |
+| proc3_apostrophe_rewrite | 9 | text | placeholder: Type the rewritten phrase. | Rewrite with a possessive apostrophe. Rewrite this | A correct answer is: the children's books |
+| proc3_apostrophe_rewrite | 10 | text | placeholder: Type the rewritten phrase. | Rewrite with a possessive apostrophe. Rewrite this | A correct answer is: the men's bags |
+| proc3_apostrophe_rewrite | 11 | text | placeholder: Type the rewritten phrase. | Rewrite with a possessive apostrophe. Rewrite this | A correct answer is: the teachers' bags |
+| proc3_apostrophe_rewrite | 12 | text | placeholder: Type the rewritten phrase. | Rewrite with a possessive apostrophe. Rewrite this | A correct answer is: Luca's bikes |
+| proc3_apostrophe_rewrite | 13 | text | placeholder: Type the rewritten phrase. | Rewrite with a possessive apostrophe. Rewrite this | A correct answer is: the girls' bags |
+| proc3_apostrophe_rewrite | 14 | text | placeholder: Type the rewritten phrase. | Rewrite with a possessive apostrophe. Rewrite this | A correct answer is: the teachers' bags |
+| proc3_apostrophe_rewrite | 15 | text | placeholder: Type the rewritten phrase. | Rewrite with a possessive apostrophe. Rewrite this | A correct answer is: the players' books |
+| proc3_apostrophe_rewrite | 16 | text | placeholder: Type the rewritten phrase. | Rewrite with a possessive apostrophe. Rewrite this | A correct answer is: Nora's coats |
+| proc3_apostrophe_rewrite | 17 | text | placeholder: Type the rewritten phrase. | Rewrite with a possessive apostrophe. Rewrite this | A correct answer is: Luca's coats |
+| proc3_apostrophe_rewrite | 18 | text | placeholder: Type the rewritten phrase. | Rewrite with a possessive apostrophe. Rewrite this | A correct answer is: the teachers' bikes |
+| proc3_apostrophe_rewrite | 19 | text | placeholder: Type the rewritten phrase. | Rewrite with a possessive apostrophe. Rewrite this | A correct answer is: Zac's boots |
+| proc3_apostrophe_rewrite | 20 | text | placeholder: Type the rewritten phrase. | Rewrite with a possessive apostrophe. Rewrite this | A correct answer is: the teachers' tickets |
+| proc3_apostrophe_rewrite | 21 | text | placeholder: Type the rewritten phrase. | Rewrite with a possessive apostrophe. Rewrite this | A correct answer is: the boys' bags |
+| proc3_apostrophe_rewrite | 22 | text | placeholder: Type the rewritten phrase. | Rewrite with a possessive apostrophe. Rewrite this | A correct answer is: Mia's coats |
+| proc3_apostrophe_rewrite | 23 | text | placeholder: Type the rewritten phrase. | Rewrite with a possessive apostrophe. Rewrite this | A correct answer is: Amira's boots |
+| proc3_apostrophe_rewrite | 24 | text | placeholder: Type the rewritten phrase. | Rewrite with a possessive apostrophe. Rewrite this | A correct answer is: the people's bikes |
+| proc3_apostrophe_rewrite | 25 | text | placeholder: Type the rewritten phrase. | Rewrite with a possessive apostrophe. Rewrite this | A correct answer is: the men's coats |
+| proc3_apostrophe_rewrite | 26 | text | placeholder: Type the rewritten phrase. | Rewrite with a possessive apostrophe. Rewrite this | A correct answer is: the men's bags |
+| proc3_apostrophe_rewrite | 27 | text | placeholder: Type the rewritten phrase. | Rewrite with a possessive apostrophe. Rewrite this | A correct answer is: Ava's bikes |
+| proc3_apostrophe_rewrite | 28 | text | placeholder: Type the rewritten phrase. | Rewrite with a possessive apostrophe. Rewrite this | A correct answer is: the men's bikes |
+| proc3_apostrophe_rewrite | 29 | text | placeholder: Type the rewritten phrase. | Rewrite with a possessive apostrophe. Rewrite this | A correct answer is: Noah's books |
+| proc3_apostrophe_rewrite | 30 | text | placeholder: Type the rewritten phrase. | Rewrite with a possessive apostrophe. Rewrite this | A correct answer is: the people's lunchboxes |
+| qg_p4_sentence_speech_transfer | 1 | single_choice | Did Mum really say "Pack your bag now"?, | Sentence function meets speech punctuation. Which  | The whole sentence is a question (sentence function), so the |
+| qg_p4_sentence_speech_transfer | 2 | single_choice | The teacher told us "Open your books to  | Sentence function meets speech punctuation. Which  | The whole sentence is a statement (reporting what was said). |
+| qg_p4_sentence_speech_transfer | 3 | single_choice | What a surprise it was when Grandad anno | Sentence function meets speech punctuation. Which  | The whole sentence begins with 'What a surprise' making it a |
+| qg_p4_sentence_speech_transfer | 4 | single_choice | Did the coach shout, "Run faster?", Did  | Sentence function meets speech punctuation. Which  | The sentence function is a question (it asks whether the coa |
+| qg_p4_sentence_speech_transfer | 5 | single_choice | Lena asked, "Where is the library?", Len | Sentence function meets speech punctuation. Which  | The sentence is a statement (reporting what Lena asked). The |
+| qg_p4_sentence_speech_transfer | 6 | single_choice | Ben shouted "What a fantastic goal that  | Sentence function meets speech punctuation. Which  | The outer sentence is a statement (it reports what Ben shout |
+| qg_p4_sentence_speech_transfer | 7 | single_choice | Did the head teacher really announce, "S | Sentence function meets speech punctuation. Which  | The outer sentence is a question. The speech inside is a sta |
+| qg_p4_sentence_speech_transfer | 8 | single_choice | How loudly the sergeant bellowed "Stand  | Sentence function meets speech punctuation. Which  | The whole sentence begins with 'How loudly' making it an exc |
+| qg_p4_sentence_speech_transfer | 9 | single_choice | Did Mum really say "Pack your bag now"?, | Sentence function meets speech punctuation. Which  | The whole sentence is a question (sentence function), so the |
+| qg_p4_sentence_speech_transfer | 10 | single_choice | The teacher told us, "Open your books to | Sentence function meets speech punctuation. Which  | The whole sentence is a statement (reporting what was said). |
+| qg_p4_sentence_speech_transfer | 11 | single_choice | What a surprise it was when Grandad anno | Sentence function meets speech punctuation. Which  | The whole sentence begins with 'What a surprise' making it a |
+| qg_p4_sentence_speech_transfer | 12 | single_choice | Did the coach shout, "Run faster?", Did  | Sentence function meets speech punctuation. Which  | The sentence function is a question (it asks whether the coa |
+| qg_p4_sentence_speech_transfer | 13 | single_choice | Lena asked "Where is the library?", Lena | Sentence function meets speech punctuation. Which  | The sentence is a statement (reporting what Lena asked). The |
+| qg_p4_sentence_speech_transfer | 14 | single_choice | Ben shouted "What a fantastic goal that  | Sentence function meets speech punctuation. Which  | The outer sentence is a statement (it reports what Ben shout |
+| qg_p4_sentence_speech_transfer | 15 | single_choice | Did the head teacher really announce, "S | Sentence function meets speech punctuation. Which  | The outer sentence is a question. The speech inside is a sta |
+| qg_p4_sentence_speech_transfer | 16 | single_choice | How loudly the sergeant bellowed "Stand  | Sentence function meets speech punctuation. Which  | The whole sentence begins with 'How loudly' making it an exc |
+| qg_p4_sentence_speech_transfer | 17 | single_choice | Did Mum really say, "Pack your bag now?" | Sentence function meets speech punctuation. Which  | The whole sentence is a question (sentence function), so the |
+| qg_p4_sentence_speech_transfer | 18 | single_choice | The teacher told us, "Open your books to | Sentence function meets speech punctuation. Which  | The whole sentence is a statement (reporting what was said). |
+| qg_p4_sentence_speech_transfer | 19 | single_choice | What a surprise it was when Grandad anno | Sentence function meets speech punctuation. Which  | The whole sentence begins with 'What a surprise' making it a |
+| qg_p4_sentence_speech_transfer | 20 | single_choice | Did the coach shout, "Run faster?", Did  | Sentence function meets speech punctuation. Which  | The sentence function is a question (it asks whether the coa |
+| qg_p4_sentence_speech_transfer | 21 | single_choice | Lena asked "Where is the library?", Lena | Sentence function meets speech punctuation. Which  | The sentence is a statement (reporting what Lena asked). The |
+| qg_p4_sentence_speech_transfer | 22 | single_choice | Ben shouted "What a fantastic goal that  | Sentence function meets speech punctuation. Which  | The outer sentence is a statement (it reports what Ben shout |
+| qg_p4_sentence_speech_transfer | 23 | single_choice | Did the head teacher really announce, "S | Sentence function meets speech punctuation. Which  | The outer sentence is a question. The speech inside is a sta |
+| qg_p4_sentence_speech_transfer | 24 | single_choice | How loudly the sergeant bellowed "Stand  | Sentence function meets speech punctuation. Which  | The whole sentence begins with 'How loudly' making it an exc |
+| qg_p4_sentence_speech_transfer | 25 | single_choice | Did Mum really say, "Pack your bag now"? | Sentence function meets speech punctuation. Which  | The whole sentence is a question (sentence function), so the |
+| qg_p4_sentence_speech_transfer | 26 | single_choice | The teacher told us, "Open your books to | Sentence function meets speech punctuation. Which  | The whole sentence is a statement (reporting what was said). |
+| qg_p4_sentence_speech_transfer | 27 | single_choice | What a surprise it was when Grandad anno | Sentence function meets speech punctuation. Which  | The whole sentence begins with 'What a surprise' making it a |
+| qg_p4_sentence_speech_transfer | 28 | single_choice | Did the coach shout, "Run faster"?, Did  | Sentence function meets speech punctuation. Which  | The sentence function is a question (it asks whether the coa |
+| qg_p4_sentence_speech_transfer | 29 | single_choice | Lena asked, "Where is the library"?, Len | Sentence function meets speech punctuation. Which  | The sentence is a statement (reporting what Lena asked). The |
+| qg_p4_sentence_speech_transfer | 30 | single_choice | Ben shouted, "What a fantastic goal that | Sentence function meets speech punctuation. Which  | The outer sentence is a statement (it reports what Ben shout |
+| qg_p4_word_class_noun_phrase_transfer | 1 | table_choice | 2 rows/fields | Word class and noun phrase analysis. Identify the  | The head noun is the main word the phrase is built around. ' |
+| qg_p4_word_class_noun_phrase_transfer | 2 | table_choice | 2 rows/fields | Word class and noun phrase analysis. Identify the  | 'Storm' is the head noun. 'Mountain' is a noun used as a mod |
+| qg_p4_word_class_noun_phrase_transfer | 3 | table_choice | 2 rows/fields | Identify the head noun and the word class of the u | 'Firefighters' is the head noun. 'Incredibly' is an adverb m |
+| qg_p4_word_class_noun_phrase_transfer | 4 | table_choice | 2 rows/fields | Word class and noun phrase analysis. Identify the  | 'Lesson' is the head noun the phrase centres on. 'Every' is  |
+| qg_p4_word_class_noun_phrase_transfer | 5 | table_choice | 2 rows/fields | Word class and noun phrase analysis. Identify the  | 'Fence' is the head noun. 'Painted' here is used as an adjec |
+| qg_p4_word_class_noun_phrase_transfer | 6 | table_choice | 2 rows/fields | Word class and noun phrase analysis. Identify the  | 'Crates' is the head noun. 'Several' is a determiner telling |
+| qg_p4_word_class_noun_phrase_transfer | 7 | table_choice | 2 rows/fields | Word class and noun phrase analysis. Identify the  | 'Costume' is the head noun. 'Swimming' is used as an adjecti |
+| qg_p4_word_class_noun_phrase_transfer | 8 | table_choice | 2 rows/fields | Word class and noun phrase analysis. Identify the  | 'Castle' is the head noun. 'Their' is a possessive determine |
+| qg_p4_word_class_noun_phrase_transfer | 9 | table_choice | 2 rows/fields | Word class and noun phrase analysis. Identify the  | The head noun is the main word the phrase is built around. ' |
+| qg_p4_word_class_noun_phrase_transfer | 10 | table_choice | 2 rows/fields | Word class and noun phrase analysis. Identify the  | 'Storm' is the head noun. 'Mountain' is a noun used as a mod |
+| qg_p4_word_class_noun_phrase_transfer | 11 | table_choice | 2 rows/fields | Identify the head noun and the word class of the u | 'Firefighters' is the head noun. 'Incredibly' is an adverb m |
+| qg_p4_word_class_noun_phrase_transfer | 12 | table_choice | 2 rows/fields | Word class and noun phrase analysis. Identify the  | 'Lesson' is the head noun the phrase centres on. 'Every' is  |
+| qg_p4_word_class_noun_phrase_transfer | 13 | table_choice | 2 rows/fields | Word class and noun phrase analysis. Identify the  | 'Fence' is the head noun. 'Painted' here is used as an adjec |
+| qg_p4_word_class_noun_phrase_transfer | 14 | table_choice | 2 rows/fields | Word class and noun phrase analysis. Identify the  | 'Crates' is the head noun. 'Several' is a determiner telling |
+| qg_p4_word_class_noun_phrase_transfer | 15 | table_choice | 2 rows/fields | Word class and noun phrase analysis. Identify the  | 'Costume' is the head noun. 'Swimming' is used as an adjecti |
+| qg_p4_word_class_noun_phrase_transfer | 16 | table_choice | 2 rows/fields | Word class and noun phrase analysis. Identify the  | 'Castle' is the head noun. 'Their' is a possessive determine |
+| qg_p4_word_class_noun_phrase_transfer | 17 | table_choice | 2 rows/fields | Word class and noun phrase analysis. Identify the  | The head noun is the main word the phrase is built around. ' |
+| qg_p4_word_class_noun_phrase_transfer | 18 | table_choice | 2 rows/fields | Word class and noun phrase analysis. Identify the  | 'Storm' is the head noun. 'Mountain' is a noun used as a mod |
+| qg_p4_word_class_noun_phrase_transfer | 19 | table_choice | 2 rows/fields | Identify the head noun and the word class of the u | 'Firefighters' is the head noun. 'Incredibly' is an adverb m |
+| qg_p4_word_class_noun_phrase_transfer | 20 | table_choice | 2 rows/fields | Word class and noun phrase analysis. Identify the  | 'Lesson' is the head noun the phrase centres on. 'Every' is  |
+| qg_p4_word_class_noun_phrase_transfer | 21 | table_choice | 2 rows/fields | Word class and noun phrase analysis. Identify the  | 'Fence' is the head noun. 'Painted' here is used as an adjec |
+| qg_p4_word_class_noun_phrase_transfer | 22 | table_choice | 2 rows/fields | Word class and noun phrase analysis. Identify the  | 'Crates' is the head noun. 'Several' is a determiner telling |
+| qg_p4_word_class_noun_phrase_transfer | 23 | table_choice | 2 rows/fields | Word class and noun phrase analysis. Identify the  | 'Costume' is the head noun. 'Swimming' is used as an adjecti |
+| qg_p4_word_class_noun_phrase_transfer | 24 | table_choice | 2 rows/fields | Word class and noun phrase analysis. Identify the  | 'Castle' is the head noun. 'Their' is a possessive determine |
+| qg_p4_word_class_noun_phrase_transfer | 25 | table_choice | 2 rows/fields | Word class and noun phrase analysis. Identify the  | The head noun is the main word the phrase is built around. ' |
+| qg_p4_word_class_noun_phrase_transfer | 26 | table_choice | 2 rows/fields | Word class and noun phrase analysis. Identify the  | 'Storm' is the head noun. 'Mountain' is a noun used as a mod |
+| qg_p4_word_class_noun_phrase_transfer | 27 | table_choice | 2 rows/fields | Identify the head noun and the word class of the u | 'Firefighters' is the head noun. 'Incredibly' is an adverb m |
+| qg_p4_word_class_noun_phrase_transfer | 28 | table_choice | 2 rows/fields | Word class and noun phrase analysis. Identify the  | 'Lesson' is the head noun the phrase centres on. 'Every' is  |
+| qg_p4_word_class_noun_phrase_transfer | 29 | table_choice | 2 rows/fields | Word class and noun phrase analysis. Identify the  | 'Fence' is the head noun. 'Painted' here is used as an adjec |
+| qg_p4_word_class_noun_phrase_transfer | 30 | table_choice | 2 rows/fields | Word class and noun phrase analysis. Identify the  | 'Crates' is the head noun. 'Several' is a determiner telling |
+| qg_p4_adverbial_clause_boundary_transfer | 1 | single_choice | Before the bell rang; the children lined | Adverbial placement with clause boundaries. Which  | A fronted adverbial clause needs a comma after it to mark th |
+| qg_p4_adverbial_clause_boundary_transfer | 2 | single_choice | After the storm cleared we inspected the | Adverbial placement with clause boundaries. Which  | The adverbial 'After the storm cleared' needs a comma to sho |
+| qg_p4_adverbial_clause_boundary_transfer | 3 | single_choice | Although the path was icy nobody slipped | Adverbial placement with clause boundaries. Which  | 'Although the path was icy' is a subordinate adverbial claus |
+| qg_p4_adverbial_clause_boundary_transfer | 4 | single_choice | During the assembly the head announced s | Adverbial placement with clause boundaries. Which  | A comma marks the fronted adverbial boundary, and a semicolo |
+| qg_p4_adverbial_clause_boundary_transfer | 5 | single_choice | When the museum opened visitors rushed t | Adverbial placement with clause boundaries. Which  | 'When the museum opened' is a fronted adverbial clause. A co |
+| qg_p4_adverbial_clause_boundary_transfer | 6 | single_choice | As soon as the whistle blew; the players | Adverbial placement with clause boundaries. Which  | A comma separates the fronted adverbial from the first main  |
+| qg_p4_adverbial_clause_boundary_transfer | 7 | single_choice | By the time, we arrived the cake had alr | Adverbial placement with clause boundaries. Which  | 'By the time we arrived' is a subordinate time adverbial. It |
+| qg_p4_adverbial_clause_boundary_transfer | 8 | single_choice | Despite the heavy rain, the match contin | Adverbial placement with clause boundaries. Which  | The fronted adverbial 'Despite the heavy rain' needs a comma |
+| qg_p4_adverbial_clause_boundary_transfer | 9 | single_choice | Before the bell rang the children lined  | Adverbial placement with clause boundaries. Which  | A fronted adverbial clause needs a comma after it to mark th |
+| qg_p4_adverbial_clause_boundary_transfer | 10 | single_choice | After the storm cleared, we inspected th | Adverbial placement with clause boundaries. Which  | The adverbial 'After the storm cleared' needs a comma to sho |
+| qg_p4_adverbial_clause_boundary_transfer | 11 | single_choice | Although the path was icy, nobody slippe | Adverbial placement with clause boundaries. Which  | 'Although the path was icy' is a subordinate adverbial claus |
+| qg_p4_adverbial_clause_boundary_transfer | 12 | single_choice | During the assembly, the head announced  | Adverbial placement with clause boundaries. Which  | A comma marks the fronted adverbial boundary, and a semicolo |
+| qg_p4_adverbial_clause_boundary_transfer | 13 | single_choice | When the museum opened; visitors rushed  | Adverbial placement with clause boundaries. Which  | 'When the museum opened' is a fronted adverbial clause. A co |
+| qg_p4_adverbial_clause_boundary_transfer | 14 | single_choice | As soon as the whistle blew, the players | Adverbial placement with clause boundaries. Which  | A comma separates the fronted adverbial from the first main  |
+| qg_p4_adverbial_clause_boundary_transfer | 15 | single_choice | By the time, we arrived the cake had alr | Adverbial placement with clause boundaries. Which  | 'By the time we arrived' is a subordinate time adverbial. It |
+| qg_p4_adverbial_clause_boundary_transfer | 16 | single_choice | Despite, the heavy rain the match contin | Adverbial placement with clause boundaries. Which  | The fronted adverbial 'Despite the heavy rain' needs a comma |
+| qg_p4_adverbial_clause_boundary_transfer | 17 | single_choice | Before the bell rang; the children lined | Adverbial placement with clause boundaries. Which  | A fronted adverbial clause needs a comma after it to mark th |
+| qg_p4_adverbial_clause_boundary_transfer | 18 | single_choice | After the storm cleared, we inspected th | Adverbial placement with clause boundaries. Which  | The adverbial 'After the storm cleared' needs a comma to sho |
+| qg_p4_adverbial_clause_boundary_transfer | 19 | single_choice | Although the path was icy nobody slipped | Adverbial placement with clause boundaries. Which  | 'Although the path was icy' is a subordinate adverbial claus |
+| qg_p4_adverbial_clause_boundary_transfer | 20 | single_choice | During the assembly, the head announced  | Adverbial placement with clause boundaries. Which  | A comma marks the fronted adverbial boundary, and a semicolo |
+| qg_p4_adverbial_clause_boundary_transfer | 21 | single_choice | When, the museum opened visitors rushed  | Adverbial placement with clause boundaries. Which  | 'When the museum opened' is a fronted adverbial clause. A co |
+| qg_p4_adverbial_clause_boundary_transfer | 22 | single_choice | As soon as the whistle blew the players  | Adverbial placement with clause boundaries. Which  | A comma separates the fronted adverbial from the first main  |
+| qg_p4_adverbial_clause_boundary_transfer | 23 | single_choice | By the time, we arrived the cake had alr | Adverbial placement with clause boundaries. Which  | 'By the time we arrived' is a subordinate time adverbial. It |
+| qg_p4_adverbial_clause_boundary_transfer | 24 | single_choice | Despite, the heavy rain the match contin | Adverbial placement with clause boundaries. Which  | The fronted adverbial 'Despite the heavy rain' needs a comma |
+| qg_p4_adverbial_clause_boundary_transfer | 25 | single_choice | Before the bell rang, the children lined | Adverbial placement with clause boundaries. Which  | A fronted adverbial clause needs a comma after it to mark th |
+| qg_p4_adverbial_clause_boundary_transfer | 26 | single_choice | After the storm cleared, we inspected th | Adverbial placement with clause boundaries. Which  | The adverbial 'After the storm cleared' needs a comma to sho |
+| qg_p4_adverbial_clause_boundary_transfer | 27 | single_choice | Although the path was icy; nobody slippe | Adverbial placement with clause boundaries. Which  | 'Although the path was icy' is a subordinate adverbial claus |
+| qg_p4_adverbial_clause_boundary_transfer | 28 | single_choice | During the assembly, the head announced  | Adverbial placement with clause boundaries. Which  | A comma marks the fronted adverbial boundary, and a semicolo |
+| qg_p4_adverbial_clause_boundary_transfer | 29 | single_choice | When the museum opened visitors rushed t | Adverbial placement with clause boundaries. Which  | 'When the museum opened' is a fronted adverbial clause. A co |
+| qg_p4_adverbial_clause_boundary_transfer | 30 | single_choice | As soon as the whistle blew the players  | Adverbial placement with clause boundaries. Which  | A comma separates the fronted adverbial from the first main  |
+| qg_p4_relative_parenthesis_transfer | 1 | single_choice | The oak tree which, was planted by the v | Relative clause with parenthesis commas. Which opt | A non-defining relative clause adds extra information about  |
+| qg_p4_relative_parenthesis_transfer | 2 | single_choice | Mrs Patel who teaches Year 6 organised t | Relative clause with parenthesis commas. Which opt | The relative clause 'who teaches Year 6' is extra informatio |
+| qg_p4_relative_parenthesis_transfer | 3 | single_choice | The River Thames which is over 200 miles | Relative clause with parenthesis commas. Which opt | The relative clause adds extra information about the Thames. |
+| qg_p4_relative_parenthesis_transfer | 4 | single_choice | The head teacher who had been watching f | Relative clause with parenthesis commas. Which opt | The relative clause 'who had been watching from the sideline |
+| qg_p4_relative_parenthesis_transfer | 5 | single_choice | The school hall which had been decorated | Relative clause with parenthesis commas. Which opt | The clause 'which had been decorated overnight' is extra inf |
+| qg_p4_relative_parenthesis_transfer | 6 | single_choice | My grandfather who served, in the navy,  | Relative clause with parenthesis commas. Which opt | The relative clause 'who served in the navy' is parenthetica |
+| qg_p4_relative_parenthesis_transfer | 7 | single_choice | The old bridge, which had been damaged i | Relative clause with parenthesis commas. Which opt | The relative clause adds non-essential information and acts  |
+| qg_p4_relative_parenthesis_transfer | 8 | single_choice | The library book, which Amir borrowed la | Relative clause with parenthesis commas. Which opt | The clause 'which Amir borrowed last week' is extra detail a |
+| qg_p4_relative_parenthesis_transfer | 9 | single_choice | The oak tree which was planted by the vi | Relative clause with parenthesis commas. Which opt | A non-defining relative clause adds extra information about  |
+| qg_p4_relative_parenthesis_transfer | 10 | single_choice | Mrs Patel, who teaches Year 6, organised | Relative clause with parenthesis commas. Which opt | The relative clause 'who teaches Year 6' is extra informatio |
+| qg_p4_relative_parenthesis_transfer | 11 | single_choice | The River Thames, which is over 200 mile | Relative clause with parenthesis commas. Which opt | The relative clause adds extra information about the Thames. |
+| qg_p4_relative_parenthesis_transfer | 12 | single_choice | The head teacher, who had been watching  | Relative clause with parenthesis commas. Which opt | The relative clause 'who had been watching from the sideline |
+| qg_p4_relative_parenthesis_transfer | 13 | single_choice | The school hall which had been decorated | Relative clause with parenthesis commas. Which opt | The clause 'which had been decorated overnight' is extra inf |
+| qg_p4_relative_parenthesis_transfer | 14 | single_choice | My grandfather, who served in the navy,  | Relative clause with parenthesis commas. Which opt | The relative clause 'who served in the navy' is parenthetica |
+| qg_p4_relative_parenthesis_transfer | 15 | single_choice | The old bridge, which had been damaged i | Relative clause with parenthesis commas. Which opt | The relative clause adds non-essential information and acts  |
+| qg_p4_relative_parenthesis_transfer | 16 | single_choice | The library book which Amir, borrowed la | Relative clause with parenthesis commas. Which opt | The clause 'which Amir borrowed last week' is extra detail a |
+| qg_p4_relative_parenthesis_transfer | 17 | single_choice | The oak tree which, was planted by the v | Relative clause with parenthesis commas. Which opt | A non-defining relative clause adds extra information about  |
+| qg_p4_relative_parenthesis_transfer | 18 | single_choice | Mrs Patel, who teaches Year 6, organised | Relative clause with parenthesis commas. Which opt | The relative clause 'who teaches Year 6' is extra informatio |
+| qg_p4_relative_parenthesis_transfer | 19 | single_choice | The River Thames which is over 200 miles | Relative clause with parenthesis commas. Which opt | The relative clause adds extra information about the Thames. |
+| qg_p4_relative_parenthesis_transfer | 20 | single_choice | The head teacher, who had been watching  | Relative clause with parenthesis commas. Which opt | The relative clause 'who had been watching from the sideline |
+| qg_p4_relative_parenthesis_transfer | 21 | single_choice | The school hall, which had been decorate | Relative clause with parenthesis commas. Which opt | The clause 'which had been decorated overnight' is extra inf |
+| qg_p4_relative_parenthesis_transfer | 22 | single_choice | My grandfather who served in the navy lo | Relative clause with parenthesis commas. Which opt | The relative clause 'who served in the navy' is parenthetica |
+| qg_p4_relative_parenthesis_transfer | 23 | single_choice | The old bridge, which had been damaged i | Relative clause with parenthesis commas. Which opt | The relative clause adds non-essential information and acts  |
+| qg_p4_relative_parenthesis_transfer | 24 | single_choice | The library book which Amir, borrowed la | Relative clause with parenthesis commas. Which opt | The clause 'which Amir borrowed last week' is extra detail a |
+| qg_p4_relative_parenthesis_transfer | 25 | single_choice | The oak tree, which was planted by the v | Relative clause with parenthesis commas. Which opt | A non-defining relative clause adds extra information about  |
+| qg_p4_relative_parenthesis_transfer | 26 | single_choice | Mrs Patel, who teaches Year 6, organised | Relative clause with parenthesis commas. Which opt | The relative clause 'who teaches Year 6' is extra informatio |
+| qg_p4_relative_parenthesis_transfer | 27 | single_choice | The River Thames which is over 200 miles | Relative clause with parenthesis commas. Which opt | The relative clause adds extra information about the Thames. |
+| qg_p4_relative_parenthesis_transfer | 28 | single_choice | The head teacher, who had been watching  | Relative clause with parenthesis commas. Which opt | The relative clause 'who had been watching from the sideline |
+| qg_p4_relative_parenthesis_transfer | 29 | single_choice | The school hall which had been decorated | Relative clause with parenthesis commas. Which opt | The clause 'which had been decorated overnight' is extra inf |
+| qg_p4_relative_parenthesis_transfer | 30 | single_choice | My grandfather who served in the navy lo | Relative clause with parenthesis commas. Which opt | The relative clause 'who served in the navy' is parenthetica |
+| qg_p4_verb_form_register_transfer | 1 | single_choice | Your child will need a packed lunch and  | Verb form meets register and standard English. Whi | The future tense ('will need') matches the upcoming trip. 'S |
+| qg_p4_verb_form_register_transfer | 2 | single_choice | The mixture changed colour, which could  | Verb form meets register and standard English. Whi | Past tense ('changed') matches yesterday. 'Could indicate' s |
+| qg_p4_verb_form_register_transfer | 3 | single_choice | A blue coat has been found; it must of b | Verb form meets register and standard English. Whi | Present perfect ('has been found') shows the action is relev |
+| qg_p4_verb_form_register_transfer | 4 | single_choice | An author will visit tomorrow; pupils ma | Verb form meets register and standard English. Whi | Future tense ('will visit') fits tomorrow. 'May ask' is a su |
+| qg_p4_verb_form_register_transfer | 5 | single_choice | Children were lining up when the alarm r | Verb form meets register and standard English. Whi | Past progressive ('were lining up') shows an ongoing action  |
+| qg_p4_verb_form_register_transfer | 6 | single_choice | Plastic takes hundreds of years to break | Verb form meets register and standard English. Whi | Present tense ('takes') states a general truth. 'Can reduce' |
+| qg_p4_verb_form_register_transfer | 7 | single_choice | Grandma hid the present before I arrived | Verb form meets register and standard English. Whi | Past perfect ('had hidden') shows an action completed before |
+| qg_p4_verb_form_register_transfer | 8 | single_choice | Pupils were reading silently for twenty  | Verb form meets register and standard English. Whi | Present tense ('read') suits a standing rule. 'May choose' g |
+| qg_p4_verb_form_register_transfer | 9 | single_choice | Your child will need a packed lunch and  | Verb form meets register and standard English. Whi | The future tense ('will need') matches the upcoming trip. 'S |
+| qg_p4_verb_form_register_transfer | 10 | single_choice | The mixture changed colour, which could  | Verb form meets register and standard English. Whi | Past tense ('changed') matches yesterday. 'Could indicate' s |
+| qg_p4_verb_form_register_transfer | 11 | single_choice | A blue coat has been found; it must belo | Verb form meets register and standard English. Whi | Present perfect ('has been found') shows the action is relev |
+| qg_p4_verb_form_register_transfer | 12 | single_choice | An author visited tomorrow; pupils may a | Verb form meets register and standard English. Whi | Future tense ('will visit') fits tomorrow. 'May ask' is a su |
+| qg_p4_verb_form_register_transfer | 13 | single_choice | Children were lining up when the alarm r | Verb form meets register and standard English. Whi | Past progressive ('were lining up') shows an ongoing action  |
+| qg_p4_verb_form_register_transfer | 14 | single_choice | Plastic takes hundreds of years to break | Verb form meets register and standard English. Whi | Present tense ('takes') states a general truth. 'Can reduce' |
+| qg_p4_verb_form_register_transfer | 15 | single_choice | Grandma hid the present before I arrived | Verb form meets register and standard English. Whi | Past perfect ('had hidden') shows an action completed before |
+| qg_p4_verb_form_register_transfer | 16 | single_choice | Pupils read silently for twenty minutes; | Verb form meets register and standard English. Whi | Present tense ('read') suits a standing rule. 'May choose' g |
+| qg_p4_verb_form_register_transfer | 17 | single_choice | Your child will need a packed lunch and  | Verb form meets register and standard English. Whi | The future tense ('will need') matches the upcoming trip. 'S |
+| qg_p4_verb_form_register_transfer | 18 | single_choice | The mixture changed colour, which could  | Verb form meets register and standard English. Whi | Past tense ('changed') matches yesterday. 'Could indicate' s |
+| qg_p4_verb_form_register_transfer | 19 | single_choice | A blue coat has been found; it must of b | Verb form meets register and standard English. Whi | Present perfect ('has been found') shows the action is relev |
+| qg_p4_verb_form_register_transfer | 20 | single_choice | An author will visit tomorrow; pupils ma | Verb form meets register and standard English. Whi | Future tense ('will visit') fits tomorrow. 'May ask' is a su |
+| qg_p4_verb_form_register_transfer | 21 | single_choice | Children are lining up when the alarm ra | Verb form meets register and standard English. Whi | Past progressive ('were lining up') shows an ongoing action  |
+| qg_p4_verb_form_register_transfer | 22 | single_choice | Plastic takes hundreds of years to break | Verb form meets register and standard English. Whi | Present tense ('takes') states a general truth. 'Can reduce' |
+| qg_p4_verb_form_register_transfer | 23 | single_choice | Grandma hid the present before I arrived | Verb form meets register and standard English. Whi | Past perfect ('had hidden') shows an action completed before |
+| qg_p4_verb_form_register_transfer | 24 | single_choice | Pupils read silently for twenty minutes; | Verb form meets register and standard English. Whi | Present tense ('read') suits a standing rule. 'May choose' g |
+| qg_p4_verb_form_register_transfer | 25 | single_choice | Your child will need a packed lunch and  | Verb form meets register and standard English. Whi | The future tense ('will need') matches the upcoming trip. 'S |
+| qg_p4_verb_form_register_transfer | 26 | single_choice | The mixture changed colour, which could  | Verb form meets register and standard English. Whi | Past tense ('changed') matches yesterday. 'Could indicate' s |
+| qg_p4_verb_form_register_transfer | 27 | single_choice | A blue coat has been found; it might of  | Verb form meets register and standard English. Whi | Present perfect ('has been found') shows the action is relev |
+| qg_p4_verb_form_register_transfer | 28 | single_choice | An author will visit tomorrow; pupils ma | Verb form meets register and standard English. Whi | Future tense ('will visit') fits tomorrow. 'May ask' is a su |
+| qg_p4_verb_form_register_transfer | 29 | single_choice | Children were lining up when the alarm r | Verb form meets register and standard English. Whi | Past progressive ('were lining up') shows an ongoing action  |
+| qg_p4_verb_form_register_transfer | 30 | single_choice | Plastic takes hundreds of years to break | Verb form meets register and standard English. Whi | Present tense ('takes') states a general truth. 'Can reduce' |
+| qg_p4_cohesion_formality_transfer | 1 | single_choice | The council has approved the plans. Them | Pronoun cohesion meets formality. Which option rep | 'It' avoids repetition of 'the council' (cohesion) while kee |
+| qg_p4_cohesion_formality_transfer | 2 | single_choice | The museum opens at nine. It shuts at fi | Pronoun cohesion meets formality. Which option imp | Joining the clauses avoids repeating 'The museum' (cohesion) |
+| qg_p4_cohesion_formality_transfer | 3 | single_choice | Dr Patel presented the findings. She the | Pronoun cohesion meets formality. Which option use | 'She then explained' uses a pronoun to avoid repetition (coh |
+| qg_p4_cohesion_formality_transfer | 4 | single_choice | The project was done on time and the gov | Pronoun cohesion meets formality. Which option lin | Joining with 'and' avoids repetition (cohesion). 'Completed' |
+| qg_p4_cohesion_formality_transfer | 5 | single_choice | James has improved his reading. The lad  | Pronoun cohesion meets formality. Which option imp | 'He' replaces the repeated name (cohesion) and the sentence  |
+| qg_p4_cohesion_formality_transfer | 6 | single_choice | They raised three thousand pounds and th | Pronoun cohesion meets formality. Which option rem | Using 'which it will' avoids repetition (cohesion) with a re |
+| qg_p4_cohesion_formality_transfer | 7 | single_choice | The headteacher addressed the assembly.  | Pronoun cohesion meets formality. Which option use | 'She reminded' uses a pronoun for cohesion and keeps the for |
+| qg_p4_cohesion_formality_transfer | 8 | single_choice | The experiment was successful. The exper | Pronoun cohesion meets formality. Which option avo | 'It will be repeated' uses a pronoun to avoid repetition (co |
+| qg_p4_cohesion_formality_transfer | 9 | single_choice | The council has approved the plans. They | Pronoun cohesion meets formality. Which option rep | 'It' avoids repetition of 'the council' (cohesion) while kee |
+| qg_p4_cohesion_formality_transfer | 10 | single_choice | The museum opens at nine and closes at f | Pronoun cohesion meets formality. Which option imp | Joining the clauses avoids repeating 'The museum' (cohesion) |
+| qg_p4_cohesion_formality_transfer | 11 | single_choice | Dr Patel presented the findings. She the | Pronoun cohesion meets formality. Which option use | 'She then explained' uses a pronoun to avoid repetition (coh |
+| qg_p4_cohesion_formality_transfer | 12 | single_choice | The project was completed on time. The p | Pronoun cohesion meets formality. Which option lin | Joining with 'and' avoids repetition (cohesion). 'Completed' |
+| qg_p4_cohesion_formality_transfer | 13 | single_choice | He's got better at reading. He reads cha | Pronoun cohesion meets formality. Which option imp | 'He' replaces the repeated name (cohesion) and the sentence  |
+| qg_p4_cohesion_formality_transfer | 14 | single_choice | The charity raised three thousand pounds | Pronoun cohesion meets formality. Which option rem | Using 'which it will' avoids repetition (cohesion) with a re |
+| qg_p4_cohesion_formality_transfer | 15 | single_choice | The headteacher addressed the assembly.  | Pronoun cohesion meets formality. Which option use | 'She reminded' uses a pronoun for cohesion and keeps the for |
+| qg_p4_cohesion_formality_transfer | 16 | single_choice | It went well so we'll have another go ne | Pronoun cohesion meets formality. Which option avo | 'It will be repeated' uses a pronoun to avoid repetition (co |
+| qg_p4_cohesion_formality_transfer | 17 | single_choice | The council has approved the plans. Them | Pronoun cohesion meets formality. Which option rep | 'It' avoids repetition of 'the council' (cohesion) while kee |
+| qg_p4_cohesion_formality_transfer | 18 | single_choice | The museum opens at nine and closes at f | Pronoun cohesion meets formality. Which option imp | Joining the clauses avoids repeating 'The museum' (cohesion) |
+| qg_p4_cohesion_formality_transfer | 19 | single_choice | Dr Patel presented the findings. She the | Pronoun cohesion meets formality. Which option use | 'She then explained' uses a pronoun to avoid repetition (coh |
+| qg_p4_cohesion_formality_transfer | 20 | single_choice | The project was completed on time and re | Pronoun cohesion meets formality. Which option lin | Joining with 'and' avoids repetition (cohesion). 'Completed' |
+| qg_p4_cohesion_formality_transfer | 21 | single_choice | James has improved his reading. James no | Pronoun cohesion meets formality. Which option imp | 'He' replaces the repeated name (cohesion) and the sentence  |
+| qg_p4_cohesion_formality_transfer | 22 | single_choice | The charity got three grand and is givin | Pronoun cohesion meets formality. Which option rem | Using 'which it will' avoids repetition (cohesion) with a re |
+| qg_p4_cohesion_formality_transfer | 23 | single_choice | The headteacher addressed the assembly.  | Pronoun cohesion meets formality. Which option use | 'She reminded' uses a pronoun for cohesion and keeps the for |
+| qg_p4_cohesion_formality_transfer | 24 | single_choice | It went well so we'll have another go ne | Pronoun cohesion meets formality. Which option avo | 'It will be repeated' uses a pronoun to avoid repetition (co |
+| qg_p4_cohesion_formality_transfer | 25 | single_choice | The council has approved the plans. It w | Pronoun cohesion meets formality. Which option rep | 'It' avoids repetition of 'the council' (cohesion) while kee |
+| qg_p4_cohesion_formality_transfer | 26 | single_choice | The museum opens at nine and closes at f | Pronoun cohesion meets formality. Which option imp | Joining the clauses avoids repeating 'The museum' (cohesion) |
+| qg_p4_cohesion_formality_transfer | 27 | single_choice | Patel presented the findings. She banged | Pronoun cohesion meets formality. Which option use | 'She then explained' uses a pronoun to avoid repetition (coh |
+| qg_p4_cohesion_formality_transfer | 28 | single_choice | The project was completed on time and re | Pronoun cohesion meets formality. Which option lin | Joining with 'and' avoids repetition (cohesion). 'Completed' |
+| qg_p4_cohesion_formality_transfer | 29 | single_choice | James has improved his reading. The lad  | Pronoun cohesion meets formality. Which option imp | 'He' replaces the repeated name (cohesion) and the sentence  |
+| qg_p4_cohesion_formality_transfer | 30 | single_choice | The charity got three grand and is givin | Pronoun cohesion meets formality. Which option rem | Using 'which it will' avoids repetition (cohesion) with a re |
+| qg_p4_voice_roles_transfer | 1 | table_choice | 2 rows/fields | Identify the voice and the grammatical role of the | The sentence is passive because the action is done TO the tr |
+| qg_p4_voice_roles_transfer | 2 | table_choice | 2 rows/fields | Identify the voice and the grammatical role of the | The sentence is active because the doer ('the goalkeeper') c |
+| qg_p4_voice_roles_transfer | 3 | table_choice | 2 rows/fields | Identify the voice and the grammatical role of the | This is passive voice: the thing affected ('the cake') has b |
+| qg_p4_voice_roles_transfer | 4 | table_choice | 2 rows/fields | Identify the voice and the grammatical role of the | The sentence is active because the doer ('Lena') performs th |
+| qg_p4_voice_roles_transfer | 5 | table_choice | 2 rows/fields | Identify the voice and the grammatical role of the | This is passive voice: the affected thing ('the windows') is |
+| qg_p4_voice_roles_transfer | 6 | table_choice | 2 rows/fields | Identify the voice and the grammatical role of the | The sentence is active: the doer ('the librarian') performs  |
+| qg_p4_voice_roles_transfer | 7 | table_choice | 2 rows/fields | Identify the voice and the grammatical role of the | Passive voice places the affected thing ('the letter') in th |
+| qg_p4_voice_roles_transfer | 8 | table_choice | 2 rows/fields | Identify the voice and the grammatical role of the | The sentence is active: the doer ('the children') performs t |
+| qg_p4_voice_roles_transfer | 9 | table_choice | 2 rows/fields | Identify the voice and the grammatical role of the | The sentence is passive because the action is done TO the tr |
+| qg_p4_voice_roles_transfer | 10 | table_choice | 2 rows/fields | Identify the voice and the grammatical role of the | The sentence is active because the doer ('the goalkeeper') c |
+| qg_p4_voice_roles_transfer | 11 | table_choice | 2 rows/fields | Identify the voice and the grammatical role of the | This is passive voice: the thing affected ('the cake') has b |
+| qg_p4_voice_roles_transfer | 12 | table_choice | 2 rows/fields | Identify the voice and the grammatical role of the | The sentence is active because the doer ('Lena') performs th |
+| qg_p4_voice_roles_transfer | 13 | table_choice | 2 rows/fields | Identify the voice and the grammatical role of the | This is passive voice: the affected thing ('the windows') is |
+| qg_p4_voice_roles_transfer | 14 | table_choice | 2 rows/fields | Identify the voice and the grammatical role of the | The sentence is active: the doer ('the librarian') performs  |
+| qg_p4_voice_roles_transfer | 15 | table_choice | 2 rows/fields | Identify the voice and the grammatical role of the | Passive voice places the affected thing ('the letter') in th |
+| qg_p4_voice_roles_transfer | 16 | table_choice | 2 rows/fields | Identify the voice and the grammatical role of the | The sentence is active: the doer ('the children') performs t |
+| qg_p4_voice_roles_transfer | 17 | table_choice | 2 rows/fields | Identify the voice and the grammatical role of the | The sentence is passive because the action is done TO the tr |
+| qg_p4_voice_roles_transfer | 18 | table_choice | 2 rows/fields | Identify the voice and the grammatical role of the | The sentence is active because the doer ('the goalkeeper') c |
+| qg_p4_voice_roles_transfer | 19 | table_choice | 2 rows/fields | Identify the voice and the grammatical role of the | This is passive voice: the thing affected ('the cake') has b |
+| qg_p4_voice_roles_transfer | 20 | table_choice | 2 rows/fields | Identify the voice and the grammatical role of the | The sentence is active because the doer ('Lena') performs th |
+| qg_p4_voice_roles_transfer | 21 | table_choice | 2 rows/fields | Identify the voice and the grammatical role of the | This is passive voice: the affected thing ('the windows') is |
+| qg_p4_voice_roles_transfer | 22 | table_choice | 2 rows/fields | Identify the voice and the grammatical role of the | The sentence is active: the doer ('the librarian') performs  |
+| qg_p4_voice_roles_transfer | 23 | table_choice | 2 rows/fields | Identify the voice and the grammatical role of the | Passive voice places the affected thing ('the letter') in th |
+| qg_p4_voice_roles_transfer | 24 | table_choice | 2 rows/fields | Identify the voice and the grammatical role of the | The sentence is active: the doer ('the children') performs t |
+| qg_p4_voice_roles_transfer | 25 | table_choice | 2 rows/fields | Identify the voice and the grammatical role of the | The sentence is passive because the action is done TO the tr |
+| qg_p4_voice_roles_transfer | 26 | table_choice | 2 rows/fields | Identify the voice and the grammatical role of the | The sentence is active because the doer ('the goalkeeper') c |
+| qg_p4_voice_roles_transfer | 27 | table_choice | 2 rows/fields | Identify the voice and the grammatical role of the | This is passive voice: the thing affected ('the cake') has b |
+| qg_p4_voice_roles_transfer | 28 | table_choice | 2 rows/fields | Identify the voice and the grammatical role of the | The sentence is active because the doer ('Lena') performs th |
+| qg_p4_voice_roles_transfer | 29 | table_choice | 2 rows/fields | Identify the voice and the grammatical role of the | This is passive voice: the affected thing ('the windows') is |
+| qg_p4_voice_roles_transfer | 30 | table_choice | 2 rows/fields | Identify the voice and the grammatical role of the | The sentence is active: the doer ('the librarian') performs  |
+| qg_p4_possession_hyphen_clarity_transfer | 1 | single_choice | The well-known authors' latest book topp | Apostrophe possession meets hyphen clarity. Which  | A hyphen in 'well-known' links the compound adjective before |
+| qg_p4_possession_hyphen_clarity_transfer | 2 | single_choice | The childrens long-awaited trip finally  | Apostrophe possession meets hyphen clarity. Which  | 'Children's' uses an apostrophe before 's' because 'children |
+| qg_p4_possession_hyphen_clarity_transfer | 3 | single_choice | The player's hard-earned medals were dis | Apostrophe possession meets hyphen clarity. Which  | 'Players'' has the apostrophe after the 's' because multiple |
+| qg_p4_possession_hyphen_clarity_transfer | 4 | single_choice | The schools state-of-the-art science lab | Apostrophe possession meets hyphen clarity. Which  | 'School's' shows the lab belongs to one school (singular pos |
+| qg_p4_possession_hyphen_clarity_transfer | 5 | single_choice | My sisters hand-painted vase sits on the | Apostrophe possession meets hyphen clarity. Which  | 'Sister's' shows the vase belongs to one sister. 'Hand-paint |
+| qg_p4_possession_hyphen_clarity_transfer | 6 | single_choice | The teachers' well prepared lesson plan  | Apostrophe possession meets hyphen clarity. Which  | 'Teacher's' shows one teacher owns the plan (singular posses |
+| qg_p4_possession_hyphen_clarity_transfer | 7 | single_choice | The company's award winning product sold | Apostrophe possession meets hyphen clarity. Which  | 'Company's' uses an apostrophe to show singular possession.  |
+| qg_p4_possession_hyphen_clarity_transfer | 8 | single_choice | The dog's bright orange collar stood out | Apostrophe possession meets hyphen clarity. Which  | The apostrophe shows the collar belongs to one dog, and the  |
+| qg_p4_possession_hyphen_clarity_transfer | 9 | single_choice | The well known authors latest book toppe | Apostrophe possession meets hyphen clarity. Which  | A hyphen in 'well-known' links the compound adjective before |
+| qg_p4_possession_hyphen_clarity_transfer | 10 | single_choice | The children's long-awaited trip finally | Apostrophe possession meets hyphen clarity. Which  | 'Children's' uses an apostrophe before 's' because 'children |
+| qg_p4_possession_hyphen_clarity_transfer | 11 | single_choice | The players' hard-earned medals were dis | Apostrophe possession meets hyphen clarity. Which  | 'Players'' has the apostrophe after the 's' because multiple |
+| qg_p4_possession_hyphen_clarity_transfer | 12 | single_choice | The school's state of the art science la | Apostrophe possession meets hyphen clarity. Which  | 'School's' shows the lab belongs to one school (singular pos |
+| qg_p4_possession_hyphen_clarity_transfer | 13 | single_choice | My sisters' hand-painted vase sits on th | Apostrophe possession meets hyphen clarity. Which  | 'Sister's' shows the vase belongs to one sister. 'Hand-paint |
+| qg_p4_possession_hyphen_clarity_transfer | 14 | single_choice | The teacher's well-prepared lesson plan  | Apostrophe possession meets hyphen clarity. Which  | 'Teacher's' shows one teacher owns the plan (singular posses |
+| qg_p4_possession_hyphen_clarity_transfer | 15 | single_choice | The company's award winning product sold | Apostrophe possession meets hyphen clarity. Which  | 'Company's' uses an apostrophe to show singular possession.  |
+| qg_p4_possession_hyphen_clarity_transfer | 16 | single_choice | The dogs' bright orange collar stood out | Apostrophe possession meets hyphen clarity. Which  | The apostrophe shows the collar belongs to one dog, and the  |
+| qg_p4_possession_hyphen_clarity_transfer | 17 | single_choice | The well-known authors' latest book topp | Apostrophe possession meets hyphen clarity. Which  | A hyphen in 'well-known' links the compound adjective before |
+| qg_p4_possession_hyphen_clarity_transfer | 18 | single_choice | The children's long-awaited trip finally | Apostrophe possession meets hyphen clarity. Which  | 'Children's' uses an apostrophe before 's' because 'children |
+| qg_p4_possession_hyphen_clarity_transfer | 19 | single_choice | The player's hard-earned medals were dis | Apostrophe possession meets hyphen clarity. Which  | 'Players'' has the apostrophe after the 's' because multiple |
+| qg_p4_possession_hyphen_clarity_transfer | 20 | single_choice | The school's state-of-the-art science la | Apostrophe possession meets hyphen clarity. Which  | 'School's' shows the lab belongs to one school (singular pos |
+| qg_p4_possession_hyphen_clarity_transfer | 21 | single_choice | My sister's hand painted vase sits on th | Apostrophe possession meets hyphen clarity. Which  | 'Sister's' shows the vase belongs to one sister. 'Hand-paint |
+| qg_p4_possession_hyphen_clarity_transfer | 22 | single_choice | The teachers well-prepared lesson plan i | Apostrophe possession meets hyphen clarity. Which  | 'Teacher's' shows one teacher owns the plan (singular posses |
+| qg_p4_possession_hyphen_clarity_transfer | 23 | single_choice | The company's award winning product sold | Apostrophe possession meets hyphen clarity. Which  | 'Company's' uses an apostrophe to show singular possession.  |
+| qg_p4_possession_hyphen_clarity_transfer | 24 | single_choice | The dogs' bright orange collar stood out | Apostrophe possession meets hyphen clarity. Which  | The apostrophe shows the collar belongs to one dog, and the  |
+| qg_p4_possession_hyphen_clarity_transfer | 25 | single_choice | The well-known author's latest book topp | Apostrophe possession meets hyphen clarity. Which  | A hyphen in 'well-known' links the compound adjective before |
+| qg_p4_possession_hyphen_clarity_transfer | 26 | single_choice | The children's long-awaited trip finally | Apostrophe possession meets hyphen clarity. Which  | 'Children's' uses an apostrophe before 's' because 'children |
+| qg_p4_possession_hyphen_clarity_transfer | 27 | single_choice | The players hard-earned medals were disp | Apostrophe possession meets hyphen clarity. Which  | 'Players'' has the apostrophe after the 's' because multiple |
+| qg_p4_possession_hyphen_clarity_transfer | 28 | single_choice | The school's state-of-the-art science la | Apostrophe possession meets hyphen clarity. Which  | 'School's' shows the lab belongs to one school (singular pos |
+| qg_p4_possession_hyphen_clarity_transfer | 29 | single_choice | My sisters hand-painted vase sits on the | Apostrophe possession meets hyphen clarity. Which  | 'Sister's' shows the vase belongs to one sister. 'Hand-paint |
+| qg_p4_possession_hyphen_clarity_transfer | 30 | single_choice | The teachers well-prepared lesson plan i | Apostrophe possession meets hyphen clarity. Which  | 'Teacher's' shows one teacher owns the plan (singular posses |

--- a/scripts/generate-grammar-qg-render-inventory.mjs
+++ b/scripts/generate-grammar-qg-render-inventory.mjs
@@ -1,11 +1,14 @@
 #!/usr/bin/env node
 /**
- * Grammar QG P10 U1 — Render Inventory
+ * Grammar QG P10 U1+U6 — Render Inventory (Enriched)
  *
  * For each of 78 templates x seeds 1..30 (2,340 items), generates the full
  * render surface (createGrammarQuestion + serialiseGrammarQuestion) and writes:
  * - reports/grammar/grammar-qg-p10-render-inventory.json (full, includes answer internals)
+ * - reports/grammar/grammar-qg-p10-render-inventory.md (full markdown for adult review)
  * - reports/grammar/grammar-qg-p10-render-inventory-redacted.md (strips answers)
+ *
+ * U6 enrichment adds: visibleOptions, rowSpecificOptions, fullSpeechOutput, _feedbackSummary
  */
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -16,13 +19,113 @@ import {
   GRAMMAR_CONTENT_RELEASE_ID,
   createGrammarQuestion,
   serialiseGrammarQuestion,
+  evaluateGrammarQuestion,
 } from '../worker/src/subjects/grammar/content.js';
+
+import { buildGrammarSpeechText } from '../src/subjects/grammar/speech.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPORTS_DIR = path.resolve(__dirname, '..', 'reports', 'grammar');
 
 const SEED_MIN = 1;
 const SEED_MAX = 30;
+
+// ---------------------------------------------------------------------------
+// U6: Visible options extraction
+// ---------------------------------------------------------------------------
+
+function extractOptionLabel(option) {
+  if (Array.isArray(option)) return String(option[1] ?? option[0] ?? '');
+  return String(option?.label ?? option?.value ?? '');
+}
+
+function extractVisibleOptions(inputSpec) {
+  if (!inputSpec || typeof inputSpec !== 'object') return null;
+
+  const type = inputSpec.type;
+
+  if (type === 'single_choice' || type === 'checkbox_list') {
+    const options = Array.isArray(inputSpec.options) ? inputSpec.options : [];
+    return options.map(extractOptionLabel).filter(Boolean);
+  }
+
+  if (type === 'table_choice') {
+    const rows = Array.isArray(inputSpec.rows) ? inputSpec.rows : [];
+    return rows.map((row) => ({
+      rowLabel: String(row?.label ?? row?.key ?? ''),
+      options: Array.isArray(row?.options)
+        ? row.options.map(extractOptionLabel).filter(Boolean)
+        : (Array.isArray(inputSpec.columns) ? inputSpec.columns.map(String) : []),
+    }));
+  }
+
+  if (type === 'text' || type === 'textarea') {
+    const placeholder = inputSpec.placeholder ? String(inputSpec.placeholder) : null;
+    return placeholder ? { placeholder } : null;
+  }
+
+  if (type === 'multi') {
+    const fields = Array.isArray(inputSpec.fields) ? inputSpec.fields : [];
+    return fields.map((field) => ({
+      label: String(field?.label ?? ''),
+      options: Array.isArray(field?.options)
+        ? field.options.map(extractOptionLabel).filter(Boolean)
+        : [],
+    }));
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// U6: Row-specific options (heterogeneous table_choice only)
+// ---------------------------------------------------------------------------
+
+function extractRowSpecificOptions(inputSpec) {
+  if (!inputSpec || inputSpec.type !== 'table_choice') return null;
+  const rows = Array.isArray(inputSpec.rows) ? inputSpec.rows : [];
+  const hasRowOptions = rows.some((row) => Array.isArray(row?.options) && row.options.length > 0);
+  if (!hasRowOptions) return null;
+  return rows.map((row) => ({
+    rowLabel: String(row?.label ?? row?.key ?? ''),
+    options: Array.isArray(row?.options) ? row.options.map(extractOptionLabel).filter(Boolean) : [],
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// U6: Full speech output
+// ---------------------------------------------------------------------------
+
+function buildFullSpeechOutput(serialised) {
+  return buildGrammarSpeechText({
+    session: {
+      type: 'practice',
+      currentItem: serialised,
+      supportGuidance: null,
+    },
+    feedback: null,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// U6: Feedback summary (evaluate with correct answer)
+// ---------------------------------------------------------------------------
+
+function extractFeedbackSummary(question) {
+  if (!question || typeof question.evaluate !== 'function') return null;
+
+  // Evaluate with an empty response — the feedbackLong field will reveal
+  // the correct answer (e.g., "The correct answer is: X") which is what
+  // we want for the adult review report.
+  const result = evaluateGrammarQuestion(question, {});
+  if (!result) return null;
+
+  return {
+    feedbackShort: result.feedbackShort || null,
+    feedbackLong: result.feedbackLong || null,
+    answerText: result.answerText || null,
+  };
+}
 
 export function buildRenderInventory() {
   const items = [];
@@ -35,22 +138,29 @@ export function buildRenderInventory() {
       const serialised = serialiseGrammarQuestion(question);
       if (!serialised) continue;
 
+      const inputSpec = serialised.inputSpec || null;
+
       items.push({
         contentReleaseId: GRAMMAR_CONTENT_RELEASE_ID,
         templateId: template.id,
         seed,
         conceptIds: serialised.skillIds || [],
-        inputType: serialised.inputSpec?.type || '',
+        inputType: inputSpec?.type || '',
         promptText: serialised.promptText || '',
         promptParts: serialised.promptParts || null,
         focusCue: serialised.focusCue || null,
         screenReaderPromptText: serialised.screenReaderPromptText || null,
         readAloudText: serialised.readAloudText || null,
-        inputSpecSummary: summariseInputSpec(serialised.inputSpec),
+        inputSpecSummary: summariseInputSpec(inputSpec),
+        // U6 enrichment fields
+        visibleOptions: extractVisibleOptions(inputSpec),
+        rowSpecificOptions: extractRowSpecificOptions(inputSpec),
+        fullSpeechOutput: buildFullSpeechOutput(serialised),
         certificationStatus: 'approved',
         // answer internals (stripped in redacted output)
         _solutionLines: serialised.solutionLines || [],
         _answerSpec: question.answerSpec || null,
+        _feedbackSummary: extractFeedbackSummary(question),
       });
     }
   }
@@ -96,6 +206,10 @@ async function writeReports(inventory) {
   const jsonPath = path.join(REPORTS_DIR, 'grammar-qg-p10-render-inventory.json');
   await fs.writeFile(jsonPath, JSON.stringify(inventory, null, 2) + '\n', 'utf8');
 
+  // Full markdown (non-redacted — for adult review, includes answers)
+  const fullMdPath = path.join(REPORTS_DIR, 'grammar-qg-p10-render-inventory.md');
+  await fs.writeFile(fullMdPath, buildFullMarkdown(inventory) + '\n', 'utf8');
+
   // Redacted markdown
   const redacted = inventory.items.map(redactItem);
   const mdLines = [
@@ -122,18 +236,62 @@ async function writeReports(inventory) {
   const redactedMdPath = path.join(REPORTS_DIR, 'grammar-qg-p10-render-inventory-redacted.md');
   await fs.writeFile(redactedMdPath, mdLines.join('\n') + '\n', 'utf8');
 
-  return { jsonPath, redactedMdPath };
+  return { jsonPath, fullMdPath, redactedMdPath };
+}
+
+function buildFullMarkdown(inventory) {
+  const lines = [
+    '# Grammar QG P10 Render Inventory',
+    '',
+    `Content Release: ${inventory.metadata.contentReleaseId}`,
+    `Total Items: ${inventory.metadata.totalItems}`,
+    `Templates: ${inventory.metadata.templateCount}`,
+    `Seed Range: ${inventory.metadata.seedRange}`,
+    `Generated: ${inventory.metadata.generatedAt}`,
+    '',
+    '_This report includes answer internals and is for adult review only._',
+    '',
+    `| templateId | seed | inputType | visibleOptions (summary) | speechOutput (truncated) | feedbackLong |`,
+    `| --- | --- | --- | --- | --- | --- |`,
+  ];
+
+  for (const item of inventory.items) {
+    const optsSummary = formatVisibleOptionsSummary(item.visibleOptions);
+    const speech = (item.fullSpeechOutput || '').slice(0, 50).replace(/\|/g, '\\|').replace(/\n/g, ' ');
+    const feedback = (item._feedbackSummary?.feedbackLong || '-').slice(0, 60).replace(/\|/g, '\\|').replace(/\n/g, ' ');
+    lines.push(`| ${item.templateId} | ${item.seed} | ${item.inputType} | ${optsSummary} | ${speech} | ${feedback} |`);
+  }
+
+  return lines.join('\n');
+}
+
+function formatVisibleOptionsSummary(visibleOptions) {
+  if (!visibleOptions) return '-';
+  if (Array.isArray(visibleOptions)) {
+    if (visibleOptions.length === 0) return '-';
+    // For flat arrays (single_choice/checkbox_list string arrays)
+    if (typeof visibleOptions[0] === 'string') {
+      return visibleOptions.slice(0, 4).join(', ').slice(0, 40).replace(/\|/g, '\\|');
+    }
+    // For table_choice or multi arrays of objects
+    return `${visibleOptions.length} rows/fields`;
+  }
+  if (typeof visibleOptions === 'object' && visibleOptions.placeholder) {
+    return `placeholder: ${visibleOptions.placeholder}`.slice(0, 40).replace(/\|/g, '\\|');
+  }
+  return '-';
 }
 
 async function main() {
   const inventory = buildRenderInventory();
   const paths = await writeReports(inventory);
 
-  console.log('Grammar QG P10 Render Inventory generated:');
+  console.log('Grammar QG P10 Render Inventory generated (enriched U6):');
   console.log(`  Total items: ${inventory.metadata.totalItems}`);
   console.log(`  Templates: ${inventory.metadata.templateCount}`);
   console.log(`  Seed range: ${inventory.metadata.seedRange}`);
   console.log(`  JSON: ${paths.jsonPath}`);
+  console.log(`  Full MD: ${paths.fullMdPath}`);
   console.log(`  Redacted MD: ${paths.redactedMdPath}`);
 }
 

--- a/tests/grammar-qg-p10-evidence-artefacts.test.js
+++ b/tests/grammar-qg-p10-evidence-artefacts.test.js
@@ -24,6 +24,7 @@ const REPORTS_DIR = path.resolve(ROOT_DIR, 'reports', 'grammar');
 describe('P10 Evidence Artefacts: file existence', () => {
   const expectedFiles = [
     'grammar-qg-p10-render-inventory.json',
+    'grammar-qg-p10-render-inventory.md',
     'grammar-qg-p10-render-inventory-redacted.md',
     'grammar-qg-p10-quality-register.json',
     'grammar-qg-p10-distractor-audit.json',
@@ -74,6 +75,91 @@ describe('P10 Evidence Artefacts: render inventory', () => {
       assert.ok(typeof item.promptText === 'string', 'item.promptText must be string');
       assert.ok(item.contentReleaseId, 'item.contentReleaseId required');
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2b. U6 enrichment: visibleOptions, fullSpeechOutput, _feedbackSummary
+// ---------------------------------------------------------------------------
+
+describe('P10 Evidence Artefacts: U6 render inventory enrichment', () => {
+  const inventoryPath = path.join(REPORTS_DIR, 'grammar-qg-p10-render-inventory.json');
+
+  it('visibleOptions is non-null for selected-response items (single_choice, checkbox_list, table_choice)', () => {
+    if (!fs.existsSync(inventoryPath)) {
+      assert.fail('Render inventory file does not exist — run generate script first');
+    }
+    const data = JSON.parse(fs.readFileSync(inventoryPath, 'utf8'));
+    const selectedResponseTypes = ['single_choice', 'checkbox_list', 'table_choice'];
+    const selectedItems = data.items.filter((item) => selectedResponseTypes.includes(item.inputType));
+    assert.ok(selectedItems.length > 0, 'Expected at least one selected-response item');
+
+    for (const item of selectedItems.slice(0, 50)) {
+      assert.ok(
+        item.visibleOptions !== null && item.visibleOptions !== undefined,
+        `visibleOptions must be non-null for ${item.templateId} seed ${item.seed} (inputType: ${item.inputType})`,
+      );
+      if (Array.isArray(item.visibleOptions)) {
+        assert.ok(item.visibleOptions.length > 0, `visibleOptions must be non-empty array for ${item.templateId} seed ${item.seed}`);
+      }
+    }
+  });
+
+  it('fullSpeechOutput is a non-empty string for items with readAloudText', () => {
+    if (!fs.existsSync(inventoryPath)) {
+      assert.fail('Render inventory file does not exist — run generate script first');
+    }
+    const data = JSON.parse(fs.readFileSync(inventoryPath, 'utf8'));
+    const readAloudItems = data.items.filter((item) => item.readAloudText);
+    assert.ok(readAloudItems.length > 0, 'Expected at least one item with readAloudText');
+
+    for (const item of readAloudItems.slice(0, 50)) {
+      assert.ok(
+        typeof item.fullSpeechOutput === 'string' && item.fullSpeechOutput.length > 0,
+        `fullSpeechOutput must be a non-empty string for ${item.templateId} seed ${item.seed}`,
+      );
+    }
+  });
+
+  it('_feedbackSummary has feedbackLong or feedbackShort for all items', () => {
+    if (!fs.existsSync(inventoryPath)) {
+      assert.fail('Render inventory file does not exist — run generate script first');
+    }
+    const data = JSON.parse(fs.readFileSync(inventoryPath, 'utf8'));
+    const sample = data.items.slice(0, 100);
+    let withFeedback = 0;
+    for (const item of sample) {
+      if (item._feedbackSummary) {
+        assert.ok(
+          item._feedbackSummary.feedbackShort || item._feedbackSummary.feedbackLong,
+          `_feedbackSummary must have feedbackShort or feedbackLong for ${item.templateId} seed ${item.seed}`,
+        );
+        withFeedback += 1;
+      }
+    }
+    // At least 90% of sampled items should have feedback
+    assert.ok(withFeedback >= 90, `Expected at least 90 items with _feedbackSummary, got ${withFeedback}`);
+  });
+
+  it('three output files exist (.json, .md, -redacted.md)', () => {
+    const files = [
+      'grammar-qg-p10-render-inventory.json',
+      'grammar-qg-p10-render-inventory.md',
+      'grammar-qg-p10-render-inventory-redacted.md',
+    ];
+    for (const file of files) {
+      const filePath = path.join(REPORTS_DIR, file);
+      assert.ok(fs.existsSync(filePath), `Expected render inventory output file: ${file}`);
+    }
+  });
+
+  it('redacted report strips _ prefixed fields', () => {
+    const redactedPath = path.join(REPORTS_DIR, 'grammar-qg-p10-render-inventory-redacted.md');
+    if (!fs.existsSync(redactedPath)) return;
+    const content = fs.readFileSync(redactedPath, 'utf8');
+    assert.ok(!content.includes('_feedbackSummary'), 'Redacted report must not contain _feedbackSummary');
+    assert.ok(!content.includes('_solutionLines'), 'Redacted report must not contain _solutionLines');
+    assert.ok(!content.includes('_answerSpec'), 'Redacted report must not contain _answerSpec');
   });
 });
 


### PR DESCRIPTION
## Summary
- Enrich the Grammar QG P10 render inventory with `visibleOptions` (actual option labels a child sees), `rowSpecificOptions` (per-row options for heterogeneous table_choice), `fullSpeechOutput` (TTS output via `buildGrammarSpeechText`), and `_feedbackSummary` (feedbackShort/feedbackLong/answerText from evaluation)
- Generate a non-redacted markdown report (`grammar-qg-p10-render-inventory.md`) for adult review alongside the existing redacted version
- Update `tests/grammar-qg-p10-evidence-artefacts.test.js` with assertions for the enriched fields and the three-file output contract

## Test plan
- [x] All 434 P10 tests pass (0 failures)
- [x] `visibleOptions` is non-null for all selected-response items
- [x] `fullSpeechOutput` is a non-empty string for items with `readAloudText`
- [x] `_feedbackSummary` has feedbackLong or feedbackShort for 90%+ items
- [x] Three output files verified (.json, .md, -redacted.md)
- [x] Redacted report strips all `_` prefixed fields