### PR TITLE
feat(ui-refactor-p3): U6 shared summary engine

### DIFF
--- a/src/platform/ui/SessionSummaryFrame.jsx
+++ b/src/platform/ui/SessionSummaryFrame.jsx
@@ -1,0 +1,160 @@
+/* Platform SessionSummaryFrame primitive (P3 U6).
+ *
+ * Shared summary engine adopted by all three ready subjects (Spelling,
+ * Punctuation, Grammar). Presents session outcomes — highlights,
+ * misconceptions, progress deltas, and next-action affordances — without
+ * claiming unearned mastery.
+ *
+ * Design contract:
+ *   - Display-only: NO mastery mutation, NO reward changes, NO star
+ *     writes. progressDelta renders what the result model already
+ *     computed — the frame never derives or inflates progress.
+ *   - Exactly one primary action per render (enforced by prop shape).
+ *   - SectionHeader adoption for "What went well" / "Try again" sections.
+ *   - Empty misconceptions array → section hidden entirely.
+ *   - Empty progressDelta array → no progress section rendered.
+ *   - Forbidden copy patterns never appear in frame-authored text.
+ *
+ * Props:
+ *   subjectId        — string: 'spelling' | 'punctuation' | 'grammar'
+ *   outcome          — string: 'secure' | 'improving' | 'needs-practice' | 'review-complete'
+ *   title            — string: session headline
+ *   highlights       — array of strings: what went well
+ *   misconceptions   — array of strings: areas to revisit (hidden if empty)
+ *   progressDelta    — array of {label, from, to}: progress change indicators
+ *   nextPrimaryAction — object: {label, dataAction, onClick}
+ *   secondaryActions — array of {label, dataAction, variant, onClick}
+ *
+ * Slot composition:
+ *   - Uses SectionHeader for section headings (3-adopter gate contribution).
+ *   - Uses Button for primary action.
+ *   - Uses ActionRow for action layout.
+ */
+import { SectionHeader } from './SectionHeader.jsx';
+import { Button } from './Button.jsx';
+import { ActionRow } from './ActionRow.jsx';
+
+const OUTCOME_LABELS = {
+  'secure': 'Secure',
+  'improving': 'Improving',
+  'needs-practice': 'Needs practice',
+  'review-complete': 'Review complete',
+};
+
+export function SessionSummaryFrame({
+  subjectId,
+  outcome,
+  title,
+  highlights = [],
+  misconceptions = [],
+  progressDelta = [],
+  nextPrimaryAction,
+  secondaryActions = [],
+}) {
+  const outcomeLabel = OUTCOME_LABELS[outcome] || outcome || '';
+  const hasHighlights = Array.isArray(highlights) && highlights.length > 0;
+  const hasMisconceptions = Array.isArray(misconceptions) && misconceptions.length > 0;
+  const hasProgress = Array.isArray(progressDelta) && progressDelta.length > 0;
+
+  const primaryButton = nextPrimaryAction ? (
+    <Button
+      variant="primary"
+      dataAction={nextPrimaryAction.dataAction}
+      onClick={nextPrimaryAction.onClick}
+    >
+      {nextPrimaryAction.label}
+    </Button>
+  ) : null;
+
+  const secondaryButtons = Array.isArray(secondaryActions)
+    ? secondaryActions.map((action) => (
+        <Button
+          key={action.dataAction}
+          variant={action.variant || 'secondary'}
+          dataAction={action.dataAction}
+          onClick={action.onClick}
+        >
+          {action.label}
+        </Button>
+      ))
+    : [];
+
+  return (
+    <section
+      className="session-summary-frame"
+      data-session-summary-frame
+      data-subject-id={subjectId}
+      data-outcome={outcome}
+    >
+      <SectionHeader
+        eyebrow={outcomeLabel}
+        title={title}
+        level={2}
+        className="session-summary-frame-header"
+      />
+
+      {hasHighlights ? (
+        <div className="session-summary-frame-highlights" data-summary-highlights>
+          <SectionHeader
+            title="What went well"
+            level={3}
+            className="session-summary-frame-section-head"
+          />
+          <ul className="session-summary-frame-list">
+            {highlights.map((item, idx) => (
+              <li key={`highlight-${idx}`}>{item}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {hasMisconceptions ? (
+        <div className="session-summary-frame-misconceptions" data-summary-misconceptions>
+          <SectionHeader
+            title="Try again"
+            level={3}
+            className="session-summary-frame-section-head"
+          />
+          <ul className="session-summary-frame-list">
+            {misconceptions.map((item, idx) => (
+              <li key={`misconception-${idx}`}>{item}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {hasProgress ? (
+        <div className="session-summary-frame-progress" data-summary-progress>
+          <ul className="session-summary-frame-progress-list">
+            {progressDelta.map((delta, idx) => (
+              <li
+                key={`progress-${idx}`}
+                className="session-summary-frame-progress-item"
+                data-progress-label={delta.label}
+              >
+                <span className="session-summary-frame-progress-label">{delta.label}</span>
+                <span className="session-summary-frame-progress-change">
+                  {delta.from} → {delta.to}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      <ActionRow
+        primary={primaryButton}
+        secondary={secondaryButtons.length === 1 ? secondaryButtons[0] : (
+          secondaryButtons.length > 1 ? (
+            <div className="session-summary-frame-secondary-group">
+              {secondaryButtons}
+            </div>
+          ) : null
+        )}
+        align="start"
+        className="session-summary-frame-actions"
+        aria-label="Session next steps"
+      />
+    </section>
+  );
+}

--- a/src/subjects/grammar/components/GrammarSummaryScene.jsx
+++ b/src/subjects/grammar/components/GrammarSummaryScene.jsx
@@ -1,4 +1,5 @@
 import { Button } from '../../../platform/ui/Button.jsx';
+import { SessionSummaryFrame } from '../../../platform/ui/SessionSummaryFrame.jsx';
 import { useSubmitLock } from '../../../platform/react/use-submit-lock.js';
 import { GrammarMiniTestReview } from './GrammarMiniTestReview.jsx';
 import { grammarSummaryCards } from './grammar-view-model.js';
@@ -188,6 +189,60 @@ function firstMissedMiniTestConceptId(summary) {
   return '';
 }
 
+// U6: Thin adapter mapping existing grammar summary view-model to
+// SessionSummaryFrame props. Preserves existing next-action routes.
+// Display-only — no mastery mutation.
+function GrammarSummaryFrameAdapter({ summary, cards, actions }) {
+  if (!summary) return null;
+  const cardMap = {};
+  for (const card of (cards || [])) {
+    if (card && typeof card.id === 'string') cardMap[card.id] = card;
+  }
+  const answered = Number(cardMap.answered?.value ?? 0);
+  const correct = Number(cardMap.correct?.value ?? 0);
+  const trouble = Number(cardMap.trouble?.value ?? 0);
+  const cleanRound = answered > 0 && correct === answered && trouble === 0;
+  const outcome = cleanRound ? 'secure' : (correct > 0 ? 'improving' : 'needs-practice');
+  const title = cleanRound
+    ? 'Clean round — every answer landed.'
+    : `${correct} of ${answered} correct.`;
+  const highlights = [];
+  for (const card of (cards || [])) {
+    if (card && card.id !== 'monster-progress' && card.label && card.value !== undefined) {
+      highlights.push(`${card.label}: ${card.value}`);
+    }
+  }
+  const misconceptions = [];
+  if (trouble > 0 && cardMap.trouble?.detail) {
+    misconceptions.push(String(cardMap.trouble.detail));
+  }
+  const nextPrimaryAction = {
+    label: 'Start another round',
+    dataAction: 'grammar-start-again',
+    onClick: () => actions.dispatch('grammar-start-again'),
+  };
+  const secondaryActions = [
+    {
+      label: 'Open Grammar Bank',
+      dataAction: 'grammar-open-concept-bank',
+      variant: 'secondary',
+      onClick: () => actions.dispatch('grammar-open-concept-bank'),
+    },
+  ];
+  return (
+    <SessionSummaryFrame
+      subjectId="grammar"
+      outcome={outcome}
+      title={title}
+      highlights={highlights}
+      misconceptions={misconceptions}
+      progressDelta={[]}
+      nextPrimaryAction={nextPrimaryAction}
+      secondaryActions={secondaryActions}
+    />
+  );
+}
+
 export function GrammarSummaryScene({ grammar, rewardState, actions, learner, runtimeReadOnly }) {
   const summary = grammar.summary || {};
   const pending = Boolean(grammar.pendingCommand);
@@ -257,6 +312,8 @@ export function GrammarSummaryScene({ grammar, rewardState, actions, learner, ru
           runtimeReadOnly={runtimeReadOnly}
           pending={pending}
         />
+        {/* U6: Shared summary engine adoption — display-only. */}
+        <GrammarSummaryFrameAdapter summary={summary} cards={cards} actions={actions} />
       </div>
     );
   }
@@ -299,6 +356,8 @@ export function GrammarSummaryScene({ grammar, rewardState, actions, learner, ru
         <PrimaryActions buttons={buttons} disabled={disabled} />
         <SecondaryActions onGrownUp={handleGrownUp} disabled={disabled} />
       </section>
+      {/* U6: Shared summary engine adoption — display-only. */}
+      <GrammarSummaryFrameAdapter summary={summary} cards={cards} actions={actions} />
     </div>
   );
 }

--- a/src/subjects/punctuation/components/PunctuationSummaryScene.jsx
+++ b/src/subjects/punctuation/components/PunctuationSummaryScene.jsx
@@ -60,6 +60,7 @@
 import { useRef } from 'react';
 
 import { Button } from '../../../platform/ui/Button.jsx';
+import { SessionSummaryFrame } from '../../../platform/ui/SessionSummaryFrame.jsx';
 import { useSubmitLock } from '../../../platform/react/use-submit-lock.js';
 import {
   ACTIVE_PUNCTUATION_MONSTER_IDS,
@@ -585,6 +586,54 @@ function NextActionRow({ ui, actions }) {
 // this surface when the adult view ships (PR body notes the deferral); the
 // Summary scene renders no Grown-up affordance today.
 
+// U6: Thin adapter mapping existing punctuation summary view-model to
+// SessionSummaryFrame props. Preserves existing telemetry event emission.
+// Display-only — no mastery mutation.
+function PunctuationSummaryFrameAdapter({ summary, actions }) {
+  if (!summary || typeof summary !== 'object') return null;
+  const total = Number(summary.total) || 0;
+  const correct = Number(summary.correct) || 0;
+  const accuracy = Number(summary.accuracy) || 0;
+  const cleanRound = total > 0 && correct === total;
+  const outcome = cleanRound ? 'secure' : (accuracy >= 70 ? 'improving' : 'needs-practice');
+  const headline = punctuationSummaryHeadline(summary);
+  const title = typeof headline === 'string' && headline ? headline : 'Punctuation session summary';
+  const highlights = [];
+  if (total > 0) highlights.push(`${correct} out of ${total} correct`);
+  if (accuracy > 0) highlights.push(`${accuracy}% accuracy`);
+  const misconceptions = [];
+  const focus = Array.isArray(summary.focus) ? summary.focus : [];
+  for (const skillId of focus) {
+    const name = CLIENT_SKILL_NAMES_BY_ID.get(skillId);
+    if (name) misconceptions.push(name);
+  }
+  const nextPrimaryAction = {
+    label: 'Start again',
+    dataAction: 'punctuation-start-again',
+    onClick: () => actions.dispatch('punctuation-start-again'),
+  };
+  const secondaryActions = [
+    {
+      label: 'Back to dashboard',
+      dataAction: 'punctuation-back',
+      variant: 'ghost',
+      onClick: () => actions.dispatch('punctuation-back'),
+    },
+  ];
+  return (
+    <SessionSummaryFrame
+      subjectId="punctuation"
+      outcome={outcome}
+      title={title}
+      highlights={highlights}
+      misconceptions={misconceptions}
+      progressDelta={[]}
+      nextPrimaryAction={nextPrimaryAction}
+      secondaryActions={secondaryActions}
+    />
+  );
+}
+
 export function PunctuationSummaryScene({
   ui = {},
   actions = { dispatch() {} },
@@ -725,6 +774,9 @@ export function PunctuationSummaryScene({
       <MonsterProgressStrip ui={ui} rewardState={rewardState} />
       <GpsReviewBlock gps={summary.gps} />
       <NextActionRow ui={ui} actions={actions} />
+      {/* U6: Shared summary engine adoption — SessionSummaryFrame renders
+          alongside the existing visual shell. Preserves telemetry emission. */}
+      <PunctuationSummaryFrameAdapter summary={summary} actions={actions} />
     </section>
   );
 }

--- a/src/subjects/spelling/components/SpellingSummaryScene.jsx
+++ b/src/subjects/spelling/components/SpellingSummaryScene.jsx
@@ -1,4 +1,5 @@
 import { Button } from '../../../platform/ui/Button.jsx';
+import { SessionSummaryFrame } from '../../../platform/ui/SessionSummaryFrame.jsx';
 import { useSubmitLock } from '../../../platform/react/use-submit-lock.js';
 import { ArrowRightIcon, CheckIcon } from './spelling-icons.jsx';
 import { AnimatedPromptCard, PathProgress, Ribbon } from './SpellingCommon.jsx';
@@ -144,6 +145,55 @@ function SummaryPatternQuestMissList({ mistakes = [] }) {
         ))}
       </div>
     </div>
+  );
+}
+
+// U6: Thin adapter mapping existing spelling summary view-model to
+// SessionSummaryFrame props. Preserves existing feedback copy and
+// next-action route dispatch. Display-only — no mastery mutation.
+function SpellingSummaryFrameAdapter({ summary, actions }) {
+  if (!summary) return null;
+  const toneGood = !summary.mistakes || !summary.mistakes.length;
+  const outcome = toneGood ? 'secure' : 'needs-practice';
+  const title = summaryHeadline(summary);
+  const highlights = [];
+  if (summary.cards) {
+    for (const card of summary.cards) {
+      if (card && card.label && card.value !== undefined) {
+        highlights.push(`${card.label}: ${card.value}`);
+      }
+    }
+  }
+  const misconceptions = [];
+  if (summary.mistakes && summary.mistakes.length) {
+    for (const word of summary.mistakes) {
+      if (word && word.word) misconceptions.push(word.word);
+    }
+  }
+  const nextPrimaryAction = {
+    label: 'Back to dashboard',
+    dataAction: 'spelling-back',
+    onClick: (event) => renderAction(actions, event, 'spelling-back'),
+  };
+  const secondaryActions = [
+    {
+      label: 'Open word bank',
+      dataAction: 'spelling-open-word-bank',
+      variant: 'ghost',
+      onClick: (event) => renderAction(actions, event, 'spelling-open-word-bank'),
+    },
+  ];
+  return (
+    <SessionSummaryFrame
+      subjectId="spelling"
+      outcome={outcome}
+      title={title}
+      highlights={highlights}
+      misconceptions={misconceptions}
+      progressDelta={[]}
+      nextPrimaryAction={nextPrimaryAction}
+      secondaryActions={secondaryActions}
+    />
   );
 }
 
@@ -379,6 +429,9 @@ export function SpellingSummaryScene({ learner, ui, accent, actions, postMastery
             </button>
           </div>
         </AnimatedPromptCard>
+        {/* U6: Shared summary engine adoption — SessionSummaryFrame renders
+            alongside the existing visual shell. Display-only, no mutation. */}
+        <SpellingSummaryFrameAdapter summary={summary} actions={actions} />
       </div>
     </div>
   );

--- a/tests/ui-summary-engine-contract.test.js
+++ b/tests/ui-summary-engine-contract.test.js
@@ -1,0 +1,300 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+
+// P3 U6: Contract tests for the shared SessionSummaryFrame primitive and
+// its three-subject adoption (Spelling, Punctuation, Grammar).
+//
+// Test surface:
+//   1. One primary action per render.
+//   2. Empty misconceptions → section hidden.
+//   3. Empty progressDelta → no progress section.
+//   4. progressDelta cannot show mastery not in result model.
+//   5. Subject-specific next-action routes dispatch correctly (data-action preserved).
+//   6. No forbidden copy patterns.
+//   7. SectionHeader adoption verified (import + render).
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function nodePaths() {
+  return [
+    path.join(rootDir, 'node_modules'),
+    ...String(process.env.NODE_PATH || '').split(path.delimiter),
+  ].filter((entry) => entry && existsSync(entry));
+}
+
+async function renderFixture(entrySource) {
+  const tmpDir = await mkdtemp(path.join(tmpdir(), 'ks2-summary-engine-'));
+  const entryPath = path.join(tmpDir, 'entry.jsx');
+  const bundlePath = path.join(tmpDir, 'entry.cjs');
+  try {
+    await writeFile(entryPath, entrySource);
+    await build({
+      absWorkingDir: rootDir,
+      entryPoints: [entryPath],
+      outfile: bundlePath,
+      bundle: true,
+      platform: 'node',
+      format: 'cjs',
+      target: ['node24'],
+      jsx: 'automatic',
+      jsxImportSource: 'react',
+      loader: { '.js': 'jsx' },
+      nodePaths: nodePaths(),
+      logLevel: 'silent',
+    });
+    return execFileSync(process.execPath, [bundlePath], {
+      cwd: rootDir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
+function absoluteSpecifier(relativePath) {
+  return JSON.stringify(path.join(rootDir, relativePath));
+}
+
+// ---------- 1. One primary action per render ---------- //
+
+test('SessionSummaryFrame renders exactly one primary action button', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { SessionSummaryFrame } from ${absoluteSpecifier('src/platform/ui/SessionSummaryFrame.jsx')};
+    const html = renderToStaticMarkup(
+      <SessionSummaryFrame
+        subjectId="spelling"
+        outcome="secure"
+        title="Round complete"
+        highlights={['5 words correct']}
+        misconceptions={[]}
+        progressDelta={[]}
+        nextPrimaryAction={{ label: 'Continue', dataAction: 'spelling-back', onClick: () => {} }}
+        secondaryActions={[
+          { label: 'Word bank', dataAction: 'spelling-open-word-bank', variant: 'ghost', onClick: () => {} },
+        ]}
+      />
+    );
+    console.log(html);
+  `);
+  // Count buttons with class containing "primary"
+  const primaryButtons = html.match(/class="btn primary[^"]*"/g) || [];
+  assert.equal(primaryButtons.length, 1, 'Must render exactly one primary action button');
+  assert.match(html, /data-action="spelling-back"/, 'Primary action data-action must be preserved');
+});
+
+// ---------- 2. Empty misconceptions → section hidden ---------- //
+
+test('SessionSummaryFrame hides misconceptions section when array is empty', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { SessionSummaryFrame } from ${absoluteSpecifier('src/platform/ui/SessionSummaryFrame.jsx')};
+    const html = renderToStaticMarkup(
+      <SessionSummaryFrame
+        subjectId="grammar"
+        outcome="secure"
+        title="Clean round"
+        highlights={['All correct']}
+        misconceptions={[]}
+        progressDelta={[]}
+        nextPrimaryAction={{ label: 'Continue', dataAction: 'grammar-start-again', onClick: () => {} }}
+        secondaryActions={[]}
+      />
+    );
+    console.log(html);
+  `);
+  assert.doesNotMatch(html, /data-summary-misconceptions/, 'Misconceptions section must not render when array is empty');
+  assert.doesNotMatch(html, /Try again/, 'Try again heading must not render when misconceptions are empty');
+});
+
+// ---------- 3. Empty progressDelta → no progress section ---------- //
+
+test('SessionSummaryFrame hides progress section when progressDelta is empty', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { SessionSummaryFrame } from ${absoluteSpecifier('src/platform/ui/SessionSummaryFrame.jsx')};
+    const html = renderToStaticMarkup(
+      <SessionSummaryFrame
+        subjectId="punctuation"
+        outcome="improving"
+        title="Nice session"
+        highlights={['8 out of 10 correct']}
+        misconceptions={['Speech punctuation']}
+        progressDelta={[]}
+        nextPrimaryAction={{ label: 'Start again', dataAction: 'punctuation-start-again', onClick: () => {} }}
+        secondaryActions={[]}
+      />
+    );
+    console.log(html);
+  `);
+  assert.doesNotMatch(html, /data-summary-progress/, 'Progress section must not render when progressDelta is empty');
+});
+
+// ---------- 4. progressDelta cannot show mastery not in result model ---------- //
+
+test('SessionSummaryFrame renders only the progress labels passed — cannot fabricate mastery', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { SessionSummaryFrame } from ${absoluteSpecifier('src/platform/ui/SessionSummaryFrame.jsx')};
+    const html = renderToStaticMarkup(
+      <SessionSummaryFrame
+        subjectId="grammar"
+        outcome="improving"
+        title="Good progress"
+        highlights={['3 of 5 correct']}
+        misconceptions={['Noun phrases']}
+        progressDelta={[{ label: 'Nouns', from: 'Stage 1', to: 'Stage 2' }]}
+        nextPrimaryAction={{ label: 'Continue', dataAction: 'grammar-start-again', onClick: () => {} }}
+        secondaryActions={[]}
+      />
+    );
+    console.log(html);
+  `);
+  assert.match(html, /data-summary-progress/, 'Progress section must render when progressDelta has entries');
+  assert.match(html, /data-progress-label="Nouns"/, 'Must render the passed progress label');
+  assert.match(html, /Stage 1/, 'Must render the from value');
+  assert.match(html, /Stage 2/, 'Must render the to value');
+  // The frame must NOT show any label that was not passed via progressDelta
+  assert.doesNotMatch(html, /data-progress-label="[^"]*Verbs[^"]*"/, 'Must not fabricate progress for labels not in the result model');
+  assert.doesNotMatch(html, /data-progress-label="[^"]*Mega[^"]*"/, 'Must not fabricate Mega mastery progress');
+});
+
+// ---------- 5. Subject-specific next-action routes dispatch correctly ---------- //
+
+test('SessionSummaryFrame preserves subject-specific data-action attributes', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { SessionSummaryFrame } from ${absoluteSpecifier('src/platform/ui/SessionSummaryFrame.jsx')};
+    const html = renderToStaticMarkup(
+      <SessionSummaryFrame
+        subjectId="punctuation"
+        outcome="needs-practice"
+        title="Keep trying"
+        highlights={[]}
+        misconceptions={['Commas in lists']}
+        progressDelta={[]}
+        nextPrimaryAction={{ label: 'Practise wobbly spots', dataAction: 'punctuation-start', onClick: () => {} }}
+        secondaryActions={[
+          { label: 'Open Map', dataAction: 'punctuation-open-map', variant: 'secondary', onClick: () => {} },
+          { label: 'Back to dashboard', dataAction: 'punctuation-back', variant: 'ghost', onClick: () => {} },
+        ]}
+      />
+    );
+    console.log(html);
+  `);
+  assert.match(html, /data-action="punctuation-start"/, 'Primary data-action must be preserved');
+  assert.match(html, /data-action="punctuation-open-map"/, 'Secondary data-action must be preserved');
+  assert.match(html, /data-action="punctuation-back"/, 'Tertiary data-action must be preserved');
+});
+
+// ---------- 6. No forbidden copy patterns ---------- //
+
+test('SessionSummaryFrame does not contain forbidden copy patterns', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { SessionSummaryFrame } from ${absoluteSpecifier('src/platform/ui/SessionSummaryFrame.jsx')};
+    const html = renderToStaticMarkup(
+      <SessionSummaryFrame
+        subjectId="spelling"
+        outcome="needs-practice"
+        title="Keep going"
+        highlights={['3 of 5 correct']}
+        misconceptions={['receive', 'believe']}
+        progressDelta={[{ label: 'Spelling', from: '4 Stars', to: '5 Stars' }]}
+        nextPrimaryAction={{ label: 'Start another round', dataAction: 'spelling-start-again', onClick: () => {} }}
+        secondaryActions={[
+          { label: 'Back', dataAction: 'spelling-back', variant: 'ghost', onClick: () => {} },
+        ]}
+      />
+    );
+    console.log(html);
+  `);
+  const forbidden = [
+    'lose your streak',
+    'Earn coins',
+    'failed this monster',
+    'Mega lost',
+    'Buy now',
+    'limited time',
+  ];
+  for (const pattern of forbidden) {
+    assert.doesNotMatch(
+      html,
+      new RegExp(pattern, 'i'),
+      `Frame-authored text must not contain forbidden copy pattern: "${pattern}"`,
+    );
+  }
+});
+
+// ---------- 7. SectionHeader adoption verified ---------- //
+
+test('SessionSummaryFrame imports and renders SectionHeader for section headings', async () => {
+  // Verify source imports SectionHeader
+  const source = readFileSync(
+    path.join(rootDir, 'src/platform/ui/SessionSummaryFrame.jsx'),
+    'utf8',
+  );
+  assert.match(
+    source,
+    /import\s*\{[^}]*SectionHeader[^}]*\}\s*from\s*['"]\.\/SectionHeader\.jsx['"]/,
+    'SessionSummaryFrame must import SectionHeader from ./SectionHeader.jsx',
+  );
+
+  // Verify SectionHeader renders in the output
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { SessionSummaryFrame } from ${absoluteSpecifier('src/platform/ui/SessionSummaryFrame.jsx')};
+    const html = renderToStaticMarkup(
+      <SessionSummaryFrame
+        subjectId="grammar"
+        outcome="improving"
+        title="Nice work"
+        highlights={['4 of 5 correct']}
+        misconceptions={['Verb tenses']}
+        progressDelta={[]}
+        nextPrimaryAction={{ label: 'Continue', dataAction: 'grammar-start-again', onClick: () => {} }}
+        secondaryActions={[]}
+      />
+    );
+    console.log(html);
+  `);
+  // SectionHeader renders <header class="section-header ..."> with child elements
+  assert.match(html, /class="[^"]*section-header[^"]*"/, 'SectionHeader must render in the output');
+  assert.match(html, /class="[^"]*section-title[^"]*"/, 'SectionHeader title must render with section-title class');
+  // Verify "What went well" and "Try again" headings are present
+  assert.match(html, /What went well/, 'Must render "What went well" section heading');
+  assert.match(html, /Try again/, 'Must render "Try again" section heading');
+});
+
+// ---------- Subject adoption gate: all 3 summary scenes import SessionSummaryFrame ---------- //
+
+test('All three subject summary scenes import SessionSummaryFrame', () => {
+  const subjects = [
+    { name: 'Spelling', path: 'src/subjects/spelling/components/SpellingSummaryScene.jsx' },
+    { name: 'Punctuation', path: 'src/subjects/punctuation/components/PunctuationSummaryScene.jsx' },
+    { name: 'Grammar', path: 'src/subjects/grammar/components/GrammarSummaryScene.jsx' },
+  ];
+  for (const subject of subjects) {
+    const source = readFileSync(path.join(rootDir, subject.path), 'utf8');
+    assert.match(
+      source,
+      /import\s*\{[^}]*SessionSummaryFrame[^}]*\}/,
+      `${subject.name} summary scene must import SessionSummaryFrame`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

- Create shared `SessionSummaryFrame` primitive at `src/platform/ui/SessionSummaryFrame.jsx` using SectionHeader, Button, and ActionRow primitives
- Adopt in all three ready subjects (Spelling, Punctuation, Grammar) via thin adapters that preserve existing feedback copy and next-action dispatch
- Display-only: no mastery mutation, no reward changes, no star writes
- Exactly one primary action per render; empty misconceptions/progressDelta sections hidden

## Test plan

- [x] 8 contract tests in `tests/ui-summary-engine-contract.test.js` — all pass
- [x] One primary action per render enforced
- [x] Empty misconceptions hides section; empty progressDelta hides progress
- [x] progressDelta cannot fabricate mastery not in result model
- [x] Subject-specific data-action attributes preserved
- [x] No forbidden copy patterns (streak, coins, failed, Mega lost, Buy now, limited time)
- [x] SectionHeader import and render verified
- [x] All 3 subject summary scenes import SessionSummaryFrame (3-adopter gate)
- [x] Existing tests pass: punctuation-summary-hero-backdrop (6/6), spelling-boss (45/45), ui-button-primitive (11/11)