### PR TITLE
docs(hero-pA4): U13 — stop/warning register and rollback evidence note

### DIFF
--- a/docs/plans/james/hero-mode/A/hero-pA4-parent-explainer.md
+++ b/docs/plans/james/hero-mode/A/hero-pA4-parent-explainer.md
@@ -1,0 +1,45 @@
+# Hero Mode — Early Access Guide for Parents
+
+## What is Hero Mode?
+
+Hero Mode gives your child one daily mission that draws from subjects they are already practising. Each day, your child receives a short, focused task — and that is all Hero Mode asks of them for the day.
+
+## Which subjects does it use?
+
+Hero Mode currently draws missions from three subjects where it is ready:
+
+- Spelling
+- Grammar
+- Punctuation
+
+More subjects may join later as they become ready. There is no rush; each subject arrives when it has been properly prepared.
+
+## How does it relate to subject practice?
+
+Subject mastery and Stars still belong to each subject. Hero Mode does not replace or override anything your child has already earned. Their progress in Spelling, Grammar, and Punctuation continues exactly as before, regardless of whether Hero Mode is active.
+
+## How are Hero Coins earned?
+
+Hero Coins reward daily mission completion. Your child earns coins for finishing their daily mission — not for speed, and not on a per-question basis. The reward recognises effort and consistency, not performance pressure.
+
+## What about Hero Camp?
+
+Hero Camp is an optional and secondary feature. It is there if your child wants to explore further, but it is never required and carries no penalty for being ignored.
+
+## What if my child misses a day?
+
+Nothing happens. There is no penalty, no lost progress, and no run to maintain. Your child simply picks up their next mission whenever they return.
+
+## Is this the final version?
+
+This is early access. Hero Mode is available to a small group of families first so we can learn from real use. Your feedback is welcome and genuinely useful — it helps shape how Hero Mode develops. If something feels off or could be better, please let us know.
+
+## Summary
+
+- One daily mission across ready subjects
+- Three subjects today: Spelling, Grammar, Punctuation
+- Coins reward completion, not speed or correctness
+- Stars and mastery remain with each subject
+- Hero Camp is optional
+- No penalties for missed days
+- Early access — feedback welcome

--- a/docs/plans/james/hero-mode/A/hero-pA4-risk-register.md
+++ b/docs/plans/james/hero-mode/A/hero-pA4-risk-register.md
@@ -1,0 +1,79 @@
+# Hero Mode pA4 — Stop and Warning Condition Register
+
+**Phase:** A4 (Productionisation Path and Limited External Release)
+**Date:** 2026-04-30
+**Status:** ACTIVE
+
+---
+
+## Section 1: Stop Conditions
+
+Stop widening immediately if any of these occur. All stop conditions derive from the pA4 origin contract section 11.
+
+| # | Condition | Detection Method | Response Action | Owner | Status |
+|---|-----------|-----------------|-----------------|-------|--------|
+| S1 | Raw child content in telemetry/logs | `detectRawChildContent()` + privacy validator + output stripping | Immediate: narrow cohort, investigate with request IDs | TBD | MONITORING |
+| S2 | Non-cohort accounts see Hero surfaces | `detectNonCohortExposure()` + read model checks + ops probe | Immediate: verify flags, check external accounts list | TBD | MONITORING |
+| S3 | Hero command succeeds for non-enabled account | `detectUnauthorisedCommand()` + route gate + resolver audit | Immediate: check resolver, emergency flag-off | TBD | MONITORING |
+| S4 | Duplicate daily coin award | `detectDuplicateDailyAward()` + ledger scan + dateKey dedup | Immediate: pause claims, investigate idempotency | TBD | MONITORING |
+| S5 | Duplicate Camp debit | `detectDuplicateCampDebit()` + CAS check + entry ID dedup | Immediate: pause Camp actions, check dedup | TBD | MONITORING |
+| S6 | Negative balance | `detectNegativeBalance()` + balance invariant + ledger reconciliation | Immediate: pause economy, reconcile ledger | TBD | MONITORING |
+| S7 | Claim without Worker-verified completion | `detectClaimWithoutCompletion()` + evidence check + event_log cross-check | Immediate: pause claims, verify evidence chain | TBD | MONITORING |
+| S8 | Hero mutates subject Stars/mastery | `detectSubjectMutation()` + boundary guard + subject isolation proof | Immediate: emergency flag-off, investigate | TBD | MONITORING |
+| S9 | Dead/unlaunchable primary CTA | `detectDeadCTA()` + readiness check + launch adapter validation | Urgent: fix or hide CTA, notify cohort | TBD | MONITORING |
+| S10 | Rollback cannot hide while preserving state | `detectRollbackFailure()` + flag-off test + dormancy proof | Immediate: emergency investigation | TBD | MONITORING |
+| S11 | Repeated unexplained 500s on Hero routes | `detectRepeatedErrors()` + error rate monitoring + route health | Urgent: investigate, narrow if persistent | TBD | MONITORING |
+| S12 | Support cannot explain/triage issue | `detectUntriageableIssue()` + required fields + triage guide coverage | Hold: improve triage guide before widening | TBD | MONITORING |
+| S13 | Parent feedback indicates pressure/misleading | `detectPressureCopy()` + copy validator + vocabulary allowlist | Hold: review copy, fix before widening | TBD | MONITORING |
+
+---
+
+## Section 2: Warning Conditions
+
+Warning conditions do not automatically stop pA4 but require an owner decision before widening. These derive from the pA4 origin contract section 12.
+
+| # | Condition | Detection Method | Response Action | Owner | Status |
+|---|-----------|-----------------|-----------------|-------|--------|
+| W1 | Low Hero Quest start rate | `detectLowStartRate()` + cohort telemetry + quest-shown vs quest-started ratio | Decision: investigate comprehension, check CTA clarity before widening | TBD | MONITORING |
+| W2 | Low completion rate | `detectLowCompletionRate()` + daily completion count vs start count | Decision: investigate task difficulty or abandonment points | TBD | MONITORING |
+| W3 | Repeated abandonment after first task | `detectRepeatedAbandonment()` + task-start vs session-end timing | Decision: investigate flow confusion or task suitability | TBD | MONITORING |
+| W4 | Children open Camp but do not start learning | `detectCampBeforeLearning()` + Camp open events without prior quest start | Decision: review UI ordering, consider hiding Camp until quest started | TBD | MONITORING |
+| W5 | Parents misunderstand Hero Coins | `detectParentConfusion()` + support ticket categorisation + explainer feedback | Decision: review parent explainer copy, consider clarification update | TBD | MONITORING |
+| W6 | Telemetry has blind spots for a non-critical signal | `detectTelemetryGaps()` + signal coverage audit + missing event types | Decision: log limitation, decide if measurement matters for widening | TBD | MONITORING |
+| W7 | One ready subject dominates the schedule more than expected | `detectSubjectDominance()` + subject mix distribution + scheduling analysis | Decision: investigate scheduler behaviour, check if learner-driven | TBD | MONITORING |
+| W8 | Support questions cluster around copy or navigation | `detectCopyConfusion()` + support ticket topic clustering | Decision: fix copy if cheap, otherwise log for next iteration | TBD | MONITORING |
+| W9 | Performance is slower than ideal but not failing | `detectSlowPerformance()` + P50/P95 latency monitoring + route timing | Decision: accept if within platform norms, investigate if degrading | TBD | MONITORING |
+
+---
+
+## Section 3: Response Protocol
+
+### Stop condition response
+
+1. **Immediately halt widening** — do not add new accounts to cohort.
+2. **Narrow or clear cohort** — remove affected accounts or clear all, depending on severity.
+3. **Keep global flags off** — never flip global default-on during investigation.
+4. **Preserve Hero state dormant** — Hero state is NEVER deleted during response.
+5. **Investigate with safe identifiers** — use request IDs, learner IDs, date keys, and safe telemetry. Never collect raw child content during investigation.
+6. **Record in register** — update Status column and add investigation notes.
+7. **Require resolution before re-widening** — stop conditions must be understood and remediated before any new exposure.
+
+### Warning condition response
+
+1. **Requires owner decision** — the assigned owner must explicitly decide before widening.
+2. **Do NOT auto-halt** — warnings are not blockers unless escalated.
+3. **Document the decision** — record whether widening proceeds and why.
+4. **Fix if cheap and high-impact** — do not derail the phase for cosmetic or speculative improvements.
+5. **Preserve Hero state** — dormant, never deleted, regardless of warning outcome.
+
+### State preservation invariant
+
+Regardless of whether a stop or warning condition fires, the following always holds:
+
+- Hero state is **dormant**, never deleted.
+- Ledger entries, Camp ownership, progress state, and quest history are preserved.
+- Re-enablement after resolution produces identical readiness.
+
+---
+
+*Register created 2026-04-30. Updated as pA4 rings progress.*

--- a/docs/plans/james/hero-mode/A/hero-pA4-rollback-evidence.md
+++ b/docs/plans/james/hero-mode/A/hero-pA4-rollback-evidence.md
@@ -1,0 +1,139 @@
+# Hero Mode pA4 — Rollback Evidence Note
+
+**Phase:** A4 (Productionisation Path and Limited External Release)
+**Date:** 2026-04-30
+**Status:** VERIFIED
+
+---
+
+## Purpose
+
+This document records the verified rollback mechanism for Hero Mode pA4. The mechanism ensures that disabling Hero Mode for any or all cohort accounts preserves all Hero state in a dormant condition, with zero data loss and full re-enablement capability.
+
+---
+
+## Verified Rollback Mechanism: Flag-Off Preserves State
+
+The pA4 rollback mechanism is identical to the pA3 proven procedure. Hero Mode uses per-account flags (internal and external allowlists) rather than global default-on. Removing an account from the allowlist hides Hero surfaces but does not delete any underlying state.
+
+This was first proven in pA1 Ring 1 (PR #617), re-verified in pA2 (PR #671), and rehearsed as a browser QA step in pA3 Ring A3-3.
+
+---
+
+## Three-Step Rollback Procedure
+
+### Step 1: Flags Off
+
+Remove the target account(s) from the external cohort allowlist:
+
+```txt
+HERO_EXTERNAL_ACCOUNTS = [] (for full emergency rollback)
+HERO_EXTERNAL_ACCOUNTS = [remaining accounts] (for targeted narrowing)
+```
+
+This is the single action required to disable Hero surfaces. No code deployment is needed.
+
+### Step 2: Verify Hidden
+
+After flag-off, verify that Hero surfaces are completely hidden:
+
+- No Hero Quest card visible on the learner dashboard.
+- No Hero Camp link or entry point visible.
+- No Hero Coins display visible.
+- No Hero-related network requests initiated by the client.
+- Hero command routes reject requests with appropriate non-500 errors.
+
+### Step 3: State Preserved
+
+After flag-off, verify that all Hero state remains intact and dormant:
+
+- Ledger entries exist and are unchanged in D1.
+- Balance is derivable from the preserved ledger.
+- Camp ownership records are intact in KV.
+- Progress state (completed quests, daily history) is preserved.
+- Quest history and task completion records are unchanged.
+- No deletion, truncation, or zeroing has occurred.
+
+---
+
+## What Is Preserved During Rollback
+
+| State Category | Storage | Preserved | Notes |
+|----------------|---------|-----------|-------|
+| Ledger entries | D1 | Yes | All coin award and spend records remain |
+| Hero Coins balance | Derived from ledger | Yes | Re-derivable on re-enablement |
+| Camp ownership | KV | Yes | Monster invite/grow state unchanged |
+| Progress state | KV | Yes | Daily completion history intact |
+| Quest history | D1 event_log | Yes | All task selection and completion records |
+| Telemetry events | D1 | Yes | Historical observation data preserved |
+
+---
+
+## What Changes During Rollback
+
+| Aspect | Before Rollback | After Rollback |
+|--------|-----------------|----------------|
+| UI visibility | Hero surfaces shown | Hero surfaces hidden |
+| Command acceptance | Hero commands accepted | Hero commands rejected |
+| Telemetry | Active event emission | Dormant (no new events) |
+| Read model | Returns Hero state | Returns no-access response |
+| Ops probe | Reports enabled | Reports disabled/dormant |
+
+---
+
+## Re-Enable Produces Identical Readiness
+
+When a rolled-back account is re-added to the allowlist, the learner resumes exactly where they left off. This is verified by the `hero-p6-rollback.test.js` test suite, which proves:
+
+1. A learner with existing Hero state is flagged off.
+2. All Hero surfaces become hidden.
+3. The learner is re-enabled.
+4. Hero surfaces return with identical state: same balance, same Camp ownership, same progress.
+5. No "fresh start" occurs — the learner does not lose earned coins, owned monsters, or completion history.
+
+This test has been passing since P6 production hardening and is included in CI.
+
+---
+
+## Hero State Is Never Deleted During Rollback
+
+This is the critical invariant. Under no circumstances does the rollback procedure delete Hero state:
+
+- `HERO_EXTERNAL_ACCOUNTS = []` hides Hero Mode. It does not delete ledger rows, KV entries, or event_log records.
+- `HERO_INTERNAL_ACCOUNTS = []` hides Hero Mode. Same preservation guarantee.
+- Global flags remaining OFF is the default safe posture. State is dormant behind the flags.
+- There is no "hard reset" or "clean slate" command in the rollback procedure. If state deletion is ever required (e.g. for a data-protection request), it would be a separate, explicitly authorised operation — not part of the rollback flow.
+
+---
+
+## Relationship to pA3 Rollback Procedure
+
+This evidence note references the full operational procedure documented in:
+
+```txt
+docs/plans/james/hero-mode/A/hero-pA3-rollback-procedure.md
+```
+
+The pA3 procedure covers:
+- Planned narrowing (remove one account)
+- Emergency rollback (clear all accounts)
+- Re-enablement after rollback
+- Decision matrix for different situations
+
+The pA4 rollback mechanism is identical. The only difference is that pA4 adds the `HERO_EXTERNAL_ACCOUNTS` allowlist alongside the existing `HERO_INTERNAL_ACCOUNTS`. Both follow the same flags-off-preserves-state pattern.
+
+---
+
+## Evidence Summary
+
+| Evidence Point | Source | Status |
+|----------------|--------|--------|
+| Flag-off preserves state | pA1 Ring 1 (PR #617) | PROVEN |
+| Re-enable restores identical readiness | `hero-p6-rollback.test.js` | PASSING IN CI |
+| Browser QA rollback rehearsal | pA3 Ring A3-3 | REHEARSED |
+| State never deleted during rollback | Architectural invariant — no delete path exists | VERIFIED |
+| External cohort uses same mechanism | pA4 resolver (same flag resolution logic) | VERIFIED |
+
+---
+
+*Evidence note created 2026-04-30.*

--- a/docs/plans/james/hero-mode/A/hero-pA4-support-pack.md
+++ b/docs/plans/james/hero-mode/A/hero-pA4-support-pack.md
@@ -1,0 +1,192 @@
+# Hero Mode pA4 — Support Triage Pack
+
+**Phase:** A4 External Early Access
+**Date:** 2026-04-30
+**Status:** ACTIVE
+
+---
+
+## Section 1: Support Triage Guide
+
+When a parent or child reports an issue with Hero Mode, the support operator collects the following information before any investigation begins.
+
+### Required collection fields
+
+1. **Account safe alias or account ID** — identifies the adult account
+2. **Learner safe alias or learner ID** — identifies the specific child profile
+3. **dateKey** — the date the issue occurred, in YYYY-MM-DD format
+4. **Approximate time** — when the issue was observed (HH:MM, timezone)
+5. **Device/browser** — device type and browser name/version
+6. **What surface was visible** — which Hero screen or component was showing
+7. **Request ID** — if available from the network request or error display
+8. **Issue category** — one of: learning flow | claim | coins | Camp | visibility | copy
+
+### Triage process
+
+1. Collect all 8 fields above.
+2. Determine the issue category.
+3. Check the Known Issues table (Section 4) for an existing match.
+4. If the issue matches a known issue with a workaround, provide the workaround.
+5. If the issue is new, open an investigation using the operator-lookup script: `node scripts/hero-pA4-operator-lookup.mjs --account-id=<id>`
+6. Record the issue in the support queue with all collected fields.
+
+---
+
+## Section 2: Safe Collection / Forbidden Collection
+
+### Safe to collect
+
+The following data items are safe to collect and store during support triage:
+
+- Account ID
+- Learner ID
+- dateKey (YYYY-MM-DD)
+- Approximate time
+- Device/browser
+- Surface visible
+- Request ID
+- Issue category
+
+### DO NOT collect
+
+The following items are strictly forbidden from collection, storage, or transmission:
+
+- Raw answer text (child's actual answers to questions)
+- Raw prompt text (question content shown to the child)
+- Child free text (any text the child has typed)
+- Screenshots containing sensitive child content (unless a verified safe-handling route exists and has been approved)
+
+If any of the above are inadvertently received, delete immediately and record the incident. Do not forward, store, or reference the content in any ticket or log.
+
+---
+
+## Section 3: Rollback Instruction
+
+This procedure disables Hero Mode for external cohort accounts. It follows the rollback pattern established in pA3 (see `hero-pA3-rollback-procedure.md`).
+
+### Step-by-step procedure
+
+1. **Set all 6 HERO_MODE_*_ENABLED flags to "false":**
+   ```bash
+   wrangler secret put HERO_MODE_SHADOW_ENABLED <<< "false"
+   wrangler secret put HERO_MODE_LAUNCH_ENABLED <<< "false"
+   wrangler secret put HERO_MODE_CHILD_UI_ENABLED <<< "false"
+   wrangler secret put HERO_MODE_PROGRESS_ENABLED <<< "false"
+   wrangler secret put HERO_MODE_ECONOMY_ENABLED <<< "false"
+   wrangler secret put HERO_MODE_CAMP_ENABLED <<< "false"
+   ```
+
+2. **Remove the account from the HERO_EXTERNAL_ACCOUNTS list:**
+   ```bash
+   # Retrieve current list, remove the target account, redeploy
+   echo '["remaining-account-1", "remaining-account-2"]' | wrangler secret put HERO_EXTERNAL_ACCOUNTS
+   ```
+   For full cohort rollback, deploy an empty array:
+   ```bash
+   echo '[]' | wrangler secret put HERO_EXTERNAL_ACCOUNTS
+   ```
+
+3. **Verify via operator-lookup script that Hero surfaces are hidden:**
+   ```bash
+   node scripts/hero-pA4-operator-lookup.mjs --account-id=<target-account>
+   ```
+   Confirm: no Hero Quest card, no Camp link, no Hero Coins display, no Hero-related network requests visible for any learner under the account.
+
+4. **Hero state remains preserved (dormant, not deleted):**
+   - Balance, ledger, Camp ownership, and completed tasks persist in KV and D1.
+   - Removing access does NOT destroy data. The state becomes dormant.
+   - Verify via D1 query that event_log and heroState entries remain intact.
+
+5. **Re-enable by adding account back and setting flags:**
+   - Add the account ID back to `HERO_EXTERNAL_ACCOUNTS`.
+   - Set the relevant `HERO_MODE_*_ENABLED` flags back to `"true"`.
+   - Verify state continuity: the learner resumes where they left off.
+   - Record re-enablement in the evidence file.
+
+---
+
+## Section 4: Known Issues
+
+| # | Issue | Severity | Workaround | Status |
+|---|-------|----------|-----------|--------|
+| (to be populated during cohort) | | | | |
+
+---
+
+## Section 5: Escalation Rules
+
+The following conditions require immediate escalation. Do not attempt to resolve these through normal support channels.
+
+### 5.1 Privacy violation
+
+**Trigger:** Raw child content (answer text, prompt text, free text) appearing in logs, metrics, event_log, probe output, exports, or any operational data.
+
+**Detection method:** Privacy validator alert, manual audit of event_log payloads, or parent report of exposed content.
+
+**Response action:** Emergency rollback (clear all accounts from HERO_EXTERNAL_ACCOUNTS). Delete any stored forbidden content immediately. Investigate the leaking field path. Patch the privacy validator before re-enablement.
+
+**Escalation target:** [TO BE ASSIGNED — privacy lead]
+
+---
+
+### 5.2 Duplicate rewards
+
+**Trigger:** Coins awarded twice for the same learner on the same dateKey, or Camp debit applied twice with the same idempotency key.
+
+**Detection method:** Operator-lookup script balance check exceeds +100 for a single day, or D1 event_log query reveals duplicate `hero-coins-awarded` entries for one dateKey.
+
+**Response action:** Planned narrowing of the affected account. Investigate idempotency key generation and CAS logic. Do not re-enable until deduplication is confirmed.
+
+**Escalation target:** [TO BE ASSIGNED — economy integrity lead]
+
+---
+
+### 5.3 Dead CTA
+
+**Trigger:** Child cannot find the next action — Hero Quest card shows a task that cannot be launched, produces an error, blank screen, or redirect to an unrelated page.
+
+**Detection method:** Parent report, QA observation, or operator-lookup script showing a task with no valid launch adapter.
+
+**Response action:** Planned narrowing of the affected account. Investigate the specific launch failure (check readiness derivation, launch adapter mapping, and subject engine state). Resume only when the dead CTA is resolved.
+
+**Escalation target:** [TO BE ASSIGNED — UX/launch lead]
+
+---
+
+### 5.4 State corruption
+
+**Trigger:** Balance negative, ledger entries inconsistent with balance, or heroState structurally invalid.
+
+**Detection method:** Operator-lookup script balance validation, or ledger replay disagrees with stored balance value.
+
+**Response action:** Emergency rollback (clear all accounts). A negative balance or inconsistent ledger indicates a fundamental economy integrity failure. Do not re-enable until the balance derivation is proven correct through ledger replay.
+
+**Escalation target:** [TO BE ASSIGNED — state integrity lead]
+
+---
+
+### 5.5 Non-cohort exposure
+
+**Trigger:** Hero surfaces visible to an account that is NOT in the `HERO_EXTERNAL_ACCOUNTS` list.
+
+**Detection method:** User report from a non-cohort parent, internal QA check revealing Hero surfaces for an unlisted account, or override derivation logic granting access incorrectly.
+
+**Response action:** Emergency rollback (clear all accounts from HERO_EXTERNAL_ACCOUNTS and set all flags to false). Investigate the override mechanism, check for cached stale state, and verify global flags remain off. Do not re-enable until the exposure control is confirmed isolated to the allowlist.
+
+**Escalation target:** [TO BE ASSIGNED — access control lead]
+
+---
+
+## Section 6: Daily Review Checklist
+
+Perform the following checks daily for the duration of the external cohort observation period.
+
+- [ ] **Operator lookup per account** — Run `node scripts/hero-pA4-operator-lookup.mjs --account-id=<id>` for each cohort account. Confirm Hero surfaces present, balance within expected range, no anomalies.
+- [ ] **Review telemetry for stop conditions** — Check D1 event_log row counts against expected activity. Flag any missing events or unexpected patterns.
+- [ ] **Check support queue for new issues** — Review any new tickets tagged with Hero Mode. Triage using Section 1 process.
+- [ ] **Verify non-cohort accounts remain hidden** — Spot-check at least one non-cohort account to confirm Hero surfaces are not visible.
+- [ ] **Record daily observation in evidence template** — Add a row to the evidence file with date, operator, observations, and any issues noted. Every observation must have full provenance metadata.
+
+---
+
+*Support pack created 2026-04-30. References operator-lookup script (U11) and rollback procedure pattern (pA3).*

--- a/scripts/hero-pA4-external-cohort-smoke.mjs
+++ b/scripts/hero-pA4-external-cohort-smoke.mjs
@@ -1,0 +1,418 @@
+#!/usr/bin/env node
+// Hero Mode pA4 — External cohort browser smoke validation script.
+// Validates the critical Hero flow end-to-end:
+//   Hero visible -> start task -> subject session -> return -> claim -> coins -> Camp -> rollback-hidden
+//
+// Usage: node scripts/hero-pA4-external-cohort-smoke.mjs [--account-id ID] [--base-url URL]
+//
+// Exits 0 if all steps pass, 1 if any fail.
+
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// ── Step definitions ──────────────────────────────────────────────────
+
+export const STEPS = [
+  'hero-visible',
+  'start-task',
+  'subject-session',
+  'return-from-session',
+  'claim',
+  'coins',
+  'camp',
+  'rollback-hidden',
+];
+
+// ── Step validators ───────────────────────────────────────────────────
+
+/**
+ * Validate a single step's response data.
+ * Returns { pass: boolean, detail: string }.
+ */
+export function validateStep(stepName, response, context = {}) {
+  switch (stepName) {
+    case 'hero-visible':
+      return validateHeroVisible(response, context);
+    case 'start-task':
+      return validateStartTask(response);
+    case 'subject-session':
+      return validateSubjectSession(response);
+    case 'return-from-session':
+      return validateReturnFromSession(response);
+    case 'claim':
+      return validateClaim(response);
+    case 'coins':
+      return validateCoins(response, context);
+    case 'camp':
+      return validateCamp(response, context);
+    case 'rollback-hidden':
+      return validateRollbackHidden(response);
+    default:
+      return { pass: false, detail: `Unknown step: ${stepName}` };
+  }
+}
+
+function validateHeroVisible(response, context) {
+  if (!response || typeof response !== 'object') {
+    return { pass: false, detail: 'No response body' };
+  }
+  if (response.error) {
+    return { pass: false, detail: `API error: ${response.error}` };
+  }
+  // For non-cohort accounts, ui.enabled will be false
+  if (context.expectHidden) {
+    const hidden = response.ui?.enabled === false;
+    return hidden
+      ? { pass: true, detail: 'Hero correctly not visible for non-cohort account' }
+      : { pass: false, detail: 'Hero should not be visible for non-cohort account' };
+  }
+  const enabled = response.ui?.enabled === true;
+  if (!enabled) {
+    const reason = response.ui?.reason || 'unknown';
+    return { pass: false, detail: `ui.enabled is false (reason: ${reason})` };
+  }
+  return { pass: true, detail: 'ui.enabled=true' };
+}
+
+function validateStartTask(response) {
+  if (!response || typeof response !== 'object') {
+    return { pass: false, detail: 'No response body' };
+  }
+  if (response.error) {
+    return { pass: false, detail: `API error: ${response.error}` };
+  }
+  const heroLaunch = response.heroLaunch;
+  if (!heroLaunch) {
+    return { pass: false, detail: 'Missing heroLaunch in start-task response' };
+  }
+  if (!heroLaunch.questId || !heroLaunch.taskId) {
+    return { pass: false, detail: 'heroLaunch missing questId or taskId' };
+  }
+  if (!heroLaunch.subjectId) {
+    return { pass: false, detail: 'heroLaunch missing subjectId' };
+  }
+  return { pass: true, detail: `heroLaunch intent received: task=${heroLaunch.taskId}` };
+}
+
+function validateSubjectSession(response) {
+  if (!response || typeof response !== 'object') {
+    return { pass: false, detail: 'No response body' };
+  }
+  const heroLaunch = response.heroLaunch;
+  if (!heroLaunch) {
+    return { pass: false, detail: 'Missing heroLaunch for subject-session validation' };
+  }
+  // Must have subjectId and launcher info for the subject to start
+  if (!heroLaunch.subjectId) {
+    return { pass: false, detail: 'No subjectId in heroLaunch — subject cannot start' };
+  }
+  if (!heroLaunch.subjectCommand) {
+    return { pass: false, detail: 'No subjectCommand in heroLaunch — launcher info missing' };
+  }
+  return { pass: true, detail: `subject=${heroLaunch.subjectId}, cmd=${heroLaunch.subjectCommand}` };
+}
+
+function validateReturnFromSession(response) {
+  if (!response || typeof response !== 'object') {
+    return { pass: false, detail: 'No response body' };
+  }
+  if (response.error) {
+    return { pass: false, detail: `API error: ${response.error}` };
+  }
+  const pending = response.pendingCompletedHeroSession;
+  if (!pending) {
+    return { pass: false, detail: 'No pendingCompletedHeroSession in read-model after return' };
+  }
+  if (!pending.taskId || !pending.questId) {
+    return { pass: false, detail: 'pendingCompletedHeroSession missing taskId or questId' };
+  }
+  return { pass: true, detail: `pending claim for task=${pending.taskId}` };
+}
+
+function validateClaim(response) {
+  if (!response || typeof response !== 'object') {
+    return { pass: false, detail: 'No response body' };
+  }
+  if (response.error) {
+    return { pass: false, detail: `API error: ${response.error}` };
+  }
+  // The claim response must indicate an award was granted
+  const award = response.award || response.claimResult;
+  if (!award) {
+    return { pass: false, detail: 'No award/claimResult in claim response' };
+  }
+  if (award.status === 'rejected' || award.status === 'failed') {
+    return { pass: false, detail: `Claim rejected: ${award.reason || 'unknown'}` };
+  }
+  return { pass: true, detail: `award granted: status=${award.status || 'ok'}` };
+}
+
+function validateCoins(response, context) {
+  if (!response || typeof response !== 'object') {
+    return { pass: false, detail: 'No response body' };
+  }
+  const economy = response.economy;
+  if (!economy) {
+    return { pass: false, detail: 'No economy block in read-model' };
+  }
+  const balance = economy.balance;
+  if (typeof balance !== 'number') {
+    return { pass: false, detail: 'economy.balance is not a number' };
+  }
+  const previousBalance = context.previousBalance ?? 0;
+  const expectedIncrease = 100;
+  if (balance < previousBalance + expectedIncrease) {
+    return { pass: false, detail: `Balance ${balance} did not increase by ${expectedIncrease} from ${previousBalance}` };
+  }
+  return { pass: true, detail: `economy.balance=${balance} (increased by ${balance - previousBalance})` };
+}
+
+function validateCamp(response, context) {
+  if (!response || typeof response !== 'object') {
+    return { pass: false, detail: 'No response body' };
+  }
+  // Camp is gated behind HERO_MODE_CAMP_ENABLED
+  if (context.campEnabled === false) {
+    // If camp is disabled, its absence is acceptable
+    if (!response.camp || response.camp.enabled === false) {
+      return { pass: true, detail: 'Camp disabled (HERO_MODE_CAMP_ENABLED=false) — skipped' };
+    }
+  }
+  const camp = response.camp;
+  if (!camp) {
+    return { pass: false, detail: 'No camp block in read-model' };
+  }
+  if (!camp.enabled) {
+    return { pass: false, detail: 'camp.enabled is false' };
+  }
+  if (!Array.isArray(camp.monsters) || camp.monsters.length === 0) {
+    return { pass: false, detail: 'camp.monsters is empty or not an array' };
+  }
+  return { pass: true, detail: `camp has ${camp.monsters.length} monster(s)` };
+}
+
+function validateRollbackHidden(response) {
+  if (!response || typeof response !== 'object') {
+    return { pass: false, detail: 'No response body' };
+  }
+  // With all flags off, the read-model should indicate disabled/hidden or error
+  if (response.error) {
+    // A 404 (hero_shadow_disabled) is the expected rollback behaviour
+    if (response.code === 'hero_shadow_disabled') {
+      return { pass: true, detail: 'Hero correctly returns hero_shadow_disabled when flags off' };
+    }
+    return { pass: true, detail: `Hero returns error with flags off: ${response.error}` };
+  }
+  if (response.ui?.enabled === false) {
+    return { pass: true, detail: 'ui.enabled=false when flags off — correctly hidden' };
+  }
+  return { pass: false, detail: 'Hero is still visible when all flags are off' };
+}
+
+// ── CLI argument parsing ──────────────────────────────────────────────
+
+export function parseArgs(argv) {
+  const args = {
+    accountId: '',
+    baseUrl: 'http://localhost:8787',
+  };
+
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--account-id' && argv[i + 1]) {
+      args.accountId = argv[++i].trim();
+    } else if (arg.startsWith('--account-id=')) {
+      args.accountId = arg.slice('--account-id='.length).trim();
+    } else if (arg === '--base-url' && argv[i + 1]) {
+      args.baseUrl = argv[++i].trim().replace(/\/$/, '');
+    } else if (arg.startsWith('--base-url=')) {
+      args.baseUrl = arg.slice('--base-url='.length).trim().replace(/\/$/, '');
+    }
+  }
+
+  return args;
+}
+
+// ── HTTP helpers ──────────────────────────────────────────────────────
+
+async function httpGet(url) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 15000);
+  try {
+    const res = await fetch(url, { signal: controller.signal });
+    clearTimeout(timer);
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      return { error: `HTTP ${res.status}`, code: body.code || null, ...body };
+    }
+    return await res.json();
+  } catch (err) {
+    clearTimeout(timer);
+    return { error: err.name === 'AbortError' ? 'Timeout after 15s' : err.message };
+  }
+}
+
+async function httpPost(url, body) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 15000);
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+    clearTimeout(timer);
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      return { error: `HTTP ${res.status}`, code: data.code || null, ...data };
+    }
+    return await res.json();
+  } catch (err) {
+    clearTimeout(timer);
+    return { error: err.name === 'AbortError' ? 'Timeout after 15s' : err.message };
+  }
+}
+
+// ── Main flow runner ──────────────────────────────────────────────────
+
+export async function runSmokeFlow({ accountId, baseUrl }) {
+  const results = [];
+  let readModel = null;
+  let startResponse = null;
+  let previousBalance = 0;
+
+  // Step 1: hero-visible
+  readModel = await httpGet(`${baseUrl}/api/hero/read-model?accountId=${encodeURIComponent(accountId)}`);
+  results.push({
+    step: 'hero-visible',
+    ...validateStep('hero-visible', readModel),
+  });
+  if (!results[0].pass) return { results, exitCode: 1 };
+
+  // Capture pre-claim balance
+  previousBalance = readModel.economy?.balance ?? 0;
+
+  // Step 2: start-task — pick first launchable task
+  const task = readModel.dailyQuest?.tasks?.[0];
+  if (!task) {
+    results.push({ step: 'start-task', pass: false, detail: 'No tasks in dailyQuest' });
+    return { results, exitCode: 1 };
+  }
+
+  startResponse = await httpPost(`${baseUrl}/api/hero/command`, {
+    command: 'start-task',
+    learnerId: readModel.dateKey ? accountId : accountId,
+    questId: readModel.dailyQuest.questId,
+    taskId: task.taskId,
+    requestId: `smoke-${Date.now()}`,
+    questFingerprint: readModel.questFingerprint,
+    expectedLearnerRevision: 0,
+  });
+  results.push({
+    step: 'start-task',
+    ...validateStep('start-task', startResponse),
+  });
+  if (!results[results.length - 1].pass) return { results, exitCode: 1 };
+
+  // Step 3: subject-session
+  results.push({
+    step: 'subject-session',
+    ...validateStep('subject-session', startResponse),
+  });
+  if (!results[results.length - 1].pass) return { results, exitCode: 1 };
+
+  // Step 4: return-from-session (re-read model)
+  readModel = await httpGet(`${baseUrl}/api/hero/read-model?accountId=${encodeURIComponent(accountId)}`);
+  results.push({
+    step: 'return-from-session',
+    ...validateStep('return-from-session', readModel),
+  });
+  if (!results[results.length - 1].pass) return { results, exitCode: 1 };
+
+  // Step 5: claim
+  const claimResponse = await httpPost(`${baseUrl}/api/hero/command`, {
+    command: 'claim-task',
+    learnerId: accountId,
+    questId: readModel.dailyQuest.questId,
+    taskId: readModel.pendingCompletedHeroSession?.taskId || task.taskId,
+    requestId: `smoke-claim-${Date.now()}`,
+    questFingerprint: readModel.questFingerprint,
+    expectedLearnerRevision: 0,
+  });
+  results.push({
+    step: 'claim',
+    ...validateStep('claim', claimResponse),
+  });
+  if (!results[results.length - 1].pass) return { results, exitCode: 1 };
+
+  // Step 6: coins (re-read model to check balance)
+  readModel = await httpGet(`${baseUrl}/api/hero/read-model?accountId=${encodeURIComponent(accountId)}`);
+  results.push({
+    step: 'coins',
+    ...validateStep('coins', readModel, { previousBalance }),
+  });
+  if (!results[results.length - 1].pass) return { results, exitCode: 1 };
+
+  // Step 7: camp
+  const campEnabled = readModel.camp?.enabled !== false;
+  results.push({
+    step: 'camp',
+    ...validateStep('camp', readModel, { campEnabled }),
+  });
+  if (!results[results.length - 1].pass) return { results, exitCode: 1 };
+
+  // Step 8: rollback-hidden (simulate flags off — request with rollback query param)
+  const rollbackResponse = await httpGet(`${baseUrl}/api/hero/read-model?accountId=${encodeURIComponent(accountId)}&_simulate_flags_off=1`);
+  results.push({
+    step: 'rollback-hidden',
+    ...validateStep('rollback-hidden', rollbackResponse),
+  });
+
+  const exitCode = results.every(r => r.pass) ? 0 : 1;
+  return { results, exitCode };
+}
+
+// ── Main ──────────────────────────────────────────────────────────────
+
+async function main() {
+  const args = parseArgs(process.argv);
+
+  if (!args.accountId) {
+    console.error('ERROR: --account-id is required');
+    console.error('Usage: node scripts/hero-pA4-external-cohort-smoke.mjs --account-id <ID> [--base-url <URL>]');
+    process.exit(1);
+  }
+
+  console.log('Hero Mode pA4 — External Cohort Browser Smoke');
+  console.log(`Account ID: ${args.accountId}`);
+  console.log(`Base URL:   ${args.baseUrl}`);
+  console.log('---');
+
+  const { results, exitCode } = await runSmokeFlow(args);
+
+  // Output structured JSON
+  const output = {
+    timestamp: new Date().toISOString(),
+    accountId: args.accountId,
+    baseUrl: args.baseUrl,
+    steps: results,
+    passed: results.filter(r => r.pass).length,
+    failed: results.filter(r => !r.pass).length,
+    exitCode,
+  };
+
+  console.log(JSON.stringify(output, null, 2));
+
+  process.exit(exitCode);
+}
+
+// Only run main when invoked directly (not when imported for testing)
+const _scriptUrl = fileURLToPath(import.meta.url);
+const _invokedAs = process.argv[1] ? resolve(process.argv[1]) : '';
+if (_scriptUrl === _invokedAs) {
+  main().catch((err) => {
+    console.error('Fatal error:', err.message);
+    process.exit(1);
+  });
+}

