### PR TITLE
feat(hero-pA4): delivery branch — U1-U3, U9, U11 with unified resolver and stop conditions

### DIFF
--- a/docs/plans/james/hero-mode/A/hero-pA4-parent-explainer.md
+++ b/docs/plans/james/hero-mode/A/hero-pA4-parent-explainer.md
@@ -1,0 +1,45 @@
+# Hero Mode — Early Access Guide for Parents
+
+## What is Hero Mode?
+
+Hero Mode gives your child one daily mission that draws from subjects they are already practising. Each day, your child receives a short, focused task — and that is all Hero Mode asks of them for the day.
+
+## Which subjects does it use?
+
+Hero Mode currently draws missions from three subjects where it is ready:
+
+- Spelling
+- Grammar
+- Punctuation
+
+More subjects may join later as they become ready. There is no rush; each subject arrives when it has been properly prepared.
+
+## How does it relate to subject practice?
+
+Subject mastery and Stars still belong to each subject. Hero Mode does not replace or override anything your child has already earned. Their progress in Spelling, Grammar, and Punctuation continues exactly as before, regardless of whether Hero Mode is active.
+
+## How are Hero Coins earned?
+
+Hero Coins reward daily mission completion. Your child earns coins for finishing their daily mission — not for speed, and not on a per-question basis. The reward recognises effort and consistency, not performance pressure.
+
+## What about Hero Camp?
+
+Hero Camp is an optional and secondary feature. It is there if your child wants to explore further, but it is never required and carries no penalty for being ignored.
+
+## What if my child misses a day?
+
+Nothing happens. There is no penalty, no lost progress, and no run to maintain. Your child simply picks up their next mission whenever they return.
+
+## Is this the final version?
+
+This is early access. Hero Mode is available to a small group of families first so we can learn from real use. Your feedback is welcome and genuinely useful — it helps shape how Hero Mode develops. If something feels off or could be better, please let us know.
+
+## Summary
+
+- One daily mission across ready subjects
+- Three subjects today: Spelling, Grammar, Punctuation
+- Coins reward completion, not speed or correctness
+- Stars and mastery remain with each subject
+- Hero Camp is optional
+- No penalties for missed days
+- Early access — feedback welcome

--- a/scripts/hero-pA4-external-cohort-smoke.mjs
+++ b/scripts/hero-pA4-external-cohort-smoke.mjs
@@ -1,0 +1,418 @@
+#!/usr/bin/env node
+// Hero Mode pA4 — External cohort browser smoke validation script.
+// Validates the critical Hero flow end-to-end:
+//   Hero visible -> start task -> subject session -> return -> claim -> coins -> Camp -> rollback-hidden
+//
+// Usage: node scripts/hero-pA4-external-cohort-smoke.mjs [--account-id ID] [--base-url URL]
+//
+// Exits 0 if all steps pass, 1 if any fail.
+
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// ── Step definitions ──────────────────────────────────────────────────
+
+export const STEPS = [
+  'hero-visible',
+  'start-task',
+  'subject-session',
+  'return-from-session',
+  'claim',
+  'coins',
+  'camp',
+  'rollback-hidden',
+];
+
+// ── Step validators ───────────────────────────────────────────────────
+
+/**
+ * Validate a single step's response data.
+ * Returns { pass: boolean, detail: string }.
+ */
+export function validateStep(stepName, response, context = {}) {
+  switch (stepName) {
+    case 'hero-visible':
+      return validateHeroVisible(response, context);
+    case 'start-task':
+      return validateStartTask(response);
+    case 'subject-session':
+      return validateSubjectSession(response);
+    case 'return-from-session':
+      return validateReturnFromSession(response);
+    case 'claim':
+      return validateClaim(response);
+    case 'coins':
+      return validateCoins(response, context);
+    case 'camp':
+      return validateCamp(response, context);
+    case 'rollback-hidden':
+      return validateRollbackHidden(response);
+    default:
+      return { pass: false, detail: `Unknown step: ${stepName}` };
+  }
+}
+
+function validateHeroVisible(response, context) {
+  if (!response || typeof response !== 'object') {
+    return { pass: false, detail: 'No response body' };
+  }
+  if (response.error) {
+    return { pass: false, detail: `API error: ${response.error}` };
+  }
+  // For non-cohort accounts, ui.enabled will be false
+  if (context.expectHidden) {
+    const hidden = response.ui?.enabled === false;
+    return hidden
+      ? { pass: true, detail: 'Hero correctly not visible for non-cohort account' }
+      : { pass: false, detail: 'Hero should not be visible for non-cohort account' };
+  }
+  const enabled = response.ui?.enabled === true;
+  if (!enabled) {
+    const reason = response.ui?.reason || 'unknown';
+    return { pass: false, detail: `ui.enabled is false (reason: ${reason})` };
+  }
+  return { pass: true, detail: 'ui.enabled=true' };
+}
+
+function validateStartTask(response) {
+  if (!response || typeof response !== 'object') {
+    return { pass: false, detail: 'No response body' };
+  }
+  if (response.error) {
+    return { pass: false, detail: `API error: ${response.error}` };
+  }
+  const heroLaunch = response.heroLaunch;
+  if (!heroLaunch) {
+    return { pass: false, detail: 'Missing heroLaunch in start-task response' };
+  }
+  if (!heroLaunch.questId || !heroLaunch.taskId) {
+    return { pass: false, detail: 'heroLaunch missing questId or taskId' };
+  }
+  if (!heroLaunch.subjectId) {
+    return { pass: false, detail: 'heroLaunch missing subjectId' };
+  }
+  return { pass: true, detail: `heroLaunch intent received: task=${heroLaunch.taskId}` };
+}
+
+function validateSubjectSession(response) {
+  if (!response || typeof response !== 'object') {
+    return { pass: false, detail: 'No response body' };
+  }
+  const heroLaunch = response.heroLaunch;
+  if (!heroLaunch) {
+    return { pass: false, detail: 'Missing heroLaunch for subject-session validation' };
+  }
+  // Must have subjectId and launcher info for the subject to start
+  if (!heroLaunch.subjectId) {
+    return { pass: false, detail: 'No subjectId in heroLaunch — subject cannot start' };
+  }
+  if (!heroLaunch.subjectCommand) {
+    return { pass: false, detail: 'No subjectCommand in heroLaunch — launcher info missing' };
+  }
+  return { pass: true, detail: `subject=${heroLaunch.subjectId}, cmd=${heroLaunch.subjectCommand}` };
+}
+
+function validateReturnFromSession(response) {
+  if (!response || typeof response !== 'object') {
+    return { pass: false, detail: 'No response body' };
+  }
+  if (response.error) {
+    return { pass: false, detail: `API error: ${response.error}` };
+  }
+  const pending = response.pendingCompletedHeroSession;
+  if (!pending) {
+    return { pass: false, detail: 'No pendingCompletedHeroSession in read-model after return' };
+  }
+  if (!pending.taskId || !pending.questId) {
+    return { pass: false, detail: 'pendingCompletedHeroSession missing taskId or questId' };
+  }
+  return { pass: true, detail: `pending claim for task=${pending.taskId}` };
+}
+
+function validateClaim(response) {
+  if (!response || typeof response !== 'object') {
+    return { pass: false, detail: 'No response body' };
+  }
+  if (response.error) {
+    return { pass: false, detail: `API error: ${response.error}` };
+  }
+  // The claim response must indicate an award was granted
+  const award = response.award || response.claimResult;
+  if (!award) {
+    return { pass: false, detail: 'No award/claimResult in claim response' };
+  }
+  if (award.status === 'rejected' || award.status === 'failed') {
+    return { pass: false, detail: `Claim rejected: ${award.reason || 'unknown'}` };
+  }
+  return { pass: true, detail: `award granted: status=${award.status || 'ok'}` };
+}
+
+function validateCoins(response, context) {
+  if (!response || typeof response !== 'object') {
+    return { pass: false, detail: 'No response body' };
+  }
+  const economy = response.economy;
+  if (!economy) {
+    return { pass: false, detail: 'No economy block in read-model' };
+  }
+  const balance = economy.balance;
+  if (typeof balance !== 'number') {
+    return { pass: false, detail: 'economy.balance is not a number' };
+  }
+  const previousBalance = context.previousBalance ?? 0;
+  const expectedIncrease = 100;
+  if (balance < previousBalance + expectedIncrease) {
+    return { pass: false, detail: `Balance ${balance} did not increase by ${expectedIncrease} from ${previousBalance}` };
+  }
+  return { pass: true, detail: `economy.balance=${balance} (increased by ${balance - previousBalance})` };
+}
+
+function validateCamp(response, context) {
+  if (!response || typeof response !== 'object') {
+    return { pass: false, detail: 'No response body' };
+  }
+  // Camp is gated behind HERO_MODE_CAMP_ENABLED
+  if (context.campEnabled === false) {
+    // If camp is disabled, its absence is acceptable
+    if (!response.camp || response.camp.enabled === false) {
+      return { pass: true, detail: 'Camp disabled (HERO_MODE_CAMP_ENABLED=false) — skipped' };
+    }
+  }
+  const camp = response.camp;
+  if (!camp) {
+    return { pass: false, detail: 'No camp block in read-model' };
+  }
+  if (!camp.enabled) {
+    return { pass: false, detail: 'camp.enabled is false' };
+  }
+  if (!Array.isArray(camp.monsters) || camp.monsters.length === 0) {
+    return { pass: false, detail: 'camp.monsters is empty or not an array' };
+  }
+  return { pass: true, detail: `camp has ${camp.monsters.length} monster(s)` };
+}
+
+function validateRollbackHidden(response) {
+  if (!response || typeof response !== 'object') {
+    return { pass: false, detail: 'No response body' };
+  }
+  // With all flags off, the read-model should indicate disabled/hidden or error
+  if (response.error) {
+    // A 404 (hero_shadow_disabled) is the expected rollback behaviour
+    if (response.code === 'hero_shadow_disabled') {
+      return { pass: true, detail: 'Hero correctly returns hero_shadow_disabled when flags off' };
+    }
+    return { pass: true, detail: `Hero returns error with flags off: ${response.error}` };
+  }
+  if (response.ui?.enabled === false) {
+    return { pass: true, detail: 'ui.enabled=false when flags off — correctly hidden' };
+  }
+  return { pass: false, detail: 'Hero is still visible when all flags are off' };
+}
+
+// ── CLI argument parsing ──────────────────────────────────────────────
+
+export function parseArgs(argv) {
+  const args = {
+    accountId: '',
+    baseUrl: 'http://localhost:8787',
+  };
+
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--account-id' && argv[i + 1]) {
+      args.accountId = argv[++i].trim();
+    } else if (arg.startsWith('--account-id=')) {
+      args.accountId = arg.slice('--account-id='.length).trim();
+    } else if (arg === '--base-url' && argv[i + 1]) {
+      args.baseUrl = argv[++i].trim().replace(/\/$/, '');
+    } else if (arg.startsWith('--base-url=')) {
+      args.baseUrl = arg.slice('--base-url='.length).trim().replace(/\/$/, '');
+    }
+  }
+
+  return args;
+}
+
+// ── HTTP helpers ──────────────────────────────────────────────────────
+
+async function httpGet(url) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 15000);
+  try {
+    const res = await fetch(url, { signal: controller.signal });
+    clearTimeout(timer);
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      return { error: `HTTP ${res.status}`, code: body.code || null, ...body };
+    }
+    return await res.json();
+  } catch (err) {
+    clearTimeout(timer);
+    return { error: err.name === 'AbortError' ? 'Timeout after 15s' : err.message };
+  }
+}
+
+async function httpPost(url, body) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 15000);
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+    clearTimeout(timer);
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      return { error: `HTTP ${res.status}`, code: data.code || null, ...data };
+    }
+    return await res.json();
+  } catch (err) {
+    clearTimeout(timer);
+    return { error: err.name === 'AbortError' ? 'Timeout after 15s' : err.message };
+  }
+}
+
+// ── Main flow runner ──────────────────────────────────────────────────
+
+export async function runSmokeFlow({ accountId, baseUrl }) {
+  const results = [];
+  let readModel = null;
+  let startResponse = null;
+  let previousBalance = 0;
+
+  // Step 1: hero-visible
+  readModel = await httpGet(`${baseUrl}/api/hero/read-model?accountId=${encodeURIComponent(accountId)}`);
+  results.push({
+    step: 'hero-visible',
+    ...validateStep('hero-visible', readModel),
+  });
+  if (!results[0].pass) return { results, exitCode: 1 };
+
+  // Capture pre-claim balance
+  previousBalance = readModel.economy?.balance ?? 0;
+
+  // Step 2: start-task — pick first launchable task
+  const task = readModel.dailyQuest?.tasks?.[0];
+  if (!task) {
+    results.push({ step: 'start-task', pass: false, detail: 'No tasks in dailyQuest' });
+    return { results, exitCode: 1 };
+  }
+
+  startResponse = await httpPost(`${baseUrl}/api/hero/command`, {
+    command: 'start-task',
+    learnerId: readModel.dateKey ? accountId : accountId,
+    questId: readModel.dailyQuest.questId,
+    taskId: task.taskId,
+    requestId: `smoke-${Date.now()}`,
+    questFingerprint: readModel.questFingerprint,
+    expectedLearnerRevision: 0,
+  });
+  results.push({
+    step: 'start-task',
+    ...validateStep('start-task', startResponse),
+  });
+  if (!results[results.length - 1].pass) return { results, exitCode: 1 };
+
+  // Step 3: subject-session
+  results.push({
+    step: 'subject-session',
+    ...validateStep('subject-session', startResponse),
+  });
+  if (!results[results.length - 1].pass) return { results, exitCode: 1 };
+
+  // Step 4: return-from-session (re-read model)
+  readModel = await httpGet(`${baseUrl}/api/hero/read-model?accountId=${encodeURIComponent(accountId)}`);
+  results.push({
+    step: 'return-from-session',
+    ...validateStep('return-from-session', readModel),
+  });
+  if (!results[results.length - 1].pass) return { results, exitCode: 1 };
+
+  // Step 5: claim
+  const claimResponse = await httpPost(`${baseUrl}/api/hero/command`, {
+    command: 'claim-task',
+    learnerId: accountId,
+    questId: readModel.dailyQuest.questId,
+    taskId: readModel.pendingCompletedHeroSession?.taskId || task.taskId,
+    requestId: `smoke-claim-${Date.now()}`,
+    questFingerprint: readModel.questFingerprint,
+    expectedLearnerRevision: 0,
+  });
+  results.push({
+    step: 'claim',
+    ...validateStep('claim', claimResponse),
+  });
+  if (!results[results.length - 1].pass) return { results, exitCode: 1 };
+
+  // Step 6: coins (re-read model to check balance)
+  readModel = await httpGet(`${baseUrl}/api/hero/read-model?accountId=${encodeURIComponent(accountId)}`);
+  results.push({
+    step: 'coins',
+    ...validateStep('coins', readModel, { previousBalance }),
+  });
+  if (!results[results.length - 1].pass) return { results, exitCode: 1 };
+
+  // Step 7: camp
+  const campEnabled = readModel.camp?.enabled !== false;
+  results.push({
+    step: 'camp',
+    ...validateStep('camp', readModel, { campEnabled }),
+  });
+  if (!results[results.length - 1].pass) return { results, exitCode: 1 };
+
+  // Step 8: rollback-hidden (simulate flags off — request with rollback query param)
+  const rollbackResponse = await httpGet(`${baseUrl}/api/hero/read-model?accountId=${encodeURIComponent(accountId)}&_simulate_flags_off=1`);
+  results.push({
+    step: 'rollback-hidden',
+    ...validateStep('rollback-hidden', rollbackResponse),
+  });
+
+  const exitCode = results.every(r => r.pass) ? 0 : 1;
+  return { results, exitCode };
+}
+
+// ── Main ──────────────────────────────────────────────────────────────
+
+async function main() {
+  const args = parseArgs(process.argv);
+
+  if (!args.accountId) {
+    console.error('ERROR: --account-id is required');
+    console.error('Usage: node scripts/hero-pA4-external-cohort-smoke.mjs --account-id <ID> [--base-url <URL>]');
+    process.exit(1);
+  }
+
+  console.log('Hero Mode pA4 — External Cohort Browser Smoke');
+  console.log(`Account ID: ${args.accountId}`);
+  console.log(`Base URL:   ${args.baseUrl}`);
+  console.log('---');
+
+  const { results, exitCode } = await runSmokeFlow(args);
+
+  // Output structured JSON
+  const output = {
+    timestamp: new Date().toISOString(),
+    accountId: args.accountId,
+    baseUrl: args.baseUrl,
+    steps: results,
+    passed: results.filter(r => r.pass).length,
+    failed: results.filter(r => !r.pass).length,
+    exitCode,
+  };
+
+  console.log(JSON.stringify(output, null, 2));
+
+  process.exit(exitCode);
+}
+
+// Only run main when invoked directly (not when imported for testing)
+const _scriptUrl = fileURLToPath(import.meta.url);
+const _invokedAs = process.argv[1] ? resolve(process.argv[1]) : '';
+if (_scriptUrl === _invokedAs) {
+  main().catch((err) => {
+    console.error('Fatal error:', err.message);
+    process.exit(1);
+  });
+}

