### PR TITLE
feat(hero-pA3): Goal 6 telemetry extraction and metrics summary

### DIFF
--- a/scripts/hero-pA3-metrics-summary.mjs
+++ b/scripts/hero-pA3-metrics-summary.mjs
@@ -1,0 +1,503 @@
+#!/usr/bin/env node
+// Hero Mode pA3 — Metrics summary (provenance-aware).
+// Reads 9-column evidence file and Goal 6 extraction results,
+// produces A3 metrics baseline with provenance-qualified confidence.
+//
+// Usage: node scripts/hero-pA3-metrics-summary.mjs \
+//   [--output PATH] \
+//   [--evidence PATH] \
+//   [--telemetry PATH]
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_EVIDENCE = resolve(__dirname, '../docs/plans/james/hero-mode/A/hero-pA3-internal-cohort-evidence.md');
+const DEFAULT_TELEMETRY = resolve(__dirname, '../reports/hero/hero-pA3-telemetry-report.json');
+const DEFAULT_OUTPUT = resolve(__dirname, '../docs/plans/james/hero-mode/A/hero-pA3-metrics-baseline.md');
+
+// ── CLI argument parsing ────────────────────────────────────────────
+
+export function parseArgs(argv) {
+  const args = {
+    output: DEFAULT_OUTPUT,
+    evidence: DEFAULT_EVIDENCE,
+    telemetry: DEFAULT_TELEMETRY,
+  };
+
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    if ((arg === '--output') && argv[i + 1]) {
+      args.output = resolve(argv[++i]);
+    } else if (arg.startsWith('--output=')) {
+      args.output = resolve(arg.slice('--output='.length));
+    } else if ((arg === '--evidence') && argv[i + 1]) {
+      args.evidence = resolve(argv[++i]);
+    } else if (arg.startsWith('--evidence=')) {
+      args.evidence = resolve(arg.slice('--evidence='.length));
+    } else if ((arg === '--telemetry') && argv[i + 1]) {
+      args.telemetry = resolve(argv[++i]);
+    } else if (arg.startsWith('--telemetry=')) {
+      args.telemetry = resolve(arg.slice('--telemetry='.length));
+    }
+  }
+
+  return args;
+}
+
+// ── 9-column evidence table parsing ─────────────────────────────────
+
+/**
+ * Parse observation table rows from 9-column evidence markdown.
+ * Expected: | Date | Learner | Source | Readiness | Balance Bucket | Ledger Entries | Reconciliation | Override | Status |
+ *
+ * Source column values: real-production, simulation, manual-inspection
+ */
+export function parseObservationTable(content) {
+  const lines = content.split('\n');
+  const observations = [];
+
+  // 9-column pattern: Date | Learner | Source | Readiness | Balance Bucket | Ledger Entries | Reconciliation | Override | Status
+  const tableRowPattern = /^\|\s*(\d{4}-\d{2}-\d{2})\s*\|\s*(.+?)\s*\|\s*(.+?)\s*\|\s*(.+?)\s*\|\s*(.+?)\s*\|\s*(.+?)\s*\|\s*(.+?)\s*\|\s*(.+?)\s*\|\s*(.+?)\s*\|$/;
+
+  for (const line of lines) {
+    const match = line.match(tableRowPattern);
+    if (match) {
+      observations.push({
+        date: match[1],
+        learner: match[2].trim(),
+        source: match[3].trim(),
+        readiness: match[4].trim(),
+        balanceBucket: match[5].trim(),
+        ledgerEntries: parseInt(match[6].trim(), 10) || 0,
+        reconciliation: match[7].trim(),
+        override: match[8].trim(),
+        status: match[9].trim(),
+      });
+    }
+  }
+
+  return observations;
+}
+
+// ── Provenance separation ───────────────────────────────────────────
+
+/**
+ * Separate observations by provenance source.
+ * Confidence is based on REAL production rows only.
+ */
+export function separateByProvenance(observations) {
+  const real = observations.filter(o => o.source === 'real-production');
+  const simulation = observations.filter(o => o.source === 'simulation');
+  const manual = observations.filter(o => o.source === 'manual-inspection');
+  const other = observations.filter(o =>
+    o.source !== 'real-production' &&
+    o.source !== 'simulation' &&
+    o.source !== 'manual-inspection'
+  );
+
+  return { real, simulation, manual, other, total: observations.length };
+}
+
+// ── Confidence classification ───────────────────────────────────────
+
+export function classifyConfidence(count) {
+  if (count >= 100) return 'high';
+  if (count >= 30) return 'medium';
+  if (count >= 10) return 'low';
+  return 'insufficient';
+}
+
+/**
+ * Provenance-qualified confidence: based on real row count, not total.
+ */
+export function classifyProvenanceConfidence(realCount, totalCount) {
+  const base = classifyConfidence(realCount);
+  if (base === 'insufficient' && totalCount >= 10) {
+    return 'insufficient-real (simulation-only data present)';
+  }
+  return base;
+}
+
+// ── Aggregation ─────────────────────────────────────────────────────
+
+function computeDistribution(values) {
+  const counts = {};
+  for (const v of values) {
+    counts[v] = (counts[v] || 0) + 1;
+  }
+  return counts;
+}
+
+export function aggregateMetrics(observations, provenance) {
+  const realCount = provenance.real.length;
+  const totalCount = observations.length;
+
+  const readinessValues = observations.map(o => o.readiness);
+  const readinessDistribution = computeDistribution(readinessValues);
+
+  const balanceValues = observations.map(o => o.balanceBucket);
+  const balanceDistribution = computeDistribution(balanceValues);
+
+  const ledgerEntries = observations.map(o => o.ledgerEntries);
+  const avgLedgerEntries = ledgerEntries.length > 0
+    ? (ledgerEntries.reduce((a, b) => a + b, 0) / ledgerEntries.length).toFixed(1)
+    : '0';
+
+  const reconciliationValues = observations.map(o => o.reconciliation);
+  const reconciliationDistribution = computeDistribution(reconciliationValues);
+
+  const overrideValues = observations.map(o => o.override);
+  const overrideDistribution = computeDistribution(overrideValues);
+
+  const stopObservations = observations.filter(o => o.status.startsWith('STOP:'));
+  const stopConditionTypes = {};
+  for (const obs of stopObservations) {
+    const conditions = obs.status.replace('STOP:', '').split(',');
+    for (const c of conditions) {
+      stopConditionTypes[c.trim()] = (stopConditionTypes[c.trim()] || 0) + 1;
+    }
+  }
+
+  return {
+    totalObservations: totalCount,
+    realObservations: realCount,
+    simulationObservations: provenance.simulation.length,
+    manualObservations: provenance.manual.length,
+    uniqueDateCount: [...new Set(observations.map(o => o.date))].length,
+    uniqueLearnerCount: [...new Set(observations.map(o => o.learner))].length,
+    provenanceConfidence: classifyProvenanceConfidence(realCount, totalCount),
+    readiness: {
+      distribution: readinessDistribution,
+      confidence: classifyProvenanceConfidence(realCount, totalCount),
+    },
+    economy: {
+      balanceDistribution,
+      avgLedgerEntries,
+      confidence: classifyProvenanceConfidence(realCount, totalCount),
+    },
+    reconciliation: {
+      distribution: reconciliationDistribution,
+      confidence: classifyProvenanceConfidence(realCount, totalCount),
+    },
+    override: {
+      distribution: overrideDistribution,
+      confidence: classifyProvenanceConfidence(realCount, totalCount),
+    },
+    stopConditions: stopConditionTypes,
+    stopCount: stopObservations.length,
+  };
+}
+
+// ── Telemetry integration ───────────────────────────────────────────
+
+/**
+ * Derive health-test dimensions from Goal 6 telemetry report (if available).
+ */
+export function deriveTelemetryDimensions(telemetryReport) {
+  if (!telemetryReport || !telemetryReport.signals) {
+    return {
+      available: false,
+      dimensions: [],
+    };
+  }
+
+  const s = telemetryReport.signals;
+  const dimensions = [];
+
+  // Start rate health
+  dimensions.push({
+    dimension: 'Start rate',
+    status: s.dailyCompletionRate?.sessionsStarted > 0 ? 'observable' : 'no-data',
+    detail: `${s.dailyCompletionRate?.sessionsStarted || 0} sessions observed`,
+  });
+
+  // Completion rate health
+  dimensions.push({
+    dimension: 'Completion rate',
+    status: s.dailyCompletionRate?.dailyCompleted > 0 ? 'observable' : 'no-data',
+    detail: `${s.dailyCompletionRate?.value || 0} (${s.dailyCompletionRate?.dailyCompleted || 0}/${s.dailyCompletionRate?.sessionsStarted || 0})`,
+  });
+
+  // Duplicate prevention health
+  dimensions.push({
+    dimension: 'Duplicate prevention',
+    status: s.coinAwards?.duplicatePreventionMeasurable === false ? 'not-observable-from-event-log' : 'observable',
+    detail: 'Coin duplicate prevention is console-only signal',
+  });
+
+  // Economy integrity health
+  const coinCount = s.coinAwards?.awardCount || 0;
+  const campCount = (s.campEvents?.invited || 0) + (s.campEvents?.grown || 0);
+  dimensions.push({
+    dimension: 'Economy integrity',
+    status: (coinCount + campCount) > 0 ? 'observable' : 'no-data',
+    detail: `${coinCount} coin awards, ${campCount} camp spends`,
+  });
+
+  // Privacy compliance health
+  dimensions.push({
+    dimension: 'Privacy compliance',
+    status: s.privacyCompliance?.passed ? 'passed' : 'failed',
+    detail: `${s.privacyCompliance?.rowsChecked || 0} rows checked`,
+  });
+
+  return { available: true, dimensions };
+}
+
+// ── Health test assessment ───────────────────────────────────────────
+
+export function assessHealthTests(metrics, telemetryDimensions) {
+  const realCount = metrics.realObservations;
+  const hasData = realCount >= 10;
+
+  function classify(condition) {
+    if (!hasData) return 'insufficient-data';
+    return condition ? 'observed' : 'not-observed';
+  }
+
+  function distHas(distribution, key) {
+    if (distribution[key] > 0) return true;
+    const alt = key.includes('-') ? key.replace(/-/g, '_') : key.replace(/_/g, '-');
+    return distribution[alt] > 0;
+  }
+
+  const probeTests = [
+    {
+      dimension: 'Clarity (learner knows what to do)',
+      status: classify(
+        distHas(metrics.readiness.distribution, 'ready') ||
+        distHas(metrics.readiness.distribution, 'not-ready')
+      ),
+      source: 'probe',
+    },
+    {
+      dimension: 'Completion (daily quest finishable)',
+      status: classify(distHas(metrics.readiness.distribution, 'ready')),
+      source: 'probe',
+    },
+    {
+      dimension: 'Spam prevention (no duplicate awards)',
+      status: classify(!(metrics.stopConditions['negative-balance'] > 0)),
+      source: 'probe',
+    },
+    {
+      dimension: 'Dead-ends (no blocked CTA)',
+      status: classify(!(metrics.stopConditions['dead-cta'] > 0)),
+      source: 'probe',
+    },
+    {
+      dimension: 'Duplicate prevention (dedup working)',
+      status: classify(!(metrics.stopConditions['duplicate-daily-award'] > 0)),
+      source: 'probe',
+    },
+    {
+      dimension: 'Privacy (no forbidden fields leaked)',
+      status: classify(!(metrics.stopConditions['privacy-violation'] > 0)),
+      source: 'probe',
+    },
+    {
+      dimension: 'Mastery distortion (subject authority intact)',
+      status: classify(distHas(metrics.reconciliation.distribution, 'no-gap')),
+      source: 'probe',
+    },
+  ];
+
+  // Add telemetry-derived dimensions
+  const telemetryTests = [];
+  if (telemetryDimensions && telemetryDimensions.available) {
+    for (const dim of telemetryDimensions.dimensions) {
+      telemetryTests.push({
+        dimension: `[Telemetry] ${dim.dimension}`,
+        status: dim.status,
+        source: 'telemetry',
+        detail: dim.detail,
+      });
+    }
+  } else {
+    // Telemetry not available — mark all as pending
+    const pendingDims = ['Start rate', 'Completion rate', 'Duplicate prevention', 'Economy integrity', 'Privacy compliance'];
+    for (const name of pendingDims) {
+      telemetryTests.push({
+        dimension: `[Telemetry] ${name}`,
+        status: 'telemetry-pending',
+        source: 'telemetry',
+        detail: 'Goal 6 telemetry report not found',
+      });
+    }
+  }
+
+  return [...probeTests, ...telemetryTests];
+}
+
+// ── Output formatting ───────────────────────────────────────────────
+
+function formatDistributionTable(distribution) {
+  const entries = Object.entries(distribution).sort(([, a], [, b]) => b - a);
+  if (entries.length === 0) return '| (no data) | 0 |\n';
+  return entries.map(([value, count]) => `| ${value} | ${count} |`).join('\n');
+}
+
+export function generateBaselineDocument(metrics, telemetryDimensions, telemetryReport) {
+  const today = new Date().toISOString().slice(0, 10);
+  const healthTests = assessHealthTests(metrics, telemetryDimensions);
+
+  let doc = `# Hero Mode pA3 — Metrics Baseline (Provenance-Aware)
+
+**Generated:** ${today}
+**Total observations:** ${metrics.totalObservations}
+**Real-production observations:** ${metrics.realObservations}
+**Simulation observations:** ${metrics.simulationObservations}
+**Manual-inspection observations:** ${metrics.manualObservations}
+**Provenance confidence:** ${metrics.provenanceConfidence}
+**Unique date keys:** ${metrics.uniqueDateCount}
+**Unique learners:** ${metrics.uniqueLearnerCount}
+
+---
+
+## 1. Readiness (confidence: ${metrics.readiness.confidence})
+
+| Value | Count |
+|-------|-------|
+${formatDistributionTable(metrics.readiness.distribution)}
+
+---
+
+## 2. Economy Health (confidence: ${metrics.economy.confidence})
+
+**Average ledger entries:** ${metrics.economy.avgLedgerEntries}
+
+| Balance Bucket | Count |
+|----------------|-------|
+${formatDistributionTable(metrics.economy.balanceDistribution)}
+
+---
+
+## 3. Reconciliation (confidence: ${metrics.reconciliation.confidence})
+
+| Value | Count |
+|-------|-------|
+${formatDistributionTable(metrics.reconciliation.distribution)}
+
+---
+
+## 4. Override Status (confidence: ${metrics.override.confidence})
+
+| Value | Count |
+|-------|-------|
+${formatDistributionTable(metrics.override.distribution)}
+
+---
+
+## Stop Conditions Summary
+
+`;
+
+  if (metrics.stopCount === 0) {
+    doc += `No stop conditions observed across ${metrics.totalObservations} observation(s).\n`;
+  } else {
+    doc += `**${metrics.stopCount} observation(s) triggered stop conditions:**\n\n`;
+    doc += `| Condition | Count |\n|-----------|-------|\n`;
+    for (const [cond, count] of Object.entries(metrics.stopConditions)) {
+      doc += `| ${cond} | ${count} |\n`;
+    }
+  }
+
+  doc += `\n---\n\n## A3 Health Test Assessment\n\n`;
+  doc += `| Dimension | Status | Source |\n|-----------|--------|--------|\n`;
+  for (const test of healthTests) {
+    doc += `| ${test.dimension} | ${test.status} | ${test.source} |\n`;
+  }
+
+  doc += `\n---\n\n## Provenance Notes\n\n`;
+  doc += `- **real-production**: Observed from live internal cohort via ops probe\n`;
+  doc += `- **simulation**: Generated by test/staging environment (does not count towards confidence)\n`;
+  doc += `- **manual-inspection**: Human-verified via admin console\n`;
+  doc += `- Confidence classification is based on **real-production row count only**\n`;
+
+  // Goal 6 telemetry section
+  doc += `\n---\n\n## Goal 6 Telemetry Integration\n\n`;
+  if (telemetryReport && telemetryReport.signals) {
+    doc += `**Telemetry report available:** Yes\n`;
+    doc += `**Total events analysed:** ${telemetryReport.totalEvents || 0}\n`;
+    doc += `**Privacy validation:** ${telemetryReport.privacyValidation?.passed ? 'PASSED' : 'FAILED'}\n\n`;
+
+    if (telemetryReport.unmeasurable && telemetryReport.unmeasurable.length > 0) {
+      doc += `### Unmeasurable signals (require client-side telemetry)\n\n`;
+      for (const u of telemetryReport.unmeasurable) {
+        doc += `- **${u.signal}**: ${u.reason}\n`;
+      }
+    }
+  } else {
+    doc += `**Telemetry report available:** No\n`;
+    doc += `All telemetry-derived dimensions are marked as \`telemetry-pending\`.\n`;
+    doc += `Run \`node scripts/hero-pA3-telemetry-extract.mjs --db-path ...\` to generate.\n`;
+  }
+
+  doc += `\n---\n\n*Generated by hero-pA3-metrics-summary.mjs*\n`;
+
+  return doc;
+}
+
+// ── Main ────────────────────────────────────────────────────────────
+
+function main() {
+  const args = parseArgs(process.argv);
+
+  console.log('Hero Mode pA3 — Metrics Summary (Provenance-Aware)');
+  console.log(`Evidence file: ${args.evidence}`);
+  console.log(`Telemetry file: ${args.telemetry}`);
+  console.log(`Output: ${args.output}`);
+  console.log('---');
+
+  // Read evidence file
+  let observations = [];
+  if (existsSync(args.evidence)) {
+    const content = readFileSync(args.evidence, 'utf8');
+    observations = parseObservationTable(content);
+    console.log(`Parsed ${observations.length} observation(s) from evidence file.`);
+  } else {
+    console.log('Evidence file not found. Proceeding with empty observations.');
+  }
+
+  // Separate by provenance
+  const provenance = separateByProvenance(observations);
+  console.log(`Real: ${provenance.real.length}, Simulation: ${provenance.simulation.length}, Manual: ${provenance.manual.length}`);
+
+  // Aggregate metrics
+  const metrics = aggregateMetrics(observations, provenance);
+
+  // Read telemetry report (if exists)
+  let telemetryReport = null;
+  if (existsSync(args.telemetry)) {
+    try {
+      telemetryReport = JSON.parse(readFileSync(args.telemetry, 'utf8'));
+      console.log(`Loaded telemetry report: ${telemetryReport.totalEvents || 0} events.`);
+    } catch (err) {
+      console.log(`Failed to parse telemetry report: ${err.message}`);
+    }
+  } else {
+    console.log('Telemetry report not found. Telemetry dimensions will be marked as pending.');
+  }
+
+  // Derive telemetry dimensions
+  const telemetryDimensions = deriveTelemetryDimensions(telemetryReport);
+
+  // Generate document
+  const doc = generateBaselineDocument(metrics, telemetryDimensions, telemetryReport);
+
+  // Write output
+  const outputDir = dirname(args.output);
+  if (!existsSync(outputDir)) {
+    mkdirSync(outputDir, { recursive: true });
+  }
+  writeFileSync(args.output, doc, 'utf8');
+  console.log(`\nBaseline written to: ${args.output}`);
+}
+
+const _scriptUrl = fileURLToPath(import.meta.url);
+const _invokedAs = process.argv[1] ? resolve(process.argv[1]) : '';
+if (_scriptUrl === _invokedAs) {
+  main();
+}

