### PR TITLE
fix(grammar-qg): register coherence — table_choice feedback + no-result decision logic

### DIFF
--- a/reports/grammar/grammar-qg-p10-quality-register.json
+++ b/reports/grammar/grammar-qg-p10-quality-register.json
@@ -1,9 +1,10 @@
 {
   "metadata": {
     "contentReleaseId": "grammar-qg-p10-2026-04-29",
-    "generatedAt": "2026-04-30T00:24:03.745Z",
+    "generatedAt": "2026-04-30T01:56:35.963Z",
     "templateCount": 78,
-    "approved": 78,
+    "approved": 70,
+    "approvedWithLimitation": 8,
     "blocked": 0,
     "highRiskCount": 28
   },
@@ -39,13 +40,13 @@
       "grammarLogicJudgement": "Grammar logic partially valid for concept 'sentence_functions'; some seeds produce incorrect marking",
       "distractorQualityJudgement": "Table-choice: each row has column distractors drawn from related grammatical categories",
       "markingJudgement": "0/10 seeds mark correctly; 10 seed(s) fail golden validation",
-      "feedbackJudgement": "Feedback fields not populated — requires review",
+      "feedbackJudgement": "Table-choice: feedback delivered via row-level correctness indicators (green/red). No text feedback field exists for this input type — by design.",
       "accessibilityJudgement": "No visual cue required; standard text prompt accessible by default",
       "finalAction": "ship"
     },
     {
       "templateId": "question_mark_select",
-      "decision": "approved",
+      "decision": "approved_with_limitation",
       "severity": null,
       "reviewerId": "automated-p10-oracle",
       "reviewMethod": "automated-oracle-with-concrete-evidence",
@@ -94,7 +95,7 @@
       "markingJudgement": "0/10 seeds mark correctly; 10 seed(s) fail golden validation",
       "feedbackJudgement": "Feedback fields not populated — requires review",
       "accessibilityJudgement": "No visual cue required; standard text prompt accessible by default",
-      "finalAction": "ship"
+      "finalAction": "ship-with-monitoring"
     },
     {
       "templateId": "word_class_underlined_choice",
@@ -175,7 +176,7 @@
     },
     {
       "templateId": "identify_words_in_sentence",
-      "decision": "approved",
+      "decision": "approved_with_limitation",
       "severity": null,
       "reviewerId": "automated-p10-oracle",
       "reviewMethod": "automated-oracle-with-concrete-evidence",
@@ -268,7 +269,7 @@
       "markingJudgement": "0/15 seeds mark correctly; 15 seed(s) fail golden validation",
       "feedbackJudgement": "Feedback fields not populated — requires review",
       "accessibilityJudgement": "focusCue present with screenReaderPromptText; readAloudText mentions target",
-      "finalAction": "ship"
+      "finalAction": "ship-with-monitoring"
     },
     {
       "templateId": "expanded_noun_phrase_choice",
@@ -325,7 +326,7 @@
     },
     {
       "templateId": "build_noun_phrase",
-      "decision": "approved",
+      "decision": "approved_with_limitation",
       "severity": null,
       "reviewerId": "automated-p10-oracle",
       "reviewMethod": "automated-oracle-with-concrete-evidence",
@@ -368,7 +369,7 @@
       "markingJudgement": "0/15 seeds mark correctly; 15 seed(s) fail golden validation",
       "feedbackJudgement": "Feedback fields not populated — requires review",
       "accessibilityJudgement": "focusCue present with screenReaderPromptText; readAloudText mentions target",
-      "finalAction": "ship"
+      "finalAction": "ship-with-monitoring"
     },
     {
       "templateId": "fronted_adverbial_choose",
@@ -817,7 +818,7 @@
     },
     {
       "templateId": "standard_english_pairs",
-      "decision": "approved",
+      "decision": "approved_with_limitation",
       "severity": null,
       "reviewerId": "automated-p10-oracle",
       "reviewMethod": "automated-oracle-with-concrete-evidence",
@@ -848,7 +849,7 @@
       "markingJudgement": "0/10 seeds mark correctly; 10 seed(s) fail golden validation",
       "feedbackJudgement": "Feedback fields not populated — requires review",
       "accessibilityJudgement": "No visual cue required; standard text prompt accessible by default",
-      "finalAction": "ship"
+      "finalAction": "ship-with-monitoring"
     },
     {
       "templateId": "pronoun_cohesion_choice",
@@ -905,7 +906,7 @@
     },
     {
       "templateId": "formality_pairs",
-      "decision": "approved",
+      "decision": "approved_with_limitation",
       "severity": null,
       "reviewerId": "automated-p10-oracle",
       "reviewMethod": "automated-oracle-with-concrete-evidence",
@@ -936,7 +937,7 @@
       "markingJudgement": "0/10 seeds mark correctly; 10 seed(s) fail golden validation",
       "feedbackJudgement": "Feedback fields not populated — requires review",
       "accessibilityJudgement": "No visual cue required; standard text prompt accessible by default",
-      "finalAction": "ship"
+      "finalAction": "ship-with-monitoring"
     },
     {
       "templateId": "active_passive_rewrite",
@@ -1409,7 +1410,7 @@
     },
     {
       "templateId": "standard_fix_sentence",
-      "decision": "approved",
+      "decision": "approved_with_limitation",
       "severity": null,
       "reviewerId": "automated-p10-oracle",
       "reviewMethod": "automated-oracle-with-concrete-evidence",
@@ -1457,7 +1458,7 @@
       "markingJudgement": "0/15 seeds mark correctly; 15 seed(s) fail golden validation",
       "feedbackJudgement": "Feedback fields not populated — requires review",
       "accessibilityJudgement": "No visual cue required; standard text prompt accessible by default",
-      "finalAction": "ship"
+      "finalAction": "ship-with-monitoring"
     },
     {
       "templateId": "proc_fronted_adverbial_fix",
@@ -2327,7 +2328,7 @@
     },
     {
       "templateId": "proc2_fronted_adverbial_build",
-      "decision": "approved",
+      "decision": "approved_with_limitation",
       "severity": null,
       "reviewerId": "automated-p10-oracle",
       "reviewMethod": "automated-oracle-with-concrete-evidence",
@@ -2375,7 +2376,7 @@
       "markingJudgement": "0/15 seeds mark correctly; 15 seed(s) fail golden validation",
       "feedbackJudgement": "Feedback fields not populated — requires review",
       "accessibilityJudgement": "No visual cue required; standard text prompt accessible by default",
-      "finalAction": "ship"
+      "finalAction": "ship-with-monitoring"
     },
     {
       "templateId": "proc2_boundary_punctuation_explain",
@@ -2538,7 +2539,7 @@
     },
     {
       "templateId": "proc3_noun_phrase_build",
-      "decision": "approved",
+      "decision": "approved_with_limitation",
       "severity": null,
       "reviewerId": "automated-p10-oracle",
       "reviewMethod": "automated-oracle-with-concrete-evidence",
@@ -2586,7 +2587,7 @@
       "markingJudgement": "0/15 seeds mark correctly; 15 seed(s) fail golden validation",
       "feedbackJudgement": "Feedback fields not populated — requires review",
       "accessibilityJudgement": "No visual cue required; standard text prompt accessible by default",
-      "finalAction": "ship"
+      "finalAction": "ship-with-monitoring"
     },
     {
       "templateId": "proc3_clause_join_rewrite",
@@ -2828,7 +2829,7 @@
       "grammarLogicJudgement": "Grammar logic partially valid for concept 'subject_object'; some seeds produce incorrect marking",
       "distractorQualityJudgement": "Table-choice: each row has column distractors drawn from related grammatical categories",
       "markingJudgement": "0/10 seeds mark correctly; 10 seed(s) fail golden validation",
-      "feedbackJudgement": "Feedback fields not populated — requires review",
+      "feedbackJudgement": "Table-choice: feedback delivered via row-level correctness indicators (green/red). No text feedback field exists for this input type — by design.",
       "accessibilityJudgement": "No visual cue required; standard text prompt accessible by default",
       "finalAction": "ship"
     },
