### PR TITLE
feat(ui-refactor-p3): U1 subject theme token contract

### DIFF
--- a/scripts/inventory-inline-styles.mjs
+++ b/scripts/inventory-inline-styles.mjs
@@ -184,6 +184,10 @@ export const CLASSIFICATION = Object.freeze({
 
   // Platform UI
   'src/platform/ui/LengthPicker.jsx': 'shared-pattern-available',
+  // P3 U1: SubjectThemeScope accepts an optional `style` prop that
+  // callers may pass for layout (e.g. `gridColumn`). Pure CSS-variable
+  // pass-through — the wrapper's own tokens are CSS-only.
+  'src/platform/ui/SubjectThemeScope.jsx': 'css-var-ready',
   // P2 U2: Card primitive emits style={{ '--card-accent': accent }} only
   // when an accent string is supplied (typically `var(--grammar-accent)`
   // / future `var(--punctuation-accent)`). Pure CSS-variable passthrough

--- a/src/platform/ui/SubjectThemeScope.jsx
+++ b/src/platform/ui/SubjectThemeScope.jsx
@@ -1,0 +1,26 @@
+// UI Refactor P3 U1 — Subject Theme Scope.
+//
+// Thin wrapper that renders a `<div>` with the `.subject-theme` class and a
+// `data-subject` attribute set to the provided subject identifier. CSS custom
+// properties declared in `styles/app.css` under
+// `.subject-theme[data-subject="X"]` cascade into all descendants, giving
+// shared primitives (Button, ProgressMeter, Card) the correct accent colour
+// without any inline style overrides or JS colour lookups.
+//
+// Zero runtime cost — no context, no hooks, no memo. If subjectId is falsy
+// the wrapper still renders (it just won't match any accent rule and the
+// fallback `var(--brand)` applies).
+
+/**
+ * @param {{ subjectId: string, children: import('react').ReactNode, className?: string, style?: object }} props
+ */
+export function SubjectThemeScope({ subjectId, children, className, style }) {
+  const classes = className
+    ? `subject-theme ${className}`
+    : 'subject-theme';
+  return (
+    <div className={classes} data-subject={subjectId || undefined} style={style}>
+      {children}
+    </div>
+  );
+}

--- a/src/platform/ui/subject-themes.js
+++ b/src/platform/ui/subject-themes.js
@@ -1,0 +1,81 @@
+// UI Refactor P3 U1 — Subject Theme Registry.
+//
+// Provides a JS-accessible registry of SubjectTheme objects for consumers that
+// need accent values in JavaScript (e.g. inline SVG fills, canvas drawing,
+// runtime style computation). These values mirror the CSS custom properties
+// defined in `styles/app.css` under `.subject-theme[data-subject]`.
+//
+// Prefer CSS variable consumption where possible — this registry is the escape
+// hatch for contexts where CSS variables are not available.
+
+/**
+ * @typedef {{
+ *   subjectId: string,
+ *   accent: string,
+ *   accentInk: string,
+ *   accentSoft: string,
+ *   accentBorder: string,
+ * }} SubjectTheme
+ */
+
+/** @type {Readonly<Record<string, SubjectTheme>>} */
+export const SUBJECT_THEMES = Object.freeze({
+  spelling: Object.freeze({
+    subjectId: 'spelling',
+    accent: '#3E6FA8',
+    accentInk: '#274D79',
+    accentSoft: '#DCE6F3',
+    accentBorder: '#C5D4E8',
+  }),
+  grammar: Object.freeze({
+    subjectId: 'grammar',
+    accent: '#7e5bb6',
+    accentInk: '#5c4490',
+    accentSoft: '#ece1f6',
+    accentBorder: '#C9B8DD',
+  }),
+  punctuation: Object.freeze({
+    subjectId: 'punctuation',
+    accent: '#B8873F',
+    accentInk: '#8C6730',
+    accentSoft: '#F5E8D0',
+    accentBorder: '#DCC9A4',
+  }),
+  reading: Object.freeze({
+    subjectId: 'reading',
+    accent: '#4B7A4A',
+    accentInk: '#366836',
+    accentSoft: '#E2F0E2',
+    accentBorder: '#B3D4B3',
+  }),
+  reasoning: Object.freeze({
+    subjectId: 'reasoning',
+    accent: '#8A5A9D',
+    accentInk: '#6B3F80',
+    accentSoft: '#F0E4F5',
+    accentBorder: '#CDAEDD',
+  }),
+  arithmetic: Object.freeze({
+    subjectId: 'arithmetic',
+    accent: '#C06B3E',
+    accentInk: '#964F2B',
+    accentSoft: '#F8E4D6',
+    accentBorder: '#DDB49A',
+  }),
+});
+
+/**
+ * Look up a subject theme by id. Returns undefined for unknown subjects
+ * (never throws).
+ * @param {string} subjectId
+ * @returns {SubjectTheme | undefined}
+ */
+export function getSubjectTheme(subjectId) {
+  return SUBJECT_THEMES[subjectId];
+}
+
+/**
+ * All registered subject ids.
+ * @type {readonly string[]}
+ */
+export const SUBJECT_IDS = Object.freeze(Object.keys(SUBJECT_THEMES));

--- a/src/subjects/punctuation/components/PunctuationMapScene.jsx
+++ b/src/subjects/punctuation/components/PunctuationMapScene.jsx
@@ -351,7 +351,7 @@ export function PunctuationMapScene({ ui, actions }) {
       className="card border-top punctuation-surface punctuation-map-scene"
       data-punctuation-map
       data-punctuation-phase="map"
-      style={{ borderTopColor: '#B8873F' }}
+      style={{ borderTopColor: 'var(--subject-accent, #B8873F)' }}
     >
       {/* Back button at the top, mirroring Spelling word-bank-topbar and
           Grammar grammar-bank-topbar (design-lens MEDIUM). A top-of-scene

--- a/src/subjects/punctuation/components/PunctuationSessionScene.jsx
+++ b/src/subjects/punctuation/components/PunctuationSessionScene.jsx
@@ -369,7 +369,7 @@ function ActiveItemBranch({ ui, actions, heroUrl = '', previousHeroUrl = '' }) {
       className="card border-top punctuation-surface punctuation-session-scene"
       data-punctuation-session-scene
       data-punctuation-phase="active-item"
-      style={{ borderTopColor: '#B8873F' }}
+      style={{ borderTopColor: 'var(--subject-accent, #B8873F)' }}
     >
       {/* U5: platform HeroBackdrop replaces the legacy static <img> inside
           `.punctuation-strip`. The outer `.punctuation-session-hero`
@@ -522,7 +522,11 @@ function FeedbackBranch({ ui, actions, heroUrl = '', previousHeroUrl = '' }) {
   const session = ui.session || {};
   const isDisabled = composeIsDisabled(ui);
   const help = punctuationSessionHelpVisibility(session, 'feedback');
-  const borderColor = feedback.kind === 'success' ? '#2E8479' : '#B8873F';
+  // P3 U1: accent tokens sourced from CSS variables instead of raw hex.
+  // Success uses `--good-strong` (semantic green); default uses subject accent.
+  const borderColor = feedback.kind === 'success'
+    ? 'var(--good-strong, #2E8479)'
+    : 'var(--subject-accent, #B8873F)';
 
   // adv-232-004: the minimal-feedback branch gates on the authoritative
   // `!help.showFeedback` signal from `punctuationSessionHelpVisibility`,

--- a/src/subjects/punctuation/components/PunctuationSummaryScene.jsx
+++ b/src/subjects/punctuation/components/PunctuationSummaryScene.jsx
@@ -683,10 +683,9 @@ export function PunctuationSummaryScene({
       className="card border-top punctuation-surface"
       data-punctuation-summary
       // U4 follower (design-lens MEDIUM 5): borderTopColor now matches the
-      // canonical Punctuation accent `#B8873F` (Bellstorm gold) rather than
-      // the stray `#2E8479` teal. Aligns with `PunctuationPracticeSurface`
-      // and the module's `accent` field.
-      style={{ borderTopColor: '#B8873F' }}
+      // canonical Punctuation accent (Bellstorm gold). P3 U1: sourced from
+      // CSS variable rather than raw hex.
+      style={{ borderTopColor: 'var(--subject-accent, #B8873F)' }}
     >
       {/* U6: platform HeroBackdrop replaces the legacy static <img> inside
           `.punctuation-strip`. Same pattern as U5's Session-scene swap — the

--- a/src/subjects/spelling/components/SpellingSetupScene.jsx
+++ b/src/subjects/spelling/components/SpellingSetupScene.jsx
@@ -290,7 +290,6 @@ export function SpellingSetupScene({
   prefs,
   ui,
   codex,
-  accent,
   actions,
   postMastery,
   setupHeroTone = '',
@@ -450,7 +449,6 @@ export function SpellingSetupScene({
           ) : showVaultLayer ? (
             <PostMegaSetupContent
               prefs={prefs}
-              accent={accent}
               actions={actions}
               postMastery={postMastery}
               stats={stats}
@@ -462,7 +460,6 @@ export function SpellingSetupScene({
           ) : (
             <LegacySetupContent
               prefs={prefs}
-              accent={accent}
               actions={actions}
               stats={stats}
               heroContrast={heroContrast}
@@ -517,7 +514,6 @@ export function SpellingSetupScene({
 
 function LegacySetupContent({
   prefs,
-  accent,
   actions,
   stats,
   heroContrast,
@@ -708,7 +704,6 @@ function CheckingWordVaultContent() {
  *    card as "next in the journey" rather than "empty". */
 function PostMegaSetupContent({
   prefs,
-  accent,
   actions,
   postMastery,
   stats,

--- a/src/subjects/spelling/components/SpellingSetupScene.jsx
+++ b/src/subjects/spelling/components/SpellingSetupScene.jsx
@@ -6,6 +6,7 @@ import { useSetupHeroContrast } from './useSetupHeroContrast.js';
 import { Button } from '../../../platform/ui/Button.jsx';
 import { LengthPicker } from '../../../platform/ui/LengthPicker.jsx';
 import { SetupSidePanel } from '../../../platform/ui/SetupSidePanel.jsx';
+import { SubjectThemeScope } from '../../../platform/ui/SubjectThemeScope.jsx';
 import {
   BOSS_DEFAULT_ROUND_LENGTH,
   SPELLING_DURABLE_PERSISTENCE_WARNING_COPY,
@@ -406,7 +407,7 @@ export function SpellingSetupScene({
   const showWorkshopLayer = !showVaultLayer && !isHydrationChecking;
 
   return (
-    <div className="setup-grid" style={{ gridColumn: '1/-1' }}>
+    <SubjectThemeScope subjectId="spelling" className="setup-grid" style={{ gridColumn: '1/-1' }}>
       <SoftLockoutBanner
         state={softLockoutState}
         onAcknowledge={softLockoutAcknowledge}
@@ -510,7 +511,7 @@ export function SpellingSetupScene({
           </button>
         )}
       />
-    </div>
+    </SubjectThemeScope>
   );
 }
 
@@ -603,18 +604,12 @@ function LegacySetupContent({
         </div>
       </div>
       <div className="setup-begin-row">
-        {/* P2 U7: third-consumer falsifier — Spelling primary CTA migrates
-         * to the shared Button primitive. The inline `--btn-accent` style
-         * (Bellstorm-gold accent threading) is preserved via Button's
-         * safelisted style rest-prop because Spelling does not yet have a
-         * `:where(.spelling-...) ` accent remap; that token unification is
-         * deferred to a future subject-token sweep. The `<ArrowRightIcon />`
-         * slot moves to Button's `endIcon` prop so DOM order
-         * (label -> trailing chevron) stays byte-identical for screen-reader
-         * announcement. */}
+        {/* P3 U1: `--btn-accent` now cascades via the SubjectThemeScope
+         * wrapper (`.subject-theme[data-subject="spelling"]` in app.css).
+         * The inline style override is removed — the CSS remap provides
+         * the same `#3E6FA8` value as the former prop-threaded accent. */}
         <Button
           size="xl"
-          style={{ '--btn-accent': accent }}
           dataAction="spelling-start"
           disabled={startDisabled}
           onClick={(event) => renderAction(actions, event, 'spelling-start')}

--- a/styles/app.css
+++ b/styles/app.css
@@ -13426,12 +13426,19 @@ html { scroll-behavior: smooth; }
   --subject-accent-soft: #DCE6F3;
   --subject-accent-border: color-mix(in oklab, #3E6FA8 30%, var(--line));
 }
-:root[data-theme="dark"] .subject-theme[data-subject="spelling"],
-:root:not([data-theme="light"]) .subject-theme[data-subject="spelling"] {
+:root[data-theme="dark"] .subject-theme[data-subject="spelling"] {
   --subject-accent: #6E9ED6;
   --subject-accent-ink: #A7C2E4;
   --subject-accent-soft: color-mix(in oklab, #3E6FA8 26%, var(--bg));
   --subject-accent-border: color-mix(in oklab, #6E9ED6 30%, var(--line));
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .subject-theme[data-subject="spelling"] {
+    --subject-accent: #6E9ED6;
+    --subject-accent-ink: #A7C2E4;
+    --subject-accent-soft: color-mix(in oklab, #3E6FA8 26%, var(--bg));
+    --subject-accent-border: color-mix(in oklab, #6E9ED6 30%, var(--line));
+  }
 }
 
 /* --- Grammar --- */
@@ -13441,12 +13448,19 @@ html { scroll-behavior: smooth; }
   --subject-accent-soft: #ece1f6;
   --subject-accent-border: color-mix(in oklab, #7e5bb6 30%, var(--line));
 }
-:root[data-theme="dark"] .subject-theme[data-subject="grammar"],
-:root:not([data-theme="light"]) .subject-theme[data-subject="grammar"] {
+:root[data-theme="dark"] .subject-theme[data-subject="grammar"] {
   --subject-accent: #b89be5;
   --subject-accent-ink: #d6c4f2;
   --subject-accent-soft: color-mix(in oklab, #7e5bb6 26%, var(--bg));
   --subject-accent-border: color-mix(in oklab, #b89be5 30%, var(--line));
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .subject-theme[data-subject="grammar"] {
+    --subject-accent: #b89be5;
+    --subject-accent-ink: #d6c4f2;
+    --subject-accent-soft: color-mix(in oklab, #7e5bb6 26%, var(--bg));
+    --subject-accent-border: color-mix(in oklab, #b89be5 30%, var(--line));
+  }
 }
 
 /* --- Punctuation --- */
@@ -13456,12 +13470,19 @@ html { scroll-behavior: smooth; }
   --subject-accent-soft: #F5E8D0;
   --subject-accent-border: color-mix(in oklab, #B8873F 30%, var(--line));
 }
-:root[data-theme="dark"] .subject-theme[data-subject="punctuation"],
-:root:not([data-theme="light"]) .subject-theme[data-subject="punctuation"] {
+:root[data-theme="dark"] .subject-theme[data-subject="punctuation"] {
   --subject-accent: #d6a86a;
   --subject-accent-ink: #e8c896;
   --subject-accent-soft: color-mix(in oklab, #B8873F 26%, var(--bg));
   --subject-accent-border: color-mix(in oklab, #d6a86a 30%, var(--line));
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .subject-theme[data-subject="punctuation"] {
+    --subject-accent: #d6a86a;
+    --subject-accent-ink: #e8c896;
+    --subject-accent-soft: color-mix(in oklab, #B8873F 26%, var(--bg));
+    --subject-accent-border: color-mix(in oklab, #d6a86a 30%, var(--line));
+  }
 }
 
 /* --- Reading (placeholder) --- */
@@ -13471,12 +13492,19 @@ html { scroll-behavior: smooth; }
   --subject-accent-soft: #E2F0E2;
   --subject-accent-border: color-mix(in oklab, #4B7A4A 30%, var(--line));
 }
-:root[data-theme="dark"] .subject-theme[data-subject="reading"],
-:root:not([data-theme="light"]) .subject-theme[data-subject="reading"] {
+:root[data-theme="dark"] .subject-theme[data-subject="reading"] {
   --subject-accent: #7CB87A;
   --subject-accent-ink: #9CC59A;
   --subject-accent-soft: color-mix(in oklab, #4B7A4A 26%, var(--bg));
   --subject-accent-border: color-mix(in oklab, #7CB87A 30%, var(--line));
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .subject-theme[data-subject="reading"] {
+    --subject-accent: #7CB87A;
+    --subject-accent-ink: #9CC59A;
+    --subject-accent-soft: color-mix(in oklab, #4B7A4A 26%, var(--bg));
+    --subject-accent-border: color-mix(in oklab, #7CB87A 30%, var(--line));
+  }
 }
 
 /* --- Reasoning (placeholder) --- */
@@ -13486,12 +13514,19 @@ html { scroll-behavior: smooth; }
   --subject-accent-soft: #F0E4F5;
   --subject-accent-border: color-mix(in oklab, #8A5A9D 30%, var(--line));
 }
-:root[data-theme="dark"] .subject-theme[data-subject="reasoning"],
-:root:not([data-theme="light"]) .subject-theme[data-subject="reasoning"] {
+:root[data-theme="dark"] .subject-theme[data-subject="reasoning"] {
   --subject-accent: #B88FCC;
   --subject-accent-ink: #C4A5D4;
   --subject-accent-soft: color-mix(in oklab, #8A5A9D 26%, var(--bg));
   --subject-accent-border: color-mix(in oklab, #B88FCC 30%, var(--line));
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .subject-theme[data-subject="reasoning"] {
+    --subject-accent: #B88FCC;
+    --subject-accent-ink: #C4A5D4;
+    --subject-accent-soft: color-mix(in oklab, #8A5A9D 26%, var(--bg));
+    --subject-accent-border: color-mix(in oklab, #B88FCC 30%, var(--line));
+  }
 }
 
 /* --- Arithmetic (placeholder) --- */
@@ -13501,12 +13536,19 @@ html { scroll-behavior: smooth; }
   --subject-accent-soft: #F8E4D6;
   --subject-accent-border: color-mix(in oklab, #C06B3E 30%, var(--line));
 }
-:root[data-theme="dark"] .subject-theme[data-subject="arithmetic"],
-:root:not([data-theme="light"]) .subject-theme[data-subject="arithmetic"] {
+:root[data-theme="dark"] .subject-theme[data-subject="arithmetic"] {
   --subject-accent: #E8975C;
   --subject-accent-ink: #F2B756;
   --subject-accent-soft: color-mix(in oklab, #C06B3E 26%, var(--bg));
   --subject-accent-border: color-mix(in oklab, #E8975C 30%, var(--line));
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .subject-theme[data-subject="arithmetic"] {
+    --subject-accent: #E8975C;
+    --subject-accent-ink: #F2B756;
+    --subject-accent-soft: color-mix(in oklab, #C06B3E 26%, var(--bg));
+    --subject-accent-border: color-mix(in oklab, #E8975C 30%, var(--line));
+  }
 }
 
 /* Subject-theme accent remap — low specificity via :where so callers can

--- a/styles/app.css
+++ b/styles/app.css
@@ -13396,3 +13396,125 @@ html { scroll-behavior: smooth; }
     gap: 8px 14px;
   }
 }
+
+/* =============================================================================
+ * Subject Theme Token System (UI Refactor P3 U1)
+ *
+ * `.subject-theme[data-subject]` blocks declare per-subject visual identity
+ * through CSS custom properties. Each subject maps four accent tokens which
+ * cascade into the cross-surface aliases that shared primitives (Button,
+ * ProgressMeter, Card) consume.
+ *
+ * Token mapping:
+ *   --subject-accent       → primary brand colour for the subject
+ *   --subject-accent-ink   → darker legible-on-white variant
+ *   --subject-accent-soft  → tinted background fill
+ *   --subject-accent-border→ border tint (30% accent mixed with --line)
+ *
+ * Remapped aliases (low specificity via :where):
+ *   --btn-accent, --card-accent, --progress-accent, --accent
+ *
+ * Dark-mode overrides follow each light block via the
+ * `:root[data-theme="dark"]` and `@media (prefers-color-scheme: dark)` pair
+ * so both explicit and system-preference dark modes are covered.
+ * ============================================================================= */
+
+/* --- Spelling --- */
+.subject-theme[data-subject="spelling"] {
+  --subject-accent: #3E6FA8;
+  --subject-accent-ink: #274D79;
+  --subject-accent-soft: #DCE6F3;
+  --subject-accent-border: color-mix(in oklab, #3E6FA8 30%, var(--line));
+}
+:root[data-theme="dark"] .subject-theme[data-subject="spelling"],
+:root:not([data-theme="light"]) .subject-theme[data-subject="spelling"] {
+  --subject-accent: #6E9ED6;
+  --subject-accent-ink: #A7C2E4;
+  --subject-accent-soft: color-mix(in oklab, #3E6FA8 26%, var(--bg));
+  --subject-accent-border: color-mix(in oklab, #6E9ED6 30%, var(--line));
+}
+
+/* --- Grammar --- */
+.subject-theme[data-subject="grammar"] {
+  --subject-accent: #7e5bb6;
+  --subject-accent-ink: #5c4490;
+  --subject-accent-soft: #ece1f6;
+  --subject-accent-border: color-mix(in oklab, #7e5bb6 30%, var(--line));
+}
+:root[data-theme="dark"] .subject-theme[data-subject="grammar"],
+:root:not([data-theme="light"]) .subject-theme[data-subject="grammar"] {
+  --subject-accent: #b89be5;
+  --subject-accent-ink: #d6c4f2;
+  --subject-accent-soft: color-mix(in oklab, #7e5bb6 26%, var(--bg));
+  --subject-accent-border: color-mix(in oklab, #b89be5 30%, var(--line));
+}
+
+/* --- Punctuation --- */
+.subject-theme[data-subject="punctuation"] {
+  --subject-accent: #B8873F;
+  --subject-accent-ink: #8C6730;
+  --subject-accent-soft: #F5E8D0;
+  --subject-accent-border: color-mix(in oklab, #B8873F 30%, var(--line));
+}
+:root[data-theme="dark"] .subject-theme[data-subject="punctuation"],
+:root:not([data-theme="light"]) .subject-theme[data-subject="punctuation"] {
+  --subject-accent: #d6a86a;
+  --subject-accent-ink: #e8c896;
+  --subject-accent-soft: color-mix(in oklab, #B8873F 26%, var(--bg));
+  --subject-accent-border: color-mix(in oklab, #d6a86a 30%, var(--line));
+}
+
+/* --- Reading (placeholder) --- */
+.subject-theme[data-subject="reading"] {
+  --subject-accent: #4B7A4A;
+  --subject-accent-ink: #366836;
+  --subject-accent-soft: #E2F0E2;
+  --subject-accent-border: color-mix(in oklab, #4B7A4A 30%, var(--line));
+}
+:root[data-theme="dark"] .subject-theme[data-subject="reading"],
+:root:not([data-theme="light"]) .subject-theme[data-subject="reading"] {
+  --subject-accent: #7CB87A;
+  --subject-accent-ink: #9CC59A;
+  --subject-accent-soft: color-mix(in oklab, #4B7A4A 26%, var(--bg));
+  --subject-accent-border: color-mix(in oklab, #7CB87A 30%, var(--line));
+}
+
+/* --- Reasoning (placeholder) --- */
+.subject-theme[data-subject="reasoning"] {
+  --subject-accent: #8A5A9D;
+  --subject-accent-ink: #6B3F80;
+  --subject-accent-soft: #F0E4F5;
+  --subject-accent-border: color-mix(in oklab, #8A5A9D 30%, var(--line));
+}
+:root[data-theme="dark"] .subject-theme[data-subject="reasoning"],
+:root:not([data-theme="light"]) .subject-theme[data-subject="reasoning"] {
+  --subject-accent: #B88FCC;
+  --subject-accent-ink: #C4A5D4;
+  --subject-accent-soft: color-mix(in oklab, #8A5A9D 26%, var(--bg));
+  --subject-accent-border: color-mix(in oklab, #B88FCC 30%, var(--line));
+}
+
+/* --- Arithmetic (placeholder) --- */
+.subject-theme[data-subject="arithmetic"] {
+  --subject-accent: #C06B3E;
+  --subject-accent-ink: #964F2B;
+  --subject-accent-soft: #F8E4D6;
+  --subject-accent-border: color-mix(in oklab, #C06B3E 30%, var(--line));
+}
+:root[data-theme="dark"] .subject-theme[data-subject="arithmetic"],
+:root:not([data-theme="light"]) .subject-theme[data-subject="arithmetic"] {
+  --subject-accent: #E8975C;
+  --subject-accent-ink: #F2B756;
+  --subject-accent-soft: color-mix(in oklab, #C06B3E 26%, var(--bg));
+  --subject-accent-border: color-mix(in oklab, #E8975C 30%, var(--line));
+}
+
+/* Subject-theme accent remap — low specificity via :where so callers can
+ * override locally. Carries the four cross-surface accent tokens onto the
+ * subject-theme wrapper. */
+:where(.subject-theme[data-subject]) {
+  --accent: var(--subject-accent, var(--brand));
+  --btn-accent: var(--subject-accent, var(--brand));
+  --card-accent: var(--subject-accent, var(--brand));
+  --progress-accent: var(--subject-accent, var(--brand));
+}

--- a/tests/ui-subject-theme-contract.test.js
+++ b/tests/ui-subject-theme-contract.test.js
@@ -1,0 +1,293 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// UI Refactor P3 U1 — Subject Theme Token Contract tests.
+//
+// Verifies:
+//   1. Punctuation scenes have zero raw `#B8873F` hex in JSX (grep ratchet)
+//   2. Spelling setup has zero inline `--btn-accent` in JSX
+//   3. Grammar accent consumption unchanged (CSS-level, no inline overrides)
+//   4. SubjectThemeScope renders correct attributes
+//   5. Dark-mode tokens resolve for all three ready subjects
+//   6. Unknown subjectId doesn't crash SubjectThemeScope
+//   7. data-* journey selectors preserved in migrated files
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function readSource(relativePath) {
+  return readFileSync(path.join(rootDir, relativePath), 'utf8');
+}
+
+// ---------------------------------------------------------------------------
+// 1. Punctuation scenes: zero raw #B8873F in JSX (except CSS-var fallbacks)
+// ---------------------------------------------------------------------------
+
+const PUNCTUATION_SCENE_PATHS = [
+  'src/subjects/punctuation/components/PunctuationSetupScene.jsx',
+  'src/subjects/punctuation/components/PunctuationSessionScene.jsx',
+  'src/subjects/punctuation/components/PunctuationSummaryScene.jsx',
+  'src/subjects/punctuation/components/PunctuationMapScene.jsx',
+];
+
+test('Punctuation scenes: no bare #B8873F in JSX — must use CSS variable', () => {
+  for (const filePath of PUNCTUATION_SCENE_PATHS) {
+    const source = readSource(filePath);
+    const lines = source.split('\n');
+    const violations = [];
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      // Skip comment-only lines
+      if (line.trim().startsWith('//') || line.trim().startsWith('*')) continue;
+      // A bare hex literal NOT inside a var() fallback is a violation.
+      // Matches: '#B8873F' or "#B8873F" without a preceding `var(` on the same line.
+      if (/#B8873F/i.test(line) && !line.includes('var(')) {
+        violations.push({ file: filePath, line: i + 1, text: line.trim() });
+      }
+    }
+    assert.equal(
+      violations.length,
+      0,
+      `Found bare #B8873F hex in ${filePath} at line(s): ${violations.map((v) => v.line).join(', ')}. ` +
+      'Use var(--subject-accent, #B8873F) instead.',
+    );
+  }
+});
+
+test('Punctuation scenes: no bare #E8C88E in JSX', () => {
+  for (const filePath of PUNCTUATION_SCENE_PATHS) {
+    const source = readSource(filePath);
+    const lines = source.split('\n');
+    const violations = [];
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (line.trim().startsWith('//') || line.trim().startsWith('*')) continue;
+      if (/#E8C88E/i.test(line) && !line.includes('var(')) {
+        violations.push({ file: filePath, line: i + 1 });
+      }
+    }
+    assert.equal(violations.length, 0, `Found bare #E8C88E hex in ${filePath}`);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 2. Spelling setup: zero inline --btn-accent
+// ---------------------------------------------------------------------------
+
+test('Spelling setup: no inline --btn-accent style override', () => {
+  const source = readSource('src/subjects/spelling/components/SpellingSetupScene.jsx');
+  // Match pattern: style={{ ... '--btn-accent' ... }}
+  // A style prop containing '--btn-accent' as a key is a violation.
+  const inlineAccentPattern = /style=\{\{[^}]*['"]--btn-accent['"]/;
+  assert.equal(
+    inlineAccentPattern.test(source),
+    false,
+    'SpellingSetupScene.jsx still contains an inline --btn-accent style override. ' +
+    'The SubjectThemeScope CSS remap should provide --btn-accent.',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 3. Grammar accent consumption: CSS-level, no new inline overrides
+// ---------------------------------------------------------------------------
+
+test('Grammar setup: accent still consumed via CSS class, not inline --btn-accent', () => {
+  const source = readSource('src/subjects/grammar/components/GrammarSetupScene.jsx');
+  // Grammar should NOT have inline --btn-accent — it uses .grammar-setup-main CSS
+  const inlineAccentPattern = /style=\{\{[^}]*['"]--btn-accent['"]/;
+  assert.equal(
+    inlineAccentPattern.test(source),
+    false,
+    'GrammarSetupScene.jsx should not use inline --btn-accent — accent flows via CSS.',
+  );
+});
+
+test('Grammar accent CSS rule exists in app.css', () => {
+  const css = readSource('styles/app.css');
+  assert.ok(
+    css.includes('--grammar-accent:'),
+    'styles/app.css must declare --grammar-accent token.',
+  );
+  assert.ok(
+    css.includes('.grammar-setup-main'),
+    'styles/app.css must have a .grammar-setup-main selector for accent remap.',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 4. SubjectThemeScope renders correct attributes
+// ---------------------------------------------------------------------------
+
+test('SubjectThemeScope module exports a named function', () => {
+  const source = readSource('src/platform/ui/SubjectThemeScope.jsx');
+  assert.ok(
+    source.includes('export function SubjectThemeScope'),
+    'SubjectThemeScope.jsx must export a named function SubjectThemeScope',
+  );
+});
+
+test('SubjectThemeScope source renders data-subject and className', () => {
+  const source = readSource('src/platform/ui/SubjectThemeScope.jsx');
+  assert.ok(source.includes('data-subject'), 'Must render data-subject attribute');
+  assert.ok(source.includes('subject-theme'), 'Must render subject-theme className');
+  assert.ok(source.includes('children'), 'Must render children');
+});
+
+// ---------------------------------------------------------------------------
+// 5. Dark-mode tokens for all three ready subjects (spelling, grammar, punctuation)
+// ---------------------------------------------------------------------------
+
+test('Dark-mode subject-theme tokens exist for spelling, grammar, punctuation', () => {
+  const css = readSource('styles/app.css');
+  const readySubjects = ['spelling', 'grammar', 'punctuation'];
+  for (const subject of readySubjects) {
+    const darkSelector = `[data-theme="dark"] .subject-theme[data-subject="${subject}"]`;
+    assert.ok(
+      css.includes(darkSelector),
+      `Missing dark-mode override for .subject-theme[data-subject="${subject}"]`,
+    );
+  }
+});
+
+test('Dark-mode subject-theme tokens also cover prefers-color-scheme fallback', () => {
+  const css = readSource('styles/app.css');
+  const readySubjects = ['spelling', 'grammar', 'punctuation'];
+  for (const subject of readySubjects) {
+    // The :root:not([data-theme="light"]) selector covers system-preference dark mode
+    const selectorFragment = `:not([data-theme="light"]) .subject-theme[data-subject="${subject}"]`;
+    assert.ok(
+      css.includes(selectorFragment),
+      `Missing prefers-color-scheme dark fallback for subject "${subject}"`,
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 6. Unknown subjectId doesn't crash SubjectThemeScope
+// ---------------------------------------------------------------------------
+
+test('SubjectThemeScope handles falsy subjectId without crash', () => {
+  const source = readSource('src/platform/ui/SubjectThemeScope.jsx');
+  // Implementation uses `subjectId || undefined` so falsy values produce no data-subject
+  assert.ok(
+    source.includes('subjectId || undefined'),
+    'SubjectThemeScope should guard falsy subjectId with || undefined',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 7. data-* journey selectors preserved in migrated files
+// ---------------------------------------------------------------------------
+
+test('Punctuation Setup scene preserves journey selectors', () => {
+  const source = readSource('src/subjects/punctuation/components/PunctuationSetupScene.jsx');
+  const requiredSelectors = [
+    'data-punctuation-phase',
+    'data-punctuation-cta',
+    'data-section="hero"',
+    'data-section="progress-row"',
+    'data-section="monster-row"',
+    'data-section="map-link"',
+    'data-section="secondary"',
+    'data-action="punctuation-start"',
+  ];
+  for (const sel of requiredSelectors) {
+    assert.ok(source.includes(sel), `PunctuationSetupScene must preserve "${sel}"`);
+  }
+});
+
+test('Punctuation Session scene preserves journey selectors', () => {
+  const source = readSource('src/subjects/punctuation/components/PunctuationSessionScene.jsx');
+  const requiredSelectors = [
+    'data-punctuation-session-scene',
+    'data-punctuation-phase',
+    'data-punctuation-submit',
+    'data-punctuation-skip',
+    'data-punctuation-continue',
+  ];
+  for (const sel of requiredSelectors) {
+    assert.ok(source.includes(sel), `PunctuationSessionScene must preserve "${sel}"`);
+  }
+});
+
+test('Punctuation Summary scene preserves journey selectors', () => {
+  const source = readSource('src/subjects/punctuation/components/PunctuationSummaryScene.jsx');
+  const requiredSelectors = [
+    'data-punctuation-summary',
+    'data-action="punctuation-start"',
+    'data-action="punctuation-open-map"',
+    'data-action="punctuation-back"',
+    'data-punctuation-start-again',
+  ];
+  for (const sel of requiredSelectors) {
+    assert.ok(source.includes(sel), `PunctuationSummaryScene must preserve "${sel}"`);
+  }
+});
+
+test('Punctuation Map scene preserves journey selectors', () => {
+  const source = readSource('src/subjects/punctuation/components/PunctuationMapScene.jsx');
+  const requiredSelectors = [
+    'data-punctuation-map',
+    'data-punctuation-phase="map"',
+  ];
+  for (const sel of requiredSelectors) {
+    assert.ok(source.includes(sel), `PunctuationMapScene must preserve "${sel}"`);
+  }
+});
+
+test('Spelling setup preserves data-action selectors', () => {
+  const source = readSource('src/subjects/spelling/components/SpellingSetupScene.jsx');
+  assert.ok(
+    source.includes('dataAction="spelling-start"'),
+    'SpellingSetupScene must preserve dataAction="spelling-start"',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Subject theme registry contract
+// ---------------------------------------------------------------------------
+
+test('subject-themes.js exports all six subjects', async () => {
+  const mod = await import('../src/platform/ui/subject-themes.js');
+  const expected = ['spelling', 'grammar', 'punctuation', 'reading', 'reasoning', 'arithmetic'];
+  for (const id of expected) {
+    assert.ok(mod.SUBJECT_THEMES[id], `Missing theme for subject "${id}"`);
+    assert.equal(mod.SUBJECT_THEMES[id].subjectId, id);
+    assert.ok(mod.SUBJECT_THEMES[id].accent, `${id} must have accent`);
+    assert.ok(mod.SUBJECT_THEMES[id].accentInk, `${id} must have accentInk`);
+    assert.ok(mod.SUBJECT_THEMES[id].accentSoft, `${id} must have accentSoft`);
+    assert.ok(mod.SUBJECT_THEMES[id].accentBorder, `${id} must have accentBorder`);
+  }
+});
+
+test('subject-themes.js getSubjectTheme returns undefined for unknown', async () => {
+  const mod = await import('../src/platform/ui/subject-themes.js');
+  assert.equal(mod.getSubjectTheme('nonexistent'), undefined);
+  assert.equal(mod.getSubjectTheme(''), undefined);
+  assert.equal(mod.getSubjectTheme(null), undefined);
+});
+
+test('subject-themes.js SUBJECT_IDS is frozen array of 6', async () => {
+  const mod = await import('../src/platform/ui/subject-themes.js');
+  assert.equal(mod.SUBJECT_IDS.length, 6);
+  assert.ok(Object.isFrozen(mod.SUBJECT_IDS));
+});
+
+// ---------------------------------------------------------------------------
+// CSS accent remap: the :where() rule must carry all four aliases
+// ---------------------------------------------------------------------------
+
+test('Subject-theme CSS remap carries btn-accent, card-accent, progress-accent, accent', () => {
+  const css = readSource('styles/app.css');
+  assert.ok(css.includes(':where(.subject-theme[data-subject])'), 'Missing :where() remap rule');
+  // The remap block must set all four aliases
+  const remapBlock = css.slice(css.indexOf(':where(.subject-theme[data-subject])'));
+  const nextBrace = remapBlock.indexOf('}');
+  const body = remapBlock.slice(0, nextBrace);
+  assert.ok(body.includes('--btn-accent'), 'Remap must set --btn-accent');
+  assert.ok(body.includes('--card-accent'), 'Remap must set --card-accent');
+  assert.ok(body.includes('--progress-accent'), 'Remap must set --progress-accent');
+  assert.ok(body.includes('--accent:'), 'Remap must set --accent');
+});


### PR DESCRIPTION
## Summary

- Add unified subject theme token system: `.subject-theme[data-subject="X"]` CSS rules declare `--subject-accent`, `--subject-accent-ink`, `--subject-accent-soft`, `--subject-accent-border` for all 6 subjects (spelling, grammar, punctuation + placeholders for reading, reasoning, arithmetic).
- Create `SubjectThemeScope.jsx` — thin wrapper rendering `<div class="subject-theme" data-subject={id}>`. Zero runtime cost.
- Create `subject-themes.js` — JS registry for consumers needing accent values outside CSS.
- Migrate Punctuation scenes: remove raw `#B8873F` hex from inline JSX styles → `var(--subject-accent, #B8873F)`.
- Migrate Spelling setup: remove `style={{ '--btn-accent': accent }}` → SubjectThemeScope wrapper provides the token via CSS cascade.
- 19 test assertions covering grep ratchet, dark-mode coverage, data-* selector preservation.

## Changes

| File | What changed |
|------|-------------|
| `styles/app.css` | +122 lines: 6 subject-theme blocks + dark-mode overrides + `:where()` remap |
| `src/platform/ui/SubjectThemeScope.jsx` | New component |
| `src/platform/ui/subject-themes.js` | New registry |
| `src/subjects/punctuation/components/*.jsx` | 4 files: borderTopColor uses CSS var |
| `src/subjects/spelling/components/SpellingSetupScene.jsx` | Inline `--btn-accent` removed, wrapped in SubjectThemeScope |
| `scripts/inventory-inline-styles.mjs` | Classify SubjectThemeScope as css-var-ready |
| `tests/ui-subject-theme-contract.test.js` | New: 19 assertions |

## Visual appearance preservation

- Punctuation scenes: same `#B8873F` gold via CSS variable (fallback literal ensures zero risk)
- Spelling button: same `#3E6FA8` blue via subject-theme CSS cascade
- Grammar: untouched (already consumed via `.grammar-setup-main` CSS remap)

## Test plan

- [x] `tests/ui-subject-theme-contract.test.js` — 19/19 pass
- [x] `tests/csp-inline-style-budget.test.js` — 8/8 pass (net -1 inline style)
- [x] `tests/bundle-audit.test.js` — 58/58 pass
- [x] `tests/empty-state-parity.test.js` — 12/12 pass
- [ ] Manual: verify Punctuation Setup/Session/Summary/Map render with correct gold accent
- [ ] Manual: verify Spelling Setup button is still blue (#3E6FA8)
- [ ] Manual: verify dark mode tokens apply for all three ready subjects