### PR TITLE
fix(grammar-qg): P10 table_choice golden derivation

### DIFF
--- a/reports/grammar/grammar-qg-p10-quality-register.json
+++ b/reports/grammar/grammar-qg-p10-quality-register.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "contentReleaseId": "grammar-qg-p10-2026-04-29",
-    "generatedAt": "2026-04-30T02:26:44.569Z",
+    "generatedAt": "2026-04-30T02:41:44.882Z",
     "templateCount": 78,
     "approved": 74,
     "approvedWithLimitation": 4,
@@ -20,27 +20,27 @@
         {
           "seed": 1,
           "promptText": "Tick one box in each row to show the sentence function.",
-          "markingResult": "no-result",
-          "feedbackSnippet": ""
+          "markingResult": "correct",
+          "feedbackSnippet": "How loudly the drums were beating! → exclamation | Why is the gate still open? → question | Our coach arrives at half past nine. → statement | Wait..."
         },
         {
           "seed": 2,
           "promptText": "Tick one box in each row to show the sentence function.",
-          "markingResult": "no-result",
-          "feedbackSnippet": ""
+          "markingResult": "correct",
+          "feedbackSnippet": "Can we finish the poster tomorrow? → question | How loudly the drums were beating! → exclamation | Mia tucked the map into her coat pocket. → state..."
         },
         {
           "seed": 3,
           "promptText": "Tick one box in each row to show the sentence function.",
-          "markingResult": "no-result",
-          "feedbackSnippet": ""
+          "markingResult": "correct",
+          "feedbackSnippet": "Where did you put the compass? → question | How loudly the drums were beating! → exclamation | Our coach arrives at half past nine. → statement | B..."
         }
       ],
-      "answerabilityJudgement": "Some seeds produce ambiguous table rows (10/10 failures)",
-      "grammarLogicJudgement": "Grammar logic partially valid for concept 'sentence_functions'; some seeds produce incorrect marking",
+      "answerabilityJudgement": "All 10 seeds produce a valid table with unambiguous row answers",
+      "grammarLogicJudgement": "Feedback correctly references grammar rule for concept 'sentence_functions'",
       "distractorQualityJudgement": "Table-choice: each row has column distractors drawn from related grammatical categories",
-      "markingJudgement": "0/10 seeds mark correctly; 10 seed(s) fail golden validation",
-      "feedbackJudgement": "Table-choice: feedback delivered via row-level correctness indicators (green/red). No text feedback field exists for this input type — by design.",
+      "markingJudgement": "Golden answers mark correct across all 10 seeds; empty/whitespace rejected",
+      "feedbackJudgement": "feedbackLong references grammar rule; feedbackShort provides one-line summary",
       "accessibilityJudgement": "No visual cue required; standard text prompt accessible by default",
       "finalAction": "ship"
     },
@@ -2809,27 +2809,27 @@
         {
           "seed": 1,
           "promptText": "Classify each named noun phrase as the subject or object.",
-          "markingResult": "no-result",
-          "feedbackSnippet": ""
+          "markingResult": "correct",
+          "feedbackSnippet": "The subject does the action; the object receives it."
         },
         {
           "seed": 2,
           "promptText": "Classify each named noun phrase as the subject or object.",
-          "markingResult": "no-result",
-          "feedbackSnippet": ""
+          "markingResult": "correct",
+          "feedbackSnippet": "The subject does the action; the object receives it."
         },
         {
           "seed": 3,
           "promptText": "Classify each named noun phrase as the subject or object.",
-          "markingResult": "no-result",
-          "feedbackSnippet": ""
+          "markingResult": "correct",
+          "feedbackSnippet": "The subject does the action; the object receives it."
         }
       ],
-      "answerabilityJudgement": "Some seeds produce ambiguous table rows (10/10 failures)",
-      "grammarLogicJudgement": "Grammar logic partially valid for concept 'subject_object'; some seeds produce incorrect marking",
+      "answerabilityJudgement": "All 10 seeds produce a valid table with unambiguous row answers",
+      "grammarLogicJudgement": "Feedback correctly references grammar rule for concept 'subject_object'",
       "distractorQualityJudgement": "Table-choice: each row has column distractors drawn from related grammatical categories",
