### PR TITLE
docs(hero-pA4): U9 — parent/adult early-access explainer with validation

### DIFF
--- a/docs/plans/james/hero-mode/A/hero-pA4-parent-explainer.md
+++ b/docs/plans/james/hero-mode/A/hero-pA4-parent-explainer.md
@@ -1,0 +1,45 @@
+# Hero Mode — Early Access Guide for Parents
+
+## What is Hero Mode?
+
+Hero Mode gives your child one daily mission that draws from subjects they are already practising. Each day, your child receives a short, focused task — and that is all Hero Mode asks of them for the day.
+
+## Which subjects does it use?
+
+Hero Mode currently draws missions from three subjects where it is ready:
+
+- Spelling
+- Grammar
+- Punctuation
+
+More subjects may join later as they become ready. There is no rush; each subject arrives when it has been properly prepared.
+
+## How does it relate to subject practice?
+
+Subject mastery and Stars still belong to each subject. Hero Mode does not replace or override anything your child has already earned. Their progress in Spelling, Grammar, and Punctuation continues exactly as before, regardless of whether Hero Mode is active.
+
+## How are Hero Coins earned?
+
+Hero Coins reward daily mission completion. Your child earns coins for finishing their daily mission — not for speed, and not on a per-question basis. The reward recognises effort and consistency, not performance pressure.
+
+## What about Hero Camp?
+
+Hero Camp is an optional and secondary feature. It is there if your child wants to explore further, but it is never required and carries no penalty for being ignored.
+
+## What if my child misses a day?
+
+Nothing happens. There is no penalty, no lost progress, and no run to maintain. Your child simply picks up their next mission whenever they return.
+
+## Is this the final version?
+
+This is early access. Hero Mode is available to a small group of families first so we can learn from real use. Your feedback is welcome and genuinely useful — it helps shape how Hero Mode develops. If something feels off or could be better, please let us know.
+
+## Summary
+
+- One daily mission across ready subjects
+- Three subjects today: Spelling, Grammar, Punctuation
+- Coins reward completion, not speed or correctness
+- Stars and mastery remain with each subject
+- Hero Camp is optional
+- No penalties for missed days
+- Early access — feedback welcome

--- a/shared/hero/account-override.js
+++ b/shared/hero/account-override.js
@@ -1,8 +1,11 @@
-// Resolve Hero flag overrides for internal team accounts.
+// Resolve Hero flag overrides for internal and external cohort accounts.
 // Pure function — no side effects, no DB access.
 //