--- a/scripts/hero-pA3-telemetry-extract.mjs
+++ b/scripts/hero-pA3-telemetry-extract.mjs
@@ -1,0 +1,634 @@
+#!/usr/bin/env node
+// Hero Mode pA3 — Goal 6 telemetry extraction.
+// Reads D1 event_log (local sqlite via better-sqlite3) for hero-mode events,
+// extracts 16 Goal 6 signals, privacy-validates every row, and outputs a
+// structured JSON report with confidence classification.
+//
+// Usage: node scripts/hero-pA3-telemetry-extract.mjs \
+//   --db-path ./local.sqlite \
+//   --learner-ids id1,id2 \
+//   --date-from 2026-04-01 \
+//   --date-to 2026-04-30 \
+//   --output reports/hero/hero-pA3-telemetry-report.json \
+//   --format json
+//
+// Key constraint: NEVER imports from worker/src/ — only from shared/hero/.
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  validateMetricPrivacyRecursive,
+  stripPrivacyFields,
+} from '../shared/hero/metrics-privacy.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_OUTPUT = resolve(__dirname, '../reports/hero/hero-pA3-telemetry-report.json');
+
+// ── CLI argument parsing ────────────────────────────────────────────
+
+export function parseArgs(argv) {
+  const args = {
+    dbPath: null,
+    learnerIds: null,
+    dateFrom: null,
+    dateTo: null,
+    output: DEFAULT_OUTPUT,
+    format: 'json',
+  };
+
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    if ((arg === '--db-path') && argv[i + 1]) {
+      args.dbPath = resolve(argv[++i]);
+    } else if (arg.startsWith('--db-path=')) {
+      args.dbPath = resolve(arg.slice('--db-path='.length));
+    } else if ((arg === '--learner-ids') && argv[i + 1]) {
+      args.learnerIds = argv[++i].split(',').map(s => s.trim()).filter(Boolean);
+    } else if (arg.startsWith('--learner-ids=')) {
+      args.learnerIds = arg.slice('--learner-ids='.length).split(',').map(s => s.trim()).filter(Boolean);
+    } else if ((arg === '--date-from') && argv[i + 1]) {
+      args.dateFrom = argv[++i];
+    } else if (arg.startsWith('--date-from=')) {
+      args.dateFrom = arg.slice('--date-from='.length);
+    } else if ((arg === '--date-to') && argv[i + 1]) {
+      args.dateTo = argv[++i];
+    } else if (arg.startsWith('--date-to=')) {
+      args.dateTo = arg.slice('--date-to='.length);
+    } else if ((arg === '--output') && argv[i + 1]) {
+      args.output = resolve(argv[++i]);
+    } else if (arg.startsWith('--output=')) {
+      args.output = resolve(arg.slice('--output='.length));
+    } else if ((arg === '--format') && argv[i + 1]) {
+      args.format = argv[++i];
+    } else if (arg.startsWith('--format=')) {
+      args.format = arg.slice('--format='.length);
+    }
+  }
+
+  return args;
+}
+
+// ── Confidence classification ───────────────────────────────────────
+
+export function classifyConfidence(count) {
+  if (count >= 100) return 'high';
+  if (count >= 30) return 'medium';
+  if (count >= 10) return 'low';
+  return 'insufficient';
+}
+
+// ── Privacy validation ──────────────────────────────────────────────
+
+/**
+ * Validate all rows' event_json for privacy compliance.
+ * @param {Array<{eventJson: object|null}>} parsedRows
+ * @returns {{ passed: boolean, rowsChecked: number, violations: Array<{rowIndex: number, violations: string[]}> }}
+ */
+export function validateAllRowsPrivacy(parsedRows) {
+  const result = { passed: true, rowsChecked: 0, violations: [] };
+
+  for (let i = 0; i < parsedRows.length; i++) {
+    const row = parsedRows[i];
+    if (!row.eventJson || typeof row.eventJson !== 'object') continue;
+    result.rowsChecked++;
+    const check = validateMetricPrivacyRecursive(row.eventJson);
+    if (!check.valid) {
+      result.passed = false;
+      result.violations.push({ rowIndex: i, violations: check.violations });
+    }
+  }
+
+  return result;
+}
+
+// ── Row parsing ─────────────────────────────────────────────────────
+
+/**
+ * Parse raw DB rows into structured objects with parsed event_json.
+ * Malformed event_json is gracefully set to null (row skipped from signal extraction).
+ */
+export function parseRows(rawRows) {
+  return rawRows.map((row) => {
+    let eventJson = null;
+    try {
+      eventJson = row.event_json ? JSON.parse(row.event_json) : null;
+    } catch {
+      eventJson = null;
+    }
+    return {
+      id: row.id,
+      learnerId: row.learner_id,
+      subjectId: row.subject_id,
+      systemId: row.system_id,
+      eventType: row.event_type,
+      eventJson,
+      createdAt: row.created_at,
+    };
+  });
+}
+
+// ── Signal extraction functions ─────────────────────────────────────
+
+/**
+ * Signal 1: Hero Quest card shown (count).
+ * This is a client-side event — NOT written to event_log.
+ */
+export function extractQuestShown(rows) {
+  // Client-side only — not measurable from event_log
+  return { count: 0, measurable: false };
+}
+
+/**
+ * Signal 2: Hero Quest start rate (started / shown).
+ * "Started" approximated by first task.completed per unique dateKey+learnerId.
+ * "Shown" is client-side — rate not computable.
+ */
+export function extractQuestStartRate(rows) {
+  // Approximate quest starts: unique (learner, dateKey) combos with a task.completed
+  const taskRows = rows.filter(r => r.eventType === 'hero.task.completed');
+  const starts = new Set();
+  for (const r of taskRows) {
+    const dateKey = r.eventJson?.data?.dateKey || r.eventJson?.dateKey || (r.createdAt ? r.createdAt.slice(0, 10) : '');
+    starts.add(`${r.learnerId}|${dateKey}`);
+  }
+  return { started: starts.size, shown: 0, value: 0, measurable: false };
+}
+
+/**
+ * Signal 3: First task start rate.
+ * Same limitation as signal 2 — "started" requires client-side event.
+ * We can count unique learner-days with at least one task.completed.
+ */
+export function extractFirstTaskStartRate(rows) {
+  const taskRows = rows.filter(r => r.eventType === 'hero.task.completed');
+  const learnerDays = new Set();
+  for (const r of taskRows) {
+    const dateKey = r.eventJson?.data?.dateKey || r.eventJson?.dateKey || (r.createdAt ? r.createdAt.slice(0, 10) : '');
+    learnerDays.add(`${r.learnerId}|${dateKey}`);
+  }
+  return { learnerDaysWithTask: learnerDays.size, measurable: false };
+}
+
+/**
+ * Signal 4: Task completion rate (completed / started).
+ * We can count completed tasks from event_log. Started requires client data.
+ */
+export function extractTaskCompletionRate(rows) {
+  const completed = rows.filter(r => r.eventType === 'hero.task.completed').length;
+  return { completed, started: 0, value: 0, measurable: false, note: 'started requires client-side event' };
+}
+
+/**
+ * Signal 5: Daily Hero Quest completion rate.
+ * Measurable: count daily.completed events vs unique learner-day sessions.
+ */
+export function extractDailyCompletionRate(rows) {
+  const dailyCompleted = rows.filter(r => r.eventType === 'hero.daily.completed').length;
+  const taskRows = rows.filter(r => r.eventType === 'hero.task.completed');
+  const learnerDays = new Set();
+  for (const r of taskRows) {
+    const dateKey = r.eventJson?.data?.dateKey || r.eventJson?.dateKey || (r.createdAt ? r.createdAt.slice(0, 10) : '');
+    learnerDays.add(`${r.learnerId}|${dateKey}`);
+  }
+  const sessionsStarted = learnerDays.size;
+  const value = sessionsStarted > 0 ? Math.round((dailyCompleted / sessionsStarted) * 1000) / 1000 : 0;
+  return { dailyCompleted, sessionsStarted, value, confidence: classifyConfidence(sessionsStarted) };
+}
+
+/**
+ * Signal 6: Abandonment reason categories.
+ * Requires session-level telemetry (client-side). Not in event_log.
+ */
+export function extractAbandonmentReasons(rows) {
+  return { categories: {}, measurable: false };
+}
+
+/**
+ * Signal 7: Subject mix distribution.
+ * Measurable from task.completed events' subjectId.
+ */
+export function extractSubjectMix(rows) {
+  const taskRows = rows.filter(r => r.eventType === 'hero.task.completed');
+  const distribution = {};
+  for (const r of taskRows) {
+    const subjectId = r.subjectId || r.eventJson?.data?.subjectId || r.eventJson?.subjectId || 'unknown';
+    distribution[subjectId] = (distribution[subjectId] || 0) + 1;
+  }
+  const total = taskRows.length;
+  return { distribution, total, confidence: classifyConfidence(total) };
+}
+
+/**
+ * Signal 8: Task intent distribution (weak-repair, due-review, retention-after-secure, breadth-maintenance).
+ * Derived from event_json data fields where intent is recorded.
+ */
+export function extractTaskIntentDistribution(rows) {
+  const taskRows = rows.filter(r => r.eventType === 'hero.task.completed');
+  const distribution = {};
+  for (const r of taskRows) {
+    const intent = r.eventJson?.data?.intent || r.eventJson?.heroTaskIntent || r.eventJson?.intent || 'unknown';
+    distribution[intent] = (distribution[intent] || 0) + 1;
+  }
+  const total = taskRows.length;
+  return { distribution, total, confidence: classifyConfidence(total) };
+}
+
+/**
+ * Signal 9: Claim success and rejection reasons.
+ * Successes = task.completed count. Rejections require structured logging (not in event_log).
+ */
+export function extractClaimSuccessAndRejections(rows) {
+  const successes = rows.filter(r => r.eventType === 'hero.task.completed').length;
+  return { successes, rejections: 0, rejectionReasons: {}, measurable: false, note: 'rejections logged to structured console, not event_log' };
+}
+
+/**
+ * Signal 10: Duplicate-claim prevention count.
+ * Not directly in event_log (ON CONFLICT DO NOTHING is silent).
+ * However coin duplicate prevention IS logged.
+ */
+export function extractDuplicateClaimPrevention(rows) {
+  // Coin duplicates are detectable via coins.awarded duplicate prevention (in console logs only)
+  return { count: 0, measurable: false, note: 'ON CONFLICT DO NOTHING is silent in event_log' };
+}
+
+/**
+ * Signal 11: Daily coin award count and duplicate-award prevention count.
+ * Measurable: coins.awarded events in event_log.
+ */
+export function extractCoinAwards(rows) {
+  const coinRows = rows.filter(r => r.eventType === 'hero.coins.awarded');
+  const totalAwarded = coinRows.length;
+  const amounts = coinRows.map(r => r.eventJson?.amount || 0);
+  const totalCoins = amounts.reduce((a, b) => a + b, 0);
+  // Duplicate prevention is not in event_log (console-only signal)
+  return {
+    awardCount: totalAwarded,
+    totalCoins,
+    duplicatePreventionCount: 0,
+    duplicatePreventionMeasurable: false,
+    confidence: classifyConfidence(totalAwarded),
+  };
+}
+
+/**
+ * Signal 12: Camp events — open, invite, grow, insufficient-coins, duplicate-spend.
+ * Invite and grow are in event_log. Others are console-only.
+ */
+export function extractCampEvents(rows) {
+  const invited = rows.filter(r => r.eventType === 'hero.camp.monster.invited').length;
+  const grown = rows.filter(r => r.eventType === 'hero.camp.monster.grown').length;
+  return {
+    invited,
+    grown,
+    opened: 0,
+    insufficientCoins: 0,
+    duplicateSpend: 0,
+    openedMeasurable: false,
+    insufficientCoinsMeasurable: false,
+    duplicateSpendMeasurable: false,
+    confidence: classifyConfidence(invited + grown),
+  };
+}
+
+/**
+ * Signal 13: Extra subject practice after daily coin cap.
+ * Requires session-level timing data. Tasks after daily.completed could approximate.
+ */
+export function extractExtraPracticeAfterCap(rows) {
+  // Approximate: tasks completed AFTER daily.completed for same learner+date
+  const dailyCompletedSet = new Map(); // learnerId|date -> created_at
+  for (const r of rows) {
+    if (r.eventType === 'hero.daily.completed') {
+      const dateKey = r.eventJson?.data?.dateKey || r.eventJson?.dateKey || (r.createdAt ? r.createdAt.slice(0, 10) : '');
+      const key = `${r.learnerId}|${dateKey}`;
+      if (!dailyCompletedSet.has(key) || r.createdAt < dailyCompletedSet.get(key)) {
+        dailyCompletedSet.set(key, r.createdAt);
+      }
+    }
+  }
+
+  let extraTaskCount = 0;
+  for (const r of rows) {
+    if (r.eventType === 'hero.task.completed') {
+      const dateKey = r.eventJson?.data?.dateKey || r.eventJson?.dateKey || (r.createdAt ? r.createdAt.slice(0, 10) : '');
+      const key = `${r.learnerId}|${dateKey}`;
+      const completedAt = dailyCompletedSet.get(key);
+      if (completedAt && r.createdAt > completedAt) {
+        extraTaskCount++;
+      }
+    }
+  }
+
+  return { extraTaskCount, measurable: extraTaskCount > 0 || dailyCompletedSet.size > 0, confidence: classifyConfidence(dailyCompletedSet.size) };
+}
+
+/**
+ * Signal 14: Signs of rushing/skipping/reward farming/too-fast completion.
+ * Requires timing analysis. Approximate via tasks-per-minute within same session.
+ */
+export function extractRushingSignals(rows) {
+  // Group tasks by learner+date, check for suspiciously rapid claims
+  const taskRows = rows.filter(r => r.eventType === 'hero.task.completed' && r.createdAt);
+  const byLearnerDate = {};
+  for (const r of taskRows) {
+    const dateKey = r.eventJson?.data?.dateKey || r.eventJson?.dateKey || (r.createdAt ? r.createdAt.slice(0, 10) : '');
+    const key = `${r.learnerId}|${dateKey}`;
+    if (!byLearnerDate[key]) byLearnerDate[key] = [];
+    byLearnerDate[key].push(r.createdAt);
+  }
+
+  let suspiciousSessionCount = 0;
+  const RAPID_THRESHOLD_MS = 30_000; // 30 seconds between tasks is suspicious
+
+  for (const timestamps of Object.values(byLearnerDate)) {
+    if (timestamps.length < 2) continue;
+    const sorted = [...timestamps].sort();
+    for (let i = 1; i < sorted.length; i++) {
+      const gap = new Date(sorted[i]).getTime() - new Date(sorted[i - 1]).getTime();
+      if (gap > 0 && gap < RAPID_THRESHOLD_MS) {
+        suspiciousSessionCount++;
+        break;
+      }
+    }
+  }
+
+  return {
+    suspiciousSessionCount,
+    sessionsAnalysed: Object.keys(byLearnerDate).length,
+    confidence: classifyConfidence(Object.keys(byLearnerDate).length),
+  };
+}
+
+/**
+ * Signal 15: Subject Stars and mastery drift (before/after Hero sessions).
+ * Requires child_subject_state table comparison — not available in event_log.
+ */
+export function extractMasteryDrift(rows) {
+  return { measurable: false, note: 'requires child_subject_state table comparison' };
+}
+
+/**
+ * Signal 16: Privacy validation — no raw child content in any telemetry path.
+ * This is handled by validateAllRowsPrivacy above; included here for completeness.
+ */
+export function extractPrivacyCompliance(parsedRows) {
+  return validateAllRowsPrivacy(parsedRows);
+}
+
+// ── Assemble full report ────────────────────────────────────────────
+
+export function assembleReport(parsedRows, args) {
+  const privacyResult = extractPrivacyCompliance(parsedRows);
+
+  // If privacy fails, return error report
+  if (!privacyResult.passed) {
+    return {
+      extractedAt: new Date().toISOString(),
+      dateRange: { from: args.dateFrom || null, to: args.dateTo || null },
+      learnerIds: args.learnerIds || [],
+      error: 'privacy-violation',
+      privacyValidation: privacyResult,
+      signals: null,
+    };
+  }
+
+  const totalEvents = parsedRows.length;
+
+  const signals = {
+    questShown: {
+      ...extractQuestShown(parsedRows),
+      confidence: 'insufficient',
+    },
+    questStartRate: {
+      ...extractQuestStartRate(parsedRows),
+      confidence: 'insufficient',
+    },
+    firstTaskStartRate: {
+      ...extractFirstTaskStartRate(parsedRows),
+      confidence: 'insufficient',
+    },
+    taskCompletionRate: {
+      ...extractTaskCompletionRate(parsedRows),
+      confidence: 'insufficient',
+    },
+    dailyCompletionRate: extractDailyCompletionRate(parsedRows),
+    abandonmentReasons: {
+      ...extractAbandonmentReasons(parsedRows),
+      confidence: 'insufficient',
+    },
+    subjectMix: extractSubjectMix(parsedRows),
+    taskIntentDistribution: extractTaskIntentDistribution(parsedRows),
+    claimSuccessAndRejections: {
+      ...extractClaimSuccessAndRejections(parsedRows),
+      confidence: classifyConfidence(parsedRows.filter(r => r.eventType === 'hero.task.completed').length),
+    },
+    duplicateClaimPrevention: {
+      ...extractDuplicateClaimPrevention(parsedRows),
+      confidence: 'insufficient',
+    },
+    coinAwards: extractCoinAwards(parsedRows),
+    campEvents: extractCampEvents(parsedRows),
+    extraPracticeAfterCap: extractExtraPracticeAfterCap(parsedRows),
+    rushingSignals: extractRushingSignals(parsedRows),
+    masteryDrift: {
+      ...extractMasteryDrift(parsedRows),
+      confidence: 'insufficient',
+    },
+    privacyCompliance: {
+      passed: privacyResult.passed,
+      rowsChecked: privacyResult.rowsChecked,
+      confidence: 'high',
+    },
+  };
+
+  const unmeasurable = [
+    { signal: 'questShown', reason: 'Hero Quest card shown is a client-side render event — not written to event_log' },
+    { signal: 'questStartRate', reason: 'Quest "shown" denominator requires client-side telemetry' },
+    { signal: 'firstTaskStartRate', reason: 'Task "started" (before completion) is client-side only' },
+    { signal: 'taskCompletionRate', reason: 'Task "started" denominator requires client-side event' },
+    { signal: 'abandonmentReasons', reason: 'Abandonment categories require session-level client telemetry' },
+    { signal: 'duplicateClaimPrevention', reason: 'ON CONFLICT DO NOTHING is silent — dedup count not persisted' },
+    { signal: 'masteryDrift', reason: 'Requires child_subject_state table comparison pre/post Hero sessions' },
+  ];
+
+  const warnings = [];
+  if (totalEvents === 0) {
+    warnings.push('No hero-mode events found in the specified range');
+  }
+  if (totalEvents < 10) {
+    warnings.push(`Only ${totalEvents} events found — most signals will have insufficient confidence`);
+  }
+
+  return {
+    extractedAt: new Date().toISOString(),
+    dateRange: { from: args.dateFrom || null, to: args.dateTo || null },
+    learnerIds: args.learnerIds || [],
+    totalEvents,
+    signals,
+    privacyValidation: { passed: true, rowsChecked: privacyResult.rowsChecked },
+    unmeasurable,
+    warnings,
+  };
+}
+
+// ── Database query ──────────────────────────────────────────────────
+
+function buildQuery(args) {
+  let sql = `SELECT id, learner_id, subject_id, system_id, event_type, event_json, created_at
+    FROM event_log WHERE system_id = 'hero-mode'`;
+  const params = [];
+
+  if (args.learnerIds && args.learnerIds.length > 0) {
+    const placeholders = args.learnerIds.map(() => '?').join(',');
+    sql += ` AND learner_id IN (${placeholders})`;
+    params.push(...args.learnerIds);
+  }
+  if (args.dateFrom) {
+    sql += ` AND created_at >= ?`;
+    params.push(args.dateFrom);
+  }
+  if (args.dateTo) {
+    sql += ` AND created_at <= ?`;
+    params.push(args.dateTo + 'T23:59:59.999Z');
+  }
+
+  sql += ` ORDER BY created_at ASC`;
+  return { sql, params };
+}
+
+// ── Format output ───────────────────────────────────────────────────
+
+function formatMarkdown(report) {
+  let md = `# Hero Mode pA3 — Goal 6 Telemetry Report\n\n`;
+  md += `**Extracted:** ${report.extractedAt}\n`;
+  md += `**Date range:** ${report.dateRange.from || 'all'} to ${report.dateRange.to || 'all'}\n`;
+  md += `**Total events:** ${report.totalEvents || 0}\n\n`;
+
+  if (report.error) {
+    md += `## ERROR: ${report.error}\n\n`;
+    md += `Privacy violations found. Cannot produce signal report.\n`;
+    return md;
+  }
+
+  md += `---\n\n## Measurable Signals\n\n`;
+  md += `| Signal | Value | Confidence |\n|--------|-------|------------|\n`;
+
+  const s = report.signals;
+  md += `| Daily completion rate | ${s.dailyCompletionRate.value} (${s.dailyCompletionRate.dailyCompleted}/${s.dailyCompletionRate.sessionsStarted}) | ${s.dailyCompletionRate.confidence} |\n`;
+  md += `| Subject mix | ${s.subjectMix.total} tasks across ${Object.keys(s.subjectMix.distribution).length} subjects | ${s.subjectMix.confidence} |\n`;
+  md += `| Task intent | ${s.taskIntentDistribution.total} tasks, ${Object.keys(s.taskIntentDistribution.distribution).length} intents | ${s.taskIntentDistribution.confidence} |\n`;
+  md += `| Claim successes | ${s.claimSuccessAndRejections.successes} | ${s.claimSuccessAndRejections.confidence} |\n`;
+  md += `| Coin awards | ${s.coinAwards.awardCount} (${s.coinAwards.totalCoins} coins) | ${s.coinAwards.confidence} |\n`;
+  md += `| Camp invited | ${s.campEvents.invited} | ${s.campEvents.confidence} |\n`;
+  md += `| Camp grown | ${s.campEvents.grown} | ${s.campEvents.confidence} |\n`;
+  md += `| Extra practice after cap | ${s.extraPracticeAfterCap.extraTaskCount} tasks | ${s.extraPracticeAfterCap.confidence} |\n`;
+  md += `| Rushing signals | ${s.rushingSignals.suspiciousSessionCount}/${s.rushingSignals.sessionsAnalysed} sessions | ${s.rushingSignals.confidence} |\n`;
+  md += `| Privacy compliance | ${s.privacyCompliance.passed ? 'PASSED' : 'FAILED'} (${s.privacyCompliance.rowsChecked} rows) | ${s.privacyCompliance.confidence} |\n`;
+
+  md += `\n---\n\n## Unmeasurable Signals\n\n`;
+  for (const u of report.unmeasurable) {
+    md += `- **${u.signal}**: ${u.reason}\n`;
+  }
+
+  if (report.warnings.length > 0) {
+    md += `\n---\n\n## Warnings\n\n`;
+    for (const w of report.warnings) {
+      md += `- ${w}\n`;
+    }
+  }
+
+  md += `\n---\n\n*Generated by hero-pA3-telemetry-extract.mjs*\n`;
+  return md;
+}
+
+// ── Main ────────────────────────────────────────────────────────────
+
+async function main() {
+  const args = parseArgs(process.argv);
+
+  console.log('Hero Mode pA3 — Goal 6 Telemetry Extraction');
+  console.log(`DB path: ${args.dbPath || '(not specified)'}`);
+  console.log(`Output: ${args.output}`);
+  console.log(`Format: ${args.format}`);
+  console.log('---');
+
+  if (!args.dbPath) {
+    console.log('No --db-path specified. Generating empty report.');
+    const emptyReport = assembleReport([], args);
+    writeOutput(emptyReport, args);
+    return;
+  }
+
+  if (!existsSync(args.dbPath)) {
+    console.log(`Database file not found: ${args.dbPath}. Generating empty report.`);
+    const emptyReport = assembleReport([], args);
+    writeOutput(emptyReport, args);
+    return;
+  }
+
+  // Dynamic import of better-sqlite3 with graceful fallback
+  let Database;
+  try {
+    const mod = await import('better-sqlite3');
+    Database = mod.default || mod;
+  } catch (err) {
+    console.log(`better-sqlite3 not available (${err.message}). Cannot read D1 database.`);
+    console.log('Install with: npm install better-sqlite3');
+    const emptyReport = assembleReport([], args);
+    emptyReport.warnings.push('better-sqlite3 not installed — could not read database');
+    writeOutput(emptyReport, args);
+    return;
+  }
+
+  // Open database and query
+  let rawRows;
+  try {
+    const db = new Database(args.dbPath, { readonly: true });
+    const { sql, params } = buildQuery(args);
+    rawRows = db.prepare(sql).all(...params);
+    db.close();
+  } catch (err) {
+    console.log(`Database query failed: ${err.message}`);
+    const emptyReport = assembleReport([], args);
+    emptyReport.warnings.push(`Database query failed: ${err.message}`);
+    writeOutput(emptyReport, args);
+    return;
+  }
+
+  console.log(`Fetched ${rawRows.length} hero-mode events from event_log.`);
+
+  // Parse rows
+  const parsedRows = parseRows(rawRows);
+
+  // Assemble report
+  const report = assembleReport(parsedRows, args);
+
+  // Write output
+  writeOutput(report, args);
+  console.log(`\nReport written to: ${args.output}`);
+}
+
+function writeOutput(report, args) {
+  const outputDir = dirname(args.output);
+  if (!existsSync(outputDir)) {
+    mkdirSync(outputDir, { recursive: true });
+  }
+
+  if (args.format === 'markdown') {
+    writeFileSync(args.output, formatMarkdown(report), 'utf8');
+  } else {
+    writeFileSync(args.output, JSON.stringify(report, null, 2), 'utf8');
+  }
+}
+
+const _scriptUrl = fileURLToPath(import.meta.url);
+const _invokedAs = process.argv[1] ? resolve(process.argv[1]) : '';
+if (_scriptUrl === _invokedAs) {
+  main().catch((err) => {
+    console.error('Fatal:', err.message);
+    process.exit(0); // Always exit 0 — report problems in output
+  });
+}