-      "markingJudgement": "0/10 seeds mark correctly; 10 seed(s) fail golden validation",
-      "feedbackJudgement": "Table-choice: feedback delivered via row-level correctness indicators (green/red). No text feedback field exists for this input type — by design.",
+      "markingJudgement": "Golden answers mark correct across all 10 seeds; empty/whitespace rejected",
+      "feedbackJudgement": "feedbackLong references grammar rule; feedbackShort provides one-line summary",
       "accessibilityJudgement": "No visual cue required; standard text prompt accessible by default",
       "finalAction": "ship"
     },
@@ -2897,27 +2897,27 @@
         {
           "seed": 1,
           "promptText": "Classify each sentence as formal or informal.",
-          "markingResult": "no-result",
-          "feedbackSnippet": ""
+          "markingResult": "correct",
+          "feedbackSnippet": "Formal writing avoids chatty phrasing and uses precise vocabulary."
         },
         {
           "seed": 2,
           "promptText": "Classify each sentence as formal or informal.",
-          "markingResult": "no-result",
-          "feedbackSnippet": ""
+          "markingResult": "correct",
+          "feedbackSnippet": "Formal writing avoids chatty phrasing and uses precise vocabulary."
         },
         {
           "seed": 3,
           "promptText": "Classify each sentence as formal or informal.",
-          "markingResult": "no-result",
-          "feedbackSnippet": ""
+          "markingResult": "correct",
+          "feedbackSnippet": "Formal writing avoids chatty phrasing and uses precise vocabulary."
         }
       ],
-      "answerabilityJudgement": "Some seeds produce ambiguous table rows (10/10 failures)",
-      "grammarLogicJudgement": "Grammar logic partially valid for concept 'formality'; some seeds produce incorrect marking",
+      "answerabilityJudgement": "All 10 seeds produce a valid table with unambiguous row answers",
+      "grammarLogicJudgement": "Feedback correctly references grammar rule for concept 'formality'",
       "distractorQualityJudgement": "Table-choice: each row has column distractors drawn from related grammatical categories",
-      "markingJudgement": "0/10 seeds mark correctly; 10 seed(s) fail golden validation",
-      "feedbackJudgement": "Table-choice: feedback delivered via row-level correctness indicators (green/red). No text feedback field exists for this input type — by design.",
+      "markingJudgement": "Golden answers mark correct across all 10 seeds; empty/whitespace rejected",
+      "feedbackJudgement": "feedbackLong references grammar rule; feedbackShort provides one-line summary",
       "accessibilityJudgement": "No visual cue required; standard text prompt accessible by default",
       "finalAction": "ship"
     },
@@ -3829,39 +3829,39 @@
         {
           "seed": 1,
           "promptText": "Identify the head noun and its word class in this expanded noun phrase. the rusty old bicycle",
-          "markingResult": "no-result",
-          "feedbackSnippet": ""
+          "markingResult": "correct",
+          "feedbackSnippet": "The head noun is the main word the phrase is built around. 'Rusty' is an adjective modifying the noun."
         },
         {
           "seed": 2,
           "promptText": "Identify the head noun and the word class of the modifier before it. a terrifying mountain storm",
-          "markingResult": "no-result",
-          "feedbackSnippet": ""
+          "markingResult": "correct",
+          "feedbackSnippet": "'Storm' is the head noun. 'Mountain' is a noun used as a modifier (a noun adjunct), not an adjective."
         },
         {
           "seed": 3,
           "promptText": "Identify the head noun and the word class of the underlined word in this noun phrase. those incredibly brave firefighters",
-          "markingResult": "no-result",
-          "feedbackSnippet": ""
+          "markingResult": "correct",
+          "feedbackSnippet": "'Firefighters' is the head noun. 'Incredibly' is an adverb modifying the adjective 'brave', not itself an adjective."
         },
         {
           "seed": 4,
           "promptText": "Identify the head noun and the word class of the first word in this noun phrase. every single morning lesson",
-          "markingResult": "no-result",
-          "feedbackSnippet": ""
+          "markingResult": "correct",
+          "feedbackSnippet": "'Lesson' is the head noun the phrase centres on. 'Every' is a determiner specifying which lesson, not an adjective."
         },
         {
           "seed": 5,
           "promptText": "Identify the head noun and the word class of the describing word. the brightly painted fence",
-          "markingResult": "no-result",
-          "feedbackSnippet": ""
+          "markingResult": "correct",
+          "feedbackSnippet": "'Fence' is the head noun. 'Painted' here is used as an adjective describing the fence, not as a verb showing ongoing action."
         }
       ],