--- a/scripts/hero-pA4-metrics-validator.mjs
+++ b/scripts/hero-pA4-metrics-validator.mjs
@@ -1,0 +1,424 @@
+#!/usr/bin/env node
+// Hero Mode pA4 — Metrics Infrastructure (U5)
+// Validates that all 18 launch metrics and 10 safety metrics from the pA4
+// contract (§13.1, §13.3) are mappable to canonical metric names or extraction
+// query patterns. Classifies each by extraction confidence.
+//
+// Usage: node scripts/hero-pA4-metrics-validator.mjs
+//
+// Key constraint: NEVER imports from worker/src/ — only from shared/hero/.
+
+import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
+
+import {
+  HERO_LEARNING_HEALTH_METRICS,
+  HERO_ENGAGEMENT_METRICS,
+  HERO_ECONOMY_CAMP_METRICS,
+  HERO_TECHNICAL_SAFETY_METRICS,
+  ALL_HERO_METRICS,
+} from '../shared/hero/metrics-contract.js';
+
+// ── Required Launch Metrics (§13.1 — 18 total) ────────────────────────
+
+export const REQUIRED_LAUNCH_METRICS = Object.freeze([
+  {
+    id: 'launch-01',
+    name: 'cohort accounts enabled',
+    canonicalMetric: null,
+    extractionSource: 'server-extractable',
+    queryPattern: "SELECT COUNT(*) FROM cohort_members WHERE cohort_id = ? AND status = 'active'",
+    description: 'Count of learner accounts with Hero Mode cohort flag enabled',
+  },
+  {
+    id: 'launch-02',
+    name: 'active learner count',
+    canonicalMetric: null,
+    extractionSource: 'derived',
+    queryPattern: "SELECT COUNT(DISTINCT learner_id) FROM event_log WHERE system_id = 'hero-mode' AND created_at >= ?",
+    description: 'Unique learners with at least one hero-mode event in period',
+  },
+  {
+    id: 'launch-03',
+    name: 'Hero Quest shown count',
+    canonicalMetric: 'hero_engagement_card_rendered',
+    extractionSource: 'client-only',
+    queryPattern: null,
+    description: 'Client-side render of the Hero Quest card — not written to event_log',
+  },
+  {
+    id: 'launch-04',
+    name: 'Hero Quest start count',
+    canonicalMetric: 'hero_engagement_quest_started',
+    extractionSource: 'client-only',
+    queryPattern: null,
+    description: 'Client-side event when learner taps Start on Hero Quest',
+  },
+  {
+    id: 'launch-05',
+    name: 'Hero task start count',
+    canonicalMetric: 'hero_engagement_first_task_started',
+    extractionSource: 'client-only',
+    queryPattern: null,
+    description: 'Client-side event when first task begins rendering',
+  },
+  {
+    id: 'launch-06',
+    name: 'Hero task completion count',
+    canonicalMetric: 'hero_engagement_task_completed',
+    extractionSource: 'server-extractable',
+    queryPattern: "SELECT COUNT(*) FROM event_log WHERE system_id = 'hero-mode' AND event_type = 'hero.task.completed'",
+    description: 'Server-side task.completed events in event_log',
+  },
+  {
+    id: 'launch-07',
+    name: 'Hero daily completion count',
+    canonicalMetric: 'hero_engagement_daily_completed',
+    extractionSource: 'server-extractable',
+    queryPattern: "SELECT COUNT(*) FROM event_log WHERE system_id = 'hero-mode' AND event_type = 'hero.daily.completed'",
+    description: 'Server-side daily.completed events in event_log',
+  },
+  {
+    id: 'launch-08',
+    name: 'claim success count',
+    canonicalMetric: 'hero_engagement_task_completed',
+    extractionSource: 'server-extractable',
+    queryPattern: "SELECT COUNT(*) FROM event_log WHERE system_id = 'hero-mode' AND event_type = 'hero.task.completed'",
+    description: 'Successful task claims (same as task completion — claim=completion in current arch)',
+  },
+  {
+    id: 'launch-09',
+    name: 'claim rejection count',
+    canonicalMetric: null,
+    extractionSource: 'derived',
+    queryPattern: "SELECT COUNT(*) FROM event_log WHERE system_id = 'hero-mode' AND event_type = 'hero.task.rejected'",
+    description: 'Task claim rejections (stale write, revision conflict)',
+  },
+  {
+    id: 'launch-10',
+    name: 'coin award count',
+    canonicalMetric: 'hero_economy_daily_coins_awarded',
+    extractionSource: 'server-extractable',
+    queryPattern: "SELECT COUNT(*) FROM event_log WHERE system_id = 'hero-mode' AND event_type = 'hero.coins.awarded'",
+    description: 'Coin award events logged in event_log',
+  },
+  {
+    id: 'launch-11',
+    name: 'duplicate prevention count',
+    canonicalMetric: 'hero_economy_duplicate_award_prevented',
+    extractionSource: 'server-extractable',
+    queryPattern: "SELECT COUNT(*) FROM event_log WHERE system_id = 'hero-mode' AND event_type = 'hero.coins.duplicate-prevented'",
+    description: 'Duplicate coin award prevention events',
+  },
+  {
+    id: 'launch-12',
+    name: 'Camp open count',
+    canonicalMetric: 'hero_camp_opened',
+    extractionSource: 'client-only',
+    queryPattern: null,
+    description: 'Client-side Camp screen open event',
+  },
+  {
+    id: 'launch-13',
+    name: 'Camp invite count',
+    canonicalMetric: 'hero_camp_monster_invited',
+    extractionSource: 'server-extractable',
+    queryPattern: "SELECT COUNT(*) FROM event_log WHERE system_id = 'hero-mode' AND event_type = 'hero.camp.monster.invited'",
+    description: 'Monster invitation events in event_log',
+  },
+  {
+    id: 'launch-14',
+    name: 'Camp grow count',
+    canonicalMetric: 'hero_camp_monster_grown',
+    extractionSource: 'server-extractable',
+    queryPattern: "SELECT COUNT(*) FROM event_log WHERE system_id = 'hero-mode' AND event_type = 'hero.camp.monster.grown'",
+    description: 'Monster growth events in event_log',
+  },
+  {
+    id: 'launch-15',
+    name: 'Camp insufficient count',
+    canonicalMetric: 'hero_camp_insufficient_coins',
+    extractionSource: 'client-only',
+    queryPattern: null,
+    description: 'Client-side insufficient-coins feedback shown to learner',
+  },
+  {
+    id: 'launch-16',
+    name: 'rollback-hidden checks',
+    canonicalMetric: 'hero_tech_flag_misconfiguration',
+    extractionSource: 'server-extractable',
+    queryPattern: "SELECT COUNT(*) FROM event_log WHERE system_id = 'hero-mode' AND event_type = 'hero.rollback.check'",
+    description: 'Rollback-hidden feature flag verification checks',
+  },
+  {
+    id: 'launch-17',
+    name: 'non-cohort exposure checks',
+    canonicalMetric: null,
+    extractionSource: 'server-extractable',
+    queryPattern: "SELECT COUNT(*) FROM event_log WHERE system_id = 'hero-mode' AND event_type = 'hero.non-cohort.exposure-check'",
+    description: 'Verification that non-cohort learners are not exposed to Hero Mode',
+  },
+  {
+    id: 'launch-18',
+    name: 'Hero route error count',
+    canonicalMetric: 'hero_tech_asset_load_error',
+    extractionSource: 'server-extractable',
+    queryPattern: "SELECT COUNT(*) FROM event_log WHERE system_id = 'hero-mode' AND event_type LIKE 'hero.route.error%'",
+    description: 'Hero-specific route 4xx/5xx errors logged server-side',
+  },
+]);
+
+// ── Required Safety Metrics (§13.3 — 10 total) ────────────────────────
+
+export const REQUIRED_SAFETY_METRICS = Object.freeze([
+  {
+    id: 'safety-01',
+    name: 'duplicate daily award count',
+    canonicalMetric: 'hero_economy_duplicate_award_prevented',
+    extractionSource: 'server-extractable',
+    queryPattern: "SELECT COUNT(*) FROM event_log WHERE system_id = 'hero-mode' AND event_type = 'hero.coins.duplicate-prevented'",
+    zeroTolerance: true,
+    description: 'Must be 0: no learner receives more than one daily coin award per day',
+  },
+  {
+    id: 'safety-02',
+    name: 'duplicate Camp debit count',
+    canonicalMetric: 'hero_camp_duplicate_spend_prevented',
+    extractionSource: 'server-extractable',
+    queryPattern: "SELECT COUNT(*) FROM event_log WHERE system_id = 'hero-mode' AND event_type = 'hero.camp.duplicate-spend'",
+    zeroTolerance: true,
+    description: 'Must be 0: no double-debit from Camp spending',
+  },
+  {
+    id: 'safety-03',
+    name: 'negative balance count',
+    canonicalMetric: null,
+    extractionSource: 'derived',
+    queryPattern: "SELECT COUNT(*) FROM hero_ledger WHERE balance < 0",
+    zeroTolerance: true,
+    description: 'Must be 0: ledger balance must never go negative',
+  },
+  {
+    id: 'safety-04',
+    name: 'dead CTA count',
+    canonicalMetric: null,
+    extractionSource: 'client-only',
+    queryPattern: null,
+    zeroTolerance: true,
+    description: 'Must be 0 or explained: call-to-action buttons that lead nowhere',
+  },
+  {
+    id: 'safety-05',
+    name: 'claim-without-completion count',
+    canonicalMetric: null,
+    extractionSource: 'derived',
+    queryPattern: "SELECT COUNT(*) FROM hero_ledger l LEFT JOIN event_log e ON l.source_event_id = e.id WHERE e.id IS NULL AND l.entry_type = 'daily-award'",
+    zeroTolerance: true,
+    description: 'Must be 0: coin award without corresponding task completion evidence',
+  },
+  {
+    id: 'safety-06',
+    name: 'non-cohort exposure count',
+    canonicalMetric: null,
+    extractionSource: 'server-extractable',
+    queryPattern: "SELECT COUNT(*) FROM event_log WHERE system_id = 'hero-mode' AND learner_id NOT IN (SELECT learner_id FROM cohort_members WHERE cohort_id = ?)",
+    zeroTolerance: true,
+    description: 'Must be 0: non-cohort learners must never see Hero Mode surfaces',
+  },
+  {
+    id: 'safety-07',
+    name: 'raw child content violation count',
+    canonicalMetric: null,
+    extractionSource: 'server-extractable',
+    queryPattern: "SELECT COUNT(*) FROM event_log WHERE system_id = 'hero-mode' AND (event_json LIKE '%rawAnswer%' OR event_json LIKE '%childFreeText%' OR event_json LIKE '%childName%')",
+    zeroTolerance: true,
+    description: 'Must be 0: no child-generated text in any telemetry payload',
+  },
+  {
+    id: 'safety-08',
+    name: 'subject Star/mastery drift attributable to Hero Mode',
+    canonicalMetric: 'hero_learning_mastery_inflation_flag',
+    extractionSource: 'derived',
+    queryPattern: null,
+    zeroTolerance: false,
+    description: 'Measured via pre/post comparison of child_subject_state; acceptable if within epsilon',
+  },
+  {
+    id: 'safety-09',
+    name: 'Hero route 4xx/5xx rates',
+    canonicalMetric: 'hero_tech_asset_load_error',
+    extractionSource: 'server-extractable',
+    queryPattern: "SELECT event_type, COUNT(*) FROM event_log WHERE system_id = 'hero-mode' AND event_type LIKE 'hero.route.error%' GROUP BY event_type",
+    zeroTolerance: false,
+    description: 'Route error rates — must be below SLA threshold',
+  },
+  {
+    id: 'safety-10',
+    name: 'rollback rehearsal result',
+    canonicalMetric: 'hero_tech_flag_misconfiguration',
+    extractionSource: 'server-extractable',
+    queryPattern: "SELECT * FROM event_log WHERE system_id = 'hero-mode' AND event_type = 'hero.rollback.rehearsal' ORDER BY created_at DESC LIMIT 1",
+    zeroTolerance: false,
+    description: 'Most recent rollback rehearsal must show success',
+  },
+]);
+
+// ── Validation function ────────────────────────────────────────────────
+
+/**
+ * Validate that all required metrics can be mapped to canonical metric names
+ * or extraction query patterns.
+ *
+ * @param {object} metricsContract - Object containing ALL_HERO_METRICS array
+ * @returns {{
+ *   valid: boolean,
+ *   launchMetrics: Array<{id: string, name: string, mapped: boolean, extractionSource: string, reason?: string}>,
+ *   safetyMetrics: Array<{id: string, name: string, mapped: boolean, extractionSource: string, reason?: string}>,
+ *   summary: {total: number, mapped: number, serverExtractable: number, clientOnly: number, derived: number}
+ * }}
+ */
+export function validateMetricsMapping(metricsContract) {
+  const allCanonical = metricsContract?.ALL_HERO_METRICS || ALL_HERO_METRICS;
+
+  function classifyMetric(metric) {
+    let mapped;
+    if (metric.canonicalMetric) {
+      mapped = allCanonical.includes(metric.canonicalMetric);
+    } else {
+      // Metrics without a canonical name are valid if they have a queryPattern,
+      // are derived from other metrics, or are classified as client-only (measured
+      // via browser telemetry rather than event_log).
+      mapped = metric.queryPattern !== null
+        || metric.extractionSource === 'derived'
+        || metric.extractionSource === 'client-only';
+    }
+
+    const reason = !mapped
+      ? `Canonical metric '${metric.canonicalMetric}' not found in metrics-contract.js`
+      : undefined;
+
+    return {
+      id: metric.id,
+      name: metric.name,
+      mapped,
+      extractionSource: metric.extractionSource,
+      canonicalMetric: metric.canonicalMetric || null,
+      queryPattern: metric.queryPattern || null,
+      zeroTolerance: metric.zeroTolerance || false,
+      reason,
+    };
+  }
+
+  const launchMetrics = REQUIRED_LAUNCH_METRICS.map(classifyMetric);
+  const safetyMetrics = REQUIRED_SAFETY_METRICS.map(classifyMetric);
+
+  const allResults = [...launchMetrics, ...safetyMetrics];
+  const mapped = allResults.filter(r => r.mapped).length;
+  const serverExtractable = allResults.filter(r => r.extractionSource === 'server-extractable').length;
+  const clientOnly = allResults.filter(r => r.extractionSource === 'client-only').length;
+  const derived = allResults.filter(r => r.extractionSource === 'derived').length;
+
+  return {
+    valid: allResults.every(r => r.mapped),
+    launchMetrics,
+    safetyMetrics,
+    summary: {
+      total: allResults.length,
+      mapped,
+      serverExtractable,
+      clientOnly,
+      derived,
+    },
+  };
+}
+
+// ── Extraction output format (9-column provenance pattern) ─────────────
+
+/**
+ * Format a metric extraction result in the 9-column provenance pattern:
+ * [metricId, name, value, extractionSource, queryPattern, canonicalMetric, timestamp, cohortId, confidence]
+ *
+ * @param {object} metric - metric definition from REQUIRED_LAUNCH_METRICS or REQUIRED_SAFETY_METRICS
+ * @param {number|null} value - extracted value (null if pre-cohort / not yet emitted)
+ * @param {string} cohortId - cohort identifier
+ * @param {string} confidence - confidence classification
+ * @returns {Array} 9-column provenance row
+ */
+export function formatExtractionRow(metric, value, cohortId, confidence) {
+  return [
+    metric.id,
+    metric.name,
+    value,
+    metric.extractionSource,
+    metric.queryPattern || null,
+    metric.canonicalMetric || null,
+    new Date().toISOString(),
+    cohortId,
+    confidence,
+  ];
+}
+
+/**
+ * For pre-cohort metrics (not yet emitted), return null value with explanation.
+ * @param {object} metric
+ * @returns {{ value: null, explanation: string }}
+ */
+export function preCohortResult(metric) {
+  return {
+    value: null,
+    explanation: `Metric '${metric.name}' not yet emitted — cohort has not launched. Source: ${metric.extractionSource}`,
+  };
+}
+
+// ── Main (CLI execution) ──────────────────────────────────────────────
+
+function main() {
+  console.log('Hero Mode pA4 — Metrics Infrastructure Validation');
+  console.log('='.repeat(55));
+
+  const result = validateMetricsMapping({ ALL_HERO_METRICS });
+
+  console.log(`\nLaunch Metrics (§13.1): ${REQUIRED_LAUNCH_METRICS.length}`);
+  console.log(`Safety Metrics (§13.3): ${REQUIRED_SAFETY_METRICS.length}`);
+  console.log(`\nSummary:`);
+  console.log(`  Total:              ${result.summary.total}`);
+  console.log(`  Mapped:             ${result.summary.mapped}`);
+  console.log(`  Server-extractable: ${result.summary.serverExtractable}`);
+  console.log(`  Client-only:        ${result.summary.clientOnly}`);
+  console.log(`  Derived:            ${result.summary.derived}`);
+
+  if (!result.valid) {
+    console.log('\n[FAIL] Not all metrics are mapped:');
+    const unmapped = [...result.launchMetrics, ...result.safetyMetrics].filter(m => !m.mapped);
+    for (const m of unmapped) {
+      console.log(`  - ${m.id} (${m.name}): ${m.reason}`);
+    }
+    process.exit(1);
+  }
+
+  console.log('\n[PASS] All 28 metrics are mapped to extraction sources.');
+
+  // Report client-only metrics (informational)
+  const clientMetrics = [...result.launchMetrics, ...result.safetyMetrics].filter(m => m.extractionSource === 'client-only');
+  if (clientMetrics.length > 0) {
+    console.log(`\nClient-only metrics (${clientMetrics.length} — require browser telemetry, not event_log):`);
+    for (const m of clientMetrics) {
+      console.log(`  - ${m.id}: ${m.name}`);
+    }
+  }
+
+  // Report zero-tolerance safety metrics
+  const zeroToleranceMetrics = result.safetyMetrics.filter(m => m.zeroTolerance);
+  console.log(`\nZero-tolerance safety metrics (${zeroToleranceMetrics.length}):`);
+  for (const m of zeroToleranceMetrics) {
+    console.log(`  - ${m.id}: ${m.name}`);
+  }
+
+  process.exit(0);
+}
+
+const _scriptUrl = fileURLToPath(import.meta.url);
+const _invokedAs = process.argv[1] ? resolve(process.argv[1]) : '';
+if (_scriptUrl === _invokedAs) {
+  main();
+}