--- a/tests/hero-pA3-metrics-summary.test.js
+++ b/tests/hero-pA3-metrics-summary.test.js
@@ -1,0 +1,303 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  parseArgs,
+  parseObservationTable,
+  separateByProvenance,
+  classifyConfidence,
+  classifyProvenanceConfidence,
+  aggregateMetrics,
+  deriveTelemetryDimensions,
+  assessHealthTests,
+  generateBaselineDocument,
+} from '../scripts/hero-pA3-metrics-summary.mjs';
+
+// ── Test data factories ─────────────────────────────────────────────
+
+function makeRow(overrides = {}) {
+  return {
+    date: overrides.date || '2026-04-28',
+    learner: overrides.learner || 'learner-1',
+    source: overrides.source || 'real-production',
+    readiness: overrides.readiness || 'ready',
+    balanceBucket: overrides.balanceBucket || '100-299',
+    ledgerEntries: overrides.ledgerEntries ?? 5,
+    reconciliation: overrides.reconciliation || 'no-gap',
+    override: overrides.override || 'internal',
+    status: overrides.status || 'ok',
+  };
+}
+
+function makeTelemetryReport(overrides = {}) {
+  return {
+    extractedAt: '2026-04-28T12:00:00Z',
+    totalEvents: overrides.totalEvents ?? 50,
+    signals: {
+      dailyCompletionRate: { sessionsStarted: 20, dailyCompleted: 15, value: 0.75, confidence: 'low' },
+      coinAwards: { awardCount: 10, totalCoins: 1000, duplicatePreventionMeasurable: false, confidence: 'low' },
+      campEvents: { invited: 3, grown: 2, confidence: 'insufficient' },
+      privacyCompliance: { passed: true, rowsChecked: 50 },
+      ...overrides.signals,
+    },
+    privacyValidation: { passed: true, rowsChecked: 50 },
+    unmeasurable: overrides.unmeasurable || [
+      { signal: 'questShown', reason: 'Client-side only' },
+    ],
+    ...(overrides.extra || {}),
+  };
+}
+
+// ── parseArgs ───────────────────────────────────────────────────────
+
+describe('parseArgs', () => {
+  it('parses --output, --evidence, --telemetry', () => {
+    const args = parseArgs(['node', 'script', '--output', './out.md', '--evidence', './ev.md', '--telemetry', './tel.json']);
+    assert.ok(args.output.endsWith('out.md'));
+    assert.ok(args.evidence.endsWith('ev.md'));
+    assert.ok(args.telemetry.endsWith('tel.json'));
+  });
+
+  it('uses defaults when no args provided', () => {
+    const args = parseArgs(['node', 'script']);
+    assert.ok(args.output.includes('hero-pA3-metrics-baseline.md'));
+    assert.ok(args.evidence.includes('hero-pA3-internal-cohort-evidence.md'));
+    assert.ok(args.telemetry.includes('hero-pA3-telemetry-report.json'));
+  });
+});
+
+// ── 9-column parsing ────────────────────────────────────────────────
+
+describe('parseObservationTable (9-column)', () => {
+  it('parses valid 9-column row with Source', () => {
+    const content = `# Evidence
+| Date | Learner | Source | Readiness | Balance Bucket | Ledger Entries | Reconciliation | Override | Status |
+|------|---------|--------|-----------|----------------|----------------|----------------|----------|--------|
+| 2026-04-28 | learner-1 | real-production | ready | 100-299 | 5 | no-gap | internal | ok |
+| 2026-04-28 | learner-2 | simulation | not-ready | 0 | 0 | gap-detected | internal | ok |
+`;
+    const rows = parseObservationTable(content);
+    assert.equal(rows.length, 2);
+    assert.equal(rows[0].source, 'real-production');
+    assert.equal(rows[0].readiness, 'ready');
+    assert.equal(rows[1].source, 'simulation');
+    assert.equal(rows[1].readiness, 'not-ready');
+  });
+
+  it('ignores header/separator rows', () => {
+    const content = `| Date | Learner | Source | Readiness | Balance Bucket | Ledger Entries | Reconciliation | Override | Status |
+|------|---------|--------|-----------|----------------|----------------|----------------|----------|--------|
+| 2026-04-28 | learner-1 | real-production | ready | 100-299 | 5 | no-gap | internal | ok |`;
+    const rows = parseObservationTable(content);
+    assert.equal(rows.length, 1);
+  });
+
+  it('returns empty array for non-matching content', () => {
+    const content = `# Some other doc\nNo table here.`;
+    const rows = parseObservationTable(content);
+    assert.deepEqual(rows, []);
+  });
+});
+
+// ── Provenance separation ───────────────────────────────────────────
+
+describe('separateByProvenance', () => {
+  it('separates real from simulation and manual', () => {
+    const observations = [
+      makeRow({ source: 'real-production' }),
+      makeRow({ source: 'real-production', learner: 'learner-2' }),
+      makeRow({ source: 'simulation' }),
+      makeRow({ source: 'simulation' }),
+      makeRow({ source: 'manual-inspection' }),
+    ];
+    const p = separateByProvenance(observations);
+    assert.equal(p.real.length, 2);
+    assert.equal(p.simulation.length, 2);
+    assert.equal(p.manual.length, 1);
+    assert.equal(p.total, 5);
+  });
+
+  it('handles unknown source in other bucket', () => {
+    const observations = [makeRow({ source: 'mystery' })];
+    const p = separateByProvenance(observations);
+    assert.equal(p.other.length, 1);
+  });
+});
+
+// ── Confidence classification ───────────────────────────────────────
+
+describe('classifyProvenanceConfidence', () => {
+  it('5 real + 10 total = insufficient-real with note', () => {
+    const c = classifyProvenanceConfidence(5, 15);
+    assert.ok(c.includes('insufficient'));
+    assert.ok(c.includes('simulation'));
+  });
+
+  it('10 real = low (regardless of total)', () => {
+    const c = classifyProvenanceConfidence(10, 50);
+    assert.equal(c, 'low');
+  });
+
+  it('30 real = medium', () => {
+    assert.equal(classifyProvenanceConfidence(30, 30), 'medium');
+  });
+
+  it('100 real = high', () => {
+    assert.equal(classifyProvenanceConfidence(100, 200), 'high');
+  });
+
+  it('0 real + 5 total = insufficient (no simulation note under 10 total)', () => {
+    const c = classifyProvenanceConfidence(0, 5);
+    assert.equal(c, 'insufficient');
+  });
+});
+
+// ── aggregateMetrics ────────────────────────────────────────────────
+
+describe('aggregateMetrics', () => {
+  it('correctly computes provenance-aware metrics', () => {
+    const observations = [
+      makeRow({ source: 'real-production' }),
+      makeRow({ source: 'real-production', learner: 'learner-2' }),
+      makeRow({ source: 'simulation' }),
+    ];
+    const provenance = separateByProvenance(observations);
+    const m = aggregateMetrics(observations, provenance);
+
+    assert.equal(m.totalObservations, 3);
+    assert.equal(m.realObservations, 2);
+    assert.equal(m.simulationObservations, 1);
+    assert.equal(m.uniqueLearnerCount, 2);
+  });
+
+  it('detects stop conditions', () => {
+    const observations = [
+      makeRow({ status: 'STOP:negative-balance,privacy-violation' }),
+      makeRow({ status: 'ok' }),
+    ];
+    const provenance = separateByProvenance(observations);
+    const m = aggregateMetrics(observations, provenance);
+
+    assert.equal(m.stopCount, 1);
+    assert.equal(m.stopConditions['negative-balance'], 1);
+    assert.equal(m.stopConditions['privacy-violation'], 1);
+  });
+});
+
+// ── deriveTelemetryDimensions ───────────────────────────────────────
+
+describe('deriveTelemetryDimensions', () => {
+  it('returns available:true with dimensions from telemetry report', () => {
+    const report = makeTelemetryReport();
+    const td = deriveTelemetryDimensions(report);
+
+    assert.equal(td.available, true);
+    assert.equal(td.dimensions.length, 5);
+    const names = td.dimensions.map(d => d.dimension);
+    assert.ok(names.includes('Start rate'));
+    assert.ok(names.includes('Privacy compliance'));
+  });
+
+  it('returns available:false when report is null', () => {
+    const td = deriveTelemetryDimensions(null);
+    assert.equal(td.available, false);
+  });
+
+  it('returns available:false when report has no signals', () => {
+    const td = deriveTelemetryDimensions({ extractedAt: '...', signals: null });
+    assert.equal(td.available, false);
+  });
+
+  it('privacy dimension shows passed status', () => {
+    const report = makeTelemetryReport();
+    const td = deriveTelemetryDimensions(report);
+    const privacy = td.dimensions.find(d => d.dimension === 'Privacy compliance');
+    assert.equal(privacy.status, 'passed');
+  });
+});
+
+// ── assessHealthTests ───────────────────────────────────────────────
+
+describe('assessHealthTests', () => {
+  it('includes telemetry-pending when telemetry not available', () => {
+    const observations = Array.from({ length: 12 }, (_, i) => makeRow({ learner: `l-${i}` }));
+    const provenance = separateByProvenance(observations);
+    const metrics = aggregateMetrics(observations, provenance);
+    const td = deriveTelemetryDimensions(null);
+    const tests = assessHealthTests(metrics, td);
+
+    const telemetryTests = tests.filter(t => t.source === 'telemetry');
+    assert.ok(telemetryTests.length > 0);
+    for (const t of telemetryTests) {
+      assert.equal(t.status, 'telemetry-pending');
+    }
+  });
+
+  it('includes telemetry dimensions when report available', () => {
+    const observations = Array.from({ length: 12 }, (_, i) => makeRow({ learner: `l-${i}` }));
+    const provenance = separateByProvenance(observations);
+    const metrics = aggregateMetrics(observations, provenance);
+    const td = deriveTelemetryDimensions(makeTelemetryReport());
+    const tests = assessHealthTests(metrics, td);
+
+    const telemetryTests = tests.filter(t => t.source === 'telemetry');
+    assert.ok(telemetryTests.length === 5);
+    const privacyTest = telemetryTests.find(t => t.dimension.includes('Privacy'));
+    assert.equal(privacyTest.status, 'passed');
+  });
+
+  it('probe tests report insufficient-data when real count < 10', () => {
+    const observations = [makeRow()]; // only 1 real observation
+    const provenance = separateByProvenance(observations);
+    const metrics = aggregateMetrics(observations, provenance);
+    const td = deriveTelemetryDimensions(null);
+    const tests = assessHealthTests(metrics, td);
+
+    const probeTests = tests.filter(t => t.source === 'probe');
+    for (const t of probeTests) {
+      assert.equal(t.status, 'insufficient-data');
+    }
+  });
+});
+
+// ── generateBaselineDocument ────────────────────────────────────────
+
+describe('generateBaselineDocument', () => {
+  it('produces readable markdown output', () => {
+    const observations = [makeRow(), makeRow({ learner: 'learner-2', source: 'simulation' })];
+    const provenance = separateByProvenance(observations);
+    const metrics = aggregateMetrics(observations, provenance);
+    const td = deriveTelemetryDimensions(null);
+    const doc = generateBaselineDocument(metrics, td, null);
+
+    assert.ok(doc.includes('# Hero Mode pA3'));
+    assert.ok(doc.includes('Provenance-Aware'));
+    assert.ok(doc.includes('Real-production observations:'));
+    assert.ok(doc.includes('telemetry-pending'));
+    assert.ok(doc.includes('hero-pA3-metrics-summary.mjs'));
+  });
+
+  it('includes Goal 6 telemetry section when report available', () => {
+    const observations = [makeRow()];
+    const provenance = separateByProvenance(observations);
+    const metrics = aggregateMetrics(observations, provenance);
+    const report = makeTelemetryReport();
+    const td = deriveTelemetryDimensions(report);
+    const doc = generateBaselineDocument(metrics, td, report);
+
+    assert.ok(doc.includes('Telemetry report available:** Yes'));
+    assert.ok(doc.includes('Privacy validation:** PASSED'));
+    assert.ok(doc.includes('Unmeasurable signals'));
+  });
+
+  it('handles missing telemetry report gracefully', () => {
+    const observations = [makeRow()];
+    const provenance = separateByProvenance(observations);
+    const metrics = aggregateMetrics(observations, provenance);
+    const td = deriveTelemetryDimensions(null);
+    const doc = generateBaselineDocument(metrics, td, null);
+
+    assert.ok(doc.includes('Telemetry report available:** No'));
+    assert.ok(doc.includes('telemetry-pending'));
+  });
+});

