### PR TITLE
fix(bootstrap): invalidate stale hydration cache

### DIFF
--- a/tests/worker-bootstrap-capacity.test.js
+++ b/tests/worker-bootstrap-capacity.test.js
@@ -329,11 +329,12 @@ test('production bootstrap keeps high-history public payloads bounded and redact
   assert.ok(payload.meta.capacity.bootstrapCapacity, 'bootstrapCapacity must be stamped on collector for public bootstrap.');
   // U7: BOOTSTRAP_CAPACITY_VERSION bumped from 1 to 2 when the
   // selected-learner-bounded envelope landed (plan line 750 release
-  // rule). U1 follow-up 2026-04-26: bumped 2 → 3 when the envelope
-  // gained `subjectStatesBounded` AND the revision-hash input set
-  // changed (added `writableLearnerStatesDigest` to close B1 — sibling
-  // subject_state writes now invalidate the notModified probe).
-  assert.equal(payload.meta.capacity.bootstrapCapacity.version, 3);
+  // rule). U1 follow-up 2026-04-26 bumped 2 -> 3 when the envelope
+  // gained `subjectStatesBounded` and the revision-hash input set
+  // changed. PR799 follow-up 2026-04-30 bumped 3 -> 4 because the
+  // Grammar public read-model representation changed and cached v3
+  // revisions must miss the notModified probe.
+  assert.equal(payload.meta.capacity.bootstrapCapacity.version, 4);
   assert.equal(payload.meta.capacity.bootstrapCapacity.mode, 'public-bounded');
   assert.equal('bootstrapPhaseTimings' in payload.meta.capacity, false, 'phase timings stay out of child-facing meta.capacity.');
 

--- a/tests/worker-bootstrap-v2.test.js
+++ b/tests/worker-bootstrap-v2.test.js
@@ -23,6 +23,7 @@ import {
   BOOTSTRAP_MODES,
   BOOTSTRAP_V2_ENVELOPE_SHAPE,
   computeBootstrapRevisionHash,
+  computeWritableLearnerStatesDigest,
 } from '../worker/src/repository.js';
 import { createWorkerRepositoryServer } from './helpers/worker-server.js';
 
@@ -139,14 +140,17 @@ async function readJsonBody(response) {
 // this test fails. Manual bump means manual snapshot regen in the same PR.
 // ---------------------------------------------------------------------------
 test('U7 scenario 15: envelope shape snapshot matches BOOTSTRAP_CAPACITY_VERSION', () => {
-  // U1 follow-up 2026-04-26: BOOTSTRAP_CAPACITY_VERSION bumped 2 → 3 in
-  // the same PR that (a) adds `bootstrapCapacity.subjectStatesBounded`
-  // (required-field addition — capacity release-gate plan line 167),
-  // (b) extends the revision-hash input set with
-  // `writableLearnerStatesDigest` (B1 blocker fix — sibling
-  // `writeSubjectState` now invalidates `bootstrapNotModifiedProbe`).
-  assert.equal(BOOTSTRAP_CAPACITY_VERSION, 3,
-    'U1 follow-up: bumps BOOTSTRAP_CAPACITY_VERSION 2→3 because the envelope gained subjectStatesBounded AND the hash input set changed.');
+  // U1 follow-up 2026-04-26: BOOTSTRAP_CAPACITY_VERSION bumped 2 -> 3
+  // when the envelope gained `bootstrapCapacity.subjectStatesBounded`
+  // and the hash input set gained `writableLearnerStatesDigest`.
+  //
+  // PR799 follow-up 2026-04-30: bumped 3 -> 4 when the public Grammar
+  // subject-state bootstrap projection changed from raw state to the
+  // public read-model. The version is part of the revision hash, so a
+  // deployed read-model representation change must invalidate cached v3
+  // `lastKnownRevision` values even when learner revisions are stable.
+  assert.equal(BOOTSTRAP_CAPACITY_VERSION, 4,
+    'PR799 follow-up: bumps BOOTSTRAP_CAPACITY_VERSION 3->4 so stale Grammar public read-model caches miss the notModified probe.');
   // Closed union for meta.capacity.bootstrapMode (canonical U7 enum).
   assert.deepEqual(
     [...BOOTSTRAP_MODES].sort(),
@@ -1077,6 +1081,47 @@ test('fresh bootstrap hydrates Punctuation and Grammar public stats from stored 
       'grammar first-paint analytics tracks stored mastery concepts');
     assert.equal(grammar.ui?.analytics?.progressSnapshot?.securedConcepts, 1,
       'grammar first-paint analytics exposes secured concepts');
+  } finally {
+    server.close();
+  }
+});
+
+test('PR799 follow-up: stale v3 Grammar hydration cache misses notModified after read-model projection change', async () => {
+  const server = createServer();
+  try {
+    insertLearner(server, 'adult-u7', { id: 'learner-a', name: 'Alpha', sortIndex: 0, selected: true });
+    insertSubjectStateFor(server, 'adult-u7', 'learner-a', 'grammar', {
+      data: grammarHydrationData({ mode: 'learn' }),
+    });
+
+    const staleV3Digest = await computeWritableLearnerStatesDigest([
+      { id: 'learner-a', state_revision: 0 },
+    ]);
+    const staleV3Revision = await computeBootstrapRevisionHash({
+      accountId: 'adult-u7',
+      accountRevision: 0,
+      selectedLearnerRevision: 0,
+      bootstrapCapacityVersion: 3,
+      accountLearnerListRevision: 0,
+      writableLearnerStatesDigest: staleV3Digest,
+    });
+
+    const response = await postBootstrap(server, { lastKnownRevision: staleV3Revision });
+    assert.equal(response.status, 200);
+    const payload = await readJsonBody(response);
+
+    assert.notEqual(payload.notModified, true,
+      'stale v3 revision must not keep a raw pre-PR799 Grammar cache alive');
+    assert.equal(payload.revision?.bootstrapCapacityVersion, BOOTSTRAP_CAPACITY_VERSION);
+    assert.notEqual(payload.revision?.hash, staleV3Revision,
+      'server emits a fresh v4 hash after the read-model projection bump');
+
+    const grammar = payload.subjectStates?.['learner-a::grammar'];
+    assert.ok(grammar, 'full bundle includes grammar subject state after probe miss');
+    assert.deepEqual(grammar.data, {}, 'raw grammar data remains stripped');
+    assert.equal(grammar.ui?.prefs?.mode, 'learn');
+    assert.equal(grammar.ui?.stats?.concepts?.secured, 1,
+      'full bundle carries the Grammar public read-model stats');
   } finally {
     server.close();
   }

--- a/worker/src/bootstrap-repository.js
+++ b/worker/src/bootstrap-repository.js
@@ -32,10 +32,15 @@ export const PUBLIC_BOOTSTRAP_RECENT_EVENT_LIMIT_PER_LEARNER = 50;
 //     writable learner) so sibling subject_state writes invalidate the
 //     `bootstrapNotModifiedProbe` short-circuit (B1 blocker).
 // Stale v2 clients will naturally miss, re-fetch, and bind to the v3 hash.
+// PR799 follow-up 2026-04-30: bumped 3 -> 4 when Grammar subject-state
+// bootstrap changed from raw state passthrough to the public read-model.
+// The response's top-level keys did not change, but the cached
+// `subjectStates.*.ui` representation did; keeping v3 would let stable
+// accounts honour `notModified` forever and keep the stale raw Grammar cache.
 // Any additive required field on the bootstrap envelope MUST bump this in
 // the same PR. `tests/worker-bootstrap-v2.test.js` has a snapshot test that
 // fails if the envelope shape changes without a version bump (scenario 15).
-export const PUBLIC_BOOTSTRAP_CAPACITY_VERSION = 3;
+export const PUBLIC_BOOTSTRAP_CAPACITY_VERSION = 4;
 export const BOOTSTRAP_CAPACITY_VERSION = PUBLIC_BOOTSTRAP_CAPACITY_VERSION;
 
 // U7: closed union for `meta.capacity.bootstrapMode` when the public
@@ -115,8 +120,8 @@ export const BOOTSTRAP_V2_ENVELOPE_SHAPE = Object.freeze({
 //
 // Changing this input format (or the truncation length) is equivalent to
 // bumping `BOOTSTRAP_CAPACITY_VERSION` — stale clients will silently
-// reject `notModified` responses via the schema check. The version bump
-// in this PR from 2→3 forces v2 clients to miss once and re-bind.
+// reject `notModified` responses via the schema check. The version bumps
+// from 2 -> 3 and 3 -> 4 force stale clients to miss once and re-bind.
 export async function computeBootstrapRevisionHash({
   accountId,
   accountRevision,


### PR DESCRIPTION
## Summary
- Bump the public bootstrap capacity/cache version from 3 to 4 so PR799's Grammar public read-model projection change invalidates stored `lastKnownRevision` caches.
- Add a regression that posts a stale v3 revision hash and asserts the server returns a full bundle with Grammar public stats instead of `notModified`.
- Update the capacity bootstrap version expectation to match the new cache contract.

## Root Cause
PR799 fixed fresh bootstrap responses, but stable accounts with a persisted v3 `lastKnownRevision` could still receive `notModified` from `POST /api/bootstrap`. That preserved the stale raw Grammar subject-state cache and bypassed the new public read-model hydration path.

## Verification
- `node --test tests/worker-bootstrap-v2.test.js` ✅ 27 pass
- `node --test tests/worker-bootstrap-capacity.test.js` ✅ 3 pass
- `npm run check` ✅ main bundle `230843 / 232000` gzip
- `git diff --check` ✅

Note: the first `npm run check` failed before `node scripts/worktree-setup.mjs` because this fresh worktree had no symlinked `node_modules` and could not resolve `esbuild`; after setup, the same check passed.