### PR TITLE
fix(test): align reviewer-pack-v3 fixture with PR #694 field rename

### DIFF
--- a/tests/punctuation-reviewer-pack-v3.test.js
+++ b/tests/punctuation-reviewer-pack-v3.test.js
@@ -299,10 +299,13 @@ test('fixed negative vectors are loaded and marked against items', () => {
   const targetItem = pool.find((i) => i.mode === 'insert' || i.mode === 'fix');
   assert.ok(targetItem, 'Need at least one insert/fix item');
 
-  // Create a synthetic negative vector for this item
+  // Create a synthetic negative vector for this item.
+  // The fixture field name is `answer` (matched in PR #694 — the
+  // negative-vector field-name bug fix). `buildItemEntry` reads
+  // `vec.answer` and surfaces it on `entry.fixedNegativeVectors[].input`.
   const negativeVectorMap = new Map();
   negativeVectorMap.set(targetItem.id, [
-    { itemId: targetItem.id, input: 'completely wrong answer here', expectedCorrect: false },
+    { itemId: targetItem.id, answer: 'completely wrong answer here', expectedCorrect: false },
   ]);
 
   const entry = buildItemEntry(targetItem, { productionIds, clusterMap, itemDecisionMap, negativeVectorMap });


### PR DESCRIPTION
## Summary

PR [#694](https://github.com/fol2/ks2-mastery/pull/694) renamed the negative-vector source field from `input` to `answer` in `scripts/review-punctuation-questions.mjs` (lines 291 + 298). `buildItemEntry` now reads `vec.answer` and surfaces it on `entry.fixedNegativeVectors[].input`.

The companion fixture in `tests/punctuation-reviewer-pack-v3.test.js:305` still set the old `input` key, so `vec.answer` resolved to undefined and the test `fixed negative vectors are loaded and marked against items` failed with `expected 'completely wrong answer here', actual undefined`. PR #694 updated `tests/punctuation-negative-vectors.test.js` but missed this sibling.

This is a one-line test fixture rename: `input:` → `answer:`. Behaviour, contract, and assertions are unchanged.

## Verification

- Before: `node --test tests/punctuation-reviewer-pack-v3.test.js` → 22 pass / **1 fail** (`fixed negative vectors are loaded and marked against items`)
- After: `node --test tests/punctuation-reviewer-pack-v3.test.js` → **23 pass / 0 fail**

## Blast radius

- 1 file touched: `tests/punctuation-reviewer-pack-v3.test.js`
- No production source change → no bundle / audit / build impact
- Unblocks every PR currently red on `npm test + npm run check` due to this single failure (e.g. PR #693 U6)

## Test plan

- [x] Targeted test passes locally on Node 22
- [x] No production source change
- [x] Fixture rename matches the script's `vec.answer` read path

🤖 Generated with [Claude Code](https://claude.com/claude-code)