### PR TITLE
feat(grammar-qg-p12): U3 — validator reads artefact paths from manifest

### DIFF
--- a/scripts/validate-grammar-qg-certification-evidence.mjs
+++ b/scripts/validate-grammar-qg-certification-evidence.mjs
@@ -864,8 +864,11 @@ export function validateMarkingMatrixCounts(manifest, rootDir) {
  * Validate that every template flagged as requiresAdultReview in the distractor
  * audit has a corresponding adultReviewDecision in the quality register.
  *
- * @param {string} rootDir - Project root directory.
- * @returns {{ pass: boolean, missing: string[], covered: string[] }}
+ * @param {object} manifest - Parsed certification manifest JSON. When `manifest.artefacts`
+ *   is present, artefact paths are resolved from the manifest; otherwise falls back to
+ *   legacy P10 report paths.
+ * @param {string} [rootDir] - Project root directory (defaults to repository root).
+ * @returns {{ pass: boolean, missing: string[], covered: string[], error?: string }}
  */
 export function validateDistractorReviewCoverage(manifest, rootDir) {
   const effectiveRoot = rootDir || ROOT_DIR;

--- a/scripts/validate-grammar-qg-certification-evidence.mjs
+++ b/scripts/validate-grammar-qg-certification-evidence.mjs
@@ -31,6 +31,62 @@ const ROOT_DIR = path.resolve(__dirname, '..');
 // ---------------------------------------------------------------------------
 
 /**
+ * Resolve an artefact path from a manifest's artefacts map.
+ *
+ * @param {object} manifest - Parsed certification manifest JSON.
+ * @param {string} key - The artefact key to look up in manifest.artefacts.
+ * @param {string} [rootDir] - Project root directory.
+ * @returns {{ ok: boolean, path: string|null, error: string|null }}
+ */
+export function requireArtefact(manifest, key, rootDir = ROOT_DIR) {
+  const rel = manifest?.artefacts?.[key];
+  if (!rel || typeof rel !== 'string') {
+    return {
+      ok: false,
+      path: null,
+      error: `Manifest missing required artefact path: artefacts.${key}`,
+    };
+  }
+  const abs = path.resolve(rootDir, rel);
+  if (!existsSync(abs)) {
+    return {
+      ok: false,
+      path: abs,
+      error: `Artefact file not found for ${key}: ${rel}`,
+    };
+  }
+  return { ok: true, path: abs, error: null };
+}
+
+/**
+ * Resolve and read a JSON artefact from a manifest's artefacts map.
+ *
+ * @param {object} manifest - Parsed certification manifest JSON.
+ * @param {string} key - The artefact key to look up in manifest.artefacts.
+ * @param {string} [rootDir] - Project root directory.
+ * @returns {{ ok: boolean, data: object|null, path: string|null, error: string|null }}
+ */
+export function readJsonArtefact(manifest, key, rootDir = ROOT_DIR) {
+  const resolved = requireArtefact(manifest, key, rootDir);
+  if (!resolved.ok) return { ok: false, error: resolved.error, data: null, path: null };
+  try {
+    return {
+      ok: true,
+      data: JSON.parse(readFileSync(resolved.path, 'utf8')),
+      path: resolved.path,
+      error: null,
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      error: `Artefact ${key} is not valid JSON: ${err.message}`,
+      data: null,
+      path: resolved.path,
+    };
+  }
+}
+
+/**
  * Parse a seed window string like "1..15" into { start, end, count }.
  */
 export function parseSeedWindow(windowStr) {
@@ -597,95 +653,149 @@ export function validateReportCounts(manifest, reportPath, opts = {}) {
   const reportContent = readFileSync(reportPath, 'utf8');
 
   // --- Marking matrix count cross-check ---
-  const markingMatrixPath = path.join(rootDir, 'reports', 'grammar', 'grammar-qg-p10-marking-matrix.json');
-  if (existsSync(markingMatrixPath)) {
-    let matrix;
-    try {
-      matrix = JSON.parse(readFileSync(markingMatrixPath, 'utf8'));
-    } catch (err) {
+  let markingMatrixPath;
+  let matrix = null;
+  if (manifest.artefacts) {
+    const matrixResult = readJsonArtefact(manifest, 'markingMatrix', rootDir);
+    if (matrixResult.ok) {
+      matrix = matrixResult.data;
+      markingMatrixPath = matrixResult.path;
+      // Validate contentReleaseId consistency
+      if (matrix?.metadata?.contentReleaseId && matrix.metadata.contentReleaseId !== manifest.contentReleaseId) {
+        mismatches.push({
+          field: 'markingMatrixReleaseIdMismatch',
+          claimed: manifest.contentReleaseId,
+          actual: matrix.metadata.contentReleaseId,
+          message: `Marking matrix metadata.contentReleaseId "${matrix.metadata.contentReleaseId}" does not match manifest contentReleaseId "${manifest.contentReleaseId}"`,
+        });
+      }
+    } else {
       mismatches.push({
-        field: 'markingMatrixParse',
-        claimed: 'valid JSON',
-        actual: `parse error: ${err.message}`,
-        message: `Marking matrix file is not valid JSON: ${err.message}`,
+        field: 'markingMatrixResolve',
+        claimed: 'artefacts.markingMatrix',
+        actual: matrixResult.error,
+        message: matrixResult.error,
       });
     }
+  } else {
+    // Legacy P10 fallback — no artefacts map in manifest
+    console.warn('WARN: manifest.artefacts not found — falling back to legacy P10 paths for markingMatrix');
+    markingMatrixPath = path.join(rootDir, 'reports', 'grammar', 'grammar-qg-p10-marking-matrix.json');
+    if (existsSync(markingMatrixPath)) {
+      try {
+        matrix = JSON.parse(readFileSync(markingMatrixPath, 'utf8'));
+      } catch (err) {
+        mismatches.push({
+          field: 'markingMatrixParse',
+          claimed: 'valid JSON',
+          actual: `parse error: ${err.message}`,
+          message: `Marking matrix file is not valid JSON: ${err.message}`,
+        });
+      }
+    }
+  }
 
-    if (matrix?.metadata?.totalEntries != null) {
-      // Extract claimed marking matrix count from report
-      // Pattern: "N marking matrix entries" or "Marking matrix (N entries"
-      const matrixCountRegex = /(\d+)\s+marking\s+matrix\s+entries|[Mm]arking\s+matrix\s*\((\d+)\s+entries/;
-      const matrixMatch = reportContent.match(matrixCountRegex);
-      if (matrixMatch) {
-        const claimedCount = Number(matrixMatch[1] || matrixMatch[2]);
-        if (claimedCount !== matrix.metadata.totalEntries) {
-          mismatches.push({
-            field: 'markingMatrixCount',
-            claimed: claimedCount,
-            actual: matrix.metadata.totalEntries,
-            message: `Report claims ${claimedCount} marking matrix entries but artefact metadata has ${matrix.metadata.totalEntries}`,
-          });
-        }
+  if (matrix?.metadata?.totalEntries != null) {
+    // Extract claimed marking matrix count from report
+    // Pattern: "N marking matrix entries" or "Marking matrix (N entries"
+    const matrixCountRegex = /(\d+)\s+marking\s+matrix\s+entries|[Mm]arking\s+matrix\s*\((\d+)\s+entries/;
+    const matrixMatch = reportContent.match(matrixCountRegex);
+    if (matrixMatch) {
+      const claimedCount = Number(matrixMatch[1] || matrixMatch[2]);
+      if (claimedCount !== matrix.metadata.totalEntries) {
+        mismatches.push({
+          field: 'markingMatrixCount',
+          claimed: claimedCount,
+          actual: matrix.metadata.totalEntries,
+          message: `Report claims ${claimedCount} marking matrix entries but artefact metadata has ${matrix.metadata.totalEntries}`,
+        });
       }
     }
   }
 
   // --- Quality register status count cross-check ---
-  const qualityRegisterPath = path.join(rootDir, 'reports', 'grammar', 'grammar-qg-p10-quality-register.json');
-  if (existsSync(qualityRegisterPath)) {
-    let register;
-    try {
-      register = JSON.parse(readFileSync(qualityRegisterPath, 'utf8'));
-    } catch (err) {
+  let qualityRegisterPath;
+  let register = null;
+  if (manifest.artefacts) {
+    const registerResult = readJsonArtefact(manifest, 'qualityRegister', rootDir);
+    if (registerResult.ok) {
+      register = registerResult.data;
+      qualityRegisterPath = registerResult.path;
+      // Validate contentReleaseId consistency
+      if (register?.metadata?.contentReleaseId && register.metadata.contentReleaseId !== manifest.contentReleaseId) {
+        mismatches.push({
+          field: 'qualityRegisterReleaseIdMismatch',
+          claimed: manifest.contentReleaseId,
+          actual: register.metadata.contentReleaseId,
+          message: `Quality register metadata.contentReleaseId "${register.metadata.contentReleaseId}" does not match manifest contentReleaseId "${manifest.contentReleaseId}"`,
+        });
+      }
+    } else {
       mismatches.push({
-        field: 'qualityRegisterParse',
-        claimed: 'valid JSON',
-        actual: `parse error: ${err.message}`,
-        message: `Quality register file is not valid JSON: ${err.message}`,
+        field: 'qualityRegisterResolve',
+        claimed: 'artefacts.qualityRegister',
+        actual: registerResult.error,
+        message: registerResult.error,
       });
     }
+  } else {
+    // Legacy P10 fallback — no artefacts map in manifest
+    console.warn('WARN: manifest.artefacts not found — falling back to legacy P10 paths for qualityRegister');
+    qualityRegisterPath = path.join(rootDir, 'reports', 'grammar', 'grammar-qg-p10-quality-register.json');
+    if (existsSync(qualityRegisterPath)) {
+      try {
+        register = JSON.parse(readFileSync(qualityRegisterPath, 'utf8'));
+      } catch (err) {
+        mismatches.push({
+          field: 'qualityRegisterParse',
+          claimed: 'valid JSON',
+          actual: `parse error: ${err.message}`,
+          message: `Quality register file is not valid JSON: ${err.message}`,
+        });
+      }
+    }
+  }
 
-    if (register?.metadata) {
-      const meta = register.metadata;
-      // Extract claimed quality register counts from report
-      // Pattern: "N approved" or "N/N templates approved" or "N approved + M approved_with_limitation"
-      const approvedRegex = /(\d+)\s+approved\s*\+\s*(\d+)\s+approved_with_limitation/;
-      const simpleApprovedRegex = /(\d+)\/(\d+)\s+templates?\s+approved|(\d+)\s+templates?\s+approved/;
+  if (register?.metadata) {
+    const meta = register.metadata;
+    // Extract claimed quality register counts from report
+    // Pattern: "N approved" or "N/N templates approved" or "N approved + M approved_with_limitation"
+    const approvedRegex = /(\d+)\s+approved\s*\+\s*(\d+)\s+approved_with_limitation/;
+    const simpleApprovedRegex = /(\d+)\/(\d+)\s+templates?\s+approved|(\d+)\s+templates?\s+approved/;
 
-      const compoundMatch = reportContent.match(approvedRegex);
-      if (compoundMatch) {
-        const claimedApproved = Number(compoundMatch[1]);
-        const claimedLimited = Number(compoundMatch[2]);
-        if (claimedApproved !== meta.approved) {
+    const compoundMatch = reportContent.match(approvedRegex);
+    if (compoundMatch) {
+      const claimedApproved = Number(compoundMatch[1]);
+      const claimedLimited = Number(compoundMatch[2]);
+      if (claimedApproved !== meta.approved) {
+        mismatches.push({
+          field: 'qualityRegisterApproved',
+          claimed: claimedApproved,
+          actual: meta.approved,
+          message: `Report claims ${claimedApproved} approved but quality register has ${meta.approved}`,
+        });
+      }
+      if (claimedLimited !== meta.approvedWithLimitation) {
+        mismatches.push({
+          field: 'qualityRegisterApprovedWithLimitation',
+          claimed: claimedLimited,
+          actual: meta.approvedWithLimitation,
+          message: `Report claims ${claimedLimited} approved_with_limitation but quality register has ${meta.approvedWithLimitation}`,
+        });
+      }
+    } else {
+      const simpleMatch = reportContent.match(simpleApprovedRegex);
+      if (simpleMatch) {
+        // "78/78 templates approved" → check total
+        const claimedTotal = Number(simpleMatch[1] || simpleMatch[3]);
+        const actualTotal = (meta.approved || 0) + (meta.approvedWithLimitation || 0);
+        if (claimedTotal !== actualTotal && claimedTotal !== meta.approved) {
           mismatches.push({
-            field: 'qualityRegisterApproved',
-            claimed: claimedApproved,
-            actual: meta.approved,
-            message: `Report claims ${claimedApproved} approved but quality register has ${meta.approved}`,
+            field: 'qualityRegisterTotal',
+            claimed: claimedTotal,
+            actual: `${meta.approved} approved + ${meta.approvedWithLimitation} approved_with_limitation = ${actualTotal} total`,
+            message: `Report claims ${claimedTotal} templates approved but quality register has ${meta.approved} approved + ${meta.approvedWithLimitation} approved_with_limitation`,
           });
-        }
-        if (claimedLimited !== meta.approvedWithLimitation) {
-          mismatches.push({
-            field: 'qualityRegisterApprovedWithLimitation',
-            claimed: claimedLimited,
-            actual: meta.approvedWithLimitation,
-            message: `Report claims ${claimedLimited} approved_with_limitation but quality register has ${meta.approvedWithLimitation}`,
-          });
-        }
-      } else {
-        const simpleMatch = reportContent.match(simpleApprovedRegex);
-        if (simpleMatch) {
-          // "78/78 templates approved" → check total
-          const claimedTotal = Number(simpleMatch[1] || simpleMatch[3]);
-          const actualTotal = (meta.approved || 0) + (meta.approvedWithLimitation || 0);
-          if (claimedTotal !== actualTotal && claimedTotal !== meta.approved) {
-            mismatches.push({
-              field: 'qualityRegisterTotal',
-              claimed: claimedTotal,
-              actual: `${meta.approved} approved + ${meta.approvedWithLimitation} approved_with_limitation = ${actualTotal} total`,
-              message: `Report claims ${claimedTotal} templates approved but quality register has ${meta.approved} approved + ${meta.approvedWithLimitation} approved_with_limitation`,
-            });
-          }
         }
       }
     }
@@ -707,17 +817,38 @@ export function validateReportCounts(manifest, reportPath, opts = {}) {
  */
 export function validateMarkingMatrixCounts(manifest, rootDir) {
   const effectiveRoot = rootDir || ROOT_DIR;
-  const matrixPath = path.join(effectiveRoot, 'reports', 'grammar', 'grammar-qg-p10-marking-matrix.json');
 
-  if (!existsSync(matrixPath)) {
-    return { pass: false, expected: 80, actual: 0, error: `Marking matrix file not found: ${matrixPath}` };
-  }
-
+  let matrixPath;
   let matrix;
-  try {
-    matrix = JSON.parse(readFileSync(matrixPath, 'utf8'));
-  } catch (err) {
-    return { pass: false, expected: 80, actual: 0, error: `Failed to parse marking matrix JSON: ${err.message}` };
+
+  if (manifest?.artefacts) {
+    const result = readJsonArtefact(manifest, 'markingMatrix', effectiveRoot);
+    if (!result.ok) {
+      return { pass: false, expected: 80, actual: 0, error: result.error };
+    }
+    matrix = result.data;
+    matrixPath = result.path;
+    // Validate contentReleaseId consistency
+    if (matrix?.metadata?.contentReleaseId && matrix.metadata.contentReleaseId !== manifest.contentReleaseId) {
+      return {
+        pass: false,
+        expected: 80,
+        actual: 0,
+        error: `Marking matrix metadata.contentReleaseId "${matrix.metadata.contentReleaseId}" does not match manifest contentReleaseId "${manifest.contentReleaseId}"`,
+      };
+    }
+  } else {
+    // Legacy P10 fallback
+    console.warn('WARN: manifest.artefacts not found — falling back to legacy P10 paths for markingMatrix');
+    matrixPath = path.join(effectiveRoot, 'reports', 'grammar', 'grammar-qg-p10-marking-matrix.json');
+    if (!existsSync(matrixPath)) {
+      return { pass: false, expected: 80, actual: 0, error: `Marking matrix file not found: ${matrixPath}` };
+    }
+    try {
+      matrix = JSON.parse(readFileSync(matrixPath, 'utf8'));
+    } catch (err) {
+      return { pass: false, expected: 80, actual: 0, error: `Failed to parse marking matrix JSON: ${err.message}` };
+    }
   }
 
   const actual = matrix?.metadata?.totalEntries ?? 0;
@@ -736,28 +867,64 @@ export function validateMarkingMatrixCounts(manifest, rootDir) {
  * @param {string} rootDir - Project root directory.
  * @returns {{ pass: boolean, missing: string[], covered: string[] }}
  */
-export function validateDistractorReviewCoverage(rootDir) {
+export function validateDistractorReviewCoverage(manifest, rootDir) {
   const effectiveRoot = rootDir || ROOT_DIR;
-  const auditPath = path.join(effectiveRoot, 'reports', 'grammar', 'grammar-qg-p10-distractor-audit.json');
-  const registerPath = path.join(effectiveRoot, 'reports', 'grammar', 'grammar-qg-p10-quality-register.json');
-
-  if (!existsSync(auditPath)) {
-    return { pass: false, missing: [], covered: [], error: `Distractor audit file not found: ${auditPath}` };
-  }
-  if (!existsSync(registerPath)) {
-    return { pass: false, missing: [], covered: [], error: `Quality register file not found: ${registerPath}` };
-  }
 
   let audit, register;
-  try {
-    audit = JSON.parse(readFileSync(auditPath, 'utf8'));
-  } catch (err) {
-    return { pass: false, missing: [], covered: [], error: `Failed to parse distractor audit: ${err.message}` };
-  }
-  try {
-    register = JSON.parse(readFileSync(registerPath, 'utf8'));
-  } catch (err) {
-    return { pass: false, missing: [], covered: [], error: `Failed to parse quality register: ${err.message}` };
+
+  if (manifest?.artefacts) {
+    const auditResult = readJsonArtefact(manifest, 'distractorAudit', effectiveRoot);
+    if (!auditResult.ok) {
+      return { pass: false, missing: [], covered: [], error: auditResult.error };
+    }
+    audit = auditResult.data;
+    // Validate contentReleaseId consistency
+    if (audit?.metadata?.contentReleaseId && audit.metadata.contentReleaseId !== manifest.contentReleaseId) {
+      return {
+        pass: false,
+        missing: [],
+        covered: [],
+        error: `Distractor audit metadata.contentReleaseId "${audit.metadata.contentReleaseId}" does not match manifest contentReleaseId "${manifest.contentReleaseId}"`,
+      };
+    }
+
+    const registerResult = readJsonArtefact(manifest, 'qualityRegister', effectiveRoot);
+    if (!registerResult.ok) {
+      return { pass: false, missing: [], covered: [], error: registerResult.error };
+    }
+    register = registerResult.data;
+    // Validate contentReleaseId consistency
+    if (register?.metadata?.contentReleaseId && register.metadata.contentReleaseId !== manifest.contentReleaseId) {
+      return {
+        pass: false,
+        missing: [],
+        covered: [],
+        error: `Quality register metadata.contentReleaseId "${register.metadata.contentReleaseId}" does not match manifest contentReleaseId "${manifest.contentReleaseId}"`,
+      };
+    }
+  } else {
+    // Legacy P10 fallback
+    console.warn('WARN: manifest.artefacts not found — falling back to legacy P10 paths for distractorAudit/qualityRegister');
+    const auditPath = path.join(effectiveRoot, 'reports', 'grammar', 'grammar-qg-p10-distractor-audit.json');
+    const registerPath = path.join(effectiveRoot, 'reports', 'grammar', 'grammar-qg-p10-quality-register.json');
+
+    if (!existsSync(auditPath)) {
+      return { pass: false, missing: [], covered: [], error: `Distractor audit file not found: ${auditPath}` };
+    }
+    if (!existsSync(registerPath)) {
+      return { pass: false, missing: [], covered: [], error: `Quality register file not found: ${registerPath}` };
+    }
+
+    try {
+      audit = JSON.parse(readFileSync(auditPath, 'utf8'));
+    } catch (err) {
+      return { pass: false, missing: [], covered: [], error: `Failed to parse distractor audit: ${err.message}` };
+    }
+    try {
+      register = JSON.parse(readFileSync(registerPath, 'utf8'));
+    } catch (err) {
+      return { pass: false, missing: [], covered: [], error: `Failed to parse quality register: ${err.message}` };
+    }
   }
 
   // Collect unique templates requiring adult review
@@ -830,8 +997,22 @@ async function main(argv) {
 
   // Gate 1b: Validate render inventory release IDs if inventory exists
   const releaseId = manifestResult.manifest.contentReleaseId;
-  const inventoryPath = path.join(ROOT_DIR, 'reports', 'grammar', `grammar-qg-p10-render-inventory.json`);
-  if (existsSync(inventoryPath)) {
+  let inventoryPath;
+  if (manifestResult.manifest.artefacts) {
+    const invResolved = requireArtefact(manifestResult.manifest, 'renderInventory', ROOT_DIR);
+    if (invResolved.ok) {
+      inventoryPath = invResolved.path;
+    }
+    // If artefact key missing or file not found, skip gracefully (no inventory = no gate)
+  } else {
+    // Legacy P10 fallback
+    console.warn('WARN: manifest.artefacts not found — falling back to legacy P10 path for renderInventory');
+    const legacyPath = path.join(ROOT_DIR, 'reports', 'grammar', 'grammar-qg-p10-render-inventory.json');
+    if (existsSync(legacyPath)) {
+      inventoryPath = legacyPath;
+    }
+  }
+  if (inventoryPath) {
     const invResult = validateInventoryReleaseIds(inventoryPath, releaseId);
     if (!invResult.pass) {
       if (jsonOutput) {

--- a/tests/grammar-qg-p11-distractor-matrix-truth.test.js
+++ b/tests/grammar-qg-p11-distractor-matrix-truth.test.js
@@ -85,7 +85,7 @@ describe('P11 U7: marking matrix totalEntries is exactly 80', () => {
 
 describe('P11 U6: all ambiguous templates have adult review decisions', () => {
   it('real quality register covers all requiresAdultReview templates', () => {
-    const result = validateDistractorReviewCoverage(ROOT_DIR);
+    const result = validateDistractorReviewCoverage({ contentReleaseId: 'grammar-qg-p11-2026-04-30' }, ROOT_DIR);
     assert.equal(
       result.pass,
       true,
@@ -131,7 +131,7 @@ describe('P11 U6: all ambiguous templates have adult review decisions', () => {
         JSON.stringify(fakeRegister)
       );
 
-      const result = validateDistractorReviewCoverage(tempRoot);
+      const result = validateDistractorReviewCoverage({ contentReleaseId: 'grammar-qg-p11-2026-04-30' }, tempRoot);
       assert.equal(result.pass, false);
       assert.deepEqual(result.missing, ['test_template_missing_review']);
     } finally {
@@ -181,7 +181,7 @@ describe('P11 U6: all ambiguous templates have adult review decisions', () => {
         JSON.stringify(fakeRegister)
       );
 
-      const result = validateDistractorReviewCoverage(tempRoot);
+      const result = validateDistractorReviewCoverage({ contentReleaseId: 'grammar-qg-p11-2026-04-30' }, tempRoot);
       assert.equal(result.pass, true);
       assert.deepEqual(result.covered, ['covered_template']);
       assert.equal(result.missing.length, 0);

--- a/tests/grammar-qg-p12-validator-paths.test.js
+++ b/tests/grammar-qg-p12-validator-paths.test.js
@@ -1,0 +1,461 @@
+/**
+ * Grammar QG P12 — U3 validator manifest-driven path resolution tests
+ *
+ * Tests the requireArtefact / readJsonArtefact helpers and their integration
+ * into validateReportCounts, validateMarkingMatrixCounts, validateDistractorReviewCoverage,
+ * and the CLI main path.
+ */
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { tmpdir } from 'node:os';
+
+import {
+  requireArtefact,
+  readJsonArtefact,
+  validateReportCounts,
+  validateMarkingMatrixCounts,
+  validateDistractorReviewCoverage,
+  validateInventoryReleaseIds,
+  validateSmokeEvidence,
+} from '../scripts/validate-grammar-qg-certification-evidence.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+const RELEASE_ID = 'grammar-qg-p11-2026-04-30';
+
+function makeManifest(overrides = {}) {
+  return {
+    contentReleaseId: RELEASE_ID,
+    certificationPhase: 'grammar-qg-p12',
+    templateDenominator: 78,
+    seedWindow: { certification: '1..30' },
+    seedWindowPerEvidenceType: {
+      'selected-response-oracle': '1..15',
+      'constructed-response-oracle': '1..10',
+      'manual-review-oracle': '1..5',
+      'redaction-oracle': '1..30',
+      'content-quality-audit': '1..30',
+    },
+    expectedItemCount: 2340,
+    artefacts: {
+      renderInventory: 'reports/grammar/render-inventory.json',
+      qualityRegister: 'reports/grammar/quality-register.json',
+      distractorAudit: 'reports/grammar/distractor-audit.json',
+      markingMatrix: 'reports/grammar/marking-matrix.json',
+    },
+    ...overrides,
+  };
+}
+
+function makeArtefactJson(extraMeta = {}) {
+  return {
+    metadata: {
+      contentReleaseId: RELEASE_ID,
+      generatedAt: '2026-04-30T12:00:00.000Z',
+      ...extraMeta,
+    },
+  };
+}
+
+function setupTmpDir() {
+  const base = path.join(tmpdir(), `grammar-qg-p12-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(path.join(base, 'reports', 'grammar'), { recursive: true });
+  return base;
+}
+
+// ---------------------------------------------------------------------------
+// requireArtefact tests
+// ---------------------------------------------------------------------------
+
+describe('requireArtefact', () => {
+  let tmpRoot;
+
+  beforeEach(() => {
+    tmpRoot = setupTmpDir();
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('resolves existing artefact file', () => {
+    const manifest = makeManifest();
+    writeFileSync(path.join(tmpRoot, 'reports', 'grammar', 'render-inventory.json'), '{}');
+    const result = requireArtefact(manifest, 'renderInventory', tmpRoot);
+    assert.equal(result.ok, true);
+    assert.equal(result.error, null);
+    assert.ok(result.path.includes('render-inventory.json'));
+  });
+
+  it('fails if artefact key missing from manifest', () => {
+    const manifest = makeManifest({ artefacts: {} });
+    const result = requireArtefact(manifest, 'renderInventory', tmpRoot);
+    assert.equal(result.ok, false);
+    assert.match(result.error, /Manifest missing required artefact path/);
+  });
+
+  it('fails if artefact file does not exist on disk', () => {
+    const manifest = makeManifest();
+    // Do not create the file
+    const result = requireArtefact(manifest, 'renderInventory', tmpRoot);
+    assert.equal(result.ok, false);
+    assert.match(result.error, /Artefact file not found/);
+  });
+
+  it('fails if manifest.artefacts is undefined', () => {
+    const manifest = makeManifest({ artefacts: undefined });
+    const result = requireArtefact(manifest, 'renderInventory', tmpRoot);
+    assert.equal(result.ok, false);
+    assert.match(result.error, /Manifest missing required artefact path/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readJsonArtefact tests
+// ---------------------------------------------------------------------------
+
+describe('readJsonArtefact', () => {
+  let tmpRoot;
+
+  beforeEach(() => {
+    tmpRoot = setupTmpDir();
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('reads and parses a valid JSON artefact', () => {
+    const manifest = makeManifest();
+    const data = makeArtefactJson({ totalEntries: 80 });
+    writeFileSync(
+      path.join(tmpRoot, 'reports', 'grammar', 'marking-matrix.json'),
+      JSON.stringify(data),
+    );
+    const result = readJsonArtefact(manifest, 'markingMatrix', tmpRoot);
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.data, data);
+    assert.equal(result.error, null);
+  });
+
+  it('fails if file is not valid JSON', () => {
+    const manifest = makeManifest();
+    writeFileSync(
+      path.join(tmpRoot, 'reports', 'grammar', 'marking-matrix.json'),
+      'NOT JSON {{{{',
+    );
+    const result = readJsonArtefact(manifest, 'markingMatrix', tmpRoot);
+    assert.equal(result.ok, false);
+    assert.match(result.error, /not valid JSON/);
+  });
+
+  it('fails if artefact path not in manifest', () => {
+    const manifest = makeManifest({ artefacts: {} });
+    const result = readJsonArtefact(manifest, 'markingMatrix', tmpRoot);
+    assert.equal(result.ok, false);
+    assert.match(result.error, /Manifest missing required artefact path/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateReportCounts — manifest-driven with release ID check
+// ---------------------------------------------------------------------------
+
+describe('validateReportCounts with P11 manifest', () => {
+  let tmpRoot;
+
+  beforeEach(() => {
+    tmpRoot = setupTmpDir();
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('passes when report claims match artefact metadata', () => {
+    const manifest = makeManifest();
+    // Create artefact files
+    writeFileSync(
+      path.join(tmpRoot, 'reports', 'grammar', 'marking-matrix.json'),
+      JSON.stringify(makeArtefactJson({ totalEntries: 80 })),
+    );
+    writeFileSync(
+      path.join(tmpRoot, 'reports', 'grammar', 'quality-register.json'),
+      JSON.stringify({ metadata: { contentReleaseId: RELEASE_ID, approved: 74, approvedWithLimitation: 4 }, entries: [] }),
+    );
+
+    // Create report that claims matching counts
+    const reportPath = path.join(tmpRoot, 'report.md');
+    writeFileSync(reportPath, '---\ncertification_decision: CERTIFIED_PRE_DEPLOY\n---\n\n80 marking matrix entries verified.\n74 approved + 4 approved_with_limitation templates.\n');
+
+    const result = validateReportCounts(manifest, reportPath, { rootDir: tmpRoot });
+    assert.equal(result.pass, true);
+    assert.equal(result.mismatches.length, 0);
+  });
+
+  it('fails if artefact metadata.contentReleaseId differs from manifest', () => {
+    const manifest = makeManifest();
+    // Create artefact with WRONG releaseId
+    writeFileSync(
+      path.join(tmpRoot, 'reports', 'grammar', 'marking-matrix.json'),
+      JSON.stringify({ metadata: { contentReleaseId: 'wrong-release-id', totalEntries: 80 } }),
+    );
+    writeFileSync(
+      path.join(tmpRoot, 'reports', 'grammar', 'quality-register.json'),
+      JSON.stringify({ metadata: { contentReleaseId: RELEASE_ID, approved: 74, approvedWithLimitation: 4 }, entries: [] }),
+    );
+
+    const reportPath = path.join(tmpRoot, 'report.md');
+    writeFileSync(reportPath, '---\ncertification_decision: CERTIFIED_PRE_DEPLOY\n---\n\n80 marking matrix entries.\n');
+
+    const result = validateReportCounts(manifest, reportPath, { rootDir: tmpRoot });
+    assert.equal(result.pass, false);
+    const releaseIdMismatch = result.mismatches.find(m => m.field === 'markingMatrixReleaseIdMismatch');
+    assert.ok(releaseIdMismatch, 'Expected markingMatrixReleaseIdMismatch');
+    assert.match(releaseIdMismatch.message, /does not match manifest contentReleaseId/);
+  });
+
+  it('fails if artefact file does not exist (manifest points to missing file)', () => {
+    const manifest = makeManifest();
+    // Don't create any artefact files
+    const reportPath = path.join(tmpRoot, 'report.md');
+    writeFileSync(reportPath, '---\ncertification_decision: CERTIFIED_PRE_DEPLOY\n---\n\nSome content.\n');
+
+    const result = validateReportCounts(manifest, reportPath, { rootDir: tmpRoot });
+    assert.equal(result.pass, false);
+    const resolveError = result.mismatches.find(m => m.field === 'markingMatrixResolve');
+    assert.ok(resolveError, 'Expected markingMatrixResolve mismatch');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateMarkingMatrixCounts — manifest-driven
+// ---------------------------------------------------------------------------
+
+describe('validateMarkingMatrixCounts with P11 manifest', () => {
+  let tmpRoot;
+
+  beforeEach(() => {
+    tmpRoot = setupTmpDir();
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('passes with correct totalEntries via manifest path', () => {
+    const manifest = makeManifest();
+    writeFileSync(
+      path.join(tmpRoot, 'reports', 'grammar', 'marking-matrix.json'),
+      JSON.stringify(makeArtefactJson({ totalEntries: 80 })),
+    );
+    const result = validateMarkingMatrixCounts(manifest, tmpRoot);
+    assert.equal(result.pass, true);
+    assert.equal(result.actual, 80);
+  });
+
+  it('fails if marking matrix has wrong totalEntries', () => {
+    const manifest = makeManifest();
+    writeFileSync(
+      path.join(tmpRoot, 'reports', 'grammar', 'marking-matrix.json'),
+      JSON.stringify(makeArtefactJson({ totalEntries: 50 })),
+    );
+    const result = validateMarkingMatrixCounts(manifest, tmpRoot);
+    assert.equal(result.pass, false);
+    assert.equal(result.actual, 50);
+  });
+
+  it('fails if marking matrix contentReleaseId does not match manifest', () => {
+    const manifest = makeManifest();
+    writeFileSync(
+      path.join(tmpRoot, 'reports', 'grammar', 'marking-matrix.json'),
+      JSON.stringify({ metadata: { contentReleaseId: 'wrong-id', totalEntries: 80 } }),
+    );
+    const result = validateMarkingMatrixCounts(manifest, tmpRoot);
+    assert.equal(result.pass, false);
+    assert.match(result.error, /does not match manifest contentReleaseId/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateDistractorReviewCoverage — manifest-driven
+// ---------------------------------------------------------------------------
+
+describe('validateDistractorReviewCoverage with P11 manifest', () => {
+  let tmpRoot;
+
+  beforeEach(() => {
+    tmpRoot = setupTmpDir();
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('passes when all flagged templates have review decisions', () => {
+    const manifest = makeManifest();
+    writeFileSync(
+      path.join(tmpRoot, 'reports', 'grammar', 'distractor-audit.json'),
+      JSON.stringify({
+        metadata: { contentReleaseId: RELEASE_ID },
+        results: [{ templateId: 't1', requiresAdultReview: true }],
+        ambiguousTemplates: [],
+      }),
+    );
+    writeFileSync(
+      path.join(tmpRoot, 'reports', 'grammar', 'quality-register.json'),
+      JSON.stringify({
+        metadata: { contentReleaseId: RELEASE_ID },
+        entries: [{ templateId: 't1', adultReviewDecision: 'approved' }],
+      }),
+    );
+    const result = validateDistractorReviewCoverage(manifest, tmpRoot);
+    assert.equal(result.pass, true);
+    assert.deepEqual(result.missing, []);
+  });
+
+  it('fails if distractor audit file not found via manifest', () => {
+    const manifest = makeManifest();
+    // quality register exists but audit does not
+    writeFileSync(
+      path.join(tmpRoot, 'reports', 'grammar', 'quality-register.json'),
+      JSON.stringify({ metadata: { contentReleaseId: RELEASE_ID }, entries: [] }),
+    );
+    const result = validateDistractorReviewCoverage(manifest, tmpRoot);
+    assert.equal(result.pass, false);
+    assert.match(result.error, /Artefact file not found/);
+  });
+
+  it('fails if distractor audit contentReleaseId mismatches manifest', () => {
+    const manifest = makeManifest();
+    writeFileSync(
+      path.join(tmpRoot, 'reports', 'grammar', 'distractor-audit.json'),
+      JSON.stringify({
+        metadata: { contentReleaseId: 'wrong-release' },
+        results: [],
+        ambiguousTemplates: [],
+      }),
+    );
+    writeFileSync(
+      path.join(tmpRoot, 'reports', 'grammar', 'quality-register.json'),
+      JSON.stringify({
+        metadata: { contentReleaseId: RELEASE_ID },
+        entries: [],
+      }),
+    );
+    const result = validateDistractorReviewCoverage(manifest, tmpRoot);
+    assert.equal(result.pass, false);
+    assert.match(result.error, /does not match manifest contentReleaseId/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Backward compatibility — P10 manifest without artefacts key
+// ---------------------------------------------------------------------------
+
+describe('backward compatibility with P10 manifest (no artefacts key)', () => {
+  let tmpRoot;
+
+  beforeEach(() => {
+    tmpRoot = setupTmpDir();
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('validateMarkingMatrixCounts falls back to legacy P10 path with warning', () => {
+    const p10Manifest = {
+      contentReleaseId: 'grammar-qg-p10-2026-04-29',
+      templateDenominator: 78,
+      seedWindow: { certification: '1..30' },
+      seedWindowPerEvidenceType: { 'selected-response-oracle': '1..15' },
+      expectedItemCount: 2340,
+      // No artefacts key!
+    };
+    // Create the legacy P10 path file
+    writeFileSync(
+      path.join(tmpRoot, 'reports', 'grammar', 'grammar-qg-p10-marking-matrix.json'),
+      JSON.stringify({ metadata: { contentReleaseId: 'grammar-qg-p10-2026-04-29', totalEntries: 80 } }),
+    );
+    const result = validateMarkingMatrixCounts(p10Manifest, tmpRoot);
+    assert.equal(result.pass, true);
+    assert.equal(result.actual, 80);
+  });
+
+  it('validateDistractorReviewCoverage falls back to legacy P10 paths', () => {
+    const p10Manifest = {
+      contentReleaseId: 'grammar-qg-p10-2026-04-29',
+      templateDenominator: 78,
+      seedWindow: { certification: '1..30' },
+      seedWindowPerEvidenceType: {},
+      expectedItemCount: 2340,
+      // No artefacts key!
+    };
+    writeFileSync(
+      path.join(tmpRoot, 'reports', 'grammar', 'grammar-qg-p10-distractor-audit.json'),
+      JSON.stringify({
+        metadata: { contentReleaseId: 'grammar-qg-p10-2026-04-29' },
+        results: [{ templateId: 'tX', requiresAdultReview: true }],
+        ambiguousTemplates: [],
+      }),
+    );
+    writeFileSync(
+      path.join(tmpRoot, 'reports', 'grammar', 'grammar-qg-p10-quality-register.json'),
+      JSON.stringify({
+        metadata: { contentReleaseId: 'grammar-qg-p10-2026-04-29' },
+        entries: [{ templateId: 'tX', adultReviewDecision: 'approved' }],
+      }),
+    );
+    const result = validateDistractorReviewCoverage(p10Manifest, tmpRoot);
+    assert.equal(result.pass, true);
+    assert.deepEqual(result.missing, []);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CERTIFIED_PRE_DEPLOY — no smoke required
+// ---------------------------------------------------------------------------
+
+describe('CERTIFIED_PRE_DEPLOY passes without smoke file', () => {
+  it('validateSmokeEvidence passes for CERTIFIED_PRE_DEPLOY', () => {
+    const manifest = makeManifest();
+    const reportContent = '---\ncertification_decision: CERTIFIED_PRE_DEPLOY\n---\n\nReport body.\n';
+    const result = validateSmokeEvidence(manifest, reportContent);
+    assert.equal(result.pass, true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CERTIFIED_POST_DEPLOY — smoke file required
+// ---------------------------------------------------------------------------
+
+describe('CERTIFIED_POST_DEPLOY requires smoke file', () => {
+  let tmpRoot;
+
+  beforeEach(() => {
+    tmpRoot = setupTmpDir();
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('fails if smoke file absent', () => {
+    const manifest = makeManifest();
+    const reportContent = '---\ncertification_decision: CERTIFIED_POST_DEPLOY\n---\n\nReport body.\n';
+    const result = validateSmokeEvidence(manifest, reportContent, { rootDir: tmpRoot });
+    assert.equal(result.pass, false);
+    const mismatch = result.mismatches.find(m => m.field === 'smokeEvidenceFile');
+    assert.ok(mismatch);
+    assert.match(mismatch.message, /smoke evidence file does not exist/);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `requireArtefact()` and `readJsonArtefact()` exported helpers that resolve artefact file paths from `manifest.artefacts` map
- Replace all 6 hardcoded `grammar-qg-p10-*` paths in the validator with manifest-driven resolution (renderInventory, markingMatrix, qualityRegister, distractorAudit)
- Add `metadata.contentReleaseId` cross-check: each loaded artefact is validated against the manifest's `contentReleaseId`
- Backward compatibility: manifests without `artefacts` key (P10 shape) fall back to legacy hardcoded paths with a `console.warn`

## Test plan
- [x] 20 new unit tests in `tests/grammar-qg-p12-validator-paths.test.js` — all pass
- [x] End-to-end run with P11 manifest and artefacts — PASS
- [x] End-to-end run with P10 manifest (backward compat) — PASS with legacy fallback warning
- [x] Tests cover: missing artefact key, missing file, invalid JSON, release ID mismatch, CERTIFIED_PRE_DEPLOY (no smoke needed), CERTIFIED_POST_DEPLOY (smoke required)