### PR TITLE
feat(hero-pA3): provenance-aware certification — validator, manifest, smoke script

### DIFF
--- a/reports/hero/hero-pA3-certification-manifest.json
+++ b/reports/hero/hero-pA3-certification-manifest.json
@@ -1,0 +1,52 @@
+{
+  "phase": "hero-pA3",
+  "date": "2026-04-30",
+  "description": "Certification manifest for Hero Mode pA3 — gates the A4 recommendation",
+  "rings": {
+    "A3-0": {
+      "name": "Evidence provenance and docs reconciliation",
+      "requiredEvidence": [
+        { "path": "docs/plans/james/hero-mode/A/hero-pA3-internal-cohort-evidence.md", "condition": "file_exists", "description": "A3 evidence file with provenance schema" },
+        { "path": "docs/plans/james/hero-mode/A/hero-pA3-rollback-procedure.md", "condition": "file_exists", "description": "Rollback procedure documented" },
+        { "path": "docs/plans/james/hero-mode/A/hero-pA3-support-checklist.md", "condition": "file_exists", "description": "Support checklist documented" }
+      ]
+    },
+    "A3-1": {
+      "name": "Real internal production cohort",
+      "requiredEvidence": [
+        { "path": "docs/plans/james/hero-mode/A/hero-pA3-internal-cohort-evidence.md", "condition": "min_real_observations_5", "description": "At least 5 real-production observations" },
+        { "path": "docs/plans/james/hero-mode/A/hero-pA3-internal-cohort-evidence.md", "condition": "min_real_datekeys_2", "description": "At least 2 unique date keys from real observations" },
+        { "path": "docs/plans/james/hero-mode/A/hero-pA3-internal-cohort-evidence.md", "condition": "min_real_learners_3", "description": "At least 3 unique learner profiles from real observations" }
+      ]
+    },
+    "A3-2": {
+      "name": "Goal 6 telemetry extraction",
+      "requiredEvidence": [
+        { "path": "reports/hero/hero-pA3-telemetry-report.json", "condition": "file_exists", "description": "Telemetry extraction report generated" },
+        { "path": "docs/plans/james/hero-mode/A/hero-pA3-metrics-baseline.md", "condition": "file_exists", "description": "A3 metrics baseline with provenance-qualified confidence" }
+      ]
+    },
+    "A3-3": {
+      "name": "Browser QA and rollback evidence",
+      "requiredEvidence": [
+        { "path": "docs/plans/james/hero-mode/A/hero-pA3-browser-qa-evidence.md", "condition": "status_not_pending", "description": "Browser QA completed (not PENDING)" }
+      ]
+    },
+    "A3-4": {
+      "name": "A4 recommendation",
+      "requiredEvidence": [
+        { "path": "docs/plans/james/hero-mode/A/hero-pA3-risk-register.md", "condition": "file_exists", "description": "A3 risk register exists" },
+        { "path": "docs/plans/james/hero-mode/A/hero-pA3-recommendation.md", "condition": "contains_decision", "description": "A4 recommendation issued" }
+      ]
+    },
+    "A3-5": {
+      "name": "External micro-cohort (optional)",
+      "optional": true,
+      "requiredEvidence": [
+        { "path": "docs/plans/james/hero-mode/A/hero-pA3-external-cohort-evidence.md", "condition": "min_real_observations_5", "description": "At least 5 external cohort observations" },
+        { "path": "docs/plans/james/hero-mode/A/hero-pA3-external-cohort-evidence.md", "condition": "min_real_datekeys_14", "description": "At least 14 unique date keys (14-day minimum)" }
+      ]
+    }
+  },
+  "certificationStates": ["NOT_CERTIFIED", "CERTIFIED_WITH_LIMITATIONS", "CERTIFIED_PRE_A4"]
+}

