### PR TITLE
feat(ui-refactor-p3): U7 home dashboard hero perspective engine

### DIFF
--- a/src/platform/ui/HomeHeroScene.jsx
+++ b/src/platform/ui/HomeHeroScene.jsx
@@ -1,0 +1,65 @@
+/* Platform HomeHeroScene wrapper (P3 U7).
+ *
+ * Unifies subject cards, creature presence, and primary action into one
+ * scene contract. WRAPS existing children (subject card grid) — does NOT
+ * replace them. Display-only: no Hero/Camp/Coin economy copy introduced.
+ *
+ * Props:
+ *   - learner        {object}   Learner summary (name, id)
+ *   - readySubjects  {array}    Subject descriptors currently live
+ *   - todayFocus     {string?}  Optional focus label for the day
+ *   - creatureHighlights {array?} Decorative creature names (text-only)
+ *   - primaryAction  {object}   {label, dataAction, onClick}
+ *   - secondaryActions {array?} Additional action descriptors
+ *   - heroQuest      {object?}  Forward-compat slot (accepted, not consumed)
+ *   - children       React children (subject card grid)
+ */
+import { Button } from './Button.jsx';
+
+export function HomeHeroScene({
+  learner,
+  readySubjects,
+  todayFocus,
+  creatureHighlights,
+  primaryAction,
+  secondaryActions,
+  heroQuest, // forward-compat: accepted without changing card APIs
+  children,
+}) {
+  return (
+    <section className="home-hero-scene" data-scene="home-hero">
+      {todayFocus && (
+        <div className="home-hero-scene-focus" aria-live="polite">
+          {todayFocus}
+        </div>
+      )}
+      {creatureHighlights && creatureHighlights.length > 0 && (
+        <div className="home-hero-scene-creatures" aria-hidden="true">
+          {creatureHighlights.join(' · ')}
+        </div>
+      )}
+      <div className="home-hero-scene-actions">
+        <Button
+          variant="primary"
+          size="xl"
+          dataAction={primaryAction.dataAction}
+          onClick={primaryAction.onClick}
+        >
+          {primaryAction.label}
+        </Button>
+        {secondaryActions && secondaryActions.map((action, i) => (
+          <Button
+            key={action.dataAction || i}
+            variant="ghost"
+            size="xl"
+            dataAction={action.dataAction}
+            onClick={action.onClick}
+          >
+            {action.label}
+          </Button>
+        ))}
+      </div>
+      {children}
+    </section>
+  );
+}

--- a/src/surfaces/home/HomeSurface.jsx
+++ b/src/surfaces/home/HomeSurface.jsx
@@ -6,6 +6,7 @@ import { HeroQuestCard } from './HeroQuestCard.jsx';
 import { HeroCampPanel } from './HeroCampPanel.jsx';
 import { IconArrowRight } from './icons.jsx';
 import { Button } from '../../platform/ui/Button.jsx';
+import { HomeHeroScene } from '../../platform/ui/HomeHeroScene.jsx';
 import {
   buildMeadowMonsters,
   buildSubjectCards,
@@ -145,24 +146,38 @@ export function HomeSurface({ model, actions, shellClassName = 'app-shell' }) {
         </div>
       </div>
 
-      <div className="home-section-head">
-        <h2 className="section-title">Your subjects</h2>
-        {model.permissions?.canOpenParentHub && (
-          <button
-            type="button"
-            className="home-section-link"
-            onClick={actions.openParentHub}
-          >
-            Parent hub →
-          </button>
-        )}
-      </div>
+      <HomeHeroScene
+        learner={model.learner}
+        readySubjects={subjectCards}
+        todayFocus={recommendation ? `Today's best: ${recommendation.subjectName}` : undefined}
+        creatureHighlights={meadowMonsters.slice(0, 3).map((m) => m.name).filter(Boolean)}
+        primaryAction={{
+          label: ctaLabel,
+          dataAction: 'open-subject',
+          onClick: () => actions.openSubject(ctaSubjectId),
+        }}
+        secondaryActions={[{ label: 'Open codex', dataAction: 'open-codex', onClick: actions.openCodex }]}
+        heroQuest={hero}
+      >
+        <div className="home-section-head">
+          <h2 className="section-title">Your subjects</h2>
+          {model.permissions?.canOpenParentHub && (
+            <button
+              type="button"
+              className="home-section-link"
+              onClick={actions.openParentHub}
+            >
+              Parent hub →
+            </button>
+          )}
+        </div>
 
-      <div className="subject-grid">
-        {subjectCards.map((subject) => (
-          <SubjectCard key={subject.id} subject={subject} onOpen={actions.openSubject} />
-        ))}
-      </div>
+        <div className="subject-grid">
+          {subjectCards.map((subject) => (
+            <SubjectCard key={subject.id} subject={subject} onOpen={actions.openSubject} />
+          ))}
+        </div>
+      </HomeHeroScene>
     </div>
   );
 }

