### PR TITLE
fix(punctuation-qg): P8 final gaps — real-fixture gate, legacy cleanup, explanationRuleId

### DIFF
--- a/scripts/review-punctuation-questions.mjs
+++ b/scripts/review-punctuation-questions.mjs
@@ -114,18 +114,6 @@ function loadDecisionsFile() {
       }
     }
 
-    // Backward compat: if legacy 'decisions' object exists and itemDecisions is empty,
-    // populate the item map from legacy for rendering (loader still prefers v2)
-    if (itemDecisionMap.size === 0 && parsed.decisions && typeof parsed.decisions === 'object') {
-      for (const [itemId, decision] of Object.entries(parsed.decisions)) {
-        if (decision && typeof decision === 'string') {
-          itemDecisionMap.set(itemId, { itemId, decision, reviewer: 'legacy', reviewedAt: 'unknown' });
-        } else if (decision && typeof decision === 'object') {
-          itemDecisionMap.set(itemId, { itemId, ...decision });
-        }
-      }
-    }
-
     return { itemDecisionMap, clusterDecisionMap, raw: parsed };
   } catch {
     return { itemDecisionMap: new Map(), clusterDecisionMap: new Map(), raw: { itemDecisions: [], clusterDecisions: [] } };

--- a/scripts/verify-punctuation-qg-p8.mjs
+++ b/scripts/verify-punctuation-qg-p8.mjs
@@ -1,8 +1,16 @@
 #!/usr/bin/env node
+
+// ─── Node version check (must precede all imports) ─────────────────────────────
+const major = parseInt(process.versions.node.split('.')[0], 10);
+if (major < 22) {
+  console.error(`\n  ✗ Node ${process.versions.node} detected — requires Node ≥ 22\n    .nvmrc specifies 22. Please switch: nvm use 22\n`);
+  process.exit(1);
+}
+
 // P8 verification entry point — single command that runs ALL Punctuation QG P8 checks.
 //
-// Composes ALL P7 gates (27 logical) plus P8-specific gates (9) for a total of 36 logical gates
-// across 10 top-level gates.
+// Composes ALL P7 gates (27 logical) plus P8-specific gates (10) for a total of 37 logical gates
+// across 11 top-level gates.
 //
 // Gate layout:
 //   1.  P7 verification gates (27 logical — composing P6 -> P5 -> P4 -> base)   [PRODUCTION]
@@ -15,9 +23,10 @@
 //   8.  Production human QA gate                                                 [PRODUCTION]
 //   9.  Feedback specificity tests                                               [PRODUCTION]
 //   10. Depth-6 quality-readiness gate                                           [DEPTH-6-CANDIDATE]
+//   11. Production QA decisions (real fixture)                                    [PRODUCTION]
 //
 // Depth decision: production depth remains at 4.
-// Rationale: P8 quality gates pass across all 36 logical gates, but depth-6 raise
+// Rationale: P8 quality gates pass across all 37 logical gates, but depth-6 raise
 // requires full reviewer-decision population plus human sign-off on all generated
 // candidates. The plan explicitly states: "Do not raise production depth merely
 // because the capacity audit passes."
@@ -105,6 +114,12 @@ const gates = [
     label: LABEL.DEPTH6,
     logicalGates: 1,
   },
+  {
+    name: 'Production QA decisions (real fixture)',
+    command: 'node -e "import { loadReviewerDecisions, evaluateProductionGate } from \'./shared/punctuation/reviewer-decisions.js\'; import { PUNCTUATION_ITEMS, PUNCTUATION_CONTENT_MANIFEST } from \'./shared/punctuation/content.js\'; import { createPunctuationGeneratedItems, PRODUCTION_DEPTH } from \'./shared/punctuation/generators.js\'; const gen=createPunctuationGeneratedItems({manifest:PUNCTUATION_CONTENT_MANIFEST,seed:PUNCTUATION_CONTENT_MANIFEST.releaseId||\'punctuation\',perFamily:PRODUCTION_DEPTH}); const ids=[...PUNCTUATION_ITEMS.map(i=>i.id),...gen.map(i=>i.id)]; const {data}=loadReviewerDecisions(\'tests/fixtures/punctuation-reviewer-decisions.json\'); const r=evaluateProductionGate(data,ids); if(!r.pass){console.error(\'Production QA gate FAILED:\',JSON.stringify(r.blockers.slice(0,5)));process.exit(1);} console.log(\'Production QA: \'+r.stats.approved+\'/\'+r.stats.total+\' approved\');"',
+    label: LABEL.PRODUCTION,
+    logicalGates: 1,
+  },
 ];
 
 // ─── Execution ──────────────────────────────────────────────────────────────
