### PR TITLE
feat(grammar-qg-p12): U7 — final production certification report (CERTIFIED_PRE_DEPLOY)

### DIFF
--- a/docs/plans/james/grammar/questions-generator/grammar-qg-p11-final-completion-report-2026-04-30.md
+++ b/docs/plans/james/grammar/questions-generator/grammar-qg-p11-final-completion-report-2026-04-30.md
@@ -21,7 +21,7 @@ final_content_release_commit: 7b39a78e
 post_merge_fix_commits:
   - "#739"
   - "#740"
-final_report_commit: pending-this-commit
+final_report_commit: f4e5ccd4
 ---
 
 # Grammar QG P11 — Final Completion Report
@@ -348,3 +348,9 @@ Two rounds of 10 independent reviewers validated the delivery against the origin
 | #739 | R1 fix | Expected-release flag and U7 schema coverage | 4 |
 | #740 | R2 fix | Assertion matching constant value not name | 0 (fix only) |
 | **Total** | **U1–U10 + review fixes** | | **~950** |
+
+---
+
+## 13. Addendum (P12 Context)
+
+P11 fixed learner-facing prompt-cue and read-aloud code. P12 locked production evidence and validated the release package.

--- a/docs/plans/james/grammar/questions-generator/grammar-qg-p12-final-production-certification-report-2026-04-30.md
+++ b/docs/plans/james/grammar/questions-generator/grammar-qg-p12-final-production-certification-report-2026-04-30.md
@@ -1,0 +1,92 @@
+---
+phase: grammar-qg-p12
+title: Grammar QG P12 — Final Production Certification Report
+certification_decision: CERTIFIED_PRE_DEPLOY
+certification_phase: grammar-qg-p12
+final_content_release_id: grammar-qg-p11-2026-04-30
+content_release_unchanged: true
+scoring_change: none
+mastery_change: none
+reward_change: none
+hero_mode_change: none
+post_deploy_smoke_evidence: pending-deployment
+template_count: 78
+concept_count: 18
+inventory_item_count: 2340
+---
+
+# Grammar QG P12 — Final Production Certification Report
+
+## 1. Source Boundary
+
+| Field | Value |
+|-------|-------|
+| Code commit | `6f89df58338737458676b530868e77f352192c75` |
+| Content release | `grammar-qg-p11-2026-04-30` |
+| Evidence manifest | `reports/grammar/grammar-qg-p11-certification-manifest.json` |
+| Smoke evidence | pending deployment |
+
+---
+
+## 2. Denominator
+
+- 18 grammar concepts
+- 78 templates (58 selected-response, 20 constructed-response, 52 generated, 26 fixed)
+- 2,340 inventory items (78 templates x 30 seeds)
+
+---
+
+## 3. P11 Learner-Surface Fix Confirmation
+
+| Template | Fix | Status |
+|----------|-----|--------|
+| `identify_words_in_sentence` | reads actual sentence (P10 bug fixed) | Confirmed |
+| `subject_object_choice` | reads actual sentence (P10 bug fixed) | Confirmed |
+| `qg_p4_voice_roles_transfer` | announces underlined noun phrase not word (P10 bug fixed) | Confirmed |
+
+---
+
+## 4. Evidence Artefact Table
+
+| Artefact | Path | Release ID |
+|----------|------|------------|
+| Certification manifest | reports/grammar/grammar-qg-p11-certification-manifest.json | grammar-qg-p11-2026-04-30 |
+| Render inventory | reports/grammar/grammar-qg-p11-render-inventory.json | grammar-qg-p11-2026-04-30 |
+| Render inventory (redacted) | reports/grammar/grammar-qg-p11-render-inventory-redacted.md | grammar-qg-p11-2026-04-30 |
+| Quality register | reports/grammar/grammar-qg-p11-quality-register.json | grammar-qg-p11-2026-04-30 |
+| Distractor audit | reports/grammar/grammar-qg-p11-distractor-audit.json | grammar-qg-p11-2026-04-30 |
+| Marking matrix | reports/grammar/grammar-qg-p11-marking-matrix.json | grammar-qg-p11-2026-04-30 |
+| Certification status map | reports/grammar/grammar-qg-p11-certification-status-map.json | grammar-qg-p11-2026-04-30 |
+| Semantic audit script | scripts/audit-grammar-prompt-cues-semantic.mjs | — |
+| Production smoke | reports/grammar/grammar-production-smoke-grammar-qg-p11-2026-04-30.json | pending |
+
+---
+
+## 5. Production Smoke Result
+
+- **Status:** pending deployment
+- The smoke script is ready and validated
+- Runbook at: `docs/plans/james/grammar/questions-generator/grammar-qg-p12-smoke-runbook.md`
+
+---
+
+## 6. Known Limitations
+
+- Production smoke evidence not yet produced (requires live deployment)
+- Report will be updated to CERTIFIED_POST_DEPLOY after smoke passes
+
+---
+
+## 7. No-Change Statement
+
+| System | Status |
+|--------|--------|
+| Scoring | unchanged |
+| Mastery | unchanged |
+| Rewards | unchanged |
+| Stars | unchanged |
+| Mega | unchanged |
+| Hero Mode | unchanged |
+| Hero Coins | unchanged |
+| Concordium | unchanged |
+| Monster progression | unchanged |