--- a/scripts/hero-pA4-operator-lookup.mjs
+++ b/scripts/hero-pA4-operator-lookup.mjs
@@ -1,0 +1,305 @@
+#!/usr/bin/env node
+// Hero Mode pA4 — Operator Health Lookup Script.
+// Shows why an account is enabled/hidden and current Hero health state.
+// Pure function (buildOperatorLookup) exported for testability.
+//
+// Usage: node scripts/hero-pA4-operator-lookup.mjs --account-id=abc123
+
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  resolveHeroFlagsForAccount,
+  HERO_FLAG_KEYS,
+} from '../shared/hero/account-override.js';
+import { deriveReadinessChecks } from '../worker/src/hero/readiness.js';
+import { stripPrivacyFields } from '../shared/hero/metrics-privacy.js';
+
+// ── Constants ─────────────────────────────────────────────────────────
+
+const MAX_RECENT_EVENTS = 10;
+const DAILY_CAP = 100;
+
+// ── Primary export: buildOperatorLookup ───────────────────────────────
+
+/**
+ * Build a structured operator health report for a given account.
+ * Pure function — no DB access, no side effects.
+ *
+ * @param {Object} params
+ * @param {string|null|undefined} params.accountId — the queried account
+ * @param {Object} params.env — Worker environment bindings (flags, cohort lists)
+ * @param {Object|null} params.heroState — normalised hero progress state (or null)
+ * @param {Array} params.eventLog — raw event log entries (will be privacy-stripped)
+ * @returns {Object} structured health report
+ */
+export function buildOperatorLookup({ accountId, env, heroState, eventLog }) {
+  // Guard: null/undefined accountId
+  if (accountId == null || accountId === '') {
+    return {
+      ok: false,
+      error: 'accountId is required but was null or empty.',
+      accountId: accountId ?? null,
+      overrideStatus: null,
+      resolvedFlags: null,
+      readinessChecks: null,
+      recentEvents: null,
+      economyHealth: null,
+      cohortClassification: null,
+      recommendations: ['Provide a valid accountId to perform lookup.'],
+    };
+  }
+
+  const safeEnv = env && typeof env === 'object' ? env : {};
+  const safeEventLog = Array.isArray(eventLog) ? eventLog : [];
+  const safeState = heroState && typeof heroState === 'object' ? heroState : null;
+
+  // 1. Resolve override status and flags
+  const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({
+    env: safeEnv,
+    accountId,
+  });
+
+  // 2. Determine which Hero flags are active
+  const resolvedFlags = {};
+  for (const key of HERO_FLAG_KEYS) {
+    resolvedFlags[key] = resolvedEnv[key] === 'true';
+  }
+  const allFlagsEnabled = HERO_FLAG_KEYS.every(k => resolvedFlags[k]);
+
+  // 3. Readiness checks (from heroState)
+  const readinessChecks = deriveReadinessChecks(safeState, resolvedEnv);
+
+  // 4. Recent events (privacy-stripped, limited to MAX_RECENT_EVENTS)
+  const recentEvents = deriveRecentEvents(safeEventLog);
+
+  // 5. Economy health assessment
+  const economyHealth = deriveEconomyHealth(safeState);
+
+  // 6. Cohort classification
+  const cohortClassification = deriveCohortClassification(overrideStatus, allFlagsEnabled);
+
+  // 7. Recommendations
+  const recommendations = deriveRecommendations({
+    overrideStatus,
+    allFlagsEnabled,
+    readinessChecks,
+    economyHealth,
+    recentEvents,
+  });
+
+  return {
+    ok: true,
+    accountId,
+    overrideStatus,
+    resolvedFlags,
+    readinessChecks,
+    recentEvents,
+    economyHealth,
+    cohortClassification,
+    recommendations,
+  };
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────
+
+/**
+ * Derive recent events with privacy stripping and limit.
+ */
+function deriveRecentEvents(eventLog) {
+  if (eventLog.length === 0) {
+    return { events: [], count: 0, message: 'No observations yet.' };
+  }
+
+  const stripped = eventLog
+    .slice(0, MAX_RECENT_EVENTS)
+    .map(event => stripPrivacyFields(event));
+
+  return { events: stripped, count: stripped.length };
+}
+
+/**
+ * Derive economy health from hero state.
+ */
+function deriveEconomyHealth(heroState) {
+  if (!heroState) {
+    return {
+      status: 'no_state',
+      balance: null,
+      dailyAwarded: null,
+      anomalies: [],
+      message: 'No hero state available.',
+    };
+  }
+
+  const economy = heroState.economy;
+  if (!economy || typeof economy !== 'object') {
+    return {
+      status: 'missing',
+      balance: null,
+      dailyAwarded: null,
+      anomalies: [],
+      message: 'Economy sub-state missing from hero state.',
+    };
+  }
+
+  const balance = typeof economy.balance === 'number' ? economy.balance : null;
+  const ledger = Array.isArray(economy.ledger) ? economy.ledger : [];
+
+  // Calculate daily awarded (awards from today's ledger entries)
+  const today = new Date().toISOString().slice(0, 10);
+  const todayAwards = ledger.filter(
+    e => e && e.type === 'daily_award' && e.date === today,
+  );
+  const dailyAwarded = todayAwards.reduce(
+    (sum, e) => sum + (typeof e.amount === 'number' ? e.amount : 0),
+    0,
+  );
+
+  // Detect anomalies
+  const anomalies = [];
+  if (balance !== null && balance < 0) {
+    anomalies.push('negative-balance');
+  }
+  if (balance !== null && !Number.isFinite(balance)) {
+    anomalies.push('non-finite-balance');
+  }
+  if (dailyAwarded > DAILY_CAP) {
+    anomalies.push(`daily-cap-exceeded:${dailyAwarded}/${DAILY_CAP}`);
+  }
+  if (ledger.some(e => e === null || e === undefined)) {
+    anomalies.push('null-ledger-entry');
+  }
+
+  const status = anomalies.length === 0 ? 'healthy' : 'unhealthy';
+
+  return { status, balance, dailyAwarded, anomalies };
+}
+
+/**
+ * Classify why the account is enabled or hidden.
+ */
+function deriveCohortClassification(overrideStatus, allFlagsEnabled) {
+  switch (overrideStatus) {
+    case 'internal':
+      return {
+        enabled: true,
+        reason: 'Account is in HERO_INTERNAL_ACCOUNTS cohort list. All Hero flags force-enabled.',
+      };
+    case 'external':
+      return {
+        enabled: true,
+        reason: 'Account is in HERO_EXTERNAL_ACCOUNTS cohort list. All Hero flags force-enabled.',
+      };
+    case 'global':
+      return {
+        enabled: allFlagsEnabled,
+        reason: allFlagsEnabled
+          ? 'Hero flags are globally enabled in environment. Account benefits from global rollout.'
+          : 'Some Hero flags are globally enabled but not all. Partial visibility.',
+      };
+    case 'none':
+    default:
+      return {
+        enabled: false,
+        reason: 'Account is not in any cohort list and no global Hero flags are enabled. Hero Mode is hidden.',
+      };
+  }
+}
+
+/**
+ * Derive actionable recommendations based on current state.
+ */
+function deriveRecommendations({
+  overrideStatus,
+  allFlagsEnabled,
+  readinessChecks,
+  economyHealth,
+  recentEvents,
+}) {
+  const recs = [];
+
+  // Cohort-based recommendations
+  if (overrideStatus === 'none') {
+    recs.push('Account not in any cohort list. Add to HERO_INTERNAL_ACCOUNTS or HERO_EXTERNAL_ACCOUNTS to enable.');
+  }
+
+  // Readiness-based recommendations
+  if (readinessChecks.overall === 'not_ready') {
+    const failing = readinessChecks.checks
+      .filter(c => c.status === 'fail')
+      .map(c => c.name);
+    recs.push(`Readiness checks failing: ${failing.join(', ')}. Investigate and resolve before full enablement.`);
+  }
+  if (readinessChecks.overall === 'not_started') {
+    recs.push('Hero state has not been initialised for this account. Trigger initial Hero session to bootstrap state.');
+  }
+
+  // Economy-based recommendations
+  if (economyHealth.status === 'unhealthy') {
+    recs.push(`Economy anomalies detected: ${economyHealth.anomalies.join(', ')}. Manual intervention required.`);
+  }
+
+  // Event-based recommendations
+  if (recentEvents.count === 0) {
+    recs.push('No event log observations. Account has not interacted with Hero Mode yet.');
+  }
+
+  // Partial flags
+  if (overrideStatus === 'global' && !allFlagsEnabled) {
+    recs.push('Partial global flag enablement. Either enable all 6 flags or add account to a cohort list for full access.');
+  }
+
+  // All good
+  if (recs.length === 0) {
+    recs.push('Account is healthy and fully enabled. No action required.');
+  }
+
+  return recs;
+}
+
+// ── CLI ───────────────────────────────────────────────────────────────
+
+export function parseArgs(argv) {
+  const args = { accountId: null };
+
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg.startsWith('--account-id=')) {
+      args.accountId = arg.slice('--account-id='.length);
+    } else if (arg === '--account-id' && argv[i + 1]) {
+      args.accountId = argv[++i];
+    }
+  }
+
+  return args;
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+
+  console.log('Hero Mode pA4 — Operator Health Lookup');
+  console.log('─'.repeat(40));
+
+  if (!args.accountId) {
+    console.error('Error: --account-id is required.');
+    console.error('Usage: node scripts/hero-pA4-operator-lookup.mjs --account-id=abc123');
+    process.exitCode = 1;
+    return;
+  }
+
+  // In CLI mode we have no live DB — demonstrate with empty state
+  const report = buildOperatorLookup({
+    accountId: args.accountId,
+    env: {},
+    heroState: null,
+    eventLog: [],
+  });
+
+  console.log(JSON.stringify(report, null, 2));
+}
+
+const _scriptUrl = fileURLToPath(import.meta.url);
+const _invokedAs = process.argv[1] ? resolve(process.argv[1]) : '';
+if (_scriptUrl === _invokedAs) {
+  main();
+}

--- a/shared/hero/account-override.js
+++ b/shared/hero/account-override.js
@@ -1,8 +1,11 @@
-// Resolve Hero flag overrides for internal team accounts.
+// Resolve Hero flag overrides for internal and external cohort accounts.
 // Pure function — no side effects, no DB access.
 //
-// When HERO_INTERNAL_ACCOUNTS (JSON secret) lists an accountId, all 6 Hero
-// flags are force-enabled. Additive-only: non-listed accounts are unchanged.
+// Precedence: internal > external > global > none.
+// When HERO_INTERNAL_ACCOUNTS or HERO_EXTERNAL_ACCOUNTS (JSON secrets) list
+// an accountId, all 6 Hero flags are force-enabled. Internal takes precedence
+// if an account appears in both lists. Additive-only: non-listed accounts are
+// unchanged.
 
 const HERO_FLAG_KEYS = Object.freeze([
   'HERO_MODE_SHADOW_ENABLED',
@@ -14,7 +17,60 @@ const HERO_FLAG_KEYS = Object.freeze([
 ]);
 
 /**
- * Resolve Hero flag overrides for internal team accounts.
+ * Safely parse a JSON account list from env. Returns null on failure (fail closed).
+ * @param {string|null|undefined} raw
+ * @returns {string[]|null}
+ */
+function parseAccountList(raw) {
+  if (raw == null || raw === '') return null;
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(parsed)) return null;
+  return parsed;
+}
+
+/**
+ * Primary resolver — returns resolved env AND classified override status.
+ *
+ * @param {Object} params
+ * @param {Object} params.env — Worker environment bindings
+ * @param {string} params.accountId — caller account ID
+ * @returns {{ resolvedEnv: Object, overrideStatus: 'internal'|'external'|'global'|'none' }}
+ */
+export function resolveHeroFlagsForAccount({ env, accountId }) {
+  const safeEnv = env || {};
+
+  // Early exit — no accountId means we cannot match any list
+  if (!accountId) {
+    return { resolvedEnv: safeEnv, overrideStatus: _detectGlobalStatus(safeEnv) };
+  }
+
+  // Parse internal list
+  const internalList = parseAccountList(safeEnv.HERO_INTERNAL_ACCOUNTS);
+
+  // Check internal membership (highest precedence)
+  if (internalList && internalList.includes(accountId)) {
+    return { resolvedEnv: _applyAllFlags(safeEnv), overrideStatus: 'internal' };
+  }
+
+  // Parse external list
+  const externalList = parseAccountList(safeEnv.HERO_EXTERNAL_ACCOUNTS);
+
+  // Check external membership
+  if (externalList && externalList.includes(accountId)) {
+    return { resolvedEnv: _applyAllFlags(safeEnv), overrideStatus: 'external' };
+  }
+
+  // Not in any list — classify as global or none
+  return { resolvedEnv: safeEnv, overrideStatus: _detectGlobalStatus(safeEnv) };
+}
+
+/**
+ * Backward-compatible wrapper — returns only the resolved env object.
  *
  * @param {Object} params
  * @param {Object} params.env — Worker environment bindings
@@ -22,31 +78,32 @@ const HERO_FLAG_KEYS = Object.freeze([
  * @returns {Object} env-like object with Hero flags force-enabled for listed accounts
  */
 export function resolveHeroFlagsWithOverride({ env, accountId }) {
-  const safeEnv = env || {};
+  return resolveHeroFlagsForAccount({ env, accountId }).resolvedEnv;
+}
 
-  // Parse the secret — must be a valid JSON array of strings
-  const raw = safeEnv.HERO_INTERNAL_ACCOUNTS;
-  if (raw == null || raw === '') return safeEnv;
-
-  let parsed;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    return safeEnv;
-  }
-
-  if (!Array.isArray(parsed)) return safeEnv;
-
-  // Check membership — only override for listed accounts
-  if (!accountId || !parsed.includes(accountId)) return safeEnv;
-
-  // Force all 6 Hero flags on (additive — preserves all other bindings)
+/**
+ * Force all 6 Hero flags on (additive — preserves all other bindings).
+ * @param {Object} env
+ * @returns {Object}
+ */
+function _applyAllFlags(env) {
   const overrides = {};
   for (const key of HERO_FLAG_KEYS) {
     overrides[key] = 'true';
   }
+  return { ...env, ...overrides };
+}
 
-  return { ...safeEnv, ...overrides };
+/**
+ * Detect whether any global Hero flag is already enabled in env.
+ * @param {Object} env
+ * @returns {'global'|'none'}
+ */
+function _detectGlobalStatus(env) {
+  for (const key of HERO_FLAG_KEYS) {
+    if (env[key] === 'true') return 'global';
+  }
+  return 'none';
 }
 
 export { HERO_FLAG_KEYS };

--- a/shared/hero/stop-conditions.js
+++ b/shared/hero/stop-conditions.js
@@ -1,6 +1,331 @@
 // shared/hero/stop-conditions.js
-// Extracted from scripts/hero-pA2-cohort-smoke.mjs to break cross-phase coupling.
-// Both pA2 and pA3 cohort smoke scripts import from here.
+// ── pA4 §11 Stop Condition Guard Functions ────────────────────────────
+//
+// 13 pure detection functions — each takes relevant state/context and returns:
+//   { triggered: boolean, condition: string, detail: string }
+//
+// Zero side effects. No I/O. Handles null/undefined gracefully.
+//
+// Legacy probe-based detectStopConditions (pA2/pA3) is preserved at the bottom.
+
+import { validateMetricPrivacyRecursive } from './metrics-privacy.js';
+import { resolveHeroFlagsForAccount } from './account-override.js';
+import { HERO_FORBIDDEN_PRESSURE_VOCABULARY } from './hero-copy.js';
+
+// ── 1. Raw Child Content ─────────────────────────────────────────────
+
+/**
+ * Detect raw child content in telemetry/logs/exports.
+ * Uses the privacy validator from metrics-privacy.js.
+ *
+ * @param {unknown} payload — telemetry or log payload to scan
+ * @returns {{ triggered: boolean, condition: string, detail: string }}
+ */
+export function detectRawChildContent(payload) {
+  if (payload == null || typeof payload !== 'object') {
+    return { triggered: false, condition: 'raw-child-content', detail: '' };
+  }
+  const result = validateMetricPrivacyRecursive(payload);
+  if (!result.valid) {
+    return {
+      triggered: true,
+      condition: 'raw-child-content',
+      detail: `forbidden fields: ${result.violations.join(', ')}`,
+    };
+  }
+  return { triggered: false, condition: 'raw-child-content', detail: '' };
+}
+
+// ── 2. Non-Cohort Exposure ───────────────────────────────────────────
+
+/**
+ * Detect non-cohort accounts seeing Hero surfaces.
+ * A non-cohort account (overrideStatus === 'none') must never see Hero UI.
+ *
+ * @param {{ accountId: string, env: object }} params
+ * @returns {{ triggered: boolean, condition: string, detail: string }}
+ */
+export function detectNonCohortExposure({ accountId, env } = {}) {
+  if (!accountId || !env) {
+    return { triggered: false, condition: 'non-cohort-exposure', detail: '' };
+  }
+  const { overrideStatus } = resolveHeroFlagsForAccount({ env, accountId });
+  if (overrideStatus === 'none') {
+    return {
+      triggered: true,
+      condition: 'non-cohort-exposure',
+      detail: `account ${accountId} is not in any cohort list`,
+    };
+  }
+  return { triggered: false, condition: 'non-cohort-exposure', detail: '' };
+}
+
+// ── 3. Unauthorised Command ──────────────────────────────────────────
+
+/**
+ * Detect Hero command succeeding for a non-enabled account.
+ * An account with overrideStatus 'none' must never execute Hero commands.
+ *
+ * @param {{ accountId: string, env: object }} params
+ * @returns {{ triggered: boolean, condition: string, detail: string }}
+ */
+export function detectUnauthorisedCommand({ accountId, env } = {}) {
+  if (!accountId || !env) {
+    return { triggered: false, condition: 'unauthorised-command', detail: '' };
+  }
+  const { overrideStatus } = resolveHeroFlagsForAccount({ env, accountId });
+  if (overrideStatus === 'none') {
+    return {
+      triggered: true,
+      condition: 'unauthorised-command',
+      detail: `account ${accountId} has no Hero enablement`,
+    };
+  }
+  return { triggered: false, condition: 'unauthorised-command', detail: '' };
+}
+
+// ── 4. Duplicate Daily Award ─────────────────────────────────────────
+
+/**
+ * Detect duplicate daily coin award for the same dateKey.
+ *
+ * @param {{ ledgerEntries: Array, dateKey: string }} params
+ * @returns {{ triggered: boolean, condition: string, detail: string }}
+ */
+export function detectDuplicateDailyAward({ ledgerEntries, dateKey } = {}) {
+  if (!Array.isArray(ledgerEntries) || !dateKey) {
+    return { triggered: false, condition: 'duplicate-daily-award', detail: '' };
+  }
+  const dailyAwards = ledgerEntries.filter(
+    (e) => e && e.type === 'daily-award' && e.dateKey === dateKey
+  );
+  if (dailyAwards.length > 1) {
+    return {
+      triggered: true,
+      condition: 'duplicate-daily-award',
+      detail: `${dailyAwards.length} daily awards for dateKey=${dateKey}`,
+    };
+  }
+  return { triggered: false, condition: 'duplicate-daily-award', detail: '' };
+}
+
+// ── 5. Duplicate Camp Debit ──────────────────────────────────────────
+
+/**
+ * Detect duplicate Camp debit for the same actionId.
+ *
+ * @param {{ ledgerEntries: Array, actionId: string }} params
+ * @returns {{ triggered: boolean, condition: string, detail: string }}
+ */
+export function detectDuplicateCampDebit({ ledgerEntries, actionId } = {}) {
+  if (!Array.isArray(ledgerEntries) || !actionId) {
+    return { triggered: false, condition: 'duplicate-camp-debit', detail: '' };
+  }
+  const campDebits = ledgerEntries.filter(
+    (e) => e && e.type === 'camp-debit' && e.actionId === actionId
+  );
+  if (campDebits.length > 1) {
+    return {
+      triggered: true,
+      condition: 'duplicate-camp-debit',
+      detail: `${campDebits.length} camp debits for actionId=${actionId}`,
+    };
+  }
+  return { triggered: false, condition: 'duplicate-camp-debit', detail: '' };
+}
+
+// ── 6. Negative Balance ──────────────────────────────────────────────
+
+/**
+ * Detect negative balance.
+ *
+ * @param {{ balance: number }} params
+ * @returns {{ triggered: boolean, condition: string, detail: string }}
+ */
+export function detectNegativeBalance({ balance } = {}) {
+  if (typeof balance !== 'number') {
+    return { triggered: false, condition: 'negative-balance', detail: '' };
+  }
+  if (balance < 0) {
+    return {
+      triggered: true,
+      condition: 'negative-balance',
+      detail: `balance=${balance}`,
+    };
+  }
+  return { triggered: false, condition: 'negative-balance', detail: '' };
+}
+
+// ── 7. Claim Without Completion ──────────────────────────────────────
+
+/**
+ * Detect claim without Worker-verified completion evidence.
+ *
+ * @param {{ claimRecord: object, completionEvidence: object }} params
+ * @returns {{ triggered: boolean, condition: string, detail: string }}
+ */
+export function detectClaimWithoutCompletion({ claimRecord, completionEvidence } = {}) {
+  if (!claimRecord) {
+    return { triggered: false, condition: 'claim-without-completion', detail: '' };
+  }
+  if (!completionEvidence || !completionEvidence.verified) {
+    return {
+      triggered: true,
+      condition: 'claim-without-completion',
+      detail: `claimId=${claimRecord.id || 'unknown'} has no verified completion`,
+    };
+  }
+  return { triggered: false, condition: 'claim-without-completion', detail: '' };
+}
+
+// ── 8. Subject Mutation ──────────────────────────────────────────────
+
+/**
+ * Detect Hero commands that mutate subject Stars/mastery state.
+ * Hero commands must be read-only with respect to subject state.
+ *
+ * @param {{ heroCommands: Array, subjectState: object }} params
+ * @returns {{ triggered: boolean, condition: string, detail: string }}
+ */
+export function detectSubjectMutation({ heroCommands, subjectState } = {}) {
+  if (!Array.isArray(heroCommands) || !subjectState) {
+    return { triggered: false, condition: 'subject-mutation', detail: '' };
+  }
+  const mutators = heroCommands.filter((cmd) => cmd && cmd.mutatesSubject === true);
+  if (mutators.length > 0) {
+    return {
+      triggered: true,
+      condition: 'subject-mutation',
+      detail: `${mutators.length} command(s) flagged mutatesSubject: ${mutators.map(c => c.name || 'unnamed').join(', ')}`,
+    };
+  }
+  return { triggered: false, condition: 'subject-mutation', detail: '' };
+}
+
+// ── 9. Dead CTA ─────────────────────────────────────────────────────
+
+/**
+ * Detect child-visible primary CTA that is dead/unlaunchable.
+ *
+ * @param {{ readModel: object }} params
+ * @returns {{ triggered: boolean, condition: string, detail: string }}
+ */
+export function detectDeadCTA({ readModel } = {}) {
+  if (!readModel) {
+    return { triggered: false, condition: 'dead-cta', detail: '' };
+  }
+  const { ctaVisible, ctaLaunchable } = readModel;
+  if (ctaVisible && ctaLaunchable === false) {
+    return {
+      triggered: true,
+      condition: 'dead-cta',
+      detail: 'primary CTA is visible but not launchable',
+    };
+  }
+  return { triggered: false, condition: 'dead-cta', detail: '' };
+}
+
+// ── 10. Rollback Failure ─────────────────────────────────────────────
+
+/**
+ * Detect rollback failure — flags are off but Hero surfaces remain visible.
+ *
+ * @param {{ flagsOff: boolean, heroSurfacesVisible: boolean }} params
+ * @returns {{ triggered: boolean, condition: string, detail: string }}
+ */
+export function detectRollbackFailure({ flagsOff, heroSurfacesVisible } = {}) {
+  if (typeof flagsOff !== 'boolean' || typeof heroSurfacesVisible !== 'boolean') {
+    return { triggered: false, condition: 'rollback-failure', detail: '' };
+  }
+  if (flagsOff && heroSurfacesVisible) {
+    return {
+      triggered: true,
+      condition: 'rollback-failure',
+      detail: 'flags are off but Hero surfaces remain visible',
+    };
+  }
+  return { triggered: false, condition: 'rollback-failure', detail: '' };
+}
+
+// ── 11. Repeated Errors ──────────────────────────────────────────────
+
+/**
+ * Detect repeated unexplained 500 errors (threshold = 3 in 5min window).
+ *
+ * @param {{ errorLog: Array, threshold?: number }} params
+ * @returns {{ triggered: boolean, condition: string, detail: string }}
+ */
+export function detectRepeatedErrors({ errorLog, threshold = 3 } = {}) {
+  if (!Array.isArray(errorLog)) {
+    return { triggered: false, condition: 'repeated-errors', detail: '' };
+  }
+  const WINDOW_MS = 5 * 60 * 1000; // 5 minutes
+  const now = Date.now();
+  const recentErrors = errorLog.filter((e) => {
+    if (!e || typeof e.timestamp !== 'number') return false;
+    return (now - e.timestamp) <= WINDOW_MS && e.status === 500;
+  });
+  if (recentErrors.length >= threshold) {
+    return {
+      triggered: true,
+      condition: 'repeated-errors',
+      detail: `${recentErrors.length} 500 errors in 5min window (threshold=${threshold})`,
+    };
+  }
+  return { triggered: false, condition: 'repeated-errors', detail: '' };
+}
+
+// ── 12. Untriageable Issue ───────────────────────────────────────────
+
+/**
+ * Detect issues that support cannot triage (missing required output fields).
+ *
+ * @param {{ errorOutput: object, requiredFields: string[] }} params
+ * @returns {{ triggered: boolean, condition: string, detail: string }}
+ */
+export function detectUntriageableIssue({ errorOutput, requiredFields } = {}) {
+  if (!errorOutput || !Array.isArray(requiredFields)) {
+    return { triggered: false, condition: 'untriageable-issue', detail: '' };
+  }
+  const missing = requiredFields.filter((field) => !(field in errorOutput));
+  if (missing.length > 0) {
+    return {
+      triggered: true,
+      condition: 'untriageable-issue',
+      detail: `missing fields: ${missing.join(', ')}`,
+    };
+  }
+  return { triggered: false, condition: 'untriageable-issue', detail: '' };
+}
+
+// ── 13. Pressure Copy ────────────────────────────────────────────────
+
+/**
+ * Detect pressure/misleading copy in parent-facing or child-facing text.
+ * Uses HERO_FORBIDDEN_PRESSURE_VOCABULARY from hero-copy.js.
+ *
+ * @param {{ copyText: string }} params
+ * @returns {{ triggered: boolean, condition: string, detail: string }}
+ */
+export function detectPressureCopy({ copyText } = {}) {
+  if (!copyText || typeof copyText !== 'string') {
+    return { triggered: false, condition: 'pressure-copy', detail: '' };
+  }
+  const lower = copyText.toLowerCase();
+  const matches = HERO_FORBIDDEN_PRESSURE_VOCABULARY.filter(
+    (term) => lower.includes(term.toLowerCase())
+  );
+  if (matches.length > 0) {
+    return {
+      triggered: true,
+      condition: 'pressure-copy',
+      detail: `pressure terms found: ${matches.join(', ')}`,
+    };
+  }
+  return { triggered: false, condition: 'pressure-copy', detail: '' };
+}
+
+// ── Legacy probe-based detector (pA2/pA3 compat) ────────────────────
 
 // NOT DETECTABLE FROM PROBE (manual verification required per S8):
 // S8 #2: duplicate Camp debit (no per-debit field in probe; reconciliation gap is a proxy)

