### PR TITLE
feat(ui-refactor-p3): U8 admin visual asset and property diagnostics

### DIFF
--- a/src/surfaces/hubs/AdminHubSurface.jsx
+++ b/src/surfaces/hubs/AdminHubSurface.jsx
@@ -9,6 +9,7 @@ import { AdminDebuggingSection } from './AdminDebuggingSection.jsx';
 import { AdminContentSection } from './AdminContentSection.jsx';
 import { AdminMarketingSection } from './AdminMarketingSection.jsx';
 import { AdminBusinessSection } from './AdminBusinessSection.jsx';
+import { AdminVisualEngineSection } from './AdminVisualEngineSection.jsx';
 import { createAccountOpsMetadataDirtyRegistry } from '../../platform/hubs/admin-metadata-dirty-registry.js';
 import { shouldBlockSectionChange } from '../../platform/hubs/admin-section-guard.js';
 // U4+U5: AdminHubSurface is now a thin shell that renders:
@@ -180,6 +181,9 @@ export function AdminHubSurface({ appState, model, hubState = {}, accountDirecto
       )}
       {activeSection === 'business' && (
         <AdminBusinessSection {...sectionProps} />
+      )}
+      {activeSection === 'visual-engine' && (
+        <AdminVisualEngineSection />
       )}
     </>
   );