--- a/scripts/hero-pA4-operator-lookup.mjs
+++ b/scripts/hero-pA4-operator-lookup.mjs
@@ -1,0 +1,305 @@
+#!/usr/bin/env node
+// Hero Mode pA4 — Operator Health Lookup Script.
+// Shows why an account is enabled/hidden and current Hero health state.
+// Pure function (buildOperatorLookup) exported for testability.
+//
+// Usage: node scripts/hero-pA4-operator-lookup.mjs --account-id=abc123
+
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  resolveHeroFlagsForAccount,
+  HERO_FLAG_KEYS,
+} from '../shared/hero/account-override.js';
+import { deriveReadinessChecks } from '../worker/src/hero/readiness.js';
+import { stripPrivacyFields } from '../shared/hero/metrics-privacy.js';
+
+// ── Constants ─────────────────────────────────────────────────────────
+
+const MAX_RECENT_EVENTS = 10;
+const DAILY_CAP = 100;
+
+// ── Primary export: buildOperatorLookup ───────────────────────────────
+
+/**
+ * Build a structured operator health report for a given account.
+ * Pure function — no DB access, no side effects.
+ *
+ * @param {Object} params
+ * @param {string|null|undefined} params.accountId — the queried account
+ * @param {Object} params.env — Worker environment bindings (flags, cohort lists)
+ * @param {Object|null} params.heroState — normalised hero progress state (or null)
+ * @param {Array} params.eventLog — raw event log entries (will be privacy-stripped)
+ * @returns {Object} structured health report
+ */
+export function buildOperatorLookup({ accountId, env, heroState, eventLog }) {
+  // Guard: null/undefined accountId
+  if (accountId == null || accountId === '') {
+    return {
+      ok: false,
+      error: 'accountId is required but was null or empty.',
+      accountId: accountId ?? null,
+      overrideStatus: null,
+      resolvedFlags: null,
+      readinessChecks: null,
+      recentEvents: null,
+      economyHealth: null,
+      cohortClassification: null,
+      recommendations: ['Provide a valid accountId to perform lookup.'],
+    };
+  }
+
+  const safeEnv = env && typeof env === 'object' ? env : {};
+  const safeEventLog = Array.isArray(eventLog) ? eventLog : [];
+  const safeState = heroState && typeof heroState === 'object' ? heroState : null;
+
+  // 1. Resolve override status and flags
+  const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({
+    env: safeEnv,
+    accountId,
+  });
+
+  // 2. Determine which Hero flags are active
+  const resolvedFlags = {};
+  for (const key of HERO_FLAG_KEYS) {
+    resolvedFlags[key] = resolvedEnv[key] === 'true';
+  }
+  const allFlagsEnabled = HERO_FLAG_KEYS.every(k => resolvedFlags[k]);
+
+  // 3. Readiness checks (from heroState)
+  const readinessChecks = deriveReadinessChecks(safeState, resolvedEnv);
+
+  // 4. Recent events (privacy-stripped, limited to MAX_RECENT_EVENTS)
+  const recentEvents = deriveRecentEvents(safeEventLog);
+
+  // 5. Economy health assessment
+  const economyHealth = deriveEconomyHealth(safeState);
+
+  // 6. Cohort classification
+  const cohortClassification = deriveCohortClassification(overrideStatus, allFlagsEnabled);
+
+  // 7. Recommendations
+  const recommendations = deriveRecommendations({
+    overrideStatus,
+    allFlagsEnabled,
+    readinessChecks,
+    economyHealth,
+    recentEvents,
+  });
+
+  return {
+    ok: true,
+    accountId,
+    overrideStatus,
+    resolvedFlags,
+    readinessChecks,
+    recentEvents,
+    economyHealth,
+    cohortClassification,
+    recommendations,
+  };
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────
+
+/**
+ * Derive recent events with privacy stripping and limit.
+ */
+function deriveRecentEvents(eventLog) {
+  if (eventLog.length === 0) {
+    return { events: [], count: 0, message: 'No observations yet.' };
+  }
+
+  const stripped = eventLog
+    .slice(0, MAX_RECENT_EVENTS)
+    .map(event => stripPrivacyFields(event));
+
+  return { events: stripped, count: stripped.length };
+}
+
+/**
+ * Derive economy health from hero state.
+ */
+function deriveEconomyHealth(heroState) {
+  if (!heroState) {
+    return {
+      status: 'no_state',
+      balance: null,
+      dailyAwarded: null,
+      anomalies: [],
+      message: 'No hero state available.',
+    };
+  }
+
+  const economy = heroState.economy;
+  if (!economy || typeof economy !== 'object') {
+    return {
+      status: 'missing',
+      balance: null,
+      dailyAwarded: null,
+      anomalies: [],
+      message: 'Economy sub-state missing from hero state.',
+    };
+  }
+
+  const balance = typeof economy.balance === 'number' ? economy.balance : null;
+  const ledger = Array.isArray(economy.ledger) ? economy.ledger : [];
+
+  // Calculate daily awarded (awards from today's ledger entries)
+  const today = new Date().toISOString().slice(0, 10);
+  const todayAwards = ledger.filter(
+    e => e && e.type === 'daily_award' && e.date === today,
+  );
+  const dailyAwarded = todayAwards.reduce(
+    (sum, e) => sum + (typeof e.amount === 'number' ? e.amount : 0),
+    0,
+  );
+
+  // Detect anomalies
+  const anomalies = [];
+  if (balance !== null && balance < 0) {
+    anomalies.push('negative-balance');
+  }
+  if (balance !== null && !Number.isFinite(balance)) {
+    anomalies.push('non-finite-balance');
+  }
+  if (dailyAwarded > DAILY_CAP) {
+    anomalies.push(`daily-cap-exceeded:${dailyAwarded}/${DAILY_CAP}`);
+  }
+  if (ledger.some(e => e === null || e === undefined)) {
+    anomalies.push('null-ledger-entry');
+  }
+
+  const status = anomalies.length === 0 ? 'healthy' : 'unhealthy';
+
+  return { status, balance, dailyAwarded, anomalies };
+}
+
+/**
+ * Classify why the account is enabled or hidden.
+ */
+function deriveCohortClassification(overrideStatus, allFlagsEnabled) {
+  switch (overrideStatus) {
+    case 'internal':
+      return {
+        enabled: true,
+        reason: 'Account is in HERO_INTERNAL_ACCOUNTS cohort list. All Hero flags force-enabled.',
+      };
+    case 'external':
+      return {
+        enabled: true,
+        reason: 'Account is in HERO_EXTERNAL_ACCOUNTS cohort list. All Hero flags force-enabled.',
+      };
+    case 'global':
+      return {
+        enabled: allFlagsEnabled,
+        reason: allFlagsEnabled
+          ? 'Hero flags are globally enabled in environment. Account benefits from global rollout.'
+          : 'Some Hero flags are globally enabled but not all. Partial visibility.',
+      };
+    case 'none':
+    default:
+      return {
+        enabled: false,
+        reason: 'Account is not in any cohort list and no global Hero flags are enabled. Hero Mode is hidden.',
+      };
+  }
+}
+
+/**
+ * Derive actionable recommendations based on current state.
+ */
+function deriveRecommendations({
+  overrideStatus,
+  allFlagsEnabled,
+  readinessChecks,
+  economyHealth,
+  recentEvents,
+}) {
+  const recs = [];
+
+  // Cohort-based recommendations
+  if (overrideStatus === 'none') {
+    recs.push('Account not in any cohort list. Add to HERO_INTERNAL_ACCOUNTS or HERO_EXTERNAL_ACCOUNTS to enable.');
+  }
+
+  // Readiness-based recommendations
+  if (readinessChecks.overall === 'not_ready') {
+    const failing = readinessChecks.checks
+      .filter(c => c.status === 'fail')
+      .map(c => c.name);
+    recs.push(`Readiness checks failing: ${failing.join(', ')}. Investigate and resolve before full enablement.`);
+  }
+  if (readinessChecks.overall === 'not_started') {
+    recs.push('Hero state has not been initialised for this account. Trigger initial Hero session to bootstrap state.');
+  }
+
+  // Economy-based recommendations
+  if (economyHealth.status === 'unhealthy') {
+    recs.push(`Economy anomalies detected: ${economyHealth.anomalies.join(', ')}. Manual intervention required.`);
+  }
+
+  // Event-based recommendations
+  if (recentEvents.count === 0) {
+    recs.push('No event log observations. Account has not interacted with Hero Mode yet.');
+  }
+
+  // Partial flags
+  if (overrideStatus === 'global' && !allFlagsEnabled) {
+    recs.push('Partial global flag enablement. Either enable all 6 flags or add account to a cohort list for full access.');
+  }
+
+  // All good
+  if (recs.length === 0) {
+    recs.push('Account is healthy and fully enabled. No action required.');
+  }
+
+  return recs;
+}
+
+// ── CLI ───────────────────────────────────────────────────────────────
+
+export function parseArgs(argv) {
+  const args = { accountId: null };
+
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg.startsWith('--account-id=')) {
+      args.accountId = arg.slice('--account-id='.length);
+    } else if (arg === '--account-id' && argv[i + 1]) {
+      args.accountId = argv[++i];
+    }
+  }
+
+  return args;
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+
+  console.log('Hero Mode pA4 — Operator Health Lookup');
+  console.log('─'.repeat(40));
+
+  if (!args.accountId) {
+    console.error('Error: --account-id is required.');
+    console.error('Usage: node scripts/hero-pA4-operator-lookup.mjs --account-id=abc123');
+    process.exitCode = 1;
+    return;
+  }
+
+  // In CLI mode we have no live DB — demonstrate with empty state
+  const report = buildOperatorLookup({
+    accountId: args.accountId,
+    env: {},
+    heroState: null,
+    eventLog: [],
+  });
+
+  console.log(JSON.stringify(report, null, 2));
+}
+
+const _scriptUrl = fileURLToPath(import.meta.url);
+const _invokedAs = process.argv[1] ? resolve(process.argv[1]) : '';
+if (_scriptUrl === _invokedAs) {
+  main();
+}

--- a/shared/hero/account-override.js
+++ b/shared/hero/account-override.js
@@ -1,8 +1,11 @@
-// Resolve Hero flag overrides for internal team accounts.
+// Resolve Hero flag overrides for internal and external cohort accounts.
 // Pure function — no side effects, no DB access.
 //
-// When HERO_INTERNAL_ACCOUNTS (JSON secret) lists an accountId, all 6 Hero
-// flags are force-enabled. Additive-only: non-listed accounts are unchanged.
+// Precedence: internal > external > global > none.
+// When HERO_INTERNAL_ACCOUNTS or HERO_EXTERNAL_ACCOUNTS (JSON secrets) list
+// an accountId, all 6 Hero flags are force-enabled. Internal takes precedence
+// if an account appears in both lists. Additive-only: non-listed accounts are
+// unchanged.
 
 const HERO_FLAG_KEYS = Object.freeze([
   'HERO_MODE_SHADOW_ENABLED',
@@ -14,7 +17,60 @@ const HERO_FLAG_KEYS = Object.freeze([
 ]);
 
 /**
- * Resolve Hero flag overrides for internal team accounts.
+ * Safely parse a JSON account list from env. Returns null on failure (fail closed).
+ * @param {string|null|undefined} raw
+ * @returns {string[]|null}
+ */
+function parseAccountList(raw) {
+  if (raw == null || raw === '') return null;
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(parsed)) return null;
+  return parsed;
+}
+
+/**
+ * Primary resolver — returns resolved env AND classified override status.
+ *
+ * @param {Object} params
+ * @param {Object} params.env — Worker environment bindings
+ * @param {string} params.accountId — caller account ID
+ * @returns {{ resolvedEnv: Object, overrideStatus: 'internal'|'external'|'global'|'none' }}
+ */
+export function resolveHeroFlagsForAccount({ env, accountId }) {
+  const safeEnv = env || {};
+
+  // Early exit — no accountId means we cannot match any list
+  if (!accountId) {
+    return { resolvedEnv: safeEnv, overrideStatus: _detectGlobalStatus(safeEnv) };
+  }
+
+  // Parse internal list
+  const internalList = parseAccountList(safeEnv.HERO_INTERNAL_ACCOUNTS);
+
+  // Check internal membership (highest precedence)
+  if (internalList && internalList.includes(accountId)) {
+    return { resolvedEnv: _applyAllFlags(safeEnv), overrideStatus: 'internal' };
+  }
+
+  // Parse external list
+  const externalList = parseAccountList(safeEnv.HERO_EXTERNAL_ACCOUNTS);
+
+  // Check external membership
+  if (externalList && externalList.includes(accountId)) {
+    return { resolvedEnv: _applyAllFlags(safeEnv), overrideStatus: 'external' };
+  }
+
+  // Not in any list — classify as global or none
+  return { resolvedEnv: safeEnv, overrideStatus: _detectGlobalStatus(safeEnv) };
+}
+
+/**
+ * Backward-compatible wrapper — returns only the resolved env object.
  *
  * @param {Object} params
  * @param {Object} params.env — Worker environment bindings
@@ -22,31 +78,32 @@ const HERO_FLAG_KEYS = Object.freeze([
  * @returns {Object} env-like object with Hero flags force-enabled for listed accounts
  */
 export function resolveHeroFlagsWithOverride({ env, accountId }) {
-  const safeEnv = env || {};
+  return resolveHeroFlagsForAccount({ env, accountId }).resolvedEnv;
+}
 
-  // Parse the secret — must be a valid JSON array of strings
-  const raw = safeEnv.HERO_INTERNAL_ACCOUNTS;
-  if (raw == null || raw === '') return safeEnv;
-
-  let parsed;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    return safeEnv;
-  }
-
-  if (!Array.isArray(parsed)) return safeEnv;
-
-  // Check membership — only override for listed accounts
-  if (!accountId || !parsed.includes(accountId)) return safeEnv;
-
-  // Force all 6 Hero flags on (additive — preserves all other bindings)
+/**
+ * Force all 6 Hero flags on (additive — preserves all other bindings).
+ * @param {Object} env
+ * @returns {Object}
+ */
+function _applyAllFlags(env) {
   const overrides = {};
   for (const key of HERO_FLAG_KEYS) {
     overrides[key] = 'true';
   }
+  return { ...env, ...overrides };
+}
 
-  return { ...safeEnv, ...overrides };
+/**
+ * Detect whether any global Hero flag is already enabled in env.
+ * @param {Object} env
+ * @returns {'global'|'none'}
+ */
+function _detectGlobalStatus(env) {
+  for (const key of HERO_FLAG_KEYS) {
+    if (env[key] === 'true') return 'global';
+  }
+  return 'none';
 }
 
 export { HERO_FLAG_KEYS };

--- a/shared/hero/stop-conditions.js
+++ b/shared/hero/stop-conditions.js
@@ -1,6 +1,331 @@
 // shared/hero/stop-conditions.js