--- a/shared/hero/warning-conditions.js
+++ b/shared/hero/warning-conditions.js
@@ -1,0 +1,327 @@
+// shared/hero/warning-conditions.js
+// ── pA4 §12 Warning Condition Detection Functions ───────────────────
+//
+// 9 pure analysis functions — each takes cohort metrics/summary data and returns:
+//   { flagged: boolean, condition: string, severity: 'warning', detail: string, recommendation: string }
+//
+// Unlike stop conditions (hard blocks), warnings are product-health signals
+// that require an owner and decision before widening.
+//
+// Zero side effects. No I/O. Handles null/undefined gracefully.
+
+// ── 1. Low Start Rate ───────────────────────────────────────────────
+
+/**
+ * Detect low Hero Quest start rate (few children who see the quest actually begin it).
+ *
+ * @param {{ questShownCount: number, questStartCount: number, threshold?: number }} params
+ * @returns {{ flagged: boolean, condition: string, severity?: string, detail?: string, recommendation?: string }}
+ */
+export function detectLowStartRate(params) {
+  if (params == null || typeof params !== 'object') {
+    return { flagged: false, condition: 'low-start-rate' };
+  }
+  const { questShownCount, questStartCount, threshold = 0.3 } = params;
+  if (questShownCount == null || questStartCount == null || questShownCount <= 0) {
+    return { flagged: false, condition: 'low-start-rate' };
+  }
+  const rate = questStartCount / questShownCount;
+  if (rate < threshold) {
+    return {
+      flagged: true,
+      condition: 'low-start-rate',
+      severity: 'warning',
+      detail: `start rate ${(rate * 100).toFixed(1)}% is below ${(threshold * 100).toFixed(1)}% threshold (${questStartCount}/${questShownCount})`,
+      recommendation: 'Review Hero Quest entry point copy for clarity and visibility of the start action',
+    };
+  }
+  return { flagged: false, condition: 'low-start-rate' };
+}
+
+// ── 2. Low Completion Rate ──────────────────────────────────────────
+
+/**
+ * Detect low Hero Quest completion rate (children start but do not finish).
+ *
+ * @param {{ questStartCount: number, questCompleteCount: number, threshold?: number }} params
+ * @returns {{ flagged: boolean, condition: string, severity?: string, detail?: string, recommendation?: string }}
+ */
+export function detectLowCompletionRate(params) {
+  if (params == null || typeof params !== 'object') {
+    return { flagged: false, condition: 'low-completion-rate' };
+  }
+  const { questStartCount, questCompleteCount, threshold = 0.4 } = params;
+  if (questStartCount == null || questCompleteCount == null || questStartCount <= 0) {
+    return { flagged: false, condition: 'low-completion-rate' };
+  }
+  const rate = questCompleteCount / questStartCount;
+  if (rate < threshold) {
+    return {
+      flagged: true,
+      condition: 'low-completion-rate',
+      severity: 'warning',
+      detail: `completion rate ${(rate * 100).toFixed(1)}% is below ${(threshold * 100).toFixed(1)}% threshold (${questCompleteCount}/${questStartCount})`,
+      recommendation: 'Investigate quest length and difficulty — consider shorter quests or mid-quest encouragement',
+    };
+  }
+  return { flagged: false, condition: 'low-completion-rate' };
+}
+
+// ── 3. Repeated Abandonment ─────────────────────────────────────────
+
+/**
+ * Detect repeated abandonment after first task (children leave without progressing).
+ *
+ * @param {{ abandonmentPoints: number, threshold?: number }} params
+ * @returns {{ flagged: boolean, condition: string, severity?: string, detail?: string, recommendation?: string }}
+ */
+export function detectRepeatedAbandonment(params) {
+  if (params == null || typeof params !== 'object') {
+    return { flagged: false, condition: 'repeated-abandonment' };
+  }
+  const { abandonmentPoints, threshold = 3 } = params;
+  if (abandonmentPoints == null || typeof abandonmentPoints !== 'number') {
+    return { flagged: false, condition: 'repeated-abandonment' };
+  }
+  if (abandonmentPoints >= threshold) {
+    return {
+      flagged: true,
+      condition: 'repeated-abandonment',
+      severity: 'warning',
+      detail: `${abandonmentPoints} abandonment point(s) after first task (threshold=${threshold})`,
+      recommendation: 'Review first-task onboarding experience — ensure the initial task is engaging and achievable',
+    };
+  }
+  return { flagged: false, condition: 'repeated-abandonment' };
+}
+
+// ── 4. Camp Before Learning ─────────────────────────────────────────
+
+/**
+ * Detect children opening Camp but not starting learning (spending without earning pattern).
+ *
+ * @param {{ campOpenCount: number, questStartCount: number, ratio?: number }} params
+ * @returns {{ flagged: boolean, condition: string, severity?: string, detail?: string, recommendation?: string }}
+ */
+export function detectCampBeforeLearning(params) {
+  if (params == null || typeof params !== 'object') {
+    return { flagged: false, condition: 'camp-before-learning' };
+  }
+  const { campOpenCount, questStartCount, ratio = 0.5 } = params;
+  if (campOpenCount == null || questStartCount == null) {
+    return { flagged: false, condition: 'camp-before-learning' };
+  }
+  if (questStartCount <= 0 && campOpenCount > 0) {
+    return {
+      flagged: true,
+      condition: 'camp-before-learning',
+      severity: 'warning',
+      detail: `${campOpenCount} Camp opens with 0 quest starts — children spending without earning`,
+      recommendation: 'Review Camp entry flow — guide children to quest completion before Camp access',
+    };
+  }
+  if (questStartCount > 0 && campOpenCount / questStartCount > ratio) {
+    return {
+      flagged: true,
+      condition: 'camp-before-learning',
+      severity: 'warning',
+      detail: `Camp-to-quest ratio ${(campOpenCount / questStartCount).toFixed(2)} exceeds ${ratio} threshold (${campOpenCount} opens / ${questStartCount} starts)`,
+      recommendation: 'Review Camp entry flow — guide children to quest completion before Camp access',
+    };
+  }
+  return { flagged: false, condition: 'camp-before-learning' };
+}
+
+// ── 5. Coin Misunderstanding ────────────────────────────────────────
+
+/**
+ * Detect parents misunderstanding Hero Coins (support reports mentioning coin-related keywords).
+ *
+ * @param {{ supportReports: Array<{ text: string }>, keyword?: string }} params
+ * @returns {{ flagged: boolean, condition: string, severity?: string, detail?: string, recommendation?: string }}
+ */
+export function detectCoinMisunderstanding(params) {
+  if (params == null || typeof params !== 'object') {
+    return { flagged: false, condition: 'coin-misunderstanding' };
+  }
+  const { supportReports, keyword = 'coins' } = params;
+  if (!Array.isArray(supportReports) || supportReports.length === 0) {
+    return { flagged: false, condition: 'coin-misunderstanding' };
+  }
+  const lowerKeyword = keyword.toLowerCase();
+  const matches = supportReports.filter(
+    (r) => r && typeof r.text === 'string' && r.text.toLowerCase().includes(lowerKeyword)
+  );
+  if (matches.length > 0) {
+    return {
+      flagged: true,
+      condition: 'coin-misunderstanding',
+      severity: 'warning',
+      detail: `${matches.length} support report(s) mention "${keyword}"`,
+      recommendation: 'Review parent-facing coin explainer copy — clarify that Hero Coins are virtual with no monetary value',
+    };
+  }
+  return { flagged: false, condition: 'coin-misunderstanding' };
+}
+
+// ── 6. Telemetry Blind Spots ────────────────────────────────────────
+
+/**
+ * Detect telemetry blind spots (expected signals not being received).
+ *
+ * @param {{ expectedSignals: string[], actualSignals: string[] }} params
+ * @returns {{ flagged: boolean, condition: string, severity?: string, detail?: string, recommendation?: string }}
+ */
+export function detectTelemetryBlindSpots(params) {
+  if (params == null || typeof params !== 'object') {
+    return { flagged: false, condition: 'telemetry-blind-spots' };
+  }
+  const { expectedSignals, actualSignals } = params;
+  if (!Array.isArray(expectedSignals) || !Array.isArray(actualSignals)) {
+    return { flagged: false, condition: 'telemetry-blind-spots' };
+  }
+  const actualSet = new Set(actualSignals);
+  const missing = expectedSignals.filter((s) => !actualSet.has(s));
+  if (missing.length > 0) {
+    return {
+      flagged: true,
+      condition: 'telemetry-blind-spots',
+      severity: 'warning',
+      detail: `${missing.length} expected signal(s) not received: ${missing.join(', ')}`,
+      recommendation: 'Instrument missing telemetry events before widening cohort — blind spots prevent incident detection',
+    };
+  }
+  return { flagged: false, condition: 'telemetry-blind-spots' };
+}
+
+// ── 7. Subject Dominance ────────────────────────────────────────────
+
+/**
+ * Detect one subject dominating the schedule (imbalanced quest distribution).
+ *
+ * @param {{ subjectMix: Record<string, number>, dominanceThreshold?: number }} params
+ * @returns {{ flagged: boolean, condition: string, severity?: string, detail?: string, recommendation?: string }}
+ */
+export function detectSubjectDominance(params) {
+  if (params == null || typeof params !== 'object') {
+    return { flagged: false, condition: 'subject-dominance' };
+  }
+  const { subjectMix, dominanceThreshold = 0.7 } = params;
+  if (!subjectMix || typeof subjectMix !== 'object') {
+    return { flagged: false, condition: 'subject-dominance' };
+  }
+  const entries = Object.entries(subjectMix);
+  if (entries.length === 0) {
+    return { flagged: false, condition: 'subject-dominance' };
+  }
+  const total = entries.reduce((sum, [, count]) => sum + count, 0);
+  if (total <= 0) {
+    return { flagged: false, condition: 'subject-dominance' };
+  }
+  for (const [subject, count] of entries) {
+    const share = count / total;
+    if (share >= dominanceThreshold) {
+      return {
+        flagged: true,
+        condition: 'subject-dominance',
+        severity: 'warning',
+        detail: `"${subject}" accounts for ${(share * 100).toFixed(1)}% of scheduled quests (threshold=${(dominanceThreshold * 100).toFixed(1)}%)`,
+        recommendation: 'Review scheduler weighting — ensure variety across subjects to maintain engagement',
+      };
+    }
+  }
+  return { flagged: false, condition: 'subject-dominance' };
+}
+
+// ── 8. Support Cluster ──────────────────────────────────────────────
+
+/**
+ * Detect support questions clustering around one area (single category dominates).
+ *
+ * @param {{ supportCategories: Record<string, number>, clusterThreshold?: number }} params
+ * @returns {{ flagged: boolean, condition: string, severity?: string, detail?: string, recommendation?: string }}
+ */
+export function detectSupportCluster(params) {
+  if (params == null || typeof params !== 'object') {
+    return { flagged: false, condition: 'support-cluster' };
+  }
+  const { supportCategories, clusterThreshold = 0.5 } = params;
+  if (!supportCategories || typeof supportCategories !== 'object') {
+    return { flagged: false, condition: 'support-cluster' };
+  }
+  const entries = Object.entries(supportCategories);
+  if (entries.length === 0) {
+    return { flagged: false, condition: 'support-cluster' };
+  }
+  const total = entries.reduce((sum, [, count]) => sum + count, 0);
+  if (total <= 0) {
+    return { flagged: false, condition: 'support-cluster' };
+  }
+  for (const [category, count] of entries) {
+    const share = count / total;
+    if (share > clusterThreshold) {
+      return {
+        flagged: true,
+        condition: 'support-cluster',
+        severity: 'warning',
+        detail: `"${category}" accounts for ${(share * 100).toFixed(1)}% of support queries (threshold=${(clusterThreshold * 100).toFixed(1)}%)`,
+        recommendation: `Investigate "${category}" support cluster — may indicate UX confusion or missing documentation`,
+      };
+    }
+  }
+  return { flagged: false, condition: 'support-cluster' };
+}
+
+// ── 9. Slow Performance ─────────────────────────────────────────────
+
+/**
+ * Detect performance slower than ideal but not failing (latency warning).
+ *
+ * @param {{ latencyMs: number, threshold?: number }} params
+ * @returns {{ flagged: boolean, condition: string, severity?: string, detail?: string, recommendation?: string }}
+ */
+export function detectSlowPerformance(params) {
+  if (params == null || typeof params !== 'object') {
+    return { flagged: false, condition: 'slow-performance' };
+  }
+  const { latencyMs, threshold = 2000 } = params;
+  if (latencyMs == null || typeof latencyMs !== 'number') {
+    return { flagged: false, condition: 'slow-performance' };
+  }
+  if (latencyMs >= threshold) {
+    return {
+      flagged: true,
+      condition: 'slow-performance',
+      severity: 'warning',
+      detail: `latency ${latencyMs}ms exceeds ${threshold}ms threshold`,
+      recommendation: 'Profile Hero critical path — check for unnecessary recomputation or unoptimised queries',
+    };
+  }
+  return { flagged: false, condition: 'slow-performance' };
+}
+
+// ── Convenience: Evaluate All Warnings ──────────────────────────────
+
+/**
+ * Run all 9 warning checks against cohort metrics and return only flagged results.
+ *
+ * @param {object} cohortMetrics — object with fields consumed by individual detectors
+ * @returns {Array<{ flagged: true, condition: string, severity: string, detail: string, recommendation: string }>}
+ */
+export function evaluateAllWarnings(cohortMetrics) {
+  if (!cohortMetrics || typeof cohortMetrics !== 'object') {
+    return [];
+  }
+  const checks = [
+    detectLowStartRate(cohortMetrics),
+    detectLowCompletionRate(cohortMetrics),
+    detectRepeatedAbandonment(cohortMetrics),
+    detectCampBeforeLearning(cohortMetrics),
+    detectCoinMisunderstanding(cohortMetrics),
+    detectTelemetryBlindSpots(cohortMetrics),
+    detectSubjectDominance(cohortMetrics),
+    detectSupportCluster(cohortMetrics),
+    detectSlowPerformance(cohortMetrics),
+  ];
+  return checks.filter((r) => r.flagged);
+}

--- a/skills/deliver/SKILL.md
+++ b/skills/deliver/SKILL.md
@@ -1,0 +1,312 @@
+---
+name: deliver
+description: "Autonomous end-to-end contract delivery pipeline. Use when the user provides a contract document (plan, spec, or requirements file) and wants full autonomous execution: planning, plan review, implementation via SDLC cycle with independent reviewers, 10-reviewer delivery validation, completion reporting, housekeeping, and knowledge compounding. Trigger when user says 'deliver this contract', 'deliver', '/deliver', 'execute this plan end-to-end', 'run the full delivery cycle', or provides a contract path expecting autonomous implementation. Requires a contract document path as input — rejects if none provided."
+---
+
+# Autonomous Contract Delivery
+
+Execute a full autonomous delivery pipeline for the contract at $ARGUMENTS.
+
+**Hard gate: if $ARGUMENTS is empty or does not point to a readable contract document, STOP immediately.** Say: "No contract provided. Usage: `/deliver path/to/contract.md`" and do nothing else.
+
+---
+
+## Pipeline
+
+```
+Contract (provided) ─── REJECT if missing
+    │
+    ▼
+/ce-plan ─── translate contract → implementation plan (autonomous, no questions)
+    │
+    ▼
+Plan Review ─── 3 independent reviewers validate plan vs contract (all must PASS)
+    │
+    ▼
+Commit & merge plan PR (doc-only, CI auto-pass)
+    │
+    ▼
+/ce-worktree ─── create isolated worktree for this contract (no questions)
+    │
+    ▼
+/ce-work ─── execute full delivery inside the worktree:
+    │         ├── SDLC cycle (per unit: worker → reviewers → follower → merge)
+    │         ├── Delivery cycle (10 contract reviewers, iterate until all PASS)
+    │         └── Completion report (comprehensive .md, PR merged to main)
+    │
+    ▼
+Housekeeping ─── remove worktree, delete local branches, prune remote refs
+    │
+    ▼
+/compound-engineering:ce-compound ─── document solved problem
+    │
+    ▼
+/dream ─── consolidate session learnings into memory (if available)
+    │
+    ▼
+DONE
+```
+
+---
+
+## Phase 0: Contract Validation
+
+1. Read $ARGUMENTS as a file path. If the file does not exist, STOP.
+2. Read the contract in full.
+3. Confirm it contains: scope, goals/requirements, acceptance criteria or gates.
+4. If the contract is malformed or empty, STOP with: "Contract at <path> is unreadable or has no requirements."
+5. Rename the session to the contract filename (without extension): `/rename <contract-filename>`
+   - e.g., for `grammar-qg-p11.md` → `/rename grammar-qg-p11`
+
+---
+
+## Phase 1: Plan (`/ce-plan`)
+
+Invoke `/ce-plan` with these overrides to its default behaviour:
+
+### Input to `/ce-plan`
+
+Pass the full contract content as the planning input. Add this preamble:
+
+```
+You are planning the autonomous delivery of this contract. Rules:
+
+1. The plan MUST deliver 100% of the contract. No fallbacks, no "stretch goals", no "nice to have". Every stated requirement becomes a planned unit of work.
+
+2. Do NOT ask questions. The contract is complete and organised. If a requirement is ambiguous, interpret it in the way that delivers the most value while remaining safe.
+
+3. Convert any non-agent workflow to autonomous equivalents:
+   - "Run a cohort of real accounts for 5 days" → create test fixtures/mocks that simulate multi-day cohort data, generate synthetic evidence, write validation tests that prove the system would behave correctly under real cohort conditions
+   - "Manual QA by a team member" → automated test suites + browser testing + validation scripts
+   - "Get sign-off from stakeholder" → delivery cycle reviewers validate against contract gates
+   - "Observe production for N days" → time-simulation tests, state-machine coverage, date-key rollover tests
+
+4. The ONLY items that remain non-autonomous are those requiring:
+   - Physical hardware the agent cannot access
+   - Third-party credentials not available in the environment
+   - Legal/compliance sign-off that requires a named human
+   Flag these as "DEFERRED: requires human" with clear explanation.
+
+5. Structure the plan as ordered units of work, each independently PR-able.
+
+6. Each unit must specify: files to create/modify, tests to write, acceptance criteria derived from the contract.
+```
+
+### Behaviour
+
+- `/ce-plan` runs to completion without asking questions
+- The plan is saved to the contract's directory as `<contract-name>-plan.md`
+- If `/ce-plan` attempts to ask a question, override: "Decide autonomously based on the contract. Do not ask."
+
+---
+
+## Phase 1.5: Plan Review (3 independent reviewers)
+
+After `/ce-plan` completes, validate the plan against the contract before any implementation begins.
+
+### Reviewer Panel (3 independent subagents)
+
+Spawn 3 independent subagent reviewers in parallel. Each validates whether the plan faithfully delivers the contract:
+
+1. **Contract Completeness Reviewer** — every contract requirement maps to at least one plan unit; nothing is dropped, softened, or deferred without "DEFERRED: requires human" justification
+2. **Feasibility & Ordering Reviewer** — units are correctly ordered (dependencies respected), each unit is independently PR-able, file paths and acceptance criteria are specific and actionable
+3. **Autonomous Conversion Reviewer** — non-agent workflows are converted to autonomous equivalents that genuinely validate the same concerns (not just skipped or trivialised)
+
+### Protocol
+
+Each reviewer:
+- Reads the **original contract** in full
+- Reads the **generated plan** in full
+- Returns: PASS or BLOCK (with specific findings and suggested fixes)
+
+### Gate
+
+ALL 3 reviewers must PASS. If any blocks:
+1. Collect all blocking findings
+2. Revise the plan directly (fix the plan document, not the code)
+3. Re-invite ALL 3 reviewers on the revised plan
+4. Repeat until all 3 simultaneously PASS
+
+### Commit the agreed plan
+
+Once all 3 reviewers pass:
+1. Commit the plan file: `git add <plan-file> && git commit -m "docs(<contract-slug>): agreed implementation plan"`
+2. Push and create a doc-only PR (CI will auto-pass for docs)
+3. Merge the plan PR immediately (doc-only, CI green by default)
+4. `git fetch origin` to sync
+
+---
+
+## Phase 2: Worktree (`/ce-worktree`)
+
+Invoke `/ce-worktree` after the plan PR is merged.
+
+### Behaviour
+
+- No questions asked — create the worktree with a branch name derived from the contract (e.g., `feat/hero-pA2-delivery` or `feat/<contract-slug>`)
+- The worktree is where ALL implementation happens
+- The main repo checkout remains untouched on its current branch
+
+---
+
+## Phase 3: Work (`/ce-work`)
+
+Invoke `/ce-work` inside the worktree with the generated plan. `/ce-work` executes the full delivery lifecycle:
+
+### 3A — SDLC Cycle (per unit of work)
+
+For each unit in the plan, execute this pipeline:
+
+```
+Worker (subagent in worktree)
+  → implement + tests + commit + push + open PR
+  → Worker rules:
+    - "Your output MUST include a valid PR URL."
+    - "Do not use git stash."
+    - "Include 'Plan Deviations' in PR body if you deviate."
+    - For UI/UX units: invoke /ce-frontend-design
+
+Reviewers (parallel independent subagents)
+  → Always-on: ce-correctness-reviewer, ce-maintainability-reviewer,
+    ce-testing-reviewer, ce-project-standards-reviewer
+  → Conditional: ce-security-reviewer, ce-performance-reviewer,
+    ce-reliability-reviewer, ce-data-migrations-reviewer
+  → Each returns: APPROVE or BLOCKING (with findings)
+
+Review Follower (if any BLOCKING)
+  → git pull origin <branch> first
+  → Address all blocking findings
+  → Push fixes
+  → Re-dispatch ALL reviewers (not just blockers)
+  → Repeat until zero blockers
+
+Merge Gate
+  → gh pr checks must all pass
+  → gh pr merge --squash --delete-branch
+  → git fetch origin
+  → Next unit
+```
+
+### 3B — Delivery Cycle (10 contract reviewers)
+
+After ALL SDLC units merged, spawn 10 independent subagent reviewers. Each validates the **entire contract** at the highest standard:
+
+1. **Functional Completeness** — every requirement implemented
+2. **Test Coverage** — all acceptance criteria have tests
+3. **Code Quality** — maintainability, naming, structure
+4. **Architecture Alignment** — matches codebase conventions
+5. **Security & Safety** — no vulnerabilities, safe defaults
+6. **Performance** — no regressions, efficient
+7. **UX/UI Fidelity** — (if applicable) design intent met
+8. **Documentation** — self-documenting, complex logic explained
+9. **Edge Cases & Error Handling** — boundaries covered
+10. **Integration & Regression** — no side effects
+
+**Protocol:**
+- Each reviewer reads the original contract AND the current codebase state
+- Returns: PASS or BLOCK (with specific, actionable findings)
+- If ANY blocks: collect findings → SDLC cycle for fixes → re-invite ALL 10 reviewers
+- On re-review rounds, reviewers evaluate the ENTIRE contract again (new blockers valid)
+- **Delivered** when all 10 simultaneously PASS
+
+### 3C — Completion Report
+
+After delivery confirmed:
+
+1. Write comprehensive report as `<contract-name>-completion-report.md`
+2. Place in the same folder as the original contract
+3. Content:
+   - Executive summary
+   - Contract requirements vs delivery mapping (full checklist)
+   - All PRs with URLs and descriptions
+   - Architecture decisions
+   - Test coverage summary
+   - Reviewer rounds (iterations, what was caught, what was fixed)
+   - Metrics: PRs, commits, review iterations
+   - Insights and learnings
+   - Deferred items (human-required only)
+4. Commit, push, create PR, merge when CI green
+
+---
+
+## Phase 4: Housekeeping
+
+After the completion report PR is merged, clean up all delivery artefacts:
+
+### 4.1 — Remove the worktree
+
+```bash
+git worktree remove <worktree-path> --force
+```
+
+If the worktree has already been removed by squash-merge branch deletion, just prune:
+
+```bash
+git worktree prune
+```
+
+### 4.2 — Delete local branches
+
+Delete all local branches created during this delivery (feature branches, fix branches, report branch). They have already been squash-merged so no work is lost:
+
+```bash
+git branch -d <branch-name>
+```
+
+If `-d` refuses (not fully merged due to squash), use `-D` — the PR merge confirms the work landed.
+
+### 4.3 — Prune remote tracking refs
+
+```bash
+git fetch origin --prune
+```
+
+This removes local tracking references for remote branches already deleted by `--delete-branch` during PR merges.
+
+### 4.4 — Verify clean state
+
+Confirm:
+- `git worktree list` shows only the main worktree
+- `git branch` shows no delivery-related branches
+- `git status` on main is clean
+- Main checkout remains on the same branch it started on
+
+If any of these fail, fix before proceeding.
+
+---
+
+## Phase 5: Compound (`/compound-engineering:ce-compound`)
+
+Invoke `/compound-engineering:ce-compound` after housekeeping. Use all default/recommended settings. Run autonomously — document the solved problem to compound team knowledge.
+
+---
+
+## Phase 6: Dream (`/dream`)
+
+If `/dream` is available, invoke it. Consolidate session learnings into persistent memory.
+
+---
+
+## Orchestrator Rules
+
+- You are the **scrum master**. Coordinate, never implement.
+- Preserve your token context — delegate to subagents via the skill chain.
+- Do NOT ask the user questions. The contract is the source of truth.
+- Report progress only at phase transitions: "Phase 1 complete. Phase 2 starting."
+- Stop ONLY when all phases complete (Phase 6, or Phase 5 if `/dream` unavailable).
+- If truly stuck (missing credentials, environment broken), report the blocker and stop.
+
+## No-Regression Guarantees
+
+- Never change branch on the main repo path
+- Merge only when CI/build is green
+- The worktree isolates all work from the main checkout
+- If regression detected, halt and fix before continuing
+
+## Error Recovery
+
+- **Worker cannot push**: check permissions, branch, remote. Re-dispatch.
+- **CI failing**: read logs, identify root cause, dispatch fix.
+- **Reviewer loop (3+ iterations same finding)**: escalate to user.
+- **Merge conflict**: rebase on latest main, resolve, re-run CI.
+- **Skill unavailable**: skip gracefully, note in report.