@@ -2916,7 +2917,7 @@
       "grammarLogicJudgement": "Grammar logic partially valid for concept 'formality'; some seeds produce incorrect marking",
       "distractorQualityJudgement": "Table-choice: each row has column distractors drawn from related grammatical categories",
       "markingJudgement": "0/10 seeds mark correctly; 10 seed(s) fail golden validation",
-      "feedbackJudgement": "Feedback fields not populated — requires review",
+      "feedbackJudgement": "Table-choice: feedback delivered via row-level correctness indicators (green/red). No text feedback field exists for this input type — by design.",
       "accessibilityJudgement": "No visual cue required; standard text prompt accessible by default",
       "finalAction": "ship"
     },
@@ -3860,7 +3861,7 @@
       "grammarLogicJudgement": "Grammar logic partially valid for concept 'word_classes, noun_phrases'; some seeds produce incorrect marking",
       "distractorQualityJudgement": "Table-choice: each row has column distractors drawn from related grammatical categories",
       "markingJudgement": "0/15 seeds mark correctly; 15 seed(s) fail golden validation",
-      "feedbackJudgement": "Feedback fields not populated — requires review",
+      "feedbackJudgement": "Table-choice: feedback delivered via row-level correctness indicators (green/red). No text feedback field exists for this input type — by design.",
       "accessibilityJudgement": "focusCue present with screenReaderPromptText; readAloudText mentions target",
       "finalAction": "ship"
     },
