### PR TITLE
feat(ui-refactor-p3): U2 action engine pass 1

### DIFF
--- a/src/platform/ui/ActionRow.jsx
+++ b/src/platform/ui/ActionRow.jsx
@@ -1,0 +1,89 @@
+/* Platform ActionRow layout primitive (P3 U2).
+ *
+ * A layout-only companion to `Button` that provides consistent flexbox
+ * alignment, gap, and wrapping for action button groups across learner-
+ * facing surfaces (session, summary, setup, home).
+ *
+ * Contract:
+ *   - NO command dispatch logic — pure layout.
+ *   - Renders a `<div>` with role="group" and aria-label for screen
+ *     readers to announce the action cluster as a group.
+ *   - `align` prop controls alignment:
+ *       "start"   → justify-content: flex-start (default)
+ *       "centre"  → justify-content: center
+ *       "end"     → justify-content: flex-end
+ *       "split"   → primary on left, secondary/tertiary on right via
+ *                    margin-left: auto on secondary wrapper.
+ *   - Handles single-button case gracefully (no empty wrapper rendered).
+ *   - `gap` defaults to 12px, consistent with .actions pattern in
+ *     styles/app.css.
+ *
+ * Locator preservation:
+ *   - data-action-row attribute for test selectors.
+ *   - className pass-through for existing .actions styling hooks.
+ */
+export function ActionRow({
+  primary,
+  secondary,
+  tertiary,
+  align = 'start',
+  className,
+  style,
+  'aria-label': ariaLabel,
+}) {
+  const hasSecondary = secondary !== null && secondary !== undefined;
+  const hasTertiary = tertiary !== null && tertiary !== undefined;
+
+  const justifyMap = {
+    start: 'flex-start',
+    centre: 'center',
+    end: 'flex-end',
+    split: 'flex-start',
+  };
+
+  const baseStyle = {
+    display: 'flex',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    gap: 12,
+    justifyContent: justifyMap[align] || 'flex-start',
+    ...style,
+  };
+
+  const classes = ['action-row'];
+  if (className) classes.push(className);
+
+  if (align === 'split') {
+    return (
+      <div
+        className={classes.join(' ')}
+        data-action-row
+        role="group"
+        aria-label={ariaLabel || 'Actions'}
+        style={baseStyle}
+      >
+        <div className="action-row-start">{primary}</div>
+        {(hasSecondary || hasTertiary) ? (
+          <div className="action-row-end" style={{ marginLeft: 'auto', display: 'flex', gap: 12, flexWrap: 'wrap', alignItems: 'center' }}>
+            {hasSecondary ? secondary : null}
+            {hasTertiary ? tertiary : null}
+          </div>
+        ) : null}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={classes.join(' ')}
+      data-action-row
+      role="group"
+      aria-label={ariaLabel || 'Actions'}
+      style={baseStyle}
+    >
+      {primary}
+      {hasSecondary ? secondary : null}
+      {hasTertiary ? tertiary : null}
+    </div>
+  );
+}

--- a/src/subjects/grammar/components/GrammarSessionScene.jsx
+++ b/src/subjects/grammar/components/GrammarSessionScene.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Button } from '../../../platform/ui/Button.jsx';
 import { useSubmitLock } from '../../../platform/react/use-submit-lock.js';
 import {
   buildGrammarSpeechText,
@@ -468,33 +469,30 @@ function RepairActions({ isMiniTest, isFeedback, help, feedback, pending, runtim
     if (tone !== 'bad') return null;
     return (
       <div className="grammar-repair-actions" aria-label="Grammar repair actions">
-        <button
-          className="btn secondary"
-          type="button"
+        <Button
+          variant="secondary"
           disabled={disabled}
           onClick={() => submitLock.run(async () => actions.dispatch('grammar-retry-current-question'))}
         >
           Retry
-        </button>
+        </Button>
         {help.showWorkedSolution ? (
-          <button
-            className="btn secondary"
-            type="button"
+          <Button
+            variant="secondary"
             disabled={disabled}
             onClick={() => submitLock.run(async () => actions.dispatch('grammar-show-worked-solution'))}
           >
             Worked solution
-          </button>
+          </Button>
         ) : null}
         {help.showSimilarProblem ? (
-          <button
-            className="btn secondary"
-            type="button"
+          <Button
+            variant="secondary"
             disabled={disabled}
             onClick={() => submitLock.run(async () => actions.dispatch('grammar-start-similar-problem'))}
           >
             Similar problem
-          </button>
+          </Button>
         ) : null}
       </div>
     );
@@ -505,22 +503,20 @@ function RepairActions({ isMiniTest, isFeedback, help, feedback, pending, runtim
   if (!help?.showFadedSupport || !help?.showSimilarProblem) return null;
   return (
     <div className="grammar-repair-actions" aria-label="Grammar support actions">
-      <button
-        className="btn secondary"
-        type="button"
+      <Button
+        variant="secondary"
         disabled={disabled}
         onClick={() => submitLock.run(async () => actions.dispatch('grammar-use-faded-support'))}
       >
         Faded support
-      </button>
-      <button
-        className="btn secondary"
-        type="button"
+      </Button>
+      <Button
+        variant="secondary"
         disabled={disabled}
         onClick={() => submitLock.run(async () => actions.dispatch('grammar-start-similar-problem'))}
       >
         Similar problem
-      </button>
+      </Button>
     </div>
   );
 }
@@ -536,22 +532,20 @@ function AiEnrichmentActions({ isMiniTest, isFeedback, pending, runtimeReadOnly,
   const explanationLabel = isFeedback ? 'Explain another way' : 'Explain this';
   return (
     <div className="grammar-ai-actions" aria-label="Grammar enrichment actions">
-      <button
-        className="btn secondary"
-        type="button"
+      <Button
+        variant="secondary"
         disabled={disabled}
         onClick={() => actions.dispatch('grammar-request-ai-enrichment', { kind: 'explanation' })}
       >
         {explanationLabel}
-      </button>
-      <button
-        className="btn secondary"
-        type="button"
+      </Button>
+      <Button
+        variant="secondary"
         disabled={disabled}
         onClick={() => actions.dispatch('grammar-request-ai-enrichment', { kind: 'revision-card' })}
       >
         Revision cards
-      </button>
+      </Button>
     </div>
   );
 }
@@ -564,9 +558,8 @@ function ReadAloudControls({ grammar }) {
 
   return (
     <div className="grammar-read-aloud" aria-label="Grammar read aloud">
-      <button
-        className="btn secondary"
-        type="button"
+      <Button
+        variant="secondary"
         disabled={disabled}
         onClick={() => {
           const result = speakGrammarReadModel(grammar, { rate: grammar.prefs?.speechRate });
@@ -574,7 +567,7 @@ function ReadAloudControls({ grammar }) {
         }}
       >
         Read aloud
-      </button>
+      </Button>
       {!speechAvailable ? <span className="small muted">Speech synthesis unavailable</span> : null}
       {status ? <span className="small muted" role="status">{status}</span> : null}
     </div>
@@ -789,40 +782,38 @@ export function GrammarSessionScene({ grammar, actions, runtimeReadOnly }) {
           <div className="actions">
             {isMiniTest ? (
               <>
-                <button className="btn primary" type="submit" name="_action" value="save" disabled={submitDisabled}>
+                <Button variant="primary" type="submit" name="_action" value="save" disabled={submitDisabled}>
                   {pending && grammar.pendingCommand === 'save-mini-test-response' ? 'Saving...' : 'Save response'}
-                </button>
-                <button className="btn secondary" type="submit" name="_action" value="save-next" disabled={submitDisabled}>
+                </Button>
+                <Button variant="secondary" type="submit" name="_action" value="save-next" disabled={submitDisabled}>
                   Save and next
-                </button>
-                <button className="btn ghost" type="submit" name="_action" value="finish" disabled={runtimeReadOnly || pending}>
+                </Button>
+                <Button variant="ghost" type="submit" name="_action" value="finish" disabled={runtimeReadOnly || pending}>
                   {pending && grammar.pendingCommand === 'finish-mini-test' ? 'Finishing...' : 'Finish mini-set'}
-                </button>
+                </Button>
               </>
             ) : (
-              <button className="btn primary" type="submit" disabled={submitDisabled}>
+              <Button variant="primary" type="submit" disabled={submitDisabled}>
                 {pending && grammar.pendingCommand === 'submit-answer' ? 'Checking...' : submitLabel}
-              </button>
+              </Button>
             )}
             {!isMiniTest && isFeedback ? (
-              <button
-                className="btn secondary"
-                type="button"
+              <Button
+                variant="secondary"
                 disabled={runtimeReadOnly || pending || submitLock.locked}
                 onClick={() => submitLock.run(async () => actions.dispatch('grammar-continue'))}
               >
                 {progressDone >= progressTotal ? 'Finish round' : 'Next question'}
-              </button>
+              </Button>
             ) : null}
             {!isMiniTest ? (
-              <button
-                className="btn ghost"
-                type="button"
+              <Button
+                variant="ghost"
                 disabled={pending}
                 onClick={() => actions.dispatch('grammar-end-early')}
               >
                 End round
-              </button>
+              </Button>
             ) : null}
           </div>
         </form>

--- a/src/subjects/grammar/components/GrammarSummaryScene.jsx
+++ b/src/subjects/grammar/components/GrammarSummaryScene.jsx
@@ -1,3 +1,4 @@
+import { Button } from '../../../platform/ui/Button.jsx';
 import { useSubmitLock } from '../../../platform/react/use-submit-lock.js';
 import { GrammarMiniTestReview } from './GrammarMiniTestReview.jsx';
 import { grammarSummaryCards } from './grammar-view-model.js';
@@ -139,16 +140,15 @@ function PrimaryActions({ buttons, disabled }) {
   return (
     <div className="grammar-summary-primary-actions" role="group" aria-label="Next steps">
       {buttons.map((button) => (
-        <button
+        <Button
           key={button.action}
-          type="button"
-          className={`btn ${button.variant || 'primary'}`}
-          data-action={button.action}
+          variant={button.variant || 'primary'}
+          dataAction={button.action}
           disabled={disabled || button.disabled === true || submitLock.locked}
           onClick={() => submitLock.run(async () => button.onClick())}
         >
           {button.label}
-        </button>
+        </Button>
       ))}
     </div>
   );
@@ -157,16 +157,15 @@ function PrimaryActions({ buttons, disabled }) {
 function SecondaryActions({ onGrownUp, disabled }) {
   return (
     <div className="grammar-summary-secondary-actions">
-      <button
-        type="button"
-        className="btn ghost"
-        data-action="grammar-open-analytics"
+      <Button
+        variant="ghost"
+        dataAction="grammar-open-analytics"
         aria-label="Open adult report"
         disabled={disabled}
         onClick={onGrownUp}
       >
         Grown-up view
-      </button>
+      </Button>
     </div>
   );
 }

--- a/src/subjects/punctuation/components/PunctuationSessionScene.jsx
+++ b/src/subjects/punctuation/components/PunctuationSessionScene.jsx
@@ -44,6 +44,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 
+import { Button } from '../../../platform/ui/Button.jsx';
 import { HeroBackdrop } from '../../../platform/ui/HeroBackdrop.jsx';
 import { useSubmitLock } from '../../../platform/react/use-submit-lock.js';
 import {
@@ -151,14 +152,14 @@ function ChoiceItem({ item, disabled, submitLabel, onSubmit, errorMessageId = ''
         ))}
       </div>
       <div className="actions">
-        <button
-          className="btn primary"
+        <Button
+          variant="primary"
           type="submit"
           disabled={disabled || choiceIndex === ''}
           data-punctuation-submit
         >
           {submitLabel}
-        </button>
+        </Button>
       </div>
     </form>
   );
@@ -229,22 +230,21 @@ function TextItem({ item, disabled, submitLabel, shape, onSubmit, errorMessageId
         />
       </label>
       <div className="actions">
-        <button
-          className="btn primary"
+        <Button
+          variant="primary"
           type="submit"
           disabled={disabled}
           data-punctuation-submit
         >
           {submitLabel}
-        </button>
-        <button
-          className="btn secondary"
-          type="button"
+        </Button>
+        <Button
+          variant="secondary"
           disabled={disabled}
           onClick={() => setTyped(initialValue)}
         >
           Reset text
-        </button>
+        </Button>
       </div>
     </form>
   );
@@ -485,24 +485,22 @@ function ActiveItemBranch({ ui, actions, heroUrl = '', previousHeroUrl = '' }) {
       ) : null}
 
       <div className="actions punctuation-session-secondary-actions" style={{ marginTop: 16 }}>
-        <button
-          className="btn ghost"
-          type="button"
+        <Button
+          variant="ghost"
           disabled={isDisabled || submitLock.locked}
           data-punctuation-skip
           onClick={() => submitLock.run(async () => actions.dispatch('punctuation-skip'))}
         >
           Skip
-        </button>
-        <button
-          className="btn ghost"
-          type="button"
+        </Button>
+        <Button
+          variant="ghost"
           disabled={isDisabled}
           data-punctuation-end-round
           onClick={() => actions.dispatch('punctuation-end-early')}
         >
           End round
-        </button>
+        </Button>
       </div>
     </section>
   );
@@ -586,23 +584,21 @@ function FeedbackBranch({ ui, actions, heroUrl = '', previousHeroUrl = '' }) {
           </div>
         </section>
         <div className="actions" style={{ marginTop: 16 }}>
-          <button
-            className="btn primary"
-            type="button"
+          <Button
+            variant="primary"
             disabled={isDisabled || submitLock.locked}
             data-punctuation-continue
             onClick={() => submitLock.run(async () => actions.dispatch('punctuation-continue'))}
           >
             Continue
-          </button>
-          <button
-            className="btn secondary"
-            type="button"
+          </Button>
+          <Button
+            variant="secondary"
             disabled={isDisabled}
             onClick={() => actions.dispatch('punctuation-end-early')}
           >
             Finish now
-          </button>
+          </Button>
         </div>
       </section>
     );
@@ -697,23 +693,21 @@ function FeedbackBranch({ ui, actions, heroUrl = '', previousHeroUrl = '' }) {
       ) : null}
 
       <div className="actions" style={{ marginTop: 16 }}>
-        <button
-          className="btn primary"
-          type="button"
+        <Button
+          variant="primary"
           disabled={isDisabled || submitLock.locked}
           data-punctuation-continue
           onClick={() => submitLock.run(async () => actions.dispatch('punctuation-continue'))}
         >
           Continue
-        </button>
-        <button
-          className="btn secondary"
-          type="button"
+        </Button>
+        <Button
+          variant="secondary"
           disabled={isDisabled}
           onClick={() => actions.dispatch('punctuation-end-early')}
         >
           Finish now
-        </button>
+        </Button>
       </div>
     </section>
   );

--- a/src/subjects/punctuation/components/PunctuationSummaryScene.jsx
+++ b/src/subjects/punctuation/components/PunctuationSummaryScene.jsx
@@ -59,6 +59,7 @@
 
 import { useRef } from 'react';
 
+import { Button } from '../../../platform/ui/Button.jsx';
 import { useSubmitLock } from '../../../platform/react/use-submit-lock.js';
 import {
   ACTIVE_PUNCTUATION_MONSTER_IDS,
@@ -536,45 +537,41 @@ function NextActionRow({ ui, actions }) {
   const isNavigationDisabled = composeIsNavigationDisabled(ui);
   return (
     <div className="actions punctuation-summary-actions" style={{ marginTop: 16 }}>
-      <button
-        className="btn primary"
-        type="button"
+      <Button
+        variant="primary"
         disabled={isDisabled}
-        data-action="punctuation-start"
-        data-value="weak"
+        dataAction="punctuation-start"
+        dataValue="weak"
         onClick={() => submitLock.run(async () => actions.dispatch('punctuation-start', { mode: 'weak' }))}
       >
         Practise wobbly spots
-      </button>
-      <button
-        className="btn secondary"
-        type="button"
+      </Button>
+      <Button
+        variant="secondary"
         disabled={isDisabled}
-        data-action="punctuation-open-map"
+        dataAction="punctuation-open-map"
         onClick={() => submitLock.run(async () => actions.dispatch('punctuation-open-map'))}
       >
         Open Punctuation Map
-      </button>
-      <button
-        className="btn secondary"
-        type="button"
+      </Button>
+      <Button
+        variant="secondary"
         disabled={isDisabled}
-        data-action="punctuation-start-again"
+        dataAction="punctuation-start-again"
         data-punctuation-start-again
         onClick={() => submitLock.run(async () => actions.dispatch('punctuation-start-again'))}
       >
         Start again
-      </button>
-      <button
-        className="btn ghost"
-        type="button"
+      </Button>
+      <Button
+        variant="ghost"
         disabled={isNavigationDisabled}
         aria-disabled={isNavigationDisabled ? 'true' : 'false'}
-        data-action="punctuation-back"
+        dataAction="punctuation-back"
         onClick={() => submitLock.run(async () => actions.dispatch('punctuation-back'))}
       >
         Back to dashboard
-      </button>
+      </Button>
     </div>
   );
 }

--- a/src/subjects/spelling/components/SpellingSessionScene.jsx
+++ b/src/subjects/spelling/components/SpellingSessionScene.jsx
@@ -12,6 +12,7 @@ import {
 import {
   SPELLING_DURABLE_PERSISTENCE_WARNING_COPY,
 } from '../service-contract.js';
+import { Button } from '../../../platform/ui/Button.jsx';
 import { SoftLockoutBanner, useSoftLockoutState } from './SoftLockoutBanner.jsx';
 import { ArrowRightIcon, SpeakerIcon, SpeakerSlowIcon } from './spelling-icons.jsx';
 import {
@@ -92,15 +93,14 @@ export function SpellingSessionScene({
       <section className="card" style={{ gridColumn: '1/-1' }}>
         <div className="eyebrow">No active session</div>
         <h2 className="section-title">Start a spelling round</h2>
-        <button
-          className="btn primary"
-          type="button"
+        <Button
+          variant="primary"
           style={{ '--btn-accent': accent }}
-          data-action="spelling-back"
+          dataAction="spelling-back"
           onClick={(event) => renderAction(actions, event, 'spelling-back')}
         >
           Back to spelling dashboard
-        </button>
+        </Button>
       </section>
     );
   }
@@ -312,35 +312,30 @@ export function SpellingSessionScene({
               />
             </div>
             <div className="audio-row">
-              <button
-                type="button"
-                className="btn icon lg"
+              <Button
+                variant="icon"
+                size="lg"
                 aria-label="Replay the dictated word"
-                data-action="spelling-replay"
+                dataAction="spelling-replay"
                 data-testid="spelling-replay"
-                // SH2-U4: disable replay buttons while a fetch is in
-                // flight so a fast second click cannot pile up a
-                // second overlapping playback. `playbackId` still
-                // guards the underlying pipeline; this visual lock
-                // makes the intent visible.
                 disabled={runtimeReadOnly || ttsStatus === 'loading'}
-                aria-busy={ttsStatus === 'loading'}
+                busy={ttsStatus === 'loading'}
                 onClick={(event) => renderAction(actions, event, 'spelling-replay')}
               >
                 <SpeakerIcon />
-              </button>
-              <button
-                type="button"
-                className="btn icon lg"
+              </Button>
+              <Button
+                variant="icon"
+                size="lg"
                 aria-label="Replay slowly"
-                data-action="spelling-replay-slow"
+                dataAction="spelling-replay-slow"
                 data-testid="spelling-replay-slow"
                 disabled={runtimeReadOnly || ttsStatus === 'loading'}
-                aria-busy={ttsStatus === 'loading'}
+                busy={ttsStatus === 'loading'}
                 onClick={(event) => renderAction(actions, event, 'spelling-replay-slow')}
               >
                 <SpeakerSlowIcon />
-              </button>
+              </Button>
               {ttsStatus === 'loading' ? (
                 <span
                   className="chip spelling-tts-pending-chip"
@@ -363,14 +358,14 @@ export function SpellingSessionScene({
               </div>
             ) : null}
             <div className="action-row">
-              <button className="btn primary lg" style={{ '--btn-accent': accent }} type="submit" disabled={awaitingAdvance || runtimeReadOnly || pending}>
+              <Button variant="primary" size="lg" style={{ '--btn-accent': accent }} type="submit" disabled={awaitingAdvance || runtimeReadOnly || pending}>
                 {effectiveSubmitLabel}{awaitingAdvance || pending ? null : <> <ArrowRightIcon /></>}
-              </button>
+              </Button>
               {awaitingAdvance ? (
-                <button
-                  className="btn good lg"
-                  type="button"
-                  data-action="spelling-continue"
+                <Button
+                  variant="good"
+                  size="lg"
+                  dataAction="spelling-continue"
                   disabled={runtimeReadOnly || pending || submitLock.locked}
                   onClick={(event) => {
                     // SH2-U1: the hook's `run()` flips `pendingRef.current`
@@ -386,20 +381,20 @@ export function SpellingSessionScene({
                   }}
                 >
                   Continue <ArrowRightIcon />
-                </button>
+                </Button>
               ) : null}
               {session.type !== 'test' && !awaitingAdvance && session.phase === 'question' ? (
-                <button
-                  className="btn ghost lg"
-                  type="button"
-                  data-action="spelling-skip"
+                <Button
+                  variant="ghost"
+                  size="lg"
+                  dataAction="spelling-skip"
                   disabled={runtimeReadOnly || pending || submitLock.locked}
                   onClick={(event) => {
                     submitLock.run(async () => renderAction(actions, event, 'spelling-skip'));
                   }}
                 >
                   {skipLabel}
-                </button>
+                </Button>
               ) : null}
             </div>
           </form>
@@ -415,15 +410,15 @@ export function SpellingSessionScene({
             <div className="voice-note small muted">{voiceNote}</div>
           </div>
           <div className="session-footer-right">
-            <button
-              className="btn sm bad"
-              type="button"
-              data-action="spelling-end-early"
+            <Button
+              variant="bad"
+              size="sm"
+              dataAction="spelling-end-early"
               disabled={runtimeReadOnly || pending}
               onClick={(event) => renderAction(actions, event, 'spelling-end-early')}
             >
               End round early
-            </button>
+            </Button>
           </div>
         </footer>
       </div>

--- a/src/subjects/spelling/components/SpellingSummaryScene.jsx
+++ b/src/subjects/spelling/components/SpellingSummaryScene.jsx
@@ -1,3 +1,4 @@
+import { Button } from '../../../platform/ui/Button.jsx';
 import { useSubmitLock } from '../../../platform/react/use-submit-lock.js';
 import { ArrowRightIcon, CheckIcon } from './spelling-icons.jsx';
 import { AnimatedPromptCard, PathProgress, Ribbon } from './SpellingCommon.jsx';
@@ -274,17 +275,17 @@ export function SpellingSummaryScene({ learner, ui, accent, actions, postMastery
                   {summary.mistakes.map((word) => (
                     <span className="fchip fchip--static" key={word.slug}>{word.word}</span>
                   ))}
-                  <button
-                    type="button"
-                    className="btn primary sm"
-                    data-action="spelling-drill-all"
+                  <Button
+                    variant="primary"
+                    size="sm"
+                    dataAction="spelling-drill-all"
                     disabled={runtimeReadOnly || pending || submitLock.locked}
                     onClick={(event) => {
                       submitLock.run(async () => renderAction(actions, event, 'spelling-drill-all'));
                     }}
                   >
                     {guardianPracticeActionLabel()} <ArrowRightIcon />
-                  </button>
+                  </Button>
                 </div>
               </div>
             ) : (
@@ -309,17 +310,17 @@ export function SpellingSummaryScene({ learner, ui, accent, actions, postMastery
                       {word.word}
                     </button>
                   ))}
-                  <button
-                    type="button"
-                    className="btn primary sm"
-                    data-action="spelling-drill-all"
+                  <Button
+                    variant="primary"
+                    size="sm"
+                    dataAction="spelling-drill-all"
                     disabled={runtimeReadOnly || pending || submitLock.locked}
                     onClick={(event) => {
                       submitLock.run(async () => renderAction(actions, event, 'spelling-drill-all'));
                     }}
                   >
                     Drill all {summary.mistakes.length} <ArrowRightIcon />
-                  </button>
+                  </Button>
                 </div>
               </div>
             )
@@ -335,37 +336,37 @@ export function SpellingSummaryScene({ learner, ui, accent, actions, postMastery
               // a pattern id and refuse. Routing back to the dashboard keeps
               // the chooser-first flow until summary state threads the
               // patternId through for a P2.5 iteration.
-              <button
-                type="button"
-                className="btn primary lg"
+              <Button
+                variant="primary"
+                size="lg"
                 style={{ '--btn-accent': accent }}
-                data-action="spelling-back"
+                dataAction="spelling-back"
                 onClick={(event) => renderAction(actions, event, 'spelling-back')}
               >
                 Back to dashboard <ArrowRightIcon />
-              </button>
+              </Button>
             ) : (
               <>
-                <button
-                  type="button"
-                  className="btn ghost lg"
-                  data-action="spelling-back"
+                <Button
+                  variant="ghost"
+                  size="lg"
+                  dataAction="spelling-back"
                   onClick={(event) => renderAction(actions, event, 'spelling-back')}
                 >
                   Back to dashboard
-                </button>
-                <button
-                  type="button"
-                  className="btn primary lg"
+                </Button>
+                <Button
+                  variant="primary"
+                  size="lg"
                   style={{ '--btn-accent': accent }}
-                  data-action="spelling-start-again"
+                  dataAction="spelling-start-again"
                   disabled={runtimeReadOnly || pending || submitLock.locked}
                   onClick={(event) => {
                     submitLock.run(async () => renderAction(actions, event, 'spelling-start-again'));
                   }}
                 >
                   {pendingCommand === 'start-session' ? 'Starting...' : 'Start another round'} <ArrowRightIcon />
-                </button>
+                </Button>
               </>
             )}
             <button

--- a/tests/ui-action-engine-contract.test.js
+++ b/tests/ui-action-engine-contract.test.js
@@ -1,0 +1,224 @@
+// P3 U2 — Action Engine Pass 1 contract tests.
+//
+// Locks in:
+//   1. ActionRow renders primary + secondary with correct structure.
+//   2. ActionRow with only primary renders without error.
+//   3. Raw .btn ratchet: count in learner surfaces is >= 20 fewer than
+//      baseline (182 from evidence map).
+//   4. data-action selectors preserved in migrated files.
+//   5. At-most-one primary action per setup/session/summary/home branch.
+//   6. Disabled/busy/error states visible via Button primitive.
+//   7. Form submit behaviour preserved (type="submit").
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+function readFile(relative) {
+  return readFileSync(path.join(REPO_ROOT, relative), 'utf8');
+}
+
+// --- ActionRow structural tests (parser-level) ---
+
+test('ActionRow module exports the named export', () => {
+  const source = readFile('src/platform/ui/ActionRow.jsx');
+  assert.match(source, /export function ActionRow\(/);
+});
+
+test('ActionRow renders role="group" for accessibility', () => {
+  const source = readFile('src/platform/ui/ActionRow.jsx');
+  assert.match(source, /role="group"/);
+});
+
+test('ActionRow supports align="split" with margin-left: auto pattern', () => {
+  const source = readFile('src/platform/ui/ActionRow.jsx');
+  assert.match(source, /marginLeft:\s*['"]auto['"]/);
+});
+
+test('ActionRow renders data-action-row locator', () => {
+  const source = readFile('src/platform/ui/ActionRow.jsx');
+  assert.match(source, /data-action-row/);
+});
+
+test('ActionRow handles single-button case (no secondary/tertiary rendering when absent)', () => {
+  const source = readFile('src/platform/ui/ActionRow.jsx');
+  // When hasSecondary is false, secondary should not render
+  assert.match(source, /hasSecondary\s*\?/);
+  assert.match(source, /hasTertiary\s*\?/);
+});
+
+// --- Raw .btn ratchet ---
+
+// Learner-facing surfaces that were migrated in U2.
+const MIGRATED_LEARNER_SURFACES = [
+  'src/subjects/spelling/components/SpellingSessionScene.jsx',
+  'src/subjects/grammar/components/GrammarSessionScene.jsx',
+  'src/subjects/punctuation/components/PunctuationSessionScene.jsx',
+  'src/subjects/spelling/components/SpellingSummaryScene.jsx',
+  'src/subjects/grammar/components/GrammarSummaryScene.jsx',
+  'src/subjects/punctuation/components/PunctuationSummaryScene.jsx',
+];
+
+test('migrated learner surfaces have zero raw className="btn " patterns', () => {
+  for (const file of MIGRATED_LEARNER_SURFACES) {
+    const source = readFile(file);
+    const rawBtnMatches = source.match(/className="btn\s/g) || [];
+    const templateBtnMatches = source.match(/className=\{`btn\s/g) || [];
+    const total = rawBtnMatches.length + templateBtnMatches.length;
+    assert.equal(
+      total,
+      0,
+      `${file} still contains ${total} raw .btn class patterns. ` +
+      'All learner-facing buttons in migrated files must use the <Button> primitive.',
+    );
+  }
+});
+
+test('raw .btn count across all learner session+summary surfaces is >= 20 fewer than 182 baseline', () => {
+  // Baseline from evidence map: 182 raw .btn across all learner surfaces.
+  // U2 target: retire at least 20.
+  const BASELINE = 182;
+  const TARGET_REDUCTION = 20;
+  // Count remaining raw .btn across ALL learner surfaces (session + summary + setup).
+  const ALL_LEARNER_SURFACES = [
+    ...MIGRATED_LEARNER_SURFACES,
+    'src/subjects/spelling/components/SpellingSetupScene.jsx',
+    'src/subjects/grammar/components/GrammarSetupScene.jsx',
+    'src/subjects/punctuation/components/PunctuationSetupScene.jsx',
+  ];
+  let remaining = 0;
+  for (const file of ALL_LEARNER_SURFACES) {
+    const source = readFile(file);
+    const rawBtnMatches = source.match(/className="btn\s/g) || [];
+    const templateBtnMatches = source.match(/className=\{`btn\s/g) || [];
+    remaining += rawBtnMatches.length + templateBtnMatches.length;
+  }
+  const retired = BASELINE - remaining;
+  assert.ok(
+    retired >= TARGET_REDUCTION,
+    `Only ${retired} raw .btn sites retired (target: >= ${TARGET_REDUCTION}). ` +
+    `Remaining: ${remaining}, baseline: ${BASELINE}.`,
+  );
+});
+
+// --- data-action preservation ---
+
+test('migrated session scenes preserve data-action selectors via Button dataAction prop', () => {
+  const expectedActions = {
+    'src/subjects/spelling/components/SpellingSessionScene.jsx': [
+      'spelling-back',
+      'spelling-replay',
+      'spelling-replay-slow',
+      'spelling-continue',
+      'spelling-skip',
+      'spelling-end-early',
+    ],
+    'src/subjects/grammar/components/GrammarSessionScene.jsx': [
+      // Grammar session uses dispatch directly; verify Button presence
+    ],
+    'src/subjects/punctuation/components/PunctuationSessionScene.jsx': [
+      // Punctuation uses data-punctuation-submit, data-punctuation-skip etc
+    ],
+  };
+
+  for (const [file, actions] of Object.entries(expectedActions)) {
+    const source = readFile(file);
+    for (const action of actions) {
+      // Check either dataAction="..." or data-action="..." is present
+      const hasDataAction = source.includes(`dataAction="${action}"`) ||
+        source.includes(`data-action="${action}"`);
+      assert.ok(
+        hasDataAction,
+        `${file} must preserve the data-action="${action}" selector ` +
+        '(via dataAction prop or data-action attribute).',
+      );
+    }
+  }
+});
+
+test('spelling summary preserves data-action selectors', () => {
+  const source = readFile('src/subjects/spelling/components/SpellingSummaryScene.jsx');
+  const expected = ['spelling-drill-all', 'spelling-back', 'spelling-start-again'];
+  for (const action of expected) {
+    const has = source.includes(`dataAction="${action}"`) ||
+      source.includes(`data-action="${action}"`);
+    assert.ok(has, `SpellingSummaryScene must preserve data-action="${action}"`);
+  }
+});
+
+test('punctuation summary preserves data-action selectors', () => {
+  const source = readFile('src/subjects/punctuation/components/PunctuationSummaryScene.jsx');
+  const expected = ['punctuation-start', 'punctuation-open-map', 'punctuation-start-again', 'punctuation-back'];
+  for (const action of expected) {
+    const has = source.includes(`dataAction="${action}"`) ||
+      source.includes(`data-action="${action}"`);
+    assert.ok(has, `PunctuationSummaryScene must preserve data-action="${action}"`);
+  }
+});
+
+// --- Button primitive adoption ---
+
+test('all migrated surfaces import Button from platform/ui/Button', () => {
+  for (const file of MIGRATED_LEARNER_SURFACES) {
+    const source = readFile(file);
+    assert.match(
+      source,
+      /import\s*\{[^}]*\bButton\b[^}]*\}\s*from\s*['"][^'"]*platform\/ui\/Button(\.jsx)?['"]/,
+      `${file} must import Button from the shared primitive.`,
+    );
+    assert.match(
+      source,
+      /<Button\b/,
+      `${file} must render <Button> at least once.`,
+    );
+  }
+});
+
+// --- Form submit behaviour preservation ---
+
+test('grammar session preserves type="submit" on form action buttons', () => {
+  const source = readFile('src/subjects/grammar/components/GrammarSessionScene.jsx');
+  // Mini-test save, save-next, finish all need type="submit"
+  const submitButtons = source.match(/type="submit"/g) || [];
+  assert.ok(
+    submitButtons.length >= 3,
+    `GrammarSessionScene must preserve at least 3 type="submit" buttons (mini-test save/save-next/finish + normal submit). Found: ${submitButtons.length}`,
+  );
+});
+
+test('punctuation session preserves type="submit" on form action buttons', () => {
+  const source = readFile('src/subjects/punctuation/components/PunctuationSessionScene.jsx');
+  const submitButtons = source.match(/type="submit"/g) || [];
+  assert.ok(
+    submitButtons.length >= 2,
+    `PunctuationSessionScene must preserve at least 2 type="submit" buttons (choice + text). Found: ${submitButtons.length}`,
+  );
+});
+
+// --- Disabled/busy states visible ---
+
+test('spelling session preserves busy state on replay buttons', () => {
+  const source = readFile('src/subjects/spelling/components/SpellingSessionScene.jsx');
+  // The Button primitive uses `busy` prop which sets aria-busy
+  assert.match(source, /busy=\{ttsStatus === 'loading'\}/, 'Replay buttons must wire busy state');
+});
+
+test('grammar session preserves disabled state on action buttons', () => {
+  const source = readFile('src/subjects/grammar/components/GrammarSessionScene.jsx');
+  assert.match(source, /disabled=\{submitDisabled\}/, 'Submit buttons must wire disabled state');
+  assert.match(source, /disabled=\{runtimeReadOnly \|\| pending \|\| submitLock\.locked\}/, 'Next question button must wire disabled state');
+});
+
+// --- ActionRow primitive exists at expected path ---
+
+test('ActionRow.jsx exists at src/platform/ui/ActionRow.jsx', () => {
+  const source = readFile('src/platform/ui/ActionRow.jsx');
+  assert.ok(source.length > 0, 'ActionRow.jsx must not be empty');
+  assert.match(source, /export function ActionRow/);
+});

--- a/tests/ui-component-adoption.test.js
+++ b/tests/ui-component-adoption.test.js
@@ -31,6 +31,14 @@ const BUTTON_CONSUMERS = [
   // to <Button>. Adding the surface to the allowlist locks the adoption
   // — a future refactor that removes the import would now fail this test.
   'src/subjects/spelling/components/SpellingSetupScene.jsx',
+  // P3 U2: Action Engine pass 1 — session + summary scenes fully migrated
+  // to <Button> primitive. All raw .btn call sites in these files retired.
+  'src/subjects/spelling/components/SpellingSessionScene.jsx',
+  'src/subjects/grammar/components/GrammarSessionScene.jsx',
+  'src/subjects/punctuation/components/PunctuationSessionScene.jsx',
+  'src/subjects/spelling/components/SpellingSummaryScene.jsx',
+  'src/subjects/grammar/components/GrammarSummaryScene.jsx',
+  'src/subjects/punctuation/components/PunctuationSummaryScene.jsx',
 ];
 
 // P2 U2: closed allowlist of production surfaces that have adopted the
@@ -85,12 +93,11 @@ test('every U1 surface imports the shared Button primitive', () => {
   }
 });
 
-test('Button has ≥ 5 unique production import sites at U1 close', () => {
-  // Five is the U1-mandated minimum. U7's third-consumer falsifier
-  // pass extends this list (Spelling + any ratified later migrations).
+test('Button has ≥ 12 unique production import sites at P3 U2 close', () => {
+  // P2 U1 mandated 5 minimum. P3 U2 adds 6 session + summary scenes.
   assert.ok(
-    BUTTON_CONSUMERS.length >= 5,
-    `U1 minimum is 5 Button consumers; got ${BUTTON_CONSUMERS.length}.`,
+    BUTTON_CONSUMERS.length >= 12,
+    `P3 U2 minimum is 12 Button consumers; got ${BUTTON_CONSUMERS.length}.`,
   );
 });
 

--- a/tests/ui-session-hud-contract.test.js
+++ b/tests/ui-session-hud-contract.test.js
@@ -254,17 +254,21 @@ test('U3 SessionHUD: adopted in PunctuationSessionScene', () => {
 
 test('U3 Spelling session: preserves all data-action selectors', () => {
   const source = readSource('src/subjects/spelling/components/SpellingSessionScene.jsx');
-  const requiredSelectors = [
-    'data-action="spelling-back"',
-    'data-action="spelling-submit-form"',
-    'data-action="spelling-replay"',
-    'data-action="spelling-replay-slow"',
-    'data-action="spelling-continue"',
-    'data-action="spelling-skip"',
-    'data-action="spelling-end-early"',
+  // P3 U2: Button primitive uses `dataAction` prop (renders as `data-action`
+  // in the DOM). Accept either the raw HTML attribute or the JSX prop form.
+  const requiredActions = [
+    'spelling-back',
+    'spelling-submit-form',
+    'spelling-replay',
+    'spelling-replay-slow',
+    'spelling-continue',
+    'spelling-skip',
+    'spelling-end-early',
   ];
-  for (const sel of requiredSelectors) {
-    assert.ok(source.includes(sel), `SpellingSessionScene must preserve "${sel}"`);
+  for (const action of requiredActions) {
+    const hasRaw = source.includes(`data-action="${action}"`);
+    const hasProp = source.includes(`dataAction="${action}"`);
+    assert.ok(hasRaw || hasProp, `SpellingSessionScene must preserve data-action="${action}" (via raw attribute or dataAction prop)`);
   }
 });
 


### PR DESCRIPTION
## Summary

- Introduce `ActionRow` layout primitive (`src/platform/ui/ActionRow.jsx`) — flexbox wrapper with `align` (start/centre/end/split), consistent 12px gap, role="group" accessibility, and data-action-row locator
- Retire **41 raw `.btn` call sites** from 6 learner-facing surfaces by migrating to the `<Button>` primitive (target was >= 20)
- All `data-action`, `disabled`, `busy`, `type="submit"`, `aria-label`, `onClick` handlers preserved — zero behaviour change

### Migrated surfaces

| Surface | Raw .btn retired |
|---------|-----------------|
| SpellingSessionScene | 7 |
| GrammarSessionScene | 14 |
| PunctuationSessionScene | 9 |
| SpellingSummaryScene | 5 |
| GrammarSummaryScene | 2 |
| PunctuationSummaryScene | 4 |
| **Total** | **41** |

## Test plan

- [x] `tests/ui-action-engine-contract.test.js` — 16 tests: ActionRow structure, raw .btn ratchet (>= 20 reduction from 182 baseline), data-action preservation, form submit preservation, disabled/busy state wiring
- [x] `tests/ui-component-adoption.test.js` — Button consumer allowlist expanded to 12 (6 new session+summary scenes)
- [x] `tests/ui-session-hud-contract.test.js` — Updated selector preservation test to accept `dataAction` prop form alongside raw `data-action` attribute
- [x] `tests/ui-primary-action-contract.test.js` — Passes unchanged (no xl buttons in session/summary)
- [x] All 48 relevant UI tests passing

## Plan Deviations

- ActionRow primitive created but not yet used for layout in the migrated files (Button migration was the primary value; ActionRow adoption at call sites deferred to avoid scope creep — the primitive is ready for U3+ consumers)
- SectionHeader adoption in summary scenes deferred — no natural section divider site emerged without forcing the pattern