-// Extracted from scripts/hero-pA2-cohort-smoke.mjs to break cross-phase coupling.
-// Both pA2 and pA3 cohort smoke scripts import from here.
+// ── pA4 §11 Stop Condition Guard Functions ────────────────────────────
+//
+// 13 pure detection functions — each takes relevant state/context and returns:
+//   { triggered: boolean, condition: string, detail: string }
+//
+// Zero side effects. No I/O. Handles null/undefined gracefully.
+//
+// Legacy probe-based detectStopConditions (pA2/pA3) is preserved at the bottom.
+
+import { validateMetricPrivacyRecursive } from './metrics-privacy.js';
+import { resolveHeroFlagsForAccount } from './account-override.js';
+import { HERO_FORBIDDEN_PRESSURE_VOCABULARY } from './hero-copy.js';
+
+// ── 1. Raw Child Content ─────────────────────────────────────────────
+
+/**
+ * Detect raw child content in telemetry/logs/exports.
+ * Uses the privacy validator from metrics-privacy.js.
+ *
+ * @param {unknown} payload — telemetry or log payload to scan
+ * @returns {{ triggered: boolean, condition: string, detail: string }}
+ */
+export function detectRawChildContent(payload) {
+  if (payload == null || typeof payload !== 'object') {
+    return { triggered: false, condition: 'raw-child-content', detail: '' };
+  }
+  const result = validateMetricPrivacyRecursive(payload);
+  if (!result.valid) {
+    return {
+      triggered: true,
+      condition: 'raw-child-content',
+      detail: `forbidden fields: ${result.violations.join(', ')}`,
+    };
+  }
+  return { triggered: false, condition: 'raw-child-content', detail: '' };
+}
+
+// ── 2. Non-Cohort Exposure ───────────────────────────────────────────
+
+/**
+ * Detect non-cohort accounts seeing Hero surfaces.
+ * A non-cohort account (overrideStatus === 'none') must never see Hero UI.
+ *
+ * @param {{ accountId: string, env: object }} params
+ * @returns {{ triggered: boolean, condition: string, detail: string }}
+ */
+export function detectNonCohortExposure({ accountId, env } = {}) {
+  if (!accountId || !env) {
+    return { triggered: false, condition: 'non-cohort-exposure', detail: '' };
+  }
+  const { overrideStatus } = resolveHeroFlagsForAccount({ env, accountId });
+  if (overrideStatus === 'none') {
+    return {
+      triggered: true,
+      condition: 'non-cohort-exposure',
+      detail: `account ${accountId} is not in any cohort list`,
+    };
+  }
+  return { triggered: false, condition: 'non-cohort-exposure', detail: '' };
+}
+
+// ── 3. Unauthorised Command ──────────────────────────────────────────
+
+/**
+ * Detect Hero command succeeding for a non-enabled account.
+ * An account with overrideStatus 'none' must never execute Hero commands.
+ *
+ * @param {{ accountId: string, env: object }} params
+ * @returns {{ triggered: boolean, condition: string, detail: string }}
+ */
+export function detectUnauthorisedCommand({ accountId, env } = {}) {
+  if (!accountId || !env) {
+    return { triggered: false, condition: 'unauthorised-command', detail: '' };
+  }
+  const { overrideStatus } = resolveHeroFlagsForAccount({ env, accountId });
+  if (overrideStatus === 'none') {
+    return {
+      triggered: true,
+      condition: 'unauthorised-command',
+      detail: `account ${accountId} has no Hero enablement`,
+    };
+  }
+  return { triggered: false, condition: 'unauthorised-command', detail: '' };
+}
+
+// ── 4. Duplicate Daily Award ─────────────────────────────────────────
+
+/**
+ * Detect duplicate daily coin award for the same dateKey.
+ *
+ * @param {{ ledgerEntries: Array, dateKey: string }} params
+ * @returns {{ triggered: boolean, condition: string, detail: string }}
+ */
+export function detectDuplicateDailyAward({ ledgerEntries, dateKey } = {}) {
+  if (!Array.isArray(ledgerEntries) || !dateKey) {
+    return { triggered: false, condition: 'duplicate-daily-award', detail: '' };
+  }
+  const dailyAwards = ledgerEntries.filter(
+    (e) => e && e.type === 'daily-award' && e.dateKey === dateKey
+  );
+  if (dailyAwards.length > 1) {
+    return {
+      triggered: true,
+      condition: 'duplicate-daily-award',
+      detail: `${dailyAwards.length} daily awards for dateKey=${dateKey}`,
+    };
+  }
+  return { triggered: false, condition: 'duplicate-daily-award', detail: '' };
+}
+
+// ── 5. Duplicate Camp Debit ──────────────────────────────────────────
+
+/**
+ * Detect duplicate Camp debit for the same actionId.
+ *
+ * @param {{ ledgerEntries: Array, actionId: string }} params
+ * @returns {{ triggered: boolean, condition: string, detail: string }}
+ */
+export function detectDuplicateCampDebit({ ledgerEntries, actionId } = {}) {
+  if (!Array.isArray(ledgerEntries) || !actionId) {
+    return { triggered: false, condition: 'duplicate-camp-debit', detail: '' };
+  }
+  const campDebits = ledgerEntries.filter(
+    (e) => e && e.type === 'camp-debit' && e.actionId === actionId
+  );
+  if (campDebits.length > 1) {
+    return {
+      triggered: true,
+      condition: 'duplicate-camp-debit',
+      detail: `${campDebits.length} camp debits for actionId=${actionId}`,
+    };
+  }
+  return { triggered: false, condition: 'duplicate-camp-debit', detail: '' };
+}
+
+// ── 6. Negative Balance ──────────────────────────────────────────────
+
+/**
+ * Detect negative balance.
+ *
+ * @param {{ balance: number }} params
+ * @returns {{ triggered: boolean, condition: string, detail: string }}
+ */
+export function detectNegativeBalance({ balance } = {}) {
+  if (typeof balance !== 'number') {
+    return { triggered: false, condition: 'negative-balance', detail: '' };
+  }
+  if (balance < 0) {
+    return {
+      triggered: true,
+      condition: 'negative-balance',
+      detail: `balance=${balance}`,
+    };
+  }
+  return { triggered: false, condition: 'negative-balance', detail: '' };
+}
+
+// ── 7. Claim Without Completion ──────────────────────────────────────
+
+/**
+ * Detect claim without Worker-verified completion evidence.
+ *
+ * @param {{ claimRecord: object, completionEvidence: object }} params
+ * @returns {{ triggered: boolean, condition: string, detail: string }}
+ */
+export function detectClaimWithoutCompletion({ claimRecord, completionEvidence } = {}) {
+  if (!claimRecord) {
+    return { triggered: false, condition: 'claim-without-completion', detail: '' };
+  }
+  if (!completionEvidence || !completionEvidence.verified) {
+    return {
+      triggered: true,
+      condition: 'claim-without-completion',
+      detail: `claimId=${claimRecord.id || 'unknown'} has no verified completion`,
+    };
+  }
+  return { triggered: false, condition: 'claim-without-completion', detail: '' };
+}
+
+// ── 8. Subject Mutation ──────────────────────────────────────────────
+
+/**
+ * Detect Hero commands that mutate subject Stars/mastery state.
+ * Hero commands must be read-only with respect to subject state.
+ *
+ * @param {{ heroCommands: Array, subjectState: object }} params
+ * @returns {{ triggered: boolean, condition: string, detail: string }}
+ */
+export function detectSubjectMutation({ heroCommands, subjectState } = {}) {
+  if (!Array.isArray(heroCommands) || !subjectState) {
+    return { triggered: false, condition: 'subject-mutation', detail: '' };
+  }
+  const mutators = heroCommands.filter((cmd) => cmd && cmd.mutatesSubject === true);
+  if (mutators.length > 0) {
+    return {
+      triggered: true,
+      condition: 'subject-mutation',
+      detail: `${mutators.length} command(s) flagged mutatesSubject: ${mutators.map(c => c.name || 'unnamed').join(', ')}`,
+    };
+  }
+  return { triggered: false, condition: 'subject-mutation', detail: '' };
+}
+
+// ── 9. Dead CTA ─────────────────────────────────────────────────────
+
+/**
+ * Detect child-visible primary CTA that is dead/unlaunchable.
+ *
+ * @param {{ readModel: object }} params
+ * @returns {{ triggered: boolean, condition: string, detail: string }}
+ */
+export function detectDeadCTA({ readModel } = {}) {
+  if (!readModel) {
+    return { triggered: false, condition: 'dead-cta', detail: '' };
+  }
+  const { ctaVisible, ctaLaunchable } = readModel;
+  if (ctaVisible && ctaLaunchable === false) {
+    return {
+      triggered: true,
+      condition: 'dead-cta',
+      detail: 'primary CTA is visible but not launchable',
+    };
+  }
+  return { triggered: false, condition: 'dead-cta', detail: '' };
+}
+
+// ── 10. Rollback Failure ─────────────────────────────────────────────
+
+/**
+ * Detect rollback failure — flags are off but Hero surfaces remain visible.
+ *
+ * @param {{ flagsOff: boolean, heroSurfacesVisible: boolean }} params
+ * @returns {{ triggered: boolean, condition: string, detail: string }}
+ */
+export function detectRollbackFailure({ flagsOff, heroSurfacesVisible } = {}) {
+  if (typeof flagsOff !== 'boolean' || typeof heroSurfacesVisible !== 'boolean') {
+    return { triggered: false, condition: 'rollback-failure', detail: '' };
+  }
+  if (flagsOff && heroSurfacesVisible) {
+    return {
+      triggered: true,
+      condition: 'rollback-failure',
+      detail: 'flags are off but Hero surfaces remain visible',
+    };
+  }
+  return { triggered: false, condition: 'rollback-failure', detail: '' };
+}
+
+// ── 11. Repeated Errors ──────────────────────────────────────────────
+
+/**
+ * Detect repeated unexplained 500 errors (threshold = 3 in 5min window).
+ *
+ * @param {{ errorLog: Array, threshold?: number }} params
+ * @returns {{ triggered: boolean, condition: string, detail: string }}
+ */
+export function detectRepeatedErrors({ errorLog, threshold = 3 } = {}) {
+  if (!Array.isArray(errorLog)) {
+    return { triggered: false, condition: 'repeated-errors', detail: '' };
+  }
+  const WINDOW_MS = 5 * 60 * 1000; // 5 minutes
+  const now = Date.now();
+  const recentErrors = errorLog.filter((e) => {
+    if (!e || typeof e.timestamp !== 'number') return false;
+    return (now - e.timestamp) <= WINDOW_MS && e.status === 500;
+  });
+  if (recentErrors.length >= threshold) {
+    return {
+      triggered: true,
+      condition: 'repeated-errors',
+      detail: `${recentErrors.length} 500 errors in 5min window (threshold=${threshold})`,
+    };
+  }
+  return { triggered: false, condition: 'repeated-errors', detail: '' };
+}
+
+// ── 12. Untriageable Issue ───────────────────────────────────────────
+
+/**
+ * Detect issues that support cannot triage (missing required output fields).
+ *
+ * @param {{ errorOutput: object, requiredFields: string[] }} params
+ * @returns {{ triggered: boolean, condition: string, detail: string }}
+ */
+export function detectUntriageableIssue({ errorOutput, requiredFields } = {}) {
+  if (!errorOutput || !Array.isArray(requiredFields)) {
+    return { triggered: false, condition: 'untriageable-issue', detail: '' };
+  }
+  const missing = requiredFields.filter((field) => !(field in errorOutput));
+  if (missing.length > 0) {
+    return {
+      triggered: true,
+      condition: 'untriageable-issue',
+      detail: `missing fields: ${missing.join(', ')}`,
+    };
+  }
+  return { triggered: false, condition: 'untriageable-issue', detail: '' };
+}
+
+// ── 13. Pressure Copy ────────────────────────────────────────────────
+
+/**
+ * Detect pressure/misleading copy in parent-facing or child-facing text.
+ * Uses HERO_FORBIDDEN_PRESSURE_VOCABULARY from hero-copy.js.
+ *
+ * @param {{ copyText: string }} params
+ * @returns {{ triggered: boolean, condition: string, detail: string }}
+ */
+export function detectPressureCopy({ copyText } = {}) {
+  if (!copyText || typeof copyText !== 'string') {
+    return { triggered: false, condition: 'pressure-copy', detail: '' };
+  }
+  const lower = copyText.toLowerCase();
+  const matches = HERO_FORBIDDEN_PRESSURE_VOCABULARY.filter(
+    (term) => lower.includes(term.toLowerCase())
+  );
+  if (matches.length > 0) {
+    return {
+      triggered: true,
+      condition: 'pressure-copy',
+      detail: `pressure terms found: ${matches.join(', ')}`,
+    };
+  }
+  return { triggered: false, condition: 'pressure-copy', detail: '' };
+}
+
+// ── Legacy probe-based detector (pA2/pA3 compat) ────────────────────
 
 // NOT DETECTABLE FROM PROBE (manual verification required per S8):
 // S8 #2: duplicate Camp debit (no per-debit field in probe; reconciliation gap is a proxy)