--- a/scripts/hero-pA3-cohort-smoke.mjs
+++ b/scripts/hero-pA3-cohort-smoke.mjs
@@ -1,0 +1,272 @@
+#!/usr/bin/env node
+// Hero Mode pA3 — Internal cohort smoke script (provenance-aware).
+// Queries the admin ops probe for each cohort account and appends
+// a 9-column observation record (with Source provenance) to the
+// cohort evidence file.
+//
+// Usage: node scripts/hero-pA3-cohort-smoke.mjs [--probe-url URL] [--dry-run]
+//        [--learner-ids id1,id2,...] [--source real-production|staging|local|simulation|manual-note]
+//
+// In dry-run mode, prints the observation record without appending.
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { detectStopConditions } from './hero-pA2-cohort-smoke.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const EVIDENCE_PATH = resolve(__dirname, '../docs/plans/james/hero-mode/A/hero-pA3-internal-cohort-evidence.md');
+
+const VALID_SOURCES = ['real-production', 'staging', 'local', 'simulation', 'manual-note'];
+
+const EVIDENCE_TEMPLATE = `# Hero Mode pA3 — Internal Cohort Evidence
+
+## Observation Log
+
+| Date | Learner | Readiness | Balance Bucket | Ledger Entries | Reconciliation | Override | Source | Status |
+|------|---------|-----------|----------------|----------------|----------------|----------|--------|--------|
+
+## Stop Conditions
+
+| Condition | Observed | Date | Details |
+|-----------|----------|------|---------|
+| Negative balance | No | | |
+| Reconciliation gap | No | | |
+`;
+
+// ── CLI argument parsing ────────────────────────────────────────────
+
+export function parseArgs(argv) {
+  const args = {
+    probeUrl: 'http://localhost:8787/api/admin/hero/telemetry-probe',
+    dryRun: false,
+    learnerIds: ['placeholder-learner-1'],
+    source: 'real-production',
+  };
+
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--dry-run') {
+      args.dryRun = true;
+    } else if (arg === '--probe-url' && argv[i + 1]) {
+      args.probeUrl = argv[++i];
+    } else if (arg.startsWith('--probe-url=')) {
+      args.probeUrl = arg.slice('--probe-url='.length);
+    } else if (arg === '--learner-ids' && argv[i + 1]) {
+      args.learnerIds = argv[++i].split(',').map(s => s.trim()).filter(Boolean);
+    } else if (arg.startsWith('--learner-ids=')) {
+      args.learnerIds = arg.slice('--learner-ids='.length).split(',').map(s => s.trim()).filter(Boolean);
+    } else if (arg === '--source' && argv[i + 1]) {
+      args.source = argv[++i].trim().toLowerCase();
+    } else if (arg.startsWith('--source=')) {
+      args.source = arg.slice('--source='.length).trim().toLowerCase();
+    }
+  }
+
+  // Validate source
+  if (!VALID_SOURCES.includes(args.source)) {
+    args.source = 'real-production';
+  }
+
+  return args;
+}
+
+// ── Probe fetching ──────────────────────────────────────────────────
+
+async function fetchProbe(probeUrl, learnerId) {
+  const url = `${probeUrl}?learnerId=${encodeURIComponent(learnerId)}&limit=5`;
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      return { error: `HTTP ${response.status}`, data: null };
+    }
+    const data = await response.json();
+    return { error: null, data };
+  } catch (err) {
+    return { error: err.message, data: null };
+  }
+}
+
+// ── Observation extraction (9-column, provenance-aware) ─────────────
+
+export function extractObservation(learnerId, probeData, source) {
+  const today = new Date().toISOString().slice(0, 10);
+
+  if (!probeData || probeData.error) {
+    return {
+      date: today,
+      learner: learnerId,
+      readiness: 'error',
+      balanceBucket: 'unknown',
+      ledgerEntries: 0,
+      reconciliation: 'unknown',
+      override: 'unknown',
+      source: 'manual-note',
+      status: `ERROR:fetch-failed`,
+      stopConditions: [],
+    };
+  }
+
+  const data = probeData.data || probeData;
+  const readiness = data.readiness?.overall ?? 'not_started';
+  const health = data.health ?? {};
+  const reconciliation = data.reconciliation ?? {};
+  const overrideStatus = data.overrideStatus ?? {};
+
+  const balanceBucket = health.balanceBucket ?? 'unknown';
+  const balance = health.balance ?? null;
+  const ledgerEntries = health.ledgerEntryCount ?? 0;
+  const hasGap = reconciliation.hasGap ?? false;
+  const overrideLabel = overrideStatus.isInternalAccount ? 'override-active' : 'no-override';
+
+  // Stop condition detection (reuses pA2 logic)
+  const stopConditions = detectStopConditions({ balance, balanceBucket, hasGap, health, readiness: data.readiness, overrideStatus });
+
+  const stops = stopConditions.filter(c => c.level === 'stop');
+  const warns = stopConditions.filter(c => c.level === 'warn');
+  const status = stops.length > 0
+    ? `STOP:${stops.map(c => c.key).join(',')}`
+    : warns.length > 0
+      ? `WARN:${warns.map(c => c.key).join(',')}`
+      : 'OK';
+
+  return {
+    date: today,
+    learner: learnerId,
+    readiness,
+    balanceBucket,
+    ledgerEntries,
+    reconciliation: hasGap ? 'gap' : 'no-gap',
+    override: overrideLabel,
+    source,
+    status,
+    stopConditions,
+  };
+}
+
+// ── Markdown formatting (9-column) ─────────────────────────────────
+
+export function formatObservationRow(obs) {
+  return `| ${obs.date} | ${obs.learner} | ${obs.readiness} | ${obs.balanceBucket} | ${obs.ledgerEntries} | ${obs.reconciliation} | ${obs.override} | ${obs.source} | ${obs.status} |`;
+}
+
+function formatStopConditionRows(observations) {
+  const rows = [];
+  for (const obs of observations) {
+    for (const condition of obs.stopConditions) {
+      const detail = condition.detail ? ` (${condition.detail})` : '';
+      rows.push(`| ${condition.key}${detail} | Yes | ${obs.date} | Learner: ${obs.learner} [${condition.level}] |`);
+    }
+  }
+  return rows;
+}
+
+// ── File insertion ────────────────────────────────────────────────
+
+export function insertIntoObservationLog(content, observationRows, stopRows) {
+  const stopConditionsIdx = content.indexOf('## Stop Conditions');
+  if (stopConditionsIdx === -1) {
+    const headerPattern = '|------|---------|-----------|';
+    const headerIdx = content.indexOf(headerPattern);
+    if (headerIdx === -1) {
+      return content + '\n' + observationRows + '\n';
+    }
+    const lineEnd = content.indexOf('\n', headerIdx);
+    const insertAt = lineEnd === -1 ? content.length : lineEnd + 1;
+    return content.slice(0, insertAt) + observationRows + '\n' + content.slice(insertAt);
+  }
+
+  const insertAt = stopConditionsIdx;
+  let result = content.slice(0, insertAt) + observationRows + '\n\n' + content.slice(insertAt);
+
+  if (stopRows.length > 0) {
+    const stopSection = result.indexOf('## Stop Conditions');
+    const afterStopSection = result.slice(stopSection);
+    const lines = afterStopSection.split('\n');
+    let lastTableRowIdx = -1;
+    for (let i = 0; i < lines.length; i++) {
+      if (lines[i].startsWith('|')) lastTableRowIdx = i;
+    }
+    if (lastTableRowIdx !== -1) {
+      lines.splice(lastTableRowIdx + 1, 0, ...stopRows);
+      result = result.slice(0, stopSection) + lines.join('\n');
+    }
+  }
+
+  return result;
+}
+
+// ── Main ────────────────────────────────────────────────────────────
+
+async function main() {
+  const args = parseArgs(process.argv);
+
+  console.log(`Hero Mode pA3 — Cohort Smoke Script (provenance-aware)`);
+  console.log(`Probe URL: ${args.probeUrl}`);
+  console.log(`Learner IDs: ${args.learnerIds.join(', ')}`);
+  console.log(`Source: ${args.source}`);
+  console.log(`Dry run: ${args.dryRun}`);
+  console.log('---');
+
+  const observations = [];
+
+  for (const learnerId of args.learnerIds) {
+    const result = await fetchProbe(args.probeUrl, learnerId);
+    const obs = extractObservation(learnerId, result, args.source);
+    observations.push(obs);
+
+    const row = formatObservationRow(obs);
+    console.log(row);
+  }
+
+  // Summary
+  console.log('---');
+  console.log(`Checked: ${observations.length} learner(s)`);
+  const withConditions = observations.filter(o => o.stopConditions.length > 0);
+  if (withConditions.length > 0) {
+    console.log(`STOP CONDITIONS DETECTED (${withConditions.length} learner(s)):`);
+    for (const obs of withConditions) {
+      for (const c of obs.stopConditions) {
+        console.log(`  - ${obs.learner}: [${c.level}] ${c.key}${c.detail ? ` (${c.detail})` : ''}`);
+      }
+    }
+  } else {
+    console.log('No stop conditions detected.');
+  }
+
+  if (!args.dryRun) {
+    let content;
+
+    // If evidence file doesn't exist, create it with the 9-column header
+    if (!existsSync(EVIDENCE_PATH)) {
+      const dir = dirname(EVIDENCE_PATH);
+      if (!existsSync(dir)) {
+        mkdirSync(dir, { recursive: true });
+      }
+      content = EVIDENCE_TEMPLATE;
+      writeFileSync(EVIDENCE_PATH, content, 'utf8');
+      console.log(`\nCreated evidence file: ${EVIDENCE_PATH}`);
+    } else {
+      content = readFileSync(EVIDENCE_PATH, 'utf8');
+    }
+
+    const observationRows = observations.map(formatObservationRow).join('\n');
+    const stopRows = formatStopConditionRows(observations);
+
+    const updated = insertIntoObservationLog(content, observationRows, stopRows);
+    writeFileSync(EVIDENCE_PATH, updated, 'utf8');
+    console.log(`Inserted ${observations.length} observation(s) into ${EVIDENCE_PATH}`);
+  } else {
+    console.log('\n(Dry run — no file written)');
+  }
+}
+
+// Only run main when invoked directly (not when imported for testing)
+const _scriptUrl = fileURLToPath(import.meta.url);
+const _invokedAs = process.argv[1] ? resolve(process.argv[1]) : '';
+if (_scriptUrl === _invokedAs) {
+  main().catch((err) => {
+    console.error('Fatal error:', err.message);
+    process.exit(0);
+  });
+}

