### PR TITLE
feat(ui-refactor-p3): U5 shared SubjectCompanionPanel

### DIFF
--- a/src/platform/ui/SubjectCompanionPanel.jsx
+++ b/src/platform/ui/SubjectCompanionPanel.jsx
@@ -1,0 +1,52 @@
+/* Platform SubjectCompanionPanel primitive (P3 U5).
+ *
+ * Display-only panel: monsters list, stats (dl/dt/dd), next-focus text.
+ * Props: subjectId, monsters [{name, discovered}], stats [{label, value, tone?}],
+ * nextFocus (string), emptyState (string). Stateless (R10): no store, no mastery writes.
+ */
+import { SectionHeader } from './SectionHeader.jsx';
+
+export function SubjectCompanionPanel({
+  subjectId,
+  monsters = [],
+  stats = [],
+  nextFocus = '',
+  emptyState = 'Nothing to show yet.',
+}) {
+  const hasContent = monsters.length > 0 || stats.length > 0;
+  if (!hasContent) {
+    return (
+      <aside className="companion-panel" data-subject={subjectId || 'unknown'} data-testid="companion-panel">
+        <p className="companion-panel-empty">{emptyState}</p>
+      </aside>
+    );
+  }
+  return (
+    <aside className="companion-panel" data-subject={subjectId || 'unknown'} data-testid="companion-panel">
+      {monsters.length > 0 ? (
+        <section className="companion-panel-monsters">
+          <SectionHeader title="Monsters" level={3} />
+          <ul className="companion-panel-monster-list">
+            {monsters.map((m) => (
+              <li key={m.name} data-discovered={m.discovered ? 'true' : 'false'}>{m.name}</li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+      {stats.length > 0 ? (
+        <section className="companion-panel-stats">
+          <SectionHeader title="Stats" level={3} />
+          <dl className="companion-panel-dl">
+            {stats.map((s) => (
+              <div key={s.label} className="companion-panel-stat" data-tone={s.tone || undefined}>
+                <dt>{s.label}</dt>
+                <dd>{s.value}</dd>
+              </div>
+            ))}
+          </dl>
+        </section>
+      ) : null}
+      {nextFocus ? <p className="companion-panel-focus">{nextFocus}</p> : null}
+    </aside>
+  );
+}

--- a/src/subjects/grammar/components/GrammarSetupScene.jsx
+++ b/src/subjects/grammar/components/GrammarSetupScene.jsx
@@ -22,6 +22,7 @@ import {
 } from './grammar-view-model.js';
 import { EmptyState } from '../../../platform/ui/EmptyState.jsx';
 import { Button } from '../../../platform/ui/Button.jsx';
+import { SubjectCompanionPanel } from '../../../platform/ui/SubjectCompanionPanel.jsx';
 
 /* Aligned Grammar setup scene.
  *
@@ -335,6 +336,20 @@ export function GrammarSetupScene({ learner, grammar, rewardState, actions, runt
                   </div>
                 )}
               </section>
+
+              <SubjectCompanionPanel
+                subjectId="grammar"
+                monsters={dashboard.monsterStrip.map((entry) => ({
+                  name: entry.name,
+                  discovered: entry.displayState !== 'not-found',
+                }))}
+                stats={(dashboard.todayCards || []).map((card) => ({
+                  label: card.label,
+                  value: String(card.value),
+                }))}
+                nextFocus={troubleCount > 0 ? 'Trouble concepts need revision' : ''}
+                emptyState="Start practising to see your Grammar companions."
+              />
             </>
           )}
           footer={(

--- a/src/subjects/punctuation/components/PunctuationSetupScene.jsx
+++ b/src/subjects/punctuation/components/PunctuationSetupScene.jsx
@@ -52,6 +52,7 @@ import { LengthPicker } from '../../../platform/ui/LengthPicker.jsx';
 import { Button } from '../../../platform/ui/Button.jsx';
 import { ProgressMeter } from '../../../platform/ui/ProgressMeter.jsx';
 import { StatCard } from '../../../platform/ui/StatCard.jsx';
+import { SubjectCompanionPanel } from '../../../platform/ui/SubjectCompanionPanel.jsx';
 
 // The 6 Phase 2 cluster mode ids + `guided` — the set that triggers the
 // one-shot stored-prefs migration. Local to this scene because the
@@ -426,6 +427,21 @@ export function PunctuationSetupScene({ ui, actions, prefs, stats, learner, rewa
                 />
               </div>
             </section>
+
+            <SubjectCompanionPanel
+              subjectId="punctuation"
+              monsters={dashboard.activeMonsters.map((m) => ({
+                name: punctuationMonsterDisplayName(m.id),
+                discovered: (m.displayStars ?? m.totalStars) > 0,
+              }))}
+              stats={[
+                { label: 'Due today', value: String(dueCount), tone: dueCount > 0 ? 'warn' : undefined },
+                { label: 'Wobbly', value: String(weakCount) },
+                { label: 'Grand Stars', value: String(grandStars) },
+              ]}
+              nextFocus={weakCount > 0 ? 'Wobbly spots need practice' : ''}
+              emptyState="Start practising to discover your first egg."
+            />
           </div>
         </section>
       </div>

--- a/src/subjects/spelling/components/SpellingSetupScene.jsx
+++ b/src/subjects/spelling/components/SpellingSetupScene.jsx
@@ -6,6 +6,7 @@ import { useSetupHeroContrast } from './useSetupHeroContrast.js';
 import { Button } from '../../../platform/ui/Button.jsx';
 import { LengthPicker } from '../../../platform/ui/LengthPicker.jsx';
 import { SetupSidePanel } from '../../../platform/ui/SetupSidePanel.jsx';
+import { SubjectCompanionPanel } from '../../../platform/ui/SubjectCompanionPanel.jsx';
 import { SubjectThemeScope } from '../../../platform/ui/SubjectThemeScope.jsx';
 import {
   BOSS_DEFAULT_ROUND_LENGTH,
@@ -491,6 +492,19 @@ export function SpellingSetupScene({
           <>
             <SetupMeadow codex={codex} repositories={repositories} />
             <SetupStatGrid stats={stats} />
+            <SubjectCompanionPanel
+              subjectId="spelling"
+              monsters={(Array.isArray(codex) ? codex : [])
+                .filter((e) => e?.progress?.caught)
+                .map((e) => ({ name: e.monster?.name || e.monster?.id || '?', discovered: true }))}
+              stats={[
+                { label: 'Secure', value: String(stats.secure ?? 0) },
+                { label: 'Due today', value: String(stats.due ?? 0), tone: 'warn' },
+                { label: 'Weak spots', value: String(stats.trouble ?? 0) },
+              ]}
+              nextFocus={stats.trouble > 0 ? 'Trouble words need attention' : ''}
+              emptyState="Catch your first monster to see companion info."
+            />
           </>
         )}
         footer={(

--- a/tests/ui-companion-panel-contract.test.js
+++ b/tests/ui-companion-panel-contract.test.js
@@ -1,0 +1,222 @@
+// U5 (ui-refactor-p3): SubjectCompanionPanel contract tests.
+//
+// Validates:
+//   - Empty monsters/stats → emptyState text rendered
+//   - Stats rendered with dl/dt/dd semantics
+//   - Unknown subjectId → safe render (no crash)
+//   - No mastery mutation (source check: no store imports)
+//   - SectionHeader adopted (import check)
+//   - 3-subject adoption gate (spelling, punctuation, grammar)
+//   - No forbidden copy patterns
+//
+// Pattern mirrors tests/platform-setup-side-panel.test.js — esbuild +
+// renderToStaticMarkup probe in a child process.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const componentSpec = path.join(rootDir, 'src/platform/ui/SubjectCompanionPanel.jsx');
+
+function nodePaths() {
+  return [
+    path.join(rootDir, 'node_modules'),
+    ...String(process.env.NODE_PATH || '').split(path.delimiter),
+  ].filter((entry) => entry && existsSync(entry));
+}
+
+function normaliseLineEndings(value) {
+  return String(value).replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+}
+
+async function runFixture(entrySource) {
+  const tmpDir = await mkdtemp(path.join(tmpdir(), 'ks2-companion-panel-'));
+  const entryPath = path.join(tmpDir, 'entry.jsx');
+  const bundlePath = path.join(tmpDir, 'entry.cjs');
+  try {
+    await writeFile(entryPath, entrySource);
+    await build({
+      absWorkingDir: rootDir,
+      entryPoints: [entryPath],
+      outfile: bundlePath,
+      bundle: true,
+      platform: 'node',
+      format: 'cjs',
+      target: ['node24'],
+      jsx: 'automatic',
+      jsxImportSource: 'react',
+      loader: { '.js': 'jsx' },
+      nodePaths: nodePaths(),
+      logLevel: 'silent',
+    });
+    const output = execFileSync(process.execPath, [bundlePath], {
+      cwd: rootDir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return normaliseLineEndings(output).replace(/\n+$/, '');
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
+function renderHeader() {
+  return `
+    const React = require('react');
+    const { renderToStaticMarkup } = require('react-dom/server');
+    const { SubjectCompanionPanel } = require(${JSON.stringify(componentSpec)});
+  `;
+}
+
+// ---------------------------------------------------------------
+// Empty state: no monsters, no stats → emptyState text rendered
+// ---------------------------------------------------------------
+
+test('SubjectCompanionPanel: empty monsters and stats renders emptyState text', async () => {
+  const html = await runFixture(`
+    ${renderHeader()}
+    const tree = React.createElement(SubjectCompanionPanel, {
+      subjectId: 'spelling',
+      monsters: [],
+      stats: [],
+      emptyState: 'Nothing here yet.',
+    });
+    console.log(renderToStaticMarkup(tree));
+  `);
+  assert.match(html, /Nothing here yet\./);
+  assert.match(html, /companion-panel-empty/);
+  assert.doesNotMatch(html, /<dl/);
+  assert.doesNotMatch(html, /<ul/);
+});
+
+// ---------------------------------------------------------------
+// Stats rendered with dl/dt/dd semantic markup
+// ---------------------------------------------------------------
+
+test('SubjectCompanionPanel: stats render as dl/dt/dd elements', async () => {
+  const html = await runFixture(`
+    ${renderHeader()}
+    const tree = React.createElement(SubjectCompanionPanel, {
+      subjectId: 'punctuation',
+      monsters: [],
+      stats: [
+        { label: 'Due', value: '5', tone: 'warn' },
+        { label: 'Secure', value: '20' },
+      ],
+    });
+    console.log(renderToStaticMarkup(tree));
+  `);
+  assert.match(html, /<dl class="companion-panel-dl">/);
+  assert.match(html, /<dt>Due<\/dt>/);
+  assert.match(html, /<dd>5<\/dd>/);
+  assert.match(html, /<dt>Secure<\/dt>/);
+  assert.match(html, /<dd>20<\/dd>/);
+  assert.match(html, /data-tone="warn"/);
+});
+
+// ---------------------------------------------------------------
+// Unknown subjectId → safe render (no crash)
+// ---------------------------------------------------------------
+
+test('SubjectCompanionPanel: unknown subjectId renders empty state without crash', async () => {
+  const html = await runFixture(`
+    ${renderHeader()}
+    const tree = React.createElement(SubjectCompanionPanel, {
+      subjectId: 'unknown-future-subject',
+      monsters: [],
+      stats: [],
+      emptyState: 'Coming soon.',
+    });
+    console.log(renderToStaticMarkup(tree));
+  `);
+  assert.match(html, /data-subject="unknown-future-subject"/);
+  assert.match(html, /Coming soon\./);
+});
+
+// ---------------------------------------------------------------
+// Monsters render as list items
+// ---------------------------------------------------------------
+
+test('SubjectCompanionPanel: monsters render as ul/li with discovered attribute', async () => {
+  const html = await runFixture(`
+    ${renderHeader()}
+    const tree = React.createElement(SubjectCompanionPanel, {
+      subjectId: 'grammar',
+      monsters: [
+        { name: 'Grammox', discovered: true },
+        { name: 'Syntaxon', discovered: false },
+      ],
+      stats: [],
+    });
+    console.log(renderToStaticMarkup(tree));
+  `);
+  assert.match(html, /<ul class="companion-panel-monster-list">/);
+  assert.match(html, /<li data-discovered="true">Grammox<\/li>/);
+  assert.match(html, /<li data-discovered="false">Syntaxon<\/li>/);
+});
+
+// ---------------------------------------------------------------
+// No mastery mutation: source file has no store imports
+// ---------------------------------------------------------------
+
+test('SubjectCompanionPanel: source has no mastery store imports (display-only)', () => {
+  const source = readFileSync(componentSpec, 'utf8');
+  // Must not import from any mastery/store/reward module
+  assert.doesNotMatch(source, /import.*from.*mastery/i);
+  assert.doesNotMatch(source, /import.*from.*store/i);
+  assert.doesNotMatch(source, /import.*from.*reward/i);
+  assert.doesNotMatch(source, /import.*from.*star/i);
+  assert.doesNotMatch(source, /dispatch/);
+  assert.doesNotMatch(source, /mutation/i);
+});
+
+// ---------------------------------------------------------------
+// SectionHeader adopted (import check)
+// ---------------------------------------------------------------
+
+test('SubjectCompanionPanel: imports SectionHeader from platform/ui', () => {
+  const source = readFileSync(componentSpec, 'utf8');
+  assert.match(source, /import.*SectionHeader.*from.*['"]\.\/SectionHeader/);
+});
+
+// ---------------------------------------------------------------
+// 3-subject adoption gate: spelling, punctuation, grammar
+// ---------------------------------------------------------------
+
+test('SubjectCompanionPanel: adopted by all three ready subjects', () => {
+  const spellingSource = readFileSync(
+    path.join(rootDir, 'src/subjects/spelling/components/SpellingSetupScene.jsx'),
+    'utf8',
+  );
+  const punctuationSource = readFileSync(
+    path.join(rootDir, 'src/subjects/punctuation/components/PunctuationSetupScene.jsx'),
+    'utf8',
+  );
+  const grammarSource = readFileSync(
+    path.join(rootDir, 'src/subjects/grammar/components/GrammarSetupScene.jsx'),
+    'utf8',
+  );
+  assert.match(spellingSource, /SubjectCompanionPanel/);
+  assert.match(punctuationSource, /SubjectCompanionPanel/);
+  assert.match(grammarSource, /SubjectCompanionPanel/);
+});
+
+// ---------------------------------------------------------------
+// No forbidden copy patterns
+// ---------------------------------------------------------------
+
+test('SubjectCompanionPanel: no forbidden copy patterns in source', () => {
+  const source = readFileSync(componentSpec, 'utf8');
+  // No hardcoded child-facing copy that could drift from the subject layer
+  assert.doesNotMatch(source, /well done/i);
+  assert.doesNotMatch(source, /congratulations/i);
+  assert.doesNotMatch(source, /amazing/i);
+  assert.doesNotMatch(source, /fantastic/i);
+});


### PR DESCRIPTION
## Summary
- Created `src/platform/ui/SubjectCompanionPanel.jsx` — 52-line display-only primitive rendering monster list (ul/li), stats (dl/dt/dd semantics), and next-focus text
- Adopted in all three ready subjects: Spelling, Punctuation, Grammar setup scenes
- Uses `SectionHeader` from `src/platform/ui/SectionHeader.jsx` for section headings
- No mastery/reward/store imports — pure display component

## Test plan
- [x] 8 contract tests pass (`tests/ui-companion-panel-contract.test.js`)
- [x] Empty state renders when no monsters/stats
- [x] Stats use semantic dl/dt/dd markup
- [x] Unknown subjectId renders safely (no crash)
- [x] Source-level no-mastery-import gate
- [x] SectionHeader import verified
- [x] 3-subject adoption gate (spelling, punctuation, grammar all import)
- [x] No forbidden child-facing copy patterns
- [x] Bundle at 230,488 B — under 232,000 B ceiling
- [x] Existing scene tests (168 punctuation, 6 spelling, 12 side-panel) all green