--- a/tests/hero-pA4-browser-smoke.test.js
+++ b/tests/hero-pA4-browser-smoke.test.js
@@ -1,0 +1,544 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  STEPS,
+  validateStep,
+  parseArgs,
+} from '../scripts/hero-pA4-external-cohort-smoke.mjs';
+
+// ── Mock data factories ───────────────────────────────────────────────
+
+function makeReadModelVisible() {
+  return {
+    version: 6,
+    mode: 'progress',
+    ui: { enabled: true, surface: 'dashboard-card', reason: 'enabled', copyVersion: 'v2' },
+    dailyQuest: {
+      questId: 'quest-abc',
+      status: 'active',
+      effortTarget: 3,
+      effortPlanned: 3,
+      tasks: [
+        {
+          taskId: 'task-001',
+          subjectId: 'grammar',
+          intent: 'practice',
+          launcher: 'session-launcher',
+          effortTarget: 1,
+          completionStatus: 'not-started',
+          launchStatus: 'launchable',
+          heroContext: { source: 'hero-mode', questId: 'quest-abc', taskId: 'task-001' },
+        },
+      ],
+    },
+    questFingerprint: 'fp-12345',
+    dateKey: '2026-04-30',
+    pendingCompletedHeroSession: null,
+    economy: { enabled: true, version: 1, balance: 200, lifetimeEarned: 200, lifetimeSpent: 0 },
+    camp: {
+      enabled: true,
+      version: 1,
+      monsters: [
+        { monsterId: 'spark', displayName: 'Spark', owned: true, stage: 1 },
+        { monsterId: 'blaze', displayName: 'Blaze', owned: false, stage: 0 },
+      ],
+      selectedMonsterId: 'spark',
+    },
+    progress: { enabled: true, canClaim: false, pendingClaimTaskId: null },
+  };
+}
+
+function makeStartTaskResponse() {
+  return {
+    heroLaunch: {
+      version: 2,
+      status: 'started',
+      questId: 'quest-abc',
+      taskId: 'task-001',
+      dateKey: '2026-04-30',
+      subjectId: 'grammar',
+      intent: 'practice',
+      launcher: 'session-launcher',
+      effortTarget: 1,
+      subjectCommand: 'start-session',
+      coinsEnabled: true,
+      claimEnabled: true,
+      childVisible: true,
+    },
+  };
+}
+
+function makeReturnReadModel() {
+  const model = makeReadModelVisible();
+  model.pendingCompletedHeroSession = {
+    taskId: 'task-001',
+    questId: 'quest-abc',
+    questFingerprint: 'fp-12345',
+    subjectId: 'grammar',
+    practiceSessionId: 'ps-999',
+  };
+  model.progress.canClaim = true;
+  model.progress.pendingClaimTaskId = 'task-001';
+  return model;
+}
+
+function makeClaimResponse() {
+  return {
+    award: {
+      status: 'granted',
+      taskId: 'task-001',
+      questId: 'quest-abc',
+      coins: 100,
+      ledgerEntryId: 'le-001',
+    },
+  };
+}
+
+function makePostClaimReadModel() {
+  const model = makeReadModelVisible();
+  model.economy.balance = 300; // increased from 200 by 100
+  model.pendingCompletedHeroSession = null;
+  return model;
+}
+
+function makeRollbackResponse() {
+  return {
+    error: 'Hero shadow read model is not available.',
+    code: 'hero_shadow_disabled',
+  };
+}
+
+// ── Step list ─────────────────────────────────────────────────────────
+
+describe('pA4 browser smoke: STEPS constant', () => {
+  it('exports all 8 critical flow steps', () => {
+    assert.equal(STEPS.length, 8);
+    assert.deepEqual(STEPS, [
+      'hero-visible',
+      'start-task',
+      'subject-session',
+      'return-from-session',
+      'claim',
+      'coins',
+      'camp',
+      'rollback-hidden',
+    ]);
+  });
+});
+
+// ── Individual step validators ────────────────────────────────────────
+
+describe('pA4 browser smoke: hero-visible step', () => {
+  it('passes when ui.enabled is true', () => {
+    const result = validateStep('hero-visible', makeReadModelVisible());
+    assert.equal(result.pass, true);
+    assert.ok(result.detail.includes('ui.enabled=true'));
+  });
+
+  it('fails when ui.enabled is false', () => {
+    const model = makeReadModelVisible();
+    model.ui.enabled = false;
+    model.ui.reason = 'shadow-disabled';
+    const result = validateStep('hero-visible', model);
+    assert.equal(result.pass, false);
+    assert.ok(result.detail.includes('shadow-disabled'));
+  });
+
+  it('fails on null response', () => {
+    const result = validateStep('hero-visible', null);
+    assert.equal(result.pass, false);
+  });
+
+  it('fails on API error response', () => {
+    const result = validateStep('hero-visible', { error: 'HTTP 500' });
+    assert.equal(result.pass, false);
+    assert.ok(result.detail.includes('API error'));
+  });
+
+  it('non-cohort account: correctly reports hero not visible', () => {
+    const model = makeReadModelVisible();
+    model.ui.enabled = false;
+    model.ui.reason = 'no-eligible-subjects';
+    const result = validateStep('hero-visible', model, { expectHidden: true });
+    assert.equal(result.pass, true);
+    assert.ok(result.detail.includes('not visible'));
+  });
+
+  it('non-cohort account: fails if hero IS visible', () => {
+    const model = makeReadModelVisible();
+    const result = validateStep('hero-visible', model, { expectHidden: true });
+    assert.equal(result.pass, false);
+  });
+});
+
+describe('pA4 browser smoke: start-task step', () => {
+  it('passes with valid heroLaunch response', () => {
+    const result = validateStep('start-task', makeStartTaskResponse());
+    assert.equal(result.pass, true);
+    assert.ok(result.detail.includes('task-001'));
+  });
+
+  it('fails when heroLaunch is missing', () => {
+    const result = validateStep('start-task', { ok: true });
+    assert.equal(result.pass, false);
+    assert.ok(result.detail.includes('Missing heroLaunch'));
+  });
+
+  it('fails when heroLaunch lacks questId', () => {
+    const resp = makeStartTaskResponse();
+    resp.heroLaunch.questId = '';
+    const result = validateStep('start-task', resp);
+    assert.equal(result.pass, false);
+  });
+
+  it('fails on API error', () => {
+    const result = validateStep('start-task', { error: 'HTTP 409' });
+    assert.equal(result.pass, false);
+  });
+});
+
+describe('pA4 browser smoke: subject-session step', () => {
+  it('passes when subjectId and subjectCommand present', () => {
+    const result = validateStep('subject-session', makeStartTaskResponse());
+    assert.equal(result.pass, true);
+    assert.ok(result.detail.includes('grammar'));
+    assert.ok(result.detail.includes('start-session'));
+  });
+
+  it('fails when subjectId missing', () => {
+    const resp = makeStartTaskResponse();
+    resp.heroLaunch.subjectId = '';
+    const result = validateStep('subject-session', resp);
+    assert.equal(result.pass, false);
+  });
+
+  it('fails when subjectCommand missing', () => {
+    const resp = makeStartTaskResponse();
+    resp.heroLaunch.subjectCommand = '';
+    const result = validateStep('subject-session', resp);
+    assert.equal(result.pass, false);
+  });
+
+  it('dead CTA: fails when heroLaunch absent', () => {
+    const result = validateStep('subject-session', {});
+    assert.equal(result.pass, false);
+    assert.ok(result.detail.includes('Missing heroLaunch'));
+  });
+});
+
+describe('pA4 browser smoke: return-from-session step', () => {
+  it('passes when pendingCompletedHeroSession present', () => {
+    const result = validateStep('return-from-session', makeReturnReadModel());
+    assert.equal(result.pass, true);
+    assert.ok(result.detail.includes('task-001'));
+  });
+
+  it('fails when pendingCompletedHeroSession is null', () => {
+    const model = makeReadModelVisible();
+    model.pendingCompletedHeroSession = null;
+    const result = validateStep('return-from-session', model);
+    assert.equal(result.pass, false);
+  });
+
+  it('fails on API error', () => {
+    const result = validateStep('return-from-session', { error: 'Timeout after 15s' });
+    assert.equal(result.pass, false);
+  });
+});
+
+describe('pA4 browser smoke: claim step', () => {
+  it('passes when award is granted', () => {
+    const result = validateStep('claim', makeClaimResponse());
+    assert.equal(result.pass, true);
+    assert.ok(result.detail.includes('granted'));
+  });
+
+  it('fails when claim is rejected', () => {
+    const result = validateStep('claim', {
+      award: { status: 'rejected', reason: 'duplicate-claim' },
+    });
+    assert.equal(result.pass, false);
+    assert.ok(result.detail.includes('rejected'));
+  });
+
+  it('fails when no award in response', () => {
+    const result = validateStep('claim', { ok: true });
+    assert.equal(result.pass, false);
+  });
+
+  it('accepts claimResult as alternative to award', () => {
+    const result = validateStep('claim', {
+      claimResult: { status: 'ok', coins: 100 },
+    });
+    assert.equal(result.pass, true);
+  });
+});
+
+describe('pA4 browser smoke: coins step', () => {
+  it('passes when balance increased by 100', () => {
+    const result = validateStep('coins', makePostClaimReadModel(), { previousBalance: 200 });
+    assert.equal(result.pass, true);
+    assert.ok(result.detail.includes('300'));
+  });
+
+  it('fails when balance did not increase', () => {
+    const model = makePostClaimReadModel();
+    model.economy.balance = 200; // no increase
+    const result = validateStep('coins', model, { previousBalance: 200 });
+    assert.equal(result.pass, false);
+    assert.ok(result.detail.includes('did not increase'));
+  });
+
+  it('fails when economy block missing', () => {
+    const model = makeReadModelVisible();
+    delete model.economy;
+    const result = validateStep('coins', model, { previousBalance: 0 });
+    assert.equal(result.pass, false);
+  });
+
+  it('uses 0 as default previousBalance', () => {
+    const model = makePostClaimReadModel();
+    model.economy.balance = 100;
+    const result = validateStep('coins', model, {});
+    assert.equal(result.pass, true);
+  });
+});
+
+describe('pA4 browser smoke: camp step', () => {
+  it('passes when camp.monsters is present and non-empty', () => {
+    const result = validateStep('camp', makePostClaimReadModel(), { campEnabled: true });
+    assert.equal(result.pass, true);
+    assert.ok(result.detail.includes('2 monster'));
+  });
+
+  it('fails when camp block is missing', () => {
+    const model = makePostClaimReadModel();
+    delete model.camp;
+    const result = validateStep('camp', model, { campEnabled: true });
+    assert.equal(result.pass, false);
+  });
+
+  it('fails when camp.monsters is empty', () => {
+    const model = makePostClaimReadModel();
+    model.camp.monsters = [];
+    const result = validateStep('camp', model, { campEnabled: true });
+    assert.equal(result.pass, false);
+  });
+
+  it('passes when camp disabled and camp block absent (flag off)', () => {
+    const model = makePostClaimReadModel();
+    delete model.camp;
+    const result = validateStep('camp', model, { campEnabled: false });
+    assert.equal(result.pass, true);
+    assert.ok(result.detail.includes('skipped'));
+  });
+
+  it('passes when camp disabled and camp.enabled=false', () => {
+    const model = makePostClaimReadModel();
+    model.camp = { enabled: false };
+    const result = validateStep('camp', model, { campEnabled: false });
+    assert.equal(result.pass, true);
+  });
+});
+
+describe('pA4 browser smoke: rollback-hidden step', () => {
+  it('passes with hero_shadow_disabled error code (flags off)', () => {
+    const result = validateStep('rollback-hidden', makeRollbackResponse());
+    assert.equal(result.pass, true);
+    assert.ok(result.detail.includes('hero_shadow_disabled'));
+  });
+
+  it('passes when ui.enabled=false (flags off)', () => {
+    const model = makeReadModelVisible();
+    model.ui.enabled = false;
+    const result = validateStep('rollback-hidden', model);
+    assert.equal(result.pass, true);
+    assert.ok(result.detail.includes('hidden'));
+  });
+
+  it('fails when hero is still visible (flags off regression)', () => {
+    const result = validateStep('rollback-hidden', makeReadModelVisible());
+    assert.equal(result.pass, false);
+    assert.ok(result.detail.includes('still visible'));
+  });
+
+  it('passes on generic API error (e.g. 404)', () => {
+    const result = validateStep('rollback-hidden', { error: 'HTTP 404', code: 'not_found' });
+    assert.equal(result.pass, true);
+  });
+});
+
+// ── Full flow simulation ──────────────────────────────────────────────
+
+describe('pA4 browser smoke: full flow all-pass', () => {
+  it('all 8 steps pass with correctly mocked data', () => {
+    const results = [];
+
+    // Step 1: hero-visible
+    results.push({ step: 'hero-visible', ...validateStep('hero-visible', makeReadModelVisible()) });
+
+    // Step 2: start-task
+    results.push({ step: 'start-task', ...validateStep('start-task', makeStartTaskResponse()) });
+
+    // Step 3: subject-session
+    results.push({ step: 'subject-session', ...validateStep('subject-session', makeStartTaskResponse()) });
+
+    // Step 4: return-from-session
+    results.push({ step: 'return-from-session', ...validateStep('return-from-session', makeReturnReadModel()) });
+
+    // Step 5: claim
+    results.push({ step: 'claim', ...validateStep('claim', makeClaimResponse()) });
+
+    // Step 6: coins
+    results.push({ step: 'coins', ...validateStep('coins', makePostClaimReadModel(), { previousBalance: 200 }) });
+
+    // Step 7: camp
+    results.push({ step: 'camp', ...validateStep('camp', makePostClaimReadModel(), { campEnabled: true }) });
+
+    // Step 8: rollback-hidden
+    results.push({ step: 'rollback-hidden', ...validateStep('rollback-hidden', makeRollbackResponse()) });
+
+    assert.equal(results.length, 8);
+    assert.ok(results.every(r => r.pass), `Some steps failed: ${results.filter(r => !r.pass).map(r => r.step).join(', ')}`);
+
+    // Simulated exit code
+    const exitCode = results.every(r => r.pass) ? 0 : 1;
+    assert.equal(exitCode, 0);
+  });
+});
+
+describe('pA4 browser smoke: partial failure (dead CTA)', () => {
+  it('subject-session failure produces exit code 1', () => {
+    const results = [];
+
+    // Steps 1-2 pass
+    results.push({ step: 'hero-visible', ...validateStep('hero-visible', makeReadModelVisible()) });
+    results.push({ step: 'start-task', ...validateStep('start-task', makeStartTaskResponse()) });
+
+    // Step 3: dead CTA — heroLaunch has no subjectCommand
+    const deadCta = makeStartTaskResponse();
+    deadCta.heroLaunch.subjectCommand = '';
+    results.push({ step: 'subject-session', ...validateStep('subject-session', deadCta) });
+
+    const exitCode = results.every(r => r.pass) ? 0 : 1;
+    assert.equal(exitCode, 1);
+    assert.equal(results[2].pass, false);
+    assert.ok(results[2].detail.includes('launcher info missing'));
+  });
+});
+
+describe('pA4 browser smoke: external cohort account (overrideStatus=external)', () => {
+  it('flow works for external cohort account when hero is visible', () => {
+    // External cohort accounts still get ui.enabled=true via per-account override
+    const model = makeReadModelVisible();
+    const result = validateStep('hero-visible', model);
+    assert.equal(result.pass, true);
+  });
+
+  it('start-task works for external cohort account', () => {
+    const result = validateStep('start-task', makeStartTaskResponse());
+    assert.equal(result.pass, true);
+  });
+
+  it('full flow passes for external cohort', () => {
+    const steps = [
+      validateStep('hero-visible', makeReadModelVisible()),
+      validateStep('start-task', makeStartTaskResponse()),
+      validateStep('subject-session', makeStartTaskResponse()),
+      validateStep('return-from-session', makeReturnReadModel()),
+      validateStep('claim', makeClaimResponse()),
+      validateStep('coins', makePostClaimReadModel(), { previousBalance: 200 }),
+      validateStep('camp', makePostClaimReadModel(), { campEnabled: true }),
+      validateStep('rollback-hidden', makeRollbackResponse()),
+    ];
+    assert.ok(steps.every(r => r.pass));
+  });
+});
+
+describe('pA4 browser smoke: non-cohort account', () => {
+  it('step 1 correctly reports hero not visible', () => {
+    const model = makeReadModelVisible();
+    model.ui.enabled = false;
+    model.ui.reason = 'no-eligible-subjects';
+    const result = validateStep('hero-visible', model, { expectHidden: true });
+    assert.equal(result.pass, true);
+    assert.ok(result.detail.includes('not visible'));
+  });
+
+  it('non-cohort without expectHidden context fails step 1', () => {
+    const model = makeReadModelVisible();
+    model.ui.enabled = false;
+    model.ui.reason = 'shadow-disabled';
+    const result = validateStep('hero-visible', model);
+    assert.equal(result.pass, false);
+  });
+});
+
+describe('pA4 browser smoke: rollback (all flags off)', () => {
+  it('step 8 correctly reports hidden when hero_shadow_disabled returned', () => {
+    const result = validateStep('rollback-hidden', {
+      error: 'Hero shadow read model is not available.',
+      code: 'hero_shadow_disabled',
+    });
+    assert.equal(result.pass, true);
+    assert.ok(result.detail.includes('hero_shadow_disabled'));
+  });
+
+  it('step 8 correctly reports hidden when ui.enabled=false', () => {
+    const result = validateStep('rollback-hidden', {
+      ui: { enabled: false, reason: 'shadow-disabled' },
+    });
+    assert.equal(result.pass, true);
+  });
+
+  it('step 8 fails if hero still visible after rollback', () => {
+    const result = validateStep('rollback-hidden', makeReadModelVisible());
+    assert.equal(result.pass, false);
+  });
+});
+
+// ── Unknown step ──────────────────────────────────────────────────────
+
+describe('pA4 browser smoke: unknown step', () => {
+  it('returns fail for unknown step name', () => {
+    const result = validateStep('nonexistent-step', {});
+    assert.equal(result.pass, false);
+    assert.ok(result.detail.includes('Unknown step'));
+  });
+});
+
+// ── parseArgs ─────────────────────────────────────────────────────────
+
+describe('pA4 browser smoke: parseArgs', () => {
+  it('defaults base-url to http://localhost:8787', () => {
+    const args = parseArgs(['node', 'script.mjs']);
+    assert.equal(args.baseUrl, 'http://localhost:8787');
+    assert.equal(args.accountId, '');
+  });
+
+  it('--account-id sets accountId', () => {
+    const args = parseArgs(['node', 'script.mjs', '--account-id', 'acc-ext-123']);
+    assert.equal(args.accountId, 'acc-ext-123');
+  });
+
+  it('--account-id= form works', () => {
+    const args = parseArgs(['node', 'script.mjs', '--account-id=acc-xyz']);
+    assert.equal(args.accountId, 'acc-xyz');
+  });
+
+  it('--base-url sets baseUrl', () => {
+    const args = parseArgs(['node', 'script.mjs', '--base-url', 'https://staging.example.com']);
+    assert.equal(args.baseUrl, 'https://staging.example.com');
+  });
+
+  it('--base-url strips trailing slash', () => {
+    const args = parseArgs(['node', 'script.mjs', '--base-url', 'http://localhost:8787/']);
+    assert.equal(args.baseUrl, 'http://localhost:8787');
+  });
+
+  it('--base-url= form works', () => {
+    const args = parseArgs(['node', 'script.mjs', '--base-url=http://custom:9000']);
+    assert.equal(args.baseUrl, 'http://custom:9000');
+  });
+});