--- a/tests/hero-pA4-browser-smoke.test.js
+++ b/tests/hero-pA4-browser-smoke.test.js
@@ -1,0 +1,544 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  STEPS,
+  validateStep,
+  parseArgs,
+} from '../scripts/hero-pA4-external-cohort-smoke.mjs';
+
+// ── Mock data factories ───────────────────────────────────────────────
+
+function makeReadModelVisible() {
+  return {
+    version: 6,
+    mode: 'progress',
+    ui: { enabled: true, surface: 'dashboard-card', reason: 'enabled', copyVersion: 'v2' },
+    dailyQuest: {
+      questId: 'quest-abc',
+      status: 'active',
+      effortTarget: 3,
+      effortPlanned: 3,
+      tasks: [
+        {
+          taskId: 'task-001',
+          subjectId: 'grammar',
+          intent: 'practice',
+          launcher: 'session-launcher',
+          effortTarget: 1,
+          completionStatus: 'not-started',
+          launchStatus: 'launchable',
+          heroContext: { source: 'hero-mode', questId: 'quest-abc', taskId: 'task-001' },
+        },
+      ],
+    },
+    questFingerprint: 'fp-12345',
+    dateKey: '2026-04-30',
+    pendingCompletedHeroSession: null,
+    economy: { enabled: true, version: 1, balance: 200, lifetimeEarned: 200, lifetimeSpent: 0 },
+    camp: {
+      enabled: true,
+      version: 1,
+      monsters: [
+        { monsterId: 'spark', displayName: 'Spark', owned: true, stage: 1 },
+        { monsterId: 'blaze', displayName: 'Blaze', owned: false, stage: 0 },
+      ],
+      selectedMonsterId: 'spark',
+    },
+    progress: { enabled: true, canClaim: false, pendingClaimTaskId: null },
+  };
+}
+
+function makeStartTaskResponse() {
+  return {
+    heroLaunch: {
+      version: 2,
+      status: 'started',
+      questId: 'quest-abc',
+      taskId: 'task-001',
+      dateKey: '2026-04-30',
+      subjectId: 'grammar',
+      intent: 'practice',
+      launcher: 'session-launcher',
+      effortTarget: 1,
+      subjectCommand: 'start-session',
+      coinsEnabled: true,
+      claimEnabled: true,
+      childVisible: true,
+    },
+  };
+}
+
+function makeReturnReadModel() {
+  const model = makeReadModelVisible();
+  model.pendingCompletedHeroSession = {
+    taskId: 'task-001',
+    questId: 'quest-abc',
+    questFingerprint: 'fp-12345',
+    subjectId: 'grammar',
+    practiceSessionId: 'ps-999',
+  };
+  model.progress.canClaim = true;
+  model.progress.pendingClaimTaskId = 'task-001';
+  return model;
+}
+
+function makeClaimResponse() {
+  return {
+    award: {
+      status: 'granted',
+      taskId: 'task-001',
+      questId: 'quest-abc',
+      coins: 100,
+      ledgerEntryId: 'le-001',
+    },
+  };
+}
+
+function makePostClaimReadModel() {
+  const model = makeReadModelVisible();
+  model.economy.balance = 300; // increased from 200 by 100
+  model.pendingCompletedHeroSession = null;
+  return model;
+}
+
+function makeRollbackResponse() {
+  return {
+    error: 'Hero shadow read model is not available.',
+    code: 'hero_shadow_disabled',
+  };
+}
+
+// ── Step list ─────────────────────────────────────────────────────────
+
+describe('pA4 browser smoke: STEPS constant', () => {
+  it('exports all 8 critical flow steps', () => {
+    assert.equal(STEPS.length, 8);
+    assert.deepEqual(STEPS, [
+      'hero-visible',
+      'start-task',
+      'subject-session',
+      'return-from-session',
+      'claim',
+      'coins',
+      'camp',
+      'rollback-hidden',
+    ]);
+  });
+});
+
+// ── Individual step validators ────────────────────────────────────────
+
+describe('pA4 browser smoke: hero-visible step', () => {
+  it('passes when ui.enabled is true', () => {
+    const result = validateStep('hero-visible', makeReadModelVisible());
+    assert.equal(result.pass, true);
+    assert.ok(result.detail.includes('ui.enabled=true'));
+  });
+
+  it('fails when ui.enabled is false', () => {
+    const model = makeReadModelVisible();
+    model.ui.enabled = false;
+    model.ui.reason = 'shadow-disabled';
+    const result = validateStep('hero-visible', model);
+    assert.equal(result.pass, false);
+    assert.ok(result.detail.includes('shadow-disabled'));
+  });
+
+  it('fails on null response', () => {
+    const result = validateStep('hero-visible', null);
+    assert.equal(result.pass, false);
+  });
+
+  it('fails on API error response', () => {
+    const result = validateStep('hero-visible', { error: 'HTTP 500' });
+    assert.equal(result.pass, false);
+    assert.ok(result.detail.includes('API error'));
+  });
+
+  it('non-cohort account: correctly reports hero not visible', () => {
+    const model = makeReadModelVisible();
+    model.ui.enabled = false;
+    model.ui.reason = 'no-eligible-subjects';
+    const result = validateStep('hero-visible', model, { expectHidden: true });
+    assert.equal(result.pass, true);
+    assert.ok(result.detail.includes('not visible'));
+  });
+
+  it('non-cohort account: fails if hero IS visible', () => {
+    const model = makeReadModelVisible();
+    const result = validateStep('hero-visible', model, { expectHidden: true });
+    assert.equal(result.pass, false);
+  });
+});
+
+describe('pA4 browser smoke: start-task step', () => {
+  it('passes with valid heroLaunch response', () => {
+    const result = validateStep('start-task', makeStartTaskResponse());
+    assert.equal(result.pass, true);
+    assert.ok(result.detail.includes('task-001'));
+  });
+
+  it('fails when heroLaunch is missing', () => {
+    const result = validateStep('start-task', { ok: true });
+    assert.equal(result.pass, false);
+    assert.ok(result.detail.includes('Missing heroLaunch'));
+  });
+
+  it('fails when heroLaunch lacks questId', () => {
+    const resp = makeStartTaskResponse();
+    resp.heroLaunch.questId = '';
+    const result = validateStep('start-task', resp);
+    assert.equal(result.pass, false);
+  });
+
+  it('fails on API error', () => {
+    const result = validateStep('start-task', { error: 'HTTP 409' });
+    assert.equal(result.pass, false);
+  });
+});
+
+describe('pA4 browser smoke: subject-session step', () => {
+  it('passes when subjectId and subjectCommand present', () => {
+    const result = validateStep('subject-session', makeStartTaskResponse());
+    assert.equal(result.pass, true);
+    assert.ok(result.detail.includes('grammar'));
+    assert.ok(result.detail.includes('start-session'));
+  });
+
+  it('fails when subjectId missing', () => {
+    const resp = makeStartTaskResponse();
+    resp.heroLaunch.subjectId = '';
+    const result = validateStep('subject-session', resp);
+    assert.equal(result.pass, false);
+  });
+
+  it('fails when subjectCommand missing', () => {
+    const resp = makeStartTaskResponse();
+    resp.heroLaunch.subjectCommand = '';
+    const result = validateStep('subject-session', resp);
+    assert.equal(result.pass, false);
+  });
+
+  it('dead CTA: fails when heroLaunch absent', () => {
+    const result = validateStep('subject-session', {});
+    assert.equal(result.pass, false);
+    assert.ok(result.detail.includes('Missing heroLaunch'));
+  });
+});
+
+describe('pA4 browser smoke: return-from-session step', () => {
+  it('passes when pendingCompletedHeroSession present', () => {
+    const result = validateStep('return-from-session', makeReturnReadModel());
+    assert.equal(result.pass, true);
+    assert.ok(result.detail.includes('task-001'));
+  });
+
+  it('fails when pendingCompletedHeroSession is null', () => {
+    const model = makeReadModelVisible();
+    model.pendingCompletedHeroSession = null;
+    const result = validateStep('return-from-session', model);
+    assert.equal(result.pass, false);
+  });
+
+  it('fails on API error', () => {
+    const result = validateStep('return-from-session', { error: 'Timeout after 15s' });
+    assert.equal(result.pass, false);
+  });
+});
+
+describe('pA4 browser smoke: claim step', () => {
+  it('passes when award is granted', () => {
+    const result = validateStep('claim', makeClaimResponse());
+    assert.equal(result.pass, true);
+    assert.ok(result.detail.includes('granted'));
+  });
+
+  it('fails when claim is rejected', () => {
+    const result = validateStep('claim', {
+      award: { status: 'rejected', reason: 'duplicate-claim' },
+    });
+    assert.equal(result.pass, false);
+    assert.ok(result.detail.includes('rejected'));
+  });
+
+  it('fails when no award in response', () => {
+    const result = validateStep('claim', { ok: true });
+    assert.equal(result.pass, false);
+  });
+
+  it('accepts claimResult as alternative to award', () => {
+    const result = validateStep('claim', {
+      claimResult: { status: 'ok', coins: 100 },
+    });
+    assert.equal(result.pass, true);
+  });
+});
+
+describe('pA4 browser smoke: coins step', () => {
+  it('passes when balance increased by 100', () => {
+    const result = validateStep('coins', makePostClaimReadModel(), { previousBalance: 200 });
+    assert.equal(result.pass, true);
+    assert.ok(result.detail.includes('300'));
+  });
+
+  it('fails when balance did not increase', () => {
+    const model = makePostClaimReadModel();
+    model.economy.balance = 200; // no increase
+    const result = validateStep('coins', model, { previousBalance: 200 });
+    assert.equal(result.pass, false);
+    assert.ok(result.detail.includes('did not increase'));
+  });
+
+  it('fails when economy block missing', () => {
+    const model = makeReadModelVisible();
+    delete model.economy;
+    const result = validateStep('coins', model, { previousBalance: 0 });
+    assert.equal(result.pass, false);
+  });
+
+  it('uses 0 as default previousBalance', () => {
+    const model = makePostClaimReadModel();
+    model.economy.balance = 100;
+    const result = validateStep('coins', model, {});
+    assert.equal(result.pass, true);
+  });
+});
+
+describe('pA4 browser smoke: camp step', () => {
+  it('passes when camp.monsters is present and non-empty', () => {
+    const result = validateStep('camp', makePostClaimReadModel(), { campEnabled: true });
+    assert.equal(result.pass, true);
+    assert.ok(result.detail.includes('2 monster'));
+  });
+
+  it('fails when camp block is missing', () => {
+    const model = makePostClaimReadModel();
+    delete model.camp;
+    const result = validateStep('camp', model, { campEnabled: true });
+    assert.equal(result.pass, false);
+  });
+
+  it('fails when camp.monsters is empty', () => {
+    const model = makePostClaimReadModel();
+    model.camp.monsters = [];
+    const result = validateStep('camp', model, { campEnabled: true });
+    assert.equal(result.pass, false);
+  });
+
+  it('passes when camp disabled and camp block absent (flag off)', () => {
+    const model = makePostClaimReadModel();
+    delete model.camp;
+    const result = validateStep('camp', model, { campEnabled: false });
+    assert.equal(result.pass, true);
+    assert.ok(result.detail.includes('skipped'));
+  });
+
+  it('passes when camp disabled and camp.enabled=false', () => {
+    const model = makePostClaimReadModel();
+    model.camp = { enabled: false };
+    const result = validateStep('camp', model, { campEnabled: false });
+    assert.equal(result.pass, true);
+  });
+});
+
+describe('pA4 browser smoke: rollback-hidden step', () => {
+  it('passes with hero_shadow_disabled error code (flags off)', () => {
+    const result = validateStep('rollback-hidden', makeRollbackResponse());
+    assert.equal(result.pass, true);
+    assert.ok(result.detail.includes('hero_shadow_disabled'));
+  });
+
+  it('passes when ui.enabled=false (flags off)', () => {
+    const model = makeReadModelVisible();
+    model.ui.enabled = false;
+    const result = validateStep('rollback-hidden', model);
+    assert.equal(result.pass, true);
+    assert.ok(result.detail.includes('hidden'));
+  });
+
+  it('fails when hero is still visible (flags off regression)', () => {
+    const result = validateStep('rollback-hidden', makeReadModelVisible());
+    assert.equal(result.pass, false);
+    assert.ok(result.detail.includes('still visible'));
+  });
+
+  it('passes on generic API error (e.g. 404)', () => {
+    const result = validateStep('rollback-hidden', { error: 'HTTP 404', code: 'not_found' });
+    assert.equal(result.pass, true);
+  });
+});
+
+// ── Full flow simulation ──────────────────────────────────────────────
+
+describe('pA4 browser smoke: full flow all-pass', () => {
+  it('all 8 steps pass with correctly mocked data', () => {
+    const results = [];
+
+    // Step 1: hero-visible
+    results.push({ step: 'hero-visible', ...validateStep('hero-visible', makeReadModelVisible()) });
+
+    // Step 2: start-task
+    results.push({ step: 'start-task', ...validateStep('start-task', makeStartTaskResponse()) });
+
+    // Step 3: subject-session
+    results.push({ step: 'subject-session', ...validateStep('subject-session', makeStartTaskResponse()) });
+
+    // Step 4: return-from-session
+    results.push({ step: 'return-from-session', ...validateStep('return-from-session', makeReturnReadModel()) });
+
+    // Step 5: claim
+    results.push({ step: 'claim', ...validateStep('claim', makeClaimResponse()) });
+
+    // Step 6: coins
+    results.push({ step: 'coins', ...validateStep('coins', makePostClaimReadModel(), { previousBalance: 200 }) });
+
+    // Step 7: camp
+    results.push({ step: 'camp', ...validateStep('camp', makePostClaimReadModel(), { campEnabled: true }) });
+
+    // Step 8: rollback-hidden
+    results.push({ step: 'rollback-hidden', ...validateStep('rollback-hidden', makeRollbackResponse()) });
+
+    assert.equal(results.length, 8);
+    assert.ok(results.every(r => r.pass), `Some steps failed: ${results.filter(r => !r.pass).map(r => r.step).join(', ')}`);
+
+    // Simulated exit code
+    const exitCode = results.every(r => r.pass) ? 0 : 1;
+    assert.equal(exitCode, 0);
+  });
+});
+
+describe('pA4 browser smoke: partial failure (dead CTA)', () => {
+  it('subject-session failure produces exit code 1', () => {
+    const results = [];
+
+    // Steps 1-2 pass
+    results.push({ step: 'hero-visible', ...validateStep('hero-visible', makeReadModelVisible()) });
+    results.push({ step: 'start-task', ...validateStep('start-task', makeStartTaskResponse()) });
+
+    // Step 3: dead CTA — heroLaunch has no subjectCommand
+    const deadCta = makeStartTaskResponse();
+    deadCta.heroLaunch.subjectCommand = '';
+    results.push({ step: 'subject-session', ...validateStep('subject-session', deadCta) });
+
+    const exitCode = results.every(r => r.pass) ? 0 : 1;
+    assert.equal(exitCode, 1);
+    assert.equal(results[2].pass, false);
+    assert.ok(results[2].detail.includes('launcher info missing'));
+  });
+});
+
+describe('pA4 browser smoke: external cohort account (overrideStatus=external)', () => {
+  it('flow works for external cohort account when hero is visible', () => {
+    // External cohort accounts still get ui.enabled=true via per-account override
+    const model = makeReadModelVisible();
+    const result = validateStep('hero-visible', model);
+    assert.equal(result.pass, true);
+  });
+
+  it('start-task works for external cohort account', () => {
+    const result = validateStep('start-task', makeStartTaskResponse());
+    assert.equal(result.pass, true);
+  });
+
+  it('full flow passes for external cohort', () => {
+    const steps = [
+      validateStep('hero-visible', makeReadModelVisible()),
+      validateStep('start-task', makeStartTaskResponse()),
+      validateStep('subject-session', makeStartTaskResponse()),
+      validateStep('return-from-session', makeReturnReadModel()),
+      validateStep('claim', makeClaimResponse()),
+      validateStep('coins', makePostClaimReadModel(), { previousBalance: 200 }),
+      validateStep('camp', makePostClaimReadModel(), { campEnabled: true }),
+      validateStep('rollback-hidden', makeRollbackResponse()),
+    ];
+    assert.ok(steps.every(r => r.pass));
+  });
+});
+
+describe('pA4 browser smoke: non-cohort account', () => {
+  it('step 1 correctly reports hero not visible', () => {
+    const model = makeReadModelVisible();
+    model.ui.enabled = false;
+    model.ui.reason = 'no-eligible-subjects';
+    const result = validateStep('hero-visible', model, { expectHidden: true });
+    assert.equal(result.pass, true);
+    assert.ok(result.detail.includes('not visible'));
+  });
+
+  it('non-cohort without expectHidden context fails step 1', () => {
+    const model = makeReadModelVisible();
+    model.ui.enabled = false;
+    model.ui.reason = 'shadow-disabled';
+    const result = validateStep('hero-visible', model);
+    assert.equal(result.pass, false);
+  });
+});
+
+describe('pA4 browser smoke: rollback (all flags off)', () => {
+  it('step 8 correctly reports hidden when hero_shadow_disabled returned', () => {
+    const result = validateStep('rollback-hidden', {
+      error: 'Hero shadow read model is not available.',
+      code: 'hero_shadow_disabled',
+    });
+    assert.equal(result.pass, true);
+    assert.ok(result.detail.includes('hero_shadow_disabled'));
+  });
+
+  it('step 8 correctly reports hidden when ui.enabled=false', () => {
+    const result = validateStep('rollback-hidden', {
+      ui: { enabled: false, reason: 'shadow-disabled' },
+    });
+    assert.equal(result.pass, true);
+  });
+
+  it('step 8 fails if hero still visible after rollback', () => {
+    const result = validateStep('rollback-hidden', makeReadModelVisible());
+    assert.equal(result.pass, false);
+  });
+});
+
+// ── Unknown step ──────────────────────────────────────────────────────
+
+describe('pA4 browser smoke: unknown step', () => {
+  it('returns fail for unknown step name', () => {
+    const result = validateStep('nonexistent-step', {});
+    assert.equal(result.pass, false);
+    assert.ok(result.detail.includes('Unknown step'));
+  });
+});
+
+// ── parseArgs ─────────────────────────────────────────────────────────
+
+describe('pA4 browser smoke: parseArgs', () => {
+  it('defaults base-url to http://localhost:8787', () => {
+    const args = parseArgs(['node', 'script.mjs']);
+    assert.equal(args.baseUrl, 'http://localhost:8787');
+    assert.equal(args.accountId, '');
+  });
+
+  it('--account-id sets accountId', () => {
+    const args = parseArgs(['node', 'script.mjs', '--account-id', 'acc-ext-123']);
+    assert.equal(args.accountId, 'acc-ext-123');
+  });
+
+  it('--account-id= form works', () => {
+    const args = parseArgs(['node', 'script.mjs', '--account-id=acc-xyz']);
+    assert.equal(args.accountId, 'acc-xyz');
+  });
+
+  it('--base-url sets baseUrl', () => {
+    const args = parseArgs(['node', 'script.mjs', '--base-url', 'https://staging.example.com']);
+    assert.equal(args.baseUrl, 'https://staging.example.com');
+  });
+
+  it('--base-url strips trailing slash', () => {
+    const args = parseArgs(['node', 'script.mjs', '--base-url', 'http://localhost:8787/']);
+    assert.equal(args.baseUrl, 'http://localhost:8787');
+  });
+
+  it('--base-url= form works', () => {
+    const args = parseArgs(['node', 'script.mjs', '--base-url=http://custom:9000']);
+    assert.equal(args.baseUrl, 'http://custom:9000');
+  });
+});

--- a/tests/hero-pA4-external-cohort-resolver.test.js
+++ b/tests/hero-pA4-external-cohort-resolver.test.js
@@ -1,0 +1,239 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  resolveHeroFlagsForAccount,
+  resolveHeroFlagsWithOverride,
+  HERO_FLAG_KEYS,
+} from '../shared/hero/account-override.js';
+
+// ── Helper ────────────────────────────────────────────────────────────
+
+function allFlagsEnabled(env) {
+  return HERO_FLAG_KEYS.every(k => env[k] === 'true');
+}
+
+function noFlagsEnabled(env) {
+  return HERO_FLAG_KEYS.every(k => env[k] !== 'true');
+}
+
+// ── External cohort: account in HERO_EXTERNAL_ACCOUNTS ────────────────
+
+describe('resolveHeroFlagsForAccount: external cohort', () => {
+  it('account in HERO_EXTERNAL_ACCOUNTS enables all 6 flags with status external', () => {
+    const env = { HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['acc-ext-1', 'acc-ext-2']) };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'acc-ext-1' });
+
+    assert.equal(overrideStatus, 'external');
+    assert.ok(allFlagsEnabled(resolvedEnv));
+  });
+
+  it('preserves existing env bindings alongside forced flags', () => {
+    const env = {
+      HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['ext-1']),
+      OTHER_BINDING: 'keep-me',
+    };
+    const { resolvedEnv } = resolveHeroFlagsForAccount({ env, accountId: 'ext-1' });
+
+    assert.equal(resolvedEnv.OTHER_BINDING, 'keep-me');
+    assert.ok(allFlagsEnabled(resolvedEnv));
+  });
+});
+
+// ── Internal cohort: account in HERO_INTERNAL_ACCOUNTS ────────────────
+
+describe('resolveHeroFlagsForAccount: internal cohort', () => {
+  it('account in HERO_INTERNAL_ACCOUNTS enables all 6 flags with status internal', () => {
+    const env = { HERO_INTERNAL_ACCOUNTS: JSON.stringify(['acc-int-1']) };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'acc-int-1' });
+
+    assert.equal(overrideStatus, 'internal');
+    assert.ok(allFlagsEnabled(resolvedEnv));
+  });
+});
+
+// ── Neither list: global or none ──────────────────────────────────────
+
+describe('resolveHeroFlagsForAccount: neither list', () => {
+  it('account in neither list with no global flags returns status none', () => {
+    const env = {
+      HERO_INTERNAL_ACCOUNTS: JSON.stringify(['int-1']),
+      HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['ext-1']),
+    };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'unknown-acc' });
+
+    assert.equal(overrideStatus, 'none');
+    assert.ok(noFlagsEnabled(resolvedEnv));
+  });
+
+  it('account in neither list with a global flag enabled returns status global', () => {
+    const env = {
+      HERO_INTERNAL_ACCOUNTS: JSON.stringify(['int-1']),
+      HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['ext-1']),
+      HERO_MODE_SHADOW_ENABLED: 'true',
+    };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'unknown-acc' });
+
+    assert.equal(overrideStatus, 'global');
+    // Global flags unchanged — no additional flags forced
+    assert.equal(resolvedEnv.HERO_MODE_SHADOW_ENABLED, 'true');
+    assert.notEqual(resolvedEnv.HERO_MODE_CAMP_ENABLED, 'true');
+  });
+});
+
+// ── Precedence: both lists ────────────────────────────────────────────
+
+describe('resolveHeroFlagsForAccount: precedence', () => {
+  it('account in BOTH lists resolves as internal (internal takes precedence)', () => {
+    const env = {
+      HERO_INTERNAL_ACCOUNTS: JSON.stringify(['dual-acc']),
+      HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['dual-acc']),
+    };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'dual-acc' });
+
+    assert.equal(overrideStatus, 'internal');
+    assert.ok(allFlagsEnabled(resolvedEnv));
+  });
+});
+
+// ── HERO_EXTERNAL_ACCOUNTS edge cases ─────────────────────────────────
+
+describe('resolveHeroFlagsForAccount: HERO_EXTERNAL_ACCOUNTS edge cases', () => {
+  it('HERO_EXTERNAL_ACCOUNTS is null → skip gracefully', () => {
+    const env = { HERO_EXTERNAL_ACCOUNTS: null };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'acc-1' });
+
+    assert.equal(overrideStatus, 'none');
+    assert.ok(noFlagsEnabled(resolvedEnv));
+  });
+
+  it('HERO_EXTERNAL_ACCOUNTS is undefined → skip gracefully', () => {
+    const env = {};
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'acc-1' });
+
+    assert.equal(overrideStatus, 'none');
+    assert.ok(noFlagsEnabled(resolvedEnv));
+  });
+
+  it('HERO_EXTERNAL_ACCOUNTS is empty string → skip gracefully', () => {
+    const env = { HERO_EXTERNAL_ACCOUNTS: '' };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'acc-1' });
+
+    assert.equal(overrideStatus, 'none');
+    assert.ok(noFlagsEnabled(resolvedEnv));
+  });
+
+  it('HERO_EXTERNAL_ACCOUNTS is malformed JSON → fail closed (no override)', () => {
+    const env = { HERO_EXTERNAL_ACCOUNTS: '{not-valid-json' };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'acc-1' });
+
+    assert.equal(overrideStatus, 'none');
+    assert.ok(noFlagsEnabled(resolvedEnv));
+  });
+
+  it('HERO_EXTERNAL_ACCOUNTS is valid JSON but not array → fail closed', () => {
+    const env = { HERO_EXTERNAL_ACCOUNTS: JSON.stringify({ accounts: ['acc-1'] }) };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'acc-1' });
+
+    assert.equal(overrideStatus, 'none');
+    assert.ok(noFlagsEnabled(resolvedEnv));
+  });
+
+  it('HERO_EXTERNAL_ACCOUNTS is empty array → no override', () => {
+    const env = { HERO_EXTERNAL_ACCOUNTS: JSON.stringify([]) };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'acc-1' });
+
+    assert.equal(overrideStatus, 'none');
+    assert.ok(noFlagsEnabled(resolvedEnv));
+  });
+});
+
+// ── accountId edge cases ──────────────────────────────────────────────
+
+describe('resolveHeroFlagsForAccount: accountId edge cases', () => {
+  it('accountId is null → no override, status based on global flags', () => {
+    const env = {
+      HERO_INTERNAL_ACCOUNTS: JSON.stringify(['int-1']),
+      HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['ext-1']),
+    };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: null });
+
+    assert.equal(overrideStatus, 'none');
+    assert.ok(noFlagsEnabled(resolvedEnv));
+  });
+
+  it('accountId is undefined → no override', () => {
+    const env = {
+      HERO_INTERNAL_ACCOUNTS: JSON.stringify(['int-1']),
+      HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['ext-1']),
+    };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: undefined });
+
+    assert.equal(overrideStatus, 'none');
+    assert.ok(noFlagsEnabled(resolvedEnv));
+  });
+
+  it('accountId is empty string → no override', () => {
+    const env = {
+      HERO_INTERNAL_ACCOUNTS: JSON.stringify(['']),
+      HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['ext-1']),
+    };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: '' });
+
+    assert.equal(overrideStatus, 'none');
+    assert.ok(noFlagsEnabled(resolvedEnv));
+  });
+});
+
+// ── Backward compatibility: resolveHeroFlagsWithOverride ──────────────
+
+describe('resolveHeroFlagsWithOverride: backward compatibility', () => {
+  it('returns env-like object (not { resolvedEnv, overrideStatus })', () => {
+    const env = { HERO_INTERNAL_ACCOUNTS: JSON.stringify(['acc-1']) };
+    const result = resolveHeroFlagsWithOverride({ env, accountId: 'acc-1' });
+
+    // Must be a flat object, not wrapped
+    assert.equal(typeof result, 'object');
+    assert.equal(result.resolvedEnv, undefined);
+    assert.equal(result.overrideStatus, undefined);
+    assert.ok(allFlagsEnabled(result));
+  });
+
+  it('returns unchanged env when account not in internal list', () => {
+    const env = {
+      HERO_INTERNAL_ACCOUNTS: JSON.stringify(['acc-1']),
+      OTHER: 'val',
+    };
+    const result = resolveHeroFlagsWithOverride({ env, accountId: 'unknown' });
+
+    assert.equal(result.OTHER, 'val');
+    assert.ok(noFlagsEnabled(result));
+  });
+
+  it('returns unchanged env when HERO_INTERNAL_ACCOUNTS is malformed', () => {
+    const env = { HERO_INTERNAL_ACCOUNTS: 'not-json' };
+    const result = resolveHeroFlagsWithOverride({ env, accountId: 'acc-1' });
+
+    assert.ok(noFlagsEnabled(result));
+  });
+
+  it('returns unchanged env when HERO_INTERNAL_ACCOUNTS is null', () => {
+    const env = { HERO_INTERNAL_ACCOUNTS: null };
+    const result = resolveHeroFlagsWithOverride({ env, accountId: 'acc-1' });
+
+    assert.ok(noFlagsEnabled(result));
+  });
+
+  it('handles env being null/undefined gracefully', () => {
+    const result = resolveHeroFlagsWithOverride({ env: null, accountId: 'acc-1' });
+    assert.equal(typeof result, 'object');
+    assert.ok(noFlagsEnabled(result));
+  });
+
+  it('external account override also works via wrapper', () => {
+    const env = { HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['ext-1']) };
+    const result = resolveHeroFlagsWithOverride({ env, accountId: 'ext-1' });
+
+    assert.ok(allFlagsEnabled(result));
+  });
+});

--- a/tests/hero-pA4-metrics-infrastructure.test.js
+++ b/tests/hero-pA4-metrics-infrastructure.test.js
@@ -1,0 +1,244 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  REQUIRED_LAUNCH_METRICS,
+  REQUIRED_SAFETY_METRICS,
+  validateMetricsMapping,
+  formatExtractionRow,
+  preCohortResult,
+} from '../scripts/hero-pA4-metrics-validator.mjs';
+
+import { ALL_HERO_METRICS } from '../shared/hero/metrics-contract.js';
+
+// ── Launch metrics completeness ───────────────────────────────────────
+
+describe('REQUIRED_LAUNCH_METRICS', () => {
+  it('contains exactly 18 launch metrics', () => {
+    assert.equal(REQUIRED_LAUNCH_METRICS.length, 18);
+  });
+
+  it('each metric has a unique id', () => {
+    const ids = REQUIRED_LAUNCH_METRICS.map(m => m.id);
+    assert.equal(new Set(ids).size, 18);
+  });
+
+  it('each metric has a non-empty name', () => {
+    for (const m of REQUIRED_LAUNCH_METRICS) {
+      assert.ok(m.name && m.name.length > 0, `Metric ${m.id} missing name`);
+    }
+  });
+
+  it('each metric has a confidence classification (extractionSource)', () => {
+    const validSources = ['server-extractable', 'client-only', 'derived'];
+    for (const m of REQUIRED_LAUNCH_METRICS) {
+      assert.ok(
+        validSources.includes(m.extractionSource),
+        `Metric ${m.id} has invalid extractionSource: '${m.extractionSource}'`,
+      );
+    }
+  });
+
+  it('server-extractable metrics have a queryPattern', () => {
+    const serverMetrics = REQUIRED_LAUNCH_METRICS.filter(m => m.extractionSource === 'server-extractable');
+    for (const m of serverMetrics) {
+      assert.ok(m.queryPattern, `Server-extractable metric ${m.id} missing queryPattern`);
+    }
+  });
+
+  it('client-only metrics have null queryPattern', () => {
+    const clientMetrics = REQUIRED_LAUNCH_METRICS.filter(m => m.extractionSource === 'client-only');
+    for (const m of clientMetrics) {
+      assert.equal(m.queryPattern, null, `Client-only metric ${m.id} should have null queryPattern`);
+    }
+  });
+});
+
+// ── Safety metrics completeness ───────────────────────────────────────
+
+describe('REQUIRED_SAFETY_METRICS', () => {
+  it('contains exactly 10 safety metrics', () => {
+    assert.equal(REQUIRED_SAFETY_METRICS.length, 10);
+  });
+
+  it('each metric has a unique id', () => {
+    const ids = REQUIRED_SAFETY_METRICS.map(m => m.id);
+    assert.equal(new Set(ids).size, 10);
+  });
+
+  it('each metric has a non-empty name', () => {
+    for (const m of REQUIRED_SAFETY_METRICS) {
+      assert.ok(m.name && m.name.length > 0, `Metric ${m.id} missing name`);
+    }
+  });
+
+  it('each metric has a confidence classification (extractionSource)', () => {
+    const validSources = ['server-extractable', 'client-only', 'derived'];
+    for (const m of REQUIRED_SAFETY_METRICS) {
+      assert.ok(
+        validSources.includes(m.extractionSource),
+        `Metric ${m.id} has invalid extractionSource: '${m.extractionSource}'`,
+      );
+    }
+  });
+
+  it('safety metrics with zero-tolerance have zeroTolerance: true', () => {
+    // First 7 safety metrics must be zero-tolerance per §13.3
+    const zeroToleranceIds = [
+      'safety-01', 'safety-02', 'safety-03', 'safety-04',
+      'safety-05', 'safety-06', 'safety-07',
+    ];
+    for (const id of zeroToleranceIds) {
+      const metric = REQUIRED_SAFETY_METRICS.find(m => m.id === id);
+      assert.ok(metric, `Safety metric ${id} not found`);
+      assert.equal(metric.zeroTolerance, true, `Safety metric ${id} must have zeroTolerance: true`);
+    }
+  });
+
+  it('non-zero-tolerance safety metrics have zeroTolerance: false', () => {
+    const nonZeroIds = ['safety-08', 'safety-09', 'safety-10'];
+    for (const id of nonZeroIds) {
+      const metric = REQUIRED_SAFETY_METRICS.find(m => m.id === id);
+      assert.ok(metric, `Safety metric ${id} not found`);
+      assert.equal(metric.zeroTolerance, false, `Safety metric ${id} must have zeroTolerance: false`);
+    }
+  });
+});
+
+// ── validateMetricsMapping ────────────────────────────────────────────
+
+describe('validateMetricsMapping', () => {
+  it('returns valid: true when given the real metrics contract', () => {
+    const result = validateMetricsMapping({ ALL_HERO_METRICS });
+    assert.equal(result.valid, true);
+  });
+
+  it('returns 18 launch metrics in result', () => {
+    const result = validateMetricsMapping({ ALL_HERO_METRICS });
+    assert.equal(result.launchMetrics.length, 18);
+  });
+
+  it('returns 10 safety metrics in result', () => {
+    const result = validateMetricsMapping({ ALL_HERO_METRICS });
+    assert.equal(result.safetyMetrics.length, 10);
+  });
+
+  it('summary totals match', () => {
+    const result = validateMetricsMapping({ ALL_HERO_METRICS });
+    assert.equal(result.summary.total, 28);
+    assert.equal(
+      result.summary.serverExtractable + result.summary.clientOnly + result.summary.derived,
+      28,
+    );
+  });
+
+  it('each result metric has mapped: true', () => {
+    const result = validateMetricsMapping({ ALL_HERO_METRICS });
+    const allResults = [...result.launchMetrics, ...result.safetyMetrics];
+    for (const m of allResults) {
+      assert.equal(m.mapped, true, `Metric ${m.id} (${m.name}) not mapped`);
+    }
+  });
+
+  it('reports unmapped metric when contract is empty', () => {
+    const result = validateMetricsMapping({ ALL_HERO_METRICS: [] });
+    // Metrics with canonicalMetric will fail; those with queryPattern or derived still pass
+    const unmapped = [...result.launchMetrics, ...result.safetyMetrics].filter(m => !m.mapped);
+    assert.ok(unmapped.length > 0, 'Expected some unmapped metrics with empty contract');
+    assert.equal(result.valid, false);
+  });
+
+  it('each unmapped metric includes a reason', () => {
+    const result = validateMetricsMapping({ ALL_HERO_METRICS: [] });
+    const unmapped = [...result.launchMetrics, ...result.safetyMetrics].filter(m => !m.mapped);
+    for (const m of unmapped) {
+      assert.ok(m.reason, `Unmapped metric ${m.id} missing reason`);
+    }
+  });
+});
+
+// ── preCohortResult ───────────────────────────────────────────────────
+
+describe('preCohortResult', () => {
+  it('returns null value with explanation for metric not yet emitted', () => {
+    const metric = REQUIRED_LAUNCH_METRICS[0];
+    const result = preCohortResult(metric);
+    assert.equal(result.value, null);
+    assert.ok(result.explanation.includes(metric.name));
+    assert.ok(result.explanation.includes('not yet emitted'));
+  });
+
+  it('includes extraction source in explanation', () => {
+    const metric = REQUIRED_SAFETY_METRICS[0];
+    const result = preCohortResult(metric);
+    assert.ok(result.explanation.includes(metric.extractionSource));
+  });
+});
+
+// ── formatExtractionRow (9-column provenance pattern) ─────────────────
+
+describe('formatExtractionRow', () => {
+  it('returns array with exactly 9 columns', () => {
+    const metric = REQUIRED_LAUNCH_METRICS[5]; // task completion count
+    const row = formatExtractionRow(metric, 42, 'cohort-alpha', 'high');
+    assert.equal(row.length, 9);
+  });
+
+  it('columns match 9-column provenance pattern', () => {
+    const metric = REQUIRED_LAUNCH_METRICS[5];
+    const row = formatExtractionRow(metric, 42, 'cohort-alpha', 'high');
+    assert.equal(row[0], metric.id);           // metricId
+    assert.equal(row[1], metric.name);         // name
+    assert.equal(row[2], 42);                  // value
+    assert.equal(row[3], metric.extractionSource); // extractionSource
+    assert.equal(row[4], metric.queryPattern); // queryPattern
+    assert.equal(row[5], metric.canonicalMetric); // canonicalMetric
+    assert.ok(row[6]);                         // timestamp (ISO string)
+    assert.equal(row[7], 'cohort-alpha');      // cohortId
+    assert.equal(row[8], 'high');              // confidence
+  });
+
+  it('handles null value for pre-cohort metric', () => {
+    const metric = REQUIRED_LAUNCH_METRICS[2]; // client-only
+    const row = formatExtractionRow(metric, null, 'cohort-beta', 'insufficient');
+    assert.equal(row[2], null);
+    assert.equal(row[4], null); // client-only has null queryPattern
+    assert.equal(row[8], 'insufficient');
+  });
+
+  it('timestamp is a valid ISO date string', () => {
+    const metric = REQUIRED_SAFETY_METRICS[0];
+    const row = formatExtractionRow(metric, 0, 'cohort-gamma', 'high');
+    const parsed = new Date(row[6]);
+    assert.ok(!isNaN(parsed.getTime()), 'Timestamp must be valid ISO date');
+  });
+});
+
+// ── Cross-reference with canonical metrics contract ───────────────────
+
+describe('canonical metric cross-reference', () => {
+  it('all referenced canonicalMetric names exist in ALL_HERO_METRICS', () => {
+    const allMetrics = [...REQUIRED_LAUNCH_METRICS, ...REQUIRED_SAFETY_METRICS];
+    const withCanonical = allMetrics.filter(m => m.canonicalMetric !== null);
+    for (const m of withCanonical) {
+      assert.ok(
+        ALL_HERO_METRICS.includes(m.canonicalMetric),
+        `Metric ${m.id} references '${m.canonicalMetric}' which is not in ALL_HERO_METRICS`,
+      );
+    }
+  });
+
+  it('metrics without canonicalMetric have alternative extraction (queryPattern, derived, or client-only)', () => {
+    const allMetrics = [...REQUIRED_LAUNCH_METRICS, ...REQUIRED_SAFETY_METRICS];
+    const withoutCanonical = allMetrics.filter(m => m.canonicalMetric === null);
+    for (const m of withoutCanonical) {
+      const hasAlternative = m.queryPattern !== null
+        || m.extractionSource === 'derived'
+        || m.extractionSource === 'client-only';
+      assert.ok(
+        hasAlternative,
+        `Metric ${m.id} has no canonicalMetric and no alternative extraction path`,
+      );
+    }
+  });
+});

