### PR TITLE
feat(ui-refactor-p3): U3 session HUD and question progress engine

### DIFF
--- a/src/platform/ui/SessionHUD.jsx
+++ b/src/platform/ui/SessionHUD.jsx
@@ -1,0 +1,107 @@
+// UI Refactor P3 U3 — Session HUD (Heads-Up Display).
+//
+// Shared progress HUD component for all subject sessions. Renders an
+// accessible ProgressMeter plus a child-safe text status line showing
+// how many questions the learner has answered and how many remain.
+//
+// Stateless by design (R10): no store subscription, no side-effect hooks.
+// The parent scene is responsible for threading the current counts from
+// whatever view-model or read-model it uses.
+//
+// The copy style is deliberately child-safe and encouraging:
+//   "You have answered 6 of 10." / "4 left in this round."
+// Forbidden patterns are listed in the plan and tested by contract tests.
+//
+// Edge cases:
+//   - totalCount=0 → safe fallback text, not NaN
+//   - remainingCount clamped to >= 0
+//   - progress percentage never exceeds 100%
+//
+// ARIA: role="progressbar" (via ProgressMeter), aria-valuenow,
+// aria-valuemin, aria-valuemax, aria-label.
+//
+// prefers-reduced-motion: the CSS rule on `.progress-meter-fill` already
+// sets `transition: none` under reduced-motion. The HUD uses no JS
+// animation — the static fill is the only visual.
+
+import { ProgressMeter } from './ProgressMeter.jsx';
+
+/**
+ * @param {{
+ *   subjectId?: string,
+ *   title?: string,
+ *   answeredCount: number,
+ *   totalCount: number,
+ *   remainingCount?: number,
+ *   currentIndex?: number,
+ *   modeLabel?: string,
+ *   supportState?: 'none'|'available'|'used'|'locked',
+ *   progressLabel?: string,
+ *   accent?: string,
+ * }} props
+ */
+export function SessionHUD({
+  subjectId,
+  title,
+  answeredCount,
+  totalCount,
+  remainingCount,
+  currentIndex,
+  modeLabel,
+  supportState,
+  progressLabel,
+  accent,
+}) {
+  // Defensive normalisation — avoids NaN / Infinity / negative values.
+  const safeTotal = Math.max(0, Number(totalCount) || 0);
+  const safeAnswered = Math.min(safeTotal, Math.max(0, Number(answeredCount) || 0));
+  const safeRemaining = typeof remainingCount === 'number'
+    ? Math.max(0, remainingCount)
+    : Math.max(0, safeTotal - safeAnswered);
+  const safeIndex = typeof currentIndex === 'number'
+    ? Math.min(safeTotal, Math.max(0, currentIndex))
+    : safeAnswered;
+
+  // Percentage clamped 0–100 (ProgressMeter also clamps internally).
+  const pct = safeTotal > 0 ? Math.min(100, Math.round((safeAnswered / safeTotal) * 100)) : 0;
+
+  // Child-safe copy. Zero-total gets a fallback that is still meaningful.
+  const answeredText = safeTotal > 0
+    ? `You have answered ${safeAnswered} of ${safeTotal}.`
+    : 'Getting ready…';
+  const remainingText = safeTotal > 0 && safeRemaining > 0
+    ? `${safeRemaining} left in this round.`
+    : '';
+
+  // Accessible label for the progressbar.
+  const ariaLabel = safeTotal > 0
+    ? `Question progress: ${safeAnswered} of ${safeTotal} answered`
+    : 'Question progress';
+
+  return (
+    <div
+      className="session-hud"
+      data-session-hud
+      data-subject={subjectId || undefined}
+      data-support-state={supportState || undefined}
+    >
+      {title || progressLabel ? (
+        <div className="session-hud-title" data-session-hud-title>
+          {title || progressLabel}
+          {modeLabel ? <span className="session-hud-mode">{modeLabel}</span> : null}
+        </div>
+      ) : null}
+      <ProgressMeter
+        value={pct}
+        min={0}
+        max={100}
+        label={ariaLabel}
+        className="session-hud-meter"
+      />
+      <div className="session-hud-status" data-session-hud-status aria-live="polite">
+        <span className="session-hud-answered">{answeredText}</span>
+        {remainingText ? <span className="session-hud-remaining">{remainingText}</span> : null}
+      </div>
+    </div>
+  );
+}

