### PR TITLE
fix(hero): pA2 final gaps — event leakage, stop condition docs, unresolved defects

### DIFF
--- a/docs/plans/james/hero-mode/A/hero-pA2-recommendation.md
+++ b/docs/plans/james/hero-mode/A/hero-pA2-recommendation.md
@@ -50,6 +50,15 @@ Hero Mode increased clarity and completion without increasing spam, dead ends, d
 
 No stop condition requires rollback. The limitation is evidence strength, not an observed safety failure.
 
+## Unresolved Defects
+
+No code-level defects remain that would block A3 consideration:
+
+- All prior reviewer-found bugs (smoke script field mismatches, certification validator placeholder false-positive, ops probe reconciliation scope, read-model override gate) were fixed in PR #697.
+- The cross-learner event leakage in the ops probe events array is a data-boundary issue (admin-only, non-exploitable by end-users) — fixed in the final gaps PR.
+- No stop conditions were triggered during the real or simulated observations.
+- The one structural limitation (ops probe measures 4/16 Goal 6 signals) is a design ceiling, not a defect — documented in the metrics baseline Coverage Limitations section.
+
 ## Privacy Assessment
 
 Privacy is acceptable for continued internal hardening:

--- a/scripts/hero-pA2-cohort-smoke.mjs
+++ b/scripts/hero-pA2-cohort-smoke.mjs
@@ -60,13 +60,17 @@ async function fetchProbe(probeUrl, learnerId) {
 
 // ── Stop condition detection (pure, exported for testing) ───────────
 
-// NOT DETECTABLE FROM PROBE (manual verification required):
-// - claim without Worker-verified completion (command-level audit)
-// - Hero mutates subject state (architectural impossibility, verified by P1-P6)
-// - stale request returns 500 (request monitoring)
-// - operators cannot explain task selection (human assessment)
-// - children directed to Camp before learning (UI review)
-// - support inspects non-existent tables (documentation review)
+// NOT DETECTABLE FROM PROBE (manual verification required per §8):
+// §8 #2: duplicate Camp debit (no per-debit field in probe; reconciliation gap is a proxy)
+// §8 #4: claim without Worker-verified completion (command-level audit)
+// §8 #5: Hero mutates subject state (architectural impossibility, verified by P1-P6)
+// §8 #6: dead CTA (requires UI-level check; readiness-degraded is an indirect proxy)
+// §8 #8: raw child content in telemetry (privacy validator is build-time gate, not runtime probe)
+// §8 #10: rollback cannot hide surfaces (requires production rehearsal)
+// §8 #11: stale request returns 500 (request-level monitoring)
+// §8 #12: operators cannot explain task selection (human assessment)
+// §8 #13: children directed to Camp before learning (UI review)
+// §8 #14: support inspects non-existent tables (documentation review)
 
 /**
  * Detect stop conditions from expanded probe fields.
@@ -100,9 +104,9 @@ export function detectStopConditions({ balance, balanceBucket, hasGap, health, r
     conditions.push({ level: 'warn', key: 'readiness-degraded', detail: failedChecks.join(',') || readiness.overall });
   }
 
-  // Override mismatch: if override exists but isInternalAccount is false
+  // §8 #9: override exposes non-listed accounts — immediate stop per contract
   if (overrideStatus && overrideStatus.isInternalAccount === false) {
-    conditions.push({ level: 'warn', key: 'override-not-internal' });
+    conditions.push({ level: 'stop', key: 'override-not-internal' });
   }
 
   return conditions;

--- a/tests/hero-pA2-cohort-smoke.test.js
+++ b/tests/hero-pA2-cohort-smoke.test.js
@@ -70,13 +70,13 @@ describe('detectStopConditions', () => {
     assert.equal(gap.level, 'stop');
   });
 
-  it('override mismatch (isInternalAccount false) fires a warn', () => {
+  it('override mismatch (isInternalAccount false) fires a stop per §8 #9', () => {
     const input = makeHealthy();
     input.overrideStatus = { accountId: 'ext-1', isInternalAccount: false, effectiveFlags: {} };
     const conditions = detectStopConditions(input);
     const ovr = conditions.find(c => c.key === 'override-not-internal');
     assert.ok(ovr, 'expected override-not-internal condition');
-    assert.equal(ovr.level, 'warn');
+    assert.equal(ovr.level, 'stop');
   });
 
   it('readiness degraded fires a warn with failed checks', () => {

--- a/worker/src/app.js
+++ b/worker/src/app.js
@@ -2687,10 +2687,9 @@ export function createWorkerApp({
           }
           const probeLimit = Number(url.searchParams.get('limit')) || 20;
           const db = requireDatabase(env);
-          const probeResult = await probeHeroTelemetry({ db, limit: probeLimit });
-
           // pA2 U4: expanded response when learnerId is provided
           const probeLearnerIdParam = url.searchParams.get('learnerId');
+          const probeResult = await probeHeroTelemetry({ db, limit: probeLimit, learnerId: probeLearnerIdParam || null });
           if (probeLearnerIdParam) {
             const heroState = await repository.readHeroProgress(probeLearnerIdParam);
             const dateKey = new Date().toISOString().slice(0, 10);

--- a/worker/src/hero/telemetry-probe.js
+++ b/worker/src/hero/telemetry-probe.js
@@ -27,7 +27,7 @@ const PRIVACY_STRIP_FIELDS = PRIVACY_FORBIDDEN_FIELDS;
  * @param {number} [params.limit=20] — max events to return (capped at 100)
  * @returns {Promise<{ events: Array, count: number, probedAt: string }>}
  */
-export async function probeHeroTelemetry({ db, limit = 20 } = {}) {
+export async function probeHeroTelemetry({ db, limit = 20, learnerId = null } = {}) {
   const probedAt = new Date().toISOString();
   const safeLimit = Math.max(1, Math.min(Number(limit) || 20, 100));
 
@@ -37,13 +37,21 @@ export async function probeHeroTelemetry({ db, limit = 20 } = {}) {
 
   let rows;
   try {
-    const result = await db.prepare(`
-      SELECT id, learner_id, subject_id, system_id, event_type, event_json, created_at
-      FROM event_log
-      WHERE system_id = 'hero-mode'
-      ORDER BY created_at DESC, id DESC
-      LIMIT ?
-    `).bind(safeLimit).all();
+    const query = learnerId
+      ? `SELECT id, learner_id, subject_id, system_id, event_type, event_json, created_at
+         FROM event_log
+         WHERE system_id = 'hero-mode' AND learner_id = ?
+         ORDER BY created_at DESC, id DESC
+         LIMIT ?`
+      : `SELECT id, learner_id, subject_id, system_id, event_type, event_json, created_at
+         FROM event_log
+         WHERE system_id = 'hero-mode'
+         ORDER BY created_at DESC, id DESC
+         LIMIT ?`;
+    const stmt = learnerId
+      ? db.prepare(query).bind(learnerId, safeLimit)
+      : db.prepare(query).bind(safeLimit);
+    const result = await stmt.all();
     rows = result?.results || [];
   } catch {
     // Table may not exist on pre-migration deploys — return empty gracefully


### PR DESCRIPTION
## Summary
Closes the last 3 reviewer-found gaps:

1. **U4 fix:** `probeHeroTelemetry` now accepts optional `learnerId` param and filters events by `learner_id` when provided. No more cross-learner event leakage.
2. **U6 fix:** Smoke script documents all 10 non-detectable §8 conditions (was 6). Escalates `override-not-internal` from WARN to STOP per contract §8 #9.
3. **U9 fix:** Adds "Unresolved Defects" section to recommendation document — explicitly states zero code-level defects remain.

## Test plan
- [ ] 47/47 affected tests pass (smoke, ops-probe, pA1-telemetry-probe)
- [ ] Probe with `?learnerId=X` returns only that learner's events
- [ ] Override exposure fires at STOP level, not WARN