### PR TITLE
docs(hero-pA5): U1 pre-A5 documentation clean-up

### DIFF
--- a/docs/plans/james/hero-mode/A/hero-pA4-external-cohort-evidence.md
+++ b/docs/plans/james/hero-mode/A/hero-pA4-external-cohort-evidence.md
@@ -35,7 +35,7 @@ One row per observation. Do not combine multiple signals into a single row. If t
 
 ## Provenance Values
 
-- `real-production` — observed in production via automated probe or manual verification against live D1/KV state
+- `real-production` — observed in production via automated probe or manual verification against live D1 child_game_state (system_id = 'hero-mode')
 - `operator-verified` — operator has independently confirmed the observation against a second source
 - `system-generated` — automatically produced by telemetry or monitoring infrastructure
 
@@ -53,7 +53,8 @@ Rows with provenance='real-production' count toward certification gates. Rows wi
 
 | Date | Source | Account | Learner | Signal | Value | Provenance | Confidence | Notes |
 |------|--------|---------|---------|--------|-------|------------|------------|-------|
-| 2026-05-01 | external-cohort | acct-example-001 | learner-A | daily-completion | 1 | real-production | high | Example row — replace with real observations |
+<!-- example row only, do not count -->
+| 2026-05-01 | external-cohort | acct-example-001 | learner-A | daily-completion | 1 | example-only | high | Example row — replace with real observations |
 
 *(Rows will be appended as real external cohort usage occurs during Ring A4-1.)*
 

--- a/docs/plans/james/hero-mode/A/hero-pA4-plan-completion-report.md
+++ b/docs/plans/james/hero-mode/A/hero-pA4-plan-completion-report.md
@@ -15,7 +15,7 @@ Hero Mode pA4 productionisation infrastructure is code-complete. The delivery im
 Key metrics:
 - 14 implementation units, all merged
 - 7 PRs: #743, #744, #745, #746, #747, #748, #749, #750
-- 503 new tests passing
+- pA4 focused local suite: 503 tests, 503 pass, 0 fail
 - 0 regression in existing test suite
 - 10/10 contract deliverables created
 - 13 stop condition guards automated
@@ -128,7 +128,7 @@ Key metrics:
 
 4. **Minimal runtime footprint**: Only `worker/src/app.js` and `shared/hero/account-override.js` were modified. All other delivery is additive scripts, tests, and documentation.
 
-5. **503 tests in 635ms**: Node.js built-in test runner keeps the full pA4 suite fast enough for CI feedback loops.
+5. **pA4 focused local suite: 503 tests, 503 pass, 0 fail** in 635ms: Node.js built-in test runner keeps the full pA4 suite fast enough for CI feedback loops.
 
 ---
 

--- a/docs/plans/james/hero-mode/A/hero-pA4-release-candidate.md
+++ b/docs/plans/james/hero-mode/A/hero-pA4-release-candidate.md
@@ -38,12 +38,12 @@ The following deliverables constitute the pA4 release candidate:
 | # | Deliverable | Location |
 |---|-------------|----------|
 | 1 | External cohort resolver (HERO_EXTERNAL_ACCOUNTS) | `shared/hero/account-override.js` |
-| 2 | Unified route integration with overrideStatus | `src/hero/routes/` |
+| 2 | Unified route integration with overrideStatus | `worker/src/hero/routes.js` |
 | 3 | 13 stop condition guards | `shared/hero/stop-conditions.js` |
 | 4 | 9 warning condition detectors | `shared/hero/warning-conditions.js` |
-| 5 | Metrics infrastructure (18 launch + 11 product + 10 safety) | `shared/hero/metrics/` |
-| 6 | Product signal analysis with reward farming detection | `shared/hero/product-metrics.js` |
-| 7 | Multi-day cohort simulation (8 accounts, 7 days) | `scripts/hero-pA4-cohort-simulation.mjs` |
+| 5 | Metrics infrastructure (18 launch + 11 product + 10 safety) | `shared/hero/product-signals.js` |
+| 6 | Product signal analysis with reward farming detection | `shared/hero/product-signals.js` |
+| 7 | Multi-day cohort simulation (8 accounts, 7 days) | `scripts/hero-pA4-external-cohort-smoke.mjs` |
 | 8 | Browser smoke validation script | `scripts/hero-pA4-external-cohort-smoke.mjs` |
 | 9 | Parent/adult explainer | `docs/plans/james/hero-mode/A/hero-pA4-parent-explainer.md` |
 | 10 | Support triage pack | `docs/plans/james/hero-mode/A/hero-pA4-support-pack.md` |


### PR DESCRIPTION
## Summary
- Fix Hero state storage wording to reference child_game_state (not KV)
- Replace stale file paths with actual codebase paths
- Convert test-count claims to named-suite format
- Mark example evidence rows to prevent false counting

## Plan reference
Unit U1 of docs/plans/2026-04-30-006-feat-hero-pA5-staged-default-on-plan.md

## Test plan
- [ ] No stale paths remain in pA4 docs
- [ ] No evidence template row has provenance `real-production` as an example
- [ ] State storage descriptions reference child_game_state