--- a/tests/hero-pA4-operator-lookup.test.js
+++ b/tests/hero-pA4-operator-lookup.test.js
@@ -1,0 +1,369 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildOperatorLookup } from '../scripts/hero-pA4-operator-lookup.mjs';
+import { HERO_FLAG_KEYS } from '../shared/hero/account-override.js';
+import { PRIVACY_FORBIDDEN_FIELDS } from '../shared/hero/metrics-privacy.js';
+
+// ── Fixtures ──────────────────────────────────────────────────────────
+
+function makeHealthyState() {
+  return {
+    version: 2,
+    economy: {
+      balance: 450,
+      ledger: [
+        { type: 'daily_award', date: new Date().toISOString().slice(0, 10), amount: 100 },
+        { type: 'camp_spend', date: new Date().toISOString().slice(0, 10), amount: -50 },
+      ],
+    },
+    heroPool: {
+      monsters: { 'monster-1': { id: 'monster-1', level: 3 } },
+    },
+  };
+}
+
+function makeUnhealthyState() {
+  return {
+    version: 2,
+    economy: {
+      balance: -10,
+      ledger: [
+        { type: 'daily_award', date: new Date().toISOString().slice(0, 10), amount: 100 },
+        null,
+      ],
+    },
+    heroPool: {
+      monsters: { 'monster-1': { id: 'monster-1', level: 1 } },
+    },
+  };
+}
+
+function makeInternalEnv(accountId) {
+  return {
+    HERO_INTERNAL_ACCOUNTS: JSON.stringify([accountId]),
+    HERO_EXTERNAL_ACCOUNTS: JSON.stringify([]),
+  };
+}
+
+function makeExternalEnv(accountId) {
+  return {
+    HERO_INTERNAL_ACCOUNTS: JSON.stringify([]),
+    HERO_EXTERNAL_ACCOUNTS: JSON.stringify([accountId]),
+  };
+}
+
+function makeNoMatchEnv() {
+  return {
+    HERO_INTERNAL_ACCOUNTS: JSON.stringify(['other-acc']),
+    HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['another-acc']),
+  };
+}
+
+// ── Internal account ──────────────────────────────────────────────────
+
+describe('buildOperatorLookup: internal account', () => {
+  it('returns overrideStatus=internal with all flags enabled', () => {
+    const report = buildOperatorLookup({
+      accountId: 'int-acc-1',
+      env: makeInternalEnv('int-acc-1'),
+      heroState: makeHealthyState(),
+      eventLog: [{ eventType: 'daily_complete', data: {} }],
+    });
+
+    assert.equal(report.ok, true);
+    assert.equal(report.overrideStatus, 'internal');
+    for (const key of HERO_FLAG_KEYS) {
+      assert.equal(report.resolvedFlags[key], true, `${key} must be enabled`);
+    }
+  });
+
+  it('cohortClassification explains internal membership', () => {
+    const report = buildOperatorLookup({
+      accountId: 'int-acc-1',
+      env: makeInternalEnv('int-acc-1'),
+      heroState: makeHealthyState(),
+      eventLog: [],
+    });
+
+    assert.equal(report.cohortClassification.enabled, true);
+    assert.ok(report.cohortClassification.reason.includes('HERO_INTERNAL_ACCOUNTS'));
+  });
+});
+
+// ── External account ──────────────────────────────────────────────────
+
+describe('buildOperatorLookup: external account', () => {
+  it('returns overrideStatus=external with all flags enabled', () => {
+    const report = buildOperatorLookup({
+      accountId: 'ext-acc-1',
+      env: makeExternalEnv('ext-acc-1'),
+      heroState: makeHealthyState(),
+      eventLog: [{ eventType: 'quest_start', data: {} }],
+    });
+
+    assert.equal(report.ok, true);
+    assert.equal(report.overrideStatus, 'external');
+    for (const key of HERO_FLAG_KEYS) {
+      assert.equal(report.resolvedFlags[key], true, `${key} must be enabled`);
+    }
+  });
+
+  it('cohortClassification explains external membership', () => {
+    const report = buildOperatorLookup({
+      accountId: 'ext-acc-1',
+      env: makeExternalEnv('ext-acc-1'),
+      heroState: makeHealthyState(),
+      eventLog: [],
+    });
+
+    assert.equal(report.cohortClassification.enabled, true);
+    assert.ok(report.cohortClassification.reason.includes('HERO_EXTERNAL_ACCOUNTS'));
+  });
+});
+
+// ── Non-cohort account (flags off) ────────────────────────────────────
+
+describe('buildOperatorLookup: non-cohort account', () => {
+  it('returns overrideStatus=none with Hero hidden', () => {
+    const report = buildOperatorLookup({
+      accountId: 'random-acc',
+      env: makeNoMatchEnv(),
+      heroState: null,
+      eventLog: [],
+    });
+
+    assert.equal(report.ok, true);
+    assert.equal(report.overrideStatus, 'none');
+    for (const key of HERO_FLAG_KEYS) {
+      assert.equal(report.resolvedFlags[key], false, `${key} must be disabled`);
+    }
+  });
+
+  it('cohortClassification shows hidden with reason', () => {
+    const report = buildOperatorLookup({
+      accountId: 'random-acc',
+      env: makeNoMatchEnv(),
+      heroState: null,
+      eventLog: [],
+    });
+
+    assert.equal(report.cohortClassification.enabled, false);
+    assert.ok(report.cohortClassification.reason.includes('not in any cohort list'));
+  });
+
+  it('recommendation mentions not in any cohort list', () => {
+    const report = buildOperatorLookup({
+      accountId: 'random-acc',
+      env: makeNoMatchEnv(),
+      heroState: null,
+      eventLog: [],
+    });
+
+    const cohortRec = report.recommendations.find(r => r.includes('not in any cohort list'));
+    assert.ok(cohortRec, 'Must have recommendation about cohort membership');
+  });
+});
+
+// ── Unhealthy state (negative balance) ────────────────────────────────
+
+describe('buildOperatorLookup: unhealthy state', () => {
+  it('readiness shows failure for negative balance', () => {
+    const report = buildOperatorLookup({
+      accountId: 'int-acc-1',
+      env: makeInternalEnv('int-acc-1'),
+      heroState: makeUnhealthyState(),
+      eventLog: [],
+    });
+
+    assert.equal(report.readinessChecks.overall, 'not_ready');
+    const economyCheck = report.readinessChecks.checks.find(c => c.name === 'economyHealthy');
+    assert.equal(economyCheck.status, 'fail');
+  });
+
+  it('economyHealth reports anomalies', () => {
+    const report = buildOperatorLookup({
+      accountId: 'int-acc-1',
+      env: makeInternalEnv('int-acc-1'),
+      heroState: makeUnhealthyState(),
+      eventLog: [],
+    });
+
+    assert.equal(report.economyHealth.status, 'unhealthy');
+    assert.ok(report.economyHealth.anomalies.includes('negative-balance'));
+    assert.ok(report.economyHealth.anomalies.includes('null-ledger-entry'));
+  });
+
+  it('recommendations mention economy anomalies', () => {
+    const report = buildOperatorLookup({
+      accountId: 'int-acc-1',
+      env: makeInternalEnv('int-acc-1'),
+      heroState: makeUnhealthyState(),
+      eventLog: [],
+    });
+
+    const econRec = report.recommendations.find(r => r.includes('Economy anomalies'));
+    assert.ok(econRec, 'Must recommend action for economy issues');
+  });
+});
+
+// ── No event log entries ──────────────────────────────────────────────
+
+describe('buildOperatorLookup: no event log', () => {
+  it('graceful message when no events exist', () => {
+    const report = buildOperatorLookup({
+      accountId: 'int-acc-1',
+      env: makeInternalEnv('int-acc-1'),
+      heroState: makeHealthyState(),
+      eventLog: [],
+    });
+
+    assert.equal(report.recentEvents.count, 0);
+    assert.equal(report.recentEvents.message, 'No observations yet.');
+  });
+
+  it('recommendation mentions no observations', () => {
+    const report = buildOperatorLookup({
+      accountId: 'int-acc-1',
+      env: makeInternalEnv('int-acc-1'),
+      heroState: makeHealthyState(),
+      eventLog: [],
+    });
+
+    const noObsRec = report.recommendations.find(r => r.includes('No event log observations'));
+    assert.ok(noObsRec, 'Must mention no observations');
+  });
+});
+
+// ── Privacy stripping ─────────────────────────────────────────────────
+
+describe('buildOperatorLookup: privacy stripping', () => {
+  it('removes forbidden fields from event log entries', () => {
+    const rawEvents = [
+      {
+        eventType: 'quest_complete',
+        data: {
+          score: 5,
+          childFreeText: 'My secret answer',
+          rawAnswer: 'raw answer text',
+          nested: { childContent: 'deep private', ok: true },
+        },
+      },
+      {
+        eventType: 'daily_award',
+        rawText: 'should be removed',
+        data: { amount: 100 },
+      },
+    ];
+
+    const report = buildOperatorLookup({
+      accountId: 'int-acc-1',
+      env: makeInternalEnv('int-acc-1'),
+      heroState: makeHealthyState(),
+      eventLog: rawEvents,
+    });
+
+    // Verify no forbidden fields in output
+    const outputStr = JSON.stringify(report.recentEvents);
+    for (const field of PRIVACY_FORBIDDEN_FIELDS) {
+      assert.ok(
+        !outputStr.includes(`"${field}"`),
+        `Forbidden field "${field}" must be stripped from output`,
+      );
+    }
+
+    // Verify allowed fields survive
+    const firstEvent = report.recentEvents.events[0];
+    assert.equal(firstEvent.eventType, 'quest_complete');
+    assert.equal(firstEvent.data.score, 5);
+    assert.equal(firstEvent.data.nested.ok, true);
+  });
+});
+
+// ── Null/undefined accountId ──────────────────────────────────────────
+
+describe('buildOperatorLookup: null/undefined accountId', () => {
+  it('null accountId returns graceful error output', () => {
+    const report = buildOperatorLookup({
+      accountId: null,
+      env: makeInternalEnv('int-acc-1'),
+      heroState: makeHealthyState(),
+      eventLog: [],
+    });
+
+    assert.equal(report.ok, false);
+    assert.ok(report.error.includes('required'));
+    assert.equal(report.accountId, null);
+    assert.equal(report.overrideStatus, null);
+    assert.ok(Array.isArray(report.recommendations));
+  });
+
+  it('undefined accountId returns graceful error output', () => {
+    const report = buildOperatorLookup({
+      accountId: undefined,
+      env: makeInternalEnv('int-acc-1'),
+      heroState: makeHealthyState(),
+      eventLog: [],
+    });
+
+    assert.equal(report.ok, false);
+    assert.ok(report.error.includes('required'));
+  });
+
+  it('empty string accountId returns graceful error output', () => {
+    const report = buildOperatorLookup({
+      accountId: '',
+      env: makeInternalEnv('int-acc-1'),
+      heroState: makeHealthyState(),
+      eventLog: [],
+    });
+
+    assert.equal(report.ok, false);
+    assert.ok(report.error.includes('required'));
+  });
+});
+
+// ── Healthy fully-enabled account produces no-action recommendation ───
+
+describe('buildOperatorLookup: healthy fully-enabled', () => {
+  it('healthy internal account with events produces no-action recommendation', () => {
+    const report = buildOperatorLookup({
+      accountId: 'int-acc-1',
+      env: makeInternalEnv('int-acc-1'),
+      heroState: makeHealthyState(),
+      eventLog: [{ eventType: 'daily_complete', data: {} }],
+    });
+
+    assert.equal(report.ok, true);
+    assert.equal(report.readinessChecks.overall, 'ready');
+    assert.equal(report.economyHealth.status, 'healthy');
+    assert.ok(
+      report.recommendations.some(r => r.includes('No action required')),
+      'Must indicate no action needed',
+    );
+  });
+});
+
+// ── Event log limiting ────────────────────────────────────────────────
+
+describe('buildOperatorLookup: event log limiting', () => {
+  it('limits to 10 most recent events', () => {
+    const manyEvents = Array.from({ length: 25 }, (_, i) => ({
+      eventType: `event-${i}`,
+      data: { index: i },
+    }));
+
+    const report = buildOperatorLookup({
+      accountId: 'int-acc-1',
+      env: makeInternalEnv('int-acc-1'),
+      heroState: makeHealthyState(),
+      eventLog: manyEvents,
+    });
+
+    assert.equal(report.recentEvents.count, 10);
+    assert.equal(report.recentEvents.events.length, 10);
+    // First 10 events (assuming input is already ordered newest-first)
+    assert.equal(report.recentEvents.events[0].eventType, 'event-0');
+    assert.equal(report.recentEvents.events[9].eventType, 'event-9');
+  });
+});

--- a/tests/hero-pA4-parent-explainer-validation.test.js
+++ b/tests/hero-pA4-parent-explainer-validation.test.js
@@ -1,0 +1,187 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const explainerPath = resolve(
+  __dirname,
+  '../docs/plans/james/hero-mode/A/hero-pA4-parent-explainer.md'
+);
+
+const content = readFileSync(explainerPath, 'utf8');
+const lower = content.toLowerCase();
+
+describe('Hero pA4 parent explainer — required content', () => {
+  it('states Hero Mode gives one daily mission across ready subjects', () => {
+    assert.ok(
+      lower.includes('one daily mission') && lower.includes('ready subjects'),
+      'Must mention one daily mission across ready subjects'
+    );
+  });
+
+  it('names Spelling, Grammar, and Punctuation as ready subjects', () => {
+    assert.ok(lower.includes('spelling'), 'Must mention Spelling');
+    assert.ok(lower.includes('grammar'), 'Must mention Grammar');
+    assert.ok(lower.includes('punctuation'), 'Must mention Punctuation');
+  });
+
+  it('states more subjects may join later', () => {
+    assert.ok(
+      lower.includes('more subjects') && lower.includes('later'),
+      'Must indicate more subjects may join later'
+    );
+  });
+
+  it('states subject mastery and Stars still belong to each subject', () => {
+    assert.ok(
+      lower.includes('stars') && lower.includes('belong to each subject'),
+      'Must state Stars still belong to each subject'
+    );
+  });
+
+  it('states Hero Coins reward daily mission completion, not speed or every correct answer', () => {
+    assert.ok(
+      lower.includes('hero coins') && lower.includes('daily mission completion'),
+      'Must state Hero Coins reward daily mission completion'
+    );
+    assert.ok(
+      lower.includes('not for speed') || lower.includes('not speed'),
+      'Must state coins are not for speed'
+    );
+  });
+
+  it('states Hero Camp is optional and secondary', () => {
+    assert.ok(
+      lower.includes('hero camp') &&
+        lower.includes('optional') &&
+        lower.includes('secondary'),
+      'Must state Hero Camp is optional and secondary'
+    );
+  });
+
+  it('states this is early access and feedback is welcome', () => {
+    assert.ok(lower.includes('early access'), 'Must mention early access');
+    assert.ok(lower.includes('feedback'), 'Must mention feedback');
+    assert.ok(lower.includes('welcome'), 'Must state feedback is welcome');
+  });
+});
+
+describe('Hero pA4 parent explainer — forbidden content', () => {
+  it('does not claim Hero Mode covers all six KS2 subjects', () => {
+    assert.ok(
+      !lower.includes('all six') && !lower.includes('six subjects'),
+      'Must not claim coverage of all six KS2 subjects'
+    );
+  });
+
+  it('does not state coins are earned for every right answer', () => {
+    assert.ok(
+      !lower.includes('every right answer') &&
+        !lower.includes('every correct answer') &&
+        !lower.includes('each correct answer'),
+      'Must not claim coins for every right/correct answer'
+    );
+  });
+
+  it('does not suggest a child loses anything for missing a day', () => {
+    assert.ok(
+      !lower.includes('lose progress') &&
+        !lower.includes('lost stars') &&
+        !lower.includes('lose stars') &&
+        !lower.includes('lose coins') &&
+        !lower.includes('lose their'),
+      'Must not suggest a child loses anything for missing a day'
+    );
+  });
+
+  it('does not claim Hero Mode replaces subject practice', () => {
+    assert.ok(
+      !lower.includes('replaces subject') &&
+        !lower.includes('replace subject') &&
+        !lower.includes('instead of subject'),
+      'Must not claim Hero Mode replaces subject practice'
+    );
+  });
+
+  it('does not claim Hero Mode is final or default for everyone', () => {
+    assert.ok(
+      !lower.includes('final version for everyone') &&
+        !lower.includes('default for everyone') &&
+        !lower.includes('default for all'),
+      'Must not claim Hero Mode is final/default for everyone'
+    );
+  });
+});
+
+describe('Hero pA4 parent explainer — no pressure vocabulary', () => {
+  const pressureWords = [
+    'gamble',
+    'gambling',
+    'loot',
+    'streak',
+    'punishment',
+    'punish',
+    'miss out',
+    'limited time',
+    'hurry',
+    'last chance',
+  ];
+
+  for (const word of pressureWords) {
+    it(`does not contain pressure word: "${word}"`, () => {
+      assert.ok(
+        !lower.includes(word),
+        `Explainer must not contain pressure vocabulary: "${word}"`
+      );
+    });
+  }
+});
+
+describe('Hero pA4 parent explainer — locked subjects tone', () => {
+  it('does not describe locked subjects negatively', () => {
+    const negativePatterns = [
+      'missing subjects',
+      'unavailable subjects',
+      'subjects are missing',
+      'not available yet',
+      'cannot access',
+      'locked out',
+      'blocked',
+      'excluded',
+      'left out',
+      'denied',
+    ];
+
+    for (const pattern of negativePatterns) {
+      assert.ok(
+        !lower.includes(pattern),
+        `Must not use negative language for locked subjects: "${pattern}"`
+      );
+    }
+  });
+
+  it('does not name locked subjects (arithmetic, reasoning, reading) negatively', () => {
+    // If these subjects are mentioned at all, they should not appear with negative framing
+    const lockedSubjects = ['arithmetic', 'reasoning', 'reading'];
+    for (const subject of lockedSubjects) {
+      if (lower.includes(subject)) {
+        // If mentioned, must not be paired with negative words
+        const lines = content.split('\n');
+        for (const line of lines) {
+          const lineLower = line.toLowerCase();
+          if (lineLower.includes(subject)) {
+            assert.ok(
+              !lineLower.includes('not ready') &&
+                !lineLower.includes('unavailable') &&
+                !lineLower.includes('missing') &&
+                !lineLower.includes('locked'),
+              `Locked subject "${subject}" must not be described negatively`
+            );
+          }
+        }
+      }
+    }
+  });
+});

--- a/tests/hero-pA4-register-validation.test.js
+++ b/tests/hero-pA4-register-validation.test.js
@@ -1,0 +1,222 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const REGISTER_PATH = resolve(__dirname, '../docs/plans/james/hero-mode/A/hero-pA4-risk-register.md');
+const ROLLBACK_PATH = resolve(__dirname, '../docs/plans/james/hero-mode/A/hero-pA4-rollback-evidence.md');
+
+const register = readFileSync(REGISTER_PATH, 'utf-8');
+const rollback = readFileSync(ROLLBACK_PATH, 'utf-8');
+
+// ─── Risk Register: Stop Conditions ─────────────────────────────────────────
+
+describe('Hero pA4 Risk Register — stop conditions (S1-S13)', () => {
+  const stopConditions = [
+    { id: 'S1', name: 'Raw child content in telemetry/logs' },
+    { id: 'S2', name: 'Non-cohort accounts see Hero surfaces' },
+    { id: 'S3', name: 'Hero command succeeds for non-enabled account' },
+    { id: 'S4', name: 'Duplicate daily coin award' },
+    { id: 'S5', name: 'Duplicate Camp debit' },
+    { id: 'S6', name: 'Negative balance' },
+    { id: 'S7', name: 'Claim without Worker-verified completion' },
+    { id: 'S8', name: 'Hero mutates subject Stars/mastery' },
+    { id: 'S9', name: 'Dead/unlaunchable primary CTA' },
+    { id: 'S10', name: 'Rollback cannot hide while preserving state' },
+    { id: 'S11', name: 'Repeated unexplained 500s on Hero routes' },
+    { id: 'S12', name: 'Support cannot explain/triage issue' },
+    { id: 'S13', name: 'Parent feedback indicates pressure/misleading' },
+  ];
+
+  it('contains exactly 13 stop conditions', () => {
+    const matches = register.match(/\| S\d+ \|/g);
+    assert.ok(matches, 'No stop condition rows found');
+    assert.equal(matches.length, 13, `Expected 13 stop conditions, found ${matches.length}`);
+  });
+
+  for (const { id, name } of stopConditions) {
+    it(`contains stop condition ${id}: ${name}`, () => {
+      assert.ok(
+        register.includes(`| ${id} |`),
+        `Missing stop condition row: ${id}`
+      );
+      assert.ok(
+        register.includes(name),
+        `Missing stop condition name: "${name}"`
+      );
+    });
+  }
+});
+
+describe('Hero pA4 Risk Register — stop condition fields', () => {
+  const stopIds = ['S1', 'S2', 'S3', 'S4', 'S5', 'S6', 'S7', 'S8', 'S9', 'S10', 'S11', 'S12', 'S13'];
+
+  for (const id of stopIds) {
+    it(`${id} has a detection method`, () => {
+      const row = register.split('\n').find(line => line.includes(`| ${id} |`));
+      assert.ok(row, `Row for ${id} not found`);
+      assert.ok(
+        row.includes('detect'),
+        `${id} row missing detection method (expected "detect" keyword)`
+      );
+    });
+
+    it(`${id} has a response action`, () => {
+      const row = register.split('\n').find(line => line.includes(`| ${id} |`));
+      assert.ok(row, `Row for ${id} not found`);
+      assert.ok(
+        row.includes('Immediate:') || row.includes('Urgent:') || row.includes('Hold:'),
+        `${id} row missing response action (expected "Immediate:", "Urgent:", or "Hold:" prefix)`
+      );
+    });
+  }
+});
+
+// ─── Risk Register: Warning Conditions ──────────────────────────────────────
+
+describe('Hero pA4 Risk Register — warning conditions (W1-W9)', () => {
+  const warningConditions = [
+    { id: 'W1', name: 'Low Hero Quest start rate' },
+    { id: 'W2', name: 'Low completion rate' },
+    { id: 'W3', name: 'Repeated abandonment after first task' },
+    { id: 'W4', name: 'Children open Camp but do not start learning' },
+    { id: 'W5', name: 'Parents misunderstand Hero Coins' },
+    { id: 'W6', name: 'Telemetry has blind spots for a non-critical signal' },
+    { id: 'W7', name: 'One ready subject dominates the schedule more than expected' },
+    { id: 'W8', name: 'Support questions cluster around copy or navigation' },
+    { id: 'W9', name: 'Performance is slower than ideal but not failing' },
+  ];
+
+  it('contains exactly 9 warning conditions', () => {
+    const matches = register.match(/\| W\d+ \|/g);
+    assert.ok(matches, 'No warning condition rows found');
+    assert.equal(matches.length, 9, `Expected 9 warning conditions, found ${matches.length}`);
+  });
+
+  for (const { id, name } of warningConditions) {
+    it(`contains warning condition ${id}: ${name}`, () => {
+      assert.ok(
+        register.includes(`| ${id} |`),
+        `Missing warning condition row: ${id}`
+      );
+      assert.ok(
+        register.includes(name),
+        `Missing warning condition name: "${name}"`
+      );
+    });
+  }
+});
+
+describe('Hero pA4 Risk Register — warning condition fields', () => {
+  const warningIds = ['W1', 'W2', 'W3', 'W4', 'W5', 'W6', 'W7', 'W8', 'W9'];
+
+  for (const id of warningIds) {
+    it(`${id} has a detection method`, () => {
+      const row = register.split('\n').find(line => line.includes(`| ${id} |`));
+      assert.ok(row, `Row for ${id} not found`);
+      assert.ok(
+        row.includes('detect'),
+        `${id} row missing detection method (expected "detect" keyword)`
+      );
+    });
+
+    it(`${id} has a response action`, () => {
+      const row = register.split('\n').find(line => line.includes(`| ${id} |`));
+      assert.ok(row, `Row for ${id} not found`);
+      assert.ok(
+        row.includes('Decision:'),
+        `${id} row missing response action (expected "Decision:" prefix)`
+      );
+    });
+  }
+});
+
+// ─── Rollback Evidence Note ─────────────────────────────────────────────────
+
+describe('Hero pA4 Rollback Evidence — key assertions', () => {
+  it('mentions "flags off" as the rollback mechanism', () => {
+    assert.ok(
+      rollback.toLowerCase().includes('flags off'),
+      'Rollback evidence must mention "flags off"'
+    );
+  });
+
+  it('mentions "state preserved" invariant', () => {
+    assert.ok(
+      rollback.toLowerCase().includes('state preserved'),
+      'Rollback evidence must mention "state preserved"'
+    );
+  });
+
+  it('mentions "never deleted" guarantee', () => {
+    assert.ok(
+      rollback.toLowerCase().includes('never deleted'),
+      'Rollback evidence must mention "never deleted"'
+    );
+  });
+
+  it('mentions re-enable test verification (hero-p6-rollback.test.js)', () => {
+    assert.ok(
+      rollback.includes('hero-p6-rollback.test.js'),
+      'Rollback evidence must reference the re-enable test file'
+    );
+  });
+
+  it('documents the three-step rollback procedure', () => {
+    assert.ok(rollback.includes('Step 1'), 'Missing Step 1');
+    assert.ok(rollback.includes('Step 2'), 'Missing Step 2');
+    assert.ok(rollback.includes('Step 3'), 'Missing Step 3');
+  });
+
+  it('documents what is preserved: ledger entries', () => {
+    assert.ok(
+      rollback.toLowerCase().includes('ledger entries'),
+      'Must document preservation of ledger entries'
+    );
+  });
+
+  it('documents what is preserved: Camp ownership', () => {
+    assert.ok(
+      rollback.toLowerCase().includes('camp ownership'),
+      'Must document preservation of Camp ownership'
+    );
+  });
+
+  it('documents what is preserved: progress state', () => {
+    assert.ok(
+      rollback.toLowerCase().includes('progress state'),
+      'Must document preservation of progress state'
+    );
+  });
+
+  it('documents what is preserved: quest history', () => {
+    assert.ok(
+      rollback.toLowerCase().includes('quest history'),
+      'Must document preservation of quest history'
+    );
+  });
+
+  it('documents what changes: UI visibility hidden', () => {
+    assert.ok(
+      rollback.toLowerCase().includes('hidden'),
+      'Must document that UI visibility becomes hidden'
+    );
+  });
+
+  it('documents what changes: commands rejected', () => {
+    assert.ok(
+      rollback.toLowerCase().includes('rejected'),
+      'Must document that commands become rejected'
+    );
+  });
+
+  it('documents what changes: telemetry dormant', () => {
+    assert.ok(
+      rollback.toLowerCase().includes('dormant'),
+      'Must document that telemetry becomes dormant'
+    );
+  });
+});