--- a/tests/hero-pA4-external-cohort-resolver.test.js
+++ b/tests/hero-pA4-external-cohort-resolver.test.js
@@ -1,0 +1,239 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  resolveHeroFlagsForAccount,
+  resolveHeroFlagsWithOverride,
+  HERO_FLAG_KEYS,
+} from '../shared/hero/account-override.js';
+
+// ── Helper ────────────────────────────────────────────────────────────
+
+function allFlagsEnabled(env) {
+  return HERO_FLAG_KEYS.every(k => env[k] === 'true');
+}
+
+function noFlagsEnabled(env) {
+  return HERO_FLAG_KEYS.every(k => env[k] !== 'true');
+}
+
+// ── External cohort: account in HERO_EXTERNAL_ACCOUNTS ────────────────
+
+describe('resolveHeroFlagsForAccount: external cohort', () => {
+  it('account in HERO_EXTERNAL_ACCOUNTS enables all 6 flags with status external', () => {
+    const env = { HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['acc-ext-1', 'acc-ext-2']) };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'acc-ext-1' });
+
+    assert.equal(overrideStatus, 'external');
+    assert.ok(allFlagsEnabled(resolvedEnv));
+  });
+
+  it('preserves existing env bindings alongside forced flags', () => {
+    const env = {
+      HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['ext-1']),
+      OTHER_BINDING: 'keep-me',
+    };
+    const { resolvedEnv } = resolveHeroFlagsForAccount({ env, accountId: 'ext-1' });
+
+    assert.equal(resolvedEnv.OTHER_BINDING, 'keep-me');
+    assert.ok(allFlagsEnabled(resolvedEnv));
+  });
+});
+
+// ── Internal cohort: account in HERO_INTERNAL_ACCOUNTS ────────────────
+
+describe('resolveHeroFlagsForAccount: internal cohort', () => {
+  it('account in HERO_INTERNAL_ACCOUNTS enables all 6 flags with status internal', () => {
+    const env = { HERO_INTERNAL_ACCOUNTS: JSON.stringify(['acc-int-1']) };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'acc-int-1' });
+
+    assert.equal(overrideStatus, 'internal');
+    assert.ok(allFlagsEnabled(resolvedEnv));
+  });
+});
+
+// ── Neither list: global or none ──────────────────────────────────────
+
+describe('resolveHeroFlagsForAccount: neither list', () => {
+  it('account in neither list with no global flags returns status none', () => {
+    const env = {
+      HERO_INTERNAL_ACCOUNTS: JSON.stringify(['int-1']),
+      HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['ext-1']),
+    };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'unknown-acc' });
+
+    assert.equal(overrideStatus, 'none');
+    assert.ok(noFlagsEnabled(resolvedEnv));
+  });
+
+  it('account in neither list with a global flag enabled returns status global', () => {
+    const env = {
+      HERO_INTERNAL_ACCOUNTS: JSON.stringify(['int-1']),
+      HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['ext-1']),
+      HERO_MODE_SHADOW_ENABLED: 'true',
+    };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'unknown-acc' });
+
+    assert.equal(overrideStatus, 'global');
+    // Global flags unchanged — no additional flags forced
+    assert.equal(resolvedEnv.HERO_MODE_SHADOW_ENABLED, 'true');
+    assert.notEqual(resolvedEnv.HERO_MODE_CAMP_ENABLED, 'true');
+  });
+});
+
+// ── Precedence: both lists ────────────────────────────────────────────
+
+describe('resolveHeroFlagsForAccount: precedence', () => {
+  it('account in BOTH lists resolves as internal (internal takes precedence)', () => {
+    const env = {
+      HERO_INTERNAL_ACCOUNTS: JSON.stringify(['dual-acc']),
+      HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['dual-acc']),
+    };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'dual-acc' });
+
+    assert.equal(overrideStatus, 'internal');
+    assert.ok(allFlagsEnabled(resolvedEnv));
+  });
+});
+
+// ── HERO_EXTERNAL_ACCOUNTS edge cases ─────────────────────────────────
+
+describe('resolveHeroFlagsForAccount: HERO_EXTERNAL_ACCOUNTS edge cases', () => {
+  it('HERO_EXTERNAL_ACCOUNTS is null → skip gracefully', () => {
+    const env = { HERO_EXTERNAL_ACCOUNTS: null };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'acc-1' });
+
+    assert.equal(overrideStatus, 'none');
+    assert.ok(noFlagsEnabled(resolvedEnv));
+  });
+
+  it('HERO_EXTERNAL_ACCOUNTS is undefined → skip gracefully', () => {
+    const env = {};
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'acc-1' });
+
+    assert.equal(overrideStatus, 'none');
+    assert.ok(noFlagsEnabled(resolvedEnv));
+  });
+
+  it('HERO_EXTERNAL_ACCOUNTS is empty string → skip gracefully', () => {
+    const env = { HERO_EXTERNAL_ACCOUNTS: '' };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'acc-1' });
+
+    assert.equal(overrideStatus, 'none');
+    assert.ok(noFlagsEnabled(resolvedEnv));
+  });
+
+  it('HERO_EXTERNAL_ACCOUNTS is malformed JSON → fail closed (no override)', () => {
+    const env = { HERO_EXTERNAL_ACCOUNTS: '{not-valid-json' };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'acc-1' });
+
+    assert.equal(overrideStatus, 'none');
+    assert.ok(noFlagsEnabled(resolvedEnv));
+  });
+
+  it('HERO_EXTERNAL_ACCOUNTS is valid JSON but not array → fail closed', () => {
+    const env = { HERO_EXTERNAL_ACCOUNTS: JSON.stringify({ accounts: ['acc-1'] }) };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'acc-1' });
+
+    assert.equal(overrideStatus, 'none');
+    assert.ok(noFlagsEnabled(resolvedEnv));
+  });
+
+  it('HERO_EXTERNAL_ACCOUNTS is empty array → no override', () => {
+    const env = { HERO_EXTERNAL_ACCOUNTS: JSON.stringify([]) };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'acc-1' });
+
+    assert.equal(overrideStatus, 'none');
+    assert.ok(noFlagsEnabled(resolvedEnv));
+  });
+});
+
+// ── accountId edge cases ──────────────────────────────────────────────
+
+describe('resolveHeroFlagsForAccount: accountId edge cases', () => {
+  it('accountId is null → no override, status based on global flags', () => {
+    const env = {
+      HERO_INTERNAL_ACCOUNTS: JSON.stringify(['int-1']),
+      HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['ext-1']),
+    };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: null });
+
+    assert.equal(overrideStatus, 'none');
+    assert.ok(noFlagsEnabled(resolvedEnv));
+  });
+
+  it('accountId is undefined → no override', () => {
+    const env = {
+      HERO_INTERNAL_ACCOUNTS: JSON.stringify(['int-1']),
+      HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['ext-1']),
+    };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: undefined });
+
+    assert.equal(overrideStatus, 'none');
+    assert.ok(noFlagsEnabled(resolvedEnv));
+  });
+
+  it('accountId is empty string → no override', () => {
+    const env = {
+      HERO_INTERNAL_ACCOUNTS: JSON.stringify(['']),
+      HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['ext-1']),
+    };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: '' });
+
+    assert.equal(overrideStatus, 'none');
+    assert.ok(noFlagsEnabled(resolvedEnv));
+  });
+});
+
+// ── Backward compatibility: resolveHeroFlagsWithOverride ──────────────
+
+describe('resolveHeroFlagsWithOverride: backward compatibility', () => {
+  it('returns env-like object (not { resolvedEnv, overrideStatus })', () => {
+    const env = { HERO_INTERNAL_ACCOUNTS: JSON.stringify(['acc-1']) };
+    const result = resolveHeroFlagsWithOverride({ env, accountId: 'acc-1' });
+
+    // Must be a flat object, not wrapped
+    assert.equal(typeof result, 'object');
+    assert.equal(result.resolvedEnv, undefined);
+    assert.equal(result.overrideStatus, undefined);
+    assert.ok(allFlagsEnabled(result));
+  });
+
+  it('returns unchanged env when account not in internal list', () => {
+    const env = {
+      HERO_INTERNAL_ACCOUNTS: JSON.stringify(['acc-1']),
+      OTHER: 'val',
+    };
+    const result = resolveHeroFlagsWithOverride({ env, accountId: 'unknown' });
+
+    assert.equal(result.OTHER, 'val');
+    assert.ok(noFlagsEnabled(result));
+  });
+
+  it('returns unchanged env when HERO_INTERNAL_ACCOUNTS is malformed', () => {
+    const env = { HERO_INTERNAL_ACCOUNTS: 'not-json' };
+    const result = resolveHeroFlagsWithOverride({ env, accountId: 'acc-1' });
+
+    assert.ok(noFlagsEnabled(result));
+  });
+
+  it('returns unchanged env when HERO_INTERNAL_ACCOUNTS is null', () => {
+    const env = { HERO_INTERNAL_ACCOUNTS: null };
+    const result = resolveHeroFlagsWithOverride({ env, accountId: 'acc-1' });
+
+    assert.ok(noFlagsEnabled(result));
+  });
+
+  it('handles env being null/undefined gracefully', () => {
+    const result = resolveHeroFlagsWithOverride({ env: null, accountId: 'acc-1' });
+    assert.equal(typeof result, 'object');
+    assert.ok(noFlagsEnabled(result));
+  });
+
+  it('external account override also works via wrapper', () => {
+    const env = { HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['ext-1']) };
+    const result = resolveHeroFlagsWithOverride({ env, accountId: 'ext-1' });
+
+    assert.ok(allFlagsEnabled(result));
+  });
+});

--- a/tests/hero-pA4-operator-lookup.test.js
+++ b/tests/hero-pA4-operator-lookup.test.js
@@ -1,0 +1,369 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildOperatorLookup } from '../scripts/hero-pA4-operator-lookup.mjs';
+import { HERO_FLAG_KEYS } from '../shared/hero/account-override.js';
+import { PRIVACY_FORBIDDEN_FIELDS } from '../shared/hero/metrics-privacy.js';
+
+// ── Fixtures ──────────────────────────────────────────────────────────
+
+function makeHealthyState() {
+  return {
+    version: 2,
+    economy: {
+      balance: 450,
+      ledger: [
+        { type: 'daily_award', date: new Date().toISOString().slice(0, 10), amount: 100 },
+        { type: 'camp_spend', date: new Date().toISOString().slice(0, 10), amount: -50 },
+      ],
+    },
+    heroPool: {
+      monsters: { 'monster-1': { id: 'monster-1', level: 3 } },
+    },
+  };
+}
+
+function makeUnhealthyState() {
+  return {
+    version: 2,
+    economy: {
+      balance: -10,
+      ledger: [
+        { type: 'daily_award', date: new Date().toISOString().slice(0, 10), amount: 100 },
+        null,
+      ],
+    },
+    heroPool: {
+      monsters: { 'monster-1': { id: 'monster-1', level: 1 } },
+    },
+  };
+}
+
+function makeInternalEnv(accountId) {
+  return {
+    HERO_INTERNAL_ACCOUNTS: JSON.stringify([accountId]),
+    HERO_EXTERNAL_ACCOUNTS: JSON.stringify([]),
+  };
+}
+
+function makeExternalEnv(accountId) {
+  return {
+    HERO_INTERNAL_ACCOUNTS: JSON.stringify([]),
+    HERO_EXTERNAL_ACCOUNTS: JSON.stringify([accountId]),
+  };
+}
+
+function makeNoMatchEnv() {
+  return {
+    HERO_INTERNAL_ACCOUNTS: JSON.stringify(['other-acc']),
+    HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['another-acc']),
+  };
+}
+
+// ── Internal account ──────────────────────────────────────────────────
+
+describe('buildOperatorLookup: internal account', () => {
+  it('returns overrideStatus=internal with all flags enabled', () => {
+    const report = buildOperatorLookup({
+      accountId: 'int-acc-1',
+      env: makeInternalEnv('int-acc-1'),
+      heroState: makeHealthyState(),
+      eventLog: [{ eventType: 'daily_complete', data: {} }],
+    });
+
+    assert.equal(report.ok, true);
+    assert.equal(report.overrideStatus, 'internal');
+    for (const key of HERO_FLAG_KEYS) {
+      assert.equal(report.resolvedFlags[key], true, `${key} must be enabled`);
+    }
+  });
+
+  it('cohortClassification explains internal membership', () => {
+    const report = buildOperatorLookup({
+      accountId: 'int-acc-1',
+      env: makeInternalEnv('int-acc-1'),
+      heroState: makeHealthyState(),
+      eventLog: [],
+    });
+
+    assert.equal(report.cohortClassification.enabled, true);
+    assert.ok(report.cohortClassification.reason.includes('HERO_INTERNAL_ACCOUNTS'));
+  });
+});
+
+// ── External account ──────────────────────────────────────────────────
+
+describe('buildOperatorLookup: external account', () => {
+  it('returns overrideStatus=external with all flags enabled', () => {
+    const report = buildOperatorLookup({
+      accountId: 'ext-acc-1',
+      env: makeExternalEnv('ext-acc-1'),
+      heroState: makeHealthyState(),
+      eventLog: [{ eventType: 'quest_start', data: {} }],
+    });
+
+    assert.equal(report.ok, true);
+    assert.equal(report.overrideStatus, 'external');
+    for (const key of HERO_FLAG_KEYS) {
+      assert.equal(report.resolvedFlags[key], true, `${key} must be enabled`);
+    }
+  });
+
+  it('cohortClassification explains external membership', () => {
+    const report = buildOperatorLookup({
+      accountId: 'ext-acc-1',
+      env: makeExternalEnv('ext-acc-1'),
+      heroState: makeHealthyState(),
+      eventLog: [],
+    });
+
+    assert.equal(report.cohortClassification.enabled, true);
+    assert.ok(report.cohortClassification.reason.includes('HERO_EXTERNAL_ACCOUNTS'));
+  });
+});
+
+// ── Non-cohort account (flags off) ────────────────────────────────────
+
+describe('buildOperatorLookup: non-cohort account', () => {
+  it('returns overrideStatus=none with Hero hidden', () => {
+    const report = buildOperatorLookup({
+      accountId: 'random-acc',
+      env: makeNoMatchEnv(),
+      heroState: null,
+      eventLog: [],
+    });
+
+    assert.equal(report.ok, true);
+    assert.equal(report.overrideStatus, 'none');
+    for (const key of HERO_FLAG_KEYS) {
+      assert.equal(report.resolvedFlags[key], false, `${key} must be disabled`);
+    }
+  });
+
+  it('cohortClassification shows hidden with reason', () => {
+    const report = buildOperatorLookup({
+      accountId: 'random-acc',
+      env: makeNoMatchEnv(),
+      heroState: null,
+      eventLog: [],
+    });
+
+    assert.equal(report.cohortClassification.enabled, false);
+    assert.ok(report.cohortClassification.reason.includes('not in any cohort list'));
+  });
+
+  it('recommendation mentions not in any cohort list', () => {
+    const report = buildOperatorLookup({
+      accountId: 'random-acc',
+      env: makeNoMatchEnv(),
+      heroState: null,
+      eventLog: [],
+    });
+
+    const cohortRec = report.recommendations.find(r => r.includes('not in any cohort list'));
+    assert.ok(cohortRec, 'Must have recommendation about cohort membership');
+  });
+});
+
+// ── Unhealthy state (negative balance) ────────────────────────────────
+
+describe('buildOperatorLookup: unhealthy state', () => {
+  it('readiness shows failure for negative balance', () => {
+    const report = buildOperatorLookup({
+      accountId: 'int-acc-1',
+      env: makeInternalEnv('int-acc-1'),
+      heroState: makeUnhealthyState(),
+      eventLog: [],
+    });
+
+    assert.equal(report.readinessChecks.overall, 'not_ready');
+    const economyCheck = report.readinessChecks.checks.find(c => c.name === 'economyHealthy');
+    assert.equal(economyCheck.status, 'fail');
+  });
+
+  it('economyHealth reports anomalies', () => {
+    const report = buildOperatorLookup({
+      accountId: 'int-acc-1',
+      env: makeInternalEnv('int-acc-1'),
+      heroState: makeUnhealthyState(),
+      eventLog: [],
+    });
+
+    assert.equal(report.economyHealth.status, 'unhealthy');
+    assert.ok(report.economyHealth.anomalies.includes('negative-balance'));
+    assert.ok(report.economyHealth.anomalies.includes('null-ledger-entry'));
+  });
+
+  it('recommendations mention economy anomalies', () => {
+    const report = buildOperatorLookup({
+      accountId: 'int-acc-1',
+      env: makeInternalEnv('int-acc-1'),
+      heroState: makeUnhealthyState(),
+      eventLog: [],
+    });
+
+    const econRec = report.recommendations.find(r => r.includes('Economy anomalies'));
+    assert.ok(econRec, 'Must recommend action for economy issues');
+  });
+});
+
+// ── No event log entries ──────────────────────────────────────────────
+
+describe('buildOperatorLookup: no event log', () => {
+  it('graceful message when no events exist', () => {
+    const report = buildOperatorLookup({
+      accountId: 'int-acc-1',
+      env: makeInternalEnv('int-acc-1'),
+      heroState: makeHealthyState(),
+      eventLog: [],
+    });
+
+    assert.equal(report.recentEvents.count, 0);
+    assert.equal(report.recentEvents.message, 'No observations yet.');
+  });
+
+  it('recommendation mentions no observations', () => {
+    const report = buildOperatorLookup({
+      accountId: 'int-acc-1',
+      env: makeInternalEnv('int-acc-1'),
+      heroState: makeHealthyState(),
+      eventLog: [],
+    });
+
+    const noObsRec = report.recommendations.find(r => r.includes('No event log observations'));
+    assert.ok(noObsRec, 'Must mention no observations');
+  });
+});
+
+// ── Privacy stripping ─────────────────────────────────────────────────
+
+describe('buildOperatorLookup: privacy stripping', () => {
+  it('removes forbidden fields from event log entries', () => {
+    const rawEvents = [
+      {
+        eventType: 'quest_complete',
+        data: {
+          score: 5,
+          childFreeText: 'My secret answer',
+          rawAnswer: 'raw answer text',
+          nested: { childContent: 'deep private', ok: true },
+        },
+      },
+      {
+        eventType: 'daily_award',
+        rawText: 'should be removed',
+        data: { amount: 100 },
+      },
+    ];
+
+    const report = buildOperatorLookup({
+      accountId: 'int-acc-1',
+      env: makeInternalEnv('int-acc-1'),
+      heroState: makeHealthyState(),
+      eventLog: rawEvents,
+    });
+
+    // Verify no forbidden fields in output
+    const outputStr = JSON.stringify(report.recentEvents);
+    for (const field of PRIVACY_FORBIDDEN_FIELDS) {
+      assert.ok(
+        !outputStr.includes(`"${field}"`),
+        `Forbidden field "${field}" must be stripped from output`,
+      );
+    }
+
+    // Verify allowed fields survive
+    const firstEvent = report.recentEvents.events[0];
+    assert.equal(firstEvent.eventType, 'quest_complete');
+    assert.equal(firstEvent.data.score, 5);
+    assert.equal(firstEvent.data.nested.ok, true);
+  });
+});
+
+// ── Null/undefined accountId ──────────────────────────────────────────
+
+describe('buildOperatorLookup: null/undefined accountId', () => {
+  it('null accountId returns graceful error output', () => {
+    const report = buildOperatorLookup({
+      accountId: null,
+      env: makeInternalEnv('int-acc-1'),
+      heroState: makeHealthyState(),
+      eventLog: [],
+    });
+
+    assert.equal(report.ok, false);
+    assert.ok(report.error.includes('required'));
+    assert.equal(report.accountId, null);
+    assert.equal(report.overrideStatus, null);
+    assert.ok(Array.isArray(report.recommendations));
+  });
+
+  it('undefined accountId returns graceful error output', () => {
+    const report = buildOperatorLookup({
+      accountId: undefined,
+      env: makeInternalEnv('int-acc-1'),
+      heroState: makeHealthyState(),
+      eventLog: [],
+    });
+
+    assert.equal(report.ok, false);
+    assert.ok(report.error.includes('required'));
+  });
+
+  it('empty string accountId returns graceful error output', () => {
+    const report = buildOperatorLookup({
+      accountId: '',
+      env: makeInternalEnv('int-acc-1'),
+      heroState: makeHealthyState(),
+      eventLog: [],
+    });
+
+    assert.equal(report.ok, false);
+    assert.ok(report.error.includes('required'));
+  });
+});
+
+// ── Healthy fully-enabled account produces no-action recommendation ───
+
+describe('buildOperatorLookup: healthy fully-enabled', () => {
+  it('healthy internal account with events produces no-action recommendation', () => {
+    const report = buildOperatorLookup({
+      accountId: 'int-acc-1',
+      env: makeInternalEnv('int-acc-1'),
+      heroState: makeHealthyState(),
+      eventLog: [{ eventType: 'daily_complete', data: {} }],
+    });
+
+    assert.equal(report.ok, true);
+    assert.equal(report.readinessChecks.overall, 'ready');
+    assert.equal(report.economyHealth.status, 'healthy');
+    assert.ok(
+      report.recommendations.some(r => r.includes('No action required')),
+      'Must indicate no action needed',
+    );
+  });
+});
+
+// ── Event log limiting ────────────────────────────────────────────────
+
+describe('buildOperatorLookup: event log limiting', () => {
+  it('limits to 10 most recent events', () => {
+    const manyEvents = Array.from({ length: 25 }, (_, i) => ({
+      eventType: `event-${i}`,
+      data: { index: i },
+    }));
+
+    const report = buildOperatorLookup({
+      accountId: 'int-acc-1',
+      env: makeInternalEnv('int-acc-1'),
+      heroState: makeHealthyState(),
+      eventLog: manyEvents,
+    });
+
+    assert.equal(report.recentEvents.count, 10);
+    assert.equal(report.recentEvents.events.length, 10);
+    // First 10 events (assuming input is already ordered newest-first)
+    assert.equal(report.recentEvents.events[0].eventType, 'event-0');
+    assert.equal(report.recentEvents.events[9].eventType, 'event-9');
+  });
+});

