### PR TITLE
fix(grammar): rename focusCue.text to focusCue.targetText

### DIFF
--- a/reports/grammar/grammar-qg-p9-ux-render-audit.md
+++ b/reports/grammar/grammar-qg-p9-ux-render-audit.md
@@ -49,7 +49,7 @@ Tested scenarios:
 
 | Cue Type | Templates | Verified |
 |---|---|---|
-| `underline` (focusCue) | `word_class_underlined_choice` + others | Yes — promptParts includes underline part matching focusCue.text |
+| `underline` (focusCue) | `word_class_underlined_choice` + others | Yes — promptParts includes underline part matching focusCue.targetText |
 | Backwards compat (no cue) | All non-cue templates | Yes — promptText present, no promptParts/focusCue |
 | `screenReaderPromptText` | All focusCue templates | Yes — always includes "Target word:" prefix |
 

--- a/scripts/audit-grammar-prompt-cues.mjs
+++ b/scripts/audit-grammar-prompt-cues.mjs
@@ -6,7 +6,7 @@
  * 1. No whole-sentence underline when prompt asks for word/phrase
  * 2. No duplicate content in promptParts
  * 3. If prompt contains cue language, focusCue must exist (or explicit fallback)
- * 4. Screen-reader/read-aloud alignment — both mention focusCue.text
+ * 4. Screen-reader/read-aloud alignment — both mention focusCue.targetText
  * 5. cueNotRequiredReason present when promptParts exist without focusCue
  *
  * Usage:
@@ -58,17 +58,17 @@ function auditQuestion(templateId, seed) {
 
   // Check 1: No whole-sentence underline when prompt asks for word/phrase
   if (q.focusCue && q.focusCue.type === 'underline') {
-    const wc = wordCount(q.focusCue.text);
+    const wc = wordCount(q.focusCue.targetText);
     if (UNDERLINE_WORD_RE.test(plainPrompt) && wc > 3) {
       failures.push({
         check: 'whole-sentence-underline-word',
-        message: `Prompt asks for "underlined word" but focusCue.text has ${wc} words: "${q.focusCue.text}"`
+        message: `Prompt asks for "underlined word" but focusCue.targetText has ${wc} words: "${q.focusCue.targetText}"`
       });
     }
     if (UNDERLINE_PHRASE_RE.test(plainPrompt) && wc > 8) {
       failures.push({
         check: 'whole-sentence-underline-phrase',
-        message: `Prompt asks for "underlined phrase/group" but focusCue.text has ${wc} words: "${q.focusCue.text}"`
+        message: `Prompt asks for "underlined phrase/group" but focusCue.targetText has ${wc} words: "${q.focusCue.targetText}"`
       });
     }
   }
@@ -100,19 +100,19 @@ function auditQuestion(templateId, seed) {
     }
   }
 
