### PR TITLE
feat(punctuation): P9 U1 — exact word-count enforcement for closed preservation

### DIFF
--- a/shared/punctuation/marking.js
+++ b/shared/punctuation/marking.js
@@ -32,7 +32,8 @@ const FACET_LABELS = Object.freeze({
  * 2. speech_punctuation — punctuation outside closing speech mark
  * 3. reporting_clause — missing comma between reporting clause and speech
  * 4. reporting_clause_words — changed the reporting clause
- * 5. preservation — changed the spoken words
+ * 5. content_preservation — extra or changed words in the answer
+ * 6. preservation — changed the spoken words
  * Returns null if all facets pass (or none are present).
  */
 function speechFailureNote(facets) {

--- a/shared/punctuation/marking.js
+++ b/shared/punctuation/marking.js
@@ -46,6 +46,8 @@ function speechFailureNote(facets) {
   if (reportingClause && !reportingClause.ok) return 'Add a comma between the reporting clause and the speech.';
   const reportingClauseWords = lookup('reporting_clause_words');
   if (reportingClauseWords && !reportingClauseWords.ok) return 'Keep the reporting clause from the question.';
+  const contentPreservation = lookup('content_preservation');
+  if (contentPreservation && !contentPreservation.ok) return 'Keep the sentence from the question and do not add extra words.';
   const preservation = lookup('preservation');
   if (preservation && !preservation.ok) return 'Keep the exact spoken words from the question.';
   return null;
@@ -290,7 +292,8 @@ export function derivePreserveTokens(stem) {
  */
 export function evaluatePreservation(answer, item) {
   const text = normaliseAnswerText(answer);
-  const expectedTokens = Array.isArray(item.preserveTokens) && item.preserveTokens.length > 0
+  const hasExplicitTokens = Array.isArray(item.preserveTokens) && item.preserveTokens.length > 0;
+  const expectedTokens = hasExplicitTokens
     ? item.preserveTokens
     : derivePreserveTokens(item.stem || '');
 
@@ -301,10 +304,19 @@ export function evaluatePreservation(answer, item) {
   const answerWords = stripPunctuation(text).split(' ').filter(Boolean);
   const expectedCount = expectedTokens.length;
 
-  // Reject answers with word count significantly exceeding expected (catches extra tails)
-  if (answerWords.length > expectedCount + 2) {
-    const extra = answerWords.slice(expectedCount);
-    return { preserved: false, extraWords: extra, missingWords: [] };
+  // Combine items with multi-line stems (bullets/notes) legitimately introduce
+  // joining words like "and" — use a generous tolerance for those only.
+  const isMultiLineStem = !hasExplicitTokens && typeof item.stem === 'string' && /\n/.test(item.stem);
+  const countTolerance = isMultiLineStem ? 2 : 0;
+
+  // Reject answers with word count outside tolerance
+  if (answerWords.length > expectedCount + countTolerance
+    || (!isMultiLineStem && answerWords.length < expectedCount)) {
+    const expectedLower = expectedTokens.map((w) => String(w).toLowerCase());
+    const answerLower = answerWords.map((w) => String(w).toLowerCase());
+    const extra = answerWords.length > expectedCount ? answerWords.slice(expectedCount) : [];
+    const missing = expectedLower.filter((w) => !answerLower.includes(w));
+    return { preserved: false, extraWords: extra, missingWords: missing };
   }
 
   // Check all expected words appear in order
@@ -1637,6 +1649,26 @@ function markExact(item, answer) {
 
   if (item.rubric?.type === 'speech') {
     rubricResult = evaluateSpeechRubric(text, item.rubric);
+    if (rubricResult.correct
+      && ['insert', 'fix', 'combine'].includes(item.mode)
+      && typeof item.stem === 'string'
+      && item.stem.trim()) {
+      const preservation = evaluatePreservation(text, item);
+      if (!preservation.preserved) {
+        rubricResult = {
+          ...rubricResult,
+          correct: false,
+          misconceptionTags: [...new Set([
+            ...(rubricResult.misconceptionTags || []),
+            'speech.extra_words_outside_reporting_clause',
+          ])],
+          facets: [
+            ...(rubricResult.facets || []),
+            facet('content_preservation', false),
+          ],
+        };
+      }
+    }
     exact = exact || rubricResult.correct;
   }
 

--- a/tests/punctuation-closed-preservation-productionisation.test.js
+++ b/tests/punctuation-closed-preservation-productionisation.test.js
@@ -1,0 +1,233 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { PUNCTUATION_CONTENT_INDEXES } from '../shared/punctuation/content.js';
+import { markPunctuationAnswer, evaluatePreservation } from '../shared/punctuation/marking.js';
+import { createPunctuationGeneratedItems } from '../shared/punctuation/generators.js';
+
+function item(id) {
+  return PUNCTUATION_CONTENT_INDEXES.itemById.get(id);
+}
+
+function facetById(result, id) {
+  return result.facets.find((entry) => entry.id === id);
+}
+
+// ─── Contract probes: closed items with extra tails must reject ──────────────
+
+test('lc_insert_supplies + "today" → reject', () => {
+  const testItem = item('lc_insert_supplies');
+  assert.ok(testItem, 'item lc_insert_supplies must exist');
+  const result = markPunctuationAnswer({
+    item: testItem,
+    answer: { typed: 'We needed pencils, rulers and glue today.' },
+  });
+  assert.equal(result.correct, false);
+  assert.equal(facetById(result, 'content_preservation')?.ok, false);
+  assert.ok(
+    result.misconceptionTags.includes('content.words_added_or_changed'),
+    `Expected content.words_added_or_changed, got: ${result.misconceptionTags}`,
+  );
+});
+
+test('lc_insert_supplies + "in class" → reject', () => {
+  const testItem = item('lc_insert_supplies');
+  const result = markPunctuationAnswer({
+    item: testItem,
+    answer: { typed: 'We needed pencils, rulers and glue in class.' },
+  });
+  assert.equal(result.correct, false);
+  assert.equal(facetById(result, 'content_preservation')?.ok, false);
+  assert.ok(
+    result.misconceptionTags.includes('content.words_added_or_changed'),
+    `Expected content.words_added_or_changed, got: ${result.misconceptionTags}`,
+  );
+});
+
+test('pa_insert_museum + "today" → reject', () => {
+  const testItem = item('pa_insert_museum');
+  assert.ok(testItem, 'item pa_insert_museum must exist');
+  const result = markPunctuationAnswer({
+    item: testItem,
+    answer: { typed: 'The museum, a former station, was busy today.' },
+  });
+  assert.equal(result.correct, false);
+  assert.equal(facetById(result, 'content_preservation')?.ok, false);
+  assert.ok(
+    result.misconceptionTags.includes('content.words_added_or_changed'),
+    `Expected content.words_added_or_changed, got: ${result.misconceptionTags}`,
+  );
+});
+
+test('pa_fix_author + "in class" → reject', () => {
+  const testItem = item('pa_fix_author');
+  assert.ok(testItem, 'item pa_fix_author must exist');
+  const result = markPunctuationAnswer({
+    item: testItem,
+    answer: { typed: 'The author, who won the prize, smiled in class.' },
+  });
+  assert.equal(result.correct, false);
+  assert.equal(facetById(result, 'content_preservation')?.ok, false);
+  assert.ok(
+    result.misconceptionTags.includes('content.words_added_or_changed'),
+    `Expected content.words_added_or_changed, got: ${result.misconceptionTags}`,
+  );
+});
+
+test('sp_insert_question + "today" → reject (speech misconception)', () => {
+  const testItem = item('sp_insert_question');
+  assert.ok(testItem, 'item sp_insert_question must exist');
+  const result = markPunctuationAnswer({
+    item: testItem,
+    answer: { typed: 'Ella asked, "Can we start now today?"' },
+  });
+  assert.equal(result.correct, false);
+  assert.ok(
+    result.misconceptionTags.includes('speech.extra_words_outside_reporting_clause'),
+    `Expected speech.extra_words_outside_reporting_clause, got: ${result.misconceptionTags}`,
+  );
+  assert.equal(facetById(result, 'content_preservation')?.ok, false);
+});
+
+test('sp_insert_question + "in the cupboard" → reject (speech misconception)', () => {
+  const testItem = item('sp_insert_question');
+  const result = markPunctuationAnswer({
+    item: testItem,
+    answer: { typed: 'Ella asked, "Can we start now in the cupboard?"' },
+  });
+  assert.equal(result.correct, false);
+  assert.ok(
+    result.misconceptionTags.includes('speech.extra_words_outside_reporting_clause'),
+    `Expected speech.extra_words_outside_reporting_clause, got: ${result.misconceptionTags}`,
+  );
+  assert.equal(facetById(result, 'content_preservation')?.ok, false);
+});
+
+test('sp_fix_question + "in class" → reject (speech misconception)', () => {
+  const testItem = item('sp_fix_question');
+  assert.ok(testItem, 'item sp_fix_question must exist');
+  const result = markPunctuationAnswer({
+    item: testItem,
+    answer: { typed: '"Where are we meeting in class?" asked Zara.' },
+  });
+  assert.equal(result.correct, false);
+  assert.ok(
+    result.misconceptionTags.includes('speech.extra_words_outside_reporting_clause'),
+    `Expected speech.extra_words_outside_reporting_clause, got: ${result.misconceptionTags}`,
+  );
+  assert.equal(facetById(result, 'content_preservation')?.ok, false);
+});
+
+// ─── Regression: model answers still mark correct ────────────────────────────
+
+test('lc_insert_supplies model answer marks correct', () => {
+  const testItem = item('lc_insert_supplies');
+  const result = markPunctuationAnswer({
+    item: testItem,
+    answer: { typed: testItem.model },
+  });
+  assert.equal(result.correct, true);
+});
+
+test('pa_insert_museum model answer marks correct', () => {
+  const testItem = item('pa_insert_museum');
+  const result = markPunctuationAnswer({
+    item: testItem,
+    answer: { typed: testItem.model },
+  });
+  assert.equal(result.correct, true);
+});
+
+test('pa_fix_author model answer marks correct', () => {
+  const testItem = item('pa_fix_author');
+  const result = markPunctuationAnswer({
+    item: testItem,
+    answer: { typed: testItem.model },
+  });
+  assert.equal(result.correct, true);
+});
+
+test('sp_insert_question model answer marks correct', () => {
+  const testItem = item('sp_insert_question');
+  const result = markPunctuationAnswer({
+    item: testItem,
+    answer: { typed: testItem.model },
+  });
+  assert.equal(result.correct, true);
+});
+
+test('sp_fix_question model answer marks correct', () => {
+  const testItem = item('sp_fix_question');
+  const result = markPunctuationAnswer({
+    item: testItem,
+    answer: { typed: testItem.model },
+  });
+  assert.equal(result.correct, true);
+});
+
+// ─── Generated closed items with short tail must reject ──────────────────────
+
+test('generated list-comma insert item + "today" rejects', () => {
+  const items = createPunctuationGeneratedItems({ depth: 1 });
+  const genItem = items.find((i) => i.generatorFamilyId === 'gen_list_commas_insert');
+  assert.ok(genItem, 'Expected at least one gen_list_commas_insert item');
+
+  // Model answer passes
+  const correct = markPunctuationAnswer({ item: genItem, answer: { typed: genItem.model } });
+  assert.equal(correct.correct, true, `Model answer should pass: ${genItem.model}`);
+
+  // With "today" appended (short tail) should reject
+  const withTail = markPunctuationAnswer({
+    item: genItem,
+    answer: { typed: genItem.model.replace(/\.$/, ' today.') },
+  });
+  assert.equal(withTail.correct, false, 'Extra "today" should reject for gen list-comma insert');
+  assert.equal(facetById(withTail, 'content_preservation')?.ok, false);
+});
+
+test('generated fronted-adverbial fix item + "today" rejects', () => {
+  const items = createPunctuationGeneratedItems({ depth: 1 });
+  const genItem = items.find((i) => i.generatorFamilyId === 'gen_fronted_adverbial_fix');
+  assert.ok(genItem, 'Expected at least one gen_fronted_adverbial_fix item');
+
+  // Model answer passes
+  const correct = markPunctuationAnswer({ item: genItem, answer: { typed: genItem.model } });
+  assert.equal(correct.correct, true, `Model answer should pass: ${genItem.model}`);
+
+  // With "today" appended (short tail) should reject
+  const withTail = markPunctuationAnswer({
+    item: genItem,
+    answer: { typed: genItem.model.replace(/\.$/, ' today.') },
+  });
+  assert.equal(withTail.correct, false, 'Extra "today" should reject for gen fronted-adverbial fix');
+  assert.equal(facetById(withTail, 'content_preservation')?.ok, false);
+});
+
+test('generated speech-insert item + "today" rejects', () => {
+  const items = createPunctuationGeneratedItems({ depth: 1 });
+  const genItem = items.find((i) => i.generatorFamilyId === 'gen_speech_insert');
+  assert.ok(genItem, 'Expected at least one gen_speech_insert item');
+
+  // Model answer passes
+  const correct = markPunctuationAnswer({ item: genItem, answer: { typed: genItem.model } });
+  assert.equal(correct.correct, true, `Model answer should pass: ${genItem.model}`);
+
+  // With "today" appended (short tail) should reject
+  const withTail = markPunctuationAnswer({
+    item: genItem,
+    answer: { typed: genItem.model.replace(/[.!?]"?'?$/, ' today.') },
+  });
+  assert.equal(withTail.correct, false, 'Extra "today" should reject for gen speech-insert');
+});
+
+// ─── Guard: at least one generated case inspected ────────────────────────────
+
+test('generated items pool is not empty', () => {
+  const items = createPunctuationGeneratedItems({ depth: 1 });
+  assert.ok(items.length > 0, 'Generator must produce at least one item');
+  const closedItems = items.filter(
+    (i) => ['insert', 'fix', 'combine'].includes(i.mode)
+      && typeof i.stem === 'string' && i.stem.trim(),
+  );
+  assert.ok(closedItems.length > 0, 'Generator must produce at least one closed item with a stem');
+});

--- a/tests/punctuation-closed-preservation-productionisation.test.js
+++ b/tests/punctuation-closed-preservation-productionisation.test.js
@@ -118,6 +118,19 @@ test('sp_fix_question + "in class" → reject (speech misconception)', () => {
   assert.equal(facetById(result, 'content_preservation')?.ok, false);
 });
 
+// ─── Word-removal: truncated answers must reject ───────────────────────────────
+
+test('lc_insert_supplies with "glue" removed → reject', () => {
+  const testItem = item('lc_insert_supplies');
+  assert.ok(testItem, 'item lc_insert_supplies must exist');
+  // Submit answer with one content word ("glue") removed from the stem
+  const result = markPunctuationAnswer({
+    item: testItem,
+    answer: { typed: 'We needed pencils, rulers and.' },
+  });
+  assert.equal(result.correct, false, 'Removing a content word must reject');
+});
+
 // ─── Regression: model answers still mark correct ────────────────────────────
 
 test('lc_insert_supplies model answer marks correct', () => {
@@ -212,12 +225,16 @@ test('generated speech-insert item + "today" rejects', () => {
   const correct = markPunctuationAnswer({ item: genItem, answer: { typed: genItem.model } });
   assert.equal(correct.correct, true, `Model answer should pass: ${genItem.model}`);
 
-  // With "today" appended (short tail) should reject
+  // With "today" appended AFTER the closing quote (short tail) should reject
+  // e.g. 'Maya asked, "Can we start now?"' → 'Maya asked, "Can we start now?" today.'
+  const badAnswer = genItem.model.replace(/\.?$/, '') + ' today.';
   const withTail = markPunctuationAnswer({
     item: genItem,
-    answer: { typed: genItem.model.replace(/[.!?]"?'?$/, ' today.') },
+    answer: { typed: badAnswer },
   });
-  assert.equal(withTail.correct, false, 'Extra "today" should reject for gen speech-insert');
+  assert.equal(withTail.correct, false, `Extra "today" should reject for gen speech-insert: ${badAnswer}`);
+  assert.equal(facetById(withTail, 'content_preservation')?.ok, false,
+    'content_preservation facet must be present and false');
 });
 
 // ─── Guard: at least one generated case inspected ────────────────────────────


### PR DESCRIPTION
## Summary
- Replaces the permissive `expectedCount + 2` word-tolerance with exact word-count enforcement in `evaluatePreservation` for insert/fix items with single-line stems
- Adds `content_preservation` facet to the `speechFailureNote` priority chain (between `reporting_clause_words` and `preservation`)
- Adds a closed-preservation override in the `markExact` speech rubric block: after a speech rubric passes for insert/fix/combine items with a stem, re-evaluates preservation and downgrades to incorrect if extra words were added
- New adversarial test file with 16 tests covering all 7 contract probes, model-answer regressions, and generated-item coverage

## Test plan
- [x] All 7 contract-specified rejection probes pass (lc_insert_supplies, pa_insert_museum, pa_fix_author, sp_insert_question, sp_fix_question)
- [x] Model answers for all probed items still mark correct (regression guard)
- [x] Generated items from list-commas, fronted-adverbial, and speech families reject short tails
- [x] Guard test asserts generated pool is non-empty
- [x] Existing `punctuation-preservation-oracle.test.js` passes (19/19)
- [x] Full punctuation test suite passes (2098/2098, 0 failures)
- [x] Grammar test suite unaffected (5691/5691)
- [x] Spelling test suite unaffected (718/718)

## Plan Deviations
- **Combine items retain +2 tolerance**: The plan specified replacing `expectedCount + 2` with exact `!== expectedCount` universally. However, combine items with multi-line bullet stems (e.g. `lc_combine_trip_list` with stem `We packed\n- torches\n- maps\n- water`) legitimately introduce joining words like "and" in the model answer. Strict exact enforcement caused a regression in the existing `punctuation-preservation-oracle.test.js` test. The fix retains a +2 tolerance specifically for multi-line stems (detected via `\n` in stem and absence of explicit `preserveTokens`), while enforcing exact counts for single-line insert/fix stems. This preserves the contract intent (no short tails on closed items) without breaking combine items.
- **FACET_LABELS already had `content_preservation`**: The plan listed adding it, but it was already present in the codebase (added in a prior PR). No change needed.