--- a/tests/hero-pA4-route-integration.test.js
+++ b/tests/hero-pA4-route-integration.test.js
@@ -1,0 +1,287 @@
+// Hero Mode pA4 U2 — Route Integration: Unified Resolver in read model and command routes.
+//
+// Verifies:
+// 1. External account gets overrideStatus 'external' in debug output
+// 2. Internal account gets overrideStatus 'internal' in debug output
+// 3. Non-cohort account with flags off gets overrideStatus 'none'
+// 4. Read model and command use same resolver (function import consistency)
+// 5. Telemetry probe overrideStatus shape includes classification field
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  resolveHeroFlagsWithOverride,
+  resolveHeroFlagsForAccount,
+  HERO_FLAG_KEYS,
+} from '../shared/hero/account-override.js';
+import { buildExpandedProbeResponse } from '../worker/src/hero/telemetry-probe.js';
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+const INTERNAL_ACCOUNT = 'acc-internal-001';
+const EXTERNAL_ACCOUNT = 'acc-external-002';
+const PUBLIC_ACCOUNT = 'acc-public-999';
+
+function baseEnv(overrides = {}) {
+  return {
+    HERO_MODE_SHADOW_ENABLED: 'false',
+    HERO_MODE_LAUNCH_ENABLED: 'false',
+    HERO_MODE_CHILD_UI_ENABLED: 'false',
+    HERO_MODE_PROGRESS_ENABLED: 'false',
+    HERO_MODE_ECONOMY_ENABLED: 'false',
+    HERO_MODE_CAMP_ENABLED: 'false',
+    APP_NAME: 'KS2 Mastery',
+    HERO_INTERNAL_ACCOUNTS: JSON.stringify([INTERNAL_ACCOUNT]),
+    HERO_EXTERNAL_ACCOUNTS: JSON.stringify([EXTERNAL_ACCOUNT]),
+    ...overrides,
+  };
+}
+
+function baseEnvWithGlobalFlags(overrides = {}) {
+  return baseEnv({
+    HERO_MODE_SHADOW_ENABLED: 'true',
+    HERO_MODE_LAUNCH_ENABLED: 'true',
+    ...overrides,
+  });
+}
+
+// ── Unit: overrideStatus classification for command route ─────────────
+
+describe('pA4 U2: command route — unified resolver overrideStatus', () => {
+  it('external account gets overrideStatus "external"', () => {
+    const env = baseEnv();
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: EXTERNAL_ACCOUNT });
+
+    assert.equal(overrideStatus, 'external');
+    // All 6 flags force-enabled for external cohort
+    for (const key of HERO_FLAG_KEYS) {
+      assert.equal(resolvedEnv[key], 'true', `${key} must be "true" for external account`);
+    }
+  });
+
+  it('internal account gets overrideStatus "internal"', () => {
+    const env = baseEnv();
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: INTERNAL_ACCOUNT });
+
+    assert.equal(overrideStatus, 'internal');
+    for (const key of HERO_FLAG_KEYS) {
+      assert.equal(resolvedEnv[key], 'true', `${key} must be "true" for internal account`);
+    }
+  });
+
+  it('non-cohort account with flags off gets overrideStatus "none"', () => {
+    const env = baseEnv();
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: PUBLIC_ACCOUNT });
+
+    assert.equal(overrideStatus, 'none');
+    for (const key of HERO_FLAG_KEYS) {
+      assert.equal(resolvedEnv[key], 'false', `${key} must remain "false" for non-cohort account`);
+    }
+  });
+
+  it('non-cohort account with global flags on gets overrideStatus "global"', () => {
+    const env = baseEnvWithGlobalFlags();
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: PUBLIC_ACCOUNT });
+
+    assert.equal(overrideStatus, 'global');
+    // Global flags preserved — only shadow and launch are 'true' in this fixture
+    assert.equal(resolvedEnv.HERO_MODE_SHADOW_ENABLED, 'true');
+    assert.equal(resolvedEnv.HERO_MODE_LAUNCH_ENABLED, 'true');
+    assert.equal(resolvedEnv.HERO_MODE_CAMP_ENABLED, 'false');
+  });
+});
+
+// ── Unit: read model and command use same resolver ────────────────────
+
+describe('pA4 U2: resolver consistency — read model and command share resolveHeroFlagsForAccount', () => {
+  it('resolveHeroFlagsForAccount is the primary export used by both routes', () => {
+    // Verify the function exists and is callable
+    assert.equal(typeof resolveHeroFlagsForAccount, 'function');
+    assert.equal(resolveHeroFlagsForAccount.length, 1, 'takes single params object');
+  });
+
+  it('resolveHeroFlagsWithOverride delegates to resolveHeroFlagsForAccount', () => {
+    const env = baseEnv();
+
+    // The wrapper returns only resolvedEnv
+    const wrapperResult = resolveHeroFlagsWithOverride({ env, accountId: INTERNAL_ACCOUNT });
+    const { resolvedEnv } = resolveHeroFlagsForAccount({ env, accountId: INTERNAL_ACCOUNT });
+
+    // Both must produce identical resolved env
+    assert.deepEqual(wrapperResult, resolvedEnv);
+  });
+
+  it('same resolver for internal: wrapper matches primary', () => {
+    const env = baseEnv();
+    const wrapperResult = resolveHeroFlagsWithOverride({ env, accountId: EXTERNAL_ACCOUNT });
+    const { resolvedEnv } = resolveHeroFlagsForAccount({ env, accountId: EXTERNAL_ACCOUNT });
+    assert.deepEqual(wrapperResult, resolvedEnv);
+  });
+
+  it('same resolver for non-cohort: wrapper matches primary', () => {
+    const env = baseEnv();
+    const wrapperResult = resolveHeroFlagsWithOverride({ env, accountId: PUBLIC_ACCOUNT });
+    const { resolvedEnv } = resolveHeroFlagsForAccount({ env, accountId: PUBLIC_ACCOUNT });
+    assert.deepEqual(wrapperResult, resolvedEnv);
+  });
+});
+
+// ── Unit: telemetry probe overrideStatus shape ───────────────────────
+
+describe('pA4 U2: telemetry probe — overrideStatus in expanded response', () => {
+  const minimalProbeResult = { events: [], count: 0, probedAt: '2026-04-30T00:00:00.000Z' };
+  const dateKey = '2026-04-30';
+
+  it('expanded probe includes overrideStatus with classification for external', () => {
+    const env = baseEnv();
+    const { resolvedEnv, overrideStatus: classification } = resolveHeroFlagsForAccount({ env, accountId: EXTERNAL_ACCOUNT });
+
+    const effectiveFlags = Object.fromEntries(
+      HERO_FLAG_KEYS.map(k => [k, resolvedEnv[k] || ''])
+    );
+
+    const overrideStatus = {
+      queriedLearnerId: 'learner-ext-01',
+      parentAccountId: EXTERNAL_ACCOUNT,
+      classification,
+      effectiveFlags,
+    };
+
+    const expanded = buildExpandedProbeResponse({
+      probeResult: minimalProbeResult,
+      heroState: null,
+      resolvedFlags: resolvedEnv,
+      dateKey,
+      overrideStatus,
+      learnerEventCount: 0,
+    });
+
+    assert.equal(expanded.ok, true);
+    assert.equal(expanded.overrideStatus.classification, 'external');
+    assert.equal(expanded.overrideStatus.queriedLearnerId, 'learner-ext-01');
+    assert.equal(expanded.overrideStatus.parentAccountId, EXTERNAL_ACCOUNT);
+    assert.equal(expanded.overrideStatus.effectiveFlags.HERO_MODE_SHADOW_ENABLED, 'true');
+  });
+
+  it('expanded probe includes overrideStatus with classification for internal', () => {
+    const env = baseEnv();
+    const { resolvedEnv, overrideStatus: classification } = resolveHeroFlagsForAccount({ env, accountId: INTERNAL_ACCOUNT });
+
+    const effectiveFlags = Object.fromEntries(
+      HERO_FLAG_KEYS.map(k => [k, resolvedEnv[k] || ''])
+    );
+
+    const overrideStatus = {
+      queriedLearnerId: 'learner-int-01',
+      parentAccountId: INTERNAL_ACCOUNT,
+      classification,
+      effectiveFlags,
+    };
+
+    const expanded = buildExpandedProbeResponse({
+      probeResult: minimalProbeResult,
+      heroState: null,
+      resolvedFlags: resolvedEnv,
+      dateKey,
+      overrideStatus,
+      learnerEventCount: 0,
+    });
+
+    assert.equal(expanded.ok, true);
+    assert.equal(expanded.overrideStatus.classification, 'internal');
+    assert.equal(expanded.overrideStatus.parentAccountId, INTERNAL_ACCOUNT);
+  });
+
+  it('expanded probe includes overrideStatus with classification "none" for public', () => {
+    const env = baseEnv();
+    const { resolvedEnv, overrideStatus: classification } = resolveHeroFlagsForAccount({ env, accountId: PUBLIC_ACCOUNT });
+
+    const effectiveFlags = Object.fromEntries(
+      HERO_FLAG_KEYS.map(k => [k, resolvedEnv[k] || ''])
+    );
+
+    const overrideStatus = {
+      queriedLearnerId: 'learner-pub-01',
+      parentAccountId: PUBLIC_ACCOUNT,
+      classification,
+      effectiveFlags,
+    };
+
+    const expanded = buildExpandedProbeResponse({
+      probeResult: minimalProbeResult,
+      heroState: null,
+      resolvedFlags: resolvedEnv,
+      dateKey,
+      overrideStatus,
+      learnerEventCount: 0,
+    });
+
+    assert.equal(expanded.ok, true);
+    assert.equal(expanded.overrideStatus.classification, 'none');
+    assert.equal(expanded.overrideStatus.effectiveFlags.HERO_MODE_SHADOW_ENABLED, 'false');
+  });
+
+  it('expanded probe with orphan learner includes reason field', () => {
+    const env = baseEnv();
+    const { resolvedEnv, overrideStatus: classification } = resolveHeroFlagsForAccount({ env, accountId: PUBLIC_ACCOUNT });
+
+    const effectiveFlags = Object.fromEntries(
+      HERO_FLAG_KEYS.map(k => [k, resolvedEnv[k] || ''])
+    );
+
+    // Simulates what app.js does when parentAccountId is null
+    const overrideStatus = {
+      queriedLearnerId: 'learner-orphan-01',
+      parentAccountId: null,
+      classification,
+      effectiveFlags,
+      reason: 'parent-account-not-found',
+    };
+
+    const expanded = buildExpandedProbeResponse({
+      probeResult: minimalProbeResult,
+      heroState: null,
+      resolvedFlags: resolvedEnv,
+      dateKey,
+      overrideStatus,
+      learnerEventCount: null,
+    });
+
+    assert.equal(expanded.ok, true);
+    assert.equal(expanded.overrideStatus.parentAccountId, null);
+    assert.equal(expanded.overrideStatus.reason, 'parent-account-not-found');
+  });
+});
+
+// ── Unit: command route heroCommandOverrideStatus availability ────────
+
+describe('pA4 U2: command route — heroCommandOverrideStatus available for telemetry', () => {
+  it('resolver returns overrideStatus alongside resolvedEnv for command route use', () => {
+    const env = baseEnv();
+    const result = resolveHeroFlagsForAccount({ env, accountId: INTERNAL_ACCOUNT });
+
+    // The route destructures as: { resolvedEnv: heroCommandEnv, overrideStatus: heroCommandOverrideStatus }
+    assert.ok('resolvedEnv' in result, 'must have resolvedEnv');
+    assert.ok('overrideStatus' in result, 'must have overrideStatus');
+    assert.equal(typeof result.resolvedEnv, 'object');
+    assert.equal(typeof result.overrideStatus, 'string');
+  });
+
+  it('overrideStatus values are one of the four valid classifications', () => {
+    const env = baseEnvWithGlobalFlags();
+    const validStatuses = ['internal', 'external', 'global', 'none'];
+
+    const { overrideStatus: s1 } = resolveHeroFlagsForAccount({ env, accountId: INTERNAL_ACCOUNT });
+    const { overrideStatus: s2 } = resolveHeroFlagsForAccount({ env, accountId: EXTERNAL_ACCOUNT });
+    const { overrideStatus: s3 } = resolveHeroFlagsForAccount({ env, accountId: PUBLIC_ACCOUNT });
+    const { overrideStatus: s4 } = resolveHeroFlagsForAccount({
+      env: baseEnv(), accountId: PUBLIC_ACCOUNT,
+    });
+
+    assert.ok(validStatuses.includes(s1), `internal → ${s1}`);
+    assert.ok(validStatuses.includes(s2), `external → ${s2}`);
+    assert.ok(validStatuses.includes(s3), `global → ${s3}`);
+    assert.ok(validStatuses.includes(s4), `none → ${s4}`);
+  });
+});

--- a/tests/hero-pA4-stop-conditions.test.js
+++ b/tests/hero-pA4-stop-conditions.test.js
@@ -1,0 +1,457 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  detectRawChildContent,
+  detectNonCohortExposure,
+  detectUnauthorisedCommand,
+  detectDuplicateDailyAward,
+  detectDuplicateCampDebit,
+  detectNegativeBalance,
+  detectClaimWithoutCompletion,
+  detectSubjectMutation,
+  detectDeadCTA,
+  detectRollbackFailure,
+  detectRepeatedErrors,
+  detectUntriageableIssue,
+  detectPressureCopy,
+} from '../shared/hero/stop-conditions.js';
+
+// ── 1. Raw Child Content ─────────────────────────────────────────────
+
+describe('detectRawChildContent', () => {
+  it('triggers when payload contains forbidden privacy field', () => {
+    const payload = { event: 'spell-attempt', rawAnswer: 'cat' };
+    const result = detectRawChildContent(payload);
+    assert.equal(result.triggered, true);
+    assert.equal(result.condition, 'raw-child-content');
+    assert.ok(result.detail.includes('rawAnswer'));
+  });
+
+  it('does not trigger for clean payload', () => {
+    const payload = { event: 'spell-attempt', score: 5, unit: 'u3' };
+    const result = detectRawChildContent(payload);
+    assert.equal(result.triggered, false);
+    assert.equal(result.condition, 'raw-child-content');
+  });
+
+  it('triggers for nested forbidden field at arbitrary depth', () => {
+    const payload = { meta: { nested: { childFreeText: 'hello' } } };
+    const result = detectRawChildContent(payload);
+    assert.equal(result.triggered, true);
+    assert.ok(result.detail.includes('childFreeText'));
+  });
+
+  it('handles null input gracefully', () => {
+    const result = detectRawChildContent(null);
+    assert.equal(result.triggered, false);
+  });
+
+  it('handles undefined input gracefully', () => {
+    const result = detectRawChildContent(undefined);
+    assert.equal(result.triggered, false);
+  });
+});
+
+// ── 2. Non-Cohort Exposure ───────────────────────────────────────────
+
+describe('detectNonCohortExposure', () => {
+  it('triggers when account is in no cohort list', () => {
+    const env = {
+      HERO_INTERNAL_ACCOUNTS: JSON.stringify(['int-1']),
+      HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['ext-1']),
+    };
+    const result = detectNonCohortExposure({ accountId: 'random-account', env });
+    assert.equal(result.triggered, true);
+    assert.equal(result.condition, 'non-cohort-exposure');
+    assert.ok(result.detail.includes('random-account'));
+  });
+
+  it('does not trigger for internal cohort account', () => {
+    const env = { HERO_INTERNAL_ACCOUNTS: JSON.stringify(['acc-1']) };
+    const result = detectNonCohortExposure({ accountId: 'acc-1', env });
+    assert.equal(result.triggered, false);
+  });
+
+  it('does not trigger for external cohort account', () => {
+    const env = { HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['ext-1']) };
+    const result = detectNonCohortExposure({ accountId: 'ext-1', env });
+    assert.equal(result.triggered, false);
+  });
+
+  it('handles null/undefined input gracefully', () => {
+    assert.equal(detectNonCohortExposure(undefined).triggered, false);
+    assert.equal(detectNonCohortExposure({}).triggered, false);
+    assert.equal(detectNonCohortExposure({ accountId: null, env: null }).triggered, false);
+  });
+});
+
+// ── 3. Unauthorised Command ──────────────────────────────────────────
+
+describe('detectUnauthorisedCommand', () => {
+  it('triggers when account has no Hero enablement', () => {
+    const env = {
+      HERO_INTERNAL_ACCOUNTS: JSON.stringify(['int-1']),
+      HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['ext-1']),
+    };
+    const result = detectUnauthorisedCommand({ accountId: 'hacker-account', env });
+    assert.equal(result.triggered, true);
+    assert.equal(result.condition, 'unauthorised-command');
+  });
+
+  it('does not trigger for enabled account', () => {
+    const env = { HERO_INTERNAL_ACCOUNTS: JSON.stringify(['valid-acc']) };
+    const result = detectUnauthorisedCommand({ accountId: 'valid-acc', env });
+    assert.equal(result.triggered, false);
+  });
+
+  it('does not trigger for global-enabled account', () => {
+    const env = { HERO_MODE_SHADOW_ENABLED: 'true' };
+    const result = detectUnauthorisedCommand({ accountId: 'any-acc', env });
+    assert.equal(result.triggered, false);
+  });
+
+  it('handles null/undefined input gracefully', () => {
+    assert.equal(detectUnauthorisedCommand(undefined).triggered, false);
+    assert.equal(detectUnauthorisedCommand({}).triggered, false);
+  });
+});
+
+// ── 4. Duplicate Daily Award ─────────────────────────────────────────
+
+describe('detectDuplicateDailyAward', () => {
+  it('triggers when two daily awards exist for the same dateKey', () => {
+    const ledgerEntries = [
+      { type: 'daily-award', dateKey: '2026-04-30', amount: 100 },
+      { type: 'daily-award', dateKey: '2026-04-30', amount: 100 },
+    ];
+    const result = detectDuplicateDailyAward({ ledgerEntries, dateKey: '2026-04-30' });
+    assert.equal(result.triggered, true);
+    assert.equal(result.condition, 'duplicate-daily-award');
+    assert.ok(result.detail.includes('2'));
+  });
+
+  it('does not trigger for a single daily award', () => {
+    const ledgerEntries = [
+      { type: 'daily-award', dateKey: '2026-04-30', amount: 100 },
+      { type: 'camp-debit', dateKey: '2026-04-30', amount: -200 },
+    ];
+    const result = detectDuplicateDailyAward({ ledgerEntries, dateKey: '2026-04-30' });
+    assert.equal(result.triggered, false);
+  });
+
+  it('does not trigger for different dateKeys', () => {
+    const ledgerEntries = [
+      { type: 'daily-award', dateKey: '2026-04-29', amount: 100 },
+      { type: 'daily-award', dateKey: '2026-04-30', amount: 100 },
+    ];
+    const result = detectDuplicateDailyAward({ ledgerEntries, dateKey: '2026-04-30' });
+    assert.equal(result.triggered, false);
+  });
+
+  it('handles null/undefined input gracefully', () => {
+    assert.equal(detectDuplicateDailyAward(undefined).triggered, false);
+    assert.equal(detectDuplicateDailyAward({}).triggered, false);
+    assert.equal(detectDuplicateDailyAward({ ledgerEntries: null, dateKey: null }).triggered, false);
+  });
+});
+
+// ── 5. Duplicate Camp Debit ──────────────────────────────────────────
+
+describe('detectDuplicateCampDebit', () => {
+  it('triggers when two camp debits share the same actionId', () => {
+    const ledgerEntries = [
+      { type: 'camp-debit', actionId: 'invite-monster-42', amount: -200 },
+      { type: 'camp-debit', actionId: 'invite-monster-42', amount: -200 },
+    ];
+    const result = detectDuplicateCampDebit({ ledgerEntries, actionId: 'invite-monster-42' });
+    assert.equal(result.triggered, true);
+    assert.equal(result.condition, 'duplicate-camp-debit');
+  });
+
+  it('does not trigger for a single camp debit', () => {
+    const ledgerEntries = [
+      { type: 'camp-debit', actionId: 'invite-monster-42', amount: -200 },
+    ];
+    const result = detectDuplicateCampDebit({ ledgerEntries, actionId: 'invite-monster-42' });
+    assert.equal(result.triggered, false);
+  });
+
+  it('does not trigger for different actionIds', () => {
+    const ledgerEntries = [
+      { type: 'camp-debit', actionId: 'invite-monster-42', amount: -200 },
+      { type: 'camp-debit', actionId: 'invite-monster-43', amount: -200 },
+    ];
+    const result = detectDuplicateCampDebit({ ledgerEntries, actionId: 'invite-monster-42' });
+    assert.equal(result.triggered, false);
+  });
+
+  it('handles null/undefined input gracefully', () => {
+    assert.equal(detectDuplicateCampDebit(undefined).triggered, false);
+    assert.equal(detectDuplicateCampDebit({}).triggered, false);
+    assert.equal(detectDuplicateCampDebit({ ledgerEntries: [], actionId: null }).triggered, false);
+  });
+});
+
+// ── 6. Negative Balance ──────────────────────────────────────────────
+
+describe('detectNegativeBalance', () => {
+  it('triggers when balance is negative', () => {
+    const result = detectNegativeBalance({ balance: -1 });
+    assert.equal(result.triggered, true);
+    assert.equal(result.condition, 'negative-balance');
+    assert.ok(result.detail.includes('-1'));
+  });
+
+  it('does not trigger for zero balance', () => {
+    const result = detectNegativeBalance({ balance: 0 });
+    assert.equal(result.triggered, false);
+  });
+
+  it('does not trigger for positive balance', () => {
+    const result = detectNegativeBalance({ balance: 500 });
+    assert.equal(result.triggered, false);
+  });
+
+  it('handles null/undefined input gracefully', () => {
+    assert.equal(detectNegativeBalance(undefined).triggered, false);
+    assert.equal(detectNegativeBalance({}).triggered, false);
+    assert.equal(detectNegativeBalance({ balance: null }).triggered, false);
+    assert.equal(detectNegativeBalance({ balance: 'not-a-number' }).triggered, false);
+  });
+});
+
+// ── 7. Claim Without Completion ──────────────────────────────────────
+
+describe('detectClaimWithoutCompletion', () => {
+  it('triggers when claimRecord exists but completionEvidence is missing', () => {
+    const result = detectClaimWithoutCompletion({
+      claimRecord: { id: 'claim-1' },
+      completionEvidence: null,
+    });
+    assert.equal(result.triggered, true);
+    assert.equal(result.condition, 'claim-without-completion');
+    assert.ok(result.detail.includes('claim-1'));
+  });
+
+  it('triggers when completionEvidence exists but not verified', () => {
+    const result = detectClaimWithoutCompletion({
+      claimRecord: { id: 'claim-2' },
+      completionEvidence: { verified: false },
+    });
+    assert.equal(result.triggered, true);
+  });
+
+  it('does not trigger when completionEvidence is verified', () => {
+    const result = detectClaimWithoutCompletion({
+      claimRecord: { id: 'claim-3' },
+      completionEvidence: { verified: true, taskId: 't-1' },
+    });
+    assert.equal(result.triggered, false);
+  });
+
+  it('handles null/undefined input gracefully', () => {
+    assert.equal(detectClaimWithoutCompletion(undefined).triggered, false);
+    assert.equal(detectClaimWithoutCompletion({}).triggered, false);
+    assert.equal(detectClaimWithoutCompletion({ claimRecord: null }).triggered, false);
+  });
+});
+
+// ── 8. Subject Mutation ──────────────────────────────────────────────
+
+describe('detectSubjectMutation', () => {
+  it('triggers when a Hero command is flagged as mutating subject state', () => {
+    const heroCommands = [
+      { name: 'claim-daily', mutatesSubject: false },
+      { name: 'complete-task', mutatesSubject: true },
+    ];
+    const result = detectSubjectMutation({ heroCommands, subjectState: { stars: 5 } });
+    assert.equal(result.triggered, true);
+    assert.equal(result.condition, 'subject-mutation');
+    assert.ok(result.detail.includes('complete-task'));
+  });
+
+  it('does not trigger when no commands mutate subject', () => {
+    const heroCommands = [
+      { name: 'claim-daily', mutatesSubject: false },
+      { name: 'refresh-quest', mutatesSubject: false },
+    ];
+    const result = detectSubjectMutation({ heroCommands, subjectState: { stars: 5 } });
+    assert.equal(result.triggered, false);
+  });
+
+  it('handles null/undefined input gracefully', () => {
+    assert.equal(detectSubjectMutation(undefined).triggered, false);
+    assert.equal(detectSubjectMutation({}).triggered, false);
+    assert.equal(detectSubjectMutation({ heroCommands: null, subjectState: null }).triggered, false);
+  });
+});
+
+// ── 9. Dead CTA ─────────────────────────────────────────────────────
+
+describe('detectDeadCTA', () => {
+  it('triggers when CTA is visible but not launchable', () => {
+    const result = detectDeadCTA({ readModel: { ctaVisible: true, ctaLaunchable: false } });
+    assert.equal(result.triggered, true);
+    assert.equal(result.condition, 'dead-cta');
+    assert.ok(result.detail.includes('not launchable'));
+  });
+
+  it('does not trigger when CTA is visible and launchable', () => {
+    const result = detectDeadCTA({ readModel: { ctaVisible: true, ctaLaunchable: true } });
+    assert.equal(result.triggered, false);
+  });
+
+  it('does not trigger when CTA is not visible', () => {
+    const result = detectDeadCTA({ readModel: { ctaVisible: false, ctaLaunchable: false } });
+    assert.equal(result.triggered, false);
+  });
+
+  it('handles null/undefined input gracefully', () => {
+    assert.equal(detectDeadCTA(undefined).triggered, false);
+    assert.equal(detectDeadCTA({}).triggered, false);
+    assert.equal(detectDeadCTA({ readModel: null }).triggered, false);
+  });
+});
+
+// ── 10. Rollback Failure ─────────────────────────────────────────────
+
+describe('detectRollbackFailure', () => {
+  it('triggers when flags are off but surfaces remain visible', () => {
+    const result = detectRollbackFailure({ flagsOff: true, heroSurfacesVisible: true });
+    assert.equal(result.triggered, true);
+    assert.equal(result.condition, 'rollback-failure');
+    assert.ok(result.detail.includes('flags are off'));
+  });
+
+  it('does not trigger when flags are off and surfaces are hidden', () => {
+    const result = detectRollbackFailure({ flagsOff: true, heroSurfacesVisible: false });
+    assert.equal(result.triggered, false);
+  });
+
+  it('does not trigger when flags are on (normal operation)', () => {
+    const result = detectRollbackFailure({ flagsOff: false, heroSurfacesVisible: true });
+    assert.equal(result.triggered, false);
+  });
+
+  it('handles null/undefined input gracefully', () => {
+    assert.equal(detectRollbackFailure(undefined).triggered, false);
+    assert.equal(detectRollbackFailure({}).triggered, false);
+    assert.equal(detectRollbackFailure({ flagsOff: null, heroSurfacesVisible: null }).triggered, false);
+  });
+});
+
+// ── 11. Repeated Errors ──────────────────────────────────────────────
+
+describe('detectRepeatedErrors', () => {
+  it('triggers when 3+ 500 errors occur within 5min window', () => {
+    const now = Date.now();
+    const errorLog = [
+      { timestamp: now - 60_000, status: 500 },
+      { timestamp: now - 30_000, status: 500 },
+      { timestamp: now - 10_000, status: 500 },
+    ];
+    const result = detectRepeatedErrors({ errorLog });
+    assert.equal(result.triggered, true);
+    assert.equal(result.condition, 'repeated-errors');
+    assert.ok(result.detail.includes('3'));
+  });
+
+  it('does not trigger when fewer than threshold errors in window', () => {
+    const now = Date.now();
+    const errorLog = [
+      { timestamp: now - 60_000, status: 500 },
+      { timestamp: now - 30_000, status: 500 },
+    ];
+    const result = detectRepeatedErrors({ errorLog });
+    assert.equal(result.triggered, false);
+  });
+
+  it('does not trigger when errors are outside 5min window', () => {
+    const now = Date.now();
+    const errorLog = [
+      { timestamp: now - 600_000, status: 500 },
+      { timestamp: now - 500_000, status: 500 },
+      { timestamp: now - 400_000, status: 500 },
+    ];
+    const result = detectRepeatedErrors({ errorLog });
+    assert.equal(result.triggered, false);
+  });
+
+  it('does not count non-500 errors', () => {
+    const now = Date.now();
+    const errorLog = [
+      { timestamp: now - 60_000, status: 500 },
+      { timestamp: now - 30_000, status: 404 },
+      { timestamp: now - 10_000, status: 429 },
+    ];
+    const result = detectRepeatedErrors({ errorLog });
+    assert.equal(result.triggered, false);
+  });
+
+  it('handles null/undefined input gracefully', () => {
+    assert.equal(detectRepeatedErrors(undefined).triggered, false);
+    assert.equal(detectRepeatedErrors({}).triggered, false);
+    assert.equal(detectRepeatedErrors({ errorLog: null }).triggered, false);
+  });
+});
+
+// ── 12. Untriageable Issue ───────────────────────────────────────────
+
+describe('detectUntriageableIssue', () => {
+  it('triggers when required fields are missing from error output', () => {
+    const errorOutput = { message: 'something failed' };
+    const requiredFields = ['message', 'accountId', 'requestId', 'timestamp'];
+    const result = detectUntriageableIssue({ errorOutput, requiredFields });
+    assert.equal(result.triggered, true);
+    assert.equal(result.condition, 'untriageable-issue');
+    assert.ok(result.detail.includes('accountId'));
+    assert.ok(result.detail.includes('requestId'));
+    assert.ok(result.detail.includes('timestamp'));
+  });
+
+  it('does not trigger when all required fields are present', () => {
+    const errorOutput = { message: 'err', accountId: 'a1', requestId: 'r1', timestamp: 123 };
+    const requiredFields = ['message', 'accountId', 'requestId', 'timestamp'];
+    const result = detectUntriageableIssue({ errorOutput, requiredFields });
+    assert.equal(result.triggered, false);
+  });
+
+  it('handles null/undefined input gracefully', () => {
+    assert.equal(detectUntriageableIssue(undefined).triggered, false);
+    assert.equal(detectUntriageableIssue({}).triggered, false);
+    assert.equal(detectUntriageableIssue({ errorOutput: null, requiredFields: null }).triggered, false);
+  });
+});
+
+// ── 13. Pressure Copy ────────────────────────────────────────────────
+
+describe('detectPressureCopy', () => {
+  it('triggers when copy contains forbidden pressure vocabulary', () => {
+    const result = detectPressureCopy({ copyText: 'Buy now and unlock treasure!' });
+    assert.equal(result.triggered, true);
+    assert.equal(result.condition, 'pressure-copy');
+    assert.ok(result.detail.includes('buy now'));
+    assert.ok(result.detail.includes('treasure'));
+  });
+
+  it('triggers for case-insensitive match', () => {
+    const result = detectPressureCopy({ copyText: "DON'T MISS OUT on this Limited Time deal" });
+    assert.equal(result.triggered, true);
+    assert.ok(result.detail.includes("don't miss out"));
+    assert.ok(result.detail.includes('limited time'));
+    assert.ok(result.detail.includes('deal'));
+  });
+
+  it('does not trigger for clean non-pressure copy', () => {
+    const result = detectPressureCopy({ copyText: 'Your Hero Quest is ready. Complete today\'s task to continue.' });
+    assert.equal(result.triggered, false);
+  });
+
+  it('handles null/undefined input gracefully', () => {
+    assert.equal(detectPressureCopy(undefined).triggered, false);
+    assert.equal(detectPressureCopy({}).triggered, false);
+    assert.equal(detectPressureCopy({ copyText: null }).triggered, false);
+    assert.equal(detectPressureCopy({ copyText: '' }).triggered, false);
+  });
+});