-      "answerabilityJudgement": "Some seeds produce ambiguous table rows (15/15 failures)",
-      "grammarLogicJudgement": "Grammar logic partially valid for concept 'word_classes, noun_phrases'; some seeds produce incorrect marking",
+      "answerabilityJudgement": "All 15 seeds produce a valid table with unambiguous row answers",
+      "grammarLogicJudgement": "Feedback correctly references grammar rule for concept 'word_classes, noun_phrases'",
       "distractorQualityJudgement": "Table-choice: each row has column distractors drawn from related grammatical categories",
-      "markingJudgement": "0/15 seeds mark correctly; 15 seed(s) fail golden validation",
-      "feedbackJudgement": "Table-choice: feedback delivered via row-level correctness indicators (green/red). No text feedback field exists for this input type — by design.",
+      "markingJudgement": "Golden answers mark correct across all 15 seeds; empty/whitespace rejected",
+      "feedbackJudgement": "feedbackLong references grammar rule; feedbackShort provides one-line summary",
       "accessibilityJudgement": "focusCue present with screenReaderPromptText; readAloudText mentions target",
       "finalAction": "ship"
     },
@@ -4088,39 +4088,39 @@
         {
           "seed": 1,
           "promptText": "Identify the voice and the grammatical role of the underlined noun phrase. The trophy was awarded to Amir by the head teacher.",
-          "markingResult": "no-result",
-          "feedbackSnippet": ""
+          "markingResult": "correct",
+          "feedbackSnippet": "The sentence is passive because the action is done TO the trophy. In a passive sentence, the thing affected ('the trophy') becomes the grammatical ..."
         },
         {
           "seed": 2,
           "promptText": "Identify the voice and the grammatical role of the underlined noun phrase. The goalkeeper saved the penalty brilliantly.",
-          "markingResult": "no-result",
-          "feedbackSnippet": ""
+          "markingResult": "correct",
+          "feedbackSnippet": "The sentence is active because the doer ('the goalkeeper') comes first and does the action. 'The penalty' receives the action, so it is the object."
         },
         {
           "seed": 3,
           "promptText": "Identify the voice and the grammatical role of the underlined noun phrase. The cake was eaten by the children before lunch.",
-          "markingResult": "no-result",
-          "feedbackSnippet": ""
+          "markingResult": "correct",
+          "feedbackSnippet": "This is passive voice: the thing affected ('the cake') has been moved to the subject position. Even though the children did the eating, 'the cake' ..."
         },
         {
           "seed": 4,
           "promptText": "Identify the voice and the grammatical role of the underlined noun phrase. Lena painted the scenery for the school play.",
-          "markingResult": "no-result",
-          "feedbackSnippet": ""
+          "markingResult": "correct",
+          "feedbackSnippet": "The sentence is active because the doer ('Lena') performs the action. 'The scenery' receives the painting, making it the object."
         },
         {
           "seed": 5,
           "promptText": "Identify the voice and the grammatical role of the underlined noun phrase. The windows were smashed by the hailstones during the storm.",
-          "markingResult": "no-result",
-          "feedbackSnippet": ""
+          "markingResult": "correct",
+          "feedbackSnippet": "This is passive voice: the affected thing ('the windows') is the grammatical subject. The doer ('the hailstones') appears later in a 'by' phrase."
         }
       ],
