### PR TITLE
feat(hero-pA4): U1 — external cohort resolver with classified override status

### DIFF
--- a/shared/hero/account-override.js
+++ b/shared/hero/account-override.js
@@ -1,8 +1,11 @@
-// Resolve Hero flag overrides for internal team accounts.
+// Resolve Hero flag overrides for internal and external cohort accounts.
 // Pure function — no side effects, no DB access.
 //
-// When HERO_INTERNAL_ACCOUNTS (JSON secret) lists an accountId, all 6 Hero
-// flags are force-enabled. Additive-only: non-listed accounts are unchanged.
+// Precedence: internal > external > global > none.
+// When HERO_INTERNAL_ACCOUNTS or HERO_EXTERNAL_ACCOUNTS (JSON secrets) list
+// an accountId, all 6 Hero flags are force-enabled. Internal takes precedence
+// if an account appears in both lists. Additive-only: non-listed accounts are
+// unchanged.
 
 const HERO_FLAG_KEYS = Object.freeze([
   'HERO_MODE_SHADOW_ENABLED',
@@ -14,7 +17,60 @@ const HERO_FLAG_KEYS = Object.freeze([
 ]);
 
 /**
- * Resolve Hero flag overrides for internal team accounts.
+ * Safely parse a JSON account list from env. Returns null on failure (fail closed).
+ * @param {string|null|undefined} raw
+ * @returns {string[]|null}
+ */
+function parseAccountList(raw) {
+  if (raw == null || raw === '') return null;
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(parsed)) return null;
+  return parsed;
+}
+
+/**
+ * Primary resolver — returns resolved env AND classified override status.
+ *
+ * @param {Object} params
+ * @param {Object} params.env — Worker environment bindings
+ * @param {string} params.accountId — caller account ID
+ * @returns {{ resolvedEnv: Object, overrideStatus: 'internal'|'external'|'global'|'none' }}
+ */
+export function resolveHeroFlagsForAccount({ env, accountId }) {
+  const safeEnv = env || {};
+
+  // Early exit — no accountId means we cannot match any list
+  if (!accountId) {
+    return { resolvedEnv: safeEnv, overrideStatus: _detectGlobalStatus(safeEnv) };
+  }
+
+  // Parse internal list
+  const internalList = parseAccountList(safeEnv.HERO_INTERNAL_ACCOUNTS);
+
+  // Check internal membership (highest precedence)
+  if (internalList && internalList.includes(accountId)) {
+    return { resolvedEnv: _applyAllFlags(safeEnv), overrideStatus: 'internal' };
+  }
+
+  // Parse external list
+  const externalList = parseAccountList(safeEnv.HERO_EXTERNAL_ACCOUNTS);
+
+  // Check external membership
+  if (externalList && externalList.includes(accountId)) {
+    return { resolvedEnv: _applyAllFlags(safeEnv), overrideStatus: 'external' };
+  }
+
+  // Not in any list — classify as global or none
+  return { resolvedEnv: safeEnv, overrideStatus: _detectGlobalStatus(safeEnv) };
+}
+
+/**
+ * Backward-compatible wrapper — returns only the resolved env object.
  *
  * @param {Object} params
  * @param {Object} params.env — Worker environment bindings
@@ -22,31 +78,32 @@ const HERO_FLAG_KEYS = Object.freeze([
  * @returns {Object} env-like object with Hero flags force-enabled for listed accounts
  */
 export function resolveHeroFlagsWithOverride({ env, accountId }) {
-  const safeEnv = env || {};
+  return resolveHeroFlagsForAccount({ env, accountId }).resolvedEnv;
+}
 
-  // Parse the secret — must be a valid JSON array of strings
-  const raw = safeEnv.HERO_INTERNAL_ACCOUNTS;
-  if (raw == null || raw === '') return safeEnv;
-
-  let parsed;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    return safeEnv;
-  }
-
-  if (!Array.isArray(parsed)) return safeEnv;
-
-  // Check membership — only override for listed accounts
-  if (!accountId || !parsed.includes(accountId)) return safeEnv;
-
-  // Force all 6 Hero flags on (additive — preserves all other bindings)
+/**
+ * Force all 6 Hero flags on (additive — preserves all other bindings).
+ * @param {Object} env
+ * @returns {Object}
+ */
+function _applyAllFlags(env) {
   const overrides = {};
   for (const key of HERO_FLAG_KEYS) {
     overrides[key] = 'true';
   }
+  return { ...env, ...overrides };
+}
 
