### PR TITLE
fix(grammar-qg): P10 R-U4 — scheduler safety engine.js blocklist wiring

### DIFF
--- a/tests/grammar-qg-p10-scheduler-safety.test.js
+++ b/tests/grammar-qg-p10-scheduler-safety.test.js
@@ -3,6 +3,9 @@
  *
  * Proves that the P10 certification status map is consistent with the quality
  * register and that blocked templates are excluded from scheduling.
+ *
+ * R-U4 addendum: proves that engine.js paths (takeDueRetry, nextItem
+ * direct-launch, startSimilarProblem) respect the blocklist.
  */
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
@@ -11,7 +14,10 @@ import fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
 import {
+  createGrammarQuestion,
+  evaluateGrammarQuestion,
   GRAMMAR_TEMPLATE_METADATA,
+  grammarTemplateById,
 } from '../worker/src/subjects/grammar/content.js';
 import {
   isTemplateBlocked,
@@ -21,6 +27,9 @@ import {
 import {
   buildGrammarMiniPack,
 } from '../worker/src/subjects/grammar/selection.js';
+import {
+  createServerGrammarEngine,
+} from '../worker/src/subjects/grammar/engine.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = path.resolve(__dirname, '..');
@@ -134,6 +143,243 @@ describe('P10 Scheduler Safety: quality register consistency', () => {
       if (entry.decision === 'blocked') {
         assert.equal(mapEntry.status, 'blocked', `Template ${entry.templateId} is blocked in register but not in status map`);
       }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Characterisation: approved template flows through engine paths unchanged
+// ---------------------------------------------------------------------------
+
+describe('P10 Scheduler Safety: characterisation — approved template engine paths', () => {
+  // Pick a single_choice sats-friendly template guaranteed to be approved
+  // so we can reliably produce a wrong answer for repair tests.
+  const SINGLE_CHOICE_TEMPLATE_ID = 'word_class_underlined_choice';
+  const approvedTemplate = GRAMMAR_TEMPLATE_METADATA.find((t) => t.id === SINGLE_CHOICE_TEMPLATE_ID);
+  const approvedId = approvedTemplate.id;
+
+  function findWrongAnswer(templateId, seed) {
+    const question = createGrammarQuestion({ templateId, seed });
+    for (const opt of (question.inputSpec.options || [])) {
+      const value = typeof opt === 'string' ? opt : opt.value;
+      const result = evaluateGrammarQuestion(question, { answer: value });
+      if (result && !result.correct) return value;
+    }
+    return null;
+  }
+
+  it('approved template starts a session via direct-launch', () => {
+    const engine = createServerGrammarEngine({ now: () => 1_777_000_000_000 });
+    const result = engine.apply({
+      learnerId: 'learner-char-1',
+      subjectRecord: {},
+      command: 'start-session',
+      requestId: 'char-direct-launch',
+      payload: { mode: 'smart', roundLength: 1, templateId: approvedId, seed: 42 },
+    });
+    assert.equal(result.state.phase, 'session');
+    assert.equal(result.state.session.currentItem.templateId, approvedId);
+  });
+
+  it('approved template in retry queue is served via takeDueRetry', () => {
+    const engine = createServerGrammarEngine({ now: () => 1_777_000_000_000 });
+    // Pre-load the retry queue with the approved template due now.
+    const retryQueue = [{ templateId: approvedId, seed: 7, dueAt: 0, conceptIds: [], reason: 'recent-miss' }];
+    const result = engine.apply({
+      learnerId: 'learner-char-2',
+      subjectRecord: { data: { retryQueue } },
+      command: 'start-session',
+      requestId: 'char-retry-serve',
+      payload: { mode: 'smart', roundLength: 1 },
+    });
+    assert.equal(result.state.phase, 'session');
+    // The first item should be the retry entry (same template + seed).
+    assert.equal(result.state.session.currentItem.templateId, approvedId);
+    assert.equal(result.state.session.currentItem.seed, 7);
+  });
+
+  it('approved template starts a similar problem after wrong answer', () => {
+    const wrongAnswer = findWrongAnswer(approvedId, 99);
+    assert.ok(wrongAnswer, 'Must have a wrong answer option for this template');
+    const engine = createServerGrammarEngine({ now: () => 1_777_000_000_000 });
+    const start = engine.apply({
+      learnerId: 'learner-char-3',
+      subjectRecord: {},
+      command: 'start-session',
+      requestId: 'char-similar-start',
+      payload: { mode: 'smart', roundLength: 2, templateId: approvedId, seed: 99 },
+    });
+    const submit = engine.apply({
+      learnerId: 'learner-char-3',
+      subjectRecord: { ui: start.state, data: start.data },
+      latestSession: start.practiceSession,
+      command: 'submit-answer',
+      requestId: 'char-similar-submit',
+      payload: { response: { answer: wrongAnswer } },
+    });
+    const similar = engine.apply({
+      learnerId: 'learner-char-3',
+      subjectRecord: { ui: submit.state, data: submit.data },
+      latestSession: submit.practiceSession,
+      command: 'start-similar-problem',
+      requestId: 'char-similar-next',
+      payload: {},
+    });
+    assert.equal(similar.state.phase, 'session');
+    assert.equal(similar.state.session.currentItem.templateId, approvedId);
+    assert.equal(similar.changed, true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. R-U4 engine.js blocklist wiring — blocked template exclusion
+// ---------------------------------------------------------------------------
+
+describe('P10 Scheduler Safety R-U4: blocked template skipped in retry queue', () => {
+  const targetTemplate = GRAMMAR_TEMPLATE_METADATA.find((t) => t.satsFriendly);
+  const blockedId = targetTemplate.id;
+
+  it('blocked template in retry queue is skipped; next eligible item served', () => {
+    _testBlockOverride.add(blockedId);
+    try {
+      const engine = createServerGrammarEngine({ now: () => 1_777_000_000_000 });
+      // Retry queue has two entries: a blocked one (due now) and an approved one (due now).
+      const approvedId = GRAMMAR_TEMPLATE_METADATA.find((t) => t.id !== blockedId && t.satsFriendly).id;
+      const retryQueue = [
+        { templateId: blockedId, seed: 10, dueAt: 0, conceptIds: [], reason: 'recent-miss' },
+        { templateId: approvedId, seed: 20, dueAt: 0, conceptIds: [], reason: 'recent-miss' },
+      ];
+      const result = engine.apply({
+        learnerId: 'learner-retry-block',
+        subjectRecord: { data: { retryQueue } },
+        command: 'start-session',
+        requestId: 'retry-block-test',
+        payload: { mode: 'smart', roundLength: 1 },
+      });
+      assert.equal(result.state.phase, 'session');
+      // The blocked template must NOT be the one served.
+      assert.notEqual(result.state.session.currentItem.templateId, blockedId,
+        'Blocked template must be skipped in retry queue');
+    } finally {
+      _testBlockOverride.delete(blockedId);
+    }
+  });
+});
+
+describe('P10 Scheduler Safety R-U4: blocked template direct-launch returns blocked', () => {
+  const targetTemplate = GRAMMAR_TEMPLATE_METADATA.find((t) => t.satsFriendly);
+  const blockedId = targetTemplate.id;
+
+  it('blocked template with direct-launch in normal mode throws grammar_template_blocked', () => {
+    _testBlockOverride.add(blockedId);
+    try {
+      const engine = createServerGrammarEngine({ now: () => 1_777_000_000_000 });
+      assert.throws(
+        () => engine.apply({
+          learnerId: 'learner-direct-block',
+          subjectRecord: {},
+          command: 'start-session',
+          requestId: 'direct-block-test',
+          payload: { mode: 'smart', roundLength: 1, templateId: blockedId, seed: 5 },
+        }),
+        (error) => error?.extra?.code === 'grammar_template_blocked',
+      );
+    } finally {
+      _testBlockOverride.delete(blockedId);
+    }
+  });
+
+  it('blocked template with debugMode: true is allowed through direct-launch', () => {
+    _testBlockOverride.add(blockedId);
+    try {
+      const engine = createServerGrammarEngine({ now: () => 1_777_000_000_000 });
+      const result = engine.apply({
+        learnerId: 'learner-direct-debug',
+        subjectRecord: {},
+        command: 'start-session',
+        requestId: 'direct-debug-test',
+        payload: { mode: 'smart', roundLength: 1, templateId: blockedId, seed: 5, debugMode: true },
+      });
+      assert.equal(result.state.phase, 'session');
+      assert.equal(result.state.session.currentItem.templateId, blockedId);
+    } finally {
+      _testBlockOverride.delete(blockedId);
+    }
+  });
+
+  it('blocked template with reviewMode: true is allowed through direct-launch', () => {
+    _testBlockOverride.add(blockedId);
+    try {
+      const engine = createServerGrammarEngine({ now: () => 1_777_000_000_000 });
+      const result = engine.apply({
+        learnerId: 'learner-direct-review',
+        subjectRecord: {},
+        command: 'start-session',
+        requestId: 'direct-review-test',
+        payload: { mode: 'smart', roundLength: 1, templateId: blockedId, seed: 5, reviewMode: true },
+      });
+      assert.equal(result.state.phase, 'session');
+      assert.equal(result.state.session.currentItem.templateId, blockedId);
+    } finally {
+      _testBlockOverride.delete(blockedId);
+    }
+  });
+});
+
+describe('P10 Scheduler Safety R-U4: blocked template returns null from startSimilarProblem', () => {
+  // Use a single_choice template so we can reliably produce a wrong answer.
+  const SINGLE_CHOICE_TEMPLATE_ID = 'word_class_underlined_choice';
+  const blockedId = SINGLE_CHOICE_TEMPLATE_ID;
+
+  function findWrongAnswer(templateId, seed) {
+    const question = createGrammarQuestion({ templateId, seed });
+    for (const opt of (question.inputSpec.options || [])) {
+      const value = typeof opt === 'string' ? opt : opt.value;
+      const result = evaluateGrammarQuestion(question, { answer: value });
+      if (result && !result.correct) return value;
+    }
+    return null;
+  }
+
+  it('startSimilarProblem with blocked base template returns no-change', () => {
+    const wrongAnswer = findWrongAnswer(blockedId, 99);
+    assert.ok(wrongAnswer, 'Must have a wrong answer option');
+    // First start a session with the template while it is still approved.
+    const engine = createServerGrammarEngine({ now: () => 1_777_000_000_000 });
+    const start = engine.apply({
+      learnerId: 'learner-similar-block',
+      subjectRecord: {},
+      command: 'start-session',
+      requestId: 'similar-block-start',
+      payload: { mode: 'smart', roundLength: 2, templateId: blockedId, seed: 99 },
+    });
+    const submit = engine.apply({
+      learnerId: 'learner-similar-block',
+      subjectRecord: { ui: start.state, data: start.data },
+      latestSession: start.practiceSession,
+      command: 'submit-answer',
+      requestId: 'similar-block-submit',
+      payload: { response: { answer: wrongAnswer } },
+    });
+
+    // NOW block the template — simulating a post-session block decision.
+    _testBlockOverride.add(blockedId);
+    try {
+      const similar = engine.apply({
+        learnerId: 'learner-similar-block',
+        subjectRecord: { ui: submit.state, data: submit.data },
+        latestSession: submit.practiceSession,
+        command: 'start-similar-problem',
+        requestId: 'similar-block-next',
+        payload: {},
+      });
+      // When the base template is blocked, startSimilarProblem returns null,
+      // which translates to changed=false (no state mutation, no similar served).
+      assert.equal(similar.changed, false);
+      // Phase stays at feedback (the submit left it in feedback/awaitingAdvance).
+      assert.equal(similar.state.phase, 'feedback');
+    } finally {
+      _testBlockOverride.delete(blockedId);
     }
   });
 });

--- a/worker/src/subjects/grammar/certification-status.js
+++ b/worker/src/subjects/grammar/certification-status.js
@@ -4,19 +4,58 @@
  * Exports the certification status map and a helper to determine whether a
  * template is blocked from learner-facing scheduling.  The underlying data
  * lives in reports/grammar/grammar-qg-p10-certification-status-map.json (the
- * evidence artefact) but is inlined here as a JS module so static import in
- * Cloudflare Workers works without JSON import assertions.
+ * evidence artefact).  At module init we attempt to read the JSON register;
+ * if unavailable (Cloudflare Worker environment has no Node.js built-ins) we
+ * fall back to the hardcoded all-approved map derived from
+ * GRAMMAR_TEMPLATE_METADATA.
  *
  * P10 evidence: oracle, review, prompt-cue-render, distractor-audit, marking-matrix.
  */
 
 import { GRAMMAR_TEMPLATE_METADATA } from './content.js';
 
-// Build the certification map at module load time from GRAMMAR_TEMPLATE_METADATA.
-// All 78 templates are approved as of P10 certification — this matches the JSON
-// artefact committed to reports/grammar/.  If a future phase needs to block a
-// template, change the status here AND in the JSON artefact.
-const CERTIFICATION_STATUS_MAP = Object.freeze(
+// ---------------------------------------------------------------------------
+// Module-init: attempt to read the JSON register from disk.
+// In Node.js (test runner) this succeeds and gives real certification decisions.
+// In Cloudflare Workers (no Node.js built-ins) the catch fires and we fall
+// back to the hardcoded all-approved map.
+// ---------------------------------------------------------------------------
+function loadFromJsonRegister() {
+  try {
+    if (typeof globalThis.process === 'undefined' || !globalThis.process.versions?.node) {
+      return null;
+    }
+    // Use Function constructor to access require() without static import of
+    // Node.js built-ins (which would break the Cloudflare Worker bundle).
+    // eslint-disable-next-line no-new-func
+    const _require = new Function('url', `
+      const { createRequire } = require('node:module');
+      return createRequire(url);
+    `)(import.meta.url);
+    const json = _require('../../../../reports/grammar/grammar-qg-p10-certification-status-map.json');
+    if (json && typeof json === 'object' && Object.keys(json).length > 0) {
+      return Object.freeze(
+        Object.fromEntries(
+          Object.entries(json).map(([id, entry]) => [
+            id,
+            Object.freeze({
+              status: entry.status || 'approved',
+              evidence: Object.freeze(Array.isArray(entry.evidence) ? entry.evidence : []),
+            }),
+          ]),
+        ),
+      );
+    }
+  } catch {
+    // Expected in Worker environment — fall through to hardcoded map.
+  }
+  return null;
+}
+
+// Build the certification map at module load time.  Prefer the JSON artefact
+// (authoritative source) when running in Node.js; fall back to the all-approved
+// hardcoded map in Cloudflare Workers.
+const CERTIFICATION_STATUS_MAP = loadFromJsonRegister() || Object.freeze(
   Object.fromEntries(
     GRAMMAR_TEMPLATE_METADATA.map((t) => [
       t.id,

--- a/worker/src/subjects/grammar/engine.js
+++ b/worker/src/subjects/grammar/engine.js
@@ -28,6 +28,7 @@ import {
   buildGrammarMiniPack,
   buildGrammarPracticeQueue,
 } from './selection.js';
+import { isTemplateBlocked } from './certification-status.js';
 import {
   GRAMMAR_TRANSFER_HISTORY_PER_PROMPT,
   GRAMMAR_TRANSFER_MAX_PROMPTS,
@@ -623,6 +624,7 @@ function weightedTemplatePick(state, { mode, focusConceptId, seed, nowTs = Date.
 function takeDueRetry(state, { mode, focusConceptId, nowTs }) {
   const index = state.retryQueue.findIndex((entry) => {
     if (Number(entry.dueAt) > nowTs) return false;
+    if (isTemplateBlocked(entry.templateId)) return false;
     const template = grammarTemplateById(entry.templateId);
     return templateFits(template, { mode, focusConceptId });
   });
@@ -642,7 +644,7 @@ function itemFromTemplate(template, seed) {
   return serialiseGrammarQuestion(question);
 }
 
-function nextItem(state, { mode, focusConceptId, seed, templateId = '', nowTs = Date.now() } = {}) {
+function nextItem(state, { mode, focusConceptId, seed, templateId = '', nowTs = Date.now(), session = null } = {}) {
   if (templateId) {
     const template = grammarTemplateById(templateId);
     if (!template) {
@@ -651,6 +653,13 @@ function nextItem(state, { mode, focusConceptId, seed, templateId = '', nowTs = 
         subjectId: SUBJECT_ID,
         templateId,
       });
+    }
+    // Blocklist gate: blocked templates are only allowed through in debug/review modes.
+    if (isTemplateBlocked(templateId)) {
+      const allowDebugBypass = Boolean(session?.debugMode) || Boolean(session?.reviewMode);
+      if (!allowDebugBypass) {
+        return { blocked: true, templateId, reason: 'template-not-certified' };
+      }
     }
     if (!templateFits(template, { mode, focusConceptId })) {
       throw new BadRequestError('Grammar template is not available for this Grammar mode or focus concept.', {
@@ -1094,7 +1103,16 @@ function startSession(state, payload, nowTs, learnerId) {
     seed: baseSeed,
     nowTs,
     templateId,
+    session: payload,
   });
+  if (firstItem && firstItem.blocked) {
+    throw new BadRequestError('Grammar template is not certified for learner-facing use.', {
+      code: 'grammar_template_blocked',
+      subjectId: SUBJECT_ID,
+      templateId: firstItem.templateId,
+      reason: firstItem.reason,
+    });
+  }
   state.phase = 'session';
   state.awaitingAdvance = false;
   state.feedback = null;
@@ -1516,6 +1534,9 @@ function startSimilarProblem(state, nowTs) {
   const session = assertRepairableSession(state);
   const repair = ensureRepairState(session);
   const baseItem = session.currentItem;
+  // Blocklist gate: if the base template is now blocked, no similar problem
+  // can be generated from it.
+  if (isTemplateBlocked(baseItem.templateId)) return null;
   const nextSimilarIndex = repair.similarProblems + 1;
   const seed = (Number(baseItem.seed) + nextSimilarIndex * 2654435761) >>> 0;
   const item = nextItem(state, {
@@ -1524,6 +1545,7 @@ function startSimilarProblem(state, nowTs) {
     seed,
     templateId: baseItem.templateId,
     nowTs,
+    session,
   });
   repair.similarProblems = nextSimilarIndex;
   repair.retryingCurrent = false;
@@ -2231,7 +2253,13 @@ export function createServerGrammarEngine({ now = Date.now } = {}) {
       } else if (command === 'show-worked-solution') {
         events = showWorkedSolution(state);
       } else if (command === 'start-similar-problem') {
-        events = startSimilarProblem(state, nowTs);
+        const similarResult = startSimilarProblem(state, nowTs);
+        if (similarResult === null) {
+          events = [];
+          changed = false;
+        } else {
+          events = similarResult;
+        }
       } else if (command === 'request-ai-enrichment') {
         aiEnrichment = requestAiEnrichment(state, payload, nowTs);
         const persistentAiEnrichment = normalisePersistentAiEnrichment(aiEnrichment);


### PR DESCRIPTION
## Summary
- Wires `isTemplateBlocked` into all three engine.js bypass paths: `takeDueRetry` (skips blocked entries), `nextItem` direct-launch (returns `{ blocked: true }` unless `debugMode`/`reviewMode`), and `startSimilarProblem` (returns null when base template is blocked)
- Upgrades `certification-status.js` to read from `reports/grammar/grammar-qg-p10-certification-status-map.json` at module init in Node.js; falls back to hardcoded all-approved map in Cloudflare Workers
- Adds 8 new tests (3 characterisation + 5 blocked-path) to `grammar-qg-p10-scheduler-safety.test.js`

## Test plan
- [x] 18/18 scheduler safety tests pass (including 8 new R-U4 tests)
- [x] 48/48 grammar engine tests pass (zero regression)
- [x] 20/20 grammar selection tests pass
- [x] 17/17 P9 blocklist scheduler tests pass
- [x] Total: 103 related tests, 0 failures