--- a/tests/hero-pA3-telemetry-extract.test.js
+++ b/tests/hero-pA3-telemetry-extract.test.js
@@ -1,0 +1,417 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  parseArgs,
+  classifyConfidence,
+  validateAllRowsPrivacy,
+  parseRows,
+  extractQuestShown,
+  extractQuestStartRate,
+  extractFirstTaskStartRate,
+  extractTaskCompletionRate,
+  extractDailyCompletionRate,
+  extractAbandonmentReasons,
+  extractSubjectMix,
+  extractTaskIntentDistribution,
+  extractClaimSuccessAndRejections,
+  extractDuplicateClaimPrevention,
+  extractCoinAwards,
+  extractCampEvents,
+  extractExtraPracticeAfterCap,
+  extractRushingSignals,
+  extractMasteryDrift,
+  extractPrivacyCompliance,
+  assembleReport,
+} from '../scripts/hero-pA3-telemetry-extract.mjs';
+
+// ── Test data factories ─────────────────────────────────────────────
+
+function makeTaskRow(overrides = {}) {
+  return {
+    id: overrides.id || 'hero-evt-req1-hero-task-completed',
+    learnerId: overrides.learnerId || 'learner-1',
+    subjectId: overrides.subjectId || 'grammar',
+    systemId: 'hero-mode',
+    eventType: 'hero.task.completed',
+    eventJson: overrides.eventJson || { data: { questId: 'q1', taskId: 't1', subjectId: 'grammar', effortCredited: 1 } },
+    createdAt: overrides.createdAt || '2026-04-28T10:00:00.000Z',
+  };
+}
+
+function makeDailyRow(overrides = {}) {
+  return {
+    id: overrides.id || 'hero-evt-req1-hero-daily-completed',
+    learnerId: overrides.learnerId || 'learner-1',
+    subjectId: null,
+    systemId: 'hero-mode',
+    eventType: 'hero.daily.completed',
+    eventJson: overrides.eventJson || { data: { questId: 'q1', dateKey: '2026-04-28', effortCompleted: 3 } },
+    createdAt: overrides.createdAt || '2026-04-28T10:05:00.000Z',
+  };
+}
+
+function makeCoinRow(overrides = {}) {
+  return {
+    id: overrides.id || 'hero-evt-ledger-1',
+    learnerId: overrides.learnerId || 'learner-1',
+    subjectId: null,
+    systemId: 'hero-mode',
+    eventType: 'hero.coins.awarded',
+    eventJson: overrides.eventJson || { questId: 'q1', dateKey: '2026-04-28', amount: 100, ledgerEntryId: 'ledger-1', balanceAfter: 200 },
+    createdAt: overrides.createdAt || '2026-04-28T10:05:01.000Z',
+  };
+}
+
+function makeCampInviteRow(overrides = {}) {
+  return {
+    id: overrides.id || 'hero-evt-camp-1',
+    learnerId: overrides.learnerId || 'learner-1',
+    subjectId: null,
+    systemId: 'hero-mode',
+    eventType: 'hero.camp.monster.invited',
+    eventJson: overrides.eventJson || { command: 'unlock-monster', monsterId: 'dragon-1', ledgerEntryId: 'camp-1' },
+    createdAt: overrides.createdAt || '2026-04-28T11:00:00.000Z',
+  };
+}
+
+function makeCampGrowRow(overrides = {}) {
+  return {
+    id: overrides.id || 'hero-evt-camp-2',
+    learnerId: overrides.learnerId || 'learner-1',
+    subjectId: null,
+    systemId: 'hero-mode',
+    eventType: 'hero.camp.monster.grown',
+    eventJson: overrides.eventJson || { command: 'evolve-monster', monsterId: 'dragon-1', ledgerEntryId: 'camp-2' },
+    createdAt: overrides.createdAt || '2026-04-28T12:00:00.000Z',
+  };
+}
+
+// ── parseArgs ───────────────────────────────────────────────────────
+
+describe('parseArgs', () => {
+  it('parses --db-path, --learner-ids, --date-from, --date-to', () => {
+    const args = parseArgs(['node', 'script', '--db-path', './test.db', '--learner-ids', 'a,b,c', '--date-from', '2026-04-01', '--date-to', '2026-04-30']);
+    assert.ok(args.dbPath.endsWith('test.db'));
+    assert.deepEqual(args.learnerIds, ['a', 'b', 'c']);
+    assert.equal(args.dateFrom, '2026-04-01');
+    assert.equal(args.dateTo, '2026-04-30');
+  });
+
+  it('defaults format to json', () => {
+    const args = parseArgs(['node', 'script']);
+    assert.equal(args.format, 'json');
+  });
+});
+
+// ── classifyConfidence ──────────────────────────────────────────────
+
+describe('classifyConfidence', () => {
+  it('>=100 is high', () => assert.equal(classifyConfidence(100), 'high'));
+  it('>=30 is medium', () => assert.equal(classifyConfidence(30), 'medium'));
+  it('>=10 is low', () => assert.equal(classifyConfidence(10), 'low'));
+  it('<10 is insufficient', () => assert.equal(classifyConfidence(9), 'insufficient'));
+  it('0 is insufficient', () => assert.equal(classifyConfidence(0), 'insufficient'));
+  it('exactly 99 is medium', () => assert.equal(classifyConfidence(99), 'medium'));
+  it('exactly 29 is low', () => assert.equal(classifyConfidence(29), 'low'));
+});
+
+// ── parseRows ───────────────────────────────────────────────────────
+
+describe('parseRows', () => {
+  it('parses valid event_json', () => {
+    const raw = [{ id: '1', learner_id: 'l1', subject_id: 's1', system_id: 'hero-mode', event_type: 'hero.task.completed', event_json: '{"data":{"taskId":"t1"}}', created_at: '2026-04-28T10:00:00Z' }];
+    const parsed = parseRows(raw);
+    assert.equal(parsed.length, 1);
+    assert.equal(parsed[0].eventType, 'hero.task.completed');
+    assert.deepEqual(parsed[0].eventJson, { data: { taskId: 't1' } });
+  });
+
+  it('handles malformed event_json gracefully (sets to null)', () => {
+    const raw = [{ id: '1', learner_id: 'l1', subject_id: null, system_id: 'hero-mode', event_type: 'hero.task.completed', event_json: '{invalid json', created_at: '2026-04-28T10:00:00Z' }];
+    const parsed = parseRows(raw);
+    assert.equal(parsed[0].eventJson, null);
+  });
+
+  it('handles null event_json', () => {
+    const raw = [{ id: '1', learner_id: 'l1', subject_id: null, system_id: 'hero-mode', event_type: 'hero.task.completed', event_json: null, created_at: '2026-04-28T10:00:00Z' }];
+    const parsed = parseRows(raw);
+    assert.equal(parsed[0].eventJson, null);
+  });
+});
+
+// ── Privacy validation ──────────────────────────────────────────────
+
+describe('validateAllRowsPrivacy', () => {
+  it('clean data passes', () => {
+    const rows = [makeTaskRow(), makeCoinRow(), makeCampInviteRow()];
+    const result = validateAllRowsPrivacy(rows);
+    assert.equal(result.passed, true);
+    assert.equal(result.rowsChecked, 3);
+    assert.deepEqual(result.violations, []);
+  });
+
+  it('privacy violation detected and reported', () => {
+    const rows = [
+      makeTaskRow({ eventJson: { data: { taskId: 't1' }, rawAnswer: 'child secret' } }),
+    ];
+    const result = validateAllRowsPrivacy(rows);
+    assert.equal(result.passed, false);
+    assert.equal(result.violations.length, 1);
+    assert.equal(result.violations[0].rowIndex, 0);
+    assert.ok(result.violations[0].violations.includes('rawAnswer'));
+  });
+
+  it('nested privacy violation detected', () => {
+    const rows = [
+      makeTaskRow({ eventJson: { data: { nested: { childFreeText: 'secret' } } } }),
+    ];
+    const result = validateAllRowsPrivacy(rows);
+    assert.equal(result.passed, false);
+  });
+
+  it('rows with null eventJson are skipped (not counted)', () => {
+    const rows = [{ ...makeTaskRow(), eventJson: null }];
+    const result = validateAllRowsPrivacy(rows);
+    assert.equal(result.passed, true);
+    assert.equal(result.rowsChecked, 0);
+  });
+});
+
+// ── Signal extraction: zero events ──────────────────────────────────
+
+describe('signal extraction with zero events', () => {
+  const emptyRows = [];
+
+  it('questShown returns zero', () => {
+    const r = extractQuestShown(emptyRows);
+    assert.equal(r.count, 0);
+  });
+
+  it('dailyCompletionRate returns zeros without errors', () => {
+    const r = extractDailyCompletionRate(emptyRows);
+    assert.equal(r.dailyCompleted, 0);
+    assert.equal(r.sessionsStarted, 0);
+    assert.equal(r.value, 0);
+  });
+
+  it('subjectMix returns empty distribution', () => {
+    const r = extractSubjectMix(emptyRows);
+    assert.deepEqual(r.distribution, {});
+    assert.equal(r.total, 0);
+  });
+
+  it('coinAwards returns zeros', () => {
+    const r = extractCoinAwards(emptyRows);
+    assert.equal(r.awardCount, 0);
+    assert.equal(r.totalCoins, 0);
+  });
+
+  it('campEvents returns zeros', () => {
+    const r = extractCampEvents(emptyRows);
+    assert.equal(r.invited, 0);
+    assert.equal(r.grown, 0);
+  });
+
+  it('rushingSignals returns zeros', () => {
+    const r = extractRushingSignals(emptyRows);
+    assert.equal(r.suspiciousSessionCount, 0);
+    assert.equal(r.sessionsAnalysed, 0);
+  });
+});
+
+// ── Signal extraction: task completion events ───────────────────────
+
+describe('extractSubjectMix', () => {
+  it('counts subjects from task.completed events', () => {
+    const rows = [
+      makeTaskRow({ subjectId: 'grammar' }),
+      makeTaskRow({ id: '2', subjectId: 'spelling' }),
+      makeTaskRow({ id: '3', subjectId: 'grammar' }),
+    ];
+    const r = extractSubjectMix(rows);
+    assert.equal(r.distribution['grammar'], 2);
+    assert.equal(r.distribution['spelling'], 1);
+    assert.equal(r.total, 3);
+  });
+});
+
+describe('extractTaskIntentDistribution', () => {
+  it('counts intent values from event_json', () => {
+    const rows = [
+      makeTaskRow({ eventJson: { data: { taskId: 't1' }, heroTaskIntent: 'weak-repair' } }),
+      makeTaskRow({ id: '2', eventJson: { data: { taskId: 't2' }, heroTaskIntent: 'due-review' } }),
+      makeTaskRow({ id: '3', eventJson: { data: { taskId: 't3' }, heroTaskIntent: 'weak-repair' } }),
+    ];
+    const r = extractTaskIntentDistribution(rows);
+    assert.equal(r.distribution['weak-repair'], 2);
+    assert.equal(r.distribution['due-review'], 1);
+    assert.equal(r.total, 3);
+  });
+
+  it('uses "unknown" for missing intent', () => {
+    const rows = [makeTaskRow({ eventJson: { data: { taskId: 't1' } } })];
+    const r = extractTaskIntentDistribution(rows);
+    assert.equal(r.distribution['unknown'], 1);
+  });
+});
+
+// ── Signal extraction: daily completion rate ────────────────────────
+
+describe('extractDailyCompletionRate', () => {
+  it('computes rate from daily.completed and task sessions', () => {
+    const rows = [
+      makeTaskRow({ createdAt: '2026-04-28T10:00:00Z' }),
+      makeTaskRow({ id: '2', learnerId: 'learner-2', createdAt: '2026-04-28T10:00:00Z' }),
+      makeDailyRow({ createdAt: '2026-04-28T10:05:00Z' }),
+    ];
+    const r = extractDailyCompletionRate(rows);
+    assert.equal(r.dailyCompleted, 1);
+    assert.equal(r.sessionsStarted, 2); // 2 unique learner-day combos
+    assert.equal(r.value, 0.5);
+  });
+});
+
+// ── Signal extraction: coin awards ──────────────────────────────────
+
+describe('extractCoinAwards', () => {
+  it('counts awards and sums amounts', () => {
+    const rows = [
+      makeCoinRow({ eventJson: { amount: 100, balanceAfter: 200 } }),
+      makeCoinRow({ id: '2', eventJson: { amount: 100, balanceAfter: 300 } }),
+    ];
+    const r = extractCoinAwards(rows);
+    assert.equal(r.awardCount, 2);
+    assert.equal(r.totalCoins, 200);
+  });
+});
+
+// ── Signal extraction: camp events ──────────────────────────────────
+
+describe('extractCampEvents', () => {
+  it('counts invited and grown events', () => {
+    const rows = [
+      makeCampInviteRow(),
+      makeCampInviteRow({ id: '2' }),
+      makeCampGrowRow(),
+    ];
+    const r = extractCampEvents(rows);
+    assert.equal(r.invited, 2);
+    assert.equal(r.grown, 1);
+  });
+});
+
+// ── Signal extraction: extra practice after cap ─────────────────────
+
+describe('extractExtraPracticeAfterCap', () => {
+  it('detects tasks after daily.completed timestamp', () => {
+    const rows = [
+      makeTaskRow({ createdAt: '2026-04-28T10:00:00Z' }),
+      makeDailyRow({ createdAt: '2026-04-28T10:05:00Z', eventJson: { data: { dateKey: '2026-04-28' } } }),
+      makeTaskRow({ id: 'extra-1', createdAt: '2026-04-28T10:10:00Z', eventJson: { data: { dateKey: '2026-04-28' } } }),
+    ];
+    const r = extractExtraPracticeAfterCap(rows);
+    assert.equal(r.extraTaskCount, 1);
+  });
+
+  it('returns zero when no tasks after completion', () => {
+    const rows = [
+      makeTaskRow({ createdAt: '2026-04-28T10:00:00Z' }),
+      makeDailyRow({ createdAt: '2026-04-28T10:05:00Z', eventJson: { data: { dateKey: '2026-04-28' } } }),
+    ];
+    const r = extractExtraPracticeAfterCap(rows);
+    assert.equal(r.extraTaskCount, 0);
+  });
+});
+
+// ── Signal extraction: rushing signals ──────────────────────────────
+
+describe('extractRushingSignals', () => {
+  it('detects rapid task claims (< 30s apart)', () => {
+    const rows = [
+      makeTaskRow({ createdAt: '2026-04-28T10:00:00.000Z' }),
+      makeTaskRow({ id: '2', createdAt: '2026-04-28T10:00:15.000Z' }), // 15s gap
+    ];
+    const r = extractRushingSignals(rows);
+    assert.equal(r.suspiciousSessionCount, 1);
+  });
+
+  it('does not flag normal pace (> 30s apart)', () => {
+    const rows = [
+      makeTaskRow({ createdAt: '2026-04-28T10:00:00.000Z' }),
+      makeTaskRow({ id: '2', createdAt: '2026-04-28T10:01:00.000Z' }), // 60s gap
+    ];
+    const r = extractRushingSignals(rows);
+    assert.equal(r.suspiciousSessionCount, 0);
+  });
+});
+
+// ── Signal extraction: unmeasurable signals ─────────────────────────
+
+describe('unmeasurable signals', () => {
+  it('questShown.measurable is false', () => {
+    assert.equal(extractQuestShown([]).measurable, false);
+  });
+
+  it('abandonmentReasons.measurable is false', () => {
+    assert.equal(extractAbandonmentReasons([]).measurable, false);
+  });
+
+  it('masteryDrift.measurable is false', () => {
+    assert.equal(extractMasteryDrift([]).measurable, false);
+  });
+
+  it('duplicateClaimPrevention.measurable is false', () => {
+    assert.equal(extractDuplicateClaimPrevention([]).measurable, false);
+  });
+});
+
+// ── assembleReport ──────────────────────────────────────────────────
+
+describe('assembleReport', () => {
+  it('produces valid report structure with events', () => {
+    const rows = [makeTaskRow(), makeDailyRow(), makeCoinRow(), makeCampInviteRow()];
+    const args = { dateFrom: '2026-04-28', dateTo: '2026-04-28', learnerIds: ['learner-1'] };
+    const report = assembleReport(rows, args);
+
+    assert.ok(report.extractedAt);
+    assert.equal(report.totalEvents, 4);
+    assert.ok(report.signals);
+    assert.ok(report.privacyValidation.passed);
+    assert.ok(Array.isArray(report.unmeasurable));
+    assert.ok(Array.isArray(report.warnings));
+  });
+
+  it('produces empty report without errors for zero events', () => {
+    const args = { dateFrom: null, dateTo: null, learnerIds: null };
+    const report = assembleReport([], args);
+
+    assert.equal(report.totalEvents, 0);
+    assert.ok(report.signals);
+    assert.ok(report.warnings.length > 0); // warns about no events
+  });
+
+  it('aborts with error report on privacy violation', () => {
+    const rows = [
+      makeTaskRow({ eventJson: { rawAnswer: 'child secret', taskId: 't1' } }),
+    ];
+    const args = { dateFrom: null, dateTo: null, learnerIds: null };
+    const report = assembleReport(rows, args);
+
+    assert.equal(report.error, 'privacy-violation');
+    assert.equal(report.signals, null);
+    assert.equal(report.privacyValidation.passed, false);
+  });
+
+  it('handles malformed eventJson rows gracefully (skipped in signal extraction)', () => {
+    const rows = [
+      { ...makeTaskRow(), eventJson: null },
+      makeTaskRow({ id: '2' }),
+    ];
+    const args = { dateFrom: null, dateTo: null, learnerIds: null };
+    const report = assembleReport(rows, args);
+
+    assert.ok(report.signals);
+    assert.equal(report.privacyValidation.passed, true);
+  });
+});