-      "answerabilityJudgement": "Some seeds produce ambiguous table rows (15/15 failures)",
-      "grammarLogicJudgement": "Grammar logic partially valid for concept 'active_passive, subject_object'; some seeds produce incorrect marking",
+      "answerabilityJudgement": "All 15 seeds produce a valid table with unambiguous row answers",
+      "grammarLogicJudgement": "Feedback correctly references grammar rule for concept 'active_passive, subject_object'",
       "distractorQualityJudgement": "Table-choice: each row has column distractors drawn from related grammatical categories",
-      "markingJudgement": "0/15 seeds mark correctly; 15 seed(s) fail golden validation",
-      "feedbackJudgement": "Table-choice: feedback delivered via row-level correctness indicators (green/red). No text feedback field exists for this input type — by design.",
+      "markingJudgement": "Golden answers mark correct across all 15 seeds; empty/whitespace rejected",
+      "feedbackJudgement": "feedbackLong references grammar rule; feedbackShort provides one-line summary",
       "accessibilityJudgement": "focusCue present with screenReaderPromptText; readAloudText mentions target",
       "finalAction": "ship"
     },

--- a/reports/grammar/grammar-qg-p10-quality-register.md
+++ b/reports/grammar/grammar-qg-p10-quality-register.md
@@ -1,7 +1,7 @@
 # Grammar QG P10 — Quality Register
 
 **Content Release:** grammar-qg-p10-2026-04-29
-**Generated:** 2026-04-30T02:26:44.569Z
+**Generated:** 2026-04-30T02:41:44.882Z
 **Templates:** 78
 **Approved:** 74 | **Blocked:** 0
 **High-risk (1..15 seeds):** 28
@@ -98,19 +98,22 @@
 - **Reviewer:** automated-p10-oracle
 - **Method:** automated-oracle-with-concrete-evidence
 - **Seed window:** 1..10
-- **Answerability:** Some seeds produce ambiguous table rows (10/10 failures)
-- **Grammar logic:** Grammar logic partially valid for concept 'sentence_functions'; some seeds produce incorrect marking
+- **Answerability:** All 10 seeds produce a valid table with unambiguous row answers
+- **Grammar logic:** Feedback correctly references grammar rule for concept 'sentence_functions'
 - **Distractor quality:** Table-choice: each row has column distractors drawn from related grammatical categories
-- **Marking:** 0/10 seeds mark correctly; 10 seed(s) fail golden validation
-- **Feedback:** Table-choice: feedback delivered via row-level correctness indicators (green/red). No text feedback field exists for this input type — by design.
+- **Marking:** Golden answers mark correct across all 10 seeds; empty/whitespace rejected
+- **Feedback:** feedbackLong references grammar rule; feedbackShort provides one-line summary
 - **Accessibility:** No visual cue required; standard text prompt accessible by default
 - **Final action:** ship
 
 **Concrete examples:**
 
-- Seed 1: "Tick one box in each row to show the sentence function." → no-result
-- Seed 2: "Tick one box in each row to show the sentence function." → no-result
-- Seed 3: "Tick one box in each row to show the sentence function." → no-result
+- Seed 1: "Tick one box in each row to show the sentence function." → correct
+  - Feedback: How loudly the drums were beating! → exclamation | Why is the gate still open? → question | Our c...
+- Seed 2: "Tick one box in each row to show the sentence function." → correct
+  - Feedback: Can we finish the poster tomorrow? → question | How loudly the drums were beating! → exclamation ...
+- Seed 3: "Tick one box in each row to show the sentence function." → correct
+  - Feedback: Where did you put the compass? → question | How loudly the drums were beating! → exclamation | Ou...
 
 ### `question_mark_select`
 
@@ -1419,19 +1422,22 @@
 - **Reviewer:** automated-p10-oracle
 - **Method:** automated-oracle-with-concrete-evidence
 - **Seed window:** 1..10
-- **Answerability:** Some seeds produce ambiguous table rows (10/10 failures)
-- **Grammar logic:** Grammar logic partially valid for concept 'subject_object'; some seeds produce incorrect marking
+- **Answerability:** All 10 seeds produce a valid table with unambiguous row answers
+- **Grammar logic:** Feedback correctly references grammar rule for concept 'subject_object'
 - **Distractor quality:** Table-choice: each row has column distractors drawn from related grammatical categories
