### PR TITLE
fix(grammar-qg-p12): update stale verify-chain assertions for P11 release gate

### DIFF
--- a/tests/grammar-qg-p11-verify-chain.test.js
+++ b/tests/grammar-qg-p11-verify-chain.test.js
@@ -74,7 +74,7 @@ describe('P11 U10 Verify Chain: verify:grammar-qg-production-release', () => {
   it('verify:grammar-qg-production-release includes the semantic audit', () => {
     const cmd = scripts['verify:grammar-qg-production-release'] || '';
     assert.ok(
-      cmd.includes('audit-grammar-prompt-cues-semantic'),
+      cmd.includes('audit:grammar-qg:semantic'),
       `verify:grammar-qg-production-release must include the semantic audit. Actual: "${cmd}"`,
     );
   });
@@ -90,7 +90,7 @@ describe('P11 U10 Verify Chain: verify:grammar-qg-production-release', () => {
   it('verify:grammar-qg-production-release references the certification manifest', () => {
     const cmd = scripts['verify:grammar-qg-production-release'] || '';
     assert.ok(
-      cmd.includes('grammar-qg-p10-certification-manifest.json'),
+      cmd.includes('grammar-qg-p11-certification-manifest.json'),
       `verify:grammar-qg-production-release must reference the manifest. Actual: "${cmd}"`,
     );
   });


### PR DESCRIPTION
## Summary
- Update semantic audit assertion from `audit-grammar-prompt-cues-semantic` to `audit:grammar-qg:semantic` (npm alias introduced in U4)
- Update manifest reference from `grammar-qg-p10-certification-manifest.json` to `grammar-qg-p11-certification-manifest.json` (P11 promotion in U4)

## Test plan
- [x] `node --test tests/grammar-qg-p11-verify-chain.test.js` — 11/11 pass