### PR TITLE
fix(punctuation-qg): P8 gap — negative vector enrichment + display fix

### DIFF
--- a/scripts/review-punctuation-questions.mjs
+++ b/scripts/review-punctuation-questions.mjs
@@ -288,14 +288,14 @@ function buildItemEntry(item, { productionIds = null, clusterMap = null, itemDec
   if (negativeVectorMap && negativeVectorMap.has(item.id)) {
     const vectors = negativeVectorMap.get(item.id);
     for (const vec of vectors) {
-      const vecAnswer = item.mode === 'choose' ? { choiceIndex: -1 } : { typed: vec.input };
+      const vecAnswer = item.mode === 'choose' ? { choiceIndex: -1 } : { typed: vec.answer };
       let vecResult;
       try {
         vecResult = markPunctuationAnswer({ item, answer: vecAnswer });
       } catch {
         vecResult = { correct: false, error: 'marking threw' };
       }
-      fixedNegativeVectors.push({ input: vec.input, expectedCorrect: vec.expectedCorrect ?? false, result: vecResult });
+      fixedNegativeVectors.push({ input: vec.answer, expectedCorrect: vec.expectedCorrect ?? false, result: vecResult });
     }
   }
 

--- a/tests/fixtures/punctuation-negative-vectors.json
+++ b/tests/fixtures/punctuation-negative-vectors.json
@@ -868,6 +868,276 @@
       "answer": "We can't find the childrens coats. The girls bags are in the hall.",
       "expectedResult": "fail",
       "failureType": "missing_punctuation"
+    },
+    {
+      "itemId": "se_insert_question",
+      "answer": "Why was the hall still open?",
+      "expectedResult": "fail",
+      "failureType": "changed_required_words"
+    },
+    {
+      "itemId": "se_fix_statement",
+      "answer": "Do not forget your reading folder.",
+      "expectedResult": "fail",
+      "failureType": "changed_required_words"
+    },
+    {
+      "itemId": "se_insert_quiet_command",
+      "answer": "Please close the classroom window.",
+      "expectedResult": "fail",
+      "failureType": "changed_required_words"
+    },
+    {
+      "itemId": "se_fix_excited_statement",
+      "answer": "What a simple idea!",
+      "expectedResult": "fail",
+      "failureType": "changed_required_words"
+    },
+    {
+      "itemId": "lc_insert_supplies",
+      "answer": "We needed pencils, rulers and tape.",
+      "expectedResult": "fail",
+      "failureType": "changed_required_words"
+    },
+    {
+      "itemId": "lc_fix_display",
+      "answer": "The display showed shells, pebbles and crystals.",
+      "expectedResult": "fail",
+      "failureType": "changed_required_words"
+    },
+    {
+      "itemId": "lc_combine_trip_list",
+      "answer": "We packed torches, maps and juice.",
+      "expectedResult": "fail",
+      "failureType": "changed_required_words"
+    },
+    {
+      "itemId": "ac_insert_contractions",
+      "answer": "You'll see that I'm ready because I've studied already.",
+      "expectedResult": "fail",
+      "failureType": "changed_required_words"
+    },
+    {
+      "itemId": "ac_fix_contractions",
+      "answer": "I can't imagine we're nearly there.",
+      "expectedResult": "fail",
+      "failureType": "changed_required_words"
+    },
+    {
+      "itemId": "ac_insert_well_youre",
+      "answer": "We'll check that you're ready before we start.",
+      "expectedResult": "fail",
+      "failureType": "changed_required_words"
+    },
+    {
+      "itemId": "ap_insert_singular",
+      "answer": "The girl's scarf was hanging on the peg.",
+      "expectedResult": "fail",
+      "failureType": "changed_required_words"
+    },
+    {
+      "itemId": "ap_fix_irregular",
+      "answer": "The children's shoes were lined up by the door.",
+      "expectedResult": "fail",
+      "failureType": "changed_required_words"
+    },
+    {
+      "itemId": "sp_insert_question",
+      "answer": "Ella asked, \"Can we begin now?\"",
+      "expectedResult": "fail",
+      "failureType": "changed_required_words"
+    },
+    {
+      "itemId": "sp_fix_question",
+      "answer": "\"Where are we sitting?\" asked Zara.",
+      "expectedResult": "fail",
+      "failureType": "changed_required_words"
+    },
+    {
+      "itemId": "fa_insert_without_warning",
+      "answer": "Without warning, the alarm began to ring.",
+      "expectedResult": "fail",
+      "failureType": "changed_required_words"
+    },
+    {
+      "itemId": "fa_fix_at_last",
+      "answer": "At last, we reached the village.",
+      "expectedResult": "fail",
+      "failureType": "changed_required_words"
+    },
+    {
+      "itemId": "fa_combine_after_storm",
+      "answer": "After the storm, the playground sparkled.",
+      "expectedResult": "fail",
+      "failureType": "changed_required_words"
+    },
+    {
+      "itemId": "cc_insert_time_travellers",
+      "answer": "Most of the time, travellers worry about queues.",
+      "expectedResult": "fail",
+      "failureType": "changed_required_words"
+    },
+    {
+      "itemId": "cc_fix_when_rain_stopped",
+      "answer": "When the rain stopped, the children clapped.",
+      "expectedResult": "fail",
+      "failureType": "changed_required_words"
+    },
+    {
+      "itemId": "cc_insert_after_supper",
+      "answer": "After supper, we read quickly.",
+      "expectedResult": "fail",
+      "failureType": "changed_required_words"
+    },
+    {
+      "itemId": "cc_fix_if_lost",
+      "answer": "If you get lost, ask a teacher.",
+      "expectedResult": "fail",
+      "failureType": "changed_required_words"
+    },
+    {
+      "itemId": "sc_insert_lights_audience",
+      "answer": "The lights dimmed; the audience fell still.",
+      "expectedResult": "fail",
+      "failureType": "changed_required_words"
+    },
+    {
+      "itemId": "sc_fix_path_map",
+      "answer": "The path was muddy; the map showed a safer route.",
+      "expectedResult": "fail",
+      "failureType": "changed_required_words"
+    },
+    {
+      "itemId": "sc_combine_rain_pitch",
+      "answer": "The rain had stopped; the pitch was still waterlogged.",
+      "expectedResult": "fail",
+      "failureType": "changed_required_words"
+    },
+    {
+      "itemId": "dc_insert_door_froze",
+      "answer": "The door creaked open – we gasped.",
+      "expectedResult": "fail",
+      "failureType": "changed_required_words"
+    },
+    {
+      "itemId": "dc_fix_signal_team",
+      "answer": "The signal failed – the team paused.",
+      "expectedResult": "fail",
+      "failureType": "changed_required_words"
+    },
+    {
+      "itemId": "dc_combine_flooded_route",
+      "answer": "The path was blocked – we took the longer route.",
+      "expectedResult": "fail",
+      "failureType": "changed_required_words"
+    },
+    {
+      "itemId": "dc_insert_alarm_rang",
+      "answer": "The alarm rang – everyone stood up.",
+      "expectedResult": "fail",
+      "failureType": "changed_required_words"
+    },
+    {
+      "itemId": "hy_insert_little_used",
+      "answer": "The little-used room was dusty.",
+      "expectedResult": "fail",
+      "failureType": "changed_required_words"
+    },
+    {
+      "itemId": "hy_fix_fast_moving",
+      "answer": "We watched a fast-moving truck.",
+      "expectedResult": "fail",
+      "failureType": "changed_required_words"
+    },
+    {
+      "itemId": "hy_insert_well_behaved",
+      "answer": "The well-behaved kitten waited by the gate.",
+      "expectedResult": "fail",
+      "failureType": "changed_required_words"
+    },
+    {
+      "itemId": "pa_insert_museum",
+      "answer": "The museum, a former station, was crowded.",
+      "expectedResult": "fail",
+      "failureType": "changed_required_words"
+    },
+    {
+      "itemId": "pa_fix_author",
+      "answer": "The author, who won the prize, waved.",
+      "expectedResult": "fail",
+      "failureType": "changed_required_words"
+    },
+    {
+      "itemId": "pa_combine_lighthouse",
+      "answer": "The lighthouse, a useful lookout, guided the ships.",
+      "expectedResult": "fail",
+      "failureType": "changed_required_words"
+    },
+    {
+      "itemId": "cl_insert_awards",
+      "answer": "The team won three awards: player of the match, best attack and fair play.",
+      "expectedResult": "fail",
+      "failureType": "changed_required_words"
+    },
+    {
+      "itemId": "cl_fix_camp",
+      "answer": "We packed three things: tents, food and lanterns.",
+      "expectedResult": "fail",
+      "failureType": "changed_required_words"
+    },
+    {
+      "itemId": "cl_combine_awards",
+      "answer": "The team won three awards: player of the match, best attack and fair play.",
+      "expectedResult": "fail",
+      "failureType": "changed_required_words"
+    },
+    {
+      "itemId": "sl_insert_cities",
+      "answer": "We visited York, England; Cardiff, Wales; and Dublin, Northern Ireland.",
+      "expectedResult": "fail",
+      "failureType": "changed_required_words"
+    },
+    {
+      "itemId": "sl_fix_captains",
+      "answer": "Our captains were Sam, Year 5; Priya, Year 6; and Noor, Year 6.",
+      "expectedResult": "fail",
+      "failureType": "changed_required_words"
+    },
+    {
+      "itemId": "sl_insert_helper_roles",
+      "answer": "The helpers were Sara, register monitor; Leo, equipment monitor; and Aisha, line leader.",
+      "expectedResult": "fail",
+      "failureType": "changed_required_words"
+    },
+    {
+      "itemId": "sl_fix_stalls",
+      "answer": "The stalls were books, table one; games, table two; and snacks, table three.",
+      "expectedResult": "fail",
+      "failureType": "changed_required_words"
+    },
+    {
+      "itemId": "bp_insert_kit",
+      "answer": "Bring:\n- a drink\n- a hat\n- a notebook",
+      "expectedResult": "fail",
+      "failureType": "changed_required_words"
+    },
+    {
+      "itemId": "bp_fix_consistency",
+      "answer": "Bring:\n- a drink\n- a hat\n- a notebook",
+      "expectedResult": "fail",
+      "failureType": "changed_required_words"
+    },
+    {
+      "itemId": "sp_insert_question",
+      "answer": "Tom asked, \"Can we start now?\"",
+      "expectedResult": "fail",
+      "failureType": "wrong_reporting_clause"
+    },
+    {
+      "itemId": "sp_fix_question",
+      "answer": "\"Where are we meeting?\" asked Tom.",
+      "expectedResult": "fail",
+      "failureType": "wrong_reporting_clause"
     }
   ],
   "choiceValidation": [

--- a/tests/punctuation-negative-vectors.test.js
+++ b/tests/punctuation-negative-vectors.test.js
@@ -38,8 +38,8 @@ test('fixture has exactly 20 choice validation entries', () => {
   assert.equal(fixture.choiceValidation.length, 20);
 });
 
-test('total negative vectors >= 144', () => {
-  assert.ok(fixture.vectors.length >= 144, `Expected >= 144 vectors, got ${fixture.vectors.length}`);
+test('total negative vectors >= 189', () => {
+  assert.ok(fixture.vectors.length >= 189, `Expected >= 189 vectors, got ${fixture.vectors.length}`);
 });
 
 // ---- Negative vector verification ----
@@ -112,4 +112,37 @@ test('vectors cover multiple failure types', () => {
   const types = new Set(fixture.vectors.map((v) => v.failureType));
   // Must have at least 4 distinct failure types
   assert.ok(types.size >= 4, `Expected >= 4 failure types, got ${types.size}: ${[...types].join(', ')}`);
+});
+
+// ---- Per-type coverage: changed_required_words ----
+
+test('every closed item (insert/fix/combine) has at least one changed_required_words vector', () => {
+  const closedModes = ['insert', 'fix', 'combine'];
+  const closedItems = PUNCTUATION_ITEMS.filter((i) => closedModes.includes(i.mode));
+  const changedWordVectors = fixture.vectors.filter((v) => v.failureType === 'changed_required_words');
+  const coveredIds = new Set(changedWordVectors.map((v) => v.itemId));
+
+  for (const item of closedItems) {
+    assert.ok(
+      coveredIds.has(item.id),
+      `Closed item ${item.id} (mode=${item.mode}) missing changed_required_words vector`,
+    );
+  }
+});
+
+// ---- Per-type coverage: wrong_reporting_clause ----
+
+test('every speech item with reportingClause has at least one wrong_reporting_clause vector', () => {
+  const speechItemsWithClause = PUNCTUATION_ITEMS.filter(
+    (i) => i.rubric && i.rubric.reportingClause,
+  );
+  const wrongClauseVectors = fixture.vectors.filter((v) => v.failureType === 'wrong_reporting_clause');
+  const coveredIds = new Set(wrongClauseVectors.map((v) => v.itemId));
+
+  for (const item of speechItemsWithClause) {
+    assert.ok(
+      coveredIds.has(item.id),
+      `Speech item ${item.id} (reportingClause="${item.rubric.reportingClause}") missing wrong_reporting_clause vector`,
+    );
+  }
 });


### PR DESCRIPTION
## Summary
- Fixes vec.input→vec.answer field mismatch in reviewer pack display
- Adds 43 changed_required_words vectors for all closed items (insert/fix/combine)
- Adds 2 wrong_reporting_clause vectors for speech items with reportingClause
- Strengthens per-type coverage assertions in test (10 tests, all pass)

## Test plan
- [x] All 189 negative vectors mark incorrect
- [x] Reviewer pack shows actual answer text (not undefined)
- [x] Per-type coverage assertions pass
- [x] Model answers for all 72 non-choice items still mark correct