### PR TITLE
fix(grammar): expose cue metadata in read model

### DIFF
--- a/tests/worker-grammar-subject-runtime.test.js
+++ b/tests/worker-grammar-subject-runtime.test.js
@@ -744,6 +744,62 @@ test('Grammar command route starts explicit templates without inheriting stored 
   DB.close();
 });
 
+test('Grammar command route exposes learner cue metadata through the read model', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const app = createWorkerApp({ now: () => 1_777_000_000_000 });
+  seedAccountLearner(DB);
+
+  const targetSentence = await postCommand(app, DB, {
+    command: 'start-session',
+    learnerId: 'learner-a',
+    requestId: 'grammar-target-sentence-cue-start',
+    expectedLearnerRevision: 0,
+    payload: {
+      mode: 'smart',
+      roundLength: 1,
+      templateId: 'identify_words_in_sentence',
+      seed: 1,
+    },
+  });
+  assert.equal(targetSentence.response.status, 200, JSON.stringify(targetSentence.body));
+  const targetSentenceItem = targetSentence.body.subjectReadModel.session.currentItem;
+  assert.equal(targetSentenceItem.templateId, 'identify_words_in_sentence');
+  assert.ok(Array.isArray(targetSentenceItem.promptParts));
+  assert.equal(targetSentenceItem.focusCue.type, 'target-sentence');
+  assert.equal(targetSentenceItem.focusCue.targetKind, 'sentence');
+  assert.ok(targetSentenceItem.focusCue.targetText.length >= 16);
+  assert.ok(targetSentenceItem.screenReaderPromptText.includes(targetSentenceItem.focusCue.targetText));
+  assert.ok(targetSentenceItem.readAloudText.includes(targetSentenceItem.focusCue.targetText));
+  assert.match(targetSentenceItem.readAloudText, /The sentence is:/);
+  assert.equal(targetSentenceItem.focusTarget, undefined);
+  assert.equal(targetSentenceItem.solutionLines, undefined);
+
+  const nounPhrase = await postCommand(app, DB, {
+    command: 'start-session',
+    learnerId: 'learner-a',
+    requestId: 'grammar-noun-phrase-cue-start',
+    expectedLearnerRevision: 1,
+    payload: {
+      mode: 'smart',
+      roundLength: 1,
+      templateId: 'qg_p4_voice_roles_transfer',
+      seed: 1,
+    },
+  });
+  assert.equal(nounPhrase.response.status, 200, JSON.stringify(nounPhrase.body));
+  const nounPhraseItem = nounPhrase.body.subjectReadModel.session.currentItem;
+  assert.equal(nounPhraseItem.templateId, 'qg_p4_voice_roles_transfer');
+  assert.equal(nounPhraseItem.focusCue.type, 'underline');
+  assert.equal(nounPhraseItem.focusCue.targetKind, 'noun-phrase');
+  assert.match(nounPhraseItem.screenReaderPromptText, /The underlined noun phrase is:/);
+  assert.match(nounPhraseItem.readAloudText, /The underlined noun phrase is:/);
+  assert.doesNotMatch(nounPhraseItem.readAloudText, /The underlined word is:/);
+  assert.equal(nounPhraseItem.focusTarget, undefined);
+  assert.equal(nounPhraseItem.solutionLines, undefined);
+
+  DB.close();
+});
+
 test('Grammar command route accepts sentence builder mode', async () => {
   const DB = createMigratedSqliteD1Database();
   const app = createWorkerApp({ now: () => 1_777_000_000_000 });

--- a/worker/src/subjects/grammar/read-models.js
+++ b/worker/src/subjects/grammar/read-models.js
@@ -46,9 +46,41 @@ function safeInputSpec(inputSpec) {
   return clone;
 }
 
+const SAFE_PROMPT_PART_KINDS = new Set(['text', 'lineBreak', 'sentence', 'underline', 'emphasis']);
+const SAFE_FOCUS_CUE_TYPES = new Set(['underline', 'bold', 'quoted-word', 'target-sentence']);
+const SAFE_FOCUS_CUE_TARGET_KINDS = new Set(['word', 'noun-phrase', 'sentence', 'group', 'pair']);
+
+function safePromptParts(promptParts) {
+  if (!Array.isArray(promptParts)) return null;
+  const parts = promptParts.map((part) => {
+    if (!isPlainObject(part)) return null;
+    if (!SAFE_PROMPT_PART_KINDS.has(part.kind)) return null;
+    const kind = part.kind;
+    const text = typeof part.text === 'string' ? part.text : '';
+    return { kind, text };
+  }).filter((part) => part && (part.kind === 'lineBreak' || part.text));
+  return parts.length ? parts : null;
+}
+
+function safeFocusCue(focusCue) {
+  if (!isPlainObject(focusCue)) return null;
+  const type = SAFE_FOCUS_CUE_TYPES.has(focusCue.type) ? focusCue.type : '';
+  const targetKind = SAFE_FOCUS_CUE_TARGET_KINDS.has(focusCue.targetKind) ? focusCue.targetKind : '';
+  const targetText = typeof focusCue.targetText === 'string' ? focusCue.targetText : '';
+  if (!type || !targetKind || !targetText) return null;
+  return {
+    type,
+    targetKind,
+    targetText,
+    targetOccurrence: Number.isFinite(Number(focusCue.targetOccurrence)) ? Number(focusCue.targetOccurrence) : 1,
+  };
+}
+
 function safeCurrentItem(item) {
   if (!isPlainObject(item)) return null;
-  return {
+  const promptParts = safePromptParts(item.promptParts);
+  const focusCue = safeFocusCue(item.focusCue);
+  const output = {
     contentReleaseId: item.contentReleaseId === GRAMMAR_CONTENT_RELEASE_ID ? GRAMMAR_CONTENT_RELEASE_ID : '',
     templateId: typeof item.templateId === 'string' ? item.templateId : '',
     templateLabel: typeof item.templateLabel === 'string' ? item.templateLabel : '',
@@ -73,6 +105,15 @@ function safeCurrentItem(item) {
       }
       : null,
   };
+  if (promptParts) output.promptParts = promptParts;
+  if (focusCue) output.focusCue = focusCue;
+  if (typeof item.screenReaderPromptText === 'string' && item.screenReaderPromptText) {
+    output.screenReaderPromptText = item.screenReaderPromptText;
+  }
+  if (typeof item.readAloudText === 'string' && item.readAloudText) {
+    output.readAloudText = item.readAloudText;
+  }
+  return output;
 }
 
 function safeMiniTestQuestion(entry, index, currentIndex, { includeItem = false, includeMarked = false } = {}) {


### PR DESCRIPTION
## Summary
- Exposes learner-facing Grammar prompt cue metadata through the Worker read-model allow-list.
- Keeps the read model fail-closed for unknown prompt/focus cue shapes.
- Adds Worker command-route regression coverage for target-sentence and noun-phrase cue metadata.

## Verification
- `npx -y node@22 --test tests/worker-grammar-subject-runtime.test.js tests/grammar-production-smoke.test.js`
- `npm test`
- `npm run check`
