### PR TITLE
feat(hero-pA5): U1-U3 docs cleanup, exposure detection, rollout resolver

### DIFF
--- a/docs/plans/james/hero-mode/A/hero-pA4-external-cohort-evidence.md
+++ b/docs/plans/james/hero-mode/A/hero-pA4-external-cohort-evidence.md
@@ -35,7 +35,7 @@ One row per observation. Do not combine multiple signals into a single row. If t
 
 ## Provenance Values
 
-- `real-production` — observed in production via automated probe or manual verification against live D1/KV state
+- `real-production` — observed in production via automated probe or manual verification against live D1 child_game_state (system_id = 'hero-mode')
 - `operator-verified` — operator has independently confirmed the observation against a second source
 - `system-generated` — automatically produced by telemetry or monitoring infrastructure
 
@@ -53,7 +53,8 @@ Rows with provenance='real-production' count toward certification gates. Rows wi
 
 | Date | Source | Account | Learner | Signal | Value | Provenance | Confidence | Notes |
 |------|--------|---------|---------|--------|-------|------------|------------|-------|
-| 2026-05-01 | external-cohort | acct-example-001 | learner-A | daily-completion | 1 | real-production | high | Example row — replace with real observations |
+<!-- example row only, do not count -->
+| 2026-05-01 | external-cohort | acct-example-001 | learner-A | daily-completion | 1 | example-only | high | Example row — replace with real observations |
 
 *(Rows will be appended as real external cohort usage occurs during Ring A4-1.)*
 

--- a/docs/plans/james/hero-mode/A/hero-pA4-plan-completion-report.md
+++ b/docs/plans/james/hero-mode/A/hero-pA4-plan-completion-report.md
@@ -15,7 +15,7 @@ Hero Mode pA4 productionisation infrastructure is code-complete. The delivery im
 Key metrics:
 - 14 implementation units, all merged
 - 7 PRs: #743, #744, #745, #746, #747, #748, #749, #750
-- 503 new tests passing
+- pA4 focused local suite: 503 tests, 503 pass, 0 fail
 - 0 regression in existing test suite
 - 10/10 contract deliverables created
 - 13 stop condition guards automated
@@ -128,7 +128,7 @@ Key metrics:
 
 4. **Minimal runtime footprint**: Only `worker/src/app.js` and `shared/hero/account-override.js` were modified. All other delivery is additive scripts, tests, and documentation.
 
-5. **503 tests in 635ms**: Node.js built-in test runner keeps the full pA4 suite fast enough for CI feedback loops.
+5. **pA4 focused local suite: 503 tests, 503 pass, 0 fail** in 635ms: Node.js built-in test runner keeps the full pA4 suite fast enough for CI feedback loops.
 
 ---
 

--- a/docs/plans/james/hero-mode/A/hero-pA4-release-candidate.md
+++ b/docs/plans/james/hero-mode/A/hero-pA4-release-candidate.md
@@ -38,12 +38,12 @@ The following deliverables constitute the pA4 release candidate:
 | # | Deliverable | Location |
 |---|-------------|----------|
 | 1 | External cohort resolver (HERO_EXTERNAL_ACCOUNTS) | `shared/hero/account-override.js` |
-| 2 | Unified route integration with overrideStatus | `src/hero/routes/` |
+| 2 | Unified route integration with overrideStatus | `worker/src/hero/routes.js` |
 | 3 | 13 stop condition guards | `shared/hero/stop-conditions.js` |
 | 4 | 9 warning condition detectors | `shared/hero/warning-conditions.js` |
-| 5 | Metrics infrastructure (18 launch + 11 product + 10 safety) | `shared/hero/metrics/` |
-| 6 | Product signal analysis with reward farming detection | `shared/hero/product-metrics.js` |
-| 7 | Multi-day cohort simulation (8 accounts, 7 days) | `scripts/hero-pA4-cohort-simulation.mjs` |
+| 5 | Metrics infrastructure (18 launch + 11 product + 10 safety) | `shared/hero/product-signals.js` |
+| 6 | Product signal analysis with reward farming detection | `shared/hero/product-signals.js` |
+| 7 | Multi-day cohort simulation (8 accounts, 7 days) | `scripts/hero-pA4-external-cohort-smoke.mjs` |
 | 8 | Browser smoke validation script | `scripts/hero-pA4-external-cohort-smoke.mjs` |
 | 9 | Parent/adult explainer | `docs/plans/james/hero-mode/A/hero-pA4-parent-explainer.md` |
 | 10 | Support triage pack | `docs/plans/james/hero-mode/A/hero-pA4-support-pack.md` |

--- a/scripts/hero-pA4-operator-lookup.mjs
+++ b/scripts/hero-pA4-operator-lookup.mjs
@@ -190,12 +190,27 @@ function deriveCohortClassification(overrideStatus, allFlagsEnabled) {
         enabled: true,
         reason: 'Account is in HERO_EXTERNAL_ACCOUNTS cohort list. All Hero flags force-enabled.',
       };
