### PR TITLE
docs(hero): record internal cohort enablement evidence

### DIFF
--- a/docs/plans/james/hero-mode/A/hero-pA2-internal-cohort-evidence.md
+++ b/docs/plans/james/hero-mode/A/hero-pA2-internal-cohort-evidence.md
@@ -2,12 +2,12 @@
 
 **Phase:** A2 Ring A2-2 + A2-3
 **Date:** 2026-04-30
-**Status:** AWAITING COHORT
+**Status:** ACTIVE
 
 ## Cohort Configuration
 
-- Internal accounts: [to be listed at enablement time]
-- Observation start: [date]
+- Internal accounts: `adult-d9BHpWh3iAL4b5qB`, `adult-2dT1zFI9zZQ_p1Zs`, `adult-9jXhUwpAdIrKB_g5`, `adult-U55c3y_goAFsgkIH`
+- Observation start: 2026-04-30
 - Minimum duration: 5 calendar days
 - Minimum date keys: 2
 
@@ -15,6 +15,7 @@
 
 | Date | Learner | Readiness | Balance Bucket | Ledger Entries | Reconciliation | Override | Status |
 |------|---------|-----------|----------------|----------------|----------------|----------|--------|
+| 2026-04-30 | learner-mog9aal4-p1f8xbmp | ready | 0 | 0 | no-gap | override-active | OK |
 
 ## Stop Conditions
 


### PR DESCRIPTION
## Summary
- Records the production internal cohort selected for Hero Mode A2-2.
- Marks the cohort evidence document as active and adds the first production observation.
- Closes #683.

## Production evidence
- `HERO_INTERNAL_ACCOUNTS` was set in production with the internal cohort.
- Production deploy completed with Worker version `babb5b24-cc14-4a1d-855e-1264c4bef848`.
- Internal account `adult-d9BHpWh3iAL4b5qB` / learner `learner-mog9aal4-p1f8xbmp` returned Hero read-model `200`, `heroVersion: 6`, `childVisible: true`, `hasDebug: false`.
- Admin telemetry probe returned `readiness: ready`, `balanceBucket: 0`, `ledgerEntryCount: 0`, `reconciliationHasGap: false`, `isInternalAccount: true`.
- A non-listed demo account still received `hero_shadow_disabled`, confirming the override stays hidden from non-cohort accounts.

## Verification
- `node scripts/validate-hero-pA2-certification-evidence.mjs` -> `CERTIFIED_WITH_LIMITATIONS`; A2-2 PASS. A2-3/A2-4 remain limited by the required multi-day observation window and later A3 recommendation artefacts.
- `npm test` -> 14134 pass, 0 fail, 6 skipped.
- `npm run check` -> dry-run build/audit passed; main bundle 227056 / 227500 bytes gzip.