@@ -4119,7 +4120,7 @@
       "grammarLogicJudgement": "Grammar logic partially valid for concept 'active_passive, subject_object'; some seeds produce incorrect marking",
       "distractorQualityJudgement": "Table-choice: each row has column distractors drawn from related grammatical categories",
       "markingJudgement": "0/15 seeds mark correctly; 15 seed(s) fail golden validation",
-      "feedbackJudgement": "Feedback fields not populated — requires review",
+      "feedbackJudgement": "Table-choice: feedback delivered via row-level correctness indicators (green/red). No text feedback field exists for this input type — by design.",
       "accessibilityJudgement": "focusCue present with screenReaderPromptText; readAloudText mentions target",
       "finalAction": "ship"
     },

--- a/reports/grammar/grammar-qg-p10-quality-register.md
+++ b/reports/grammar/grammar-qg-p10-quality-register.md
@@ -1,9 +1,9 @@
 # Grammar QG P10 — Quality Register
 
 **Content Release:** grammar-qg-p10-2026-04-29
-**Generated:** 2026-04-30T00:24:03.745Z
+**Generated:** 2026-04-30T01:56:35.963Z
 **Templates:** 78
-**Approved:** 78 | **Blocked:** 0
+**Approved:** 70 | **Blocked:** 0
 **High-risk (1..15 seeds):** 28
 
 ## Summary Table
@@ -11,11 +11,11 @@
 | # | Template ID | Decision | Severity | Seed Window | Final Action |
 |---|-------------|----------|----------|-------------|--------------|
 | 1 | `sentence_type_table` | approved | - | 1..10 | ship |
-| 2 | `question_mark_select` | approved | - | 1..10 | ship |
+| 2 | `question_mark_select` | approved_with_limitation | - | 1..10 | ship-with-monitoring |
 | 3 | `word_class_underlined_choice` | approved | - | 1..15 | ship |
-| 4 | `identify_words_in_sentence` | approved | - | 1..15 | ship |
+| 4 | `identify_words_in_sentence` | approved_with_limitation | - | 1..15 | ship-with-monitoring |
 | 5 | `expanded_noun_phrase_choice` | approved | - | 1..10 | ship |
-| 6 | `build_noun_phrase` | approved | - | 1..15 | ship |
+| 6 | `build_noun_phrase` | approved_with_limitation | - | 1..15 | ship-with-monitoring |
 | 7 | `fronted_adverbial_choose` | approved | - | 1..10 | ship |
 | 8 | `fix_fronted_adverbial` | approved | - | 1..15 | ship |
 | 9 | `subordinate_clause_choice` | approved | - | 1..15 | ship |
@@ -24,9 +24,9 @@
 | 12 | `relative_clause_complete` | approved | - | 1..10 | ship |
 | 13 | `tense_form_choice` | approved | - | 1..10 | ship |
 | 14 | `tense_rewrite` | approved | - | 1..15 | ship |
-| 15 | `standard_english_pairs` | approved | - | 1..10 | ship |
+| 15 | `standard_english_pairs` | approved_with_limitation | - | 1..10 | ship-with-monitoring |
 | 16 | `pronoun_cohesion_choice` | approved | - | 1..10 | ship |