--- a/scripts/validate-hero-pA3-certification-evidence.mjs
+++ b/scripts/validate-hero-pA3-certification-evidence.mjs
@@ -1,0 +1,370 @@
+#!/usr/bin/env node
+/**
+ * Hero Mode pA3 Certification Evidence Validator (U2)
+ *
+ * Provenance-aware validator that distinguishes `real-production` from
+ * `simulation` rows. Validates ring-by-ring evidence required to gate
+ * the A4 recommendation.
+ *
+ * Exit code: always 0 (reports status, does not crash).
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT_DIR = path.resolve(__dirname, '..');
+
+// ---------------------------------------------------------------------------
+// Condition evaluators
+// ---------------------------------------------------------------------------
+
+/**
+ * Check that a file does NOT contain "Status: PENDING" or "**Status:** PENDING".
+ */
+export function checkStatusNotPending(content) {
+  const pendingPattern = /(?:\*\*Status:\*\*|Status:)\s*PENDING/i;
+  return !pendingPattern.test(content);
+}
+
+/**
+ * Check that the file contains one of the valid A4 decision keywords on a labelled
+ * line (Decision: / Recommendation:) and NOT inside bracket-enclosed placeholder
+ * text like [PROCEED TO A4 / HOLD AND HARDEN / ROLL BACK].
+ */
+export function checkContainsDecision(content) {
+  const lines = content.split('\n');
+  const labelPattern = /(?:Decision|Recommendation):\s*\*?\*?\s*(PROCEED TO A4|HOLD AND HARDEN|ROLL BACK)/i;
+  return lines.some(line => {
+    if (/\[.*(?:PROCEED|HOLD|ROLL\s*BACK).*\]/.test(line)) return false;
+    return labelPattern.test(line);
+  });
+}
+
+/**
+ * Count observation lines by provenance (Source column).
+ *
+ * Parses a 9-column markdown table:
+ * | Date | Learner | Readiness | Balance Bucket | Ledger Entries | Reconciliation | Override | Source | Status |
+ *
+ * Source column is column index 7 (0-indexed). Classifies each row.
+ * Legacy rows (fewer than 9 columns) are treated defensively as `simulation`.
+ *
+ * @param {string} content - File content
+ * @returns {{ total: number, realProduction: number, simulation: number, staging: number, local: number, manualNote: number, dateKeys: string[], realDateKeys: string[], realLearners: string[] }}
+ */
+export function countObservationsByProvenance(content) {
+  const result = {
+    total: 0,
+    realProduction: 0,
+    simulation: 0,
+    staging: 0,
+    local: 0,
+    manualNote: 0,
+    dateKeys: [],
+    realDateKeys: [],
+    realLearners: [],
+  };
+
+  const dateKeySet = new Set();
+  const realDateKeySet = new Set();
+  const realLearnerSet = new Set();
+
+  const lines = content.split('\n');
+
+  for (const line of lines) {
+    // Must be a table row starting with | and containing a date pattern
+    if (!line.startsWith('|')) continue;
+
+    const cells = line.split('|').map(c => c.trim()).filter(c => c.length > 0);
+
+    // Skip header/separator rows
+    if (cells.length === 0) continue;
+    if (/^-+$/.test(cells[0])) continue;
+    if (cells[0] === 'Date') continue;
+
+    // Must have a date pattern in first cell
+    const dateMatch = cells[0].match(/^(20\d{2}-\d{2}-\d{2})$/);
+    if (!dateMatch) continue;
+
+    const date = dateMatch[1];
+    result.total++;
+    dateKeySet.add(date);
+
+    // Extract source from column 7 (0-indexed); if fewer columns, treat as simulation
+    const source = cells.length >= 8 ? cells[7].toLowerCase().trim() : 'simulation';
+    const learner = cells.length >= 2 ? cells[1].trim() : '';
+
+    switch (source) {
+      case 'real-production':
+        result.realProduction++;
+        realDateKeySet.add(date);
+        if (learner) realLearnerSet.add(learner);
+        break;
+      case 'staging':
+        result.staging++;
+        break;
+      case 'local':
+        result.local++;
+        break;
+      case 'manual-note':
+        result.manualNote++;
+        break;
+      case 'simulation':
+      default:
+        result.simulation++;
+        break;
+    }
+  }
+
+  result.dateKeys = [...dateKeySet];
+  result.realDateKeys = [...realDateKeySet];
+  result.realLearners = [...realLearnerSet];
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Core validation logic (pure — accepts fileReader for testability)
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {Object} FileReader
+ * @property {(filePath: string) => boolean} exists
+ * @property {(filePath: string) => string} read
+ */
+
+/**
+ * @typedef {Object} RingResult
+ * @property {string} name
+ * @property {boolean} pass
+ * @property {string[]} failures
+ */
+
+/**
+ * @typedef {Object} CertificationResult
+ * @property {'NOT_CERTIFIED' | 'CERTIFIED_WITH_LIMITATIONS' | 'CERTIFIED_PRE_A4'} status
+ * @property {Record<string, RingResult>} rings
+ * @property {string[]} failures
+ * @property {string[]} limitations
+ */
+
+/**
+ * Parse a condition string like "min_real_observations_5" or "min_real_datekeys_14"
+ * into { type, threshold }.
+ */
+function parseCondition(condition) {
+  const obsMatch = condition.match(/^min_real_observations_(\d+)$/);
+  if (obsMatch) return { type: 'min_real_observations', threshold: parseInt(obsMatch[1], 10) };
+
+  const dateMatch = condition.match(/^min_real_datekeys_(\d+)$/);
+  if (dateMatch) return { type: 'min_real_datekeys', threshold: parseInt(dateMatch[1], 10) };
+
+  const learnerMatch = condition.match(/^min_real_learners_(\d+)$/);
+  if (learnerMatch) return { type: 'min_real_learners', threshold: parseInt(learnerMatch[1], 10) };
+
+  return { type: condition, threshold: null };
+}
+
+/**
+ * Validate all rings declared in the manifest.
+ *
+ * @param {object} manifest - Parsed certification manifest JSON.
+ * @param {FileReader} fileReader - Dependency-injected file operations.
+ * @param {string} rootDir - Project root for resolving relative paths.
+ * @returns {CertificationResult}
+ */
+export function validateCertification(manifest, fileReader, rootDir) {
+  const rings = {};
+  const allFailures = [];
+  const limitations = [];
+
+  for (const [ringId, ringDef] of Object.entries(manifest.rings)) {
+    const ringResult = { name: ringDef.name, pass: true, failures: [] };
+
+    // --- requiredTests: check test file existence ---
+    if (ringDef.requiredTests) {
+      for (const testPath of ringDef.requiredTests) {
+        const fullPath = path.join(rootDir, testPath);
+        if (!fileReader.exists(fullPath)) {
+          ringResult.pass = false;
+          ringResult.failures.push(`Test file missing: ${testPath}`);
+        }
+      }
+    }
+
+    // --- requiredEvidence: check each condition ---
+    if (ringDef.requiredEvidence) {
+      for (const evidence of ringDef.requiredEvidence) {
+        const fullPath = path.join(rootDir, evidence.path);
+        const parsed = parseCondition(evidence.condition);
+
+        if (parsed.type === 'file_exists') {
+          if (!fileReader.exists(fullPath)) {
+            ringResult.pass = false;
+            ringResult.failures.push(`File missing: ${evidence.path} — ${evidence.description}`);
+          }
+        } else if (parsed.type === 'status_not_pending') {
+          if (!fileReader.exists(fullPath)) {
+            ringResult.pass = false;
+            ringResult.failures.push(`File missing: ${evidence.path} — ${evidence.description}`);
+          } else {
+            const content = fileReader.read(fullPath);
+            if (!checkStatusNotPending(content)) {
+              ringResult.pass = false;
+              ringResult.failures.push(`Status still PENDING: ${evidence.path}`);
+            }
+          }
+        } else if (parsed.type === 'contains_decision') {
+          if (!fileReader.exists(fullPath)) {
+            ringResult.pass = false;
+            ringResult.failures.push(`File missing: ${evidence.path} — ${evidence.description}`);
+          } else {
+            const content = fileReader.read(fullPath);
+            if (!checkContainsDecision(content)) {
+              ringResult.pass = false;
+              ringResult.failures.push(`No decision keyword found: ${evidence.path} — expected PROCEED TO A4 / HOLD AND HARDEN / ROLL BACK`);
+            }
+          }
+        } else if (parsed.type === 'min_real_observations') {
+          if (!fileReader.exists(fullPath)) {
+            ringResult.pass = false;
+            ringResult.failures.push(`File missing: ${evidence.path} — ${evidence.description}`);
+          } else {
+            const content = fileReader.read(fullPath);
+            const counts = countObservationsByProvenance(content);
+            if (counts.realProduction < parsed.threshold) {
+              ringResult.pass = false;
+              ringResult.failures.push(`Insufficient real-production observations (${counts.realProduction}/${parsed.threshold}): ${evidence.path}`);
+            }
+          }
+        } else if (parsed.type === 'min_real_datekeys') {
+          if (!fileReader.exists(fullPath)) {
+            ringResult.pass = false;
+            ringResult.failures.push(`File missing: ${evidence.path} — ${evidence.description}`);
+          } else {
+            const content = fileReader.read(fullPath);
+            const counts = countObservationsByProvenance(content);
+            if (counts.realDateKeys.length < parsed.threshold) {
+              ringResult.pass = false;
+              ringResult.failures.push(`Insufficient real-production date keys (${counts.realDateKeys.length}/${parsed.threshold}): ${evidence.path}`);
+            }
+          }
+        } else if (parsed.type === 'min_real_learners') {
+          if (!fileReader.exists(fullPath)) {
+            ringResult.pass = false;
+            ringResult.failures.push(`File missing: ${evidence.path} — ${evidence.description}`);
+          } else {
+            const content = fileReader.read(fullPath);
+            const counts = countObservationsByProvenance(content);
+            if (counts.realLearners.length < parsed.threshold) {
+              ringResult.pass = false;
+              ringResult.failures.push(`Insufficient real-production learners (${counts.realLearners.length}/${parsed.threshold}): ${evidence.path}`);
+            }
+          }
+        }
+      }
+    }
+
+    rings[ringId] = ringResult;
+    if (!ringResult.pass) {
+      allFailures.push(...ringResult.failures);
+    }
+  }
+
+  // --- Determine certification status ---
+  const ring0Pass = rings['A3-0']?.pass ?? false;
+  const ring1Pass = rings['A3-1']?.pass ?? false;
+  const ring2Pass = rings['A3-2']?.pass ?? true;
+  const ring3Pass = rings['A3-3']?.pass ?? true;
+  const ring4Pass = rings['A3-4']?.pass ?? true;
+  // A3-5 is optional — failure does NOT downgrade status
+  // (explicitly skipped from status logic)
+
+  let status;
+  if (!ring0Pass || !ring1Pass) {
+    status = 'NOT_CERTIFIED';
+  } else if (!ring2Pass || !ring3Pass || !ring4Pass) {
+    status = 'CERTIFIED_WITH_LIMITATIONS';
+    // Collect limitations from failing non-critical rings
+    for (const ringId of ['A3-2', 'A3-3', 'A3-4']) {
+      if (!rings[ringId]?.pass) {
+        limitations.push(`${ringId} (${rings[ringId].name}): ${rings[ringId].failures.join('; ')}`);
+      }
+    }
+  } else {
+    status = 'CERTIFIED_PRE_A4';
+  }
+
+  return { status, rings, failures: allFailures, limitations };
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry point
+// ---------------------------------------------------------------------------
+
+function main() {
+  const manifestPath = path.join(ROOT_DIR, 'reports', 'hero', 'hero-pA3-certification-manifest.json');
+
+  if (!existsSync(manifestPath)) {
+    console.error(`Manifest not found: ${manifestPath}`);
+    process.exit(0);
+  }
+
+  let manifest;
+  try {
+    manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  } catch (err) {
+    console.error(`Failed to parse manifest: ${err.message}`);
+    process.exit(0);
+  }
+
+  // Real filesystem reader
+  const fileReader = {
+    exists: (p) => existsSync(p),
+    read: (p) => readFileSync(p, 'utf8'),
+  };
+
+  const result = validateCertification(manifest, fileReader, ROOT_DIR);
+
+  // --- Human-readable output ---
+  console.log('');
+  console.log('╔══════════════════════════════════════════════════════════════╗');
+  console.log('║   Hero Mode pA3 — Certification Evidence Validator         ║');
+  console.log('╚══════════════════════════════════════════════════════════════╝');
+  console.log('');
+
+  for (const [ringId, ringResult] of Object.entries(result.rings)) {
+    const icon = ringResult.pass ? 'PASS' : 'FAIL';
+    const optionalTag = manifest.rings[ringId]?.optional ? ' (optional)' : '';
+    console.log(`  [${icon}] ${ringId}${optionalTag}: ${ringResult.name}`);
+    if (!ringResult.pass) {
+      for (const f of ringResult.failures) {
+        console.log(`         - ${f}`);
+      }
+    }
+  }
+
+  console.log('');
+  console.log(`  Status: ${result.status}`);
+
+  if (result.limitations.length > 0) {
+    console.log('');
+    console.log('  Limitations:');
+    for (const l of result.limitations) {
+      console.log(`    - ${l}`);
+    }
+  }
+
+  console.log('');
+
+  // JSON output for machine consumption
+  if (process.argv.includes('--json')) {
+    console.log(JSON.stringify(result, null, 2));
+  }
+}
+
+if (fileURLToPath(import.meta.url) === path.resolve(process.argv[1] || '')) {
+  main();
+}

--- a/tests/hero-pA3-certification-evidence.test.js
+++ b/tests/hero-pA3-certification-evidence.test.js
@@ -1,0 +1,465 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  validateCertification,
+  checkStatusNotPending,
+  checkContainsDecision,
+  countObservationsByProvenance,
+} from '../scripts/validate-hero-pA3-certification-evidence.mjs';
+
+// ── Fixtures ────────────────────────────────────────────────────────
+
+const MANIFEST = {
+  phase: 'hero-pA3',
+  date: '2026-04-30',
+  description: 'Certification manifest for Hero Mode pA3',
+  rings: {
+    'A3-0': {
+      name: 'Evidence provenance and docs reconciliation',
+      requiredEvidence: [
+        { path: 'docs/plans/james/hero-mode/A/hero-pA3-internal-cohort-evidence.md', condition: 'file_exists', description: 'A3 evidence file' },
+        { path: 'docs/plans/james/hero-mode/A/hero-pA3-rollback-procedure.md', condition: 'file_exists', description: 'Rollback procedure' },
+        { path: 'docs/plans/james/hero-mode/A/hero-pA3-support-checklist.md', condition: 'file_exists', description: 'Support checklist' },
+      ],
+    },
+    'A3-1': {
+      name: 'Real internal production cohort',
+      requiredEvidence: [
+        { path: 'docs/plans/james/hero-mode/A/hero-pA3-internal-cohort-evidence.md', condition: 'min_real_observations_5', description: 'At least 5 real observations' },
+        { path: 'docs/plans/james/hero-mode/A/hero-pA3-internal-cohort-evidence.md', condition: 'min_real_datekeys_2', description: 'At least 2 real date keys' },
+        { path: 'docs/plans/james/hero-mode/A/hero-pA3-internal-cohort-evidence.md', condition: 'min_real_learners_3', description: 'At least 3 real learners' },
+      ],
+    },
+    'A3-2': {
+      name: 'Goal 6 telemetry extraction',
+      requiredEvidence: [
+        { path: 'reports/hero/hero-pA3-telemetry-report.json', condition: 'file_exists', description: 'Telemetry report' },
+        { path: 'docs/plans/james/hero-mode/A/hero-pA3-metrics-baseline.md', condition: 'file_exists', description: 'Metrics baseline' },
+      ],
+    },
+    'A3-3': {
+      name: 'Browser QA and rollback evidence',
+      requiredEvidence: [
+        { path: 'docs/plans/james/hero-mode/A/hero-pA3-browser-qa-evidence.md', condition: 'status_not_pending', description: 'Browser QA completed' },
+      ],
+    },
+    'A3-4': {
+      name: 'A4 recommendation',
+      requiredEvidence: [
+        { path: 'docs/plans/james/hero-mode/A/hero-pA3-risk-register.md', condition: 'file_exists', description: 'Risk register' },
+        { path: 'docs/plans/james/hero-mode/A/hero-pA3-recommendation.md', condition: 'contains_decision', description: 'A4 recommendation issued' },
+      ],
+    },
+    'A3-5': {
+      name: 'External micro-cohort (optional)',
+      optional: true,
+      requiredEvidence: [
+        { path: 'docs/plans/james/hero-mode/A/hero-pA3-external-cohort-evidence.md', condition: 'min_real_observations_5', description: 'External cohort observations' },
+        { path: 'docs/plans/james/hero-mode/A/hero-pA3-external-cohort-evidence.md', condition: 'min_real_datekeys_14', description: '14-day minimum' },
+      ],
+    },
+  },
+  certificationStates: ['NOT_CERTIFIED', 'CERTIFIED_WITH_LIMITATIONS', 'CERTIFIED_PRE_A4'],
+};
+
+const ROOT = '/fake/root';
+
+function fullPath(relativePath) {
+  return `${ROOT}/${relativePath}`;
+}
+
+// ── Mock file reader factory ────────────────────────────────────────
+
+function createMockReader(fileMap) {
+  return {
+    exists: (p) => {
+      const normalised = p.replace(/\\/g, '/');
+      return normalised in fileMap;
+    },
+    read: (p) => {
+      const normalised = p.replace(/\\/g, '/');
+      if (!(normalised in fileMap)) throw new Error(`File not found: ${normalised}`);
+      return fileMap[normalised];
+    },
+  };
+}
+
+// ── Full happy-path file map ────────────────────────────────────────
+
+function makeEvidenceContent(rows) {
+  const header = [
+    '# Hero Mode pA3 — Internal Cohort Evidence',
+    '',
+    '## Observation Log',
+    '',
+    '| Date | Learner | Readiness | Balance Bucket | Ledger Entries | Reconciliation | Override | Source | Status |',
+    '|------|---------|-----------|----------------|----------------|----------------|----------|--------|--------|',
+  ];
+  return [...header, ...rows].join('\n');
+}
+
+function happyFileMap() {
+  const evidenceRows = [
+    '| 2026-04-25 | learner-A | ready | 300-599 | 5 | no-gap | override-active | real-production | OK |',
+    '| 2026-04-25 | learner-B | ready | 300-599 | 3 | no-gap | override-active | real-production | OK |',
+    '| 2026-04-26 | learner-C | ready | 100-299 | 2 | no-gap | no-override | real-production | OK |',
+    '| 2026-04-26 | learner-A | ready | 300-599 | 6 | no-gap | override-active | real-production | OK |',
+    '| 2026-04-27 | learner-B | ready | 300-599 | 4 | no-gap | override-active | real-production | OK |',
+    '| 2026-04-27 | learner-D | ready | 0-99 | 1 | no-gap | no-override | simulation | OK |',
+  ];
+
+  return {
+    [fullPath('docs/plans/james/hero-mode/A/hero-pA3-internal-cohort-evidence.md')]: makeEvidenceContent(evidenceRows),
+    [fullPath('docs/plans/james/hero-mode/A/hero-pA3-rollback-procedure.md')]: '# Rollback Procedure\n\nSteps documented.',
+    [fullPath('docs/plans/james/hero-mode/A/hero-pA3-support-checklist.md')]: '# Support Checklist\n\nAll items covered.',
+    [fullPath('reports/hero/hero-pA3-telemetry-report.json')]: '{"metrics": []}',
+    [fullPath('docs/plans/james/hero-mode/A/hero-pA3-metrics-baseline.md')]: '# Metrics Baseline\n\nBaseline captured.',
+    [fullPath('docs/plans/james/hero-mode/A/hero-pA3-browser-qa-evidence.md')]: '# Browser QA\n\nStatus: COMPLETE\n\nAll tests passed.',
+    [fullPath('docs/plans/james/hero-mode/A/hero-pA3-risk-register.md')]: '# Risk Register\n\nNo blocking risks.',
+    [fullPath('docs/plans/james/hero-mode/A/hero-pA3-recommendation.md')]: '# Recommendation\n\nDecision: PROCEED TO A4\n\nRationale: all rings pass.',
+    [fullPath('docs/plans/james/hero-mode/A/hero-pA3-external-cohort-evidence.md')]: makeEvidenceContent([
+      '| 2026-04-15 | ext-1 | ready | 300-599 | 5 | no-gap | no-override | real-production | OK |',
+      '| 2026-04-16 | ext-2 | ready | 300-599 | 3 | no-gap | no-override | real-production | OK |',
+      '| 2026-04-17 | ext-1 | ready | 300-599 | 6 | no-gap | no-override | real-production | OK |',
+      '| 2026-04-18 | ext-3 | ready | 300-599 | 2 | no-gap | no-override | real-production | OK |',
+      '| 2026-04-19 | ext-2 | ready | 300-599 | 4 | no-gap | no-override | real-production | OK |',
+      '| 2026-04-20 | ext-1 | ready | 300-599 | 7 | no-gap | no-override | real-production | OK |',
+      '| 2026-04-21 | ext-3 | ready | 300-599 | 3 | no-gap | no-override | real-production | OK |',
+      '| 2026-04-22 | ext-2 | ready | 300-599 | 5 | no-gap | no-override | real-production | OK |',
+      '| 2026-04-23 | ext-1 | ready | 300-599 | 6 | no-gap | no-override | real-production | OK |',
+      '| 2026-04-24 | ext-3 | ready | 300-599 | 4 | no-gap | no-override | real-production | OK |',
+      '| 2026-04-25 | ext-2 | ready | 300-599 | 5 | no-gap | no-override | real-production | OK |',
+      '| 2026-04-26 | ext-1 | ready | 300-599 | 7 | no-gap | no-override | real-production | OK |',
+      '| 2026-04-27 | ext-3 | ready | 300-599 | 3 | no-gap | no-override | real-production | OK |',
+      '| 2026-04-28 | ext-2 | ready | 300-599 | 4 | no-gap | no-override | real-production | OK |',
+    ]),
+  };
+}
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+describe('Hero pA3 Certification Validator', () => {
+  // ── countObservationsByProvenance ──────────────────────────────────
+
+  describe('helper: countObservationsByProvenance', () => {
+    it('counts 5 real + 2 simulation correctly', () => {
+      const content = makeEvidenceContent([
+        '| 2026-04-25 | learner-A | ready | 300-599 | 5 | no-gap | override-active | real-production | OK |',
+        '| 2026-04-25 | learner-B | ready | 300-599 | 3 | no-gap | override-active | real-production | OK |',
+        '| 2026-04-26 | learner-C | ready | 100-299 | 2 | no-gap | no-override | real-production | OK |',
+        '| 2026-04-26 | learner-A | ready | 300-599 | 6 | no-gap | override-active | real-production | OK |',
+        '| 2026-04-27 | learner-B | ready | 300-599 | 4 | no-gap | override-active | real-production | OK |',
+        '| 2026-04-27 | learner-D | ready | 0-99 | 1 | no-gap | no-override | simulation | OK |',
+        '| 2026-04-28 | learner-D | ready | 0-99 | 2 | no-gap | no-override | simulation | OK |',
+      ]);
+      const result = countObservationsByProvenance(content);
+      assert.equal(result.total, 7);
+      assert.equal(result.realProduction, 5);
+      assert.equal(result.simulation, 2);
+    });
+
+    it('all simulation returns realProduction=0', () => {
+      const content = makeEvidenceContent([
+        '| 2026-04-25 | sim-1 | ready | 300-599 | 5 | no-gap | no-override | simulation | OK |',
+        '| 2026-04-26 | sim-2 | ready | 300-599 | 3 | no-gap | no-override | simulation | OK |',
+        '| 2026-04-27 | sim-3 | ready | 100-299 | 2 | no-gap | no-override | simulation | OK |',
+      ]);
+      const result = countObservationsByProvenance(content);
+      assert.equal(result.total, 3);
+      assert.equal(result.realProduction, 0);
+      assert.equal(result.simulation, 3);
+      assert.equal(result.realDateKeys.length, 0);
+    });
+
+    it('legacy format (no Source column) treats all as simulation', () => {
+      // 8-column format (missing Source) — legacy pA2 format
+      const content = [
+        '| Date | Learner | Readiness | Balance Bucket | Ledger Entries | Reconciliation | Override | Status |',
+        '|------|---------|-----------|----------------|----------------|----------------|----------|--------|',
+        '| 2026-04-25 | learner-1 | ready | 300-599 | 5 | no-gap | override-active | OK |',
+        '| 2026-04-26 | learner-2 | ready | 300-599 | 3 | no-gap | override-active | OK |',
+      ].join('\n');
+      const result = countObservationsByProvenance(content);
+      assert.equal(result.total, 2);
+      assert.equal(result.realProduction, 0);
+      assert.equal(result.simulation, 2);
+    });
+
+    it('empty content returns all zeros', () => {
+      const result = countObservationsByProvenance('');
+      assert.equal(result.total, 0);
+      assert.equal(result.realProduction, 0);
+      assert.equal(result.simulation, 0);
+      assert.equal(result.staging, 0);
+      assert.equal(result.local, 0);
+      assert.equal(result.manualNote, 0);
+      assert.deepEqual(result.dateKeys, []);
+      assert.deepEqual(result.realDateKeys, []);
+      assert.deepEqual(result.realLearners, []);
+    });
+
+    it('counts unique real learners correctly', () => {
+      const content = makeEvidenceContent([
+        '| 2026-04-25 | learner-A | ready | 300-599 | 5 | no-gap | override-active | real-production | OK |',
+        '| 2026-04-25 | learner-B | ready | 300-599 | 3 | no-gap | override-active | real-production | OK |',
+        '| 2026-04-26 | learner-A | ready | 300-599 | 6 | no-gap | override-active | real-production | OK |',
+        '| 2026-04-26 | learner-C | ready | 100-299 | 2 | no-gap | no-override | simulation | OK |',
+      ]);
+      const result = countObservationsByProvenance(content);
+      assert.equal(result.realLearners.length, 2); // learner-A, learner-B
+      assert.ok(result.realLearners.includes('learner-A'));
+      assert.ok(result.realLearners.includes('learner-B'));
+    });
+
+    it('classifies staging, local, and manual-note correctly', () => {
+      const content = makeEvidenceContent([
+        '| 2026-04-25 | l-1 | ready | 300-599 | 5 | no-gap | no-override | staging | OK |',
+        '| 2026-04-26 | l-2 | ready | 300-599 | 3 | no-gap | no-override | local | OK |',
+        '| 2026-04-27 | l-3 | ready | 300-599 | 2 | no-gap | no-override | manual-note | OK |',
+      ]);
+      const result = countObservationsByProvenance(content);
+      assert.equal(result.staging, 1);
+      assert.equal(result.local, 1);
+      assert.equal(result.manualNote, 1);
+      assert.equal(result.realProduction, 0);
+    });
+  });
+
+  // ── checkContainsDecision (A4 keywords) ───────────────────────────
+
+  describe('helper: checkContainsDecision', () => {
+    it('finds PROCEED TO A4 with Decision: prefix', () => {
+      assert.equal(checkContainsDecision('Decision: PROCEED TO A4'), true);
+    });
+
+    it('finds HOLD AND HARDEN with Recommendation: prefix', () => {
+      assert.equal(checkContainsDecision('**Recommendation:** HOLD AND HARDEN'), true);
+    });
+
+    it('finds ROLL BACK with Decision: prefix', () => {
+      assert.equal(checkContainsDecision('Decision: ROLL BACK'), true);
+    });
+
+    it('returns false when no decision keyword', () => {
+      assert.equal(checkContainsDecision('No decision here.'), false);
+    });
+
+    it('rejects placeholder text inside square brackets', () => {
+      const placeholder = '**Recommendation:** [PROCEED TO A4 / HOLD AND HARDEN / ROLL BACK]';
+      assert.equal(checkContainsDecision(placeholder), false);
+    });
+
+    it('returns false when decision keyword in body without label prefix', () => {
+      assert.equal(checkContainsDecision('We should PROCEED TO A4 based on evidence.'), false);
+    });
+
+    it('finds decision on multi-line document with label', () => {
+      const doc = [
+        '# Recommendation',
+        '',
+        'Some preamble.',
+        '',
+        '**Decision:** PROCEED TO A4',
+        '',
+        'Rationale: all rings pass.',
+      ].join('\n');
+      assert.equal(checkContainsDecision(doc), true);
+    });
+  });
+
+  // ── Gate conditions ───────────────────────────────────────────────
+
+  describe('gate conditions', () => {
+    it('min_real_observations_5 passes with 5 real rows', () => {
+      const files = happyFileMap();
+      const reader = createMockReader(files);
+      const result = validateCertification(MANIFEST, reader, ROOT);
+      assert.equal(result.rings['A3-1'].pass, true);
+    });
+
+    it('min_real_observations_5 fails with only 3 real + 4 sim', () => {
+      const files = happyFileMap();
+      files[fullPath('docs/plans/james/hero-mode/A/hero-pA3-internal-cohort-evidence.md')] = makeEvidenceContent([
+        '| 2026-04-25 | learner-A | ready | 300-599 | 5 | no-gap | override-active | real-production | OK |',
+        '| 2026-04-26 | learner-B | ready | 300-599 | 3 | no-gap | override-active | real-production | OK |',
+        '| 2026-04-27 | learner-C | ready | 100-299 | 2 | no-gap | no-override | real-production | OK |',
+        '| 2026-04-25 | sim-1 | ready | 300-599 | 5 | no-gap | no-override | simulation | OK |',
+        '| 2026-04-26 | sim-2 | ready | 300-599 | 3 | no-gap | no-override | simulation | OK |',
+        '| 2026-04-27 | sim-3 | ready | 100-299 | 2 | no-gap | no-override | simulation | OK |',
+        '| 2026-04-28 | sim-4 | ready | 0-99 | 1 | no-gap | no-override | simulation | OK |',
+      ]);
+      const reader = createMockReader(files);
+      const result = validateCertification(MANIFEST, reader, ROOT);
+      assert.equal(result.rings['A3-1'].pass, false);
+      assert.ok(result.rings['A3-1'].failures.some(f => f.includes('real-production observations (3/5)')));
+    });
+
+    it('min_real_datekeys_2 passes with 2 unique dates from real rows', () => {
+      const files = happyFileMap();
+      // Default happy path has 3 real date keys (25, 26, 27)
+      const reader = createMockReader(files);
+      const result = validateCertification(MANIFEST, reader, ROOT);
+      assert.equal(result.rings['A3-1'].pass, true);
+    });
+
+    it('min_real_datekeys_2 fails when 2 dates but one is simulation-only', () => {
+      const files = happyFileMap();
+      files[fullPath('docs/plans/james/hero-mode/A/hero-pA3-internal-cohort-evidence.md')] = makeEvidenceContent([
+        '| 2026-04-25 | learner-A | ready | 300-599 | 5 | no-gap | override-active | real-production | OK |',
+        '| 2026-04-25 | learner-B | ready | 300-599 | 3 | no-gap | override-active | real-production | OK |',
+        '| 2026-04-25 | learner-C | ready | 100-299 | 2 | no-gap | no-override | real-production | OK |',
+        '| 2026-04-25 | learner-D | ready | 300-599 | 6 | no-gap | override-active | real-production | OK |',
+        '| 2026-04-25 | learner-E | ready | 300-599 | 4 | no-gap | override-active | real-production | OK |',
+        '| 2026-04-26 | sim-1 | ready | 0-99 | 1 | no-gap | no-override | simulation | OK |',
+      ]);
+      const reader = createMockReader(files);
+      const result = validateCertification(MANIFEST, reader, ROOT);
+      // Real date keys: only 2026-04-25 (1 key), fails min_real_datekeys_2
+      assert.equal(result.rings['A3-1'].pass, false);
+      assert.ok(result.rings['A3-1'].failures.some(f => f.includes('real-production date keys (1/2)')));
+    });
+
+    it('min_real_learners_3 passes with 3 unique learners from real rows', () => {
+      const files = happyFileMap();
+      // Default happy path has learner-A, learner-B, learner-C as real learners
+      const reader = createMockReader(files);
+      const result = validateCertification(MANIFEST, reader, ROOT);
+      assert.equal(result.rings['A3-1'].pass, true);
+    });
+
+    it('min_real_learners_3 fails with only 2 real learners', () => {
+      const files = happyFileMap();
+      files[fullPath('docs/plans/james/hero-mode/A/hero-pA3-internal-cohort-evidence.md')] = makeEvidenceContent([
+        '| 2026-04-25 | learner-A | ready | 300-599 | 5 | no-gap | override-active | real-production | OK |',
+        '| 2026-04-26 | learner-B | ready | 300-599 | 3 | no-gap | override-active | real-production | OK |',
+        '| 2026-04-27 | learner-A | ready | 100-299 | 2 | no-gap | no-override | real-production | OK |',
+        '| 2026-04-28 | learner-B | ready | 300-599 | 6 | no-gap | override-active | real-production | OK |',
+        '| 2026-04-29 | learner-A | ready | 300-599 | 4 | no-gap | override-active | real-production | OK |',
+      ]);
+      const reader = createMockReader(files);
+      const result = validateCertification(MANIFEST, reader, ROOT);
+      assert.equal(result.rings['A3-1'].pass, false);
+      assert.ok(result.rings['A3-1'].failures.some(f => f.includes('real-production learners (2/3)')));
+    });
+  });
+
+  // ── Certification status logic ────────────────────────────────────
+
+  describe('certification status logic', () => {
+    it('all rings pass returns CERTIFIED_PRE_A4', () => {
+      const reader = createMockReader(happyFileMap());
+      const result = validateCertification(MANIFEST, reader, ROOT);
+      assert.equal(result.status, 'CERTIFIED_PRE_A4');
+      assert.equal(result.failures.length, 0);
+      assert.equal(result.limitations.length, 0);
+    });
+
+    it('A3-0 failure returns NOT_CERTIFIED', () => {
+      const files = happyFileMap();
+      delete files[fullPath('docs/plans/james/hero-mode/A/hero-pA3-rollback-procedure.md')];
+      const reader = createMockReader(files);
+      const result = validateCertification(MANIFEST, reader, ROOT);
+      assert.equal(result.status, 'NOT_CERTIFIED');
+      assert.equal(result.rings['A3-0'].pass, false);
+    });
+
+    it('A3-1 failure returns NOT_CERTIFIED', () => {
+      const files = happyFileMap();
+      // Replace evidence with all simulation
+      files[fullPath('docs/plans/james/hero-mode/A/hero-pA3-internal-cohort-evidence.md')] = makeEvidenceContent([
+        '| 2026-04-25 | sim-1 | ready | 300-599 | 5 | no-gap | no-override | simulation | OK |',
+      ]);
+      const reader = createMockReader(files);
+      const result = validateCertification(MANIFEST, reader, ROOT);
+      assert.equal(result.status, 'NOT_CERTIFIED');
+      assert.equal(result.rings['A3-1'].pass, false);
+    });
+
+    it('A3-2 failure returns CERTIFIED_WITH_LIMITATIONS', () => {
+      const files = happyFileMap();
+      delete files[fullPath('reports/hero/hero-pA3-telemetry-report.json')];
+      const reader = createMockReader(files);
+      const result = validateCertification(MANIFEST, reader, ROOT);
+      assert.equal(result.status, 'CERTIFIED_WITH_LIMITATIONS');
+      assert.equal(result.rings['A3-2'].pass, false);
+      assert.ok(result.limitations.some(l => l.includes('A3-2')));
+    });
+
+    it('A3-5 failure (optional) does NOT downgrade status', () => {
+      const files = happyFileMap();
+      // Remove the external cohort evidence to make A3-5 fail
+      delete files[fullPath('docs/plans/james/hero-mode/A/hero-pA3-external-cohort-evidence.md')];
+      const reader = createMockReader(files);
+      const result = validateCertification(MANIFEST, reader, ROOT);
+      // A3-5 fails but status remains CERTIFIED_PRE_A4 because it is optional
+      assert.equal(result.rings['A3-5'].pass, false);
+      assert.equal(result.status, 'CERTIFIED_PRE_A4');
+    });
+
+    it('A3-3 PENDING status returns CERTIFIED_WITH_LIMITATIONS', () => {
+      const files = happyFileMap();
+      files[fullPath('docs/plans/james/hero-mode/A/hero-pA3-browser-qa-evidence.md')] =
+        '# Browser QA\n\n**Status:** PENDING\n\nAwaiting results.';
+      const reader = createMockReader(files);
+      const result = validateCertification(MANIFEST, reader, ROOT);
+      assert.equal(result.status, 'CERTIFIED_WITH_LIMITATIONS');
+      assert.equal(result.rings['A3-3'].pass, false);
+    });
+
+    it('A3-4 missing recommendation returns CERTIFIED_WITH_LIMITATIONS', () => {
+      const files = happyFileMap();
+      files[fullPath('docs/plans/james/hero-mode/A/hero-pA3-recommendation.md')] =
+        '# Recommendation\n\nPending decision.';
+      const reader = createMockReader(files);
+      const result = validateCertification(MANIFEST, reader, ROOT);
+      assert.equal(result.status, 'CERTIFIED_WITH_LIMITATIONS');
+      assert.equal(result.rings['A3-4'].pass, false);
+    });
+  });
+
+  // ── Full pipeline with mock fileReader ────────────────────────────
+
+  describe('full pipeline', () => {
+    it('empty file system returns NOT_CERTIFIED with all rings failing', () => {
+      const reader = createMockReader({});
+      const result = validateCertification(MANIFEST, reader, ROOT);
+      assert.equal(result.status, 'NOT_CERTIFIED');
+      for (const ring of Object.values(result.rings)) {
+        assert.equal(ring.pass, false);
+      }
+    });
+
+    it('critical rings pass but non-critical fail returns CERTIFIED_WITH_LIMITATIONS', () => {
+      const files = happyFileMap();
+      // Remove A3-2 evidence (non-critical)
+      delete files[fullPath('reports/hero/hero-pA3-telemetry-report.json')];
+      // Remove A3-4 evidence (non-critical)
+      delete files[fullPath('docs/plans/james/hero-mode/A/hero-pA3-risk-register.md')];
+      const reader = createMockReader(files);
+      const result = validateCertification(MANIFEST, reader, ROOT);
+      assert.equal(result.status, 'CERTIFIED_WITH_LIMITATIONS');
+      assert.equal(result.rings['A3-0'].pass, true);
+      assert.equal(result.rings['A3-1'].pass, true);
+      assert.equal(result.rings['A3-2'].pass, false);
+      assert.equal(result.rings['A3-4'].pass, false);
+      assert.equal(result.limitations.length, 2);
+    });
+  });
+
+  // ── checkStatusNotPending ─────────────────────────────────────────
+
+  describe('helper: checkStatusNotPending', () => {
+    it('returns true when no PENDING status', () => {
+      assert.equal(checkStatusNotPending('Status: APPROVED'), true);
+    });
+
+    it('returns false for plain Status: PENDING', () => {
+      assert.equal(checkStatusNotPending('Status: PENDING'), false);
+    });
+
+    it('returns false for bold **Status:** PENDING', () => {
+      assert.equal(checkStatusNotPending('**Status:** PENDING'), false);
+    });
+  });
+});

--- a/tests/hero-pA3-cohort-smoke.test.js
+++ b/tests/hero-pA3-cohort-smoke.test.js
@@ -1,0 +1,220 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  parseArgs,
+  extractObservation,
+  formatObservationRow,
+  insertIntoObservationLog,
+} from '../scripts/hero-pA3-cohort-smoke.mjs';
+import { detectStopConditions } from '../scripts/hero-pA2-cohort-smoke.mjs';
+
+// ── 9-column row generation ────────────────────────────────────────
+
+describe('pA3 cohort smoke: row generation', () => {
+  it('generates 9-column row with correct Source column', () => {
+    const obs = extractObservation('learner-1', {
+      error: null,
+      data: {
+        readiness: { overall: 'ready' },
+        health: { balanceBucket: '300-599', balance: 400, ledgerEntryCount: 5, duplicateAwardPreventedCount: 0 },
+        reconciliation: { hasGap: false },
+        overrideStatus: { accountId: 'acc-1', isInternalAccount: true, effectiveFlags: {} },
+      },
+    }, 'real-production');
+
+    assert.equal(obs.source, 'real-production');
+    assert.equal(obs.learner, 'learner-1');
+    assert.equal(obs.readiness, 'ready');
+    assert.equal(obs.status, 'OK');
+
+    const row = formatObservationRow(obs);
+    const cells = row.split('|').map(c => c.trim()).filter(c => c.length > 0);
+    assert.equal(cells.length, 9);
+    assert.equal(cells[7], 'real-production');
+    assert.equal(cells[8], 'OK');
+  });
+
+  it('source column reflects --source flag override', () => {
+    const obs = extractObservation('learner-2', {
+      error: null,
+      data: {
+        readiness: { overall: 'ready' },
+        health: { balanceBucket: '100-299', balance: 150, ledgerEntryCount: 3, duplicateAwardPreventedCount: 0 },
+        reconciliation: { hasGap: false },
+        overrideStatus: { accountId: 'acc-2', isInternalAccount: true, effectiveFlags: {} },
+      },
+    }, 'staging');
+
+    assert.equal(obs.source, 'staging');
+    const row = formatObservationRow(obs);
+    assert.ok(row.includes('| staging |'));
+  });
+
+  it('probe failure produces manual-note source and ERROR status', () => {
+    const obs = extractObservation('learner-3', { error: 'HTTP 500', data: null }, 'real-production');
+
+    assert.equal(obs.source, 'manual-note');
+    assert.equal(obs.status, 'ERROR:fetch-failed');
+    assert.equal(obs.readiness, 'error');
+
+    const row = formatObservationRow(obs);
+    assert.ok(row.includes('| manual-note |'));
+    assert.ok(row.includes('| ERROR:fetch-failed |'));
+  });
+
+  it('null probe data produces manual-note source and ERROR status', () => {
+    const obs = extractObservation('learner-4', null, 'real-production');
+
+    assert.equal(obs.source, 'manual-note');
+    assert.equal(obs.status, 'ERROR:fetch-failed');
+  });
+});
+
+// ── --source flag parsing ──────────────────────────────────────────
+
+describe('pA3 cohort smoke: parseArgs', () => {
+  it('defaults source to real-production', () => {
+    const args = parseArgs(['node', 'script.mjs']);
+    assert.equal(args.source, 'real-production');
+  });
+
+  it('--source staging overrides default', () => {
+    const args = parseArgs(['node', 'script.mjs', '--source', 'staging']);
+    assert.equal(args.source, 'staging');
+  });
+
+  it('--source=local overrides default', () => {
+    const args = parseArgs(['node', 'script.mjs', '--source=local']);
+    assert.equal(args.source, 'local');
+  });
+
+  it('--source=simulation accepted', () => {
+    const args = parseArgs(['node', 'script.mjs', '--source=simulation']);
+    assert.equal(args.source, 'simulation');
+  });
+
+  it('--source=manual-note accepted', () => {
+    const args = parseArgs(['node', 'script.mjs', '--source=manual-note']);
+    assert.equal(args.source, 'manual-note');
+  });
+
+  it('invalid source falls back to real-production', () => {
+    const args = parseArgs(['node', 'script.mjs', '--source', 'invalid-value']);
+    assert.equal(args.source, 'real-production');
+  });
+
+  it('--dry-run flag sets dryRun', () => {
+    const args = parseArgs(['node', 'script.mjs', '--dry-run']);
+    assert.equal(args.dryRun, true);
+  });
+
+  it('--learner-ids parses comma-separated list', () => {
+    const args = parseArgs(['node', 'script.mjs', '--learner-ids', 'a,b,c']);
+    assert.deepEqual(args.learnerIds, ['a', 'b', 'c']);
+  });
+
+  it('--probe-url sets the probe URL', () => {
+    const args = parseArgs(['node', 'script.mjs', '--probe-url', 'http://example.com/probe']);
+    assert.equal(args.probeUrl, 'http://example.com/probe');
+  });
+});
+
+// ── --dry-run behaviour ─────────────────────────────────────────────
+
+describe('pA3 cohort smoke: dry-run semantics', () => {
+  it('dry-run does not produce file writes (tested via extractObservation purity)', () => {
+    // extractObservation is a pure function — calling it never writes
+    const obs = extractObservation('learner-1', {
+      error: null,
+      data: {
+        readiness: { overall: 'ready' },
+        health: { balanceBucket: '300-599', balance: 400, ledgerEntryCount: 5, duplicateAwardPreventedCount: 0 },
+        reconciliation: { hasGap: false },
+        overrideStatus: { accountId: 'acc-1', isInternalAccount: true, effectiveFlags: {} },
+      },
+    }, 'real-production');
+    // If this doesn't throw, no side effect occurred
+    assert.ok(obs.date);
+    assert.ok(obs.learner);
+  });
+});
+
+// ── Stop condition detection (reuses pA2 detectStopConditions) ──────
+
+describe('pA3 cohort smoke: stop condition detection', () => {
+  function makeHealthy() {
+    return {
+      balance: 500,
+      balanceBucket: '300-599',
+      hasGap: false,
+      health: { duplicateAwardPreventedCount: 0, balance: 500 },
+      readiness: { overall: 'ready', flags: true, state: true },
+      overrideStatus: { accountId: 'acc-1', isInternalAccount: true, effectiveFlags: {} },
+    };
+  }
+
+  it('negative balance fires stop condition in pA3 context', () => {
+    const input = makeHealthy();
+    input.balance = -5;
+    const conditions = detectStopConditions(input);
+    assert.ok(conditions.some(c => c.key === 'negative-balance' && c.level === 'stop'));
+  });
+
+  it('reconciliation gap fires stop condition', () => {
+    const input = makeHealthy();
+    input.hasGap = true;
+    const conditions = detectStopConditions(input);
+    assert.ok(conditions.some(c => c.key === 'reconciliation-gap' && c.level === 'stop'));
+  });
+
+  it('override-not-internal fires stop per contract', () => {
+    const input = makeHealthy();
+    input.overrideStatus = { accountId: 'ext-1', isInternalAccount: false, effectiveFlags: {} };
+    const conditions = detectStopConditions(input);
+    assert.ok(conditions.some(c => c.key === 'override-not-internal' && c.level === 'stop'));
+  });
+
+  it('healthy probe yields no stop conditions', () => {
+    const conditions = detectStopConditions(makeHealthy());
+    assert.equal(conditions.length, 0);
+  });
+});
+
+// ── insertIntoObservationLog ────────────────────────────────────────
+
+describe('pA3 cohort smoke: insertIntoObservationLog', () => {
+  const TEMPLATE = `# Hero Mode pA3 — Internal Cohort Evidence
+
+## Observation Log
+
+| Date | Learner | Readiness | Balance Bucket | Ledger Entries | Reconciliation | Override | Source | Status |
+|------|---------|-----------|----------------|----------------|----------------|----------|--------|--------|
+
+## Stop Conditions
+
+| Condition | Observed | Date | Details |
+|-----------|----------|------|---------|
+| Negative balance | No | | |
+| Reconciliation gap | No | | |
+`;
+
+  it('inserts 9-column row before Stop Conditions section', () => {
+    const row = '| 2026-04-30 | learner-1 | ready | 300-599 | 5 | no-gap | override-active | real-production | OK |';
+    const result = insertIntoObservationLog(TEMPLATE, row, []);
+    const obsLogIdx = result.indexOf('|------|');
+    const stopIdx = result.indexOf('## Stop Conditions');
+    const rowIdx = result.indexOf(row);
+    assert.ok(rowIdx > obsLogIdx, 'row after header');
+    assert.ok(rowIdx < stopIdx, 'row before stop conditions');
+  });
+
+  it('preserves all 9 columns in inserted row', () => {
+    const row = '| 2026-04-30 | l-1 | ready | 300-599 | 5 | no-gap | override-active | staging | OK |';
+    const result = insertIntoObservationLog(TEMPLATE, row, []);
+    assert.ok(result.includes(row));
+    // Verify the row has 9 data cells
+    const cells = row.split('|').map(c => c.trim()).filter(c => c.length > 0);
+    assert.equal(cells.length, 9);
+  });
+});