--- a/tests/hero-pA4-parent-explainer-validation.test.js
+++ b/tests/hero-pA4-parent-explainer-validation.test.js
@@ -1,0 +1,187 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const explainerPath = resolve(
+  __dirname,
+  '../docs/plans/james/hero-mode/A/hero-pA4-parent-explainer.md'
+);
+
+const content = readFileSync(explainerPath, 'utf8');
+const lower = content.toLowerCase();
+
+describe('Hero pA4 parent explainer — required content', () => {
+  it('states Hero Mode gives one daily mission across ready subjects', () => {
+    assert.ok(
+      lower.includes('one daily mission') && lower.includes('ready subjects'),
+      'Must mention one daily mission across ready subjects'
+    );
+  });
+
+  it('names Spelling, Grammar, and Punctuation as ready subjects', () => {
+    assert.ok(lower.includes('spelling'), 'Must mention Spelling');
+    assert.ok(lower.includes('grammar'), 'Must mention Grammar');
+    assert.ok(lower.includes('punctuation'), 'Must mention Punctuation');
+  });
+
+  it('states more subjects may join later', () => {
+    assert.ok(
+      lower.includes('more subjects') && lower.includes('later'),
+      'Must indicate more subjects may join later'
+    );
+  });
+
+  it('states subject mastery and Stars still belong to each subject', () => {
+    assert.ok(
+      lower.includes('stars') && lower.includes('belong to each subject'),
+      'Must state Stars still belong to each subject'
+    );
+  });
+
+  it('states Hero Coins reward daily mission completion, not speed or every correct answer', () => {
+    assert.ok(
+      lower.includes('hero coins') && lower.includes('daily mission completion'),
+      'Must state Hero Coins reward daily mission completion'
+    );
+    assert.ok(
+      lower.includes('not for speed') || lower.includes('not speed'),
+      'Must state coins are not for speed'
+    );
+  });
+
+  it('states Hero Camp is optional and secondary', () => {
+    assert.ok(
+      lower.includes('hero camp') &&
+        lower.includes('optional') &&
+        lower.includes('secondary'),
+      'Must state Hero Camp is optional and secondary'
+    );
+  });
+
+  it('states this is early access and feedback is welcome', () => {
+    assert.ok(lower.includes('early access'), 'Must mention early access');
+    assert.ok(lower.includes('feedback'), 'Must mention feedback');
+    assert.ok(lower.includes('welcome'), 'Must state feedback is welcome');
+  });
+});
+
+describe('Hero pA4 parent explainer — forbidden content', () => {
+  it('does not claim Hero Mode covers all six KS2 subjects', () => {
+    assert.ok(
+      !lower.includes('all six') && !lower.includes('six subjects'),
+      'Must not claim coverage of all six KS2 subjects'
+    );
+  });
+
+  it('does not state coins are earned for every right answer', () => {
+    assert.ok(
+      !lower.includes('every right answer') &&
+        !lower.includes('every correct answer') &&
+        !lower.includes('each correct answer'),
+      'Must not claim coins for every right/correct answer'
+    );
+  });
+
+  it('does not suggest a child loses anything for missing a day', () => {
+    assert.ok(
+      !lower.includes('lose progress') &&
+        !lower.includes('lost stars') &&
+        !lower.includes('lose stars') &&
+        !lower.includes('lose coins') &&
+        !lower.includes('lose their'),
+      'Must not suggest a child loses anything for missing a day'
+    );
+  });
+
+  it('does not claim Hero Mode replaces subject practice', () => {
+    assert.ok(
+      !lower.includes('replaces subject') &&
+        !lower.includes('replace subject') &&
+        !lower.includes('instead of subject'),
+      'Must not claim Hero Mode replaces subject practice'
+    );
+  });
+
+  it('does not claim Hero Mode is final or default for everyone', () => {
+    assert.ok(
+      !lower.includes('final version for everyone') &&
+        !lower.includes('default for everyone') &&
+        !lower.includes('default for all'),
+      'Must not claim Hero Mode is final/default for everyone'
+    );
+  });
+});
+
+describe('Hero pA4 parent explainer — no pressure vocabulary', () => {
+  const pressureWords = [
+    'gamble',
+    'gambling',
+    'loot',
+    'streak',
+    'punishment',
+    'punish',
+    'miss out',
+    'limited time',
+    'hurry',
+    'last chance',
+  ];
+
+  for (const word of pressureWords) {
+    it(`does not contain pressure word: "${word}"`, () => {
+      assert.ok(
+        !lower.includes(word),
+        `Explainer must not contain pressure vocabulary: "${word}"`
+      );
+    });
+  }
+});
+
+describe('Hero pA4 parent explainer — locked subjects tone', () => {
+  it('does not describe locked subjects negatively', () => {
+    const negativePatterns = [
+      'missing subjects',
+      'unavailable subjects',
+      'subjects are missing',
+      'not available yet',
+      'cannot access',
+      'locked out',
+      'blocked',
+      'excluded',
+      'left out',
+      'denied',
+    ];
+
+    for (const pattern of negativePatterns) {
+      assert.ok(
+        !lower.includes(pattern),
+        `Must not use negative language for locked subjects: "${pattern}"`
+      );
+    }
+  });
+
+  it('does not name locked subjects (arithmetic, reasoning, reading) negatively', () => {
+    // If these subjects are mentioned at all, they should not appear with negative framing
+    const lockedSubjects = ['arithmetic', 'reasoning', 'reading'];
+    for (const subject of lockedSubjects) {
+      if (lower.includes(subject)) {
+        // If mentioned, must not be paired with negative words
+        const lines = content.split('\n');
+        for (const line of lines) {
+          const lineLower = line.toLowerCase();
+          if (lineLower.includes(subject)) {
+            assert.ok(
+              !lineLower.includes('not ready') &&
+                !lineLower.includes('unavailable') &&
+                !lineLower.includes('missing') &&
+                !lineLower.includes('locked'),
+              `Locked subject "${subject}" must not be described negatively`
+            );
+          }
+        }
+      }
+    }
+  });
+});

