### PR TITLE
fix(grammar-qg): P10 remediation U8+U9 — final cleanup

### DIFF
--- a/docs/plans/james/grammar/questions-generator/grammar-qg-p10-final-completion-report-2026-04-29.md
+++ b/docs/plans/james/grammar/questions-generator/grammar-qg-p10-final-completion-report-2026-04-29.md
@@ -10,10 +10,17 @@ implementation_prs:
   - "#668"
   - "#669"
   - "#675"
+  - "#687"
+  - "#688"
+  - "#689"
+  - "#690"
+  - "#691"
+  - "#692"
+  - "#698"
 final_content_release_commit: "a28d4962"
 post_merge_fix_commits:
   - "665 (U2 target-sentence dedup hotfix)"
-final_report_commit: "pending-this-commit"
+final_report_commit: "01f6bb98"
 baseline_content_release_id: grammar-qg-p9-2026-04-29
 final_content_release_id: grammar-qg-p10-2026-04-29
 content_release_id_changed: "true"
@@ -29,7 +36,7 @@ post_deploy_smoke_evidence: not-run
 
 ## Executive Summary
 
-P10 returns the Grammar Question Generator to first principles: every question a child sees must be logically correct, visually unambiguous, correctly marked, accessible, and backed by reproducible evidence. Where P9 built certification infrastructure, P10 locks the actual question pool to production quality.
+P10 returns the Grammar Question Generator to first principles: every question a child sees must be logically correct, visually unambiguous, correctly marked, accessible, and backed by reproducible evidence. Where P9 built certification infrastructure, P10 locks the actual question pool to production quality. A seven-PR remediation pass (PRs #687–#692, #698) closed minor test coverage gaps, added inventory cross-check validation, and resolved all evidence-truth placeholders.
 
 **Key numbers:**
 - 6 PRs across 11 implementation units (U0–U9, U11)

--- a/scripts/validate-grammar-qg-certification-evidence.mjs
+++ b/scripts/validate-grammar-qg-certification-evidence.mjs
@@ -450,6 +450,73 @@ export function validateSmokeEvidence(manifest, reportContent, opts = {}) {
 }
 
 // ---------------------------------------------------------------------------
+// Cross-check: render inventory release ID consistency (P10-R-U9)
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate that a render inventory JSON file has a consistent contentReleaseId
+ * in both its metadata and sampled items.
+ *
+ * @param {string} inventoryPath - Path to the render inventory JSON file.
+ * @param {string} expectedReleaseId - The expected content release ID.
+ * @returns {{ pass: boolean, mismatches: Array<{ field: string, claimed: any, actual: any, message: string }> }}
+ */
+export function validateInventoryReleaseIds(inventoryPath, expectedReleaseId) {
+  const mismatches = [];
+
+  if (!existsSync(inventoryPath)) {
+    mismatches.push({
+      field: 'inventoryFile',
+      claimed: inventoryPath,
+      actual: 'not found',
+      message: `Inventory file not found: ${inventoryPath}`,
+    });
+    return { pass: false, mismatches };
+  }
+
+  let inventory;
+  try {
+    inventory = JSON.parse(readFileSync(inventoryPath, 'utf8'));
+  } catch (err) {
+    mismatches.push({
+      field: 'inventoryParse',
+      claimed: 'valid JSON',
+      actual: `parse error: ${err.message}`,
+      message: `Inventory file is not valid JSON: ${err.message}`,
+    });
+    return { pass: false, mismatches };
+  }
+
+  // Check metadata.contentReleaseId
+  const metadataReleaseId = inventory?.metadata?.contentReleaseId;
+  if (metadataReleaseId !== expectedReleaseId) {
+    mismatches.push({
+      field: 'inventoryMetadataReleaseId',
+      claimed: metadataReleaseId,
+      actual: expectedReleaseId,
+      message: `Inventory metadata.contentReleaseId "${metadataReleaseId}" does not match expected "${expectedReleaseId}"`,
+    });
+  }
+
+  // Sample first 10 items and check their contentReleaseId
+  const items = Array.isArray(inventory?.items) ? inventory.items : [];
+  const sampleSize = Math.min(10, items.length);
+  for (let i = 0; i < sampleSize; i++) {
+    const item = items[i];
+    if (item?.contentReleaseId !== expectedReleaseId) {
+      mismatches.push({
+        field: `inventoryItem[${i}].contentReleaseId`,
+        claimed: item?.contentReleaseId,
+        actual: expectedReleaseId,
+        message: `Inventory item[${i}] contentReleaseId "${item?.contentReleaseId}" does not match expected "${expectedReleaseId}"`,
+      });
+    }
+  }
+
+  return { pass: mismatches.length === 0, mismatches };
+}
+
+// ---------------------------------------------------------------------------
 // Cross-check: manifest ↔ code ↔ report release ID consistency (P10-U0)
 // ---------------------------------------------------------------------------
 
@@ -520,6 +587,25 @@ async function main(argv) {
   }
 
   console.log(`PASS: Manifest schema valid (${Object.keys(manifestResult.manifest.seedWindowPerEvidenceType).length} oracle families)`);
+
+  // Gate 1b: Validate render inventory release IDs if inventory exists
+  const releaseId = manifestResult.manifest.contentReleaseId;
+  const inventoryPath = path.join(ROOT_DIR, 'reports', 'grammar', `grammar-qg-p10-render-inventory.json`);
+  if (existsSync(inventoryPath)) {
+    const invResult = validateInventoryReleaseIds(inventoryPath, releaseId);
+    if (!invResult.pass) {
+      if (jsonOutput) {
+        console.log(JSON.stringify({ pass: false, gate: 'inventory-release-ids', mismatches: invResult.mismatches }, null, 2));
+      } else {
+        console.log(`FAIL: Inventory release ID cross-check — ${invResult.mismatches.length} mismatch(es)\n`);
+        for (const m of invResult.mismatches) {
+          console.log(`  [${m.field}] ${m.message}`);
+        }
+      }
+      process.exit(1);
+    }
+    console.log(`PASS: Inventory release IDs consistent with manifest (${releaseId})`);
+  }
 
   // Gate 2: Cross-validate report if provided
   if (reportPath) {

--- a/tests/grammar-qg-p10-evidence-truth.test.js
+++ b/tests/grammar-qg-p10-evidence-truth.test.js
@@ -8,6 +8,7 @@ import { GRAMMAR_CONTENT_RELEASE_ID } from '../worker/src/subjects/grammar/conte
 import {
   validateReleaseIdConsistency,
   validateEvidenceManifest,
+  validateInventoryReleaseIds,
 } from '../scripts/validate-grammar-qg-certification-evidence.mjs';
 import {
   validateReleaseFrontmatter,
@@ -294,5 +295,29 @@ describe('P10 Evidence Truth: report-vs-manifest release ID', () => {
     const manifest = { contentReleaseId: GRAMMAR_CONTENT_RELEASE_ID };
     const result = validateReleaseIdConsistency(manifest, GRAMMAR_CONTENT_RELEASE_ID);
     assert.equal(result.pass, true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. Inventory release ID cross-check (P10-R-U9)
+// ---------------------------------------------------------------------------
+
+describe('P10 Evidence Truth: inventory release ID cross-check', () => {
+  const inventoryPath = path.join(REPORTS_DIR, 'grammar-qg-p10-render-inventory.json');
+
+  it('inventory metadata release ID matches code constant', () => {
+    assert.ok(fs.existsSync(inventoryPath), 'Render inventory must exist');
+    const result = validateInventoryReleaseIds(inventoryPath, GRAMMAR_CONTENT_RELEASE_ID);
+    const metadataMismatch = result.mismatches.find((m) => m.field === 'inventoryMetadataReleaseId');
+    assert.equal(metadataMismatch, undefined,
+      `Inventory metadata.contentReleaseId must match ${GRAMMAR_CONTENT_RELEASE_ID}`);
+  });
+
+  it('inventory items release IDs match code constant', () => {
+    assert.ok(fs.existsSync(inventoryPath), 'Render inventory must exist');
+    const result = validateInventoryReleaseIds(inventoryPath, GRAMMAR_CONTENT_RELEASE_ID);
+    const itemMismatches = result.mismatches.filter((m) => m.field.startsWith('inventoryItem['));
+    assert.equal(itemMismatches.length, 0,
+      `All sampled inventory items must have contentReleaseId === ${GRAMMAR_CONTENT_RELEASE_ID}`);
   });
 });

--- a/tests/grammar-qg-p10-read-aloud-alignment.test.js
+++ b/tests/grammar-qg-p10-read-aloud-alignment.test.js
@@ -4,6 +4,10 @@ import assert from 'node:assert/strict';
 import {
   buildGrammarSpeechText,
 } from '../src/subjects/grammar/speech.js';
+import {
+  createGrammarQuestion,
+  serialiseGrammarQuestion,
+} from '../worker/src/subjects/grammar/content.js';
 
 // --- Helpers ---
 
@@ -183,4 +187,55 @@ test('table_choice row-specific options with readAloudText still announces per-r
   assert.match(text, /Classify the underlined words/);
   assert.match(text, /Row cat: Noun, Verb/);
   assert.match(text, /Row run: Noun, Verb/);
+});
+
+// --- U8: mini-test mode uses readAloudText ---
+
+test('mini-test mode uses readAloudText from current question item', () => {
+  const grammarObj = {
+    session: {
+      type: 'mini-set',
+      miniTest: {
+        questions: [{
+          current: true,
+          item: {
+            readAloudText: 'The underlined word is: cat.',
+            promptText: 'fallback',
+            inputSpec: {
+              type: 'single_choice',
+              options: [['a', 'Noun'], ['b', 'Verb']],
+            },
+          },
+        }],
+        currentIndex: 0,
+      },
+    },
+    feedback: null,
+  };
+
+  const text = buildGrammarSpeechText(grammarObj);
+
+  assert.match(text, /underlined word is: cat/);
+  // Should NOT use the fallback promptText
+  assert.doesNotMatch(text, /fallback/);
+});
+
+// --- U8: qg_p4_voice_roles_transfer generates readAloudText with focusCue ---
+
+test('qg_p4_voice_roles_transfer generates speech text including focusCue.text', () => {
+  const question = createGrammarQuestion({ templateId: 'qg_p4_voice_roles_transfer', seed: 1 });
+  assert.ok(question, 'qg_p4_voice_roles_transfer must generate a question at seed 1');
+
+  const serialised = serialiseGrammarQuestion(question);
+  assert.ok(serialised, 'serialiseGrammarQuestion must return a serialised object');
+  assert.ok(serialised.focusCue, 'qg_p4_voice_roles_transfer must produce a focusCue');
+  assert.ok(serialised.focusCue.text, 'focusCue must have a text field');
+
+  // Build a speech grammar object from the serialised question
+  const grammarObj = wrapSession(serialised);
+  const text = buildGrammarSpeechText(grammarObj);
+
+  assert.ok(text.length > 0, 'speech text must not be empty');
+  assert.match(text, new RegExp(serialised.focusCue.text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')),
+    `speech text must include focusCue.text "${serialised.focusCue.text}"`);
 });


### PR DESCRIPTION
## Summary
- **U8:** Add two test coverage gaps to `tests/grammar-qg-p10-read-aloud-alignment.test.js` — mini-test mode readAloudText and `qg_p4_voice_roles_transfer` focusCue speech integration.
- **U9:** Replace `pending-this-commit` placeholder with `01f6bb98`, add 7 remediation PRs (#687–#692, #698) to the completion report, add `validateInventoryReleaseIds()` to the certification evidence validator, and add inventory release ID cross-check tests.

This is the FINAL PR of the P10 remediation sprint.

## Test plan
- [x] `node --test tests/grammar-qg-p10-read-aloud-alignment.test.js` — 9/9 pass
- [x] `node --test tests/grammar-qg-p10-evidence-truth.test.js` — 24/24 pass
- [x] Inventory cross-check validates metadata and first 10 items match code constant