--- a/src/subjects/grammar/components/GrammarSessionScene.jsx
+++ b/src/subjects/grammar/components/GrammarSessionScene.jsx
@@ -13,6 +13,7 @@ import {
   grammarFeedbackTone,
 } from '../session-ui.js';
 import { translateGrammarSessionError } from '../module.js';
+import { SessionHUD } from '../../../platform/ui/SessionHUD.jsx';
 
 function optionLabel(option) {
   if (Array.isArray(option)) return String(option[1] ?? option[0] ?? '');
@@ -664,6 +665,16 @@ export function GrammarSessionScene({ grammar, actions, runtimeReadOnly }) {
           <span>{progressDone}</span>
           <small>of {progressTotal}</small>
         </div>
+        <SessionHUD
+          subjectId="grammar"
+          answeredCount={progressDone}
+          totalCount={progressTotal}
+          remainingCount={Math.max(0, progressTotal - progressDone)}
+          currentIndex={progressDone}
+          modeLabel={session.mode || ''}
+          supportState={help.showFadedSupport ? 'available' : 'none'}
+          progressLabel={progressLabel}
+        />
       </div>
 
       <div className="grammar-prompt-card">

--- a/src/subjects/punctuation/components/PunctuationSessionScene.jsx
+++ b/src/subjects/punctuation/components/PunctuationSessionScene.jsx
@@ -64,6 +64,7 @@ import {
   punctuationSessionSubmitLabel,
 } from '../session-ui.js';
 import { PUNCTUATION_CLIENT_SKILLS } from '../read-model.js';
+import { SessionHUD } from '../../../platform/ui/SessionHUD.jsx';
 
 // --- Local helpers ---------------------------------------------------------
 
@@ -402,6 +403,17 @@ function ActiveItemBranch({ ui, actions, heroUrl = '', previousHeroUrl = '' }) {
           <p className="subtitle">{currentItemInstruction(item)}</p>
         </div>
       </section>
+
+      <SessionHUD
+        subjectId="punctuation"
+        answeredCount={Number(session.answeredCount) || 0}
+        totalCount={Number(session.length) || 0}
+        remainingCount={Math.max(0, (Number(session.length) || 0) - (Number(session.answeredCount) || 0))}
+        currentIndex={(Number(session.answeredCount) || 0) + 1}
+        modeLabel={modeLabel}
+        supportState={help.showTeachBox ? 'available' : 'none'}
+        progressLabel={progressLabel}
+      />
 
       {isGps ? <GpsDelayedFeedbackChips session={session} /> : null}
       {help.showTeachBox ? <CollapsedTeachBox guided={session.guided} /> : null}

--- a/src/subjects/spelling/components/SpellingSessionScene.jsx
+++ b/src/subjects/spelling/components/SpellingSessionScene.jsx
@@ -35,6 +35,7 @@ import {
   spellingSessionProgressIndex,
 } from './spelling-view-model.js';
 import { isPostMasteryMode } from '../service-contract.js';
+import { SessionHUD } from '../../../platform/ui/SessionHUD.jsx';
 
 // Self-contained post-Mega branch lookup — Phaeton (the spelling grand
 // master) anchors the f-region vista regardless of the rest of the
@@ -243,6 +244,14 @@ export function SpellingSessionScene({
         <header className="session-head">
           <PathProgress done={pathDone} current={pathCurrent} total={progressTotal} />
           <span className="path-count">Word {progressCurrent} of {progressTotal}</span>
+          <SessionHUD
+            subjectId="spelling"
+            answeredCount={done}
+            totalCount={progressTotal}
+            remainingCount={Math.max(0, progressTotal - done)}
+            currentIndex={progressCurrent}
+            modeLabel={session.mode || ''}
+          />
         </header>
 
         {showPersistenceBanner ? (

--- a/tests/ui-session-hud-contract.test.js
+++ b/tests/ui-session-hud-contract.test.js
@@ -1,0 +1,310 @@
+// UI Refactor P3 U3 — Session HUD contract tests.
+//
+// Verifies the shared SessionHUD component meets its behavioural contract:
+//   1. Progress never exceeds 100%
+//   2. remainingCount cannot be negative
+//   3. zero-total renders safe fallback, not NaN
+//   4. aria-valuenow, aria-valuemin, aria-valuemax present
+//   5. Accessible label describes progress
+//   6. Reduced-motion produces static progress (CSS-level, verified via source)
+//   7. No forbidden copy patterns
+//   8. SubjectThemeScope integration (uses subject tokens for accent)
+//   9. Component is stateless (no store imports)
+//  10. Adoption in all three ready subjects
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function readSource(relativePath) {
+  return readFileSync(path.join(rootDir, relativePath), 'utf8');
+}
+
+const HUD_SOURCE = readSource('src/platform/ui/SessionHUD.jsx');
+
+// ---------------------------------------------------------------------------
+// 1. Progress never exceeds 100%
+// ---------------------------------------------------------------------------
+
+test('U3 SessionHUD: progress percentage clamped to 100 max via Math.min', () => {
+  // The source must clamp percent to max 100
+  assert.ok(
+    HUD_SOURCE.includes('Math.min(100,'),
+    'SessionHUD must clamp percentage to 100 via Math.min(100, ...)',
+  );
+});
+
+test('U3 SessionHUD: safeAnswered cannot exceed safeTotal', () => {
+  // safeAnswered = Math.min(safeTotal, ...)
+  assert.ok(
+    HUD_SOURCE.includes('Math.min(safeTotal, Math.max(0,'),
+    'SessionHUD must clamp answered to safeTotal',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 2. remainingCount cannot be negative
+// ---------------------------------------------------------------------------
+
+test('U3 SessionHUD: remainingCount floored to 0', () => {
+  assert.ok(
+    HUD_SOURCE.includes('Math.max(0, remainingCount)'),
+    'SessionHUD must floor remainingCount to 0',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 3. zero-total renders safe fallback, not NaN
+// ---------------------------------------------------------------------------
+
+test('U3 SessionHUD: zero total renders "Getting ready" fallback', () => {
+  assert.ok(
+    HUD_SOURCE.includes("'Getting ready\\u2026'") || HUD_SOURCE.includes("'Getting ready…'"),
+    'SessionHUD must render a safe fallback string when total is 0',
+  );
+});
+
+test('U3 SessionHUD: safeTotal uses Math.max(0, ...) to avoid negative', () => {
+  assert.ok(
+    HUD_SOURCE.includes('Math.max(0, Number(totalCount)'),
+    'SessionHUD must normalise totalCount to non-negative',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 4. aria-valuenow, aria-valuemin, aria-valuemax present (via ProgressMeter)
+// ---------------------------------------------------------------------------
+
+test('U3 SessionHUD: uses ProgressMeter which provides ARIA attributes', () => {
+  assert.ok(
+    HUD_SOURCE.includes("import { ProgressMeter }"),
+    'SessionHUD must import ProgressMeter',
+  );
+  assert.ok(
+    HUD_SOURCE.includes('<ProgressMeter'),
+    'SessionHUD must render a ProgressMeter element',
+  );
+});
+
+test('U3 ProgressMeter: has aria-valuenow, aria-valuemin, aria-valuemax', () => {
+  const source = readSource('src/platform/ui/ProgressMeter.jsx');
+  assert.ok(source.includes('aria-valuenow'), 'ProgressMeter must have aria-valuenow');
+  assert.ok(source.includes('aria-valuemin'), 'ProgressMeter must have aria-valuemin');
+  assert.ok(source.includes('aria-valuemax'), 'ProgressMeter must have aria-valuemax');
+  assert.ok(source.includes('role="progressbar"'), 'ProgressMeter must have role="progressbar"');
+});
+
+// ---------------------------------------------------------------------------
+// 5. Accessible label describes progress
+// ---------------------------------------------------------------------------
+
+test('U3 SessionHUD: passes a descriptive aria label to ProgressMeter', () => {
+  assert.ok(
+    HUD_SOURCE.includes('Question progress:'),
+    'SessionHUD must include "Question progress:" in the aria label',
+  );
+  assert.ok(
+    HUD_SOURCE.includes('answered'),
+    'SessionHUD aria label must mention "answered"',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 6. Reduced-motion produces static progress (CSS-level)
+// ---------------------------------------------------------------------------
+
+test('U3 SessionHUD: CSS reduces motion on progress-meter-fill', () => {
+  const css = readSource('styles/app.css');
+  // The existing CSS has @media (prefers-reduced-motion: reduce) rule for
+  // .progress-meter-fill that sets transition: none
+  assert.ok(
+    css.includes('prefers-reduced-motion: reduce'),
+    'app.css must have a prefers-reduced-motion rule',
+  );
+  assert.ok(
+    css.includes('.progress-meter-fill') && css.includes('transition: none'),
+    'app.css must disable progress-meter-fill transition under reduced-motion',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 7. No forbidden copy patterns
+// ---------------------------------------------------------------------------
+
+const FORBIDDEN_COPY = [
+  'lose your streak',
+  'Earn coins',
+  'failed this monster',
+  'Mega lost',
+];
+
+// Strip single-line comments before checking for forbidden copy — the
+// constraint is that these strings never appear in rendered JSX output,
+// not that they cannot be mentioned in documentation comments.
+function stripComments(source) {
+  return source.split('\n')
+    .filter((line) => !line.trim().startsWith('//') && !line.trim().startsWith('*'))
+    .join('\n');
+}
+
+test('U3 SessionHUD: no forbidden copy patterns in rendered output', () => {
+  const code = stripComments(HUD_SOURCE);
+  for (const pattern of FORBIDDEN_COPY) {
+    assert.ok(
+      !code.toLowerCase().includes(pattern.toLowerCase()),
+      `SessionHUD must not contain forbidden copy "${pattern}" in rendered output`,
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 8. SubjectThemeScope integration — data-subject attribute present
+// ---------------------------------------------------------------------------
+
+test('U3 SessionHUD: renders data-subject for theme cascade', () => {
+  assert.ok(
+    HUD_SOURCE.includes('data-subject'),
+    'SessionHUD must render data-subject attribute for SubjectThemeScope integration',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 9. Component is stateless — no store subscription
+// ---------------------------------------------------------------------------
+
+test('U3 SessionHUD: no store import (stateless contract)', () => {
+  const code = stripComments(HUD_SOURCE);
+  assert.ok(
+    !code.includes('usePlatformStore'),
+    'SessionHUD must not import usePlatformStore',
+  );
+  assert.ok(
+    !code.includes('useStore'),
+    'SessionHUD must not import useStore',
+  );
+  assert.ok(
+    !code.includes('useState'),
+    'SessionHUD must not use useState (stateless)',
+  );
+  assert.ok(
+    !code.includes('useEffect'),
+    'SessionHUD must not use useEffect (stateless)',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 10. Adoption in all three ready subjects
+// ---------------------------------------------------------------------------
+
+test('U3 SessionHUD: adopted in SpellingSessionScene', () => {
+  const source = readSource('src/subjects/spelling/components/SpellingSessionScene.jsx');
+  assert.ok(
+    source.includes("import { SessionHUD }"),
+    'SpellingSessionScene must import SessionHUD',
+  );
+  assert.ok(
+    source.includes('<SessionHUD'),
+    'SpellingSessionScene must render SessionHUD',
+  );
+  assert.ok(
+    source.includes('subjectId="spelling"'),
+    'SpellingSessionScene must pass subjectId="spelling" to SessionHUD',
+  );
+});
+
+test('U3 SessionHUD: adopted in GrammarSessionScene', () => {
+  const source = readSource('src/subjects/grammar/components/GrammarSessionScene.jsx');
+  assert.ok(
+    source.includes("import { SessionHUD }"),
+    'GrammarSessionScene must import SessionHUD',
+  );
+  assert.ok(
+    source.includes('<SessionHUD'),
+    'GrammarSessionScene must render SessionHUD',
+  );
+  assert.ok(
+    source.includes('subjectId="grammar"'),
+    'GrammarSessionScene must pass subjectId="grammar" to SessionHUD',
+  );
+});
+
+test('U3 SessionHUD: adopted in PunctuationSessionScene', () => {
+  const source = readSource('src/subjects/punctuation/components/PunctuationSessionScene.jsx');
+  assert.ok(
+    source.includes("import { SessionHUD }"),
+    'PunctuationSessionScene must import SessionHUD',
+  );
+  assert.ok(
+    source.includes('<SessionHUD'),
+    'PunctuationSessionScene must render SessionHUD',
+  );
+  assert.ok(
+    source.includes('subjectId="punctuation"'),
+    'PunctuationSessionScene must pass subjectId="punctuation" to SessionHUD',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 11. Existing data-action / data-value selectors preserved
+// ---------------------------------------------------------------------------
+
+test('U3 Spelling session: preserves all data-action selectors', () => {
+  const source = readSource('src/subjects/spelling/components/SpellingSessionScene.jsx');
+  const requiredSelectors = [
+    'data-action="spelling-back"',
+    'data-action="spelling-submit-form"',
+    'data-action="spelling-replay"',
+    'data-action="spelling-replay-slow"',
+    'data-action="spelling-continue"',
+    'data-action="spelling-skip"',
+    'data-action="spelling-end-early"',
+  ];
+  for (const sel of requiredSelectors) {
+    assert.ok(source.includes(sel), `SpellingSessionScene must preserve "${sel}"`);
+  }
+});
+
+test('U3 Grammar session: preserves data-grammar-phase-root selector', () => {
+  const source = readSource('src/subjects/grammar/components/GrammarSessionScene.jsx');
+  assert.ok(
+    source.includes('data-grammar-phase-root="session"'),
+    'GrammarSessionScene must preserve data-grammar-phase-root="session"',
+  );
+});
+
+test('U3 Punctuation session: preserves data-punctuation selectors', () => {
+  const source = readSource('src/subjects/punctuation/components/PunctuationSessionScene.jsx');
+  const requiredSelectors = [
+    'data-punctuation-session-scene',
+    'data-punctuation-phase',
+    'data-punctuation-submit',
+    'data-punctuation-skip',
+    'data-punctuation-continue',
+    'data-punctuation-end-round',
+  ];
+  for (const sel of requiredSelectors) {
+    assert.ok(source.includes(sel), `PunctuationSessionScene must preserve "${sel}"`);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 12. Module-level export contract
+// ---------------------------------------------------------------------------
+
+test('U3 SessionHUD: exports a named function', () => {
+  assert.ok(
+    HUD_SOURCE.includes('export function SessionHUD'),
+    'SessionHUD.jsx must export a named function SessionHUD',
+  );
+});
+
+test('U3 SessionHUD: module imports ProgressMeter from correct path', () => {
+  assert.ok(
+    HUD_SOURCE.includes("from './ProgressMeter.jsx'"),
+    'SessionHUD must import ProgressMeter from the platform ui directory',
+  );
+});


### PR DESCRIPTION
## Summary

- Created shared `src/platform/ui/SessionHUD.jsx` component rendering accessible progress (ProgressMeter + child-safe text status)
- Adopted SessionHUD in all three ready subjects: Spelling, Grammar, and Punctuation session scenes
- 20 contract tests covering ARIA, edge cases, forbidden copy, stateless guarantees, and data-selector preservation

## Details

**SessionHUD props:** `subjectId`, `answeredCount`, `totalCount`, `remainingCount`, `currentIndex`, `modeLabel`, `supportState`, `progressLabel`, `title`, `accent`

**Edge case handling:**
- `totalCount=0` renders "Getting ready..." (not NaN)
- `remainingCount` clamped to >= 0
- Progress percentage never exceeds 100%
- `safeAnswered` cannot exceed `safeTotal`

**Accessibility:**
- Uses ProgressMeter primitive (role="progressbar", aria-valuenow/min/max)
- Descriptive aria-label: "Question progress: N of M answered"
- `prefers-reduced-motion`: CSS `transition: none` on fill (existing rule)

**Stateless contract:** No useState, useEffect, useStore, or usePlatformStore

## Test plan

- [x] 20/20 contract tests pass (`tests/ui-session-hud-contract.test.js`)
- [x] Existing spelling-session-ui tests pass (17/17)
- [x] Existing punctuation-session-ui tests pass (18/18)
- [x] Existing ui-subject-theme-contract tests pass (19/19)
- [x] Existing ui-component-adoption tests pass (9/9)
- [x] Existing ui-primary-action-contract tests pass (3/3)
- [x] All data-action and data-value selectors preserved
- [x] No learning logic, marking, reward, or Worker command changes