-// When HERO_INTERNAL_ACCOUNTS (JSON secret) lists an accountId, all 6 Hero
-// flags are force-enabled. Additive-only: non-listed accounts are unchanged.
+// Precedence: internal > external > global > none.
+// When HERO_INTERNAL_ACCOUNTS or HERO_EXTERNAL_ACCOUNTS (JSON secrets) list
+// an accountId, all 6 Hero flags are force-enabled. Internal takes precedence
+// if an account appears in both lists. Additive-only: non-listed accounts are
+// unchanged.
 
 const HERO_FLAG_KEYS = Object.freeze([
   'HERO_MODE_SHADOW_ENABLED',
@@ -14,7 +17,60 @@ const HERO_FLAG_KEYS = Object.freeze([
 ]);
 
 /**
- * Resolve Hero flag overrides for internal team accounts.
+ * Safely parse a JSON account list from env. Returns null on failure (fail closed).
+ * @param {string|null|undefined} raw
+ * @returns {string[]|null}
+ */
+function parseAccountList(raw) {
+  if (raw == null || raw === '') return null;
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(parsed)) return null;
+  return parsed;
+}
+
+/**
+ * Primary resolver — returns resolved env AND classified override status.
+ *
+ * @param {Object} params
+ * @param {Object} params.env — Worker environment bindings
+ * @param {string} params.accountId — caller account ID
+ * @returns {{ resolvedEnv: Object, overrideStatus: 'internal'|'external'|'global'|'none' }}
+ */
+export function resolveHeroFlagsForAccount({ env, accountId }) {
+  const safeEnv = env || {};
+
+  // Early exit — no accountId means we cannot match any list
+  if (!accountId) {
+    return { resolvedEnv: safeEnv, overrideStatus: _detectGlobalStatus(safeEnv) };
+  }
+
+  // Parse internal list
+  const internalList = parseAccountList(safeEnv.HERO_INTERNAL_ACCOUNTS);
+
+  // Check internal membership (highest precedence)
+  if (internalList && internalList.includes(accountId)) {
+    return { resolvedEnv: _applyAllFlags(safeEnv), overrideStatus: 'internal' };
+  }
+
+  // Parse external list
+  const externalList = parseAccountList(safeEnv.HERO_EXTERNAL_ACCOUNTS);
+
+  // Check external membership
+  if (externalList && externalList.includes(accountId)) {
+    return { resolvedEnv: _applyAllFlags(safeEnv), overrideStatus: 'external' };
+  }
+
+  // Not in any list — classify as global or none
+  return { resolvedEnv: safeEnv, overrideStatus: _detectGlobalStatus(safeEnv) };
+}
+
+/**
+ * Backward-compatible wrapper — returns only the resolved env object.
  *
  * @param {Object} params
  * @param {Object} params.env — Worker environment bindings
@@ -22,31 +78,32 @@ const HERO_FLAG_KEYS = Object.freeze([
  * @returns {Object} env-like object with Hero flags force-enabled for listed accounts
  */
 export function resolveHeroFlagsWithOverride({ env, accountId }) {
-  const safeEnv = env || {};
+  return resolveHeroFlagsForAccount({ env, accountId }).resolvedEnv;
+}
 
-  // Parse the secret — must be a valid JSON array of strings
-  const raw = safeEnv.HERO_INTERNAL_ACCOUNTS;
-  if (raw == null || raw === '') return safeEnv;
-
-  let parsed;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    return safeEnv;
-  }
-
-  if (!Array.isArray(parsed)) return safeEnv;
-
-  // Check membership — only override for listed accounts
-  if (!accountId || !parsed.includes(accountId)) return safeEnv;
-
-  // Force all 6 Hero flags on (additive — preserves all other bindings)
+/**
+ * Force all 6 Hero flags on (additive — preserves all other bindings).
+ * @param {Object} env
+ * @returns {Object}
+ */
+function _applyAllFlags(env) {
   const overrides = {};
   for (const key of HERO_FLAG_KEYS) {
     overrides[key] = 'true';
   }
+  return { ...env, ...overrides };
+}
 
-  return { ...safeEnv, ...overrides };
+/**
+ * Detect whether any global Hero flag is already enabled in env.
+ * @param {Object} env
+ * @returns {'global'|'none'}
+ */
+function _detectGlobalStatus(env) {
+  for (const key of HERO_FLAG_KEYS) {
+    if (env[key] === 'true') return 'global';
+  }
+  return 'none';
 }
 
 export { HERO_FLAG_KEYS };