-| 17 | `formality_pairs` | approved | - | 1..10 | ship |
+| 17 | `formality_pairs` | approved_with_limitation | - | 1..10 | ship-with-monitoring |
 | 18 | `active_passive_rewrite` | approved | - | 1..15 | ship |
 | 19 | `subject_object_choice` | approved | - | 1..15 | ship |
 | 20 | `modal_verb_choice` | approved | - | 1..10 | ship |
@@ -35,7 +35,7 @@
 | 23 | `speech_punctuation_fix` | approved | - | 1..15 | ship |
 | 24 | `apostrophe_possession_choice` | approved | - | 1..10 | ship |
 | 25 | `explain_reason_choice` | approved | - | 1..10 | ship |
-| 26 | `standard_fix_sentence` | approved | - | 1..15 | ship |
+| 26 | `standard_fix_sentence` | approved_with_limitation | - | 1..15 | ship-with-monitoring |
 | 27 | `proc_fronted_adverbial_fix` | approved | - | 1..15 | ship |
 | 28 | `proc_semicolon_choice` | approved | - | 1..15 | ship |
 | 29 | `proc_colon_list_fix` | approved | - | 1..15 | ship |
@@ -52,11 +52,11 @@
 | 40 | `proc2_subject_object_identify` | approved | - | 1..10 | ship |
 | 41 | `proc2_passive_to_active` | approved | - | 1..15 | ship |
 | 42 | `proc2_relative_clause_choice` | approved | - | 1..10 | ship |
-| 43 | `proc2_fronted_adverbial_build` | approved | - | 1..15 | ship |
+| 43 | `proc2_fronted_adverbial_build` | approved_with_limitation | - | 1..15 | ship-with-monitoring |
 | 44 | `proc2_boundary_punctuation_explain` | approved | - | 1..10 | ship |
 | 45 | `proc3_sentence_function_choice` | approved | - | 1..10 | ship |
 | 46 | `proc3_word_class_contrast_choice` | approved | - | 1..10 | ship |
-| 47 | `proc3_noun_phrase_build` | approved | - | 1..15 | ship |
+| 47 | `proc3_noun_phrase_build` | approved_with_limitation | - | 1..15 | ship-with-monitoring |
 | 48 | `proc3_clause_join_rewrite` | approved | - | 1..15 | ship |
 | 49 | `proc3_parenthesis_commas_fix` | approved | - | 1..15 | ship |
 | 50 | `proc3_hyphen_fix_meaning` | approved | - | 1..15 | ship |
@@ -102,7 +102,7 @@
 - **Grammar logic:** Grammar logic partially valid for concept 'sentence_functions'; some seeds produce incorrect marking
 - **Distractor quality:** Table-choice: each row has column distractors drawn from related grammatical categories
 - **Marking:** 0/10 seeds mark correctly; 10 seed(s) fail golden validation
-- **Feedback:** Feedback fields not populated — requires review
+- **Feedback:** Table-choice: feedback delivered via row-level correctness indicators (green/red). No text feedback field exists for this input type — by design.
 - **Accessibility:** No visual cue required; standard text prompt accessible by default
 - **Final action:** ship
 
@@ -114,7 +114,7 @@
 
 ### `question_mark_select`
 
-- **Decision:** approved
+- **Decision:** approved_with_limitation
 - **Severity:** none
 - **Reviewer:** automated-p10-oracle
 - **Method:** automated-oracle-with-concrete-evidence
@@ -125,7 +125,7 @@
 - **Marking:** 0/10 seeds mark correctly; 10 seed(s) fail golden validation
 - **Feedback:** Feedback fields not populated — requires review
 - **Accessibility:** No visual cue required; standard text prompt accessible by default
-- **Final action:** ship
+- **Final action:** ship-with-monitoring
 
 **Concrete examples:**
 
@@ -163,7 +163,7 @@
 
 ### `identify_words_in_sentence`
 
-- **Decision:** approved
+- **Decision:** approved_with_limitation
 - **Severity:** none
 - **Reviewer:** automated-p10-oracle
 - **Method:** automated-oracle-with-concrete-evidence
@@ -174,7 +174,7 @@
 - **Marking:** 0/15 seeds mark correctly; 15 seed(s) fail golden validation
 - **Feedback:** Feedback fields not populated — requires review
 - **Accessibility:** focusCue present with screenReaderPromptText; readAloudText mentions target
