### PR TITLE
fix(hero-pA5): security findings — generic 403, strip debug

### DIFF
--- a/worker/src/app.js
+++ b/worker/src/app.js
@@ -1451,10 +1451,7 @@ export function createWorkerApp({
             } catch { /* best-effort */ }
 
             // No overrideStatus, no account lists, no rollout salt in the response body.
-            return json({
-              error: 'hero-unavailable',
-              reason: heroCommandOverrideStatus === 'emergency-off' ? 'emergency-disabled' : 'account-excluded',
-            }, 403);
+            return json({ error: 'hero-unavailable' }, 403);
           }
 
           if (!envFlagEnabled(heroCommandEnv.HERO_MODE_LAUNCH_ENABLED)) {

--- a/worker/src/hero/routes.js
+++ b/worker/src/hero/routes.js
@@ -131,9 +131,9 @@ export async function handleHeroReadModel({
   } catch { /* best-effort */ }
 
   // Strip debug block from the child-visible response — debug data is
-  // useful for shadow/internal diagnostics but must not leak to the child browser.
+  // only available via operator scripts / event_log, never over HTTP.
   const { debug, ...safeResult } = result;
-  const responseHero = envFlagEnabled(resolvedEnv.HERO_MODE_CHILD_UI_ENABLED) ? safeResult : result;
+  const responseHero = safeResult;
 
   return json({ ok: true, hero: responseHero });
 }


### PR DESCRIPTION
## Summary
- 403 command rejection now returns generic `{ error: 'hero-unavailable' }` for all blocked accounts
- Read-model response always uses stripped/safe result (no debug data to any client)
- Fixes §6.1 child-privacy requirement

## Security findings addressed
1. Response no longer distinguishes emergency-disabled from account-excluded
2. Debug diagnostics never sent to child in any mode

## Test plan
- [ ] 403 response is generic (no reason field)
- [ ] Read-model never includes debug data
- [ ] All existing tests pass