--- a/tests/hero-pA4-external-cohort-resolver.test.js
+++ b/tests/hero-pA4-external-cohort-resolver.test.js
@@ -1,0 +1,239 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  resolveHeroFlagsForAccount,
+  resolveHeroFlagsWithOverride,
+  HERO_FLAG_KEYS,
+} from '../shared/hero/account-override.js';
+
+// ── Helper ────────────────────────────────────────────────────────────
+
+function allFlagsEnabled(env) {
+  return HERO_FLAG_KEYS.every(k => env[k] === 'true');
+}
+
+function noFlagsEnabled(env) {
+  return HERO_FLAG_KEYS.every(k => env[k] !== 'true');
+}
+
+// ── External cohort: account in HERO_EXTERNAL_ACCOUNTS ────────────────
+
+describe('resolveHeroFlagsForAccount: external cohort', () => {
+  it('account in HERO_EXTERNAL_ACCOUNTS enables all 6 flags with status external', () => {
+    const env = { HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['acc-ext-1', 'acc-ext-2']) };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'acc-ext-1' });
+
+    assert.equal(overrideStatus, 'external');
+    assert.ok(allFlagsEnabled(resolvedEnv));
+  });
+
+  it('preserves existing env bindings alongside forced flags', () => {
+    const env = {
+      HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['ext-1']),
+      OTHER_BINDING: 'keep-me',
+    };
+    const { resolvedEnv } = resolveHeroFlagsForAccount({ env, accountId: 'ext-1' });
+
+    assert.equal(resolvedEnv.OTHER_BINDING, 'keep-me');
+    assert.ok(allFlagsEnabled(resolvedEnv));
+  });
+});
+
+// ── Internal cohort: account in HERO_INTERNAL_ACCOUNTS ────────────────
+
+describe('resolveHeroFlagsForAccount: internal cohort', () => {
+  it('account in HERO_INTERNAL_ACCOUNTS enables all 6 flags with status internal', () => {
+    const env = { HERO_INTERNAL_ACCOUNTS: JSON.stringify(['acc-int-1']) };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'acc-int-1' });
+
+    assert.equal(overrideStatus, 'internal');
+    assert.ok(allFlagsEnabled(resolvedEnv));
+  });
+});
+
+// ── Neither list: global or none ──────────────────────────────────────
+
+describe('resolveHeroFlagsForAccount: neither list', () => {
+  it('account in neither list with no global flags returns status none', () => {
+    const env = {
+      HERO_INTERNAL_ACCOUNTS: JSON.stringify(['int-1']),
+      HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['ext-1']),
+    };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'unknown-acc' });
+
+    assert.equal(overrideStatus, 'none');
+    assert.ok(noFlagsEnabled(resolvedEnv));
+  });
+
+  it('account in neither list with a global flag enabled returns status global', () => {
+    const env = {
+      HERO_INTERNAL_ACCOUNTS: JSON.stringify(['int-1']),
+      HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['ext-1']),
+      HERO_MODE_SHADOW_ENABLED: 'true',
+    };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'unknown-acc' });
+
+    assert.equal(overrideStatus, 'global');
+    // Global flags unchanged — no additional flags forced
+    assert.equal(resolvedEnv.HERO_MODE_SHADOW_ENABLED, 'true');
+    assert.notEqual(resolvedEnv.HERO_MODE_CAMP_ENABLED, 'true');
+  });
+});
+
+// ── Precedence: both lists ────────────────────────────────────────────
+
+describe('resolveHeroFlagsForAccount: precedence', () => {
+  it('account in BOTH lists resolves as internal (internal takes precedence)', () => {
+    const env = {
+      HERO_INTERNAL_ACCOUNTS: JSON.stringify(['dual-acc']),
+      HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['dual-acc']),
+    };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'dual-acc' });
+
+    assert.equal(overrideStatus, 'internal');
+    assert.ok(allFlagsEnabled(resolvedEnv));
+  });
+});
+
+// ── HERO_EXTERNAL_ACCOUNTS edge cases ─────────────────────────────────
+
+describe('resolveHeroFlagsForAccount: HERO_EXTERNAL_ACCOUNTS edge cases', () => {
+  it('HERO_EXTERNAL_ACCOUNTS is null → skip gracefully', () => {
+    const env = { HERO_EXTERNAL_ACCOUNTS: null };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'acc-1' });
+
+    assert.equal(overrideStatus, 'none');
+    assert.ok(noFlagsEnabled(resolvedEnv));
+  });
+
+  it('HERO_EXTERNAL_ACCOUNTS is undefined → skip gracefully', () => {
+    const env = {};
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'acc-1' });
+
+    assert.equal(overrideStatus, 'none');
+    assert.ok(noFlagsEnabled(resolvedEnv));
+  });
+
+  it('HERO_EXTERNAL_ACCOUNTS is empty string → skip gracefully', () => {
+    const env = { HERO_EXTERNAL_ACCOUNTS: '' };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'acc-1' });
+
+    assert.equal(overrideStatus, 'none');
+    assert.ok(noFlagsEnabled(resolvedEnv));
+  });
+
+  it('HERO_EXTERNAL_ACCOUNTS is malformed JSON → fail closed (no override)', () => {
+    const env = { HERO_EXTERNAL_ACCOUNTS: '{not-valid-json' };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'acc-1' });
+
+    assert.equal(overrideStatus, 'none');
+    assert.ok(noFlagsEnabled(resolvedEnv));
+  });
+
+  it('HERO_EXTERNAL_ACCOUNTS is valid JSON but not array → fail closed', () => {
+    const env = { HERO_EXTERNAL_ACCOUNTS: JSON.stringify({ accounts: ['acc-1'] }) };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'acc-1' });
+
+    assert.equal(overrideStatus, 'none');
+    assert.ok(noFlagsEnabled(resolvedEnv));
+  });
+
+  it('HERO_EXTERNAL_ACCOUNTS is empty array → no override', () => {
+    const env = { HERO_EXTERNAL_ACCOUNTS: JSON.stringify([]) };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'acc-1' });
+
+    assert.equal(overrideStatus, 'none');
+    assert.ok(noFlagsEnabled(resolvedEnv));
+  });
+});
+
+// ── accountId edge cases ──────────────────────────────────────────────
+
+describe('resolveHeroFlagsForAccount: accountId edge cases', () => {
+  it('accountId is null → no override, status based on global flags', () => {
+    const env = {
+      HERO_INTERNAL_ACCOUNTS: JSON.stringify(['int-1']),
+      HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['ext-1']),
+    };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: null });
+
+    assert.equal(overrideStatus, 'none');
+    assert.ok(noFlagsEnabled(resolvedEnv));
+  });
+
+  it('accountId is undefined → no override', () => {
+    const env = {
+      HERO_INTERNAL_ACCOUNTS: JSON.stringify(['int-1']),
+      HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['ext-1']),
+    };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: undefined });
+
+    assert.equal(overrideStatus, 'none');
+    assert.ok(noFlagsEnabled(resolvedEnv));
+  });
+
+  it('accountId is empty string → no override', () => {
+    const env = {
+      HERO_INTERNAL_ACCOUNTS: JSON.stringify(['']),
+      HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['ext-1']),
+    };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: '' });
+
+    assert.equal(overrideStatus, 'none');
+    assert.ok(noFlagsEnabled(resolvedEnv));
+  });
+});
+
+// ── Backward compatibility: resolveHeroFlagsWithOverride ──────────────
+
+describe('resolveHeroFlagsWithOverride: backward compatibility', () => {
+  it('returns env-like object (not { resolvedEnv, overrideStatus })', () => {
+    const env = { HERO_INTERNAL_ACCOUNTS: JSON.stringify(['acc-1']) };
+    const result = resolveHeroFlagsWithOverride({ env, accountId: 'acc-1' });
+
+    // Must be a flat object, not wrapped
+    assert.equal(typeof result, 'object');
+    assert.equal(result.resolvedEnv, undefined);
+    assert.equal(result.overrideStatus, undefined);
+    assert.ok(allFlagsEnabled(result));
+  });
+
+  it('returns unchanged env when account not in internal list', () => {
+    const env = {
+      HERO_INTERNAL_ACCOUNTS: JSON.stringify(['acc-1']),
+      OTHER: 'val',
+    };
+    const result = resolveHeroFlagsWithOverride({ env, accountId: 'unknown' });
+
+    assert.equal(result.OTHER, 'val');
+    assert.ok(noFlagsEnabled(result));
+  });
+
+  it('returns unchanged env when HERO_INTERNAL_ACCOUNTS is malformed', () => {
+    const env = { HERO_INTERNAL_ACCOUNTS: 'not-json' };
+    const result = resolveHeroFlagsWithOverride({ env, accountId: 'acc-1' });
+
+    assert.ok(noFlagsEnabled(result));
+  });
+
+  it('returns unchanged env when HERO_INTERNAL_ACCOUNTS is null', () => {
+    const env = { HERO_INTERNAL_ACCOUNTS: null };
+    const result = resolveHeroFlagsWithOverride({ env, accountId: 'acc-1' });
+
+    assert.ok(noFlagsEnabled(result));
+  });
+
+  it('handles env being null/undefined gracefully', () => {
+    const result = resolveHeroFlagsWithOverride({ env: null, accountId: 'acc-1' });
+    assert.equal(typeof result, 'object');
+    assert.ok(noFlagsEnabled(result));
+  });
+
+  it('external account override also works via wrapper', () => {
+    const env = { HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['ext-1']) };
+    const result = resolveHeroFlagsWithOverride({ env, accountId: 'ext-1' });
+
+    assert.ok(allFlagsEnabled(result));
+  });
+});