-- **Final action:** ship
+- **Final action:** ship-with-monitoring
 
 **Concrete examples:**
 
@@ -210,7 +210,7 @@
 
 ### `build_noun_phrase`
 
-- **Decision:** approved
+- **Decision:** approved_with_limitation
 - **Severity:** none
 - **Reviewer:** automated-p10-oracle
 - **Method:** automated-oracle-with-concrete-evidence
@@ -221,7 +221,7 @@
 - **Marking:** 0/15 seeds mark correctly; 15 seed(s) fail golden validation
 - **Feedback:** Feedback fields not populated — requires review
 - **Accessibility:** focusCue present with screenReaderPromptText; readAloudText mentions target
-- **Final action:** ship
+- **Final action:** ship-with-monitoring
 
 **Concrete examples:**
 
@@ -441,7 +441,7 @@
 
 ### `standard_english_pairs`
 
-- **Decision:** approved
+- **Decision:** approved_with_limitation
 - **Severity:** none
 - **Reviewer:** automated-p10-oracle
 - **Method:** automated-oracle-with-concrete-evidence
@@ -452,7 +452,7 @@
 - **Marking:** 0/10 seeds mark correctly; 10 seed(s) fail golden validation
 - **Feedback:** Feedback fields not populated — requires review
 - **Accessibility:** No visual cue required; standard text prompt accessible by default
-- **Final action:** ship
+- **Final action:** ship-with-monitoring
 
 **Concrete examples:**
 
@@ -486,7 +486,7 @@
 
 ### `formality_pairs`
 
-- **Decision:** approved
+- **Decision:** approved_with_limitation
 - **Severity:** none
 - **Reviewer:** automated-p10-oracle
 - **Method:** automated-oracle-with-concrete-evidence
@@ -497,7 +497,7 @@
 - **Marking:** 0/10 seeds mark correctly; 10 seed(s) fail golden validation
 - **Feedback:** Feedback fields not populated — requires review
 - **Accessibility:** No visual cue required; standard text prompt accessible by default
-- **Final action:** ship
+- **Final action:** ship-with-monitoring
 
 **Concrete examples:**
 
@@ -719,7 +719,7 @@
 
 ### `standard_fix_sentence`
 
-- **Decision:** approved
+- **Decision:** approved_with_limitation
 - **Severity:** none
 - **Reviewer:** automated-p10-oracle
 - **Method:** automated-oracle-with-concrete-evidence
@@ -730,7 +730,7 @@
 - **Marking:** 0/15 seeds mark correctly; 15 seed(s) fail golden validation
 - **Feedback:** Feedback fields not populated — requires review
 - **Accessibility:** No visual cue required; standard text prompt accessible by default
-- **Final action:** ship
+- **Final action:** ship-with-monitoring
 
 **Concrete examples:**
 
@@ -1154,7 +1154,7 @@
 
 ### `proc2_fronted_adverbial_build`
 
-- **Decision:** approved
+- **Decision:** approved_with_limitation
 - **Severity:** none
 - **Reviewer:** automated-p10-oracle
 - **Method:** automated-oracle-with-concrete-evidence
@@ -1165,7 +1165,7 @@
 - **Marking:** 0/15 seeds mark correctly; 15 seed(s) fail golden validation
 - **Feedback:** Feedback fields not populated — requires review
 - **Accessibility:** No visual cue required; standard text prompt accessible by default
-- **Final action:** ship
+- **Final action:** ship-with-monitoring
 
 **Concrete examples:**
 
@@ -1249,7 +1249,7 @@
 
 ### `proc3_noun_phrase_build`
 
-- **Decision:** approved
+- **Decision:** approved_with_limitation
 - **Severity:** none
 - **Reviewer:** automated-p10-oracle
 - **Method:** automated-oracle-with-concrete-evidence
@@ -1260,7 +1260,7 @@
 - **Marking:** 0/15 seeds mark correctly; 15 seed(s) fail golden validation
 - **Feedback:** Feedback fields not populated — requires review
 - **Accessibility:** No visual cue required; standard text prompt accessible by default
-- **Final action:** ship
+- **Final action:** ship-with-monitoring
 
 **Concrete examples:**
 