-  // Check 4: Screen-reader/read-aloud alignment — both must mention focusCue.text
-  if (q.focusCue && q.focusCue.text) {
-    const cueTextLower = q.focusCue.text.toLowerCase();
+  // Check 4: Screen-reader/read-aloud alignment — both must mention focusCue.targetText
+  if (q.focusCue && q.focusCue.targetText) {
+    const cueTextLower = q.focusCue.targetText.toLowerCase();
     if (q.screenReaderPromptText && !q.screenReaderPromptText.toLowerCase().includes(cueTextLower)) {
       failures.push({
         check: 'screen-reader-misaligned',
-        message: `screenReaderPromptText does not mention focusCue.text "${q.focusCue.text}"`
+        message: `screenReaderPromptText does not mention focusCue.targetText "${q.focusCue.targetText}"`
       });
     }
     if (q.readAloudText && !q.readAloudText.toLowerCase().includes(cueTextLower)) {
       failures.push({
         check: 'read-aloud-misaligned',
-        message: `readAloudText does not mention focusCue.text "${q.focusCue.text}"`
+        message: `readAloudText does not mention focusCue.targetText "${q.focusCue.targetText}"`
       });
     }
   }

--- a/scripts/generate-grammar-qg-render-inventory.mjs
+++ b/scripts/generate-grammar-qg-render-inventory.mjs
@@ -228,7 +228,7 @@ async function writeReports(inventory) {
   ];
 
   for (const item of redacted) {
-    const cue = item.focusCue ? `${item.focusCue.type}: ${item.focusCue.text}` : '-';
+    const cue = item.focusCue ? `${item.focusCue.type}: ${item.focusCue.targetText}` : '-';
     const prompt = (item.promptText || '').slice(0, 60).replace(/\|/g, '\\|').replace(/\n/g, ' ');
     mdLines.push(`| ${item.templateId} | ${item.seed} | ${item.inputType} | ${cue} | ${prompt} |`);
   }

--- a/tests/grammar-qg-p10-prompt-cue-contract.test.js
+++ b/tests/grammar-qg-p10-prompt-cue-contract.test.js
@@ -2,7 +2,7 @@
  * Grammar QG P10 U2 — Explicit Prompt Target Contract
  *
  * Validates that:
- * - focusCue.text correctly targets the intended word/phrase, never the whole sentence
+ * - focusCue.targetText correctly targets the intended word/phrase, never the whole sentence
  * - promptParts does not duplicate sentence content
  * - Templates mentioning "underlined" produce valid focusCue or explicit fallback
  */
@@ -27,44 +27,44 @@ function wordCount(text) {
 }
 
 // ---------------------------------------------------------------------------
-// 1. word_class_underlined_choice: focusCue.text is a single word
+// 1. word_class_underlined_choice: focusCue.targetText is a single word
 // ---------------------------------------------------------------------------
 
 describe('P10 U2: word_class_underlined_choice — focusCue targets single word', () => {
   for (let seed = 1; seed <= 5; seed++) {
-    it(`seed ${seed}: focusCue.text is a single word`, () => {
+    it(`seed ${seed}: focusCue.targetText is a single word`, () => {
       const q = generateQuestion('word_class_underlined_choice', seed);
       assert.ok(q, 'question must be generated');
       assert.ok(q.focusCue, 'focusCue must be present');
       assert.strictEqual(q.focusCue.type, 'underline');
       assert.ok(
-        wordCount(q.focusCue.text) <= 2,
-        `focusCue.text must be 1-2 words (a single word), got ${wordCount(q.focusCue.text)} words: "${q.focusCue.text}"`
+        wordCount(q.focusCue.targetText) <= 2,
+        `focusCue.targetText must be 1-2 words (a single word), got ${wordCount(q.focusCue.targetText)} words: "${q.focusCue.targetText}"`
       );
     });
   }
 });
 
 // ---------------------------------------------------------------------------
-// 2. qg_p4_voice_roles_transfer: focusCue.text is a noun phrase (2-4 words)
+// 2. qg_p4_voice_roles_transfer: focusCue.targetText is a noun phrase (2-4 words)
 // ---------------------------------------------------------------------------
 
 describe('P10 U2: qg_p4_voice_roles_transfer — focusCue targets noun phrase', () => {
   for (let seed = 1; seed <= 5; seed++) {
-    it(`seed ${seed}: focusCue.text is a noun phrase (2-4 words, not a full sentence)`, () => {
+    it(`seed ${seed}: focusCue.targetText is a noun phrase (2-4 words, not a full sentence)`, () => {
       const q = generateQuestion('qg_p4_voice_roles_transfer', seed);
       assert.ok(q, 'question must be generated');
       assert.ok(q.focusCue, 'focusCue must be present');
       assert.strictEqual(q.focusCue.type, 'underline');
-      const wc = wordCount(q.focusCue.text);
+      const wc = wordCount(q.focusCue.targetText);
       assert.ok(
         wc >= 2 && wc <= 4,
-        `focusCue.text must be 2-4 words (noun phrase), got ${wc} words: "${q.focusCue.text}"`
+        `focusCue.targetText must be 2-4 words (noun phrase), got ${wc} words: "${q.focusCue.targetText}"`
       );
       // Must NOT be a full sentence (no verb typically, and shorter than the example)
       assert.ok(
-        !q.focusCue.text.includes('.'),
-        'focusCue.text must not contain a full stop (not a full sentence)'
+        !q.focusCue.targetText.includes('.'),
+        'focusCue.targetText must not contain a full stop (not a full sentence)'
       );
     });
   }
@@ -75,13 +75,13 @@ describe('P10 U2: qg_p4_voice_roles_transfer — focusCue targets noun phrase', 
 // ---------------------------------------------------------------------------
 
 describe('P10 U2: qg_p4_word_class_noun_phrase_transfer seed 3 — focusCue targets word', () => {
-  it('seed 3: focusCue.text is the specific word, not the whole phrase', () => {
+  it('seed 3: focusCue.targetText is the specific word, not the whole phrase', () => {
     const q = generateQuestion('qg_p4_word_class_noun_phrase_transfer', 3);
     assert.ok(q, 'question must be generated');
     assert.ok(q.focusCue, 'focusCue must be present');
     assert.strictEqual(q.focusCue.type, 'underline');
-    assert.strictEqual(q.focusCue.text, 'incredibly');
-    assert.strictEqual(wordCount(q.focusCue.text), 1, 'focusCue.text must be exactly 1 word');
+    assert.strictEqual(q.focusCue.targetText, 'incredibly');
+    assert.strictEqual(wordCount(q.focusCue.targetText), 1, 'focusCue.targetText must be exactly 1 word');
   });
 });
 
@@ -92,21 +92,21 @@ describe('P10 U2: qg_p4_word_class_noun_phrase_transfer seed 3 — focusCue targ
 describe('P10 U2: qg_p3_noun_phrases_explain — underline on noun phrase', () => {
   // Seeds 3 and 7 have "underlined group" prompts
   for (const seed of [3, 7]) {
-    it(`seed ${seed}: focusCue.text is the noun phrase, not the whole sentence`, () => {
+    it(`seed ${seed}: focusCue.targetText is the noun phrase, not the whole sentence`, () => {
       const q = generateQuestion('qg_p3_noun_phrases_explain', seed);
       assert.ok(q, 'question must be generated');
       assert.ok(q.focusCue, `focusCue must be present for seed ${seed}`);
       assert.strictEqual(q.focusCue.type, 'underline');
       // The noun phrase should be 4-8 words (a phrase), not a full sentence
-      const wc = wordCount(q.focusCue.text);
+      const wc = wordCount(q.focusCue.targetText);
       assert.ok(
         wc >= 3 && wc <= 8,
-        `focusCue.text must be 3-8 words (noun phrase), got ${wc} words: "${q.focusCue.text}"`
+        `focusCue.targetText must be 3-8 words (noun phrase), got ${wc} words: "${q.focusCue.targetText}"`
       );
       // Must not end with a full stop (sentence indicator)
       assert.ok(
-        !q.focusCue.text.endsWith('.'),
-        'focusCue.text must not end with full stop — it is a phrase, not a sentence'
+        !q.focusCue.targetText.endsWith('.'),
+        'focusCue.targetText must not end with full stop — it is a phrase, not a sentence'
       );
     });
   }
@@ -180,10 +180,10 @@ describe('P10 U2: cue consistency enforcement', () => {
 });
 
 // ---------------------------------------------------------------------------
-// 7. focusCue.text must not be unreasonably long (whole-sentence detection)
+// 7. focusCue.targetText must not be unreasonably long (whole-sentence detection)
 // ---------------------------------------------------------------------------
 
-describe('P10 U2: focusCue.text is not a whole sentence', () => {
+describe('P10 U2: focusCue.targetText is not a whole sentence', () => {
   const underlinedTemplates = GRAMMAR_TEMPLATE_METADATA.filter(t => {
     const q = createGrammarQuestion({ templateId: t.id, seed: 1 });
     if (!q || !q.focusCue) return false;
@@ -192,13 +192,13 @@ describe('P10 U2: focusCue.text is not a whole sentence', () => {
 
   for (const template of underlinedTemplates) {
     for (let seed = 1; seed <= 3; seed++) {
-      it(`${template.id} seed ${seed}: focusCue.text is not a whole sentence (<=8 words)`, () => {
+      it(`${template.id} seed ${seed}: focusCue.targetText is not a whole sentence (<=8 words)`, () => {
         const q = createGrammarQuestion({ templateId: template.id, seed });
         if (!q || !q.focusCue || q.focusCue.type !== 'underline') return;
-        const wc = wordCount(q.focusCue.text);
+        const wc = wordCount(q.focusCue.targetText);
         assert.ok(
           wc <= 8,
-          `focusCue.text should be a word/phrase, not a sentence. Got ${wc} words: "${q.focusCue.text}"`
+          `focusCue.targetText should be a word/phrase, not a sentence. Got ${wc} words: "${q.focusCue.targetText}"`
         );
       });
     }
@@ -240,35 +240,35 @@ describe('P10 U2 REGRESSION: target-sentence cue produces visible sentence part'
 });
 
 // ---------------------------------------------------------------------------
-// 9. P10 U7: screenReaderPromptText includes focusCue.text
+// 9. P10 U7: screenReaderPromptText includes focusCue.targetText
 // ---------------------------------------------------------------------------
 
-describe('P10 U7: screenReaderPromptText includes focusCue.text', () => {
-  it('word_class_underlined_choice seed 1: screenReaderPromptText mentions focusCue.text', () => {
+describe('P10 U7: screenReaderPromptText includes focusCue.targetText', () => {
+  it('word_class_underlined_choice seed 1: screenReaderPromptText mentions focusCue.targetText', () => {
     const q = generateQuestion('word_class_underlined_choice', 1);
     assert.ok(q, 'question must be generated');
     assert.ok(q.focusCue, 'focusCue must be present');
     assert.ok(q.screenReaderPromptText, 'screenReaderPromptText must be present');
     assert.ok(
-      q.screenReaderPromptText.toLowerCase().includes(q.focusCue.text.toLowerCase()),
-      `screenReaderPromptText must contain focusCue.text "${q.focusCue.text}" — got "${q.screenReaderPromptText}"`
+      q.screenReaderPromptText.toLowerCase().includes(q.focusCue.targetText.toLowerCase()),
+      `screenReaderPromptText must contain focusCue.targetText "${q.focusCue.targetText}" — got "${q.screenReaderPromptText}"`
     );
   });
 });
 
 // ---------------------------------------------------------------------------
-// 10. P10 U7: readAloudText includes focusCue.text
+// 10. P10 U7: readAloudText includes focusCue.targetText
 // ---------------------------------------------------------------------------
 
-describe('P10 U7: readAloudText includes focusCue.text', () => {
-  it('word_class_underlined_choice seed 1: readAloudText mentions focusCue.text', () => {
+describe('P10 U7: readAloudText includes focusCue.targetText', () => {
+  it('word_class_underlined_choice seed 1: readAloudText mentions focusCue.targetText', () => {
     const q = generateQuestion('word_class_underlined_choice', 1);
     assert.ok(q, 'question must be generated');
     assert.ok(q.focusCue, 'focusCue must be present');
     assert.ok(q.readAloudText, 'readAloudText must be present');
     assert.ok(
-      q.readAloudText.toLowerCase().includes(q.focusCue.text.toLowerCase()),
-      `readAloudText must contain focusCue.text "${q.focusCue.text}" — got "${q.readAloudText}"`
+      q.readAloudText.toLowerCase().includes(q.focusCue.targetText.toLowerCase()),
+      `readAloudText must contain focusCue.targetText "${q.focusCue.targetText}" — got "${q.readAloudText}"`
     );
   });
 });

--- a/tests/grammar-qg-p10-read-aloud-alignment.test.js
+++ b/tests/grammar-qg-p10-read-aloud-alignment.test.js
@@ -222,20 +222,20 @@ test('mini-test mode uses readAloudText from current question item', () => {
 
 // --- U8: qg_p4_voice_roles_transfer generates readAloudText with focusCue ---
 
-test('qg_p4_voice_roles_transfer generates speech text including focusCue.text', () => {
+test('qg_p4_voice_roles_transfer generates speech text including focusCue.targetText', () => {
   const question = createGrammarQuestion({ templateId: 'qg_p4_voice_roles_transfer', seed: 1 });
   assert.ok(question, 'qg_p4_voice_roles_transfer must generate a question at seed 1');
 
   const serialised = serialiseGrammarQuestion(question);
   assert.ok(serialised, 'serialiseGrammarQuestion must return a serialised object');
   assert.ok(serialised.focusCue, 'qg_p4_voice_roles_transfer must produce a focusCue');
-  assert.ok(serialised.focusCue.text, 'focusCue must have a text field');
+  assert.ok(serialised.focusCue.targetText, 'focusCue must have a targetText field');
 
   // Build a speech grammar object from the serialised question
   const grammarObj = wrapSession(serialised);
   const text = buildGrammarSpeechText(grammarObj);
 
   assert.ok(text.length > 0, 'speech text must not be empty');
-  assert.match(text, new RegExp(serialised.focusCue.text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')),
-    `speech text must include focusCue.text "${serialised.focusCue.text}"`);
+  assert.match(text, new RegExp(serialised.focusCue.targetText.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')),
+    `speech text must include focusCue.targetText "${serialised.focusCue.targetText}"`);
 });

--- a/tests/grammar-qg-p9-learner-surface.test.js
+++ b/tests/grammar-qg-p9-learner-surface.test.js
@@ -40,7 +40,7 @@ describe('P9 prompt cue: word_class_underlined_choice', () => {
     assert.ok(q, 'question must be generated');
     assert.ok(q.focusCue, 'focusCue must be present');
     assert.strictEqual(q.focusCue.type, 'underline');
-    assert.ok(q.focusCue.text.length > 0, 'focusCue.text must be non-empty');
+    assert.ok(q.focusCue.targetText.length > 0, 'focusCue.targetText must be non-empty');
   });
 
   it('question has promptParts array', () => {
@@ -51,7 +51,7 @@ describe('P9 prompt cue: word_class_underlined_choice', () => {
     // Must contain an underline part matching the focusCue word
     const underlinePart = q.promptParts.find(p => p.kind === 'underline');
     assert.ok(underlinePart, 'must have an underline part');
-    assert.strictEqual(underlinePart.text, q.focusCue.text);
+    assert.strictEqual(underlinePart.text, q.focusCue.targetText);
   });
 
   it('screenReaderPromptText mentions the target word', () => {
@@ -59,8 +59,8 @@ describe('P9 prompt cue: word_class_underlined_choice', () => {
     assert.ok(q, 'question must be generated');
     assert.ok(q.screenReaderPromptText, 'screenReaderPromptText must exist');
     assert.ok(
-      q.screenReaderPromptText.includes(q.focusCue.text),
-      `screenReaderPromptText must mention '${q.focusCue.text}'`
+      q.screenReaderPromptText.includes(q.focusCue.targetText),
+      `screenReaderPromptText must mention '${q.focusCue.targetText}'`
     );
     assert.ok(
       q.screenReaderPromptText.includes('Target word:'),
@@ -73,7 +73,7 @@ describe('P9 prompt cue: word_class_underlined_choice', () => {
     assert.ok(q, 'question must be generated');
     assert.ok(q.readAloudText, 'readAloudText must exist');
     assert.ok(
-      q.readAloudText.includes(q.focusCue.text),
+      q.readAloudText.includes(q.focusCue.targetText),
       'readAloudText must mention the underlined word'
     );
   });
@@ -212,12 +212,12 @@ describe('P9 prompt cue: screenReaderPromptText mentions target', () => {
   });
 
   for (const template of cueTemplates) {
-    it(`${template.id}: screenReaderPromptText mentions focusCue.text`, () => {
+    it(`${template.id}: screenReaderPromptText mentions focusCue.targetText`, () => {
       const q = createGrammarQuestion({ templateId: template.id, seed: 1 });
       assert.ok(q.screenReaderPromptText, 'screenReaderPromptText must exist');
       assert.ok(
-        q.screenReaderPromptText.includes(q.focusCue.text),
-        `screenReaderPromptText must mention '${q.focusCue.text}'`
+        q.screenReaderPromptText.includes(q.focusCue.targetText),
+        `screenReaderPromptText must mention '${q.focusCue.targetText}'`
       );
     });
   }

--- a/worker/src/subjects/grammar/content.js
+++ b/worker/src/subjects/grammar/content.js
@@ -7730,13 +7730,13 @@ function enrichPromptCue(question) {
   // Build focusCue (targetOccurrence: 1 disambiguates which occurrence is the
   // target when the cue text appears multiple times in the sentence)
   if (cueType === 'underline' && targetWord) {
-    question.focusCue = { type: 'underline', text: targetWord, targetOccurrence: 1 };
+    question.focusCue = { type: 'underline', targetText: targetWord, targetOccurrence: 1 };
   } else if (cueType === 'bold' && boldSentence) {
-    question.focusCue = { type: 'bold', text: boldSentence, targetOccurrence: 1 };
+    question.focusCue = { type: 'bold', targetText: boldSentence, targetOccurrence: 1 };
   } else if (cueType === 'quoted-word' && targetWord) {
-    question.focusCue = { type: 'quoted-word', text: targetWord, targetOccurrence: 1 };
+    question.focusCue = { type: 'quoted-word', targetText: targetWord, targetOccurrence: 1 };
   } else if (cueType === 'target-sentence' && targetSentence) {
-    question.focusCue = { type: 'target-sentence', text: targetSentence, targetOccurrence: 1 };
+    question.focusCue = { type: 'target-sentence', targetText: targetSentence, targetOccurrence: 1 };
   }
 
   // P10 U2: Cue consistency enforcement — if cueType is 'underline' but we
@@ -7758,7 +7758,7 @@ function enrichPromptCue(question) {
 
   // screenReaderPromptText — mentions the target word clearly
   if (question.focusCue) {
-    const word = question.focusCue.text;
+    const word = question.focusCue.targetText;
     if (cueType === 'underline') {
       question.screenReaderPromptText = `${plainPrompt} Target word: ${word}`;
     } else if (cueType === 'bold') {
@@ -7772,7 +7772,7 @@ function enrichPromptCue(question) {
 
   // readAloudText — full spoken form including cue
   if (question.focusCue) {
-    const word = question.focusCue.text;
+    const word = question.focusCue.targetText;
     if (cueType === 'underline') {
       question.readAloudText = `${plainPrompt} The underlined word is: ${word}.`;
     } else if (cueType === 'target-sentence') {


### PR DESCRIPTION
## Summary
- Renames `focusCue.text` to `focusCue.targetText` across the entire codebase
- Disambiguates the focus-cue target field from the generic `.text` property on `promptParts` elements
- Shape is now `{ type, targetText, targetOccurrence }` — no functional change

## Files changed (7)
- `worker/src/subjects/grammar/content.js` — 4 assignment sites + 2 read sites
- `scripts/audit-grammar-prompt-cues.mjs` — all reads updated
- `scripts/generate-grammar-qg-render-inventory.mjs` — inventory column read
- `tests/grammar-qg-p10-prompt-cue-contract.test.js` — all assertions
- `tests/grammar-qg-p10-read-aloud-alignment.test.js` — speech alignment test
- `tests/grammar-qg-p9-learner-surface.test.js` — learner surface assertions
- `reports/grammar/grammar-qg-p9-ux-render-audit.md` — doc reference

## Test plan
- [x] `node --test tests/grammar-qg-p10-prompt-cue-contract.test.js` — 118 pass
- [x] `node --test tests/grammar-qg-p10-read-aloud-alignment.test.js` — 9 pass
- [x] `node --test tests/grammar-qg-p9-learner-surface.test.js` — 65 pass
- [x] `node scripts/audit-grammar-prompt-cues.mjs --seeds=1..5` — 390/390 PASS
- [x] Global grep for `focusCue.text` — zero remaining occurrences