### PR DESCRIPTION
## Summary
- **U2**: Provenance-aware certification validator (`scripts/validate-hero-pA3-certification-evidence.mjs`) with `countObservationsByProvenance`, `min_real_observations_N`, `min_real_datekeys_N`, `min_real_learners_N` gates, and A4 decision keywords
- **U3**: A3 certification manifest (`reports/hero/hero-pA3-certification-manifest.json`) — 6 rings (A3-0 through A3-5), A3-5 explicitly optional
- **U5**: Cohort smoke script (`scripts/hero-pA3-cohort-smoke.mjs`) with 9-column provenance-aware output, `--source` flag, auto-creation of evidence file
- 51 tests across 2 test files covering gate conditions, provenance classification, pipeline status logic, and error handling

## Design decisions
- Source column (index 7) in 9-column table distinguishes `real-production` from `simulation`/`staging`/`local`/`manual-note`
- Legacy 8-column rows (missing Source) treated defensively as `simulation`
- Ring A3-5 is optional — failure does NOT downgrade certification status
- Probe failures produce `manual-note` source with `ERROR:fetch-failed` status
- Zero runtime code changes — scripts and tests only

## Test plan
- [x] `node --test tests/hero-pA3-certification-evidence.test.js` — 31 pass
- [x] `node --test tests/hero-pA3-cohort-smoke.test.js` — 20 pass
- [ ] Manual: `node scripts/validate-hero-pA3-certification-evidence.mjs` reports NOT_CERTIFIED (no evidence files yet)
- [ ] Manual: `node scripts/hero-pA3-cohort-smoke.mjs --dry-run` prints rows without writing