--- a/tests/hero-pA4-route-integration.test.js
+++ b/tests/hero-pA4-route-integration.test.js
@@ -1,0 +1,287 @@
+// Hero Mode pA4 U2 — Route Integration: Unified Resolver in read model and command routes.
+//
+// Verifies:
+// 1. External account gets overrideStatus 'external' in debug output
+// 2. Internal account gets overrideStatus 'internal' in debug output
+// 3. Non-cohort account with flags off gets overrideStatus 'none'
+// 4. Read model and command use same resolver (function import consistency)
+// 5. Telemetry probe overrideStatus shape includes classification field
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  resolveHeroFlagsWithOverride,
+  resolveHeroFlagsForAccount,
+  HERO_FLAG_KEYS,
+} from '../shared/hero/account-override.js';
+import { buildExpandedProbeResponse } from '../worker/src/hero/telemetry-probe.js';
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+const INTERNAL_ACCOUNT = 'acc-internal-001';
+const EXTERNAL_ACCOUNT = 'acc-external-002';
+const PUBLIC_ACCOUNT = 'acc-public-999';
+
+function baseEnv(overrides = {}) {
+  return {
+    HERO_MODE_SHADOW_ENABLED: 'false',
+    HERO_MODE_LAUNCH_ENABLED: 'false',
+    HERO_MODE_CHILD_UI_ENABLED: 'false',
+    HERO_MODE_PROGRESS_ENABLED: 'false',
+    HERO_MODE_ECONOMY_ENABLED: 'false',
+    HERO_MODE_CAMP_ENABLED: 'false',
+    APP_NAME: 'KS2 Mastery',
+    HERO_INTERNAL_ACCOUNTS: JSON.stringify([INTERNAL_ACCOUNT]),
+    HERO_EXTERNAL_ACCOUNTS: JSON.stringify([EXTERNAL_ACCOUNT]),
+    ...overrides,
+  };
+}
+
+function baseEnvWithGlobalFlags(overrides = {}) {
+  return baseEnv({
+    HERO_MODE_SHADOW_ENABLED: 'true',
+    HERO_MODE_LAUNCH_ENABLED: 'true',
+    ...overrides,
+  });
+}
+
+// ── Unit: overrideStatus classification for command route ─────────────
+
+describe('pA4 U2: command route — unified resolver overrideStatus', () => {
+  it('external account gets overrideStatus "external"', () => {
+    const env = baseEnv();
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: EXTERNAL_ACCOUNT });
+
+    assert.equal(overrideStatus, 'external');
+    // All 6 flags force-enabled for external cohort
+    for (const key of HERO_FLAG_KEYS) {
+      assert.equal(resolvedEnv[key], 'true', `${key} must be "true" for external account`);
+    }
+  });
+
+  it('internal account gets overrideStatus "internal"', () => {
+    const env = baseEnv();
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: INTERNAL_ACCOUNT });
+
+    assert.equal(overrideStatus, 'internal');
+    for (const key of HERO_FLAG_KEYS) {
+      assert.equal(resolvedEnv[key], 'true', `${key} must be "true" for internal account`);
+    }
+  });
+
+  it('non-cohort account with flags off gets overrideStatus "none"', () => {
+    const env = baseEnv();
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: PUBLIC_ACCOUNT });
+
+    assert.equal(overrideStatus, 'none');
+    for (const key of HERO_FLAG_KEYS) {
+      assert.equal(resolvedEnv[key], 'false', `${key} must remain "false" for non-cohort account`);
+    }
+  });
+
+  it('non-cohort account with global flags on gets overrideStatus "global"', () => {
+    const env = baseEnvWithGlobalFlags();
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: PUBLIC_ACCOUNT });
+
+    assert.equal(overrideStatus, 'global');
+    // Global flags preserved — only shadow and launch are 'true' in this fixture
+    assert.equal(resolvedEnv.HERO_MODE_SHADOW_ENABLED, 'true');
+    assert.equal(resolvedEnv.HERO_MODE_LAUNCH_ENABLED, 'true');
+    assert.equal(resolvedEnv.HERO_MODE_CAMP_ENABLED, 'false');
+  });
+});
+
+// ── Unit: read model and command use same resolver ────────────────────
+
+describe('pA4 U2: resolver consistency — read model and command share resolveHeroFlagsForAccount', () => {
+  it('resolveHeroFlagsForAccount is the primary export used by both routes', () => {
+    // Verify the function exists and is callable
+    assert.equal(typeof resolveHeroFlagsForAccount, 'function');
+    assert.equal(resolveHeroFlagsForAccount.length, 1, 'takes single params object');
+  });
+
+  it('resolveHeroFlagsWithOverride delegates to resolveHeroFlagsForAccount', () => {
+    const env = baseEnv();
+
+    // The wrapper returns only resolvedEnv
+    const wrapperResult = resolveHeroFlagsWithOverride({ env, accountId: INTERNAL_ACCOUNT });
+    const { resolvedEnv } = resolveHeroFlagsForAccount({ env, accountId: INTERNAL_ACCOUNT });
+
+    // Both must produce identical resolved env
+    assert.deepEqual(wrapperResult, resolvedEnv);
+  });
+
+  it('same resolver for internal: wrapper matches primary', () => {
+    const env = baseEnv();
+    const wrapperResult = resolveHeroFlagsWithOverride({ env, accountId: EXTERNAL_ACCOUNT });
+    const { resolvedEnv } = resolveHeroFlagsForAccount({ env, accountId: EXTERNAL_ACCOUNT });
+    assert.deepEqual(wrapperResult, resolvedEnv);
+  });
+
+  it('same resolver for non-cohort: wrapper matches primary', () => {
+    const env = baseEnv();
+    const wrapperResult = resolveHeroFlagsWithOverride({ env, accountId: PUBLIC_ACCOUNT });
+    const { resolvedEnv } = resolveHeroFlagsForAccount({ env, accountId: PUBLIC_ACCOUNT });
+    assert.deepEqual(wrapperResult, resolvedEnv);
+  });
+});
+
+// ── Unit: telemetry probe overrideStatus shape ───────────────────────
+
+describe('pA4 U2: telemetry probe — overrideStatus in expanded response', () => {
+  const minimalProbeResult = { events: [], count: 0, probedAt: '2026-04-30T00:00:00.000Z' };
+  const dateKey = '2026-04-30';
+
+  it('expanded probe includes overrideStatus with classification for external', () => {
+    const env = baseEnv();
+    const { resolvedEnv, overrideStatus: classification } = resolveHeroFlagsForAccount({ env, accountId: EXTERNAL_ACCOUNT });
+
+    const effectiveFlags = Object.fromEntries(
+      HERO_FLAG_KEYS.map(k => [k, resolvedEnv[k] || ''])
+    );
+
+    const overrideStatus = {
+      queriedLearnerId: 'learner-ext-01',
+      parentAccountId: EXTERNAL_ACCOUNT,
+      classification,
+      effectiveFlags,
+    };
+
+    const expanded = buildExpandedProbeResponse({
+      probeResult: minimalProbeResult,
+      heroState: null,
+      resolvedFlags: resolvedEnv,
+      dateKey,
+      overrideStatus,
+      learnerEventCount: 0,
+    });
+
+    assert.equal(expanded.ok, true);
+    assert.equal(expanded.overrideStatus.classification, 'external');
+    assert.equal(expanded.overrideStatus.queriedLearnerId, 'learner-ext-01');
+    assert.equal(expanded.overrideStatus.parentAccountId, EXTERNAL_ACCOUNT);
+    assert.equal(expanded.overrideStatus.effectiveFlags.HERO_MODE_SHADOW_ENABLED, 'true');
+  });
+
+  it('expanded probe includes overrideStatus with classification for internal', () => {
+    const env = baseEnv();
+    const { resolvedEnv, overrideStatus: classification } = resolveHeroFlagsForAccount({ env, accountId: INTERNAL_ACCOUNT });
+
+    const effectiveFlags = Object.fromEntries(
+      HERO_FLAG_KEYS.map(k => [k, resolvedEnv[k] || ''])
+    );
+
+    const overrideStatus = {
+      queriedLearnerId: 'learner-int-01',
+      parentAccountId: INTERNAL_ACCOUNT,
+      classification,
+      effectiveFlags,
+    };
+
+    const expanded = buildExpandedProbeResponse({
+      probeResult: minimalProbeResult,
+      heroState: null,
+      resolvedFlags: resolvedEnv,
+      dateKey,
+      overrideStatus,
+      learnerEventCount: 0,
+    });
+
+    assert.equal(expanded.ok, true);
+    assert.equal(expanded.overrideStatus.classification, 'internal');
+    assert.equal(expanded.overrideStatus.parentAccountId, INTERNAL_ACCOUNT);
+  });
+
+  it('expanded probe includes overrideStatus with classification "none" for public', () => {
+    const env = baseEnv();
+    const { resolvedEnv, overrideStatus: classification } = resolveHeroFlagsForAccount({ env, accountId: PUBLIC_ACCOUNT });
+
+    const effectiveFlags = Object.fromEntries(
+      HERO_FLAG_KEYS.map(k => [k, resolvedEnv[k] || ''])
+    );
+
+    const overrideStatus = {
+      queriedLearnerId: 'learner-pub-01',
+      parentAccountId: PUBLIC_ACCOUNT,
+      classification,
+      effectiveFlags,
+    };
+
+    const expanded = buildExpandedProbeResponse({
+      probeResult: minimalProbeResult,
+      heroState: null,
+      resolvedFlags: resolvedEnv,
+      dateKey,
+      overrideStatus,
+      learnerEventCount: 0,
+    });
+
+    assert.equal(expanded.ok, true);
+    assert.equal(expanded.overrideStatus.classification, 'none');
+    assert.equal(expanded.overrideStatus.effectiveFlags.HERO_MODE_SHADOW_ENABLED, 'false');
+  });
+
+  it('expanded probe with orphan learner includes reason field', () => {
+    const env = baseEnv();
+    const { resolvedEnv, overrideStatus: classification } = resolveHeroFlagsForAccount({ env, accountId: PUBLIC_ACCOUNT });
+
+    const effectiveFlags = Object.fromEntries(
+      HERO_FLAG_KEYS.map(k => [k, resolvedEnv[k] || ''])
+    );
+
+    // Simulates what app.js does when parentAccountId is null
+    const overrideStatus = {
+      queriedLearnerId: 'learner-orphan-01',
+      parentAccountId: null,
+      classification,
+      effectiveFlags,
+      reason: 'parent-account-not-found',
+    };
+
+    const expanded = buildExpandedProbeResponse({
+      probeResult: minimalProbeResult,
+      heroState: null,
+      resolvedFlags: resolvedEnv,
+      dateKey,
+      overrideStatus,
+      learnerEventCount: null,
+    });
+
+    assert.equal(expanded.ok, true);
+    assert.equal(expanded.overrideStatus.parentAccountId, null);
+    assert.equal(expanded.overrideStatus.reason, 'parent-account-not-found');
+  });
+});
+
+// ── Unit: command route heroCommandOverrideStatus availability ────────
+
+describe('pA4 U2: command route — heroCommandOverrideStatus available for telemetry', () => {
+  it('resolver returns overrideStatus alongside resolvedEnv for command route use', () => {
+    const env = baseEnv();
+    const result = resolveHeroFlagsForAccount({ env, accountId: INTERNAL_ACCOUNT });
+
+    // The route destructures as: { resolvedEnv: heroCommandEnv, overrideStatus: heroCommandOverrideStatus }
+    assert.ok('resolvedEnv' in result, 'must have resolvedEnv');
+    assert.ok('overrideStatus' in result, 'must have overrideStatus');
+    assert.equal(typeof result.resolvedEnv, 'object');
+    assert.equal(typeof result.overrideStatus, 'string');
+  });
+
+  it('overrideStatus values are one of the four valid classifications', () => {
+    const env = baseEnvWithGlobalFlags();
+    const validStatuses = ['internal', 'external', 'global', 'none'];
+
+    const { overrideStatus: s1 } = resolveHeroFlagsForAccount({ env, accountId: INTERNAL_ACCOUNT });
+    const { overrideStatus: s2 } = resolveHeroFlagsForAccount({ env, accountId: EXTERNAL_ACCOUNT });
+    const { overrideStatus: s3 } = resolveHeroFlagsForAccount({ env, accountId: PUBLIC_ACCOUNT });
+    const { overrideStatus: s4 } = resolveHeroFlagsForAccount({
+      env: baseEnv(), accountId: PUBLIC_ACCOUNT,
+    });
+
+    assert.ok(validStatuses.includes(s1), `internal → ${s1}`);
+    assert.ok(validStatuses.includes(s2), `external → ${s2}`);
+    assert.ok(validStatuses.includes(s3), `global → ${s3}`);
+    assert.ok(validStatuses.includes(s4), `none → ${s4}`);
+  });
+});