-- **Marking:** 0/10 seeds mark correctly; 10 seed(s) fail golden validation
-- **Feedback:** Table-choice: feedback delivered via row-level correctness indicators (green/red). No text feedback field exists for this input type — by design.
+- **Marking:** Golden answers mark correct across all 10 seeds; empty/whitespace rejected
+- **Feedback:** feedbackLong references grammar rule; feedbackShort provides one-line summary
 - **Accessibility:** No visual cue required; standard text prompt accessible by default
 - **Final action:** ship
 
 **Concrete examples:**
 
-- Seed 1: "Classify each named noun phrase as the subject or object." → no-result
-- Seed 2: "Classify each named noun phrase as the subject or object." → no-result
-- Seed 3: "Classify each named noun phrase as the subject or object." → no-result
+- Seed 1: "Classify each named noun phrase as the subject or object." → correct
+  - Feedback: The subject does the action; the object receives it.
+- Seed 2: "Classify each named noun phrase as the subject or object." → correct
+  - Feedback: The subject does the action; the object receives it.
+- Seed 3: "Classify each named noun phrase as the subject or object." → correct
+  - Feedback: The subject does the action; the object receives it.
 
 ### `qg_pronoun_referent_identify`
 
@@ -1464,19 +1470,22 @@
 - **Reviewer:** automated-p10-oracle
 - **Method:** automated-oracle-with-concrete-evidence
 - **Seed window:** 1..10
-- **Answerability:** Some seeds produce ambiguous table rows (10/10 failures)
-- **Grammar logic:** Grammar logic partially valid for concept 'formality'; some seeds produce incorrect marking
+- **Answerability:** All 10 seeds produce a valid table with unambiguous row answers
+- **Grammar logic:** Feedback correctly references grammar rule for concept 'formality'
 - **Distractor quality:** Table-choice: each row has column distractors drawn from related grammatical categories
-- **Marking:** 0/10 seeds mark correctly; 10 seed(s) fail golden validation
-- **Feedback:** Table-choice: feedback delivered via row-level correctness indicators (green/red). No text feedback field exists for this input type — by design.
+- **Marking:** Golden answers mark correct across all 10 seeds; empty/whitespace rejected
+- **Feedback:** feedbackLong references grammar rule; feedbackShort provides one-line summary
 - **Accessibility:** No visual cue required; standard text prompt accessible by default
 - **Final action:** ship
 
 **Concrete examples:**
 
-- Seed 1: "Classify each sentence as formal or informal." → no-result
-- Seed 2: "Classify each sentence as formal or informal." → no-result
-- Seed 3: "Classify each sentence as formal or informal." → no-result
+- Seed 1: "Classify each sentence as formal or informal." → correct
+  - Feedback: Formal writing avoids chatty phrasing and uses precise vocabulary.
+- Seed 2: "Classify each sentence as formal or informal." → correct
+  - Feedback: Formal writing avoids chatty phrasing and uses precise vocabulary.
+- Seed 3: "Classify each sentence as formal or informal." → correct
+  - Feedback: Formal writing avoids chatty phrasing and uses precise vocabulary.
 
 ### `qg_modal_verb_explain`
 
@@ -1897,21 +1906,26 @@
 - **Reviewer:** automated-p10-oracle
 - **Method:** automated-oracle-with-concrete-evidence
 - **Seed window:** 1..15
-- **Answerability:** Some seeds produce ambiguous table rows (15/15 failures)
-- **Grammar logic:** Grammar logic partially valid for concept 'word_classes, noun_phrases'; some seeds produce incorrect marking
+- **Answerability:** All 15 seeds produce a valid table with unambiguous row answers
+- **Grammar logic:** Feedback correctly references grammar rule for concept 'word_classes, noun_phrases'
 - **Distractor quality:** Table-choice: each row has column distractors drawn from related grammatical categories