--- a/tests/ui-home-hero-scene-contract.test.js
+++ b/tests/ui-home-hero-scene-contract.test.js
@@ -1,0 +1,282 @@
+// U7 (ui-refactor-p3): HomeHeroScene contract tests.
+//
+// Validates:
+//   1. Children (subject cards) rendered unchanged inside the scene wrapper
+//   2. One primary action CTA rendered with data-action
+//   3. No Hero/Camp/Coin copy introduced (regex assertion)
+//   4. todayFocus optional — no crash when absent
+//   5. creatureHighlights optional — no crash when absent
+//   6. Forward-compat: heroQuest prop accepted without error
+//   7. data-action selectors preserved through HomeSurface adoption
+//
+// Pattern mirrors tests/ui-button-primitive.test.js — esbuild bundle +
+// renderToStaticMarkup probe in a child process.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const componentPath = path.join(rootDir, 'src/platform/ui/HomeHeroScene.jsx');
+
+function nodePaths() {
+  return [
+    path.join(rootDir, 'node_modules'),
+    ...String(process.env.NODE_PATH || '').split(path.delimiter),
+  ].filter((entry) => entry && existsSync(entry));
+}
+
+function normalise(value) {
+  return String(value).replace(/\r\n/g, '\n').replace(/\r/g, '\n').trim();
+}
+
+async function renderFixture(entrySource) {
+  const tmpDir = await mkdtemp(path.join(tmpdir(), 'ks2-home-hero-scene-'));
+  const entryPath = path.join(tmpDir, 'entry.jsx');
+  const bundlePath = path.join(tmpDir, 'entry.cjs');
+  try {
+    await writeFile(entryPath, entrySource);
+    await build({
+      absWorkingDir: rootDir,
+      entryPoints: [entryPath],
+      outfile: bundlePath,
+      bundle: true,
+      platform: 'node',
+      format: 'cjs',
+      target: ['node24'],
+      jsx: 'automatic',
+      jsxImportSource: 'react',
+      loader: { '.js': 'jsx' },
+      nodePaths: nodePaths(),
+      logLevel: 'silent',
+    });
+    const output = execFileSync(process.execPath, [bundlePath], {
+      cwd: rootDir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return normalise(output);
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
+function abs(rel) {
+  return JSON.stringify(path.join(rootDir, rel));
+}
+
+// ---------------------------------------------------------------
+// 1. Children rendered unchanged inside the scene wrapper
+// ---------------------------------------------------------------
+
+test('HomeHeroScene renders children (subject cards) unchanged inside the scene wrapper', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { HomeHeroScene } from ${abs('src/platform/ui/HomeHeroScene.jsx')};
+    const html = renderToStaticMarkup(
+      <HomeHeroScene
+        learner={{ name: 'Alice', id: 'a1' }}
+        readySubjects={[{ id: 'spelling', name: 'Spelling' }]}
+        primaryAction={{ label: 'Start Spelling', dataAction: 'open-subject', onClick: () => {} }}
+      >
+        <div className="subject-grid" data-action="open-subject" data-subject-id="spelling">
+          <span>Spelling Card</span>
+        </div>
+      </HomeHeroScene>
+    );
+    console.log(html);
+  `);
+  assert.match(html, /class="home-hero-scene"/, 'scene wrapper must render');
+  assert.match(html, /data-scene="home-hero"/, 'data-scene attribute preserved');
+  assert.match(html, /class="subject-grid"/, 'children subject-grid must render inside wrapper');
+  assert.match(html, /data-subject-id="spelling"/, 'data-subject-id preserved on children');
+  assert.match(html, /Spelling Card/, 'child content preserved');
+});
+
+// ---------------------------------------------------------------
+// 2. One primary action CTA rendered with data-action
+// ---------------------------------------------------------------
+
+test('HomeHeroScene renders one primary action button with correct data-action', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { HomeHeroScene } from ${abs('src/platform/ui/HomeHeroScene.jsx')};
+    const html = renderToStaticMarkup(
+      <HomeHeroScene
+        learner={{ name: 'Bob', id: 'b1' }}
+        readySubjects={[]}
+        primaryAction={{ label: 'Continue learning', dataAction: 'open-subject', onClick: () => {} }}
+      >
+        <div>cards</div>
+      </HomeHeroScene>
+    );
+    console.log(html);
+  `);
+  assert.match(html, /data-action="open-subject"/, 'primary action data-action attribute rendered');
+  assert.match(html, /Continue learning/, 'primary action label rendered');
+});
+
+// ---------------------------------------------------------------
+// 3. No Hero/Camp/Coin copy introduced
+// ---------------------------------------------------------------
+
+test('HomeHeroScene does not introduce Hero/Camp/Coin economy copy', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { HomeHeroScene } from ${abs('src/platform/ui/HomeHeroScene.jsx')};
+    const html = renderToStaticMarkup(
+      <HomeHeroScene
+        learner={{ name: 'Cai', id: 'c1' }}
+        readySubjects={[{ id: 'grammar', name: 'Grammar' }]}
+        todayFocus="Grammar practice"
+        creatureHighlights={['Sparky', 'Noodle']}
+        primaryAction={{ label: 'Start Grammar', dataAction: 'open-subject', onClick: () => {} }}
+        heroQuest={{ id: 'q1', status: 'active' }}
+      >
+        <div>subject cards</div>
+      </HomeHeroScene>
+    );
+    console.log(html);
+  `);
+  // Forbidden economy copy patterns
+  assert.doesNotMatch(html, /Hero Coin/i, 'must not introduce Hero Coin copy');
+  assert.doesNotMatch(html, /Hero Camp/i, 'must not introduce Hero Camp copy');
+  assert.doesNotMatch(html, /\bcoin(?:s)?\b/i, 'must not introduce coin copy');
+});
+
+// ---------------------------------------------------------------
+// 4. todayFocus optional — no crash when absent
+// ---------------------------------------------------------------
+
+test('HomeHeroScene renders without crash when todayFocus is absent', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { HomeHeroScene } from ${abs('src/platform/ui/HomeHeroScene.jsx')};
+    const html = renderToStaticMarkup(
+      <HomeHeroScene
+        learner={{ name: 'Dee', id: 'd1' }}
+        readySubjects={[]}
+        primaryAction={{ label: 'Go', dataAction: 'open-subject', onClick: () => {} }}
+      >
+        <div>cards</div>
+      </HomeHeroScene>
+    );
+    console.log(html);
+  `);
+  assert.match(html, /class="home-hero-scene"/, 'renders without todayFocus');
+  assert.doesNotMatch(html, /home-hero-scene-focus/, 'focus block not rendered when prop absent');
+});
+
+// ---------------------------------------------------------------
+// 5. creatureHighlights optional — no crash when absent
+// ---------------------------------------------------------------
+
+test('HomeHeroScene renders without crash when creatureHighlights is absent', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { HomeHeroScene } from ${abs('src/platform/ui/HomeHeroScene.jsx')};
+    const html = renderToStaticMarkup(
+      <HomeHeroScene
+        learner={{ name: 'Eve', id: 'e1' }}
+        readySubjects={[]}
+        primaryAction={{ label: 'Go', dataAction: 'open-subject', onClick: () => {} }}
+      >
+        <div>cards</div>
+      </HomeHeroScene>
+    );
+    console.log(html);
+  `);
+  assert.match(html, /class="home-hero-scene"/, 'renders without creatureHighlights');
+  assert.doesNotMatch(html, /home-hero-scene-creatures/, 'creatures block not rendered when prop absent');
+});
+
+// ---------------------------------------------------------------
+// 6. Forward-compat: heroQuest prop accepted without error
+// ---------------------------------------------------------------
+
+test('HomeHeroScene accepts heroQuest prop without error (forward-compat)', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { HomeHeroScene } from ${abs('src/platform/ui/HomeHeroScene.jsx')};
+    const html = renderToStaticMarkup(
+      <HomeHeroScene
+        learner={{ name: 'Fay', id: 'f1' }}
+        readySubjects={[]}
+        primaryAction={{ label: 'Go', dataAction: 'open-subject', onClick: () => {} }}
+        heroQuest={{ id: 'quest-99', status: 'active', taskId: 't1' }}
+      >
+        <div>cards</div>
+      </HomeHeroScene>
+    );
+    console.log(html);
+  `);
+  assert.match(html, /class="home-hero-scene"/, 'renders with heroQuest without error');
+});
+
+// ---------------------------------------------------------------
+// 7. data-action selectors preserved through HomeSurface adoption
+// ---------------------------------------------------------------
+
+test('HomeSurface wraps subject cards inside HomeHeroScene while preserving data-action selectors', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { HomeSurface } from ${abs('src/surfaces/home/HomeSurface.jsx')};
+    const model = {
+      learner: { name: 'Test', id: 'learner-1' },
+      subjects: [
+        { id: 'spelling', name: 'Spelling', blurb: 'Practice words', status: 'live', progress: 0.5 },
+      ],
+      dashboardStats: {},
+      monsterSummary: [],
+      theme: 'light',
+      now: new Date(2026, 3, 30, 10, 0),
+    };
+    const actions = {
+      toggleTheme() {},
+      navigateHome() {},
+      selectLearner() {},
+      openProfileSettings() {},
+      logout() {},
+      openSubject() {},
+      openCodex() {},
+      openParentHub() {},
+      openAdminHub() {},
+      refreshHeroQuest() {},
+    };
+    const html = renderToStaticMarkup(React.createElement(HomeSurface, { model, actions }));
+    console.log(html);
+  `);
+  assert.match(html, /data-scene="home-hero"/, 'HomeHeroScene wrapper present in HomeSurface output');
+  assert.match(html, /data-action="open-subject"/, 'data-action="open-subject" preserved');
+  assert.match(html, /data-subject-id="spelling"/, 'data-subject-id preserved on subject card');
+  assert.match(html, /class="subject-grid"/, 'subject-grid class preserved');
+});
+
+// ---------------------------------------------------------------
+// 8. Source: no Hero/Camp/Coin copy in HomeHeroScene.jsx
+// ---------------------------------------------------------------
+
+test('HomeHeroScene.jsx source does not contain Hero/Camp/Coin economy copy in executable code', () => {
+  const source = readFileSync(componentPath, 'utf8');
+  // Strip block + line comments so documentation describing the constraint
+  // does not trigger the regex. Mirrors the pattern in ui-button-primitive.test.js.
+  const codeOnly = source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/[^\n]*/g, '');
+  assert.doesNotMatch(codeOnly, /Hero Coin/i, 'executable code must not contain Hero Coin copy');
+  assert.doesNotMatch(codeOnly, /Hero Camp/i, 'executable code must not contain Hero Camp copy');
+  assert.doesNotMatch(codeOnly, /\bcoin(?:s)?\b/i, 'executable code must not contain coin copy');
+});


### PR DESCRIPTION
## Summary
- Create `HomeHeroScene` wrapper (`src/platform/ui/HomeHeroScene.jsx`, 65 lines) that unifies subject cards, creature presence, and primary action into one scene contract
- Wrap-not-replace: existing subject cards render as children unchanged, all data-action selectors preserved
- Adopt in `HomeSurface` around the subject-grid section with todayFocus, creatureHighlights, primaryAction, and forward-compatible heroQuest prop
- No Hero/Camp/Coin economy copy introduced; display-only

## Test plan
- [x] 8 contract tests pass (`tests/ui-home-hero-scene-contract.test.js`)
- [x] Children (subject cards) rendered unchanged inside scene wrapper
- [x] One primary action CTA with correct data-action
- [x] No Hero/Camp/Coin copy (regex on rendered HTML + source code)
- [x] todayFocus optional — no crash when absent
- [x] creatureHighlights optional — no crash when absent
- [x] Forward-compat: heroQuest prop accepted without error
- [x] HomeSurface adoption preserves data-action selectors
- [x] Existing `react-home-surface.test.js` (13 tests) still green — zero regression