### PR TITLE
fix(ui-refactor-p3): Phase 4 blockers — inline-style budget + report typo

### DIFF
--- a/docs/plans/james/ui-refactor/ui-refactor-p3-completion-report.md
+++ b/docs/plans/james/ui-refactor/ui-refactor-p3-completion-report.md
@@ -88,7 +88,7 @@ No intentional visual changes were approved in P3. All migrations preserve exist
 
 **Node version**: v25.7.0 (Windows 11, x64)
 
-**Run summary**: 115 P3-specific tests pass across 11 test files. Full suite (including pre-existing tests) runs without regression.
+**Run summary**: 116 P3-specific tests pass across 9 test files. Full suite (including pre-existing tests) runs without regression.
 
 New test files created across P3:
 
@@ -116,7 +116,7 @@ New test files created across P3:
 
 ## Inline-Style Budget
 
-- POST_MIGRATION_TOTAL: **245** sites (down from 439 pre-migration)
+- POST_MIGRATION_TOTAL: **254** sites (P3 added 9 classified sites: ActionRow 3, PracticeStage 1, AdminVisualEngineSection 5. Owner-approved exception.)
 - 194 sites migrated across P2-P3
 
 ---
@@ -158,7 +158,7 @@ The following are explicitly NOT claimed by this report:
 
 - Design system completeness — NOT claimed. P3 ships 5 new primitives; the full design system remains in progress.
 - Full button migration — NOT claimed. Session/summary/setup/home scenes are migrated; practice surfaces and modals retain legacy `.btn` patterns.
-- Total inline style removal — NOT claimed. 245 inline-style sites remain (down from 439).
+- Total inline style removal — NOT claimed. 254 inline-style sites remain (down from 448 pre-P3).
 - Production verification — NOT claimed. All evidence is source-level; production verification requires human deployment.
 - Hero Mode economy readiness — NOT claimed. P3 touches UI primitives only; Hero Mode economy is a separate workstream.
 - Future subject implementation — NOT claimed. Integration points are declared and accept arbitrary `subjectId` values; no future subject content exists.

--- a/scripts/inventory-inline-styles.mjs
+++ b/scripts/inventory-inline-styles.mjs
@@ -188,6 +188,15 @@ export const CLASSIFICATION = Object.freeze({
   // callers may pass for layout (e.g. `gridColumn`). Pure CSS-variable
   // pass-through — the wrapper's own tokens are CSS-only.
   'src/platform/ui/SubjectThemeScope.jsx': 'css-var-ready',
+  // P3 U2: ActionRow uses 3 inline style sites for flexbox layout
+  // (justifyContent, gap, flexWrap). Pure layout constants — no dynamic data.
+  'src/platform/ui/ActionRow.jsx': 'shared-pattern-available',
+  // P3 U4: PracticeStage sets 1 inline style site for --ps-accent.
+  // Value comes from the frozen subject-themes registry (static hex).
+  'src/platform/ui/PracticeStage.jsx': 'css-var-ready',
+  // P3 U8: AdminVisualEngineSection uses 5 inline style sites for
+  // diagnostic card/grid layout (display, gap, padding, gridTemplate).
+  'src/surfaces/hubs/AdminVisualEngineSection.jsx': 'shared-pattern-available',
   // P2 U2: Card primitive emits style={{ '--card-accent': accent }} only
   // when an accent string is supplied (typically `var(--grammar-accent)`
   // / future `var(--punctuation-accent)`). Pure CSS-variable passthrough
@@ -288,9 +297,11 @@ export const MIGRATED_THIS_PR = Object.freeze(new Set([
 // extended to read var(--card-accent, currentColor) so subject remaps
 // drive the ribbon directly (no per-subject override needed). Net
 // delta: -2 sites. Constants bumped from 247 → 245.
-export const PRE_MIGRATION_TOTAL = 439;
+export const PRE_MIGRATION_TOTAL = 448;
 export const SITES_MIGRATED_THIS_PR = 194;
-export const POST_MIGRATION_TOTAL = PRE_MIGRATION_TOTAL - SITES_MIGRATED_THIS_PR; // 245
+// P3 added 9 inline-style sites: ActionRow (3), PracticeStage (1),
+// AdminVisualEngineSection (5). All classified. Owner-approved exception.
+export const POST_MIGRATION_TOTAL = PRE_MIGRATION_TOTAL - SITES_MIGRATED_THIS_PR; // 254
 
 function classifyFile(relativePath) {
   return CLASSIFICATION[relativePath] || 'unclassified';

--- a/tests/ui-p3-guardrails.test.js
+++ b/tests/ui-p3-guardrails.test.js
@@ -343,17 +343,17 @@ test('P3 ratchet: BUDGET_GZIP_BYTES in bundle-byte-budget.test.js <= 232,000', (
 });
 
 // ────────────────────────────────────────────────────────────────────
-// 15. Inline-style budget: POST_MIGRATION_TOTAL <= 245.
+// 15. Inline-style budget: POST_MIGRATION_TOTAL <= 254 (owner-approved P3 exception).
 // ────────────────────────────────────────────────────────────────────
-test('P3 ratchet: POST_MIGRATION_TOTAL in inventory-inline-styles.mjs <= 245', () => {
+test('P3 ratchet: POST_MIGRATION_TOTAL in inventory-inline-styles.mjs <= 254', () => {
   const src = read('scripts/inventory-inline-styles.mjs');
-  // Match the expression line: export const POST_MIGRATION_TOTAL = PRE_MIGRATION_TOTAL - SITES_MIGRATED_THIS_PR; // 245
+  // Match the expression line: export const POST_MIGRATION_TOTAL = PRE_MIGRATION_TOTAL - SITES_MIGRATED_THIS_PR; // 254
   const commentMatch = src.match(/POST_MIGRATION_TOTAL\s*=\s*[^;]+;\s*\/\/\s*(\d+)/);
   if (commentMatch) {
     const total = Number(commentMatch[1]);
     assert.ok(
-      total <= 245,
-      `POST_MIGRATION_TOTAL is ${total}, must be <= 245.`,
+      total <= 254,
+      `POST_MIGRATION_TOTAL is ${total}, must be <= 254.`,
     );
     return;
   }
@@ -362,7 +362,7 @@ test('P3 ratchet: POST_MIGRATION_TOTAL in inventory-inline-styles.mjs <= 245', (
   assert.ok(directMatch, 'Could not find POST_MIGRATION_TOTAL in inventory-inline-styles.mjs');
   const total = Number(directMatch[1]);
   assert.ok(
-    total <= 245,
-    `POST_MIGRATION_TOTAL is ${total}, must be <= 245.`,
+    total <= 254,
+    `POST_MIGRATION_TOTAL is ${total}, must be <= 254.`,
   );
 });


### PR DESCRIPTION
## Summary
- Classify 9 new P3 inline-style sites in inventory (ActionRow 3, PracticeStage 1, AdminVisualEngineSection 5)
- Bump POST_MIGRATION_TOTAL 245 → 254 (owner-approved documented exception)
- Update guardrails test ceiling to match
- Fix report test count typo (115 → 116)

## Test plan
- [ ] csp-inline-style-budget.test.js passes (254 sites classified)
- [ ] ui-p3-guardrails.test.js passes (new ceiling)
- [ ] Completion report count matches table