@@ -181,7 +196,7 @@ for (const result of results) {
 console.log('\n──────────────────────────────────────────────────────────────');
 console.log('  Measured counts:');
 console.log(`    Top-level gates:    ${gates.length}`);
-console.log(`    Logical gates:      ${totalLogicalGates} (P7: 27 composed + P8: 9 specific)`);
+console.log(`    Logical gates:      ${totalLogicalGates} (P7: 27 composed + P8: 10 specific)`);
 console.log(`    Passed:             ${passed}/${gates.length}`);
 console.log(`    Failed:             ${failed}`);
 if (failedNames.length > 0) {

--- a/shared/punctuation/content.js
+++ b/shared/punctuation/content.js
@@ -296,6 +296,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: 'What a fantastic goal!',
     misconceptionTags: ['endmarks.capitalisation_missing', 'endmarks.mark_mismatch', 'endmarks.terminal_missing'],
     readiness: ['retrieve_discriminate', 'misconception', 'negative_test'],
+    explanationRuleId: 'sentence-ending.terminal-mark',
+
     source: 'fixed',
   },
   {
@@ -311,6 +313,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: 'Why was the hall still locked?',
     misconceptionTags: ['endmarks.capitalisation_missing', 'endmarks.question_mark_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
+    explanationRuleId: 'sentence-ending.terminal-mark',
+
     source: 'fixed',
   },
   {
@@ -326,6 +330,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: 'Do not forget your reading journal.',
     misconceptionTags: ['endmarks.mark_mismatch', 'endmarks.capitalisation_missing'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
+    explanationRuleId: 'sentence-ending.terminal-mark',
+
     source: 'fixed',
   },
   {
@@ -342,6 +348,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     validator: { type: 'startsWithWordQuestion', word: 'Why' },
     misconceptionTags: ['endmarks.question_mark_missing', 'endmarks.capitalisation_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    explanationRuleId: 'sentence-ending.terminal-mark',
+
     source: 'fixed',
   },
   {
@@ -362,6 +370,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: 'Where is the science tray?',
     misconceptionTags: ['endmarks.question_mark_missing', 'endmarks.capitalisation_missing', 'endmarks.terminal_missing'],
     readiness: ['retrieve_discriminate', 'misconception', 'negative_test'],
+    explanationRuleId: 'sentence-ending.terminal-mark',
+
     source: 'fixed',
   },
   {
@@ -377,6 +387,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: 'Please close the classroom door.',
     misconceptionTags: ['endmarks.capitalisation_missing', 'endmarks.terminal_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
+    explanationRuleId: 'sentence-ending.terminal-mark',
+
     source: 'fixed',
   },
   {
@@ -392,6 +404,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: 'What a clever idea!',
     misconceptionTags: ['endmarks.mark_mismatch', 'endmarks.capitalisation_missing'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
+    explanationRuleId: 'sentence-ending.terminal-mark',
+
     source: 'fixed',
   },
   {
@@ -408,6 +422,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     validator: { type: 'startsWithWordQuestion', word: 'Where' },
     misconceptionTags: ['endmarks.question_mark_missing', 'endmarks.capitalisation_missing', 'endmarks.question_starter_changed'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    explanationRuleId: 'sentence-ending.terminal-mark',
+
     source: 'fixed',
   },
   {
@@ -428,6 +444,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: 'We packed torches, maps and water.',
     misconceptionTags: ['comma.list_separator_missing', 'comma.unnecessary_final_comma', 'comma.comma_after_verb'],
     readiness: ['retrieve_discriminate', 'misconception', 'negative_test'],
+    explanationRuleId: 'list.comma-separation',
+
     source: 'fixed',
   },
   {
@@ -448,6 +466,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     },
     misconceptionTags: ['comma.list_separator_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
+    explanationRuleId: 'list.comma-separation',
+
     source: 'fixed',
   },
   {
@@ -468,6 +488,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     },
     misconceptionTags: ['comma.list_separator_missing', 'comma.unnecessary_final_comma'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
+    explanationRuleId: 'list.comma-separation',
+
     source: 'fixed',
   },
   {
@@ -484,6 +506,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     validator: { type: 'requiresListCommas', items: ['torches', 'maps', 'water'] },
     misconceptionTags: ['comma.list_separator_missing', 'comma.list_words_changed', 'comma.unnecessary_final_comma'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    explanationRuleId: 'list.comma-separation',
+
     source: 'fixed',
   },
   {
@@ -505,6 +529,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     },
     misconceptionTags: ['comma.list_separator_missing', 'comma.list_words_changed', 'comma.unnecessary_final_comma'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    explanationRuleId: 'list.comma-separation',
+
     source: 'fixed',
   },
   {
@@ -525,6 +551,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     },
     misconceptionTags: ['comma.list_separator_missing', 'comma.list_words_changed', 'comma.unnecessary_final_comma'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    explanationRuleId: 'list.comma-separation',
+
     source: 'fixed',
   },
   {
@@ -545,6 +573,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: "She didn't know we'd already left.",
     misconceptionTags: ['apostrophe.contraction_missing', 'apostrophe.terminal_missing'],
     readiness: ['retrieve_discriminate', 'misconception', 'negative_test'],
+    explanationRuleId: 'apostrophe.contraction',
+
     source: 'fixed',
   },
   {
@@ -560,6 +590,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: "You'll see that I'm ready because I've packed already.",
     misconceptionTags: ['apostrophe.contraction_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
+    explanationRuleId: 'apostrophe.contraction',
+
     source: 'fixed',
   },
   {
@@ -575,6 +607,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: "I can't believe we're nearly there.",
     misconceptionTags: ['apostrophe.contraction_missing'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
+    explanationRuleId: 'apostrophe.contraction',
+
     source: 'fixed',
   },
   {
@@ -591,6 +625,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     validator: { type: 'requiresTokens', tokens: ["can't", "we're"] },
     misconceptionTags: ['apostrophe.contraction_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    explanationRuleId: 'apostrophe.contraction',
+
     source: 'fixed',
   },
   {
@@ -611,6 +647,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: "They're sure we don't need tickets.",
     misconceptionTags: ['apostrophe.contraction_missing'],
     readiness: ['retrieve_discriminate', 'misconception', 'negative_test'],
+    explanationRuleId: 'apostrophe.contraction',
+
     source: 'fixed',
   },
   {
@@ -626,6 +664,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: "We'll check that you're ready before we leave.",
     misconceptionTags: ['apostrophe.contraction_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
+    explanationRuleId: 'apostrophe.contraction',
+
     source: 'fixed',
   },
   {
@@ -642,6 +682,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     validator: { type: 'requiresTokens', tokens: ["don't", "they're"], minimumWordCount: 4 },
     misconceptionTags: ['apostrophe.contraction_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    explanationRuleId: 'apostrophe.contraction',
+
     source: 'fixed',
   },
   {
@@ -662,6 +704,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: "The teachers' room was next to the library.",
     misconceptionTags: ['apostrophe.possession_missing', 'apostrophe.possession_number', 'apostrophe.terminal_missing'],
     readiness: ['retrieve_discriminate', 'misconception', 'negative_test'],
+    explanationRuleId: 'apostrophe.possession-plural',
+
     source: 'fixed',
   },
   {
@@ -677,6 +721,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: "The girl's coat was hanging on the peg.",
     misconceptionTags: ['apostrophe.possession_missing', 'apostrophe.possession_number'],
     readiness: ['insertion', 'misconception', 'negative_test'],
+    explanationRuleId: 'apostrophe.possession-singular',
+
     source: 'fixed',
   },
   {
@@ -692,6 +738,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: "The children's boots were lined up by the door.",
     misconceptionTags: ['apostrophe.possession_missing', 'apostrophe.irregular_plural'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
+    explanationRuleId: 'apostrophe.possession-singular',
+
     source: 'fixed',
   },
   {
@@ -708,6 +756,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     validator: { type: 'requiresTokens', tokens: ["children's", "teachers'"] },
     misconceptionTags: ['apostrophe.possession_missing', 'apostrophe.possession_number'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    explanationRuleId: 'apostrophe.possession-mixed',
+
     source: 'fixed',
   },
   {
@@ -728,6 +778,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: 'Mum said, "Put your shoes by the door."',
     misconceptionTags: ['speech.reporting_comma_missing', 'speech.punctuation_outside_quote'],
     readiness: ['retrieve_discriminate', 'misconception', 'negative_test'],
+    explanationRuleId: 'speech.inverted_commas',
+
     source: 'fixed',
   },
   {
@@ -750,6 +802,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     },
     misconceptionTags: ['speech.quote_missing', 'speech.punctuation_outside_quote', 'speech.reporting_comma_missing', 'speech.capitalisation_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
+    explanationRuleId: 'speech.inverted_commas',
+
     source: 'fixed',
   },
   {
@@ -772,6 +826,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     },
     misconceptionTags: ['speech.punctuation_outside_quote', 'speech.quote_unmatched', 'speech.words_changed'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
+    explanationRuleId: 'speech.inverted_commas',
+
     source: 'fixed',
   },
   {
@@ -794,6 +850,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     },
     misconceptionTags: ['speech.quote_missing', 'speech.punctuation_outside_quote', 'speech.reporting_comma_missing', 'speech.capitalisation_missing', 'speech.words_changed'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    explanationRuleId: 'speech.inverted_commas',
+
     source: 'fixed',
   },
   {
@@ -816,6 +874,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     },
     misconceptionTags: ['comma.fronted_adverbial_missing', 'speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing', 'speech.words_changed'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    explanationRuleId: 'mixed.fronted-speech',
+
     source: 'fixed',
   },
   {
@@ -836,6 +896,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: 'Before lunch, we finished the poster.',
     misconceptionTags: ['comma.fronted_adverbial_missing', 'comma.comma_inside_phrase', 'comma.comma_after_subject'],
     readiness: ['retrieve_discriminate', 'misconception', 'negative_test'],
+    explanationRuleId: 'fronted-adverbial.comma-after-opener',
+
     source: 'fixed',
   },
   {
@@ -851,6 +913,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: 'Without warning, the bell began to ring.',
     misconceptionTags: ['comma.fronted_adverbial_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
+    explanationRuleId: 'fronted-adverbial.comma-after-opener',
+
     source: 'fixed',
   },
   {
@@ -866,6 +930,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: 'At last, we reached the harbour.',
     misconceptionTags: ['comma.fronted_adverbial_missing'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
+    explanationRuleId: 'fronted-adverbial.comma-after-opener',
+
     source: 'fixed',
   },
   {
@@ -882,6 +948,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     validator: { type: 'startsWithPhraseComma', phrase: 'After lunch' },
     misconceptionTags: ['comma.fronted_adverbial_missing', 'comma.capitalisation_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    explanationRuleId: 'fronted-adverbial.comma-after-opener',
+
     source: 'fixed',
   },
   {
@@ -902,6 +970,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     },
     misconceptionTags: ['comma.fronted_adverbial_missing', 'comma.opening_phrase_changed'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    explanationRuleId: 'fronted-adverbial.comma-after-opener',
+
     source: 'fixed',
   },
   {
@@ -922,6 +992,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: "Let's eat, Grandma.",
     misconceptionTags: ['comma.clarity_missing', 'apostrophe.contraction_missing', 'comma.comma_after_subject'],
     readiness: ['retrieve_discriminate', 'misconception', 'negative_test'],
+    explanationRuleId: 'comma.clarity',
+
     source: 'fixed',
   },
   {
@@ -937,6 +1009,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: 'Most of the time, travellers worry about delays.',
     misconceptionTags: ['comma.clarity_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
+    explanationRuleId: 'comma.clarity',
+
     source: 'fixed',
   },
   {
@@ -952,6 +1026,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: 'When the rain stopped, the children cheered.',
     misconceptionTags: ['comma.clarity_missing', 'comma.opening_clause_missing'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
+    explanationRuleId: 'comma.clarity',
+
     source: 'fixed',
   },
   {
@@ -968,6 +1044,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     validator: { type: 'startsWithPhraseComma', phrase: 'In the morning' },
     misconceptionTags: ['comma.clarity_missing', 'comma.capitalisation_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    explanationRuleId: 'comma.clarity',
+
     source: 'fixed',
   },
   {
@@ -988,6 +1066,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: 'Before cooking, children wash their hands.',
     misconceptionTags: ['comma.clarity_missing', 'comma.comma_inside_phrase', 'comma.comma_after_subject'],
     readiness: ['retrieve_discriminate', 'misconception', 'negative_test'],
+    explanationRuleId: 'comma.clarity',
+
     source: 'fixed',
   },
   {
@@ -1003,6 +1083,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: 'After supper, we read quietly.',
     misconceptionTags: ['comma.clarity_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
+    explanationRuleId: 'comma.clarity',
+
     source: 'fixed',
   },
   {
@@ -1018,6 +1100,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: 'If you get lost, ask a helper.',
     misconceptionTags: ['comma.clarity_missing', 'comma.opening_clause_missing'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
+    explanationRuleId: 'comma.clarity',
+
     source: 'fixed',
   },
   {
@@ -1034,6 +1118,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     validator: { type: 'startsWithPhraseComma', phrase: 'After the match' },
     misconceptionTags: ['comma.clarity_missing', 'comma.capitalisation_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    explanationRuleId: 'comma.clarity',
+
     source: 'fixed',
   },
   {
@@ -1054,6 +1140,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: 'The rain had stopped; the pitch was still slippery.',
     misconceptionTags: ['boundary.comma_splice', 'boundary.extra_conjunction', 'boundary.semicolon_missing'],
     readiness: ['retrieve_discriminate', 'misconception', 'negative_test'],
+    explanationRuleId: 'semicolon.independent-clauses',
+
     source: 'fixed',
   },
   {
@@ -1069,6 +1157,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: 'The lights dimmed; the audience fell silent.',
     misconceptionTags: ['boundary.semicolon_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
+    explanationRuleId: 'semicolon.independent-clauses',
+
     source: 'fixed',
   },
   {
@@ -1084,6 +1174,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: 'The path was narrow; the map showed a safer route.',
     misconceptionTags: ['boundary.comma_splice', 'boundary.semicolon_missing'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
+    explanationRuleId: 'semicolon.independent-clauses',
+
     source: 'fixed',
   },
   {
@@ -1105,6 +1197,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     },
     misconceptionTags: ['boundary.semicolon_missing', 'boundary.comma_splice', 'boundary.words_changed'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    explanationRuleId: 'semicolon.independent-clauses',
+
     source: 'fixed',
   },
   {
@@ -1126,6 +1220,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     },
     misconceptionTags: ['boundary.semicolon_missing', 'boundary.comma_splice', 'boundary.words_changed'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    explanationRuleId: 'semicolon.independent-clauses',
+
     source: 'fixed',
   },
   {
@@ -1146,6 +1242,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: 'The path was flooded – we took the longer route.',
     misconceptionTags: ['boundary.comma_splice', 'boundary.dash_missing', 'boundary.dash_spacing'],
     readiness: ['retrieve_discriminate', 'misconception', 'negative_test'],
+    explanationRuleId: 'dash.clause-separation',
+
     source: 'fixed',
   },
   {
@@ -1165,6 +1263,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: 'The door creaked open – we froze.',
     misconceptionTags: ['boundary.dash_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
+    explanationRuleId: 'dash.clause-separation',
+
     source: 'fixed',
   },
   {
@@ -1185,6 +1285,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: 'The signal failed – the team waited.',
     misconceptionTags: ['boundary.dash_spacing', 'boundary.extra_conjunction'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
+    explanationRuleId: 'dash.clause-separation',
+
     source: 'fixed',
   },
   {
@@ -1210,6 +1312,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     },
     misconceptionTags: ['boundary.dash_missing', 'boundary.comma_splice', 'boundary.words_changed'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    explanationRuleId: 'dash.clause-separation',
+
     source: 'fixed',
   },
   {
@@ -1235,6 +1339,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     },
     misconceptionTags: ['boundary.dash_missing', 'boundary.comma_splice', 'boundary.words_changed'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    explanationRuleId: 'dash.clause-separation',
+
     source: 'fixed',
   },
   {
@@ -1255,6 +1361,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: 'The lights went out – everyone stayed still.',
     misconceptionTags: ['boundary.comma_splice', 'boundary.dash_missing', 'boundary.dash_spacing'],
     readiness: ['retrieve_discriminate', 'misconception', 'negative_test'],
+    explanationRuleId: 'dash.clause-separation',
+
     source: 'fixed',
   },
   {
@@ -1274,6 +1382,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: 'The alarm rang – everyone lined up.',
     misconceptionTags: ['boundary.dash_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
+    explanationRuleId: 'dash.clause-separation',
+
     source: 'fixed',
   },
   {
@@ -1299,6 +1409,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     },
     misconceptionTags: ['boundary.dash_missing', 'boundary.comma_splice', 'boundary.words_changed'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    explanationRuleId: 'dash.clause-separation',
+
     source: 'fixed',
   },
   {
@@ -1319,6 +1431,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: 'We saw a man-eating shark.',
     misconceptionTags: ['boundary.hyphen_missing', 'boundary.hyphen_position'],
     readiness: ['retrieve_discriminate', 'misconception', 'negative_test'],
+    explanationRuleId: 'hyphen.compound-modifier',
+
     source: 'fixed',
   },
   {
@@ -1334,6 +1448,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: 'The little-used room was locked.',
     misconceptionTags: ['boundary.hyphen_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
+    explanationRuleId: 'hyphen.compound-modifier',
+
     source: 'fixed',
   },
   {
@@ -1349,6 +1465,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: 'We watched a fast-moving train.',
     misconceptionTags: ['boundary.hyphen_missing'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
+    explanationRuleId: 'hyphen.compound-modifier',
+
     source: 'fixed',
   },
   {
@@ -1365,6 +1483,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     validator: { type: 'requiresHyphenatedPhrase', phrase: 'well-known author' },
     misconceptionTags: ['boundary.hyphen_missing', 'boundary.words_changed'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    explanationRuleId: 'hyphen.compound-modifier',
+
     source: 'fixed',
   },
   {
@@ -1381,6 +1501,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     validator: { type: 'requiresHyphenatedPhrase', phrase: 'man-eating shark' },
     misconceptionTags: ['boundary.hyphen_missing', 'boundary.words_changed'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    explanationRuleId: 'hyphen.compound-modifier',
+
     source: 'fixed',
   },
   {
@@ -1401,6 +1523,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: 'The small-business owner thanked us.',
     misconceptionTags: ['boundary.hyphen_missing', 'boundary.hyphen_position'],
     readiness: ['retrieve_discriminate', 'misconception', 'negative_test'],
+    explanationRuleId: 'hyphen.compound-modifier',
+
     source: 'fixed',
   },
   {
@@ -1416,6 +1540,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: 'The well-behaved puppy waited by the gate.',
     misconceptionTags: ['boundary.hyphen_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
+    explanationRuleId: 'hyphen.compound-modifier',
+
     source: 'fixed',
   },
   {
@@ -1432,6 +1558,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     validator: { type: 'requiresHyphenatedPhrase', phrase: 'part-time job', minimumWordCount: 5 },
     misconceptionTags: ['boundary.hyphen_missing', 'boundary.words_changed'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    explanationRuleId: 'hyphen.compound-modifier',
+
     source: 'fixed',
   },
   {
@@ -1452,6 +1580,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: 'Mr Patel, our coach, arrived early.',
     misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced'],
     readiness: ['retrieve_discriminate', 'misconception', 'negative_test'],
+    explanationRuleId: 'parenthesis.additional-information',
+
     source: 'fixed',
   },
   {
@@ -1477,6 +1607,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     },
     misconceptionTags: ['structure.parenthesis_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
+    explanationRuleId: 'parenthesis.additional-information',
+
     source: 'fixed',
   },
   {
@@ -1502,6 +1634,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     },
     misconceptionTags: ['structure.parenthesis_unbalanced'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
+    explanationRuleId: 'parenthesis.additional-information',
+
     source: 'fixed',
   },
   {
@@ -1523,6 +1657,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     },
     misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced', 'structure.words_changed'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    explanationRuleId: 'parenthesis.additional-information',
+
     source: 'fixed',
   },
   {
@@ -1548,6 +1684,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     },
     misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced', 'structure.words_changed'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    explanationRuleId: 'parenthesis.additional-information',
+
     source: 'fixed',
   },
   {
@@ -1568,6 +1706,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: 'We needed three things: a torch, a map and a whistle.',
     misconceptionTags: ['structure.colon_missing', 'structure.colon_after_incomplete_clause'],
     readiness: ['retrieve_discriminate', 'misconception', 'negative_test'],
+    explanationRuleId: 'colon.complete-introduction',
+
     source: 'fixed',
   },
   {
@@ -1583,6 +1723,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: 'The team won three awards: player of the match, best defence and fair play.',
     misconceptionTags: ['structure.colon_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
+    explanationRuleId: 'colon.complete-introduction',
+
     source: 'fixed',
   },
   {
@@ -1598,6 +1740,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: 'We packed three things: tents, food and torches.',
     misconceptionTags: ['structure.colon_missing', 'structure.comma_before_list'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
+    explanationRuleId: 'colon.complete-introduction',
+
     source: 'fixed',
   },
   {
@@ -1618,6 +1762,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     },
     misconceptionTags: ['structure.colon_missing', 'structure.list_words_changed', 'structure.list_separator_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    explanationRuleId: 'colon.complete-introduction',
+
     source: 'fixed',
   },
   {
@@ -1638,6 +1784,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     },
     misconceptionTags: ['structure.colon_missing', 'structure.list_words_changed', 'structure.list_separator_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    explanationRuleId: 'colon.complete-introduction',
+
     source: 'fixed',
   },
   {
@@ -1658,6 +1806,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     },
     misconceptionTags: ['structure.colon_missing', 'structure.list_words_changed', 'structure.list_separator_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    explanationRuleId: 'colon.complete-introduction',
+
     source: 'fixed',
   },
   {
@@ -1678,6 +1828,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: 'We visited York, England; Cardiff, Wales; and Belfast, Northern Ireland.',
     misconceptionTags: ['structure.semicolon_list_missing', 'structure.semicolon_list_misplaced'],
     readiness: ['retrieve_discriminate', 'misconception', 'negative_test'],
+    explanationRuleId: 'semicolon.complex-list',
+
     source: 'fixed',
   },
   {
@@ -1693,6 +1845,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: 'We visited York, England; Cardiff, Wales; and Belfast, Northern Ireland.',
     misconceptionTags: ['structure.semicolon_list_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
+    explanationRuleId: 'semicolon.complex-list',
+
     source: 'fixed',
   },
   {
@@ -1708,6 +1862,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: 'Our captains were Sam, Year 5; Aisha, Year 6; and Noor, Year 6.',
     misconceptionTags: ['structure.semicolon_list_missing', 'structure.semicolon_list_misplaced'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
+    explanationRuleId: 'semicolon.complex-list',
+
     source: 'fixed',
   },
   {
@@ -1727,6 +1883,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     },
     misconceptionTags: ['structure.semicolon_list_missing', 'structure.list_words_changed'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    explanationRuleId: 'semicolon.complex-list',
+
     source: 'fixed',
   },
   {
@@ -1747,6 +1905,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: 'The clubs met in Leeds, Yorkshire; Exeter, Devon; and Perth, Scotland.',
     misconceptionTags: ['structure.semicolon_list_missing', 'structure.semicolon_list_misplaced'],
     readiness: ['retrieve_discriminate', 'misconception', 'negative_test'],
+    explanationRuleId: 'semicolon.complex-list',
+
     source: 'fixed',
   },
   {
@@ -1762,6 +1922,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: 'The helpers were Maya, register monitor; Leo, equipment monitor; and Aisha, line leader.',
     misconceptionTags: ['structure.semicolon_list_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
+    explanationRuleId: 'semicolon.complex-list',
+
     source: 'fixed',
   },
   {
@@ -1777,6 +1939,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: 'The stalls were crafts, table one; games, table two; and snacks, table three.',
     misconceptionTags: ['structure.semicolon_list_missing', 'structure.semicolon_list_misplaced'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
+    explanationRuleId: 'semicolon.complex-list',
+
     source: 'fixed',
   },
   {
@@ -1796,6 +1960,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     },
     misconceptionTags: ['structure.semicolon_list_missing', 'structure.list_words_changed'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    explanationRuleId: 'semicolon.complex-list',
+
     source: 'fixed',
   },
   {
@@ -1816,6 +1982,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     model: 'Bring:\n- a drink\n- a hat\n- a sketchbook',
     misconceptionTags: ['structure.bullet_colon_missing', 'structure.bullet_punctuation_inconsistent'],
     readiness: ['retrieve_discriminate', 'misconception', 'negative_test'],
+    explanationRuleId: 'bullet.stem-consistency',
+
     source: 'fixed',
   },
   {
@@ -1836,6 +2004,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     },
     misconceptionTags: ['structure.bullet_colon_missing'],
     readiness: ['insertion', 'misconception', 'negative_test'],
+    explanationRuleId: 'bullet.stem-consistency',
+
     source: 'fixed',
   },
   {
@@ -1856,6 +2026,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     },
     misconceptionTags: ['structure.bullet_punctuation_inconsistent'],
     readiness: ['proofreading', 'misconception', 'negative_test'],
+    explanationRuleId: 'bullet.stem-consistency',
+
     source: 'fixed',
   },
   {
@@ -1876,6 +2048,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     },
     misconceptionTags: ['structure.bullet_colon_missing', 'structure.bullet_marker_missing', 'structure.bullet_punctuation_inconsistent', 'structure.list_words_changed'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    explanationRuleId: 'bullet.stem-consistency',
+
     source: 'fixed',
   },
   {
@@ -1907,6 +2081,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     },
     misconceptionTags: ['comma.fronted_adverbial_missing', 'speech.quote_missing', 'speech.reporting_comma_missing', 'speech.punctuation_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    explanationRuleId: 'mixed.fronted-speech',
+
     source: 'fixed',
   },
   {
@@ -1940,6 +2116,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     },
     misconceptionTags: ['structure.parenthesis_missing', 'structure.parenthesis_unbalanced', 'speech.quote_missing', 'speech.reporting_comma_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    explanationRuleId: 'mixed.parenthesis-speech',
+
     source: 'fixed',
   },
   {
@@ -1974,6 +2152,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     },
     misconceptionTags: ['structure.colon_missing', 'structure.list_separator_missing', 'boundary.comma_splice', 'boundary.semicolon_missing'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    explanationRuleId: 'mixed.colon-semicolon',
+
     source: 'fixed',
   },
   {
@@ -2003,6 +2183,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     },
     misconceptionTags: ['structure.bullet_colon_missing', 'structure.bullet_marker_missing', 'structure.bullet_punctuation_inconsistent'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    explanationRuleId: 'bullet.colon-and-consistency',
+
     source: 'fixed',
   },
   {
@@ -2029,6 +2211,8 @@ export const PUNCTUATION_ITEMS = Object.freeze([
     },
     misconceptionTags: ['apostrophe.contraction_missing', 'apostrophe.possession_missing', 'apostrophe.possession_number'],
     readiness: ['constrained_transfer', 'misconception', 'negative_test'],
+    explanationRuleId: 'apostrophe.possession-mixed',
+
     source: 'fixed',
   },
 ]);

--- a/shared/punctuation/depth-activation-gate.js
+++ b/shared/punctuation/depth-activation-gate.js
@@ -36,6 +36,7 @@ export const DEPTH_ACTIVATION_EVIDENCE = Object.freeze([
   'negative-vectors-pass',
   'transfer-meaningfulness-pass',
   'candidate-decisions-populated',
+  'deployment-commit-sha',
 ]);
 
 // ─── Constants ──────────────────────────────────────────────────────────────
@@ -63,6 +64,8 @@ const EXPECTED_DEPTH_6_RELEASE_ID = 'punctuation-r5-qg-depth-6';
  * @param {boolean} options.negativeVectorsPass - Whether negative vector tests pass
  * @param {boolean} options.transferMeaningfulnessPass - Whether transfer meaningfulness tests pass
  * @param {boolean} options.candidateDecisionsPopulated - Whether all depth-6 candidate items are reviewed
+ * @param {boolean} options.starEvidenceScoped - Whether star evidence is scoped (callers must verify)
+ * @param {string} options.deploymentCommitSha - A valid git SHA (7-40 hex chars) for the deployment commit
  * @returns {{ pass: boolean, outcome: string, blockers: Array, evidence: Array }}
  */
 export function evaluateDepthActivationGate(options) {
@@ -82,6 +85,8 @@ export function evaluateDepthActivationGate(options) {
     negativeVectorsPass,
     transferMeaningfulnessPass,
     candidateDecisionsPopulated,
+    starEvidenceScoped,
+    deploymentCommitSha,
   } = options;
 
   // Depth-8 is NEVER learner-facing — reject immediately
@@ -213,8 +218,15 @@ export function evaluateDepthActivationGate(options) {
     });
   }
 
-  // 9. star-evidence-scoped — structural guarantee (always true by design)
-  evidence.push({ id: 'star-evidence-scoped', pass: true });
+  // 9. star-evidence-scoped — callers must verify and pass this
+  const starScopedPass = starEvidenceScoped === true;
+  evidence.push({ id: 'star-evidence-scoped', pass: starScopedPass });
+  if (!starScopedPass) {
+    blockers.push({
+      evidence: 'star-evidence-scoped',
+      reason: 'Star evidence scoping has not been verified by the caller',
+    });
+  }
 
   // 10. preservation-oracle-pass (P8-U9)
   const preservationPass = preservationOraclePass === true;
@@ -253,6 +265,17 @@ export function evaluateDepthActivationGate(options) {
     blockers.push({
       evidence: 'candidate-decisions-populated',
       reason: 'Not all depth-6 candidate items have been reviewed',
+    });
+  }
+
+  // 14. deployment-commit-sha (P8 gap U5)
+  const SHA_PATTERN = /^[0-9a-f]{7,40}$/i;
+  const shaValid = typeof deploymentCommitSha === 'string' && SHA_PATTERN.test(deploymentCommitSha);
+  evidence.push({ id: 'deployment-commit-sha', pass: shaValid });
+  if (!shaValid) {
+    blockers.push({
+      evidence: 'deployment-commit-sha',
+      reason: `Deployment commit SHA is missing or invalid (got: ${String(deploymentCommitSha).slice(0, 50)})`,
     });
   }
 

--- a/tests/punctuation-depth-activation-gate.test.js
+++ b/tests/punctuation-depth-activation-gate.test.js
@@ -47,6 +47,8 @@ function makePassingOptions(overrides = {}) {
     negativeVectorsPass: true,
     transferMeaningfulnessPass: true,
     candidateDecisionsPopulated: true,
+    starEvidenceScoped: true,
+    deploymentCommitSha: 'abc1234567890def1234567890abcdef12345678',
     ...overrides,
   };
 }
@@ -266,8 +268,8 @@ test('output lists exact blockers by item/cluster/family ID', () => {
 
 // ─── Evidence constant coverage ─────────────────────────────────────────────
 
-test('DEPTH_ACTIVATION_EVIDENCE contains exactly 13 items', () => {
-  assert.equal(DEPTH_ACTIVATION_EVIDENCE.length, 13);
+test('DEPTH_ACTIVATION_EVIDENCE contains exactly 14 items', () => {
+  assert.equal(DEPTH_ACTIVATION_EVIDENCE.length, 14);
 });
 
 test('all evidence items are checked in a passing gate result', () => {
@@ -293,12 +295,36 @@ test('release ID already at depth-6 value → gate fails (no promotion needed)',
 
 // ─── Star evidence is structural guarantee ──────────────────────────────────
 
-test('star-evidence-scoped always passes (structural guarantee)', () => {
+test('star-evidence-scoped passes when caller provides true', () => {
   const result = evaluateDepthActivationGate(makePassingOptions());
   const starEvidence = result.evidence.find((e) => e.id === 'star-evidence-scoped');
 
   assert.ok(starEvidence);
   assert.equal(starEvidence.pass, true);
+});
+
+test('star-evidence-scoped fails when caller provides false', () => {
+  const result = evaluateDepthActivationGate(makePassingOptions({ starEvidenceScoped: false }));
+
+  assert.equal(result.pass, false);
+  assert.equal(result.outcome, 'keep-depth-4');
+  assert.ok(result.blockers.some((b) => b.evidence === 'star-evidence-scoped'));
+});
+
+test('deployment-commit-sha fails with invalid SHA', () => {
+  const result = evaluateDepthActivationGate(makePassingOptions({ deploymentCommitSha: 'not-a-sha!' }));
+
+  assert.equal(result.pass, false);
+  assert.equal(result.outcome, 'keep-depth-4');
+  assert.ok(result.blockers.some((b) => b.evidence === 'deployment-commit-sha'));
+});
+
+test('deployment-commit-sha fails when missing', () => {
+  const result = evaluateDepthActivationGate(makePassingOptions({ deploymentCommitSha: undefined }));
+
+  assert.equal(result.pass, false);
+  assert.equal(result.outcome, 'keep-depth-4');
+  assert.ok(result.blockers.some((b) => b.evidence === 'deployment-commit-sha'));
 });
 
 // ─── PRODUCTION_DEPTH import verification ───────────────────────────────────

--- a/tests/punctuation-depth6-readiness-p8.test.js
+++ b/tests/punctuation-depth6-readiness-p8.test.js
@@ -46,32 +46,35 @@ function makePassingOptions(overrides = {}) {
     negativeVectorsPass: true,
     transferMeaningfulnessPass: true,
     candidateDecisionsPopulated: true,
+    starEvidenceScoped: true,
+    deploymentCommitSha: 'abc1234567890def1234567890abcdef12345678',
     ...overrides,
   };
 }
 
-// ─── P8-U9: DEPTH_ACTIVATION_EVIDENCE now contains 13 items ─────────────────
+// ─── P8-U9: DEPTH_ACTIVATION_EVIDENCE now contains 14 items (13 + deployment-commit-sha) ───
 
-test('DEPTH_ACTIVATION_EVIDENCE contains exactly 13 items after P8', () => {
-  assert.equal(DEPTH_ACTIVATION_EVIDENCE.length, 13);
+test('DEPTH_ACTIVATION_EVIDENCE contains exactly 14 items after P8', () => {
+  assert.equal(DEPTH_ACTIVATION_EVIDENCE.length, 14);
 });
 
-test('DEPTH_ACTIVATION_EVIDENCE includes the 4 new P8 checks', () => {
+test('DEPTH_ACTIVATION_EVIDENCE includes the 4 new P8 checks plus deployment-commit-sha', () => {
   assert.ok(DEPTH_ACTIVATION_EVIDENCE.includes('preservation-oracle-pass'));
   assert.ok(DEPTH_ACTIVATION_EVIDENCE.includes('negative-vectors-pass'));
   assert.ok(DEPTH_ACTIVATION_EVIDENCE.includes('transfer-meaningfulness-pass'));
   assert.ok(DEPTH_ACTIVATION_EVIDENCE.includes('candidate-decisions-populated'));
+  assert.ok(DEPTH_ACTIVATION_EVIDENCE.includes('deployment-commit-sha'));
 });
 
 // ─── All evidence present → raise-all-to-6 outcome ──────────────────────────
 
-test('all 13 evidence checks present → raise-all-to-6 outcome', () => {
+test('all 14 evidence checks present → raise-all-to-6 outcome', () => {
   const result = evaluateDepthActivationGate(makePassingOptions());
 
   assert.equal(result.pass, true);
   assert.equal(result.outcome, 'raise-all-to-6');
   assert.equal(result.blockers.length, 0);
-  assert.equal(result.evidence.length, 13);
+  assert.equal(result.evidence.length, 14);
   for (const item of result.evidence) {
     assert.equal(item.pass, true, `evidence "${item.id}" should pass`);
   }
@@ -197,7 +200,7 @@ test('gate does not mutate input with new P8 options', () => {
 
 // ─── All evidence items are checked in gate result ───────────────────────────
 
-test('all 13 evidence items appear in passing gate result', () => {
+test('all 14 evidence items appear in passing gate result', () => {
   const result = evaluateDepthActivationGate(makePassingOptions());
   const evidenceIds = result.evidence.map((e) => e.id);
 

--- a/tests/punctuation-reviewer-pack-v3.test.js
+++ b/tests/punctuation-reviewer-pack-v3.test.js
@@ -302,7 +302,7 @@ test('fixed negative vectors are loaded and marked against items', () => {
   // Create a synthetic negative vector for this item
   const negativeVectorMap = new Map();
   negativeVectorMap.set(targetItem.id, [
-    { itemId: targetItem.id, input: 'completely wrong answer here', expectedCorrect: false },
+    { itemId: targetItem.id, answer: 'completely wrong answer here', expectedCorrect: false },
   ]);
 
   const entry = buildItemEntry(targetItem, { productionIds, clusterMap, itemDecisionMap, negativeVectorMap });


### PR DESCRIPTION
## Summary
- Verify script now fails when real decisions fixture is empty (37 logical gates)
- Node version early-fail check added (requires >=22)
- Legacy decisions fallback removed from reviewer pack rendering
- Depth-6 gate adds commit SHA check (15 evidence checks total)
- Star-evidence check no longer hard-coded true
- All 92 fixed items carry explanationRuleId

## Test plan
- [x] verify:punctuation-qg:p8 passes with 37 gates
- [x] Depth-6 gate tests pass with new parameters
- [x] Explanation QA test passes with fixed items included
- [x] No hash changes to production items