-  return { ...safeEnv, ...overrides };
+/**
+ * Detect whether any global Hero flag is already enabled in env.
+ * @param {Object} env
+ * @returns {'global'|'none'}
+ */
+function _detectGlobalStatus(env) {
+  for (const key of HERO_FLAG_KEYS) {
+    if (env[key] === 'true') return 'global';
+  }
+  return 'none';
 }
 
 export { HERO_FLAG_KEYS };

--- a/tests/hero-pA4-external-cohort-resolver.test.js
+++ b/tests/hero-pA4-external-cohort-resolver.test.js
@@ -1,0 +1,239 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  resolveHeroFlagsForAccount,
+  resolveHeroFlagsWithOverride,
+  HERO_FLAG_KEYS,
+} from '../shared/hero/account-override.js';
+
+// ── Helper ────────────────────────────────────────────────────────────
+
+function allFlagsEnabled(env) {
+  return HERO_FLAG_KEYS.every(k => env[k] === 'true');
+}
+
+function noFlagsEnabled(env) {
+  return HERO_FLAG_KEYS.every(k => env[k] !== 'true');
+}
+
+// ── External cohort: account in HERO_EXTERNAL_ACCOUNTS ────────────────
+
+describe('resolveHeroFlagsForAccount: external cohort', () => {
+  it('account in HERO_EXTERNAL_ACCOUNTS enables all 6 flags with status external', () => {
+    const env = { HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['acc-ext-1', 'acc-ext-2']) };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'acc-ext-1' });
+
+    assert.equal(overrideStatus, 'external');
+    assert.ok(allFlagsEnabled(resolvedEnv));
+  });
+
+  it('preserves existing env bindings alongside forced flags', () => {
+    const env = {
+      HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['ext-1']),
+      OTHER_BINDING: 'keep-me',
+    };
+    const { resolvedEnv } = resolveHeroFlagsForAccount({ env, accountId: 'ext-1' });
+
+    assert.equal(resolvedEnv.OTHER_BINDING, 'keep-me');
+    assert.ok(allFlagsEnabled(resolvedEnv));
+  });
+});
+
+// ── Internal cohort: account in HERO_INTERNAL_ACCOUNTS ────────────────
+
+describe('resolveHeroFlagsForAccount: internal cohort', () => {
+  it('account in HERO_INTERNAL_ACCOUNTS enables all 6 flags with status internal', () => {
+    const env = { HERO_INTERNAL_ACCOUNTS: JSON.stringify(['acc-int-1']) };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'acc-int-1' });
+
+    assert.equal(overrideStatus, 'internal');
+    assert.ok(allFlagsEnabled(resolvedEnv));
+  });
+});
+
+// ── Neither list: global or none ──────────────────────────────────────
+
+describe('resolveHeroFlagsForAccount: neither list', () => {
+  it('account in neither list with no global flags returns status none', () => {
+    const env = {
+      HERO_INTERNAL_ACCOUNTS: JSON.stringify(['int-1']),
+      HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['ext-1']),
+    };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'unknown-acc' });
+
+    assert.equal(overrideStatus, 'none');
+    assert.ok(noFlagsEnabled(resolvedEnv));
+  });
+
+  it('account in neither list with a global flag enabled returns status global', () => {
+    const env = {
+      HERO_INTERNAL_ACCOUNTS: JSON.stringify(['int-1']),
+      HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['ext-1']),
+      HERO_MODE_SHADOW_ENABLED: 'true',
+    };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'unknown-acc' });
+
+    assert.equal(overrideStatus, 'global');
+    // Global flags unchanged — no additional flags forced
+    assert.equal(resolvedEnv.HERO_MODE_SHADOW_ENABLED, 'true');
+    assert.notEqual(resolvedEnv.HERO_MODE_CAMP_ENABLED, 'true');
+  });
+});
+
+// ── Precedence: both lists ────────────────────────────────────────────
+
+describe('resolveHeroFlagsForAccount: precedence', () => {
+  it('account in BOTH lists resolves as internal (internal takes precedence)', () => {
+    const env = {
+      HERO_INTERNAL_ACCOUNTS: JSON.stringify(['dual-acc']),
+      HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['dual-acc']),
+    };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'dual-acc' });
+
+    assert.equal(overrideStatus, 'internal');
+    assert.ok(allFlagsEnabled(resolvedEnv));
+  });
+});
+
+// ── HERO_EXTERNAL_ACCOUNTS edge cases ─────────────────────────────────
+
+describe('resolveHeroFlagsForAccount: HERO_EXTERNAL_ACCOUNTS edge cases', () => {
+  it('HERO_EXTERNAL_ACCOUNTS is null → skip gracefully', () => {
+    const env = { HERO_EXTERNAL_ACCOUNTS: null };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'acc-1' });
+
+    assert.equal(overrideStatus, 'none');
+    assert.ok(noFlagsEnabled(resolvedEnv));
+  });
+
+  it('HERO_EXTERNAL_ACCOUNTS is undefined → skip gracefully', () => {
+    const env = {};
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'acc-1' });
+
+    assert.equal(overrideStatus, 'none');
+    assert.ok(noFlagsEnabled(resolvedEnv));
+  });
+
+  it('HERO_EXTERNAL_ACCOUNTS is empty string → skip gracefully', () => {
+    const env = { HERO_EXTERNAL_ACCOUNTS: '' };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'acc-1' });
+
+    assert.equal(overrideStatus, 'none');
+    assert.ok(noFlagsEnabled(resolvedEnv));
+  });
+
+  it('HERO_EXTERNAL_ACCOUNTS is malformed JSON → fail closed (no override)', () => {
+    const env = { HERO_EXTERNAL_ACCOUNTS: '{not-valid-json' };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'acc-1' });
+
+    assert.equal(overrideStatus, 'none');
+    assert.ok(noFlagsEnabled(resolvedEnv));
+  });
+
+  it('HERO_EXTERNAL_ACCOUNTS is valid JSON but not array → fail closed', () => {
+    const env = { HERO_EXTERNAL_ACCOUNTS: JSON.stringify({ accounts: ['acc-1'] }) };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'acc-1' });
+
+    assert.equal(overrideStatus, 'none');
+    assert.ok(noFlagsEnabled(resolvedEnv));
+  });
+
+  it('HERO_EXTERNAL_ACCOUNTS is empty array → no override', () => {
+    const env = { HERO_EXTERNAL_ACCOUNTS: JSON.stringify([]) };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'acc-1' });
+
+    assert.equal(overrideStatus, 'none');
+    assert.ok(noFlagsEnabled(resolvedEnv));
+  });
+});
+
+// ── accountId edge cases ──────────────────────────────────────────────
+
+describe('resolveHeroFlagsForAccount: accountId edge cases', () => {
+  it('accountId is null → no override, status based on global flags', () => {
+    const env = {
+      HERO_INTERNAL_ACCOUNTS: JSON.stringify(['int-1']),
+      HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['ext-1']),
+    };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: null });
+
+    assert.equal(overrideStatus, 'none');
+    assert.ok(noFlagsEnabled(resolvedEnv));
+  });
+
+  it('accountId is undefined → no override', () => {
+    const env = {
+      HERO_INTERNAL_ACCOUNTS: JSON.stringify(['int-1']),
+      HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['ext-1']),
+    };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: undefined });
+
+    assert.equal(overrideStatus, 'none');
+    assert.ok(noFlagsEnabled(resolvedEnv));
+  });
+
+  it('accountId is empty string → no override', () => {
+    const env = {
+      HERO_INTERNAL_ACCOUNTS: JSON.stringify(['']),
+      HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['ext-1']),
+    };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: '' });
+
+    assert.equal(overrideStatus, 'none');
+    assert.ok(noFlagsEnabled(resolvedEnv));
+  });
+});
+
+// ── Backward compatibility: resolveHeroFlagsWithOverride ──────────────
+
+describe('resolveHeroFlagsWithOverride: backward compatibility', () => {
+  it('returns env-like object (not { resolvedEnv, overrideStatus })', () => {
+    const env = { HERO_INTERNAL_ACCOUNTS: JSON.stringify(['acc-1']) };
+    const result = resolveHeroFlagsWithOverride({ env, accountId: 'acc-1' });
+
+    // Must be a flat object, not wrapped
+    assert.equal(typeof result, 'object');
+    assert.equal(result.resolvedEnv, undefined);
+    assert.equal(result.overrideStatus, undefined);
+    assert.ok(allFlagsEnabled(result));
+  });
+
+  it('returns unchanged env when account not in internal list', () => {
+    const env = {
+      HERO_INTERNAL_ACCOUNTS: JSON.stringify(['acc-1']),
+      OTHER: 'val',
+    };
+    const result = resolveHeroFlagsWithOverride({ env, accountId: 'unknown' });
+
+    assert.equal(result.OTHER, 'val');
+    assert.ok(noFlagsEnabled(result));
+  });
+
+  it('returns unchanged env when HERO_INTERNAL_ACCOUNTS is malformed', () => {
+    const env = { HERO_INTERNAL_ACCOUNTS: 'not-json' };
+    const result = resolveHeroFlagsWithOverride({ env, accountId: 'acc-1' });
+
+    assert.ok(noFlagsEnabled(result));
+  });
+
+  it('returns unchanged env when HERO_INTERNAL_ACCOUNTS is null', () => {
+    const env = { HERO_INTERNAL_ACCOUNTS: null };
+    const result = resolveHeroFlagsWithOverride({ env, accountId: 'acc-1' });
+
+    assert.ok(noFlagsEnabled(result));
+  });
+
+  it('handles env being null/undefined gracefully', () => {
+    const result = resolveHeroFlagsWithOverride({ env: null, accountId: 'acc-1' });
+    assert.equal(typeof result, 'object');
+    assert.ok(noFlagsEnabled(result));
+  });
+
+  it('external account override also works via wrapper', () => {
+    const env = { HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['ext-1']) };
+    const result = resolveHeroFlagsWithOverride({ env, accountId: 'ext-1' });
+
+    assert.ok(allFlagsEnabled(result));
+  });
+});


### PR DESCRIPTION
## Summary
- Extend `shared/hero/account-override.js` with `resolveHeroFlagsForAccount()` returning `{ resolvedEnv, overrideStatus }` where status is `internal | external | global | none`
- Parse `HERO_EXTERNAL_ACCOUNTS` with same safety as internal (null/empty skip, malformed JSON fail closed, non-array fail closed)
- Internal takes precedence over external when account appears in both lists
- Keep `resolveHeroFlagsWithOverride` as backward-compatible wrapper (returns only resolvedEnv)

## Test plan
- [x] 21 tests covering all scenarios: internal, external, global, none, precedence, edge cases, backward compat
- [x] All existing pA1/pA2/pA3 tests pass (15 + 16 + 35 = 66 tests green)
- [x] `node --test tests/hero-pA4-external-cohort-resolver.test.js` — 21/21 pass