--- a/src/surfaces/hubs/AdminSectionTabs.jsx
+++ b/src/surfaces/hubs/AdminSectionTabs.jsx
@@ -17,6 +17,7 @@ export const ADMIN_SECTION_TABS = [
   { key: 'content', label: 'Content' },
   { key: 'marketing', label: 'Marketing' },
   { key: 'business', label: 'Business' },
+  { key: 'visual-engine', label: 'Visual Engine' },
 ];
 
 export function AdminSectionTabs({ activeSection = 'overview', onTabChange }) {

--- a/src/surfaces/hubs/AdminVisualEngineSection.jsx
+++ b/src/surfaces/hubs/AdminVisualEngineSection.jsx
@@ -1,0 +1,204 @@
+import React from 'react';
+import { AdminPanelFrame } from './AdminPanelFrame.jsx';
+import { SectionHeader } from '../../platform/ui/SectionHeader.jsx';
+import { SUBJECT_THEMES, SUBJECT_IDS } from '../../platform/ui/subject-themes.js';
+import { MONSTER_ASSET_MANIFEST } from '../../platform/game/monster-asset-manifest.js';
+import { BUNDLED_MONSTER_VISUAL_CONFIG, MONSTER_VISUAL_CONTEXTS, MONSTER_VISUAL_MOTION_PROFILE_OPTIONS } from '../../platform/game/monster-visual-config.js';
+import { MONSTERS, MONSTERS_BY_SUBJECT } from '../../platform/game/monsters.js';
+
+// U8: Read-only diagnostic panel for admin inspection of subject theme tokens,
+// monster asset availability, and visual engine configuration.
+// NO production write endpoints — diagnostic display only.
+
+function detectPlaceholderAssets(manifest) {
+  // Assets with sizes array containing only 320 and no real srcBySize entries
+  // or where the path references a lean/placeholder stub are flagged as
+  // "placeholder" (info-level), never as "broken" (error-level).
+  const results = [];
+  for (const asset of manifest.assets) {
+    const hasSrc = asset.srcBySize && Object.keys(asset.srcBySize).length > 0;
+    const isPlaceholder = !hasSrc || asset.placeholder === true;
+    if (isPlaceholder) {
+      results.push({ key: asset.key, status: 'placeholder' });
+    }
+  }
+  return results;
+}
+
+function detectMissingAltText(manifest) {
+  // Monster assets that lack an alt text mapping
+  return manifest.assets
+    .filter((a) => !a.alt && !MONSTERS[a.monsterId]?.name)
+    .map((a) => a.key);
+}
+
+function getMotionProfiles() {
+  const profiles = new Map();
+  const config = BUNDLED_MONSTER_VISUAL_CONFIG;
+  for (const [assetKey, entry] of Object.entries(config.assets)) {
+    for (const ctx of MONSTER_VISUAL_CONTEXTS) {
+      const profile = entry.contexts?.[ctx]?.motionProfile;
+      if (profile && profile !== 'still') {
+        if (!profiles.has(profile)) profiles.set(profile, []);
+        profiles.get(profile).push(`${assetKey}/${ctx}`);
+      }
+    }
+  }
+  return profiles;
+}
+
+export function AdminVisualEngineSection() {
+  const placeholders = detectPlaceholderAssets(MONSTER_ASSET_MANIFEST);
+  const missingAlt = detectMissingAltText(MONSTER_ASSET_MANIFEST);
+  const motionProfiles = getMotionProfiles();
+  const totalAssets = MONSTER_ASSET_MANIFEST.assets.length;
+
+  return (
+    <AdminPanelFrame
+      eyebrow="Visual Engine"
+      title="Asset & Property Diagnostics"
+      subtitle="Read-only inspection of theme tokens, monster assets, and visual configuration."
+      data={SUBJECT_IDS}
+      refreshedAt={Date.now()}
+    >
+      {/* Subject Theme Tokens */}
+      <SectionHeader
+        eyebrow="Theme Registry"
+        title="Subject Theme Tokens"
+        level={3}
+        data-testid="section-subject-themes"
+      />
+      <table className="admin-table" data-testid="theme-tokens-table">
+        <thead>
+          <tr>
+            <th>Subject</th>
+            <th>Accent</th>
+            <th>Ink</th>
+            <th>Soft</th>
+            <th>Border</th>
+          </tr>
+        </thead>
+        <tbody>
+          {SUBJECT_IDS.map((id) => {
+            const theme = SUBJECT_THEMES[id];
+            return (
+              <tr key={id} data-subject={id}>
+                <td><strong>{id}</strong></td>
+                <td><code>{theme.accent}</code></td>
+                <td><code>{theme.accentInk}</code></td>
+                <td><code>{theme.accentSoft}</code></td>
+                <td><code>{theme.accentBorder}</code></td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+
+      {/* Monster Asset Availability */}
+      <SectionHeader
+        eyebrow="Monster System"
+        title="Asset Availability"
+        level={3}
+        statusChip={<span className="chip good">{totalAssets} assets</span>}
+        data-testid="section-monster-assets"
+      />
+      <div data-testid="monster-availability">
+        {Object.entries(MONSTERS_BY_SUBJECT).map(([subjectKey, monsterIds]) => (
+          <div key={subjectKey} style={{ marginBottom: 12 }}>
+            <strong>{subjectKey}:</strong>{' '}
+            {monsterIds.map((mId) => (
+              <span key={mId} className="chip" style={{ marginRight: 4 }}>
+                {MONSTERS[mId]?.name || mId}
+              </span>
+            ))}
+          </div>
+        ))}
+      </div>
+
+      {/* Placeholder Detection */}
+      <SectionHeader
+        eyebrow="Asset Health"
+        title="Placeholder Detection"
+        level={3}
+        statusChip={
+          placeholders.length > 0
+            ? <span className="chip" data-severity="info">{placeholders.length} placeholder(s)</span>
+            : <span className="chip good">All assets present</span>
+        }
+        data-testid="section-placeholders"
+      />
+      {placeholders.length > 0 ? (
+        <ul data-testid="placeholder-list">
+          {placeholders.map((p) => (
+            <li key={p.key}>
+              <code>{p.key}</code>{' '}
+              <span className="chip" data-severity="info" data-status="placeholder">placeholder</span>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p>No placeholder assets detected in the current manifest.</p>
+      )}
+
+      {/* Background / Stage Assignments */}
+      <SectionHeader
+        eyebrow="Visual Contexts"
+        title="Background & Stage Assignments"
+        level={3}
+        data-testid="section-stage-assignments"
+      />
+      <div data-testid="visual-contexts">
+        <p><strong>Registered contexts:</strong>{' '}
+          {MONSTER_VISUAL_CONTEXTS.map((ctx) => (
+            <span key={ctx} className="chip" style={{ marginRight: 4 }}>{ctx}</span>
+          ))}
+        </p>
+        <p><strong>Config source:</strong> {BUNDLED_MONSTER_VISUAL_CONFIG.source}</p>
+        <p><strong>Schema version:</strong> {BUNDLED_MONSTER_VISUAL_CONFIG.schemaVersion}</p>
+        <p><strong>Manifest hash:</strong> <code>{BUNDLED_MONSTER_VISUAL_CONFIG.manifestHash}</code></p>
+      </div>
+
+      {/* Motion Profiles */}
+      <SectionHeader
+        eyebrow="Animation"
+        title="Motion Profiles"
+        level={3}
+        statusChip={<span className="chip">{motionProfiles.size} active profile(s)</span>}
+        data-testid="section-motion-profiles"
+      />
+      <div data-testid="motion-profiles">
+        {MONSTER_VISUAL_MOTION_PROFILE_OPTIONS.map((profile) => (
+          <div key={profile} style={{ marginBottom: 4 }}>
+            <code>{profile}</code>:{' '}
+            {motionProfiles.has(profile)
+              ? <span className="chip">{motionProfiles.get(profile).length} binding(s)</span>
+              : <span className="chip" style={{ opacity: 0.5 }}>unused</span>
+            }
+          </div>
+        ))}
+      </div>
+
+      {/* Missing Alt Text Warnings */}
+      <SectionHeader
+        eyebrow="Accessibility"
+        title="Missing Alt Text"
+        level={3}
+        statusChip={
+          missingAlt.length > 0
+            ? <span className="chip bad">{missingAlt.length} missing</span>
+            : <span className="chip good">All covered</span>
+        }
+        data-testid="section-alt-text"
+      />
+      {missingAlt.length > 0 ? (
+        <ul data-testid="missing-alt-list">
+          {missingAlt.map((key) => (
+            <li key={key}><code>{key}</code> — no alt text source</li>
+          ))}
+        </ul>
+      ) : (
+        <p>All monster assets have alt text coverage via the MONSTERS registry.</p>
+      )}
+    </AdminPanelFrame>
+  );
+}

--- a/tests/admin-visual-engine-diagnostics.test.js
+++ b/tests/admin-visual-engine-diagnostics.test.js
@@ -1,0 +1,241 @@
+// U8 — Admin Visual Engine diagnostics panel characterisation tests.
+//
+// Validates:
+//   1. All 6 subjects displayed with accent values
+//   2. Read-only (no write endpoints, no mutation)
+//   3. Placeholder reported as "placeholder" not "broken"
+//   4. SectionHeader adopted
+//   5. Section renders within admin hub tab registry
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function nodePaths() {
+  return [
+    path.join(rootDir, 'node_modules'),
+    ...String(process.env.NODE_PATH || '').split(path.delimiter),
+  ].filter((entry) => entry && existsSync(entry));
+}
+
+async function renderFixture(entrySource) {
+  const tmpDir = await mkdtemp(path.join(tmpdir(), 'ks2-admin-visual-'));
+  const entryPath = path.join(tmpDir, 'entry.jsx');
+  const bundlePath = path.join(tmpDir, 'entry.cjs');
+  try {
+    await writeFile(entryPath, entrySource);
+    await build({
+      absWorkingDir: rootDir,
+      entryPoints: [entryPath],
+      outfile: bundlePath,
+      bundle: true,
+      platform: 'node',
+      format: 'cjs',
+      target: ['node24'],
+      jsx: 'automatic',
+      jsxImportSource: 'react',
+      loader: { '.js': 'jsx' },
+      nodePaths: nodePaths(),
+      logLevel: 'silent',
+    });
+    return execFileSync(process.execPath, [bundlePath], {
+      cwd: rootDir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
+function absoluteSpecifier(relativePath) {
+  return JSON.stringify(path.join(rootDir, relativePath));
+}
+
+// ---------- Test 1: All 6 subjects rendered with accent values ---------- //
+
+test('AdminVisualEngineSection renders all 6 subject theme tokens with accent values', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { AdminVisualEngineSection } from ${absoluteSpecifier('src/surfaces/hubs/AdminVisualEngineSection.jsx')};
+    const markup = renderToStaticMarkup(React.createElement(AdminVisualEngineSection));
+    console.log(markup);
+  `);
+
+  // All 6 subject IDs must appear
+  const subjects = ['spelling', 'grammar', 'punctuation', 'reading', 'reasoning', 'arithmetic'];
+  for (const subject of subjects) {
+    assert.ok(
+      html.includes(`data-subject="${subject}"`),
+      `Expected subject "${subject}" to appear in rendered output`
+    );
+  }
+
+  // Accent values must appear
+  const accents = ['#3E6FA8', '#7e5bb6', '#B8873F', '#4B7A4A', '#8A5A9D', '#C06B3E'];
+  for (const accent of accents) {
+    assert.ok(
+      html.includes(accent),
+      `Expected accent "${accent}" to appear in rendered output`
+    );
+  }
+});
+
+// ---------- Test 2: Read-only — no write endpoints, no mutation ---------- //
+
+test('AdminVisualEngineSection contains no form elements, buttons, or mutation handlers', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { AdminVisualEngineSection } from ${absoluteSpecifier('src/surfaces/hubs/AdminVisualEngineSection.jsx')};
+    const markup = renderToStaticMarkup(React.createElement(AdminVisualEngineSection));
+    console.log(markup);
+  `);
+
+  // No form elements that imply write capability
+  assert.ok(!html.includes('<form'), 'Should not contain <form> elements');
+  assert.ok(!html.includes('<input'), 'Should not contain <input> elements');
+  assert.ok(!html.includes('<textarea'), 'Should not contain <textarea> elements');
+  // No onClick handlers in the rendered body content (buttons in AdminPanelFrame header are OK)
+  // The section body should be purely display-oriented
+  assert.ok(!html.includes('onSubmit'), 'Should not contain onSubmit handlers');
+});
+
+// ---------- Test 3: Placeholder reported as "placeholder" not "broken" ---------- //
+
+test('AdminVisualEngineSection reports placeholder assets with info severity not error', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { AdminVisualEngineSection } from ${absoluteSpecifier('src/surfaces/hubs/AdminVisualEngineSection.jsx')};
+    const markup = renderToStaticMarkup(React.createElement(AdminVisualEngineSection));
+    console.log(markup);
+  `);
+
+  // If any placeholders exist, they must use severity="info" and status="placeholder"
+  // Either way, the word "broken" must NEVER appear as a status
+  assert.ok(!html.includes('data-status="broken"'), 'Should never report assets as "broken"');
+  assert.ok(!html.includes('data-severity="error"'), 'Should never use error severity for placeholders');
+
+  // If placeholder text is present, it must be info-level
+  if (html.includes('data-status="placeholder"')) {
+    assert.ok(
+      html.includes('data-severity="info"'),
+      'Placeholder assets must use info severity'
+    );
+  }
+});
+
+// ---------- Test 4: SectionHeader adopted ---------- //
+
+test('AdminVisualEngineSection uses SectionHeader primitive for diagnostic categories', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { AdminVisualEngineSection } from ${absoluteSpecifier('src/surfaces/hubs/AdminVisualEngineSection.jsx')};
+    const markup = renderToStaticMarkup(React.createElement(AdminVisualEngineSection));
+    console.log(markup);
+  `);
+
+  // SectionHeader renders <header class="section-header"> with h3 elements
+  assert.ok(
+    html.includes('class="section-header"'),
+    'Expected SectionHeader class in rendered output'
+  );
+
+  // Multiple section headers for each diagnostic category
+  const sectionTestIds = [
+    'section-subject-themes',
+    'section-monster-assets',
+    'section-placeholders',
+    'section-stage-assignments',
+    'section-motion-profiles',
+    'section-alt-text',
+  ];
+  for (const testId of sectionTestIds) {
+    assert.ok(
+      html.includes(`data-testid="${testId}"`),
+      `Expected SectionHeader with data-testid="${testId}"`
+    );
+  }
+});
+
+// ---------- Test 5: Section renders within admin hub tab registry ---------- //
+
+test('Visual Engine tab is registered in ADMIN_SECTION_TABS', async () => {
+  const output = await renderFixture(`
+    import { ADMIN_SECTION_TABS } from ${absoluteSpecifier('src/surfaces/hubs/AdminSectionTabs.jsx')};
+    const visualTab = ADMIN_SECTION_TABS.find((t) => t.key === 'visual-engine');
+    console.log(JSON.stringify(visualTab));
+  `);
+  const visualTab = JSON.parse(output.trim());
+  assert.ok(visualTab, 'Expected "visual-engine" tab in ADMIN_SECTION_TABS');
+  assert.equal(visualTab.key, 'visual-engine');
+  assert.equal(visualTab.label, 'Visual Engine');
+});
+
+// ---------- Test 6: Monster visual contexts are displayed ---------- //
+
+test('AdminVisualEngineSection displays all registered visual contexts', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { AdminVisualEngineSection } from ${absoluteSpecifier('src/surfaces/hubs/AdminVisualEngineSection.jsx')};
+    const markup = renderToStaticMarkup(React.createElement(AdminVisualEngineSection));
+    console.log(markup);
+  `);
+
+  const contexts = ['meadow', 'codexCard', 'codexFeature', 'lightbox', 'celebrationOverlay', 'toastPortrait'];
+  for (const ctx of contexts) {
+    assert.ok(
+      html.includes(ctx),
+      `Expected visual context "${ctx}" in rendered output`
+    );
+  }
+});
+
+// ---------- Test 7: Motion profiles section is present ---------- //
+
+test('AdminVisualEngineSection displays motion profile options', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { AdminVisualEngineSection } from ${absoluteSpecifier('src/surfaces/hubs/AdminVisualEngineSection.jsx')};
+    const markup = renderToStaticMarkup(React.createElement(AdminVisualEngineSection));
+    console.log(markup);
+  `);
+
+  const profiles = ['still', 'egg-breathe', 'walk', 'walk-b', 'fly-a', 'fly-b'];
+  for (const profile of profiles) {
+    assert.ok(
+      html.includes(profile),
+      `Expected motion profile "${profile}" in rendered output`
+    );
+  }
+});
+
+// ---------- Test 8: AdminPanelFrame wraps the section ---------- //
+
+test('AdminVisualEngineSection is wrapped in AdminPanelFrame', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { AdminVisualEngineSection } from ${absoluteSpecifier('src/surfaces/hubs/AdminVisualEngineSection.jsx')};
+    const markup = renderToStaticMarkup(React.createElement(AdminVisualEngineSection));
+    console.log(markup);
+  `);
+
+  // AdminPanelFrame renders with data-panel-frame attribute
+  assert.ok(
+    html.includes('data-panel-frame="Asset &amp; Property Diagnostics"'),
+    'Expected AdminPanelFrame wrapper with panel title'
+  );
+});


### PR DESCRIPTION
## Summary
- Adds read-only `AdminVisualEngineSection` diagnostic panel displaying subject theme tokens (all 6 subjects), monster asset availability, placeholder detection (info-level, not error), background/stage assignments, motion profiles, and missing alt text warnings
- Registers "Visual Engine" tab in `AdminSectionTabs` and wires it into `AdminHubSurface`
- Uses `SectionHeader` primitive (contributes to 3-adopter gate) and `AdminPanelFrame` wrapper
- Imports from `subject-themes.js`, `monster-asset-manifest.js`, and `monster-visual-config.js` — no production write endpoints

## Test plan
- [x] 8 characterisation tests passing (esbuild SSR render pattern)
- [x] All 6 subjects displayed with accent values
- [x] Read-only verified (no form/input/textarea/onSubmit in rendered output)
- [x] Placeholder assets reported as "placeholder" (info), never "broken" (error)
- [x] SectionHeader adopted with 6 diagnostic category headers
- [x] Visual Engine tab registered in ADMIN_SECTION_TABS
- [x] AdminPanelFrame wraps the section
- [x] Motion profiles and visual contexts displayed