### PR TITLE
fix(grammar): align display stages with monster assets

### DIFF
--- a/shared/grammar/grammar-stars.js
+++ b/shared/grammar/grammar-stars.js
@@ -31,9 +31,9 @@ export const GRAMMAR_MONSTER_STAR_MAX = 100;
 export const GRAMMAR_GRAND_STAR_MODEL_VERSION = 2;
 
 /**
- * Named stage thresholds. Internal stage 0-4 uses egg/hatch/evolve3/mega.
- * Display stage 0-5 uses all six. See grammarStarStageFor and
- * grammarStarDisplayStage for the mapping.
+ * Named stage thresholds. Asset stage 0-4 uses egg/hatch/evolve/strong/mega.
+ * Display stage 0-5 includes the hidden not-found state. See
+ * grammarStarStageFor and grammarStarDisplayStage for the mapping.
  */
 export const GRAMMAR_STAR_STAGE_THRESHOLDS = Object.freeze({
   egg: 1,
@@ -415,14 +415,14 @@ export function grammarStarNextMilestone(displayStage) {
 // ---------------------------------------------------------------------------
 
 /**
- * Maps Stars to internal stage 0-4 for compatibility with the existing
- * monster system (stages 0 = not found, 1 = egg, 2 = hatch/growing,
- * 3 = nearly mega, 4 = mega).
+ * Maps Stars to asset stage 0-4 for compatibility with monster webp assets.
+ * Stage 0 is the egg asset; 0 Stars are hidden by displayState='not-found'.
  *
  * Stage mapping:
- *   0 Stars        → 0 (Not found)
- *   1-14 Stars     → 1 (Egg found)
- *   15-64 Stars    → 2 (Hatched / Growing)
+ *   0 Stars        → 0 (hidden by display state; do not render as egg)
+ *   1-14 Stars     → 0 (Egg found)
+ *   15-34 Stars    → 1 (Hatched)
+ *   35-64 Stars    → 2 (Growing)
  *   65-99 Stars    → 3 (Nearly Mega)
  *   100 Stars      → 4 (Mega)
  */
@@ -430,8 +430,9 @@ export function grammarStarStageFor(stars) {
   const s = safeNum(stars);
   if (s >= GRAMMAR_STAR_STAGE_THRESHOLDS.mega) return 4;
   if (s >= GRAMMAR_STAR_STAGE_THRESHOLDS.evolve3) return 3;
-  if (s >= GRAMMAR_STAR_STAGE_THRESHOLDS.hatch) return 2;
-  if (s >= GRAMMAR_STAR_STAGE_THRESHOLDS.egg) return 1;
+  if (s >= GRAMMAR_STAR_STAGE_THRESHOLDS.evolve2) return 2;
+  if (s >= GRAMMAR_STAR_STAGE_THRESHOLDS.hatch) return 1;
+  if (s >= GRAMMAR_STAR_STAGE_THRESHOLDS.egg) return 0;
   return 0;
 }
 

--- a/src/surfaces/home/data.js
+++ b/src/surfaces/home/data.js
@@ -286,6 +286,23 @@ function subjectUsesStarDisplayState(subjectId) {
   return subjectId === 'punctuation' || subjectId === 'grammar';
 }
 
+function grammarAssetStageForDisplayState(displayState, displayStage, fallbackStage) {
+  switch (displayState) {
+    case 'egg-found': return 0;
+    case 'hatch': return 1;
+    case 'evolve': return 2;
+    case 'strong': return 3;
+    case 'mega': return 4;
+    default: {
+      const numericDisplayStage = Math.floor(Number(displayStage));
+      if (Number.isFinite(numericDisplayStage) && numericDisplayStage > 0) {
+        return Math.max(0, Math.min(4, numericDisplayStage - 1));
+      }
+      return Math.max(0, Math.min(4, Math.floor(Number(fallbackStage) || 0)));
+    }
+  }
+}
+
 function entryDisplayInfo(entry = {}) {
   const progress = entry.progress || {};
   const stage = Math.max(0, Math.min(4, Number(progress?.stage) || 0));
@@ -306,7 +323,9 @@ function entryDisplayInfo(entry = {}) {
   const displayState = typeof progress.displayState === 'string' ? progress.displayState : '';
   const found = displayState ? displayState !== 'not-found' : progress.caught === true || displayStars > 0 || (Number(progress.mastered) || 0) > 0;
   const isEgg = found && (displayState === 'egg-found' || (!displayState && rawDisplayStage === 0));
-  const assetStage = isEgg ? 0 : Math.max(0, Math.min(4, rawDisplayStage || stage));
+  const assetStage = subjectId === 'grammar'
+    ? grammarAssetStageForDisplayState(displayState, rawDisplayStage, stage)
+    : (isEgg ? 0 : Math.max(0, Math.min(4, rawDisplayStage || stage)));
   return {
     displayStars,
     displayStage: rawDisplayStage,

--- a/tests/grammar-star-events.test.js
+++ b/tests/grammar-star-events.test.js
@@ -104,6 +104,7 @@ test('U6 star event: first Star on Bracehart fires caught only', () => {
   assert.equal(events.length, 1, 'exactly one event');
   assert.equal(events[0].kind, 'caught', 'first Star emits caught');
   assert.equal(events[0].monsterId, 'bracehart');
+  assert.equal(events[0].next.stage, 0, 'first Star renders the egg asset stage');
   assert.equal(events[0].next.displayState, 'egg-found');
   assert.equal(events.some((e) => e.kind === 'evolve'), false, 'no evolve on first Star');
 });
@@ -123,6 +124,7 @@ test('U6 star event: 14->15 Stars fires evolve for Hatch', () => {
 
   assert.equal(events.length, 1, 'one threshold event');
   assert.equal(events[0].kind, 'evolve', 'Hatch threshold emits evolve');
+  assert.equal(events[0].next.stage, 1, 'Hatch renders asset stage 1');
   assert.equal(events[0].next.displayState, 'hatch');
 });
 
@@ -141,6 +143,7 @@ test('U6 star event: 34->35 Stars fires evolve for Growing', () => {
 
   assert.equal(events.length, 1, 'one threshold event');
   assert.equal(events[0].kind, 'evolve', 'Growing threshold emits evolve');
+  assert.equal(events[0].next.stage, 2, 'Growing renders asset stage 2');
   assert.equal(events[0].next.displayState, 'evolve');
 });
 
@@ -159,6 +162,7 @@ test('U6 star event: 64->65 Stars fires evolve for Nearly Mega', () => {
 
   assert.equal(events.length, 1, 'one threshold event');
   assert.equal(events[0].kind, 'evolve', 'Nearly Mega threshold emits evolve');
+  assert.equal(events[0].next.stage, 3, 'Nearly Mega renders asset stage 3');
   assert.equal(events[0].next.displayState, 'strong');
 });
 
@@ -177,6 +181,7 @@ test('U6 star event: 99->100 Stars fires mega', () => {
 
   assert.equal(events.length, 1, 'one threshold event');
   assert.equal(events[0].kind, 'mega', 'Mega threshold emits mega');
+  assert.equal(events[0].next.stage, 4, 'Mega renders asset stage 4');
   assert.equal(events[0].next.displayState, 'mega');
 });
 
@@ -853,8 +858,8 @@ test('U5 Egg: caught:true persists in progressForGrammarMonster after star-evide
   assert.ok(progress.stars >= 1, 'progress.stars >= 1');
   assert.equal(progress.starHighWater, 1, 'progress.starHighWater is 1');
 
-  // stage should be at least 1 (Egg found)
-  assert.ok(progress.stage >= 1, 'stage >= 1 (Egg found)');
+  assert.equal(progress.displayState, 'egg-found', 'displayState marks the found egg');
+  assert.equal(progress.stage, 0, 'Egg found renders asset stage 0');
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/grammar-star-staging.test.js
+++ b/tests/grammar-star-staging.test.js
@@ -4,7 +4,7 @@
 //
 // Verifies:
 //  1. progressForGrammarMonster returns Star fields (stars, starMax, displayStage, stageName, starHighWater).
-//  2. Stage thresholds map Stars to correct internal stage 0-4 and display stage 0-5.
+//  2. Stage thresholds map Stars to correct asset stage 0-4 and display stage 0-5.
 //  3. starHighWater latch: display Stars = max(computed, persisted high-water).
 //  4. Legacy migration: pre-P5 learners with no starHighWater get a Star floor from their old stage.
 //  5. recordGrammarConceptMastery preserves starHighWater on written state.
@@ -59,26 +59,26 @@ function makeRepository(initialState = {}) {
 }
 
 // =============================================================================
-// 1. Star stage thresholds — grammarStarStageFor (internal 0-4)
+// 1. Star stage thresholds — grammarStarStageFor (asset 0-4)
 // =============================================================================
 
-test('U4 star staging: 0 Stars -> stage 0', () => {
+test('U4 star staging: 0 Stars -> stage 0 sentinel hidden by display state', () => {
   assert.equal(grammarStarStageFor(0), 0);
 });
 
-test('U4 star staging: 1 Star -> stage 1', () => {
-  assert.equal(grammarStarStageFor(1), 1);
+test('U4 star staging: 1 Star -> asset stage 0 (egg)', () => {
+  assert.equal(grammarStarStageFor(1), 0);
 });
 
-test('U4 star staging: 14 Stars -> stage 1 (below hatch)', () => {
-  assert.equal(grammarStarStageFor(14), 1);
+test('U4 star staging: 14 Stars -> asset stage 0 (egg, below hatch)', () => {
+  assert.equal(grammarStarStageFor(14), 0);
 });
 
-test('U4 star staging: 15 Stars -> stage 2 (hatched)', () => {
-  assert.equal(grammarStarStageFor(15), 2);
+test('U4 star staging: 15 Stars -> asset stage 1 (hatched)', () => {
+  assert.equal(grammarStarStageFor(15), 1);
 });
 
-test('U4 star staging: 35 Stars -> stage 2 (still internal stage 2)', () => {
+test('U4 star staging: 35 Stars -> asset stage 2 (growing)', () => {
   assert.equal(grammarStarStageFor(35), 2);
 });
 

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -555,6 +555,70 @@ test('codex entries use grammar displayState for first-Star Egg Found', async ()
   assert.match(entry.img, /bracehart-b2-0\.640\.webp/);
 });
 
+test('codex entries map grammar display stages to monster asset stages', async () => {
+  const { buildCodexEntries } = await import('../src/surfaces/home/data.js');
+  const entries = buildCodexEntries([
+    {
+      subjectId: 'grammar',
+      monster: MONSTERS.bracehart,
+      progress: {
+        caught: true,
+        mastered: 2,
+        stage: 1,
+        displayStars: 15,
+        displayStage: 2,
+        displayState: 'hatch',
+        branch: 'b2',
+      },
+    },
+    {
+      subjectId: 'grammar',
+      monster: MONSTERS.couronnail,
+      progress: {
+        caught: true,
+        mastered: 3,
+        stage: 2,
+        displayStars: 35,
+        displayStage: 3,
+        displayState: 'evolve',
+        branch: 'b1',
+      },
+    },
+    {
+      subjectId: 'grammar',
+      monster: MONSTERS.concordium,
+      progress: {
+        caught: true,
+        mastered: 4,
+        stage: 3,
+        displayStars: 65,
+        displayStage: 4,
+        displayState: 'strong',
+        branch: 'b1',
+      },
+    },
+  ]);
+
+  const bracehart = entries.find((entry) => entry.id === 'bracehart');
+  const couronnail = entries.find((entry) => entry.id === 'couronnail');
+  const concordium = entries.find((entry) => entry.id === 'concordium');
+
+  assert.equal(bracehart.stage, 1);
+  assert.equal(bracehart.name, 'Bracehart');
+  assert.equal(bracehart.stageLabel, 'Hatched');
+  assert.match(bracehart.img, /bracehart-b2-1\.640\.webp/);
+
+  assert.equal(couronnail.stage, 2);
+  assert.equal(couronnail.name, 'Regalcurl');
+  assert.equal(couronnail.stageLabel, 'Growing');
+  assert.match(couronnail.img, /couronnail-b1-2\.640\.webp/);
+
+  assert.equal(concordium.stage, 3);
+  assert.equal(concordium.name, 'Crowncord');
+  assert.equal(concordium.stageLabel, 'Nearly Mega');
+  assert.match(concordium.img, /concordium-b1-3\.640\.webp/);
+});
+
 test('home meadow keeps grammar first-Star Egg Found as an egg', async () => {
   const { buildMeadowMonsters } = await import('../src/surfaces/home/data.js');
   const [egg] = buildMeadowMonsters([
@@ -576,6 +640,29 @@ test('home meadow keeps grammar first-Star Egg Found as an egg', async () => {
   assert.equal(egg.id, 'bracehart-egg');
   assert.equal(egg.stage, 0);
   assert.equal(egg.path, 'none');
+});
+
+test('home meadow maps grammar hatch displayState to asset stage 1', async () => {
+  const { buildMeadowMonsters } = await import('../src/surfaces/home/data.js');
+  const [monster] = buildMeadowMonsters([
+    {
+      subjectId: 'grammar',
+      monster: MONSTERS.bracehart,
+      progress: {
+        caught: true,
+        mastered: 2,
+        stage: 1,
+        displayStars: 15,
+        displayStage: 2,
+        displayState: 'hatch',
+        branch: 'b1',
+      },
+    },
+  ]);
+
+  assert.equal(monster.id, 'bracehart-caught');
+  assert.equal(monster.stage, 1);
+  assert.notEqual(monster.path, 'none');
 });
 
 test('codex subject groups arrive in spelling → punctuation → grammar order with totals', async () => {


### PR DESCRIPTION
## Summary
- Align Grammar star-derived asset stages with the webp convention: 1-14 Stars render egg stage 0, 15-34 render hatch stage 1, 35-64 render evolve stage 2, 65-99 render strong stage 3, and 100 renders mega stage 4.
- Keep the six-state display vocabulary unchanged (`not-found`, `egg-found`, `hatch`, `evolve`, `strong`, `mega`) so thresholds and calibration are untouched.
- Map Grammar display states to asset stages in Codex/Home surfaces so Eugenia-style 15-Star cards render the hatch/kid asset rather than the teen/evolve asset.

## Verification
- `node --test tests/grammar-star-staging.test.js tests/grammar-star-events.test.js tests/render.test.js`
- `node --test tests/grammar-ui-model.test.js tests/grammar-star-e2e.test.js tests/render-effect-caught.test.js tests/monster-celebrations.test.js`
- `npm run check` (bundle 230463 / 232000 gzip)
- `git diff --check`

## Full-suite note
- `npm test` is currently red on pre-existing main failures unrelated to this PR. I reproduced the same failing areas on `origin/main`: `ui-token-contract`, `worker-hero-read-model`, and `worker-mutation-capability-coverage`; the subject-contract subset in the temp worktree could not run because that detached worktree had no local React install. The branch-specific targeted suites above pass.
