### PR TITLE
fix(grammar): rename faded guidance mix-up key

### DIFF
--- a/src/subjects/grammar/components/GrammarSessionScene.jsx
+++ b/src/subjects/grammar/components/GrammarSessionScene.jsx
@@ -286,6 +286,7 @@ function GuidancePanel({ support }) {
   const notices = Array.isArray(support.notices) ? support.notices.filter(Boolean) : [];
   const example = support.workedExample || {};
   const contrast = support.contrast || {};
+  const commonMixUp = contrast.commonMixUp || contrast.nearMiss || '';
 
   return (
     <aside className={`grammar-guidance ${worked ? 'worked' : 'faded'}`} aria-label={support.title || 'Grammar guidance'}>
@@ -304,10 +305,10 @@ function GuidancePanel({ support }) {
 
       {!worked && support.summary ? <p className="grammar-guidance-summary">{support.summary}</p> : null}
 
-      {!worked && (contrast.secureExample || contrast.nearMiss || contrast.why) ? (
+      {!worked && (contrast.secureExample || commonMixUp || contrast.why) ? (
         <div className="grammar-guidance-contrast">
           {contrast.secureExample ? <p><span>Secure</span>{contrast.secureExample}</p> : null}
-          {contrast.nearMiss ? <p><span>Near miss</span>{contrast.nearMiss}</p> : null}
+          {commonMixUp ? <p><span>Near miss</span>{commonMixUp}</p> : null}
           {contrast.why ? <p><span>Check</span>{contrast.why}</p> : null}
         </div>
       ) : null}

--- a/src/subjects/grammar/speech.js
+++ b/src/subjects/grammar/speech.js
@@ -115,7 +115,7 @@ function pushSupportGuidance(parts, support) {
 
   const contrast = isPlainObject(support.contrast) ? support.contrast : {};
   pushText(parts, contrast.secureExample, 220);
-  pushText(parts, contrast.nearMiss, 220);
+  pushText(parts, contrast.commonMixUp || contrast.nearMiss, 220);
   pushText(parts, contrast.why, 260);
 }
 

--- a/tests/grammar-production-smoke.test.js
+++ b/tests/grammar-production-smoke.test.js
@@ -157,6 +157,7 @@ test('Grammar production smoke scans mini-test, support, and AI enrichment read 
       supportGuidance: {
         kind: 'faded',
         notices: ['Use the visible prompt only.'],
+        contrast: { commonMixUp: 'A safe visible mix-up.' },
       },
     },
     aiEnrichment: {
@@ -179,6 +180,13 @@ test('Grammar production smoke scans mini-test, support, and AI enrichment read 
       session: { supportGuidance: { workedExample: { correctResponses: ['A'] } } },
     }, 'grammar.supportModel'),
     /grammar\.supportModel\.session\.supportGuidance\.workedExample\.correctResponses exposed a server-only field/,
+  );
+
+  assert.throws(
+    () => assertNoForbiddenGrammarReadModelKeys({
+      session: { supportGuidance: { contrast: { nearMiss: 'Hidden answer-spec vocabulary.' } } },
+    }, 'grammar.supportModel'),
+    /grammar\.supportModel\.session\.supportGuidance\.contrast\.nearMiss exposed a server-only field/,
   );
 
   assert.throws(

--- a/tests/worker-grammar-subject-runtime.test.js
+++ b/tests/worker-grammar-subject-runtime.test.js
@@ -610,6 +610,10 @@ test('Grammar command route persists repair actions through Worker commands', as
   assert.equal(faded.response.status, 200, JSON.stringify(faded.body));
   assert.equal(faded.body.subjectReadModel.session.supportLevel, 1);
   assert.equal(faded.body.subjectReadModel.session.supportGuidance.kind, 'faded');
+  assert.equal(
+    Object.prototype.hasOwnProperty.call(faded.body.subjectReadModel.session.supportGuidance.contrast || {}, 'nearMiss'),
+    false,
+  );
 
   const submit = await postCommand(app, DB, {
     command: 'submit-answer',
@@ -851,7 +855,8 @@ test('Grammar faded guidance omits contrast examples that match current options'
   assert.ok(optionLabels.includes('The club got set up last year.'));
   assert.equal(session.supportGuidance.kind, 'faded');
   assert.equal(session.supportGuidance.contrast.secureExample, undefined);
-  assert.equal(session.supportGuidance.contrast.nearMiss, undefined);
+  assert.equal(session.supportGuidance.contrast.commonMixUp, undefined);
+  assert.equal(Object.prototype.hasOwnProperty.call(session.supportGuidance.contrast, 'nearMiss'), false);
   assert.equal(session.supportGuidance.contrast.why, 'The first is more formal.');
   assert.equal(JSON.stringify(session.supportGuidance).includes('The club was established last year.'), false);
   assert.equal(JSON.stringify(session.supportGuidance).includes('The club got set up last year.'), false);

--- a/worker/src/subjects/grammar/read-models.js
+++ b/worker/src/subjects/grammar/read-models.js
@@ -318,12 +318,12 @@ function safeContrast(concept, currentTexts = new Set()) {
   const contrast = isPlainObject(concept?.contrast) ? concept.contrast : {};
   if (!contrast.good && !contrast.nearMiss && !contrast.why) return null;
   const secureExample = safeGuidanceText(contrast.good, currentTexts);
-  const nearMiss = safeGuidanceText(contrast.nearMiss, currentTexts);
+  const commonMixUp = safeGuidanceText(contrast.nearMiss, currentTexts);
   const why = safeGuidanceText(contrast.why, currentTexts);
-  if (!secureExample && !nearMiss && !why) return null;
+  if (!secureExample && !commonMixUp && !why) return null;
   const model = {};
   if (secureExample) model.secureExample = secureExample;
-  if (nearMiss) model.nearMiss = nearMiss;
+  if (commonMixUp) model.commonMixUp = commonMixUp;
   if (why) model.why = why;
   return model;
 }


### PR DESCRIPTION
## Summary
- Rename learner-facing faded-guidance contrast metadata from forbidden nearMiss to safe commonMixUp.
- Keep Grammar UI and speech rendering the same visible Near miss copy while accepting both current and legacy payload shapes.
- Add production-smoke oracle and Worker-route regression coverage so supportGuidance.contrast.nearMiss cannot re-enter browser read models.

## Verification
- npx -y node@22 --test tests/worker-grammar-subject-runtime.test.js tests/grammar-production-smoke.test.js tests/react-grammar-surface.test.js tests/grammar-speech.test.js
- npm test
- npm run check

## Production context
Post-deploy P13 Grammar smoke found a second forbidden key after the summary session-id fix: supportGuidance.contrast.nearMiss. This hotfix removes that server-only key from the read model while preserving the child-facing guidance text.