--- a/tests/grammar-qg-p12-report-frontmatter.test.js
+++ b/tests/grammar-qg-p12-report-frontmatter.test.js
@@ -1,0 +1,178 @@
+/**
+ * Grammar QG P12 — Report frontmatter validation tests.
+ *
+ * Validates that P12 and P11 reports have no unresolved placeholder values
+ * in their YAML frontmatter, and that key fields are correct.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const REPORTS_DIR = join(__dirname, '..', 'docs', 'plans', 'james', 'grammar', 'questions-generator');
+
+const P12_REPORT = join(REPORTS_DIR, 'grammar-qg-p12-final-production-certification-report-2026-04-30.md');
+const P11_REPORT = join(REPORTS_DIR, 'grammar-qg-p11-final-completion-report-2026-04-30.md');
+
+/**
+ * Parse YAML frontmatter from a markdown file.
+ * Returns an object mapping frontmatter keys to their string values.
+ */
+function parseFrontmatter(filePath) {
+  const content = readFileSync(filePath, 'utf8').replace(/\r\n/g, '\n');
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) throw new Error(`No frontmatter found in ${filePath}`);
+  const lines = match[1].split('\n');
+  const result = {};
+  let currentKey = null;
+  for (const line of lines) {
+    // Handle array items (indented with -)
+    if (/^\s+-/.test(line)) {
+      if (currentKey && !Array.isArray(result[currentKey])) {
+        result[currentKey] = [];
+      }
+      if (currentKey) {
+        result[currentKey].push(line.replace(/^\s+-\s*/, '').replace(/^["']|["']$/g, ''));
+      }
+      continue;
+    }
+    const kvMatch = line.match(/^([^:]+):\s*(.*)/);
+    if (kvMatch) {
+      currentKey = kvMatch[1].trim();
+      const value = kvMatch[2].trim();
+      if (value === '') {
+        // Might be start of array or empty value
+        result[currentKey] = '';
+      } else {
+        result[currentKey] = value.replace(/^["']|["']$/g, '');
+      }
+    }
+  }
+  return result;
+}
+
+/**
+ * Validates that a frontmatter value is not a forbidden placeholder.
+ * Forbidden patterns: pending-*, todo-*, tbd-*, unknown-*, empty strings.
+ *
+ * Exception: `pending-deployment` is allowed when certification_decision
+ * is CERTIFIED_PRE_DEPLOY.
+ */
+function validateNoPlaceholders(value, key, certificationDecision) {
+  if (typeof value !== 'string') return true;
+
+  // Allow pending-deployment for smoke evidence in PRE_DEPLOY state
+  if (
+    key === 'post_deploy_smoke_evidence' &&
+    value === 'pending-deployment' &&
+    certificationDecision === 'CERTIFIED_PRE_DEPLOY'
+  ) {
+    return true;
+  }
+
+  const forbiddenPatterns = [
+    /^pending-/,
+    /^todo-/,
+    /^tbd-/,
+    /^unknown-/,
+  ];
+
+  if (value === '') return false;
+
+  for (const pattern of forbiddenPatterns) {
+    if (pattern.test(value)) return false;
+  }
+
+  return true;
+}
+
+describe('P12 report frontmatter validation', () => {
+  const frontmatter = parseFrontmatter(P12_REPORT);
+
+  it('has no pending-* values (except post_deploy_smoke_evidence in CERTIFIED_PRE_DEPLOY)', () => {
+    const certDecision = frontmatter['certification_decision'];
+    for (const [key, value] of Object.entries(frontmatter)) {
+      if (Array.isArray(value)) continue;
+      const valid = validateNoPlaceholders(value, key, certDecision);
+      assert.ok(valid, `Frontmatter key "${key}" has forbidden placeholder value: "${value}"`);
+    }
+  });
+
+  it('certification_decision is valid (CERTIFIED_PRE_DEPLOY or CERTIFIED_POST_DEPLOY)', () => {
+    const validDecisions = ['CERTIFIED_PRE_DEPLOY', 'CERTIFIED_POST_DEPLOY'];
+    assert.ok(
+      validDecisions.includes(frontmatter['certification_decision']),
+      `certification_decision "${frontmatter['certification_decision']}" is not valid. Expected one of: ${validDecisions.join(', ')}`
+    );
+  });
+
+  it('final_content_release_id equals grammar-qg-p11-2026-04-30', () => {
+    assert.equal(
+      frontmatter['final_content_release_id'],
+      'grammar-qg-p11-2026-04-30'
+    );
+  });
+});
+
+describe('P11 report frontmatter validation', () => {
+  it('no longer has pending-this-commit in frontmatter', () => {
+    const content = readFileSync(P11_REPORT, 'utf8').replace(/\r\n/g, '\n');
+    const match = content.match(/^---\n([\s\S]*?)\n---/);
+    assert.ok(match, 'P11 report should have frontmatter');
+    assert.ok(
+      !match[1].includes('pending-this-commit'),
+      'P11 report frontmatter still contains "pending-this-commit"'
+    );
+  });
+});
+
+describe('frontmatter placeholder validator rejects forbidden values', () => {
+  it('rejects pending-* values', () => {
+    assert.equal(validateNoPlaceholders('pending-something', 'test_key', 'CERTIFIED_POST_DEPLOY'), false);
+    assert.equal(validateNoPlaceholders('pending-this-commit', 'test_key', 'CERTIFIED_POST_DEPLOY'), false);
+  });
+
+  it('rejects todo-* values', () => {
+    assert.equal(validateNoPlaceholders('todo-fill-in', 'test_key', 'CERTIFIED_POST_DEPLOY'), false);
+    assert.equal(validateNoPlaceholders('todo-later', 'test_key', 'CERTIFIED_POST_DEPLOY'), false);
+  });
+
+  it('rejects tbd-* values', () => {
+    assert.equal(validateNoPlaceholders('tbd-decision', 'test_key', 'CERTIFIED_POST_DEPLOY'), false);
+    assert.equal(validateNoPlaceholders('tbd-unknown', 'test_key', 'CERTIFIED_POST_DEPLOY'), false);
+  });
+
+  it('rejects unknown-* values', () => {
+    assert.equal(validateNoPlaceholders('unknown-sha', 'test_key', 'CERTIFIED_POST_DEPLOY'), false);
+    assert.equal(validateNoPlaceholders('unknown-value', 'test_key', 'CERTIFIED_POST_DEPLOY'), false);
+  });
+
+  it('rejects empty strings', () => {
+    assert.equal(validateNoPlaceholders('', 'test_key', 'CERTIFIED_POST_DEPLOY'), false);
+  });
+
+  it('accepts valid values', () => {
+    assert.equal(validateNoPlaceholders('grammar-qg-p11-2026-04-30', 'test_key', 'CERTIFIED_POST_DEPLOY'), true);
+    assert.equal(validateNoPlaceholders('CERTIFIED_PRE_DEPLOY', 'test_key', 'CERTIFIED_POST_DEPLOY'), true);
+    assert.equal(validateNoPlaceholders('f4e5ccd4', 'test_key', 'CERTIFIED_POST_DEPLOY'), true);
+    assert.equal(validateNoPlaceholders('none', 'test_key', 'CERTIFIED_POST_DEPLOY'), true);
+  });
+
+  it('allows pending-deployment for post_deploy_smoke_evidence when CERTIFIED_PRE_DEPLOY', () => {
+    assert.equal(
+      validateNoPlaceholders('pending-deployment', 'post_deploy_smoke_evidence', 'CERTIFIED_PRE_DEPLOY'),
+      true
+    );
+  });
+
+  it('rejects pending-deployment for post_deploy_smoke_evidence when CERTIFIED_POST_DEPLOY', () => {
+    assert.equal(
+      validateNoPlaceholders('pending-deployment', 'post_deploy_smoke_evidence', 'CERTIFIED_POST_DEPLOY'),
+      false
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes P11 completion report `final_report_commit: pending-this-commit` placeholder with actual merge SHA `f4e5ccd4`
- Creates P12 final production certification report with CERTIFIED_PRE_DEPLOY decision, full evidence artefact table, and no-change statement
- Adds 12 frontmatter validation tests ensuring no unresolved placeholders remain in either report

## Test plan

- [x] `node --test tests/grammar-qg-p12-report-frontmatter.test.js` — 12/12 pass
- [x] P11 report no longer contains `pending-this-commit`
- [x] P12 report frontmatter has valid certification decision
- [x] Placeholder validator rejects `pending-*`, `todo-*`, `tbd-*`, `unknown-*`, empty strings
- [x] `pending-deployment` allowed only for smoke evidence in PRE_DEPLOY state