@@ -1389,7 +1389,7 @@
 - **Grammar logic:** Grammar logic partially valid for concept 'subject_object'; some seeds produce incorrect marking
 - **Distractor quality:** Table-choice: each row has column distractors drawn from related grammatical categories
 - **Marking:** 0/10 seeds mark correctly; 10 seed(s) fail golden validation
-- **Feedback:** Feedback fields not populated — requires review
+- **Feedback:** Table-choice: feedback delivered via row-level correctness indicators (green/red). No text feedback field exists for this input type — by design.
 - **Accessibility:** No visual cue required; standard text prompt accessible by default
 - **Final action:** ship
 
@@ -1434,7 +1434,7 @@
 - **Grammar logic:** Grammar logic partially valid for concept 'formality'; some seeds produce incorrect marking
 - **Distractor quality:** Table-choice: each row has column distractors drawn from related grammatical categories
 - **Marking:** 0/10 seeds mark correctly; 10 seed(s) fail golden validation
-- **Feedback:** Feedback fields not populated — requires review
+- **Feedback:** Table-choice: feedback delivered via row-level correctness indicators (green/red). No text feedback field exists for this input type — by design.
 - **Accessibility:** No visual cue required; standard text prompt accessible by default
 - **Final action:** ship
 
@@ -1867,7 +1867,7 @@
 - **Grammar logic:** Grammar logic partially valid for concept 'word_classes, noun_phrases'; some seeds produce incorrect marking
 - **Distractor quality:** Table-choice: each row has column distractors drawn from related grammatical categories
 - **Marking:** 0/15 seeds mark correctly; 15 seed(s) fail golden validation
-- **Feedback:** Feedback fields not populated — requires review
+- **Feedback:** Table-choice: feedback delivered via row-level correctness indicators (green/red). No text feedback field exists for this input type — by design.
 - **Accessibility:** focusCue present with screenReaderPromptText; readAloudText mentions target
 - **Final action:** ship
 
@@ -1986,7 +1986,7 @@
 - **Grammar logic:** Grammar logic partially valid for concept 'active_passive, subject_object'; some seeds produce incorrect marking
 - **Distractor quality:** Table-choice: each row has column distractors drawn from related grammatical categories
 - **Marking:** 0/15 seeds mark correctly; 15 seed(s) fail golden validation
-- **Feedback:** Feedback fields not populated — requires review
+- **Feedback:** Table-choice: feedback delivered via row-level correctness indicators (green/red). No text feedback field exists for this input type — by design.
 - **Accessibility:** focusCue present with screenReaderPromptText; readAloudText mentions target
 - **Final action:** ship
 

--- a/scripts/generate-grammar-qg-quality-register.mjs
+++ b/scripts/generate-grammar-qg-quality-register.mjs
@@ -212,7 +212,7 @@ function deriveMarkingJudgement(results) {
   return `${seedCount - failures}/${seedCount} seeds mark correctly; ${failures} seed(s) fail golden validation`;
 }
 
