### PR TITLE
fix(grammar-qg): report frontmatter release ID cross-check in validateReleaseIdConsistency

### DIFF
--- a/scripts/validate-grammar-qg-certification-evidence.mjs
+++ b/scripts/validate-grammar-qg-certification-evidence.mjs
@@ -20,6 +20,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { GRAMMAR_CONTENT_RELEASE_ID } from '../worker/src/subjects/grammar/content.js';
+import { extractFrontmatter } from './validate-grammar-qg-completion-report.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -528,7 +529,7 @@ export function validateInventoryReleaseIds(inventoryPath, expectedReleaseId) {
  * @param {string} [reportReleaseId] - Release ID extracted from a completion report (optional).
  * @returns {{ pass: boolean, mismatches: Array<{ field: string, claimed: any, actual: any, message: string }> }}
  */
-export function validateReleaseIdConsistency(manifest, reportReleaseId) {
+export function validateReleaseIdConsistency(manifest, reportReleaseId, reportContent) {
   const mismatches = [];
 
   if (manifest.contentReleaseId !== GRAMMAR_CONTENT_RELEASE_ID) {
@@ -547,6 +548,19 @@ export function validateReleaseIdConsistency(manifest, reportReleaseId) {
       actual: manifest.contentReleaseId,
       message: `Report release ID "${reportReleaseId}" does not match manifest contentReleaseId "${manifest.contentReleaseId}"`,
     });
+  }
+
+  // Cross-check report frontmatter final_content_release_id if reportContent provided
+  if (reportContent != null) {
+    const fm = extractFrontmatter(reportContent);
+    if (fm.final_content_release_id != null && fm.final_content_release_id !== GRAMMAR_CONTENT_RELEASE_ID) {
+      mismatches.push({
+        field: 'reportFrontmatterVsCodeReleaseId',
+        claimed: fm.final_content_release_id,
+        actual: GRAMMAR_CONTENT_RELEASE_ID,
+        message: `Report frontmatter final_content_release_id "${fm.final_content_release_id}" does not match code GRAMMAR_CONTENT_RELEASE_ID "${GRAMMAR_CONTENT_RELEASE_ID}"`,
+      });
+    }
   }
 
   return { pass: mismatches.length === 0, mismatches };

--- a/scripts/validate-grammar-qg-completion-report.mjs
+++ b/scripts/validate-grammar-qg-completion-report.mjs
@@ -92,7 +92,7 @@ function extractProductionSmokeStatus(reportContent) {
  * Extract YAML frontmatter as a flat key→value map.
  * Only handles top-level scalar and list fields (no nested objects).
  */
-function extractFrontmatter(reportContent) {
+export function extractFrontmatter(reportContent) {
   const fm = {};
   const fmBlock = reportContent.match(/^---\r?\n([\s\S]*?)\r?\n---/);
   if (!fmBlock) return fm;

--- a/tests/grammar-qg-p10-evidence-truth.test.js
+++ b/tests/grammar-qg-p10-evidence-truth.test.js
@@ -299,6 +299,33 @@ describe('P10 Evidence Truth: report-vs-manifest release ID', () => {
 });
 
 // ---------------------------------------------------------------------------
+// 7b. Report frontmatter final_content_release_id cross-check
+// ---------------------------------------------------------------------------
+
+describe('P10 Evidence Truth: report frontmatter final_content_release_id', () => {
+  it('wrong final_content_release_id in report frontmatter triggers mismatch', () => {
+    const manifest = { contentReleaseId: GRAMMAR_CONTENT_RELEASE_ID };
+    const reportContent = [
+      '---',
+      'final_content_release_id: grammar-qg-p8-stale-2026-04-29',
+      'implementation_prs:',
+      '  - "#650"',
+      'final_content_release_commit: a1b2c3d4e5f6g7h8',
+      'post_merge_fix_commits: []',
+      'final_report_commit: b2c3d4e5f6a7b8c9',
+      '---',
+      '',
+      '# Report',
+    ].join('\n');
+    const result = validateReleaseIdConsistency(manifest, null, reportContent);
+    assert.equal(result.pass, false);
+    const fm_mismatch = result.mismatches.find((m) => m.field === 'reportFrontmatterVsCodeReleaseId');
+    assert.ok(fm_mismatch, 'Expected mismatch for reportFrontmatterVsCodeReleaseId');
+    assert.match(fm_mismatch.message, /grammar-qg-p8-stale/);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // 8. Inventory release ID cross-check (P10-R-U9)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Export `extractFrontmatter` from `validate-grammar-qg-completion-report.mjs` (was private, now public)
- `validateReleaseIdConsistency` in `validate-grammar-qg-certification-evidence.mjs` accepts optional `reportContent` string; when provided, extracts `final_content_release_id` from frontmatter and checks it against `GRAMMAR_CONTENT_RELEASE_ID`
- New test in `grammar-qg-p10-evidence-truth.test.js`: report with wrong `final_content_release_id` triggers mismatch

## Test plan
- [x] All 25 tests in `grammar-qg-p10-evidence-truth.test.js` pass (including new test)
- [x] No circular import issues between the two scripts
- [x] Existing callers of `validateReleaseIdConsistency(manifest, reportReleaseId)` unaffected (third param is optional)