-- **Marking:** 0/15 seeds mark correctly; 15 seed(s) fail golden validation
-- **Feedback:** Table-choice: feedback delivered via row-level correctness indicators (green/red). No text feedback field exists for this input type — by design.
+- **Marking:** Golden answers mark correct across all 15 seeds; empty/whitespace rejected
+- **Feedback:** feedbackLong references grammar rule; feedbackShort provides one-line summary
 - **Accessibility:** focusCue present with screenReaderPromptText; readAloudText mentions target
 - **Final action:** ship
 
 **Concrete examples:**
 
-- Seed 1: "Identify the head noun and its word class in this expanded noun phrase. the r..." → no-result
-- Seed 2: "Identify the head noun and the word class of the modifier before it. a terrif..." → no-result
-- Seed 3: "Identify the head noun and the word class of the underlined word in this noun..." → no-result
-- Seed 4: "Identify the head noun and the word class of the first word in this noun phra..." → no-result
-- Seed 5: "Identify the head noun and the word class of the describing word. the brightl..." → no-result
+- Seed 1: "Identify the head noun and its word class in this expanded noun phrase. the r..." → correct
+  - Feedback: The head noun is the main word the phrase is built around. 'Rusty' is an adjective modifying the ...
+- Seed 2: "Identify the head noun and the word class of the modifier before it. a terrif..." → correct
+  - Feedback: 'Storm' is the head noun. 'Mountain' is a noun used as a modifier (a noun adjunct), not an adject...
+- Seed 3: "Identify the head noun and the word class of the underlined word in this noun..." → correct
+  - Feedback: 'Firefighters' is the head noun. 'Incredibly' is an adverb modifying the adjective 'brave', not i...
+- Seed 4: "Identify the head noun and the word class of the first word in this noun phra..." → correct
+  - Feedback: 'Lesson' is the head noun the phrase centres on. 'Every' is a determiner specifying which lesson,...
+- Seed 5: "Identify the head noun and the word class of the describing word. the brightl..." → correct
+  - Feedback: 'Fence' is the head noun. 'Painted' here is used as an adjective describing the fence, not as a v...
 
 ### `qg_p4_adverbial_clause_boundary_transfer`
 
@@ -2016,21 +2030,26 @@
 - **Reviewer:** automated-p10-oracle
 - **Method:** automated-oracle-with-concrete-evidence
 - **Seed window:** 1..15
-- **Answerability:** Some seeds produce ambiguous table rows (15/15 failures)
-- **Grammar logic:** Grammar logic partially valid for concept 'active_passive, subject_object'; some seeds produce incorrect marking
+- **Answerability:** All 15 seeds produce a valid table with unambiguous row answers
+- **Grammar logic:** Feedback correctly references grammar rule for concept 'active_passive, subject_object'
 - **Distractor quality:** Table-choice: each row has column distractors drawn from related grammatical categories
-- **Marking:** 0/15 seeds mark correctly; 15 seed(s) fail golden validation
-- **Feedback:** Table-choice: feedback delivered via row-level correctness indicators (green/red). No text feedback field exists for this input type — by design.
+- **Marking:** Golden answers mark correct across all 15 seeds; empty/whitespace rejected
+- **Feedback:** feedbackLong references grammar rule; feedbackShort provides one-line summary
 - **Accessibility:** focusCue present with screenReaderPromptText; readAloudText mentions target
 - **Final action:** ship
 
 **Concrete examples:**
 