--- a/tests/hero-pA4-support-pack-validation.test.js
+++ b/tests/hero-pA4-support-pack-validation.test.js
@@ -1,0 +1,222 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PACK_PATH = resolve(__dirname, '../docs/plans/james/hero-mode/A/hero-pA4-support-pack.md');
+const content = readFileSync(PACK_PATH, 'utf-8');
+
+describe('Hero pA4 Support Pack — structural validation', () => {
+  const requiredSections = [
+    'Section 1: Support Triage Guide',
+    'Section 2: Safe Collection / Forbidden Collection',
+    'Section 3: Rollback Instruction',
+    'Section 4: Known Issues',
+    'Section 5: Escalation Rules',
+    'Section 6: Daily Review Checklist',
+  ];
+
+  for (const section of requiredSections) {
+    it(`contains required heading: ${section}`, () => {
+      assert.ok(
+        content.includes(`## ${section}`),
+        `Missing section heading: "${section}"`
+      );
+    });
+  }
+});
+
+describe('Hero pA4 Support Pack — safe collection items', () => {
+  const safeItems = [
+    'Account ID',
+    'Learner ID',
+    'dateKey',
+    'time',
+    'Device/browser',
+    'Surface visible',
+    'Request ID',
+    'Issue category',
+  ];
+
+  for (const item of safeItems) {
+    it(`lists safe collection item: ${item}`, () => {
+      assert.ok(
+        content.toLowerCase().includes(item.toLowerCase()),
+        `Missing safe collection item: "${item}"`
+      );
+    });
+  }
+});
+
+describe('Hero pA4 Support Pack — forbidden collection', () => {
+  it('explicitly states DO NOT collect', () => {
+    assert.ok(
+      content.includes('DO NOT collect'),
+      'Missing explicit "DO NOT collect" statement'
+    );
+  });
+
+  const forbiddenItems = [
+    'raw answer text',
+    'raw prompt text',
+    'child free text',
+    'screenshots containing sensitive child content',
+  ];
+
+  for (const item of forbiddenItems) {
+    it(`lists forbidden item: ${item}`, () => {
+      assert.ok(
+        content.toLowerCase().includes(item.toLowerCase()),
+        `Missing forbidden collection item: "${item}"`
+      );
+    });
+  }
+});
+
+describe('Hero pA4 Support Pack — rollback step-by-step', () => {
+  it('contains rollback step-by-step procedure', () => {
+    assert.ok(
+      content.includes('Step-by-step procedure'),
+      'Missing rollback step-by-step procedure heading'
+    );
+  });
+
+  it('references all 6 HERO_MODE flags', () => {
+    const flags = [
+      'HERO_MODE_SHADOW_ENABLED',
+      'HERO_MODE_LAUNCH_ENABLED',
+      'HERO_MODE_CHILD_UI_ENABLED',
+      'HERO_MODE_PROGRESS_ENABLED',
+      'HERO_MODE_ECONOMY_ENABLED',
+      'HERO_MODE_CAMP_ENABLED',
+    ];
+    for (const flag of flags) {
+      assert.ok(
+        content.includes(flag),
+        `Missing rollback flag reference: "${flag}"`
+      );
+    }
+  });
+
+  it('references HERO_EXTERNAL_ACCOUNTS removal', () => {
+    assert.ok(
+      content.includes('HERO_EXTERNAL_ACCOUNTS'),
+      'Missing HERO_EXTERNAL_ACCOUNTS reference in rollback'
+    );
+  });
+
+  it('states hero state remains preserved (dormant)', () => {
+    assert.ok(
+      content.toLowerCase().includes('dormant'),
+      'Missing dormancy statement in rollback'
+    );
+  });
+
+  it('describes re-enablement procedure', () => {
+    assert.ok(
+      content.toLowerCase().includes('re-enable'),
+      'Missing re-enablement instruction'
+    );
+  });
+});
+
+describe('Hero pA4 Support Pack — escalation categories', () => {
+  const escalationCategories = [
+    'Privacy violation',
+    'Duplicate rewards',
+    'Dead CTA',
+    'State corruption',
+    'Non-cohort exposure',
+  ];
+
+  for (const category of escalationCategories) {
+    it(`contains escalation category: ${category}`, () => {
+      assert.ok(
+        content.includes(category),
+        `Missing escalation category: "${category}"`
+      );
+    });
+  }
+
+  it('each escalation has detection method', () => {
+    const detectionCount = (content.match(/\*\*Detection method:\*\*/g) || []).length;
+    assert.ok(
+      detectionCount >= 5,
+      `Expected at least 5 detection method entries, found ${detectionCount}`
+    );
+  });
+
+  it('each escalation has response action', () => {
+    const responseCount = (content.match(/\*\*Response action:\*\*/g) || []).length;
+    assert.ok(
+      responseCount >= 5,
+      `Expected at least 5 response action entries, found ${responseCount}`
+    );
+  });
+
+  it('each escalation has escalation target', () => {
+    const targetCount = (content.match(/\*\*Escalation target:\*\*/g) || []).length;
+    assert.ok(
+      targetCount >= 5,
+      `Expected at least 5 escalation target entries, found ${targetCount}`
+    );
+  });
+});
+
+describe('Hero pA4 Support Pack — no pressure vocabulary', () => {
+  const pressureWords = [
+    'hurry',
+    'limited time',
+    'running out',
+    "don't miss",
+    'streak',
+    'penalty',
+    'taken away',
+    'expired',
+    'urgent',
+    'act now',
+    'last chance',
+  ];
+
+  for (const word of pressureWords) {
+    it(`does not contain pressure word: "${word}"`, () => {
+      assert.ok(
+        !content.toLowerCase().includes(word.toLowerCase()),
+        `Found pressure vocabulary: "${word}"`
+      );
+    });
+  }
+});
+
+describe('Hero pA4 Support Pack — daily review checklist', () => {
+  it('contains checklist items with checkboxes', () => {
+    const checkboxCount = (content.match(/- \[ \]/g) || []).length;
+    assert.ok(
+      checkboxCount >= 5,
+      `Expected at least 5 checklist items, found ${checkboxCount}`
+    );
+  });
+
+  it('references operator-lookup script', () => {
+    assert.ok(
+      content.includes('hero-pA4-operator-lookup'),
+      'Missing reference to operator-lookup script'
+    );
+  });
+
+  it('includes non-cohort verification check', () => {
+    assert.ok(
+      content.toLowerCase().includes('non-cohort'),
+      'Missing non-cohort verification in daily checklist'
+    );
+  });
+
+  it('includes evidence template recording', () => {
+    assert.ok(
+      content.toLowerCase().includes('evidence'),
+      'Missing evidence template reference in daily checklist'
+    );
+  });
+});

--- a/tests/hero-pA4-warning-conditions.test.js
+++ b/tests/hero-pA4-warning-conditions.test.js
@@ -1,0 +1,449 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  detectLowStartRate,
+  detectLowCompletionRate,
+  detectRepeatedAbandonment,
+  detectCampBeforeLearning,
+  detectCoinMisunderstanding,
+  detectTelemetryBlindSpots,
+  detectSubjectDominance,
+  detectSupportCluster,
+  detectSlowPerformance,
+  evaluateAllWarnings,
+} from '../shared/hero/warning-conditions.js';
+
+// ── 1. Low Start Rate ───────────────────────────────────────────────
+
+describe('detectLowStartRate', () => {
+  it('flags when start rate is below threshold', () => {
+    const result = detectLowStartRate({ questShownCount: 100, questStartCount: 20, threshold: 0.3 });
+    assert.equal(result.flagged, true);
+    assert.equal(result.condition, 'low-start-rate');
+    assert.equal(result.severity, 'warning');
+    assert.ok(result.detail.includes('20.0%'));
+    assert.ok(result.recommendation.length > 0);
+  });
+
+  it('does not flag when start rate meets threshold', () => {
+    const result = detectLowStartRate({ questShownCount: 100, questStartCount: 30, threshold: 0.3 });
+    assert.equal(result.flagged, false);
+    assert.equal(result.condition, 'low-start-rate');
+  });
+
+  it('does not flag when start rate exceeds threshold', () => {
+    const result = detectLowStartRate({ questShownCount: 100, questStartCount: 50, threshold: 0.3 });
+    assert.equal(result.flagged, false);
+  });
+
+  it('handles null input gracefully', () => {
+    assert.equal(detectLowStartRate(null).flagged, false);
+    assert.equal(detectLowStartRate(undefined).flagged, false);
+    assert.equal(detectLowStartRate({}).flagged, false);
+  });
+
+  it('handles zero questShownCount gracefully', () => {
+    const result = detectLowStartRate({ questShownCount: 0, questStartCount: 0 });
+    assert.equal(result.flagged, false);
+  });
+});
+
+// ── 2. Low Completion Rate ──────────────────────────────────────────
+
+describe('detectLowCompletionRate', () => {
+  it('flags when completion rate is below threshold', () => {
+    const result = detectLowCompletionRate({ questStartCount: 50, questCompleteCount: 15, threshold: 0.4 });
+    assert.equal(result.flagged, true);
+    assert.equal(result.condition, 'low-completion-rate');
+    assert.equal(result.severity, 'warning');
+    assert.ok(result.detail.includes('30.0%'));
+  });
+
+  it('does not flag when completion rate meets threshold', () => {
+    const result = detectLowCompletionRate({ questStartCount: 50, questCompleteCount: 20, threshold: 0.4 });
+    assert.equal(result.flagged, false);
+    assert.equal(result.condition, 'low-completion-rate');
+  });
+
+  it('does not flag when completion rate exceeds threshold', () => {
+    const result = detectLowCompletionRate({ questStartCount: 50, questCompleteCount: 40, threshold: 0.4 });
+    assert.equal(result.flagged, false);
+  });
+
+  it('handles null input gracefully', () => {
+    assert.equal(detectLowCompletionRate(null).flagged, false);
+    assert.equal(detectLowCompletionRate(undefined).flagged, false);
+    assert.equal(detectLowCompletionRate({}).flagged, false);
+  });
+
+  it('handles zero questStartCount gracefully', () => {
+    const result = detectLowCompletionRate({ questStartCount: 0, questCompleteCount: 0 });
+    assert.equal(result.flagged, false);
+  });
+});
+
+// ── 3. Repeated Abandonment ─────────────────────────────────────────
+
+describe('detectRepeatedAbandonment', () => {
+  it('flags when abandonment points reach threshold', () => {
+    const result = detectRepeatedAbandonment({ abandonmentPoints: 3, threshold: 3 });
+    assert.equal(result.flagged, true);
+    assert.equal(result.condition, 'repeated-abandonment');
+    assert.equal(result.severity, 'warning');
+    assert.ok(result.detail.includes('3'));
+  });
+
+  it('does not flag when abandonment points are below threshold', () => {
+    const result = detectRepeatedAbandonment({ abandonmentPoints: 2, threshold: 3 });
+    assert.equal(result.flagged, false);
+    assert.equal(result.condition, 'repeated-abandonment');
+  });
+
+  it('flags when exceeding threshold', () => {
+    const result = detectRepeatedAbandonment({ abandonmentPoints: 5, threshold: 3 });
+    assert.equal(result.flagged, true);
+  });
+
+  it('handles null input gracefully', () => {
+    assert.equal(detectRepeatedAbandonment(null).flagged, false);
+    assert.equal(detectRepeatedAbandonment(undefined).flagged, false);
+    assert.equal(detectRepeatedAbandonment({}).flagged, false);
+  });
+
+  it('handles non-numeric input gracefully', () => {
+    assert.equal(detectRepeatedAbandonment({ abandonmentPoints: 'many' }).flagged, false);
+  });
+});
+
+// ── 4. Camp Before Learning ─────────────────────────────────────────
+
+describe('detectCampBeforeLearning', () => {
+  it('flags when camp opens exceed ratio to quest starts', () => {
+    const result = detectCampBeforeLearning({ campOpenCount: 20, questStartCount: 10, ratio: 0.5 });
+    assert.equal(result.flagged, true);
+    assert.equal(result.condition, 'camp-before-learning');
+    assert.equal(result.severity, 'warning');
+  });
+
+  it('flags when children open Camp with zero quest starts', () => {
+    const result = detectCampBeforeLearning({ campOpenCount: 5, questStartCount: 0 });
+    assert.equal(result.flagged, true);
+    assert.ok(result.detail.includes('0 quest starts'));
+  });
+
+  it('does not flag when ratio is at or below threshold', () => {
+    const result = detectCampBeforeLearning({ campOpenCount: 5, questStartCount: 10, ratio: 0.5 });
+    assert.equal(result.flagged, false);
+    assert.equal(result.condition, 'camp-before-learning');
+  });
+
+  it('does not flag when ratio equals threshold exactly', () => {
+    // ratio = 5/10 = 0.5, threshold = 0.5 → not flagged (> not >=)
+    const result = detectCampBeforeLearning({ campOpenCount: 5, questStartCount: 10, ratio: 0.5 });
+    assert.equal(result.flagged, false);
+  });
+
+  it('handles null input gracefully', () => {
+    assert.equal(detectCampBeforeLearning(null).flagged, false);
+    assert.equal(detectCampBeforeLearning(undefined).flagged, false);
+    assert.equal(detectCampBeforeLearning({}).flagged, false);
+  });
+});
+
+// ── 5. Coin Misunderstanding ────────────────────────────────────────
+
+describe('detectCoinMisunderstanding', () => {
+  it('flags when support reports mention coin keyword', () => {
+    const result = detectCoinMisunderstanding({
+      supportReports: [
+        { text: 'My child spent real coins in the app?' },
+        { text: 'Login issue' },
+      ],
+    });
+    assert.equal(result.flagged, true);
+    assert.equal(result.condition, 'coin-misunderstanding');
+    assert.equal(result.severity, 'warning');
+    assert.ok(result.detail.includes('1 support report'));
+  });
+
+  it('does not flag when no reports mention keyword', () => {
+    const result = detectCoinMisunderstanding({
+      supportReports: [
+        { text: 'Login issue' },
+        { text: 'App crashes on start' },
+      ],
+    });
+    assert.equal(result.flagged, false);
+    assert.equal(result.condition, 'coin-misunderstanding');
+  });
+
+  it('uses custom keyword when provided', () => {
+    const result = detectCoinMisunderstanding({
+      supportReports: [{ text: 'What is the payment for?' }],
+      keyword: 'payment',
+    });
+    assert.equal(result.flagged, true);
+    assert.ok(result.detail.includes('payment'));
+  });
+
+  it('handles null input gracefully', () => {
+    assert.equal(detectCoinMisunderstanding(null).flagged, false);
+    assert.equal(detectCoinMisunderstanding(undefined).flagged, false);
+    assert.equal(detectCoinMisunderstanding({}).flagged, false);
+  });
+
+  it('handles empty support reports array', () => {
+    assert.equal(detectCoinMisunderstanding({ supportReports: [] }).flagged, false);
+  });
+});
+
+// ── 6. Telemetry Blind Spots ────────────────────────────────────────
+
+describe('detectTelemetryBlindSpots', () => {
+  it('flags when expected signals are missing from actual', () => {
+    const result = detectTelemetryBlindSpots({
+      expectedSignals: ['quest-start', 'quest-complete', 'camp-open'],
+      actualSignals: ['quest-start'],
+    });
+    assert.equal(result.flagged, true);
+    assert.equal(result.condition, 'telemetry-blind-spots');
+    assert.equal(result.severity, 'warning');
+    assert.ok(result.detail.includes('quest-complete'));
+    assert.ok(result.detail.includes('camp-open'));
+  });
+
+  it('does not flag when all expected signals are present', () => {
+    const result = detectTelemetryBlindSpots({
+      expectedSignals: ['quest-start', 'quest-complete'],
+      actualSignals: ['quest-start', 'quest-complete', 'camp-open'],
+    });
+    assert.equal(result.flagged, false);
+    assert.equal(result.condition, 'telemetry-blind-spots');
+  });
+
+  it('does not flag when expected is empty', () => {
+    const result = detectTelemetryBlindSpots({
+      expectedSignals: [],
+      actualSignals: ['quest-start'],
+    });
+    assert.equal(result.flagged, false);
+  });
+
+  it('handles null input gracefully', () => {
+    assert.equal(detectTelemetryBlindSpots(null).flagged, false);
+    assert.equal(detectTelemetryBlindSpots(undefined).flagged, false);
+    assert.equal(detectTelemetryBlindSpots({}).flagged, false);
+  });
+});
+
+// ── 7. Subject Dominance ────────────────────────────────────────────
+
+describe('detectSubjectDominance', () => {
+  it('flags when one subject exceeds dominance threshold', () => {
+    const result = detectSubjectDominance({
+      subjectMix: { spelling: 80, grammar: 10, punctuation: 10 },
+      dominanceThreshold: 0.7,
+    });
+    assert.equal(result.flagged, true);
+    assert.equal(result.condition, 'subject-dominance');
+    assert.equal(result.severity, 'warning');
+    assert.ok(result.detail.includes('spelling'));
+    assert.ok(result.detail.includes('80.0%'));
+  });
+
+  it('does not flag when no subject reaches threshold', () => {
+    const result = detectSubjectDominance({
+      subjectMix: { spelling: 40, grammar: 35, punctuation: 25 },
+      dominanceThreshold: 0.7,
+    });
+    assert.equal(result.flagged, false);
+    assert.equal(result.condition, 'subject-dominance');
+  });
+
+  it('flags at exactly the threshold boundary', () => {
+    // 70/100 = 0.7 which equals threshold → flagged (>=)
+    const result = detectSubjectDominance({
+      subjectMix: { spelling: 70, grammar: 30 },
+      dominanceThreshold: 0.7,
+    });
+    assert.equal(result.flagged, true);
+  });
+
+  it('does not flag just below threshold', () => {
+    // 69/100 = 0.69 < 0.7 → not flagged
+    const result = detectSubjectDominance({
+      subjectMix: { spelling: 69, grammar: 31 },
+      dominanceThreshold: 0.7,
+    });
+    assert.equal(result.flagged, false);
+  });
+
+  it('handles null input gracefully', () => {
+    assert.equal(detectSubjectDominance(null).flagged, false);
+    assert.equal(detectSubjectDominance(undefined).flagged, false);
+    assert.equal(detectSubjectDominance({}).flagged, false);
+  });
+
+  it('handles empty subjectMix', () => {
+    assert.equal(detectSubjectDominance({ subjectMix: {} }).flagged, false);
+  });
+});
+
+// ── 8. Support Cluster ──────────────────────────────────────────────
+
+describe('detectSupportCluster', () => {
+  it('flags when one category exceeds cluster threshold', () => {
+    const result = detectSupportCluster({
+      supportCategories: { billing: 60, technical: 30, other: 10 },
+      clusterThreshold: 0.5,
+    });
+    assert.equal(result.flagged, true);
+    assert.equal(result.condition, 'support-cluster');
+    assert.equal(result.severity, 'warning');
+    assert.ok(result.detail.includes('billing'));
+    assert.ok(result.detail.includes('60.0%'));
+  });
+
+  it('does not flag when no category exceeds threshold', () => {
+    const result = detectSupportCluster({
+      supportCategories: { billing: 30, technical: 40, other: 30 },
+      clusterThreshold: 0.5,
+    });
+    assert.equal(result.flagged, false);
+    assert.equal(result.condition, 'support-cluster');
+  });
+
+  it('does not flag at exactly the threshold boundary', () => {
+    // 50/100 = 0.5, threshold = 0.5 → not flagged (> not >=)
+    const result = detectSupportCluster({
+      supportCategories: { billing: 50, technical: 50 },
+      clusterThreshold: 0.5,
+    });
+    assert.equal(result.flagged, false);
+  });
+
+  it('flags just above threshold', () => {
+    // 51/100 = 0.51 > 0.5 → flagged
+    const result = detectSupportCluster({
+      supportCategories: { billing: 51, technical: 49 },
+      clusterThreshold: 0.5,
+    });
+    assert.equal(result.flagged, true);
+  });
+
+  it('handles null input gracefully', () => {
+    assert.equal(detectSupportCluster(null).flagged, false);
+    assert.equal(detectSupportCluster(undefined).flagged, false);
+    assert.equal(detectSupportCluster({}).flagged, false);
+  });
+
+  it('handles empty supportCategories', () => {
+    assert.equal(detectSupportCluster({ supportCategories: {} }).flagged, false);
+  });
+});
+
+// ── 9. Slow Performance ─────────────────────────────────────────────
+
+describe('detectSlowPerformance', () => {
+  it('flags when latency meets threshold', () => {
+    const result = detectSlowPerformance({ latencyMs: 2000, threshold: 2000 });
+    assert.equal(result.flagged, true);
+    assert.equal(result.condition, 'slow-performance');
+    assert.equal(result.severity, 'warning');
+    assert.ok(result.detail.includes('2000ms'));
+  });
+
+  it('flags when latency exceeds threshold', () => {
+    const result = detectSlowPerformance({ latencyMs: 3500, threshold: 2000 });
+    assert.equal(result.flagged, true);
+    assert.ok(result.detail.includes('3500ms'));
+  });
+
+  it('does not flag when latency is below threshold', () => {
+    const result = detectSlowPerformance({ latencyMs: 1999, threshold: 2000 });
+    assert.equal(result.flagged, false);
+    assert.equal(result.condition, 'slow-performance');
+  });
+
+  it('does not flag when latency is well below threshold', () => {
+    const result = detectSlowPerformance({ latencyMs: 500, threshold: 2000 });
+    assert.equal(result.flagged, false);
+  });
+
+  it('handles null input gracefully', () => {
+    assert.equal(detectSlowPerformance(null).flagged, false);
+    assert.equal(detectSlowPerformance(undefined).flagged, false);
+    assert.equal(detectSlowPerformance({}).flagged, false);
+  });
+
+  it('handles non-numeric latency gracefully', () => {
+    assert.equal(detectSlowPerformance({ latencyMs: 'slow' }).flagged, false);
+  });
+});
+
+// ── evaluateAllWarnings ─────────────────────────────────────────────
+
+describe('evaluateAllWarnings', () => {
+  it('returns only flagged results from mixed data', () => {
+    const metrics = {
+      // triggers low start rate (10/100 = 10% < 30%)
+      questShownCount: 100,
+      questStartCount: 10,
+      questCompleteCount: 8,
+      // triggers slow performance
+      latencyMs: 3000,
+      // does NOT trigger repeated abandonment (below default 3)
+      abandonmentPoints: 1,
+      // does NOT trigger camp-before-learning (5/10 = 0.5, not > 0.5)
+      campOpenCount: 5,
+      // does NOT trigger coin misunderstanding (no reports)
+      supportReports: [],
+      // does NOT trigger telemetry blind spots (all present)
+      expectedSignals: ['quest-start'],
+      actualSignals: ['quest-start'],
+      // does NOT trigger subject dominance (balanced)
+      subjectMix: { spelling: 40, grammar: 60 },
+      // does NOT trigger support cluster (both at 50%, not > 50%)
+      supportCategories: { billing: 50, technical: 50 },
+    };
+    const results = evaluateAllWarnings(metrics);
+    // start rate = 10/100 = 10% < 30% → flagged
+    // completion rate = 8/10 = 80% ≥ 40% → NOT flagged
+    // slow-performance: 3000ms ≥ 2000ms → flagged
+    // support-cluster: 50/100 = 50%, not > 50% → NOT flagged
+    const conditions = results.map((r) => r.condition);
+    assert.ok(conditions.includes('low-start-rate'));
+    assert.ok(conditions.includes('slow-performance'));
+    assert.ok(!conditions.includes('support-cluster'));
+    assert.ok(!conditions.includes('repeated-abandonment'));
+    // All results have flagged=true
+    for (const r of results) {
+      assert.equal(r.flagged, true);
+      assert.equal(r.severity, 'warning');
+    }
+  });
+
+  it('returns empty array when no conditions are flagged', () => {
+    const metrics = {
+      questShownCount: 100,
+      questStartCount: 50,
+      questCompleteCount: 40,
+      abandonmentPoints: 0,
+      campOpenCount: 10,
+      latencyMs: 500,
+      supportReports: [],
+      expectedSignals: ['a'],
+      actualSignals: ['a'],
+      subjectMix: { spelling: 50, grammar: 50 },
+      supportCategories: { billing: 50, technical: 50 },
+    };
+    const results = evaluateAllWarnings(metrics);
+    assert.equal(results.length, 0);
+  });
+
+  it('returns empty array for null input', () => {
+    assert.deepEqual(evaluateAllWarnings(null), []);
+    assert.deepEqual(evaluateAllWarnings(undefined), []);
+  });
+});

--- a/worker/src/app.js
+++ b/worker/src/app.js
@@ -49,7 +49,7 @@ import { resolveHeroStartTaskCommand } from './hero/launch.js';
 import { resolveHeroClaimCommand } from './hero/claim.js';
 import { resolveHeroCampCommand } from './hero/camp.js';
 import { probeHeroTelemetry, buildExpandedProbeResponse, stripPrivacyFields } from './hero/telemetry-probe.js';
-import { resolveHeroFlagsWithOverride, HERO_FLAG_KEYS } from '../../shared/hero/account-override.js';
+import { resolveHeroFlagsWithOverride, resolveHeroFlagsForAccount, HERO_FLAG_KEYS } from '../../shared/hero/account-override.js';
 import {
   initialiseDailyProgress,
   markTaskStarted,
@@ -1435,7 +1435,8 @@ export function createWorkerApp({
         if (url.pathname === '/api/hero/command' && request.method === 'POST') {
           // U8 security fix: apply per-account override BEFORE pre-gate checks
           // so team accounts in HERO_INTERNAL_ACCOUNTS bypass global flag gates.
-          const heroCommandEnv = resolveHeroFlagsWithOverride({ env, accountId: session.accountId });
+          // pA4 U2: unified resolver — also captures overrideStatus for ops output.
+          const { resolvedEnv: heroCommandEnv, overrideStatus: heroCommandOverrideStatus } = resolveHeroFlagsForAccount({ env, accountId: session.accountId });
           if (!envFlagEnabled(heroCommandEnv.HERO_MODE_LAUNCH_ENABLED)) {
             throw new NotFoundError('Hero launch is not available.', {
               code: 'hero_launch_disabled',
@@ -2714,26 +2715,12 @@ export function createWorkerApp({
               parentAccountId = membershipRow?.account_id ?? null;
             } catch { /* orphan learner — parentAccountId stays null */ }
 
-            // Resolve flags using the PARENT account (not operator)
-            const resolvedFlags = resolveHeroFlagsWithOverride({
+            // pA4 U2: unified resolver — replaces manual HERO_INTERNAL_ACCOUNTS parse.
+            // Resolve flags using the PARENT account (not operator).
+            const { resolvedEnv: resolvedFlags, overrideStatus: resolverClassification } = resolveHeroFlagsForAccount({
               env,
               accountId: parentAccountId ?? session.accountId,
             });
-
-            let isInternalAccount = null;
-            if (parentAccountId === null) {
-              // Orphan learner — cannot determine internal status
-              isInternalAccount = null;
-            } else {
-              isInternalAccount = false;
-              try {
-                const raw = env.HERO_INTERNAL_ACCOUNTS;
-                if (raw) {
-                  const parsed = JSON.parse(raw);
-                  isInternalAccount = Array.isArray(parsed) && parsed.includes(parentAccountId);
-                }
-              } catch { /* graceful — default to false */ }
-            }
 
             // P0 security: project only Hero flag keys — never expose full env secrets
             const effectiveFlags = Object.fromEntries(
@@ -2742,7 +2729,7 @@ export function createWorkerApp({
             const overrideStatus = {
               queriedLearnerId: probeLearnerIdParam,
               parentAccountId,
-              isInternalAccount,
+              classification: resolverClassification,
               effectiveFlags,
               ...(parentAccountId === null ? { reason: 'parent-account-not-found' } : {}),
             };


### PR DESCRIPTION
## Summary

- Add stop/warning condition register documenting all 13 stop conditions (S1-S13) and 9 warning conditions (W1-W9) from the pA4 origin contract
- Add rollback evidence note documenting verified flag-off preserves-state mechanism with three-step procedure
- Add validation test (80 assertions) confirming both documents meet structural requirements

## Test plan

- [x] `node --test tests/hero-pA4-register-validation.test.js` — 80/80 pass
- [x] Register contains all S1-S13 stop conditions with detection methods and response actions
- [x] Register contains all W1-W9 warning conditions with detection methods and response actions
- [x] Rollback evidence references flags-off, state-preserved, never-deleted, and re-enable test