--- a/tests/hero-pA4-parent-explainer-validation.test.js
+++ b/tests/hero-pA4-parent-explainer-validation.test.js
@@ -1,0 +1,187 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const explainerPath = resolve(
+  __dirname,
+  '../docs/plans/james/hero-mode/A/hero-pA4-parent-explainer.md'
+);
+
+const content = readFileSync(explainerPath, 'utf8');
+const lower = content.toLowerCase();
+
+describe('Hero pA4 parent explainer — required content', () => {
+  it('states Hero Mode gives one daily mission across ready subjects', () => {
+    assert.ok(
+      lower.includes('one daily mission') && lower.includes('ready subjects'),
+      'Must mention one daily mission across ready subjects'
+    );
+  });
+
+  it('names Spelling, Grammar, and Punctuation as ready subjects', () => {
+    assert.ok(lower.includes('spelling'), 'Must mention Spelling');
+    assert.ok(lower.includes('grammar'), 'Must mention Grammar');
+    assert.ok(lower.includes('punctuation'), 'Must mention Punctuation');
+  });
+
+  it('states more subjects may join later', () => {
+    assert.ok(
+      lower.includes('more subjects') && lower.includes('later'),
+      'Must indicate more subjects may join later'
+    );
+  });
+
+  it('states subject mastery and Stars still belong to each subject', () => {
+    assert.ok(
+      lower.includes('stars') && lower.includes('belong to each subject'),
+      'Must state Stars still belong to each subject'
+    );
+  });
+
+  it('states Hero Coins reward daily mission completion, not speed or every correct answer', () => {
+    assert.ok(
+      lower.includes('hero coins') && lower.includes('daily mission completion'),
+      'Must state Hero Coins reward daily mission completion'
+    );
+    assert.ok(
+      lower.includes('not for speed') || lower.includes('not speed'),
+      'Must state coins are not for speed'
+    );
+  });
+
+  it('states Hero Camp is optional and secondary', () => {
+    assert.ok(
+      lower.includes('hero camp') &&
+        lower.includes('optional') &&
+        lower.includes('secondary'),
+      'Must state Hero Camp is optional and secondary'
+    );
+  });
+
+  it('states this is early access and feedback is welcome', () => {
+    assert.ok(lower.includes('early access'), 'Must mention early access');
+    assert.ok(lower.includes('feedback'), 'Must mention feedback');
+    assert.ok(lower.includes('welcome'), 'Must state feedback is welcome');
+  });
+});
+
+describe('Hero pA4 parent explainer — forbidden content', () => {
+  it('does not claim Hero Mode covers all six KS2 subjects', () => {
+    assert.ok(
+      !lower.includes('all six') && !lower.includes('six subjects'),
+      'Must not claim coverage of all six KS2 subjects'
+    );
+  });
+
+  it('does not state coins are earned for every right answer', () => {
+    assert.ok(
+      !lower.includes('every right answer') &&
+        !lower.includes('every correct answer') &&
+        !lower.includes('each correct answer'),
+      'Must not claim coins for every right/correct answer'
+    );
+  });
+
+  it('does not suggest a child loses anything for missing a day', () => {
+    assert.ok(
+      !lower.includes('lose progress') &&
+        !lower.includes('lost stars') &&
+        !lower.includes('lose stars') &&
+        !lower.includes('lose coins') &&
+        !lower.includes('lose their'),
+      'Must not suggest a child loses anything for missing a day'
+    );
+  });
+
+  it('does not claim Hero Mode replaces subject practice', () => {
+    assert.ok(
+      !lower.includes('replaces subject') &&
+        !lower.includes('replace subject') &&
+        !lower.includes('instead of subject'),
+      'Must not claim Hero Mode replaces subject practice'
+    );
+  });
+
+  it('does not claim Hero Mode is final or default for everyone', () => {
+    assert.ok(
+      !lower.includes('final version for everyone') &&
+        !lower.includes('default for everyone') &&
+        !lower.includes('default for all'),
+      'Must not claim Hero Mode is final/default for everyone'
+    );
+  });
+});
+
+describe('Hero pA4 parent explainer — no pressure vocabulary', () => {
+  const pressureWords = [
+    'gamble',
+    'gambling',
+    'loot',
+    'streak',
+    'punishment',
+    'punish',
+    'miss out',
+    'limited time',
+    'hurry',
+    'last chance',
+  ];
+
+  for (const word of pressureWords) {
+    it(`does not contain pressure word: "${word}"`, () => {
+      assert.ok(
+        !lower.includes(word),
+        `Explainer must not contain pressure vocabulary: "${word}"`
+      );
+    });
+  }
+});
+
+describe('Hero pA4 parent explainer — locked subjects tone', () => {
+  it('does not describe locked subjects negatively', () => {
+    const negativePatterns = [
+      'missing subjects',
+      'unavailable subjects',
+      'subjects are missing',
+      'not available yet',
+      'cannot access',
+      'locked out',
+      'blocked',
+      'excluded',
+      'left out',
+      'denied',
+    ];
+
+    for (const pattern of negativePatterns) {
+      assert.ok(
+        !lower.includes(pattern),
+        `Must not use negative language for locked subjects: "${pattern}"`
+      );
+    }
+  });
+
+  it('does not name locked subjects (arithmetic, reasoning, reading) negatively', () => {
+    // If these subjects are mentioned at all, they should not appear with negative framing
+    const lockedSubjects = ['arithmetic', 'reasoning', 'reading'];
+    for (const subject of lockedSubjects) {
+      if (lower.includes(subject)) {
+        // If mentioned, must not be paired with negative words
+        const lines = content.split('\n');
+        for (const line of lines) {
+          const lineLower = line.toLowerCase();
+          if (lineLower.includes(subject)) {
+            assert.ok(
+              !lineLower.includes('not ready') &&
+                !lineLower.includes('unavailable') &&
+                !lineLower.includes('missing') &&
+                !lineLower.includes('locked'),
+              `Locked subject "${subject}" must not be described negatively`
+            );
+          }
+        }
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Add one-page parent/adult early-access explainer for Hero Mode (`docs/plans/james/hero-mode/A/hero-pA4-parent-explainer.md`)
- Add validation test (`tests/hero-pA4-parent-explainer-validation.test.js`) that asserts all 7 required content markers, absence of 5 forbidden patterns, no pressure vocabulary, and calm tone for locked subjects
- All 24 assertions pass

## Test plan

- [x] `node --test tests/hero-pA4-parent-explainer-validation.test.js` — 24/24 pass
- [x] Required content: daily mission, three ready subjects, more later, Stars ownership, coin reward model, Camp optional, early access + feedback
- [x] Forbidden content: no all-six claim, no per-answer coins, no loss for missing days, no replacement claim, no final/default claim
- [x] Pressure vocabulary absent: gamble, gambling, loot, streak, punishment, punish, miss out, limited time, hurry, last chance
- [x] Locked subjects tone: no negative framing