-- Seed 1: "Identify the voice and the grammatical role of the underlined noun phrase. Th..." → no-result
-- Seed 2: "Identify the voice and the grammatical role of the underlined noun phrase. Th..." → no-result
-- Seed 3: "Identify the voice and the grammatical role of the underlined noun phrase. Th..." → no-result
-- Seed 4: "Identify the voice and the grammatical role of the underlined noun phrase. Le..." → no-result
-- Seed 5: "Identify the voice and the grammatical role of the underlined noun phrase. Th..." → no-result
+- Seed 1: "Identify the voice and the grammatical role of the underlined noun phrase. Th..." → correct
+  - Feedback: The sentence is passive because the action is done TO the trophy. In a passive sentence, the thin...
+- Seed 2: "Identify the voice and the grammatical role of the underlined noun phrase. Th..." → correct
+  - Feedback: The sentence is active because the doer ('the goalkeeper') comes first and does the action. 'The ...
+- Seed 3: "Identify the voice and the grammatical role of the underlined noun phrase. Th..." → correct
+  - Feedback: This is passive voice: the thing affected ('the cake') has been moved to the subject position. Ev...
+- Seed 4: "Identify the voice and the grammatical role of the underlined noun phrase. Le..." → correct
+  - Feedback: The sentence is active because the doer ('Lena') performs the action. 'The scenery' receives the ...
+- Seed 5: "Identify the voice and the grammatical role of the underlined noun phrase. Th..." → correct
+  - Feedback: This is passive voice: the affected thing ('the windows') is the grammatical subject. The doer ('...
 
 ### `qg_p4_possession_hyphen_clarity_transfer`
 

--- a/scripts/generate-grammar-qg-quality-register.mjs
+++ b/scripts/generate-grammar-qg-quality-register.mjs
@@ -89,9 +89,40 @@ function buildGoldenResponse(question) {
 
 function buildTableGolden(question) {
   if (question.inputSpec?.type !== 'table_choice') return null;
+
+  // Pattern 1: Heterogeneous tables with multiField answerSpec
+  // e.g. qg_p4_voice_roles_transfer, qg_p4_word_class_noun_phrase_transfer,
+  //      qg_subject_object_classify_table, qg_formality_classify_table
+  if (question.answerSpec?.kind === 'multiField') {
+    const fields = question.answerSpec.params?.fields;
+    if (fields) {
+      const resp = {};
+      for (const [key, spec] of Object.entries(fields)) {
+        resp[key] = spec.golden[0];
+      }
+      return resp;
+    }
+  }
+
+  // Pattern 2: Homogeneous tables with closure evaluator (no answerSpec)
+  // e.g. sentence_type_table — derive answers from feedback text
+  if (!question.answerSpec) {
+    const wrongResult = evaluateGrammarQuestion(question, {});
+    const text = wrongResult?.answerText || wrongResult?.feedbackLong || '';
+    if (text.includes(' | ') || text.includes(' → ')) {
+      const pairs = text.split(' | ');
+      const resp = {};
+      pairs.forEach((pair, i) => {
+        const answer = pair.split(' → ')[1]?.trim();
+        if (answer) resp[`row${i}`] = answer;
+      });
+      if (Object.keys(resp).length > 0) return resp;
+    }
+  }
+
+  // Fallback: brute-force each row with column values
   const rows = question.inputSpec.rows || [];
   const resp = {};
-  // Brute-force each row: try each column value
   for (let i = 0; i < rows.length; i++) {
     const cols = question.inputSpec.columns || rows[i].columns || [];
     for (const col of cols) {


### PR DESCRIPTION
## Summary

- Fix `buildTableGolden` in the quality register script to handle two table_choice patterns that previously produced `markingResult: "no-result"`:
  1. **Heterogeneous tables** (multiField answerSpec) — reads golden directly from `answerSpec.params.fields[key].golden[0]`
  2. **Homogeneous tables** (closure evaluator, no answerSpec) — submits empty response, parses `answerText` feedback to derive per-row values
- All 5 affected templates (`qg_p4_voice_roles_transfer`, `qg_p4_word_class_noun_phrase_transfer`, `qg_subject_object_classify_table`, `qg_formality_classify_table`, `sentence_type_table`) now mark correctly with real feedback
- Regenerated `reports/grammar/grammar-qg-p10-quality-register.json` and `.md`

## Test plan

- [x] Script runs without errors: 78 templates, 74 approved, 0 blocked
- [x] All 5 table_choice templates: `markingResult: "correct"` across all seeds
- [x] `decision: "approved"`, `finalAction: "ship"` for all 5
- [x] Real `feedbackSnippet` populated (not empty)
- [x] `markingJudgement` reads "Golden answers mark correct across all N seeds"