### PR TITLE
fix(grammar-qg-p10): close final 4 audit gaps

### DIFF
--- a/scripts/validate-grammar-qg-certification-evidence.mjs
+++ b/scripts/validate-grammar-qg-certification-evidence.mjs
@@ -498,10 +498,9 @@ export function validateInventoryReleaseIds(inventoryPath, expectedReleaseId) {
     });
   }
 
-  // Sample first 10 items and check their contentReleaseId
+  // Check ALL items for contentReleaseId consistency (no sampling — full sweep)
   const items = Array.isArray(inventory?.items) ? inventory.items : [];
-  const sampleSize = Math.min(10, items.length);
-  for (let i = 0; i < sampleSize; i++) {
+  for (let i = 0; i < items.length; i++) {
     const item = items[i];
     if (item?.contentReleaseId !== expectedReleaseId) {
       mismatches.push({

--- a/tests/grammar-qg-p10-evidence-truth.test.js
+++ b/tests/grammar-qg-p10-evidence-truth.test.js
@@ -318,6 +318,6 @@ describe('P10 Evidence Truth: inventory release ID cross-check', () => {
     const result = validateInventoryReleaseIds(inventoryPath, GRAMMAR_CONTENT_RELEASE_ID);
     const itemMismatches = result.mismatches.filter((m) => m.field.startsWith('inventoryItem['));
     assert.equal(itemMismatches.length, 0,
-      `All sampled inventory items must have contentReleaseId === ${GRAMMAR_CONTENT_RELEASE_ID}`);
+      `All inventory items must have contentReleaseId === ${GRAMMAR_CONTENT_RELEASE_ID}`);
   });
 });

--- a/tests/grammar-qg-p10-mobile-table.test.js
+++ b/tests/grammar-qg-p10-mobile-table.test.js
@@ -1,0 +1,114 @@
+/**
+ * Grammar QG P10 U9 — Mobile-Width Table Rendering Test
+ *
+ * Validates that table_choice templates render safely at mobile viewport widths
+ * (375px, iPhone SE). Since the project does not have a full Playwright browser
+ * harness for grammar sessions, this uses jsdom to verify:
+ *
+ * 1. The `.grammar-table-wrap` wrapper class is present (which carries
+ *    `overflow-x: auto` in styles/app.css, enabling horizontal scroll)
+ * 2. No inline `style` attribute on any table element sets a `min-width`
+ *    exceeding 390px (which would force clipping on a 375px viewport)
+ *
+ * Every test asserts >0 generated items (empty-fails invariant).
+ */
+import { describe, it, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+
+import {
+  createGrammarQuestion,
+  serialiseGrammarQuestion,
+} from '../worker/src/subjects/grammar/content.js';
+
+import {
+  renderGrammarItem,
+  cleanupGrammarRenderHarness,
+} from './helpers/grammar-render-harness.js';
+
+const SEED_COUNT = 15;
+const MOBILE_MAX_WIDTH_PX = 390;
+
+after(() => {
+  cleanupGrammarRenderHarness();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function parseHtml(html) {
+  const dom = new JSDOM(html);
+  return dom.window.document;
+}
+
+/**
+ * Extract all inline min-width values (in px) from a DOM tree.
+ * Returns an array of { element, value } where value is the numeric px amount.
+ */
+function extractInlineMinWidths(doc) {
+  const results = [];
+  const allElements = doc.querySelectorAll('[style]');
+  for (const el of allElements) {
+    const style = el.getAttribute('style') || '';
+    const match = style.match(/min-width\s*:\s*(\d+(?:\.\d+)?)\s*px/i);
+    if (match) {
+      results.push({ element: el.tagName.toLowerCase(), value: parseFloat(match[1]) });
+    }
+  }
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Table templates to verify at mobile width
+// ---------------------------------------------------------------------------
+
+const TABLE_TEMPLATES = [
+  'qg_p4_voice_roles_transfer',
+  'sentence_type_table',
+];
+
+for (const templateId of TABLE_TEMPLATES) {
+  describe(`P10 Mobile Table — ${templateId}`, () => {
+    const items = [];
+
+    for (let seed = 1; seed <= SEED_COUNT; seed++) {
+      const q = createGrammarQuestion({ templateId, seed });
+      if (q && q.inputSpec?.type === 'table_choice') {
+        items.push({ seed, question: q, serialised: serialiseGrammarQuestion(q) });
+      }
+    }
+
+    it('generates >0 table_choice items (empty-fails invariant)', () => {
+      assert.ok(
+        items.length > 0,
+        `Expected >0 table_choice items for "${templateId}" but got ${items.length}`,
+      );
+    });
+
+    for (const { seed, serialised } of items) {
+      it(`seed=${seed}: rendered HTML includes .grammar-table-wrap class`, () => {
+        const html = renderGrammarItem(serialised);
+        const doc = parseHtml(html);
+        const wrapper = doc.querySelector('.grammar-table-wrap');
+        assert.ok(
+          wrapper,
+          `Expected .grammar-table-wrap element in rendered output for "${templateId}" seed=${seed}`,
+        );
+      });
+
+      it(`seed=${seed}: no inline min-width exceeds ${MOBILE_MAX_WIDTH_PX}px`, () => {
+        const html = renderGrammarItem(serialised);
+        const doc = parseHtml(html);
+        const minWidths = extractInlineMinWidths(doc);
+        const oversized = minWidths.filter((mw) => mw.value > MOBILE_MAX_WIDTH_PX);
+        assert.equal(
+          oversized.length,
+          0,
+          `Found ${oversized.length} element(s) with inline min-width > ${MOBILE_MAX_WIDTH_PX}px: ` +
+          oversized.map((o) => `<${o.element}> min-width:${o.value}px`).join(', '),
+        );
+      });
+    }
+  });
+}

--- a/tests/grammar-qg-p10-render-surface.test.js
+++ b/tests/grammar-qg-p10-render-surface.test.js
@@ -128,6 +128,51 @@ describe('P10 Render Surface — qg_p4_voice_roles_transfer DOM', () => {
 });
 
 // ---------------------------------------------------------------------------
+// 2b. qg_p4_word_class_noun_phrase_transfer: underline on 1-3 word target
+// ---------------------------------------------------------------------------
+
+describe('P10 Render Surface — qg_p4_word_class_noun_phrase_transfer DOM', () => {
+  const TEMPLATE_ID = 'qg_p4_word_class_noun_phrase_transfer';
+  const items = generateForTemplate(TEMPLATE_ID, 5).filter(
+    ({ serialised }) =>
+      serialised.promptParts && serialised.promptParts.some((p) => p.kind === 'underline'),
+  );
+
+  it('generates >0 items with underline promptParts (empty-fails invariant)', () => {
+    assert.ok(
+      items.length > 0,
+      `Expected >0 items with underline promptParts for "${TEMPLATE_ID}" but got ${items.length}`,
+    );
+  });
+
+  for (const { seed, serialised } of items) {
+    it(`seed=${seed}: HTML contains a .prompt-underline element`, () => {
+      const html = renderGrammarItem(serialised);
+      const doc = parseHtml(html);
+      const underlines = doc.querySelectorAll('.prompt-underline');
+      assert.ok(
+        underlines.length >= 1,
+        `Expected at least one .prompt-underline element but found ${underlines.length}`,
+      );
+    });
+
+    it(`seed=${seed}: underlined text is 1-3 words (target word within noun phrase)`, () => {
+      const html = renderGrammarItem(serialised);
+      const doc = parseHtml(html);
+      const underline = doc.querySelector('.prompt-underline');
+      assert.ok(underline, 'Must have .prompt-underline element in rendered HTML');
+      const text = underline.textContent.trim();
+      assert.ok(text.length > 0, 'Underline text must be non-empty');
+      const wordCount = text.split(/\s+/).length;
+      assert.ok(
+        wordCount >= 1 && wordCount <= 3,
+        `Underlined text "${text}" should be 1-3 words, got ${wordCount}`,
+      );
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
 // 3. Homogeneous table: all <tr> rows have the same radio input count
 // ---------------------------------------------------------------------------
 

--- a/worker/src/subjects/grammar/content.js
+++ b/worker/src/subjects/grammar/content.js
@@ -7727,15 +7727,16 @@ function enrichPromptCue(question) {
   }
   const targetSentence = boldSentence || null;
 
-  // Build focusCue
+  // Build focusCue (targetOccurrence: 1 disambiguates which occurrence is the
+  // target when the cue text appears multiple times in the sentence)
   if (cueType === 'underline' && targetWord) {
-    question.focusCue = { type: 'underline', text: targetWord };
+    question.focusCue = { type: 'underline', text: targetWord, targetOccurrence: 1 };
   } else if (cueType === 'bold' && boldSentence) {
-    question.focusCue = { type: 'bold', text: boldSentence };
+    question.focusCue = { type: 'bold', text: boldSentence, targetOccurrence: 1 };
   } else if (cueType === 'quoted-word' && targetWord) {
-    question.focusCue = { type: 'quoted-word', text: targetWord };
+    question.focusCue = { type: 'quoted-word', text: targetWord, targetOccurrence: 1 };
   } else if (cueType === 'target-sentence' && targetSentence) {
-    question.focusCue = { type: 'target-sentence', text: targetSentence };
+    question.focusCue = { type: 'target-sentence', text: targetSentence, targetOccurrence: 1 };
   }
 
   // P10 U2: Cue consistency enforcement — if cueType is 'underline' but we


### PR DESCRIPTION
## Summary

- **U0**: Inventory cross-check now validates ALL 2,340 items instead of sampling only the first 10
- **U2**: Added `targetOccurrence: 1` to every `focusCue` object to disambiguate which occurrence is the target when cue text appears multiple times in a sentence
- **U9**: Added `qg_p4_word_class_noun_phrase_transfer` DOM render test asserting `.prompt-underline` exists with 1-3 word content
- **U9**: Added mobile-width table rendering test verifying `.grammar-table-wrap` class is present and no inline `min-width` exceeds 390px (safe at 375px iPhone SE viewport)

## Test plan

- [x] `grammar-qg-p10-evidence-truth.test.js` — 24/24 pass (inventory cross-check uses full sweep)
- [x] `grammar-qg-p10-render-surface.test.js` — 128/128 pass (new noun-phrase-transfer section included)
- [x] `grammar-qg-p10-mobile-table.test.js` — 62/62 pass (new file)
- [x] `grammar-qg-p10-prompt-cue-contract.test.js` — 118/118 pass (targetOccurrence compatible)
- [x] `grammar-qg-p10-table-render.test.js` — 163/163 pass
- [x] `grammar-engine.test.js` — 48/48 pass
- [x] `grammar-qg-p9-table-choice-contract.test.js` — 425/425 pass