--- a/tests/hero-pA4-stop-conditions.test.js
+++ b/tests/hero-pA4-stop-conditions.test.js
@@ -1,0 +1,457 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  detectRawChildContent,
+  detectNonCohortExposure,
+  detectUnauthorisedCommand,
+  detectDuplicateDailyAward,
+  detectDuplicateCampDebit,
+  detectNegativeBalance,
+  detectClaimWithoutCompletion,
+  detectSubjectMutation,
+  detectDeadCTA,
+  detectRollbackFailure,
+  detectRepeatedErrors,
+  detectUntriageableIssue,
+  detectPressureCopy,
+} from '../shared/hero/stop-conditions.js';
+
+// ── 1. Raw Child Content ─────────────────────────────────────────────
+
+describe('detectRawChildContent', () => {
+  it('triggers when payload contains forbidden privacy field', () => {
+    const payload = { event: 'spell-attempt', rawAnswer: 'cat' };
+    const result = detectRawChildContent(payload);
+    assert.equal(result.triggered, true);
+    assert.equal(result.condition, 'raw-child-content');
+    assert.ok(result.detail.includes('rawAnswer'));
+  });
+
+  it('does not trigger for clean payload', () => {
+    const payload = { event: 'spell-attempt', score: 5, unit: 'u3' };
+    const result = detectRawChildContent(payload);
+    assert.equal(result.triggered, false);
+    assert.equal(result.condition, 'raw-child-content');
+  });
+
+  it('triggers for nested forbidden field at arbitrary depth', () => {
+    const payload = { meta: { nested: { childFreeText: 'hello' } } };
+    const result = detectRawChildContent(payload);
+    assert.equal(result.triggered, true);
+    assert.ok(result.detail.includes('childFreeText'));
+  });
+
+  it('handles null input gracefully', () => {
+    const result = detectRawChildContent(null);
+    assert.equal(result.triggered, false);
+  });
+
+  it('handles undefined input gracefully', () => {
+    const result = detectRawChildContent(undefined);
+    assert.equal(result.triggered, false);
+  });
+});
+
+// ── 2. Non-Cohort Exposure ───────────────────────────────────────────
+
+describe('detectNonCohortExposure', () => {
+  it('triggers when account is in no cohort list', () => {
+    const env = {
+      HERO_INTERNAL_ACCOUNTS: JSON.stringify(['int-1']),
+      HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['ext-1']),
+    };
+    const result = detectNonCohortExposure({ accountId: 'random-account', env });
+    assert.equal(result.triggered, true);
+    assert.equal(result.condition, 'non-cohort-exposure');
+    assert.ok(result.detail.includes('random-account'));
+  });
+
+  it('does not trigger for internal cohort account', () => {
+    const env = { HERO_INTERNAL_ACCOUNTS: JSON.stringify(['acc-1']) };
+    const result = detectNonCohortExposure({ accountId: 'acc-1', env });
+    assert.equal(result.triggered, false);
+  });
+
+  it('does not trigger for external cohort account', () => {
+    const env = { HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['ext-1']) };
+    const result = detectNonCohortExposure({ accountId: 'ext-1', env });
+    assert.equal(result.triggered, false);
+  });
+
+  it('handles null/undefined input gracefully', () => {
+    assert.equal(detectNonCohortExposure(undefined).triggered, false);
+    assert.equal(detectNonCohortExposure({}).triggered, false);
+    assert.equal(detectNonCohortExposure({ accountId: null, env: null }).triggered, false);
+  });
+});
+
+// ── 3. Unauthorised Command ──────────────────────────────────────────
+
+describe('detectUnauthorisedCommand', () => {
+  it('triggers when account has no Hero enablement', () => {
+    const env = {
+      HERO_INTERNAL_ACCOUNTS: JSON.stringify(['int-1']),
+      HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['ext-1']),
+    };
+    const result = detectUnauthorisedCommand({ accountId: 'hacker-account', env });
+    assert.equal(result.triggered, true);
+    assert.equal(result.condition, 'unauthorised-command');
+  });
+
+  it('does not trigger for enabled account', () => {
+    const env = { HERO_INTERNAL_ACCOUNTS: JSON.stringify(['valid-acc']) };
+    const result = detectUnauthorisedCommand({ accountId: 'valid-acc', env });
+    assert.equal(result.triggered, false);
+  });
+
+  it('does not trigger for global-enabled account', () => {
+    const env = { HERO_MODE_SHADOW_ENABLED: 'true' };
+    const result = detectUnauthorisedCommand({ accountId: 'any-acc', env });
+    assert.equal(result.triggered, false);
+  });
+
+  it('handles null/undefined input gracefully', () => {
+    assert.equal(detectUnauthorisedCommand(undefined).triggered, false);
+    assert.equal(detectUnauthorisedCommand({}).triggered, false);
+  });
+});
+
+// ── 4. Duplicate Daily Award ─────────────────────────────────────────
+
+describe('detectDuplicateDailyAward', () => {
+  it('triggers when two daily awards exist for the same dateKey', () => {
+    const ledgerEntries = [
+      { type: 'daily-award', dateKey: '2026-04-30', amount: 100 },
+      { type: 'daily-award', dateKey: '2026-04-30', amount: 100 },
+    ];
+    const result = detectDuplicateDailyAward({ ledgerEntries, dateKey: '2026-04-30' });
+    assert.equal(result.triggered, true);
+    assert.equal(result.condition, 'duplicate-daily-award');
+    assert.ok(result.detail.includes('2'));
+  });
+
+  it('does not trigger for a single daily award', () => {
+    const ledgerEntries = [
+      { type: 'daily-award', dateKey: '2026-04-30', amount: 100 },
+      { type: 'camp-debit', dateKey: '2026-04-30', amount: -200 },
+    ];
+    const result = detectDuplicateDailyAward({ ledgerEntries, dateKey: '2026-04-30' });
+    assert.equal(result.triggered, false);
+  });
+
+  it('does not trigger for different dateKeys', () => {
+    const ledgerEntries = [
+      { type: 'daily-award', dateKey: '2026-04-29', amount: 100 },
+      { type: 'daily-award', dateKey: '2026-04-30', amount: 100 },
+    ];
+    const result = detectDuplicateDailyAward({ ledgerEntries, dateKey: '2026-04-30' });
+    assert.equal(result.triggered, false);
+  });
+
+  it('handles null/undefined input gracefully', () => {
+    assert.equal(detectDuplicateDailyAward(undefined).triggered, false);
+    assert.equal(detectDuplicateDailyAward({}).triggered, false);
+    assert.equal(detectDuplicateDailyAward({ ledgerEntries: null, dateKey: null }).triggered, false);
+  });
+});
+
+// ── 5. Duplicate Camp Debit ──────────────────────────────────────────
+
+describe('detectDuplicateCampDebit', () => {
+  it('triggers when two camp debits share the same actionId', () => {
+    const ledgerEntries = [
+      { type: 'camp-debit', actionId: 'invite-monster-42', amount: -200 },
+      { type: 'camp-debit', actionId: 'invite-monster-42', amount: -200 },
+    ];
+    const result = detectDuplicateCampDebit({ ledgerEntries, actionId: 'invite-monster-42' });
+    assert.equal(result.triggered, true);
+    assert.equal(result.condition, 'duplicate-camp-debit');
+  });
+
+  it('does not trigger for a single camp debit', () => {
+    const ledgerEntries = [
+      { type: 'camp-debit', actionId: 'invite-monster-42', amount: -200 },
+    ];
+    const result = detectDuplicateCampDebit({ ledgerEntries, actionId: 'invite-monster-42' });
+    assert.equal(result.triggered, false);
+  });
+
+  it('does not trigger for different actionIds', () => {
+    const ledgerEntries = [
+      { type: 'camp-debit', actionId: 'invite-monster-42', amount: -200 },
+      { type: 'camp-debit', actionId: 'invite-monster-43', amount: -200 },
+    ];
+    const result = detectDuplicateCampDebit({ ledgerEntries, actionId: 'invite-monster-42' });
+    assert.equal(result.triggered, false);
+  });
+
+  it('handles null/undefined input gracefully', () => {
+    assert.equal(detectDuplicateCampDebit(undefined).triggered, false);
+    assert.equal(detectDuplicateCampDebit({}).triggered, false);
+    assert.equal(detectDuplicateCampDebit({ ledgerEntries: [], actionId: null }).triggered, false);
+  });
+});
+
+// ── 6. Negative Balance ──────────────────────────────────────────────
+
+describe('detectNegativeBalance', () => {
+  it('triggers when balance is negative', () => {
+    const result = detectNegativeBalance({ balance: -1 });
+    assert.equal(result.triggered, true);
+    assert.equal(result.condition, 'negative-balance');
+    assert.ok(result.detail.includes('-1'));
+  });
+
+  it('does not trigger for zero balance', () => {
+    const result = detectNegativeBalance({ balance: 0 });
+    assert.equal(result.triggered, false);
+  });
+
+  it('does not trigger for positive balance', () => {
+    const result = detectNegativeBalance({ balance: 500 });
+    assert.equal(result.triggered, false);
+  });
+
+  it('handles null/undefined input gracefully', () => {
+    assert.equal(detectNegativeBalance(undefined).triggered, false);
+    assert.equal(detectNegativeBalance({}).triggered, false);
+    assert.equal(detectNegativeBalance({ balance: null }).triggered, false);
+    assert.equal(detectNegativeBalance({ balance: 'not-a-number' }).triggered, false);
+  });
+});
+
+// ── 7. Claim Without Completion ──────────────────────────────────────
+
+describe('detectClaimWithoutCompletion', () => {
+  it('triggers when claimRecord exists but completionEvidence is missing', () => {
+    const result = detectClaimWithoutCompletion({
+      claimRecord: { id: 'claim-1' },
+      completionEvidence: null,
+    });
+    assert.equal(result.triggered, true);
+    assert.equal(result.condition, 'claim-without-completion');
+    assert.ok(result.detail.includes('claim-1'));
+  });
+
+  it('triggers when completionEvidence exists but not verified', () => {
+    const result = detectClaimWithoutCompletion({
+      claimRecord: { id: 'claim-2' },
+      completionEvidence: { verified: false },
+    });
+    assert.equal(result.triggered, true);
+  });
+
+  it('does not trigger when completionEvidence is verified', () => {
+    const result = detectClaimWithoutCompletion({
+      claimRecord: { id: 'claim-3' },
+      completionEvidence: { verified: true, taskId: 't-1' },
+    });
+    assert.equal(result.triggered, false);
+  });
+
+  it('handles null/undefined input gracefully', () => {
+    assert.equal(detectClaimWithoutCompletion(undefined).triggered, false);
+    assert.equal(detectClaimWithoutCompletion({}).triggered, false);
+    assert.equal(detectClaimWithoutCompletion({ claimRecord: null }).triggered, false);
+  });
+});
+
+// ── 8. Subject Mutation ──────────────────────────────────────────────
+
+describe('detectSubjectMutation', () => {
+  it('triggers when a Hero command is flagged as mutating subject state', () => {
+    const heroCommands = [
+      { name: 'claim-daily', mutatesSubject: false },
+      { name: 'complete-task', mutatesSubject: true },
+    ];
+    const result = detectSubjectMutation({ heroCommands, subjectState: { stars: 5 } });
+    assert.equal(result.triggered, true);
+    assert.equal(result.condition, 'subject-mutation');
+    assert.ok(result.detail.includes('complete-task'));
+  });
+
+  it('does not trigger when no commands mutate subject', () => {
+    const heroCommands = [
+      { name: 'claim-daily', mutatesSubject: false },
+      { name: 'refresh-quest', mutatesSubject: false },
+    ];
+    const result = detectSubjectMutation({ heroCommands, subjectState: { stars: 5 } });
+    assert.equal(result.triggered, false);
+  });
+
+  it('handles null/undefined input gracefully', () => {
+    assert.equal(detectSubjectMutation(undefined).triggered, false);
+    assert.equal(detectSubjectMutation({}).triggered, false);
+    assert.equal(detectSubjectMutation({ heroCommands: null, subjectState: null }).triggered, false);
+  });
+});
+
+// ── 9. Dead CTA ─────────────────────────────────────────────────────
+
+describe('detectDeadCTA', () => {
+  it('triggers when CTA is visible but not launchable', () => {
+    const result = detectDeadCTA({ readModel: { ctaVisible: true, ctaLaunchable: false } });
+    assert.equal(result.triggered, true);
+    assert.equal(result.condition, 'dead-cta');
+    assert.ok(result.detail.includes('not launchable'));
+  });
+
+  it('does not trigger when CTA is visible and launchable', () => {
+    const result = detectDeadCTA({ readModel: { ctaVisible: true, ctaLaunchable: true } });
+    assert.equal(result.triggered, false);
+  });
+
+  it('does not trigger when CTA is not visible', () => {
+    const result = detectDeadCTA({ readModel: { ctaVisible: false, ctaLaunchable: false } });
+    assert.equal(result.triggered, false);
+  });
+
+  it('handles null/undefined input gracefully', () => {
+    assert.equal(detectDeadCTA(undefined).triggered, false);
+    assert.equal(detectDeadCTA({}).triggered, false);
+    assert.equal(detectDeadCTA({ readModel: null }).triggered, false);
+  });
+});
+
+// ── 10. Rollback Failure ─────────────────────────────────────────────
+
+describe('detectRollbackFailure', () => {
+  it('triggers when flags are off but surfaces remain visible', () => {
+    const result = detectRollbackFailure({ flagsOff: true, heroSurfacesVisible: true });
+    assert.equal(result.triggered, true);
+    assert.equal(result.condition, 'rollback-failure');
+    assert.ok(result.detail.includes('flags are off'));
+  });
+
+  it('does not trigger when flags are off and surfaces are hidden', () => {
+    const result = detectRollbackFailure({ flagsOff: true, heroSurfacesVisible: false });
+    assert.equal(result.triggered, false);
+  });
+
+  it('does not trigger when flags are on (normal operation)', () => {
+    const result = detectRollbackFailure({ flagsOff: false, heroSurfacesVisible: true });
+    assert.equal(result.triggered, false);
+  });
+
+  it('handles null/undefined input gracefully', () => {
+    assert.equal(detectRollbackFailure(undefined).triggered, false);
+    assert.equal(detectRollbackFailure({}).triggered, false);
+    assert.equal(detectRollbackFailure({ flagsOff: null, heroSurfacesVisible: null }).triggered, false);
+  });
+});
+
+// ── 11. Repeated Errors ──────────────────────────────────────────────
+
+describe('detectRepeatedErrors', () => {
+  it('triggers when 3+ 500 errors occur within 5min window', () => {
+    const now = Date.now();
+    const errorLog = [
+      { timestamp: now - 60_000, status: 500 },
+      { timestamp: now - 30_000, status: 500 },
+      { timestamp: now - 10_000, status: 500 },
+    ];
+    const result = detectRepeatedErrors({ errorLog });
+    assert.equal(result.triggered, true);
+    assert.equal(result.condition, 'repeated-errors');
+    assert.ok(result.detail.includes('3'));
+  });
+
+  it('does not trigger when fewer than threshold errors in window', () => {
+    const now = Date.now();
+    const errorLog = [
+      { timestamp: now - 60_000, status: 500 },
+      { timestamp: now - 30_000, status: 500 },
+    ];
+    const result = detectRepeatedErrors({ errorLog });
+    assert.equal(result.triggered, false);
+  });
+
+  it('does not trigger when errors are outside 5min window', () => {
+    const now = Date.now();
+    const errorLog = [
+      { timestamp: now - 600_000, status: 500 },
+      { timestamp: now - 500_000, status: 500 },
+      { timestamp: now - 400_000, status: 500 },
+    ];
+    const result = detectRepeatedErrors({ errorLog });
+    assert.equal(result.triggered, false);
+  });
+
+  it('does not count non-500 errors', () => {
+    const now = Date.now();
+    const errorLog = [
+      { timestamp: now - 60_000, status: 500 },
+      { timestamp: now - 30_000, status: 404 },
+      { timestamp: now - 10_000, status: 429 },
+    ];
+    const result = detectRepeatedErrors({ errorLog });
+    assert.equal(result.triggered, false);
+  });
+
+  it('handles null/undefined input gracefully', () => {
+    assert.equal(detectRepeatedErrors(undefined).triggered, false);
+    assert.equal(detectRepeatedErrors({}).triggered, false);
+    assert.equal(detectRepeatedErrors({ errorLog: null }).triggered, false);
+  });
+});
+
+// ── 12. Untriageable Issue ───────────────────────────────────────────
+
+describe('detectUntriageableIssue', () => {
+  it('triggers when required fields are missing from error output', () => {
+    const errorOutput = { message: 'something failed' };
+    const requiredFields = ['message', 'accountId', 'requestId', 'timestamp'];
+    const result = detectUntriageableIssue({ errorOutput, requiredFields });
+    assert.equal(result.triggered, true);
+    assert.equal(result.condition, 'untriageable-issue');
+    assert.ok(result.detail.includes('accountId'));
+    assert.ok(result.detail.includes('requestId'));
+    assert.ok(result.detail.includes('timestamp'));
+  });
+
+  it('does not trigger when all required fields are present', () => {
+    const errorOutput = { message: 'err', accountId: 'a1', requestId: 'r1', timestamp: 123 };
+    const requiredFields = ['message', 'accountId', 'requestId', 'timestamp'];
+    const result = detectUntriageableIssue({ errorOutput, requiredFields });
+    assert.equal(result.triggered, false);
+  });
+
+  it('handles null/undefined input gracefully', () => {
+    assert.equal(detectUntriageableIssue(undefined).triggered, false);
+    assert.equal(detectUntriageableIssue({}).triggered, false);
+    assert.equal(detectUntriageableIssue({ errorOutput: null, requiredFields: null }).triggered, false);
+  });
+});
+
+// ── 13. Pressure Copy ────────────────────────────────────────────────
+
+describe('detectPressureCopy', () => {
+  it('triggers when copy contains forbidden pressure vocabulary', () => {
+    const result = detectPressureCopy({ copyText: 'Buy now and unlock treasure!' });
+    assert.equal(result.triggered, true);
+    assert.equal(result.condition, 'pressure-copy');
+    assert.ok(result.detail.includes('buy now'));
+    assert.ok(result.detail.includes('treasure'));
+  });
+
+  it('triggers for case-insensitive match', () => {
+    const result = detectPressureCopy({ copyText: "DON'T MISS OUT on this Limited Time deal" });
+    assert.equal(result.triggered, true);
+    assert.ok(result.detail.includes("don't miss out"));
+    assert.ok(result.detail.includes('limited time'));
+    assert.ok(result.detail.includes('deal'));
+  });
+
+  it('does not trigger for clean non-pressure copy', () => {
+    const result = detectPressureCopy({ copyText: 'Your Hero Quest is ready. Complete today\'s task to continue.' });
+    assert.equal(result.triggered, false);
+  });
+
+  it('handles null/undefined input gracefully', () => {
+    assert.equal(detectPressureCopy(undefined).triggered, false);
+    assert.equal(detectPressureCopy({}).triggered, false);
+    assert.equal(detectPressureCopy({ copyText: null }).triggered, false);
+    assert.equal(detectPressureCopy({ copyText: '' }).triggered, false);
+  });
+});

--- a/worker/src/app.js
+++ b/worker/src/app.js
@@ -49,7 +49,7 @@ import { resolveHeroStartTaskCommand } from './hero/launch.js';
 import { resolveHeroClaimCommand } from './hero/claim.js';
 import { resolveHeroCampCommand } from './hero/camp.js';
 import { probeHeroTelemetry, buildExpandedProbeResponse, stripPrivacyFields } from './hero/telemetry-probe.js';
-import { resolveHeroFlagsWithOverride, HERO_FLAG_KEYS } from '../../shared/hero/account-override.js';
+import { resolveHeroFlagsWithOverride, resolveHeroFlagsForAccount, HERO_FLAG_KEYS } from '../../shared/hero/account-override.js';
 import {
   initialiseDailyProgress,
   markTaskStarted,
@@ -1435,7 +1435,8 @@ export function createWorkerApp({
         if (url.pathname === '/api/hero/command' && request.method === 'POST') {
           // U8 security fix: apply per-account override BEFORE pre-gate checks
           // so team accounts in HERO_INTERNAL_ACCOUNTS bypass global flag gates.
-          const heroCommandEnv = resolveHeroFlagsWithOverride({ env, accountId: session.accountId });
+          // pA4 U2: unified resolver — also captures overrideStatus for ops output.
+          const { resolvedEnv: heroCommandEnv, overrideStatus: heroCommandOverrideStatus } = resolveHeroFlagsForAccount({ env, accountId: session.accountId });
           if (!envFlagEnabled(heroCommandEnv.HERO_MODE_LAUNCH_ENABLED)) {
             throw new NotFoundError('Hero launch is not available.', {
               code: 'hero_launch_disabled',
@@ -2714,26 +2715,12 @@ export function createWorkerApp({
               parentAccountId = membershipRow?.account_id ?? null;
             } catch { /* orphan learner — parentAccountId stays null */ }
 
-            // Resolve flags using the PARENT account (not operator)
-            const resolvedFlags = resolveHeroFlagsWithOverride({
+            // pA4 U2: unified resolver — replaces manual HERO_INTERNAL_ACCOUNTS parse.
+            // Resolve flags using the PARENT account (not operator).
+            const { resolvedEnv: resolvedFlags, overrideStatus: resolverClassification } = resolveHeroFlagsForAccount({
               env,
               accountId: parentAccountId ?? session.accountId,
             });
-
-            let isInternalAccount = null;
-            if (parentAccountId === null) {
-              // Orphan learner — cannot determine internal status
-              isInternalAccount = null;
-            } else {
-              isInternalAccount = false;
-              try {
-                const raw = env.HERO_INTERNAL_ACCOUNTS;
-                if (raw) {
-                  const parsed = JSON.parse(raw);
-                  isInternalAccount = Array.isArray(parsed) && parsed.includes(parentAccountId);
-                }
-              } catch { /* graceful — default to false */ }
-            }
 
             // P0 security: project only Hero flag keys — never expose full env secrets
             const effectiveFlags = Object.fromEntries(
@@ -2742,7 +2729,7 @@ export function createWorkerApp({
             const overrideStatus = {
               queriedLearnerId: probeLearnerIdParam,
               parentAccountId,
-              isInternalAccount,
+              classification: resolverClassification,
               effectiveFlags,
               ...(parentAccountId === null ? { reason: 'parent-account-not-found' } : {}),
             };


### PR DESCRIPTION
## Summary
Multi-unit delivery branch for Hero Mode pA4:

- **U1**: External cohort resolver with classified override status (`resolveHeroFlagsForAccount`)
- **U2**: Unified resolver in Hero routes — replaces `resolveHeroFlagsWithOverride` in command route and telemetry probe with `resolveHeroFlagsForAccount`, exposing classified `overrideStatus` ('internal'|'external'|'global'|'none') in ops debug output
- **U3**: 13 pure stop-condition guard functions for operational monitoring
- **U9**: Parent/adult early-access explainer with validation tests
- **U11**: Operator health lookup script with cohort classification

## Test plan
- [x] `node --test tests/hero-pA4-route-integration.test.js` — 14 pass (U2)
- [x] `node --test tests/hero-pA1-account-override.test.js` — 15 pass (no regression)
- [x] `node --test tests/hero-pA4-external-cohort-resolver.test.js` — 21 pass (U1)
- [x] `node --test tests/hero-pA4-stop-conditions.test.js` — (U3)
- [x] `node --test tests/hero-pA4-operator-lookup.test.js` — 18 pass (U11)
- [ ] Verify telemetry probe response includes `classification` field instead of `isInternalAccount`