-    case 'global':
+    case 'global-default':
       return {
         enabled: allFlagsEnabled,
         reason: allFlagsEnabled
           ? 'Hero flags are globally enabled in environment. Account benefits from global rollout.'
           : 'Some Hero flags are globally enabled but not all. Partial visibility.',
+      };
+    case 'emergency-off':
+      return {
+        enabled: false,
+        reason: 'HERO_EMERGENCY_DISABLED is active. All Hero functionality is disabled system-wide.',
+      };
+    case 'excluded':
+      return {
+        enabled: false,
+        reason: 'Account is in HERO_EXCLUDED_ACCOUNTS list. Hero Mode is explicitly disabled for this account.',
+      };
+    case 'rollout-bucket':
+      return {
+        enabled: true,
+        reason: 'Account falls within the deterministic rollout bucket. All Hero flags force-enabled via percentage rollout.',
       };
     case 'none':
     default:
@@ -245,7 +260,7 @@ function deriveRecommendations({
   }
 
   // Partial flags
-  if (overrideStatus === 'global' && !allFlagsEnabled) {
+  if (overrideStatus === 'global-default' && !allFlagsEnabled) {
     recs.push('Partial global flag enablement. Either enable all 6 flags or add account to a cohort list for full access.');
   }
 

--- a/shared/hero/account-override.js
+++ b/shared/hero/account-override.js
@@ -1,4 +1,4 @@
-// Resolve Hero flag overrides with 6-way classification.
+// Resolve Hero flag overrides with 7-way classification.
 // Pure function — no side effects, no DB access.
 //
 // Precedence (highest first):

--- a/shared/hero/account-override.js
+++ b/shared/hero/account-override.js
@@ -1,11 +1,18 @@
-// Resolve Hero flag overrides for internal and external cohort accounts.
+// Resolve Hero flag overrides with 6-way classification.
 // Pure function — no side effects, no DB access.
 //
-// Precedence: internal > external > global > none.
-// When HERO_INTERNAL_ACCOUNTS or HERO_EXTERNAL_ACCOUNTS (JSON secrets) list
-// an accountId, all 6 Hero flags are force-enabled. Internal takes precedence
-// if an account appears in both lists. Additive-only: non-listed accounts are
-// unchanged.
+// Precedence (highest first):
+//   1. emergency-off  — HERO_EMERGENCY_DISABLED === 'true'
+//   2. excluded       — accountId in HERO_EXCLUDED_ACCOUNTS
+//   3. internal       — accountId in HERO_INTERNAL_ACCOUNTS
+//   4. external       — accountId in HERO_EXTERNAL_ACCOUNTS
+//   5. rollout-bucket — hash(accountId:salt) < HERO_ROLLOUT_PERCENT
+//   6. global-default — any HERO_MODE_*_ENABLED flag is 'true'
+//   7. none           — no override
+//
+// Emergency-off and excluded return env UNCHANGED (Hero disabled for them).
+// Internal, external, and rollout-bucket force all 6 Hero flags on.
+// Fail closed on all malformed input.
 
 const HERO_FLAG_KEYS = Object.freeze([
   'HERO_MODE_SHADOW_ENABLED',
@@ -34,38 +41,73 @@ function parseAccountList(raw) {
 }
 
 /**
+ * Deterministic hash of an input string to a bucket 0–99.
+ * Stable: same input = same output forever (no randomness, no crypto).
+ * Exported as _hashAccountToBucket for testing.
+ *
+ * @param {string} input
+ * @returns {number} integer 0–99
+ */
+export function _hashAccountToBucket(input) {
+  let hash = 0;
+  for (let i = 0; i < input.length; i++) {
+    hash = ((hash << 5) - hash + input.charCodeAt(i)) | 0;
+  }
+  return (hash >>> 0) % 100;
+}
+
+/**
  * Primary resolver — returns resolved env AND classified override status.
  *
  * @param {Object} params
  * @param {Object} params.env — Worker environment bindings
  * @param {string} params.accountId — caller account ID
- * @returns {{ resolvedEnv: Object, overrideStatus: 'internal'|'external'|'global'|'none' }}
+ * @returns {{ resolvedEnv: Object, overrideStatus: 'emergency-off'|'excluded'|'internal'|'external'|'rollout-bucket'|'global-default'|'none' }}
  */
 export function resolveHeroFlagsForAccount({ env, accountId }) {
   const safeEnv = env || {};
+
+  // 1. Emergency kill switch — highest precedence
+  if (safeEnv.HERO_EMERGENCY_DISABLED === 'true') {
+    return { resolvedEnv: safeEnv, overrideStatus: 'emergency-off' };
+  }
 
   // Early exit — no accountId means we cannot match any list
   if (!accountId) {
     return { resolvedEnv: safeEnv, overrideStatus: _detectGlobalStatus(safeEnv) };
   }
 
-  // Parse internal list
-  const internalList = parseAccountList(safeEnv.HERO_INTERNAL_ACCOUNTS);
+  // 2. Excluded accounts — opt-out override
+  const excludedList = parseAccountList(safeEnv.HERO_EXCLUDED_ACCOUNTS);
+  if (excludedList && excludedList.includes(accountId)) {
+    return { resolvedEnv: safeEnv, overrideStatus: 'excluded' };
+  }
 
-  // Check internal membership (highest precedence)
+  // 3. Internal cohort
+  const internalList = parseAccountList(safeEnv.HERO_INTERNAL_ACCOUNTS);
   if (internalList && internalList.includes(accountId)) {
     return { resolvedEnv: _applyAllFlags(safeEnv), overrideStatus: 'internal' };
   }
 
-  // Parse external list
+  // 4. External cohort
   const externalList = parseAccountList(safeEnv.HERO_EXTERNAL_ACCOUNTS);
-
-  // Check external membership
   if (externalList && externalList.includes(accountId)) {
     return { resolvedEnv: _applyAllFlags(safeEnv), overrideStatus: 'external' };
   }
 
-  // Not in any list — classify as global or none
+  // 5. Deterministic rollout bucket
+  const salt = safeEnv.HERO_ROLLOUT_SALT;
+  if (salt && salt !== '') {
+    const percent = _parseRolloutPercent(safeEnv.HERO_ROLLOUT_PERCENT);
+    if (percent > 0) {
+      const bucket = _hashAccountToBucket(accountId + ':' + salt);
+      if (bucket < percent) {
+        return { resolvedEnv: _applyAllFlags(safeEnv), overrideStatus: 'rollout-bucket' };
+      }
+    }
+  }
+
+  // 6/7. Global-default or none
   return { resolvedEnv: safeEnv, overrideStatus: _detectGlobalStatus(safeEnv) };
 }
 
@@ -97,13 +139,26 @@ function _applyAllFlags(env) {
 /**
  * Detect whether any global Hero flag is already enabled in env.
  * @param {Object} env
- * @returns {'global'|'none'}
+ * @returns {'global-default'|'none'}
  */
 function _detectGlobalStatus(env) {
   for (const key of HERO_FLAG_KEYS) {
-    if (env[key] === 'true') return 'global';
+    if (env[key] === 'true') return 'global-default';
   }
   return 'none';
+}
+
+/**
+ * Parse HERO_ROLLOUT_PERCENT to a safe integer 0–100.
+ * Returns 0 (fail closed) on NaN, negative, or >100.
+ * @param {string|null|undefined} raw
+ * @returns {number}
+ */
+function _parseRolloutPercent(raw) {
+  if (raw == null || raw === '') return 0;
+  const n = parseInt(raw, 10);
+  if (Number.isNaN(n) || n < 0 || n > 100) return 0;
+  return n;
 }
 
 export { HERO_FLAG_KEYS };

--- a/shared/hero/stop-conditions.js
+++ b/shared/hero/stop-conditions.js
@@ -40,21 +40,37 @@ export function detectRawChildContent(payload) {
 
 /**
  * Detect non-cohort accounts seeing Hero surfaces.
- * A non-cohort account (overrideStatus === 'none') must never see Hero UI.
+ * Requires both:
+ *   1. overrideStatus is 'none' or 'excluded' (not in any cohort)
+ *   2. At least one observed exposure signal is true
  *
- * @param {{ accountId: string, env: object }} params
+ * This eliminates false positives from normal accounts that never saw Hero UI.
+ * If no exposure signals are provided, returns not-triggered (fail safe).
+ *
+ * @param {{ accountId: string, env: object, heroSurfaceVisible?: boolean, commandAccepted?: boolean, readModelEnabled?: boolean }} params
  * @returns {{ triggered: boolean, condition: string, detail: string }}
  */
-export function detectNonCohortExposure({ accountId, env } = {}) {
+export function detectNonCohortExposure({ accountId, env, heroSurfaceVisible, commandAccepted, readModelEnabled } = {}) {
   if (!accountId || !env) {
     return { triggered: false, condition: 'non-cohort-exposure', detail: '' };
   }
+
+  // Fail safe: if no exposure signals provided at all, do not trigger
+  const hasAnySignal = heroSurfaceVisible === true || commandAccepted === true || readModelEnabled === true;
+  if (!hasAnySignal) {
+    return { triggered: false, condition: 'non-cohort-exposure', detail: '' };
+  }
+
   const { overrideStatus } = resolveHeroFlagsForAccount({ env, accountId });
-  if (overrideStatus === 'none') {
+  if (overrideStatus === 'none' || overrideStatus === 'excluded') {
+    const signals = [];
+    if (heroSurfaceVisible) signals.push('heroSurfaceVisible');
+    if (commandAccepted) signals.push('commandAccepted');
+    if (readModelEnabled) signals.push('readModelEnabled');
     return {
       triggered: true,
       condition: 'non-cohort-exposure',
-      detail: `account ${accountId} is not in any cohort list`,
+      detail: `account ${accountId} is not in any cohort list; exposure signals: ${signals.join(', ')}`,
     };
   }
   return { triggered: false, condition: 'non-cohort-exposure', detail: '' };

--- a/shared/hero/stop-conditions.js
+++ b/shared/hero/stop-conditions.js
@@ -80,7 +80,7 @@ export function detectNonCohortExposure({ accountId, env, heroSurfaceVisible, co
 
 /**
  * Detect Hero command succeeding for a non-enabled account.
- * An account with overrideStatus 'none' must never execute Hero commands.
+ * An account with overrideStatus 'none' or 'excluded' must never execute Hero commands.
  *
  * @param {{ accountId: string, env: object }} params
  * @returns {{ triggered: boolean, condition: string, detail: string }}
@@ -90,11 +90,11 @@ export function detectUnauthorisedCommand({ accountId, env } = {}) {
     return { triggered: false, condition: 'unauthorised-command', detail: '' };
   }
   const { overrideStatus } = resolveHeroFlagsForAccount({ env, accountId });
-  if (overrideStatus === 'none') {
+  if (overrideStatus === 'none' || overrideStatus === 'excluded') {
     return {
       triggered: true,
       condition: 'unauthorised-command',
-      detail: `account ${accountId} has no Hero enablement`,
+      detail: `account ${accountId} has no Hero enablement (status: ${overrideStatus})`,
     };
   }
   return { triggered: false, condition: 'unauthorised-command', detail: '' };

--- a/tests/hero-pA4-external-cohort-resolver.test.js
+++ b/tests/hero-pA4-external-cohort-resolver.test.js
@@ -5,6 +5,7 @@ import {
   resolveHeroFlagsForAccount,
   resolveHeroFlagsWithOverride,
   HERO_FLAG_KEYS,
+  _hashAccountToBucket,
 } from '../shared/hero/account-override.js';
 
 // ── Helper ────────────────────────────────────────────────────────────
@@ -66,7 +67,7 @@ describe('resolveHeroFlagsForAccount: neither list', () => {
     assert.ok(noFlagsEnabled(resolvedEnv));
   });
 
-  it('account in neither list with a global flag enabled returns status global', () => {
+  it('account in neither list with a global flag enabled returns status global-default', () => {
     const env = {
       HERO_INTERNAL_ACCOUNTS: JSON.stringify(['int-1']),
       HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['ext-1']),
@@ -74,7 +75,7 @@ describe('resolveHeroFlagsForAccount: neither list', () => {
     };
     const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'unknown-acc' });
 
-    assert.equal(overrideStatus, 'global');
+    assert.equal(overrideStatus, 'global-default');
     // Global flags unchanged — no additional flags forced
     assert.equal(resolvedEnv.HERO_MODE_SHADOW_ENABLED, 'true');
     assert.notEqual(resolvedEnv.HERO_MODE_CAMP_ENABLED, 'true');
@@ -185,6 +186,278 @@ describe('resolveHeroFlagsForAccount: accountId edge cases', () => {
   });
 });
 
+// ── Emergency-off: HERO_EMERGENCY_DISABLED ──────────────────────────────
+
+describe('resolveHeroFlagsForAccount: emergency-off', () => {
+  it('HERO_EMERGENCY_DISABLED=true overrides everything — flags NOT enabled', () => {
+    const env = {
+      HERO_EMERGENCY_DISABLED: 'true',
+      HERO_INTERNAL_ACCOUNTS: JSON.stringify(['acc-1']),
+      HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['acc-1']),
+      HERO_MODE_SHADOW_ENABLED: 'true',
+    };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'acc-1' });
+
+    assert.equal(overrideStatus, 'emergency-off');
+    // Flags NOT force-enabled — env returned unchanged
+    assert.equal(resolvedEnv.HERO_MODE_CAMP_ENABLED, undefined);
+    assert.equal(resolvedEnv.HERO_MODE_ECONOMY_ENABLED, undefined);
+  });
+
+  it('HERO_EMERGENCY_DISABLED=true overrides even with no accountId', () => {
+    const env = { HERO_EMERGENCY_DISABLED: 'true' };
+    const { overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: null });
+
+    assert.equal(overrideStatus, 'emergency-off');
+  });
+
+  it('HERO_EMERGENCY_DISABLED=false does NOT trigger emergency-off', () => {
+    const env = {
+      HERO_EMERGENCY_DISABLED: 'false',
+      HERO_INTERNAL_ACCOUNTS: JSON.stringify(['acc-1']),
+    };
+    const { overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'acc-1' });
+
+    assert.equal(overrideStatus, 'internal');
+  });
+
+  it('HERO_EMERGENCY_DISABLED missing does NOT trigger emergency-off', () => {
+    const env = { HERO_INTERNAL_ACCOUNTS: JSON.stringify(['acc-1']) };
+    const { overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'acc-1' });
+
+    assert.equal(overrideStatus, 'internal');
+  });
+});
+
+// ── Excluded accounts: HERO_EXCLUDED_ACCOUNTS ────────────────────────────
+
+describe('resolveHeroFlagsForAccount: excluded accounts', () => {
+  it('excluded account does NOT get flags enabled', () => {
+    const env = {
+      HERO_EXCLUDED_ACCOUNTS: JSON.stringify(['banned-1']),
+      HERO_INTERNAL_ACCOUNTS: JSON.stringify(['banned-1']),
+    };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'banned-1' });
+
+    assert.equal(overrideStatus, 'excluded');
+    assert.ok(noFlagsEnabled(resolvedEnv));
+  });
+
+  it('excluded beats external membership', () => {
+    const env = {
+      HERO_EXCLUDED_ACCOUNTS: JSON.stringify(['acc-x']),
+      HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['acc-x']),
+    };
+    const { overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'acc-x' });
+
+    assert.equal(overrideStatus, 'excluded');
+  });
+
+  it('malformed HERO_EXCLUDED_ACCOUNTS is ignored (fail closed = not excluded)', () => {
+    const env = {
+      HERO_EXCLUDED_ACCOUNTS: 'not-json',
+      HERO_INTERNAL_ACCOUNTS: JSON.stringify(['acc-1']),
+    };
+    const { overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'acc-1' });
+
+    assert.equal(overrideStatus, 'internal');
+  });
+
+  it('empty HERO_EXCLUDED_ACCOUNTS array does not exclude anyone', () => {
+    const env = {
+      HERO_EXCLUDED_ACCOUNTS: JSON.stringify([]),
+      HERO_INTERNAL_ACCOUNTS: JSON.stringify(['acc-1']),
+    };
+    const { overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'acc-1' });
+
+    assert.equal(overrideStatus, 'internal');
+  });
+});
+
+// ── Rollout bucket: deterministic percentage ─────────────────────────────
+
+describe('resolveHeroFlagsForAccount: rollout bucket', () => {
+  it('account in bucket gets flags enabled with status rollout-bucket', () => {
+    // Use 100% rollout to guarantee bucket inclusion
+    const env = {
+      HERO_ROLLOUT_SALT: 'test-salt-v1',
+      HERO_ROLLOUT_PERCENT: '100',
+    };
+    const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'any-account' });
+
+    assert.equal(overrideStatus, 'rollout-bucket');
+    assert.ok(allFlagsEnabled(resolvedEnv));
+  });
+
+  it('0% rollout means no one gets bucketed', () => {
+    const env = {
+      HERO_ROLLOUT_SALT: 'test-salt-v1',
+      HERO_ROLLOUT_PERCENT: '0',
+    };
+    const { overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'any-account' });
+
+    assert.equal(overrideStatus, 'none');
+  });
+
+  it('missing salt skips bucket check entirely', () => {
+    const env = { HERO_ROLLOUT_PERCENT: '100' };
+    const { overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'any-account' });
+
+    assert.equal(overrideStatus, 'none');
+  });
+
+  it('empty string salt skips bucket check', () => {
+    const env = { HERO_ROLLOUT_SALT: '', HERO_ROLLOUT_PERCENT: '100' };
+    const { overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'any-account' });
+
+    assert.equal(overrideStatus, 'none');
+  });
+
+  it('NaN percent treated as 0 (fail closed)', () => {
+    const env = { HERO_ROLLOUT_SALT: 'salt', HERO_ROLLOUT_PERCENT: 'abc' };
+    const { overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'any-account' });
+
+    assert.equal(overrideStatus, 'none');
+  });
+
+  it('negative percent treated as 0 (fail closed)', () => {
+    const env = { HERO_ROLLOUT_SALT: 'salt', HERO_ROLLOUT_PERCENT: '-5' };
+    const { overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'any-account' });
+
+    assert.equal(overrideStatus, 'none');
+  });
+
+  it('>100 percent treated as 0 (fail closed)', () => {
+    const env = { HERO_ROLLOUT_SALT: 'salt', HERO_ROLLOUT_PERCENT: '101' };
+    const { overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'any-account' });
+
+    assert.equal(overrideStatus, 'none');
+  });
+
+  it('internal account takes precedence over rollout bucket', () => {
+    const env = {
+      HERO_INTERNAL_ACCOUNTS: JSON.stringify(['acc-1']),
+      HERO_ROLLOUT_SALT: 'salt',
+      HERO_ROLLOUT_PERCENT: '100',
+    };
+    const { overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'acc-1' });
+
+    assert.equal(overrideStatus, 'internal');
+  });
+
+  it('excluded account takes precedence over rollout bucket', () => {
+    const env = {
+      HERO_EXCLUDED_ACCOUNTS: JSON.stringify(['acc-1']),
+      HERO_ROLLOUT_SALT: 'salt',
+      HERO_ROLLOUT_PERCENT: '100',
+    };
+    const { overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'acc-1' });
+
+    assert.equal(overrideStatus, 'excluded');
+  });
+});
+
+// ── _hashAccountToBucket: determinism and range ──────────────────────────
+
+describe('_hashAccountToBucket', () => {
+  it('returns integer in range 0–99', () => {
+    for (const input of ['a', 'test', 'acc-123:salt-v1', '']) {
+      const result = _hashAccountToBucket(input);
+      assert.ok(Number.isInteger(result), `expected integer for "${input}"`);
+      assert.ok(result >= 0, `expected >= 0 for "${input}"`);
+      assert.ok(result <= 99, `expected <= 99 for "${input}"`);
+    }
+  });
+
+  it('same input always produces same output (stability)', () => {
+    const input = 'account-xyz:salt-production-v3';
+    const first = _hashAccountToBucket(input);
+    const second = _hashAccountToBucket(input);
+    const third = _hashAccountToBucket(input);
+
+    assert.equal(first, second);
+    assert.equal(second, third);
+  });
+
+  it('different inputs produce different outputs (distribution)', () => {
+    const results = new Set();
+    for (let i = 0; i < 200; i++) {
+      results.add(_hashAccountToBucket(`account-${i}:salt`));
+    }
+    // With 200 inputs into 100 buckets, expect at least 50 distinct values
+    assert.ok(results.size > 50, `expected good distribution, got ${results.size} distinct values`);
+  });
+
+  it('empty string produces a deterministic value', () => {
+    const result = _hashAccountToBucket('');
+    assert.equal(result, 0); // hash of empty = 0, 0 % 100 = 0
+  });
+});
+
+// ── Full precedence chain ────────────────────────────────────────────────
+
+describe('resolveHeroFlagsForAccount: full precedence chain', () => {
+  it('emergency-off > excluded > internal > external > rollout > global-default > none', () => {
+    const fullEnv = {
+      HERO_EMERGENCY_DISABLED: 'true',
+      HERO_EXCLUDED_ACCOUNTS: JSON.stringify(['acc-1']),
+      HERO_INTERNAL_ACCOUNTS: JSON.stringify(['acc-1']),
+      HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['acc-1']),
+      HERO_ROLLOUT_SALT: 'salt',
+      HERO_ROLLOUT_PERCENT: '100',
+      HERO_MODE_SHADOW_ENABLED: 'true',
+    };
+
+    // Level 1: emergency-off wins over everything
+    assert.equal(
+      resolveHeroFlagsForAccount({ env: fullEnv, accountId: 'acc-1' }).overrideStatus,
+      'emergency-off'
+    );
+
+    // Level 2: excluded wins when emergency is off
+    const noEmergency = { ...fullEnv, HERO_EMERGENCY_DISABLED: 'false' };
+    assert.equal(
+      resolveHeroFlagsForAccount({ env: noEmergency, accountId: 'acc-1' }).overrideStatus,
+      'excluded'
+    );
+
+    // Level 3: internal wins when not excluded
+    const noExcluded = { ...noEmergency, HERO_EXCLUDED_ACCOUNTS: JSON.stringify([]) };
+    assert.equal(
+      resolveHeroFlagsForAccount({ env: noExcluded, accountId: 'acc-1' }).overrideStatus,
+      'internal'
+    );
+
+    // Level 4: external wins when not internal
+    const noInternal = { ...noExcluded, HERO_INTERNAL_ACCOUNTS: JSON.stringify([]) };
+    assert.equal(
+      resolveHeroFlagsForAccount({ env: noInternal, accountId: 'acc-1' }).overrideStatus,
+      'external'
+    );
+
+    // Level 5: rollout-bucket when not in named lists
+    const noExternal = { ...noInternal, HERO_EXTERNAL_ACCOUNTS: JSON.stringify([]) };
+    assert.equal(
+      resolveHeroFlagsForAccount({ env: noExternal, accountId: 'acc-1' }).overrideStatus,
+      'rollout-bucket'
+    );
+
+    // Level 6: global-default when not in bucket
+    const noRollout = { ...noExternal, HERO_ROLLOUT_PERCENT: '0' };
+    assert.equal(
+      resolveHeroFlagsForAccount({ env: noRollout, accountId: 'acc-1' }).overrideStatus,
+      'global-default'
+    );
+
+    // Level 7: none when no global flags
+    const noGlobal = { ...noRollout, HERO_MODE_SHADOW_ENABLED: 'false' };
+    assert.equal(
+      resolveHeroFlagsForAccount({ env: noGlobal, accountId: 'acc-1' }).overrideStatus,
+      'none'
+    );
+  });
+});
+
 // ── Backward compatibility: resolveHeroFlagsWithOverride ──────────────
 
 describe('resolveHeroFlagsWithOverride: backward compatibility', () => {
@@ -233,6 +506,26 @@ describe('resolveHeroFlagsWithOverride: backward compatibility', () => {
   it('external account override also works via wrapper', () => {
     const env = { HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['ext-1']) };
     const result = resolveHeroFlagsWithOverride({ env, accountId: 'ext-1' });
+
+    assert.ok(allFlagsEnabled(result));
+  });
+
+  it('emergency-off returns unchanged env via wrapper (no flags forced)', () => {
+    const env = {
+      HERO_EMERGENCY_DISABLED: 'true',
+      HERO_INTERNAL_ACCOUNTS: JSON.stringify(['acc-1']),
+    };
+    const result = resolveHeroFlagsWithOverride({ env, accountId: 'acc-1' });
+
+    assert.ok(noFlagsEnabled(result));
+  });
+
+  it('rollout-bucket returns flags-enabled env via wrapper', () => {
+    const env = {
+      HERO_ROLLOUT_SALT: 'salt',
+      HERO_ROLLOUT_PERCENT: '100',
+    };
+    const result = resolveHeroFlagsWithOverride({ env, accountId: 'any-acc' });
 
     assert.ok(allFlagsEnabled(result));
   });

--- a/tests/hero-pA4-external-cohort-resolver.test.js
+++ b/tests/hero-pA4-external-cohort-resolver.test.js
@@ -355,6 +355,19 @@ describe('resolveHeroFlagsForAccount: rollout bucket', () => {
 
     assert.equal(overrideStatus, 'excluded');
   });
+
+  it('account outside bucket at intermediate percent is not enrolled', () => {
+    // Find an account whose hash is >= 50
+    const bucket = _hashAccountToBucket('test-account-xyz:test-salt');
+    // Use a percent that's below this bucket value
+    const percent = Math.max(1, bucket - 1);
+    const env = {
+      HERO_ROLLOUT_PERCENT: String(percent),
+      HERO_ROLLOUT_SALT: 'test-salt',
+    };
+    const { overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: 'test-account-xyz' });
+    assert.equal(overrideStatus, 'none');
+  });
 });
 
 // ── _hashAccountToBucket: determinism and range ──────────────────────────
@@ -391,6 +404,12 @@ describe('_hashAccountToBucket', () => {
   it('empty string produces a deterministic value', () => {
     const result = _hashAccountToBucket('');
     assert.equal(result, 0); // hash of empty = 0, 0 % 100 = 0
+  });
+
+  it('different salt produces different bucket for same account', () => {
+    const result1 = _hashAccountToBucket('acc-test:salt-one');
+    const result2 = _hashAccountToBucket('acc-test:salt-two');
+    assert.notEqual(result1, result2);
   });
 });
 

--- a/tests/hero-pA4-route-integration.test.js
+++ b/tests/hero-pA4-route-integration.test.js
@@ -80,11 +80,11 @@ describe('pA4 U2: command route — unified resolver overrideStatus', () => {
     }
   });
 
-  it('non-cohort account with global flags on gets overrideStatus "global"', () => {
+  it('non-cohort account with global flags on gets overrideStatus "global-default"', () => {
     const env = baseEnvWithGlobalFlags();
     const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: PUBLIC_ACCOUNT });
 
-    assert.equal(overrideStatus, 'global');
+    assert.equal(overrideStatus, 'global-default');
     // Global flags preserved — only shadow and launch are 'true' in this fixture
     assert.equal(resolvedEnv.HERO_MODE_SHADOW_ENABLED, 'true');
     assert.equal(resolvedEnv.HERO_MODE_LAUNCH_ENABLED, 'true');
@@ -268,9 +268,9 @@ describe('pA4 U2: command route — heroCommandOverrideStatus available for tele
     assert.equal(typeof result.overrideStatus, 'string');
   });
 
-  it('overrideStatus values are one of the four valid classifications', () => {
+  it('overrideStatus values are one of the valid classifications', () => {
     const env = baseEnvWithGlobalFlags();
-    const validStatuses = ['internal', 'external', 'global', 'none'];
+    const validStatuses = ['internal', 'external', 'global-default', 'none', 'emergency-off', 'excluded', 'rollout-bucket'];
 
     const { overrideStatus: s1 } = resolveHeroFlagsForAccount({ env, accountId: INTERNAL_ACCOUNT });
     const { overrideStatus: s2 } = resolveHeroFlagsForAccount({ env, accountId: EXTERNAL_ACCOUNT });
@@ -281,7 +281,7 @@ describe('pA4 U2: command route — heroCommandOverrideStatus available for tele
 
     assert.ok(validStatuses.includes(s1), `internal → ${s1}`);
     assert.ok(validStatuses.includes(s2), `external → ${s2}`);
-    assert.ok(validStatuses.includes(s3), `global → ${s3}`);
+    assert.ok(validStatuses.includes(s3), `global-default → ${s3}`);
     assert.ok(validStatuses.includes(s4), `none → ${s4}`);
   });
 });

--- a/tests/hero-pA4-stop-conditions.test.js
+++ b/tests/hero-pA4-stop-conditions.test.js
@@ -111,11 +111,10 @@ describe('detectNonCohortExposure', () => {
   });
 
   it('triggers for excluded account with exposure signal', () => {
-    // Simulate excluded by using an env where the account resolves to 'none'
-    // (excluded status will be added in U3; for now 'none' covers the same branch)
     const env = {
       HERO_INTERNAL_ACCOUNTS: JSON.stringify(['int-1']),
       HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['ext-1']),
+      HERO_EXCLUDED_ACCOUNTS: JSON.stringify(['excluded-acc']),
     };
     const result = detectNonCohortExposure({
       accountId: 'excluded-acc', env, heroSurfaceVisible: true,
@@ -158,6 +157,17 @@ describe('detectUnauthorisedCommand', () => {
     const env = { HERO_INTERNAL_ACCOUNTS: JSON.stringify(['valid-acc']) };
     const result = detectUnauthorisedCommand({ accountId: 'valid-acc', env });
     assert.equal(result.triggered, false);
+  });
+
+  it('triggers for excluded account', () => {
+    const env = {
+      HERO_EXCLUDED_ACCOUNTS: JSON.stringify(['banned-acc']),
+      HERO_INTERNAL_ACCOUNTS: JSON.stringify(['banned-acc']),
+    };
+    const result = detectUnauthorisedCommand({ accountId: 'banned-acc', env });
+    assert.equal(result.triggered, true);
+    assert.equal(result.condition, 'unauthorised-command');
+    assert.ok(result.detail.includes('excluded'));
   });
 
   it('does not trigger for global-enabled account', () => {

--- a/tests/hero-pA4-stop-conditions.test.js
+++ b/tests/hero-pA4-stop-conditions.test.js
@@ -56,26 +56,81 @@ describe('detectRawChildContent', () => {
 // ── 2. Non-Cohort Exposure ───────────────────────────────────────────
 
 describe('detectNonCohortExposure', () => {
-  it('triggers when account is in no cohort list', () => {
+  const nonCohortEnv = {
+    HERO_INTERNAL_ACCOUNTS: JSON.stringify(['int-1']),
+    HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['ext-1']),
+  };
+
+  it('triggers for non-cohort account with heroSurfaceVisible', () => {
+    const result = detectNonCohortExposure({
+      accountId: 'random-account', env: nonCohortEnv, heroSurfaceVisible: true,
+    });
+    assert.equal(result.triggered, true);
+    assert.equal(result.condition, 'non-cohort-exposure');
+    assert.ok(result.detail.includes('random-account'));
+    assert.ok(result.detail.includes('heroSurfaceVisible'));
+  });
+
+  it('triggers for non-cohort account with commandAccepted', () => {
+    const result = detectNonCohortExposure({
+      accountId: 'random-account', env: nonCohortEnv, commandAccepted: true,
+    });
+    assert.equal(result.triggered, true);
+    assert.equal(result.condition, 'non-cohort-exposure');
+    assert.ok(result.detail.includes('commandAccepted'));
+  });
+
+  it('triggers for non-cohort account with readModelEnabled', () => {
+    const result = detectNonCohortExposure({
+      accountId: 'random-account', env: nonCohortEnv, readModelEnabled: true,
+    });
+    assert.equal(result.triggered, true);
+    assert.equal(result.condition, 'non-cohort-exposure');
+    assert.ok(result.detail.includes('readModelEnabled'));
+  });
+
+  it('does not trigger for internal cohort account even with all exposure signals', () => {
+    const env = { HERO_INTERNAL_ACCOUNTS: JSON.stringify(['acc-1']) };
+    const result = detectNonCohortExposure({
+      accountId: 'acc-1', env, heroSurfaceVisible: true, commandAccepted: true, readModelEnabled: true,
+    });
+    assert.equal(result.triggered, false);
+  });
+
+  it('does not trigger for non-cohort account with all exposure signals false', () => {
+    const result = detectNonCohortExposure({
+      accountId: 'random-account', env: nonCohortEnv,
+      heroSurfaceVisible: false, commandAccepted: false, readModelEnabled: false,
+    });
+    assert.equal(result.triggered, false);
+  });
+
+  it('does not trigger when no exposure signals are provided (backward compat)', () => {
+    const result = detectNonCohortExposure({ accountId: 'random-account', env: nonCohortEnv });
+    assert.equal(result.triggered, false);
+  });
+
+  it('triggers for excluded account with exposure signal', () => {
+    // Simulate excluded by using an env where the account resolves to 'none'
+    // (excluded status will be added in U3; for now 'none' covers the same branch)
     const env = {
       HERO_INTERNAL_ACCOUNTS: JSON.stringify(['int-1']),
       HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['ext-1']),
     };
-    const result = detectNonCohortExposure({ accountId: 'random-account', env });
+    const result = detectNonCohortExposure({
+      accountId: 'excluded-acc', env, heroSurfaceVisible: true,
+    });
     assert.equal(result.triggered, true);
-    assert.equal(result.condition, 'non-cohort-exposure');
-    assert.ok(result.detail.includes('random-account'));
+    assert.ok(result.detail.includes('excluded-acc'));
   });
 
-  it('does not trigger for internal cohort account', () => {
-    const env = { HERO_INTERNAL_ACCOUNTS: JSON.stringify(['acc-1']) };
-    const result = detectNonCohortExposure({ accountId: 'acc-1', env });
+  it('does not trigger when accountId is missing', () => {
+    const result = detectNonCohortExposure({ env: nonCohortEnv, heroSurfaceVisible: true });
     assert.equal(result.triggered, false);
   });
 
-  it('does not trigger for external cohort account', () => {
-    const env = { HERO_EXTERNAL_ACCOUNTS: JSON.stringify(['ext-1']) };
-    const result = detectNonCohortExposure({ accountId: 'ext-1', env });
+  it('does not trigger when env is missing', () => {
+    const result = detectNonCohortExposure({ accountId: 'acc-1', heroSurfaceVisible: true });
     assert.equal(result.triggered, false);
   });
 


### PR DESCRIPTION
## Summary
- **U1**: Fix Hero state storage wording, correct stale paths, reconcile test-count format, mark example evidence rows
- **U2**: Tighten detectNonCohortExposure to require observed exposure signals (eliminates false positives)
- **U3**: Extend rollout resolver with 6-way classification (emergency-off, excluded, rollout-bucket, global-default)

## Plan reference
Units U1, U2, U3 of docs/plans/2026-04-30-006-feat-hero-pA5-staged-default-on-plan.md

## Test plan
- [ ] No stale paths remain in pA4 docs
- [ ] Non-cohort + exposure signal → triggers stop condition
- [ ] Non-cohort + no exposure → does NOT trigger (false positive fix)
- [ ] Emergency-off overrides everything
- [ ] Excluded beats internal/external
- [ ] Rollout bucket deterministic and stable
- [ ] Malformed JSON/numbers fail closed
- [ ] All existing tests pass