### PR DESCRIPTION
## Summary
- U6: `scripts/hero-pA3-telemetry-extract.mjs` — reads D1 event_log (local sqlite via better-sqlite3), extracts all 16 Goal 6 signals with privacy validation and confidence classification. Explicitly lists 7 unmeasurable signals (client-side only) with explanations.
- U7: `scripts/hero-pA3-metrics-summary.mjs` — provenance-aware metrics baseline. Parses 9-column evidence table (with Source column), separates real-production from simulation rows, integrates Goal 6 telemetry report when available, marks telemetry dimensions as `telemetry-pending` otherwise.
- 64 tests across 2 test files covering all extraction functions, privacy violation abort, zero-event handling, provenance separation, and telemetry integration.

## Key design decisions
- Zero runtime code changes — scripts only read from existing event_log
- Never imports from `worker/src/` — only from `shared/hero/` (privacy module)
- Confidence classification based on **real-production row count** only (provenance-qualified)
- Scripts always exit 0 — problems reported in output, never crash
- Main functions guarded with `import.meta.url` check for test importability

## Test plan
- [x] All 64 tests pass (`node --test tests/hero-pA3-*.test.js`)
- [x] No file side-effects during test import (main() guarded)
- [x] Privacy violation → report aborts with error (not crash)
- [x] Zero events → all signals report zeros without errors
- [x] Malformed event_json → gracefully skipped
- [x] Missing telemetry report → dimensions marked `telemetry-pending`