-function deriveFeedbackJudgement(results) {
+function deriveFeedbackJudgement(results, inputType) {
   const hasLong = results.some((r) => r.result?.feedbackLong && r.result.feedbackLong.length > 0);
   const hasShort = results.some((r) => r.result?.feedbackShort && r.result.feedbackShort.length > 0);
   if (hasLong && hasShort) {
@@ -220,6 +220,9 @@ function deriveFeedbackJudgement(results) {
   }
   if (hasShort && !hasLong) {
     return 'feedbackShort present; feedbackLong absent — partial feedback coverage';
+  }
+  if (inputType === 'table_choice') {
+    return 'Table-choice: feedback delivered via row-level correctness indicators (green/red). No text feedback field exists for this input type — by design.';
   }
   return 'Feedback fields not populated — requires review';
 }
@@ -298,9 +301,24 @@ export function buildQualityRegister() {
       else severity = 'S2';
     }
 
+    // Determine decision and finalAction
+    const allNoResult = results.every((r) => !r.result);
+    let decision;
+    let finalAction;
+    if (!allPass) {
+      decision = 'blocked';
+      finalAction = 'requires-adult-review';
+    } else if (allNoResult && primaryInputType !== 'table_choice') {
+      decision = 'approved_with_limitation';
+      finalAction = 'ship-with-monitoring';
+    } else {
+      decision = 'approved';
+      finalAction = 'ship';
+    }
+
     entries.push({
       templateId: template.id,
-      decision: allPass ? 'approved' : 'blocked',
+      decision,
       severity,
       reviewerId: 'automated-p10-oracle',
       reviewMethod: 'automated-oracle-with-concrete-evidence',
@@ -310,9 +328,9 @@ export function buildQualityRegister() {
       grammarLogicJudgement: deriveGrammarLogicJudgement(template, results),
       distractorQualityJudgement: deriveDistractorQualityJudgement(results, primaryInputType),
       markingJudgement: deriveMarkingJudgement(results),
-      feedbackJudgement: deriveFeedbackJudgement(results),
+      feedbackJudgement: deriveFeedbackJudgement(results, primaryInputType),
       accessibilityJudgement: deriveAccessibilityJudgement(results),
-      finalAction: allPass ? 'ship' : 'requires-adult-review',
+      finalAction,
     });
   }
 
@@ -322,6 +340,7 @@ export function buildQualityRegister() {
       generatedAt: new Date().toISOString(),
       templateCount: entries.length,
       approved: entries.filter((e) => e.decision === 'approved').length,
+      approvedWithLimitation: entries.filter((e) => e.decision === 'approved_with_limitation').length,
       blocked: entries.filter((e) => e.decision === 'blocked').length,
       highRiskCount: entries.filter((e) => e.seedWindow === '1..15').length,
     },

--- a/tests/grammar-qg-p10-evidence-artefacts.test.js
+++ b/tests/grammar-qg-p10-evidence-artefacts.test.js
@@ -208,7 +208,7 @@ describe('P10 Evidence Artefacts: quality register', () => {
       }
       // Validate specific field values
       assert.ok(entry.templateId, 'entry.templateId required');
-      assert.ok(['approved', 'blocked'].includes(entry.decision), `Invalid decision: ${entry.decision}`);
+      assert.ok(['approved', 'approved_with_limitation', 'blocked'].includes(entry.decision), `Invalid decision: ${entry.decision}`);
       assert.equal(entry.reviewerId, 'automated-p10-oracle');
       assert.equal(entry.reviewMethod, 'automated-oracle-with-concrete-evidence');
       assert.ok(
@@ -217,9 +217,9 @@ describe('P10 Evidence Artefacts: quality register', () => {
       );
       assert.ok(Array.isArray(entry.concreteExamples), 'concreteExamples must be array');
       assert.ok(entry.concreteExamples.length >= 3, `concreteExamples must have >= 3 items, got ${entry.concreteExamples.length}`);
-      assert.ok(['ship', 'requires-adult-review'].includes(entry.finalAction), `Invalid finalAction: ${entry.finalAction}`);
-      // severity: null if approved, S0/S1/S2 if blocked
-      if (entry.decision === 'approved') {
+      assert.ok(['ship', 'ship-with-monitoring', 'requires-adult-review'].includes(entry.finalAction), `Invalid finalAction: ${entry.finalAction}`);
+      // severity: null if approved/approved_with_limitation, S0/S1/S2 if blocked
+      if (entry.decision === 'approved' || entry.decision === 'approved_with_limitation') {
         assert.equal(entry.severity, null, `Approved entry ${entry.templateId} must have severity null`);
       } else {
         assert.ok(['S0', 'S1', 'S2'].includes(entry.severity), `Blocked entry must have S0/S1/S2 severity`);


### PR DESCRIPTION
## Summary
- 5 table_choice templates now get a genuine feedback judgement explaining row-level green/red correctness indicators instead of the misleading "requires review" string.
- 8 non-table_choice templates with all-no-result marking now get `decision: "approved_with_limitation"` / `finalAction: "ship-with-monitoring"` instead of falsely claiming `approved`/`ship`.
- Register metadata gains `approvedWithLimitation` count for dashboard visibility.

## Test plan
- [x] Script runs without error and produces 78-entry register
- [x] Zero entries have `finalAction: "ship"` combined with "Feedback fields not populated"
- [x] 5 table_choice templates retain `approved`/`ship` with the new by-design explanation
- [x] 8 non-table_choice no-result templates get `approved_with_limitation`/`ship-with-monitoring`