### PR TITLE
feat(hero-pA5): U4 emergency rollback route integration

### DIFF
--- a/worker/src/app.js
+++ b/worker/src/app.js
@@ -1437,6 +1437,26 @@ export function createWorkerApp({
           // so team accounts in HERO_INTERNAL_ACCOUNTS bypass global flag gates.
           // pA4 U2: unified resolver — also captures overrideStatus for ops output.
           const { resolvedEnv: heroCommandEnv, overrideStatus: heroCommandOverrideStatus } = resolveHeroFlagsForAccount({ env, accountId: session.accountId });
+
+          // pA5 U4: Emergency-off or excluded — reject command with 403.
+          // State remains dormant (no mutation, no deletion). Event logged for ops.
+          if (heroCommandOverrideStatus === 'emergency-off' || heroCommandOverrideStatus === 'excluded') {
+            try {
+              // eslint-disable-next-line no-console
+              console.log(JSON.stringify({
+                event: 'hero_command_blocked',
+                accountId: session.accountId,
+                overrideStatus: heroCommandOverrideStatus,
+              }));
+            } catch { /* best-effort */ }
+
+            // No overrideStatus, no account lists, no rollout salt in the response body.
+            return json({
+              error: 'hero-unavailable',
+              reason: heroCommandOverrideStatus === 'emergency-off' ? 'emergency-disabled' : 'account-excluded',
+            }, 403);
+          }
+
           if (!envFlagEnabled(heroCommandEnv.HERO_MODE_LAUNCH_ENABLED)) {
             throw new NotFoundError('Hero launch is not available.', {
               code: 'hero_launch_disabled',

--- a/worker/src/hero/routes.js
+++ b/worker/src/hero/routes.js
@@ -7,7 +7,7 @@
 import { json } from '../http.js';
 import { NotFoundError } from '../errors.js';
 import { buildHeroShadowReadModel } from './read-model.js';
-import { resolveHeroFlagsWithOverride } from '../../../shared/hero/account-override.js';
+import { resolveHeroFlagsForAccount } from '../../../shared/hero/account-override.js';
 
 function envFlagEnabled(value) {
   return ['1', 'true', 'yes', 'on'].includes(String(value || '').trim().toLowerCase());
@@ -40,7 +40,37 @@ export async function handleHeroReadModel({
   // 1. Apply per-account override before feature flag gate (pA2 #683 fix).
   //    Without this, internal cohort accounts with global flags OFF cannot
   //    access the read-model — the override only applied on command routes.
-  const resolvedEnv = resolveHeroFlagsWithOverride({ env, accountId: session.accountId });
+  //    pA5 U4: use full resolver to capture overrideStatus for emergency/excluded guard.
+  const { resolvedEnv, overrideStatus } = resolveHeroFlagsForAccount({ env, accountId: session.accountId });
+
+  // pA5 U4: Emergency-off or excluded — return empty/hidden Hero state.
+  // State remains dormant (no mutation, no deletion). Event logged for ops.
+  if (overrideStatus === 'emergency-off' || overrideStatus === 'excluded') {
+    try {
+      // eslint-disable-next-line no-console
+      console.log(JSON.stringify({
+        event: 'hero_read_model_blocked',
+        learnerId: url.searchParams.get('learnerId') || account.selected_learner_id || '',
+        accountId: session.accountId,
+        overrideStatus,
+      }));
+    } catch { /* best-effort */ }
+
+    // Return a valid response shape with Hero effectively hidden.
+    // No overrideStatus, no account lists, no rollout salt in the response.
+    return json({
+      ok: true,
+      hero: {
+        version: 6,
+        heroEnabled: false,
+        ui: { enabled: false },
+        dailyQuest: null,
+        activeHeroSession: null,
+        economy: null,
+        camp: null,
+      },
+    });
+  }
 
   if (!envFlagEnabled(resolvedEnv.HERO_MODE_SHADOW_ENABLED)) {
     throw new NotFoundError('Hero shadow read model is not available.', {


### PR DESCRIPTION
## Summary
- Emergency-off and excluded accounts now blocked at route level
- Read-model returns empty/hidden Hero state (no surfaces visible to child)
- Commands return 403 with machine-readable error code
- State preserved dormant (no deletion, no mutation)
- Event log records overrideStatus for ops observability

## Plan reference
Unit U4 of docs/plans/2026-04-30-006-feat-hero-pA5-staged-default-on-plan.md

## Test plan
- [ ] Emergency-off → read-model returns hidden state
- [ ] Emergency-off → command returns 403
- [ ] Excluded account → same behaviour
- [ ] State not mutated during rollback
- [ ] Event log includes overrideStatus
- [ ] Response body never contains overrideStatus/lists/salt