### PR TITLE
fix(bootstrap): hydrate subject stats on refresh

### DIFF
--- a/tests/worker-bootstrap-multi-learner-regression.test.js
+++ b/tests/worker-bootstrap-multi-learner-regression.test.js
@@ -128,10 +128,9 @@ function insertSubjectState(server, learnerId, subjectId, {
     learnerId,
     subjectId,
     typeof ui === 'string' ? ui : JSON.stringify(ui),
-    // Grammar preserves `data` verbatim through `subjectStateRowToRecord`.
-    // Spelling and punctuation return `data: {}` through `publicSubjectStateRowToRecord`
-    // — the fixture marker does NOT survive those code paths.
-    // All identity assertions in this file use grammar for this reason.
+    // The public transform strips `data` for all child-facing subject
+    // projections. Grammar keeps this marker under `ui.prefs` after the
+    // Worker read-model is rebuilt.
     JSON.stringify(stateData),
     updatedAt,
     ACCOUNT_ID,
@@ -291,31 +290,35 @@ test('multi-learner #1: POST bootstrap ships child_subject_state for all 3 writa
     assert.deepEqual(subjectKeys, expectedKeys,
       `subjectStates must include all writable learners across all 3 subjects, got ${JSON.stringify(subjectKeys)}`);
 
-    // Verify data identity via the grammar path (grammar preserves `data`
-    // verbatim through `subjectStateRowToRecord`; spelling/punctuation
-    // redact private session fields but keep `prefs` + `progress`).
+    // Verify identity via the Grammar public read-model. The public transform
+    // strips raw data for all three subjects, so subject identity must survive
+    // through the redacted UI payload instead.
     const aGrammar = payload.subjectStates['learner-a::grammar'];
     assert.ok(aGrammar, 'learner-a grammar subject state present');
-    assert.equal(aGrammar?.data?.prefs?.marker?.fixture, 'learner-a-grammar',
-      `learner-a grammar fixture marker identity, got ${JSON.stringify(aGrammar?.data?.prefs?.marker)}`);
-    assert.equal(aGrammar?.data?.prefs?.marker?.progress, 88);
+    assert.deepEqual(aGrammar.data, {}, 'learner-a grammar data stripped by public transform');
+    assert.equal(aGrammar?.ui?.learnerId, 'learner-a');
+    assert.equal(aGrammar?.ui?.prefs?.marker?.fixture, 'learner-a-grammar',
+      `learner-a grammar fixture marker identity, got ${JSON.stringify(aGrammar?.ui?.prefs?.marker)}`);
+    assert.equal(aGrammar?.ui?.prefs?.marker?.progress, 88);
 
     const bGrammar = payload.subjectStates['learner-b::grammar'];
     assert.ok(bGrammar, 'learner-b grammar subject state present');
-    assert.equal(bGrammar?.data?.prefs?.marker?.fixture, 'learner-b-grammar',
-      `learner-b grammar fixture marker identity, got ${JSON.stringify(bGrammar?.data?.prefs?.marker)}`);
-    assert.equal(bGrammar?.data?.prefs?.marker?.progress, 53);
+    assert.deepEqual(bGrammar.data, {}, 'learner-b grammar data stripped by public transform');
+    assert.equal(bGrammar?.ui?.learnerId, 'learner-b');
+    assert.equal(bGrammar?.ui?.prefs?.marker?.fixture, 'learner-b-grammar',
+      `learner-b grammar fixture marker identity, got ${JSON.stringify(bGrammar?.ui?.prefs?.marker)}`);
+    assert.equal(bGrammar?.ui?.prefs?.marker?.progress, 53);
 
     const cGrammar = payload.subjectStates['learner-c::grammar'];
     assert.ok(cGrammar, 'learner-c grammar subject state present');
-    assert.equal(cGrammar?.data?.prefs?.marker?.fixture, 'learner-c-grammar',
-      `learner-c grammar fixture marker identity, got ${JSON.stringify(cGrammar?.data?.prefs?.marker)}`);
-    assert.equal(cGrammar?.data?.prefs?.marker?.progress, 12);
+    assert.deepEqual(cGrammar.data, {}, 'learner-c grammar data stripped by public transform');
+    assert.equal(cGrammar?.ui?.learnerId, 'learner-c');
+    assert.equal(cGrammar?.ui?.prefs?.marker?.fixture, 'learner-c-grammar',
+      `learner-c grammar fixture marker identity, got ${JSON.stringify(cGrammar?.ui?.prefs?.marker)}`);
+    assert.equal(cGrammar?.ui?.prefs?.marker?.progress, 12);
 
-    // Spelling and punctuation entries exist but data is stripped by public transform.
-    // Grammar preserves `data` verbatim — spelling/punctuation return `data: {}`.
-    // Check each writable learner's spelling + punctuation entries confirm the
-    // public transform ran (data stripped) while verifying correct learner routing.
+    // Spelling and punctuation entries also strip raw data in the public
+    // transform while preserving the correct learner routing.
     const aSpelling = payload.subjectStates['learner-a::spelling'];
     assert.ok(aSpelling, 'learner-a spelling entry present');
     assert.deepEqual(aSpelling.data, {}, 'learner-a spelling data stripped by public transform');
@@ -600,9 +603,9 @@ test('multi-learner #5: GET bootstrap returns same multi-learner structure', asy
       'learner-c::monster-codex',
     ], 'GET: gameState keys match writable learners');
 
-    // Identity check via grammar data.
+    // Identity check via the Grammar public read-model.
     assert.equal(
-      payload.subjectStates['learner-b::grammar']?.data?.prefs?.marker?.fixture,
+      payload.subjectStates['learner-b::grammar']?.ui?.prefs?.marker?.fixture,
       'learner-b-grammar',
       'GET: learner-b grammar fixture identity',
     );
@@ -830,7 +833,22 @@ test('multi-learner #10: notModified invalidation on sibling subject-state write
       SET data_json = ?, updated_at = ?
       WHERE learner_id = ? AND subject_id = ?
     `, [
-      JSON.stringify({ prefs: { mode: 'smart', marker: { fixture: 'learner-b-grammar-mutated', progress: 99 } }, progress: { possess: { stage: 99 } } }),
+      JSON.stringify({
+        prefs: { mode: 'learn', marker: { fixture: 'learner-b-grammar-mutated', progress: 99 } },
+        mastery: {
+          concepts: {
+            sentence_functions: {
+              attempts: 3,
+              correct: 3,
+              wrong: 0,
+              strength: 0.9,
+              correctStreak: 3,
+              intervalDays: 8,
+              dueAt: NOW + 365 * 86_400_000,
+            },
+          },
+        },
+      }),
       NOW + 1,
       'learner-b',
       'grammar',
@@ -845,13 +863,16 @@ test('multi-learner #10: notModified invalidation on sibling subject-state write
     assert.notEqual(payload.revision?.hash, H1,
       'new hash differs from H1 after sibling write');
 
-    // Value-level: mutated data ships through.
+    // Value-level: mutated data is reflected in the redacted read-model.
     const bGrammar = payload.subjectStates?.['learner-b::grammar'];
     assert.ok(bGrammar, 'B grammar state present in full bundle');
-    assert.equal(bGrammar?.data?.prefs?.marker?.fixture, 'learner-b-grammar-mutated',
-      'mutated fixture marker ships through');
-    assert.equal(bGrammar?.data?.progress?.possess?.stage, 99,
-      'mutated progress stage ships through');
+    assert.deepEqual(bGrammar.data, {}, 'B grammar raw data stays stripped');
+    assert.equal(bGrammar?.ui?.prefs?.marker?.fixture, 'learner-b-grammar-mutated',
+      'mutated fixture marker ships through the read-model');
+    assert.equal(bGrammar?.ui?.prefs?.mode, 'learn',
+      'mutated prefs mode ships through the read-model');
+    assert.equal(bGrammar?.ui?.stats?.concepts?.secured, 1,
+      'mutated mastery ships through the read-model stats');
   } finally {
     server.close();
   }

--- a/tests/worker-bootstrap-v2.test.js
+++ b/tests/worker-bootstrap-v2.test.js
@@ -837,15 +837,63 @@ test('U7 scenario 22: POST notModified does not rotate session cookies', async (
 // design.md.
 // ---------------------------------------------------------------------------
 
-function insertSubjectStateFor(server, accountId, learnerId, subjectId) {
+function grammarHydrationData({ mode = 'smart', marker = null } = {}) {
+  return {
+    prefs: {
+      mode,
+      ...(marker ? { marker } : {}),
+    },
+    mastery: {
+      concepts: {
+        sentence_functions: {
+          attempts: 3,
+          correct: 3,
+          wrong: 0,
+          strength: 0.9,
+          correctStreak: 3,
+          intervalDays: 8,
+          dueAt: NOW + 365 * 86_400_000,
+        },
+      },
+    },
+  };
+}
+
+function punctuationHydrationData() {
+  return {
+    prefs: { mode: 'smart', roundLength: '4' },
+    progress: {
+      items: {},
+      facets: {},
+      rewardUnits: {},
+      attempts: [{
+        ts: NOW,
+        itemId: 'bootstrap-punctuation-item',
+        mode: 'choose',
+        itemMode: 'choose',
+        skillIds: ['endmarks_full_stop'],
+        rewardUnitId: 'endmarks',
+        sessionMode: 'smart',
+        supportLevel: 0,
+        meaningful: true,
+        correct: true,
+        misconceptionTags: [],
+        facetOutcomes: [],
+      }],
+      sessionsCompleted: 1,
+    },
+  };
+}
+
+function insertSubjectStateFor(server, accountId, learnerId, subjectId, { ui = { phase: 'idle' }, data = null } = {}) {
   runSql(server, `
     INSERT INTO child_subject_state (learner_id, subject_id, ui_json, data_json, updated_at, updated_by_account_id)
     VALUES (?, ?, ?, ?, ?, ?)
   `, [
     learnerId,
     subjectId,
-    JSON.stringify({ phase: 'idle' }),
-    JSON.stringify({ prefs: { mode: 'smart' }, progress: { possess: { stage: 3 } } }),
+    JSON.stringify(ui),
+    JSON.stringify(data || { prefs: { mode: 'smart' }, progress: { possess: { stage: 3 } } }),
     NOW,
     accountId,
   ]);
@@ -935,18 +983,15 @@ test('U1 hotfix: child_subject_state ships for all writable learners (multi-lear
       'bootstrapCapacity.subjectStatesBounded must be stamped false (U1 contract)');
 
     // M1 follow-up 2026-04-26: value-level assertion. Prove the seeded
-    // `data_json` marker actually flows through for a non-selected
-    // sibling — not an empty placeholder keyed only by learnerId. We
-    // use `grammar` because `publicSubjectStateRowToRecord` only
-    // redacts `data` on `spelling`/`punctuation` (per the private-
-    // prompt leak test at scenario 21); `grammar` falls through to
-    // `subjectStateRowToRecord`, which preserves `data` verbatim.
+    // `data_json` marker actually flows through for a non-selected sibling
+    // via the public Grammar read-model, while raw data stays stripped.
     const siblingGrammar = payload.subjectStates['learner-b::grammar'];
     assert.ok(siblingGrammar, 'sibling grammar subject-state row present');
-    assert.equal(siblingGrammar?.data?.prefs?.mode, 'smart',
-      `M1: sibling subjectState.data carries the seeded prefs.mode marker, got ${JSON.stringify(siblingGrammar)}`);
-    assert.equal(siblingGrammar?.data?.progress?.possess?.stage, 3,
-      'M1: sibling subjectState.data carries the seeded progress.possess.stage marker');
+    assert.deepEqual(siblingGrammar.data, {}, 'M1: sibling grammar raw data is stripped');
+    assert.equal(siblingGrammar?.ui?.learnerId, 'learner-b',
+      'M1: sibling grammar read-model is built for learner-b');
+    assert.equal(siblingGrammar?.ui?.prefs?.mode, 'smart',
+      `M1: sibling grammar read-model carries the seeded prefs.mode marker, got ${JSON.stringify(siblingGrammar)}`);
   } finally {
     server.close();
   }
@@ -988,6 +1033,50 @@ test('U1 hotfix: GET /api/bootstrap also ships child_subject_state for all writa
 
     assert.equal(payload.meta?.capacity?.bootstrapMode, 'selected-learner-bounded');
     assert.equal(payload.bootstrapCapacity?.subjectStatesBounded, false);
+  } finally {
+    server.close();
+  }
+});
+
+test('fresh bootstrap hydrates Punctuation and Grammar public stats from stored subject state', async () => {
+  const server = createServer();
+  try {
+    insertLearner(server, 'adult-u7', { id: 'learner-a', name: 'Alpha', sortIndex: 0, selected: true });
+    insertSubjectStateFor(server, 'adult-u7', 'learner-a', 'punctuation', {
+      data: punctuationHydrationData(),
+    });
+    insertSubjectStateFor(server, 'adult-u7', 'learner-a', 'grammar', {
+      data: grammarHydrationData({ mode: 'learn' }),
+    });
+
+    const response = await getBootstrap(server);
+    assert.equal(response.status, 200);
+    const payload = await readJsonBody(response);
+    assert.equal(payload.ok, true);
+
+    const punctuation = payload.subjectStates?.['learner-a::punctuation'];
+    assert.ok(punctuation, 'fresh bootstrap includes punctuation subject state');
+    assert.deepEqual(punctuation.data, {}, 'punctuation raw data stays stripped');
+    assert.equal(punctuation.ui?.learnerId, 'learner-a');
+    assert.equal(punctuation.ui?.stats?.attempts, 1,
+      'punctuation stored attempts hydrate into first-paint stats');
+    assert.equal(punctuation.ui?.stats?.correct, 1,
+      'punctuation stored correct count hydrates into first-paint stats');
+    assert.ok(punctuation.ui?.starView?.perMonster,
+      'punctuation first-paint read-model includes starView');
+
+    const grammar = payload.subjectStates?.['learner-a::grammar'];
+    assert.ok(grammar, 'fresh bootstrap includes grammar subject state');
+    assert.deepEqual(grammar.data, {}, 'grammar raw data stays stripped');
+    assert.equal(grammar.ui?.learnerId, 'learner-a');
+    assert.equal(grammar.ui?.prefs?.mode, 'learn',
+      'grammar stored prefs hydrate into first-paint read-model');
+    assert.equal(grammar.ui?.stats?.concepts?.secured, 1,
+      'grammar stored mastery hydrates into first-paint stats');
+    assert.equal(grammar.ui?.analytics?.progressSnapshot?.trackedConcepts, 1,
+      'grammar first-paint analytics tracks stored mastery concepts');
+    assert.equal(grammar.ui?.analytics?.progressSnapshot?.securedConcepts, 1,
+      'grammar first-paint analytics exposes secured concepts');
   } finally {
     server.close();
   }
@@ -1041,7 +1130,7 @@ test('U1 follow-up B1: sibling subject_state write invalidates lastKnownRevision
       SET data_json = ?, updated_at = ?
       WHERE learner_id = ? AND subject_id = ?
     `, [
-      JSON.stringify({ prefs: { mode: 'smart' }, progress: { possess: { stage: 4 } } }),
+      JSON.stringify(grammarHydrationData({ mode: 'learn' })),
       NOW + 1,
       'learner-b',
       'grammar',
@@ -1058,11 +1147,15 @@ test('U1 follow-up B1: sibling subject_state write invalidates lastKnownRevision
     assert.notEqual(payload.revision.hash, H1,
       'B1: new revision hash differs from H1 after sibling write');
 
-    // Value-level check: B's mutated data ships through on the full bundle.
+    // Value-level check: B's mutated state ships through on the full bundle
+    // as a redacted Grammar read-model.
     const siblingGrammar = payload.subjectStates?.['learner-b::grammar'];
     assert.ok(siblingGrammar, 'B1: sibling grammar state present in full bundle');
-    assert.equal(siblingGrammar?.data?.progress?.possess?.stage, 4,
-      'B1: mutated stage marker ships in the full bundle after probe miss');
+    assert.deepEqual(siblingGrammar.data, {}, 'B1: sibling grammar raw data is stripped');
+    assert.equal(siblingGrammar?.ui?.prefs?.mode, 'learn',
+      'B1: mutated prefs ship in the full bundle after probe miss');
+    assert.equal(siblingGrammar?.ui?.stats?.concepts?.secured, 1,
+      'B1: mutated mastery stats ship in the full bundle after probe miss');
   } finally {
     server.close();
   }

--- a/worker/src/repository.js
+++ b/worker/src/repository.js
@@ -156,6 +156,7 @@ import {
 } from './projections/events.js';
 import { buildSpellingAudioCue } from './subjects/spelling/audio.js';
 import { buildPunctuationReadModel } from './subjects/punctuation/read-models.js';
+import { buildGrammarReadModel } from './subjects/grammar/read-models.js';
 import { listPunctuationEvents } from './subjects/punctuation/events.js';
 import { createPunctuationService } from '../../shared/punctuation/service.js';
 import {
@@ -336,25 +337,49 @@ function redactPunctuationUiForClient(ui, data = {}, learnerId = '', { now = Dat
   return readModel;
 }
 
-async function publicSubjectStateRowToRecord(row, { spellingContentSnapshot = null, now = Date.now() } = {}) {
-  const record = subjectStateRowToRecord(row);
-  if (row.subject_id === 'punctuation') {
-    return normaliseSubjectStateRecord({
-      ui: redactPunctuationUiForClient(record.ui, record.data, row.learner_id, { now }),
-      data: {},
-      updatedAt: record.updatedAt,
-    });
-  }
-  if (row.subject_id !== 'spelling') return record;
-  const audio = await buildSpellingAudioCue({
-    learnerId: row.learner_id,
-    state: record.ui,
+function redactGrammarUiForClient(ui, data = {}, learnerId = '', { now = Date.now() } = {}) {
+  const state = {
+    ...(data && typeof data === 'object' && !Array.isArray(data) ? data : {}),
+    ...(ui && typeof ui === 'object' && !Array.isArray(ui) ? ui : {}),
+  };
+  return buildGrammarReadModel({
+    learnerId,
+    state,
+    now,
+    aiEnrichment: state.aiEnrichment || null,
   });
-  return normaliseSubjectStateRecord({
-    ui: redactSpellingUiForClient(record.ui, record.data, row.learner_id, {
+}
+
+const PUBLIC_SUBJECT_READ_MODEL_BUILDERS = Object.freeze({
+  async spelling({ record, row, spellingContentSnapshot, now }) {
+    const audio = await buildSpellingAudioCue({
+      learnerId: row.learner_id,
+      state: record.ui,
+    });
+    return redactSpellingUiForClient(record.ui, record.data, row.learner_id, {
       audio,
       contentSnapshot: spellingContentSnapshot,
       now,
+    });
+  },
+  punctuation({ record, row, now }) {
+    return redactPunctuationUiForClient(record.ui, record.data, row.learner_id, { now });
+  },
+  grammar({ record, row, now }) {
+    return redactGrammarUiForClient(record.ui, record.data, row.learner_id, { now });
+  },
+});
+
+async function publicSubjectStateRowToRecord(row, { spellingContentSnapshot = null, now = Date.now() } = {}) {
+  const record = subjectStateRowToRecord(row);
+  const buildPublicUi = PUBLIC_SUBJECT_READ_MODEL_BUILDERS[row.subject_id];
+  if (!buildPublicUi) return record;
+  return normaliseSubjectStateRecord({
+    ui: await buildPublicUi({
+      record,
+      row,
+      now,
+      spellingContentSnapshot,
     }),
     data: {},
     updatedAt: record.updatedAt,


### PR DESCRIPTION
## Summary
- Rebuild public subject-state bootstrap rows through a registry of subject read-model builders instead of subject-specific fall-through logic.
- Add Grammar to the bootstrap hydration path so fresh refresh includes public `stats` / `analytics` from stored `child_subject_state`, matching Punctuation's existing `stats` / `starView` first-paint behaviour.
- Keep raw `data` stripped from public subject-state payloads and update multi-learner bootstrap regressions to assert identity through the public read-model.

## Why
Fresh refresh was shipping raw Grammar subject rows through `subjectStateRowToRecord`, so the client only saw Grammar stats after the learner played a command and received a command read-model. The registry keeps future subjects/modules from needing another hard-coded branch in this function.

## Verification
- `node --test tests/worker-bootstrap-v2.test.js tests/worker-bootstrap-multi-learner-regression.test.js tests/worker-punctuation-runtime.test.js` ✅ 62 pass
- `node --test tests/worker-grammar-subject-runtime.test.js tests/grammar-ui-model.test.js tests/punctuation-view-model.test.js tests/punctuation-star-parity-worker-backed.test.js` ✅ 296 pass
- `node --test tests/worker-bootstrap-capacity.test.js` ✅ 3 pass
- `npm run check` ✅ main bundle `230494 / 232000` gzip
- `git diff --check` ✅
- `npm test` ⚠️ 16073 pass / 2 fail / 6 skipped; both failures are pre-existing environment failures from missing `jsdom` in `tests/grammar-qg-p10-mobile-table.test.js` and `tests/grammar-qg-p10-render-surface.test.js`, unrelated to this bootstrap patch.
