### PR TITLE
fix(grammar-qg): P11 U3 — cue-kind accessibility copy

### DIFF
--- a/tests/grammar-qg-p11-accessibility-copy.test.js
+++ b/tests/grammar-qg-p11-accessibility-copy.test.js
@@ -1,0 +1,185 @@
+/**
+ * Grammar QG P11 U3 — Cue-Kind Accessibility Copy
+ *
+ * Validates that:
+ * - focusCue.targetKind is set correctly (noun-phrase, word, sentence, group, pair)
+ * - screenReaderPromptText uses kind-appropriate phrasing
+ * - readAloudText uses kind-appropriate phrasing
+ * - No double punctuation (e.g. `..` or `!!`) at end of readAloudText
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  createGrammarQuestion,
+  GRAMMAR_TEMPLATE_METADATA,
+} from '../worker/src/subjects/grammar/content.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function generateQuestion(templateId, seed = 1) {
+  return createGrammarQuestion({ templateId, seed });
+}
+
+// ---------------------------------------------------------------------------
+// 1. qg_p4_voice_roles_transfer: targetKind is 'noun-phrase'
+// ---------------------------------------------------------------------------
+
+describe('P11 U3: qg_p4_voice_roles_transfer — targetKind is noun-phrase', () => {
+  it('seed 1: focusCue.targetKind is noun-phrase', () => {
+    const q = generateQuestion('qg_p4_voice_roles_transfer', 1);
+    assert.ok(q, 'question must be generated');
+    assert.ok(q.focusCue, 'focusCue must be present');
+    assert.strictEqual(q.focusCue.targetKind, 'noun-phrase');
+  });
+
+  it('seed 1: readAloudText says "The underlined noun phrase is:" (NOT "word")', () => {
+    const q = generateQuestion('qg_p4_voice_roles_transfer', 1);
+    assert.ok(q.readAloudText, 'readAloudText must be present');
+    assert.match(
+      q.readAloudText,
+      /The underlined noun phrase is:/,
+      `readAloudText must use noun-phrase phrasing, got: "${q.readAloudText}"`
+    );
+    assert.doesNotMatch(
+      q.readAloudText,
+      /The underlined word is:/,
+      'readAloudText must NOT say "underlined word" for a noun phrase'
+    );
+  });
+
+  it('seed 1: screenReaderPromptText says "The underlined noun phrase is:"', () => {
+    const q = generateQuestion('qg_p4_voice_roles_transfer', 1);
+    assert.ok(q.screenReaderPromptText, 'screenReaderPromptText must be present');
+    assert.match(
+      q.screenReaderPromptText,
+      /The underlined noun phrase is:/,
+      `screenReaderPromptText must use noun-phrase phrasing, got: "${q.screenReaderPromptText}"`
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. word_class_underlined_choice: targetKind is 'word'
+// ---------------------------------------------------------------------------
+
+describe('P11 U3: word_class_underlined_choice — targetKind is word', () => {
+  it('seed 1: focusCue.targetKind is word', () => {
+    const q = generateQuestion('word_class_underlined_choice', 1);
+    assert.ok(q, 'question must be generated');
+    assert.ok(q.focusCue, 'focusCue must be present');
+    assert.strictEqual(q.focusCue.targetKind, 'word');
+  });
+
+  it('seed 1: readAloudText says "The underlined word is:"', () => {
+    const q = generateQuestion('word_class_underlined_choice', 1);
+    assert.ok(q.readAloudText, 'readAloudText must be present');
+    assert.match(
+      q.readAloudText,
+      /The underlined word is:/,
+      `readAloudText must use word phrasing, got: "${q.readAloudText}"`
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. identify_words_in_sentence: targetKind is 'sentence'
+// ---------------------------------------------------------------------------
+
+describe('P11 U3: identify_words_in_sentence — targetKind is sentence', () => {
+  it('seed 1: focusCue.targetKind is sentence', () => {
+    const q = generateQuestion('identify_words_in_sentence', 1);
+    assert.ok(q, 'question must be generated');
+    assert.ok(q.focusCue, 'focusCue must be present');
+    assert.strictEqual(q.focusCue.targetKind, 'sentence');
+  });
+
+  it('seed 1: readAloudText says "The sentence is:" with single full stop (no "..")', () => {
+    const q = generateQuestion('identify_words_in_sentence', 1);
+    assert.ok(q.readAloudText, 'readAloudText must be present');
+    assert.match(
+      q.readAloudText,
+      /The sentence is:/,
+      `readAloudText must use sentence phrasing, got: "${q.readAloudText}"`
+    );
+    assert.doesNotMatch(
+      q.readAloudText,
+      /[.!?]{2,}$/,
+      `readAloudText must not end with double punctuation, got: "${q.readAloudText}"`
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Sentence ending in '!': no extra '.' appended
+// ---------------------------------------------------------------------------
+
+describe('P11 U3: conditional punctuation — no dot after exclamation', () => {
+  // Test across seeds for identify_words_in_sentence to find one ending in ! or .
+  for (let seed = 1; seed <= 20; seed++) {
+    it(`seed ${seed}: readAloudText never ends with double punctuation`, () => {
+      const q = generateQuestion('identify_words_in_sentence', seed);
+      if (!q || !q.readAloudText) return; // skip if no readAloudText
+      assert.doesNotMatch(
+        q.readAloudText,
+        /[.!?]{2,}$/,
+        `readAloudText must not end with double punctuation, got: "${q.readAloudText}"`
+      );
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 5. parenthesis_replace_choice / proc_semicolon_choice: no double punctuation
+// ---------------------------------------------------------------------------
+
+describe('P11 U3: parenthesis_replace_choice — no double punctuation', () => {
+  for (let seed = 1; seed <= 5; seed++) {
+    it(`seed ${seed}: readAloudText has no double punctuation`, () => {
+      const q = generateQuestion('parenthesis_replace_choice', seed);
+      if (!q || !q.readAloudText) return;
+      assert.doesNotMatch(
+        q.readAloudText,
+        /[.!?]{2,}/,
+        `readAloudText must not contain double punctuation, got: "${q.readAloudText}"`
+      );
+    });
+  }
+});
+
+describe('P11 U3: proc_semicolon_choice — no double punctuation', () => {
+  for (let seed = 1; seed <= 5; seed++) {
+    it(`seed ${seed}: readAloudText has no double punctuation`, () => {
+      const q = generateQuestion('proc_semicolon_choice', seed);
+      if (!q || !q.readAloudText) return;
+      assert.doesNotMatch(
+        q.readAloudText,
+        /[.!?]{2,}/,
+        `readAloudText must not contain double punctuation, got: "${q.readAloudText}"`
+      );
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 6. Sweeping test: all 78 templates x seeds 1..5 — no double punctuation
+// ---------------------------------------------------------------------------
+
+describe('P11 U3: sweep all templates — no readAloudText ends with double punctuation', () => {
+  const templates = GRAMMAR_TEMPLATE_METADATA;
+  for (const tmpl of templates) {
+    for (let seed = 1; seed <= 5; seed++) {
+      it(`${tmpl.id} seed ${seed}: no double punctuation in readAloudText`, () => {
+        const q = generateQuestion(tmpl.id, seed);
+        if (!q || !q.readAloudText) return; // skip templates without readAloudText
+        assert.doesNotMatch(
+          q.readAloudText,
+          /[.!?]{2,}$/,
+          `readAloudText must not end with double punctuation for ${tmpl.id} seed ${seed}, got: "${q.readAloudText}"`
+        );
+      });
+    }
+  }
+});

--- a/worker/src/subjects/grammar/content.js
+++ b/worker/src/subjects/grammar/content.js
@@ -7625,6 +7625,21 @@ function detectCueType(plainPrompt) {
   return null;
 }
 
+// P11 U3: Maps cue-pattern match to a semantic target kind used for
+// kind-aware accessibility copy (screen-reader / read-aloud phrasing).
+// Order matters: specific underline variants must precede the generic 'sentence'
+// fallback, because prompts like "underlined word in the sentence below" contain
+// both patterns but the cue target is the word, not the sentence.
+function detectTargetKind(plainPrompt) {
+  if (/\bunderlined\s+noun\s+phrase/i.test(plainPrompt)) return 'noun-phrase';
+  if (/\bunderlined\s+group/i.test(plainPrompt)) return 'group';
+  if (/\bunderlined\s+pair/i.test(plainPrompt)) return 'pair';
+  if (/\bunderlined\s+word/i.test(plainPrompt)) return 'word';
+  if (/\bin\s+bold\b/i.test(plainPrompt)) return 'word';
+  if (/\bsentence\s+below/i.test(plainPrompt)) return 'sentence';
+  return 'word';
+}
+
 function extractUnderlinedWord(stemHtml) {
   const match = stemHtml.match(/<u>([^<]+)<\/u>/);
   return match ? match[1] : null;
@@ -7764,16 +7779,19 @@ function enrichPromptCue(question) {
     ? resolveTargetSentence(question, plainPrompt)
     : (boldSentence || null);
 
+  // P11 U3: Determine the semantic kind of the cue target for accessibility copy
+  const targetKind = detectTargetKind(plainPrompt);
+
   // Build focusCue (targetOccurrence: 1 disambiguates which occurrence is the
   // target when the cue text appears multiple times in the sentence)
   if (cueType === 'underline' && targetWord) {
-    question.focusCue = { type: 'underline', targetText: targetWord, targetOccurrence: 1 };
+    question.focusCue = { type: 'underline', targetKind, targetText: targetWord, targetOccurrence: 1 };
   } else if (cueType === 'bold' && boldSentence) {
-    question.focusCue = { type: 'bold', targetText: boldSentence, targetOccurrence: 1 };
+    question.focusCue = { type: 'bold', targetKind, targetText: boldSentence, targetOccurrence: 1 };
   } else if (cueType === 'quoted-word' && targetWord) {
-    question.focusCue = { type: 'quoted-word', targetText: targetWord, targetOccurrence: 1 };
+    question.focusCue = { type: 'quoted-word', targetKind, targetText: targetWord, targetOccurrence: 1 };
   } else if (cueType === 'target-sentence' && targetSentence) {
-    question.focusCue = { type: 'target-sentence', targetText: targetSentence, targetOccurrence: 1 };
+    question.focusCue = { type: 'target-sentence', targetKind: 'sentence', targetText: targetSentence, targetOccurrence: 1 };
   }
 
   // P10 U2: Cue consistency enforcement — if cueType is 'underline' but we
@@ -7793,29 +7811,46 @@ function enrichPromptCue(question) {
   // Build promptParts
   question.promptParts = buildPromptParts(plainPrompt, cueType, targetWord, targetSentence);
 
-  // screenReaderPromptText — mentions the target word clearly
+  // P11 U3: screenReaderPromptText — kind-aware phrasing for assistive tech
   if (question.focusCue) {
     const word = question.focusCue.targetText;
+    const kind = question.focusCue.targetKind;
     if (cueType === 'underline') {
-      question.screenReaderPromptText = `${plainPrompt} Target word: ${word}`;
+      if (kind === 'noun-phrase') {
+        question.screenReaderPromptText = `${plainPrompt} The underlined noun phrase is: ${word}`;
+      } else if (kind === 'group' || kind === 'pair') {
+        question.screenReaderPromptText = `${plainPrompt} The underlined ${kind} is: ${word}`;
+      } else {
+        question.screenReaderPromptText = `${plainPrompt} Target word: ${word}`;
+      }
     } else if (cueType === 'bold') {
       question.screenReaderPromptText = `${plainPrompt} Focus: ${word}`;
     } else if (cueType === 'target-sentence') {
-      question.screenReaderPromptText = `${plainPrompt} Sentence: ${word}`;
+      question.screenReaderPromptText = `${plainPrompt} The sentence is: ${word}`;
     } else {
       question.screenReaderPromptText = `${plainPrompt} Target: ${word}`;
     }
   }
 
-  // readAloudText — full spoken form including cue
+  // P11 U3: readAloudText — kind-aware spoken form with conditional punctuation
   if (question.focusCue) {
     const word = question.focusCue.targetText;
+    const kind = question.focusCue.targetKind;
+    const needsDot = !/[.!?]$/.test(word.trim());
+    const dot = needsDot ? '.' : '';
+
     if (cueType === 'underline') {
-      question.readAloudText = `${plainPrompt} The underlined word is: ${word}.`;
+      if (kind === 'noun-phrase') {
+        question.readAloudText = `${plainPrompt} The underlined noun phrase is: ${word}${dot}`;
+      } else if (kind === 'group' || kind === 'pair') {
+        question.readAloudText = `${plainPrompt} The underlined ${kind} is: ${word}${dot}`;
+      } else {
+        question.readAloudText = `${plainPrompt} The underlined word is: ${word}${dot}`;
+      }
     } else if (cueType === 'target-sentence') {
-      question.readAloudText = `${plainPrompt} The sentence is: ${word}.`;
+      question.readAloudText = `${plainPrompt} The sentence is: ${word}${dot}`;
     } else {
-      question.readAloudText = `${plainPrompt} Focus on: ${word}.`;
+      question.readAloudText = `${plainPrompt} Focus on: ${word}${dot}`;
     }
   }
 


### PR DESCRIPTION
## Summary
- Added `detectTargetKind()` that classifies cue targets as `noun-phrase`, `group`, `pair`, `sentence`, or `word` based on prompt language
- `focusCue` now includes `targetKind` field on every cue object
- `screenReaderPromptText` uses kind-specific phrasing ("The underlined noun phrase is:" instead of generic "Target word:")
- `readAloudText` uses kind-specific phrasing with conditional punctuation — appends `.` only if the target text does not already end with `.`, `!`, or `?`, eliminating double-punctuation bugs

## Test plan
- [x] `qg_p4_voice_roles_transfer` seed 1: `targetKind` is `noun-phrase`, readAloudText says "The underlined noun phrase is:"
- [x] `word_class_underlined_choice` seed 1: `targetKind` is `word`, readAloudText says "The underlined word is:"
- [x] `identify_words_in_sentence` seed 1: `targetKind` is `sentence`, readAloudText says "The sentence is:" — single full stop
- [x] `parenthesis_replace_choice` and `proc_semicolon_choice`: no double punctuation
- [x] Sweep all 78 templates × seeds 1..5 (390 combinations): no `readAloudText` ends with `/[.!?]{2,}$/`
- [x] Regression: `grammar-qg-p11-target-extraction`, `grammar-qg-p10-prompt-cue-contract`, `grammar-qg-p10-read-aloud-alignment` — 138 tests pass