### PR TITLE
docs(punctuation-qg): certify P10 post-deploy

### DIFF
--- a/docs/plans/james/punctuation/questions-generator/punctuation-qg-p10-completion-report.md
+++ b/docs/plans/james/punctuation/questions-generator/punctuation-qg-p10-completion-report.md
@@ -1,22 +1,22 @@
 ---
 phase: punctuation-qg-p10
-title: Punctuation QG P10 — Pre-Deploy Certification Report
-status: certified_pre_deploy
+title: Punctuation QG P10 — Post-Deploy Certification Report
+status: certified_post_deploy
 owner: KS2 Mastery / Punctuation
 language: en-GB
 created: 2026-04-30
 source_contract: docs/plans/james/punctuation/questions-generator/punctuation-qg-p10.md
 verification_log: reports/punctuation/punctuation-qg-p10-verify.log
-verification_log_sha256: d50205eb5d034233a13e275c853209543f608fbf0daa0ccb07e9e291d8cb4b8e
+verification_log_sha256: fe9f36d7766e5e1136ef6465cc091b06a434cb44afa1fdadf3348a4152f9a320
 ---
 
-# Punctuation QG P10 — Pre-Deploy Certification Report
+# Punctuation QG P10 — Post-Deploy Certification Report
 
 ## Executive summary
 
 P10 closes the remaining generated-item lexical-preservation leak for closed punctuation transfer items. Closed generated and fixed `insert` and `fix` items now reject any failed preservation, including same-count lexical substitutions where the learner changes a content word but keeps the punctuation shape.
 
-The machine-verifiable P10 gates pass under Node `v22.16.0` / npm `10.9.2`. James has accepted the depth-4 P10 release scope as product owner: 192 production items and 47 review-required clusters. The canonical verifier therefore reports `CERTIFIED_PRE_DEPLOY`. Live production smoke is still `not_run`, so post-deploy certification is not claimed.
+The machine-verifiable P10 gates pass under Node `v22.16.0` / npm `10.9.2`. James has accepted the depth-4 P10 release scope as product owner: 192 production items and 47 review-required clusters. The release was deployed to production and the Punctuation production smoke passed against `https://ks2.eugnel.uk`, so the canonical verifier reports `CERTIFIED_POST_DEPLOY`.
 
 ## Delivery mapping
 
@@ -25,9 +25,9 @@ The machine-verifiable P10 gates pass under Node `v22.16.0` / npm `10.9.2`. Jame
 | U1 lexical preservation lock | Done | `shared/punctuation/marking.js` rejects any failed preservation for closed `insert` / `fix` transfer items. |
 | U2 P10 lexical-replacement oracle | Done | `tests/punctuation-closed-lexical-preservation-p10.test.js`, 4 tests passing. |
 | U3 P10 verifier | Done | `npm run verify:punctuation-qg:p10`, 10 top-level gates / 56 logical gates. |
-| U4 certification manifest and validator | Done, pre-deploy certifying | `reports/punctuation/punctuation-qg-p10-certification-manifest.json` and `scripts/validate-punctuation-qg-certification-evidence.mjs`. |
+| U4 certification manifest and validator | Done, post-deploy certifying | `reports/punctuation/punctuation-qg-p10-certification-manifest.json` and `scripts/validate-punctuation-qg-certification-evidence.mjs`. |
 | U5 human acceptance truth gate | Done | Fixture records James as product-owner acceptor for 192 items and 47 review-required clusters, with no blockers. |
-| U6 live production smoke | Not run | Manifest records `liveProductionSmoke.status: not_run`; verifier blocks post-deploy certification. |
+| U6 live production smoke | Done | `reports/punctuation/punctuation-qg-p10-production-smoke-2026-04-30.json`; release `punctuation-r4-full-14-skill-structure`, 192 runtime items, generated depth 4. |
 | U7 depth-6 scope | Preserved blocked | `PRODUCTION_DEPTH` remains 4; depth-6 candidate delta remains blocked. |
 
 ## AI simulated acceptance
@@ -55,14 +55,26 @@ Logical gates: 56
 Passed: 10/10
 Failed: 0
 Production depth: 4
-Certification: CERTIFIED_PRE_DEPLOY
+Certification: CERTIFIED_POST_DEPLOY
+```
+
+Post-deploy production smoke:
+
+```text
+node ./scripts/punctuation-production-smoke.mjs --env production --commit-sha 2169acdac51848c9f0f2691b2da00f5fe5aa6c55 --json
+origin: https://ks2.eugnel.uk
+worker: b9a9bf07-817a-44d8-b7b1-7897f4f334d9
+releaseId: punctuation-r4-full-14-skill-structure
+runtimeItems: 192
+generatedDepth: 4
+sha256: 0d80db44fa033f5ddc5874fa318f3e7aca3006446afb6a19d16c91bfbce04196
 ```
 
 Archived verifier output:
 
 ```text
 reports/punctuation/punctuation-qg-p10-verify.log
-sha256: d50205eb5d034233a13e275c853209543f608fbf0daa0ccb07e9e291d8cb4b8e
+sha256: fe9f36d7766e5e1136ef6465cc091b06a434cb44afa1fdadf3348a4152f9a320
 ```
 
 Focused checks:
@@ -107,14 +119,12 @@ AI-simulated accepted: proven as a non-certifying review artefact. It is explici
 
 Human-accepted: proven for depth 4. James accepted the 192-item production pool and 47 review-required clusters on 2026-04-30 as product owner, with no blockers.
 
-Live-production-proven: not proven. No smoke was run against `https://ks2.eugnel.uk` for this P10 release identity.
+Live-production-proven: proven. Production smoke passed against `https://ks2.eugnel.uk` for release `punctuation-r4-full-14-skill-structure`, merged main commit `2169acdac51848c9f0f2691b2da00f5fe5aa6c55`, and Worker version `b9a9bf07-817a-44d8-b7b1-7897f4f334d9`.
 
 ## Final status
 
-Punctuation QG P10 is certified pre-deploy for the depth-4 source snapshot. The correct current status is:
+Punctuation QG P10 is certified post-deploy for the depth-4 source snapshot. The correct current status is:
 
 ```text
-CERTIFIED_PRE_DEPLOY
+CERTIFIED_POST_DEPLOY
 ```
-
-The release may only move to `CERTIFIED_POST_DEPLOY` after live production smoke passes with origin, environment, release identity, deployed commit or Worker version, timestamp, result, artefact path, and artefact SHA-256.

--- a/reports/punctuation/punctuation-qg-p10-certification-manifest.json
+++ b/reports/punctuation/punctuation-qg-p10-certification-manifest.json
@@ -2,8 +2,8 @@
   "schemaVersion": 1,
   "subject": "punctuation",
   "phase": "punctuation-qg-p10",
-  "certificationStatus": "CERTIFIED_PRE_DEPLOY",
-  "statusRationale": "Depth-4 P10 source and local gates pass, and James has accepted the 192-item depth-4 production pool with 47 review-required clusters. Live production smoke has not run, so post-deploy certification remains unavailable.",
+  "certificationStatus": "CERTIFIED_POST_DEPLOY",
+  "statusRationale": "Depth-4 P10 source and local gates pass, James has accepted the 192-item depth-4 production pool with 47 review-required clusters, and live production smoke passed on https://ks2.eugnel.uk after deploy.",
   "releaseId": "punctuation-r4-full-14-skill-structure",
   "source": {
     "zip": {
@@ -12,8 +12,8 @@
     },
     "git": {
       "repository": "fol2/ks2-mastery",
-      "ref": "codex/punctuation-qg-p10-delivery",
-      "commitSha": "ba5d901dac5f4d5ca2d619e10402c82ef3da8ad8",
+      "ref": "main",
+      "commitSha": "2169acdac51848c9f0f2691b2da00f5fe5aa6c55",
       "commitContainsAllVerifiedPaths": true,
       "verifiedPaths": [
         "package.json",
@@ -51,7 +51,7 @@
     "npmVersion": "10.9.2",
     "logicalGates": 56,
     "logPath": "reports/punctuation/punctuation-qg-p10-verify.log",
-    "logSha256": "d50205eb5d034233a13e275c853209543f608fbf0daa0ccb07e9e291d8cb4b8e"
+    "logSha256": "fe9f36d7766e5e1136ef6465cc091b06a434cb44afa1fdadf3348a4152f9a320"
   },
   "review": {
     "aiPreReview": {
@@ -78,16 +78,16 @@
     }
   },
   "liveProductionSmoke": {
-    "status": "not_run",
-    "environment": null,
-    "origin": null,
+    "status": "pass",
+    "environment": "production",
+    "origin": "https://ks2.eugnel.uk",
     "releaseId": "punctuation-r4-full-14-skill-structure",
-    "deployedCommitOrWorkerVersion": null,
-    "timestamp": null,
-    "command": null,
-    "result": null,
-    "artefactPath": null,
-    "artefactSha256": null
+    "deployedCommitOrWorkerVersion": "main 2169acdac51848c9f0f2691b2da00f5fe5aa6c55; worker b9a9bf07-817a-44d8-b7b1-7897f4f334d9",
+    "timestamp": "2026-04-30T22:01:04.476Z",
+    "command": "node ./scripts/punctuation-production-smoke.mjs --env production --commit-sha 2169acdac51848c9f0f2691b2da00f5fe5aa6c55 --json",
+    "result": "pass",
+    "artefactPath": "reports/punctuation/punctuation-qg-p10-production-smoke-2026-04-30.json",
+    "artefactSha256": "0d80db44fa033f5ddc5874fa318f3e7aca3006446afb6a19d16c91bfbce04196"
   },
   "depth6": {
     "status": "blocked",

--- a/reports/punctuation/punctuation-qg-p10-production-smoke-2026-04-30.json
+++ b/reports/punctuation/punctuation-qg-p10-production-smoke-2026-04-30.json
@@ -1,0 +1,82 @@
+{
+  "ok": true,
+  "origin": "https://ks2.eugnel.uk",
+  "accountId": "demo-h3g3J1uyIA9BTA",
+  "learnerId": "learner-demo-KVokvEjuLuIS-g",
+  "attestation": {
+    "environment": "production",
+    "releaseId": "punctuation-r4-full-14-skill-structure",
+    "runtimeItemCount": 192,
+    "generatedDepth": 4,
+    "workerCommitSha": "2169acdac51848c9f0f2691b2da00f5fe5aa6c55",
+    "timestamp": "2026-04-30T22:01:04.476Z",
+    "authenticatedCoverage": false,
+    "adminHubCoverage": false
+  },
+  "punctuation": {
+    "productionObserved": {
+      "releaseId": "punctuation-r4-full-14-skill-structure",
+      "runtimeItems": 192,
+      "publishedRewardUnits": 14,
+      "generatedItemCommandPathProbe": {
+        "itemId": "gen_speech_insert_1srve21_3",
+        "mode": "insert",
+        "skillIds": [
+          "speech"
+        ],
+        "feedbackKind": "error",
+        "misconceptionTags": [
+          "speech.quote_missing"
+        ]
+      }
+    },
+    "localReleaseManifestExpectation": {
+      "fixedItems": 92,
+      "generatedItems": 100,
+      "generatedPerFamily": 4,
+      "runtimeItems": 192,
+      "publishedRewardUnits": 14
+    },
+    "smartItemId": "pa_choose_coach",
+    "smartSummaryTotal": 1,
+    "generatedIncorrectItemId": "gen_speech_insert_1srve21_3",
+    "generatedIncorrectMisconceptionTags": [
+      "speech.quote_missing"
+    ],
+    "dashAcceptance": [
+      {
+        "variant": "spaced-hyphen",
+        "itemId": "dc_insert_door_froze",
+        "mode": "insert",
+        "skillIds": [
+          "dash_clause"
+        ]
+      },
+      {
+        "variant": "en-dash",
+        "itemId": "gen_dash_clause_fix_14ggaft_1",
+        "mode": "fix",
+        "skillIds": [
+          "dash_clause"
+        ]
+      },
+      {
+        "variant": "em-dash",
+        "itemId": "dc_transfer_curtain_rose",
+        "mode": "transfer",
+        "skillIds": [
+          "dash_clause"
+        ]
+      }
+    ],
+    "oxfordCommaItemId": "gen_list_commas_combine_peklr6_1",
+    "advancedMode": "gps",
+    "advancedItemId": "sl_choose_clubs",
+    "advancedReviewItems": 1,
+    "parentHubAttempts": 30
+  },
+  "spelling": {
+    "progressTotal": 1,
+    "hasPromptToken": true
+  }
+}

--- a/reports/punctuation/punctuation-qg-p10-verify.log
+++ b/reports/punctuation/punctuation-qg-p10-verify.log
@@ -7,7 +7,7 @@
 PUNCTUATION QG P10 VERIFICATION
 ══════════════════════════════════════════════════════════════
 
-  ▶ P9 composed gates ...  ✓ P9 composed gates (10.6s)
+  ▶ P9 composed gates ...  ✓ P9 composed gates (10.1s)
   ▶ P10 lexical-replacement oracle ...  ✓ P10 lexical-replacement oracle (0.2s)
   ▶ Model-answer preservation after P10 patch ...  ✓ Model-answer preservation after P10 patch (0.0s) — items=148, answers=169
   ▶ Reviewer decision integrity ...  ✓ Reviewer decision integrity (0.1s) — schema=3, ai_pre_review=complete, items=192, review_required_clusters=47
@@ -16,7 +16,7 @@ PUNCTUATION QG P10 VERIFICATION
   ▶ Certification manifest validation ...  ✓ Certification manifest validation (0.2s)
   ▶ Depth-4 production-depth lock ...  ✓ Depth-4 production-depth lock (0.0s) — PRODUCTION_DEPTH=4, fixed=92, generated=100, total=192
   ▶ Depth-6 remains blocked ...  ✓ Depth-6 remains blocked (0.0s) — depth6_candidate_delta=50, status=blocked
-  ▶ Live production smoke truth gate ...  ✓ Live production smoke truth gate (0.0s) — liveProductionSmoke=not_run
+  ▶ Live production smoke truth gate ...  ✓ Live production smoke truth gate (0.0s) — liveProductionSmoke=pass
 
 ──────────────────────────────────────────────────────────────
   Summary:
@@ -25,12 +25,9 @@ PUNCTUATION QG P10 VERIFICATION
     Passed:             10/10
     Failed:             0
     Production depth:   4
-    Certification:      CERTIFIED_PRE_DEPLOY
-    Elapsed:            11.2s
+    Certification:      CERTIFIED_POST_DEPLOY
+    Elapsed:            10.7s
 ──────────────────────────────────────────────────────────────
 
-  Post-deploy blockers:
-    - Live production smoke has not run, so post-deploy certification is unavailable.
-
-  RESULT: CERTIFIED_PRE_DEPLOY
+  RESULT: CERTIFIED_POST_DEPLOY
 


### PR DESCRIPTION
## Summary
- record the passing Punctuation P10 production smoke for https://ks2.eugnel.uk
- update the P10 manifest and completion report to CERTIFIED_POST_DEPLOY
- refresh the archived P10 verifier log/hash

## Verification
- npm test
- npm run check
- npm run deploy
- node ./scripts/punctuation-production-smoke.mjs --env production --commit-sha 2169acdac51848c9f0f2691b2da00f5fe5aa6c55 --json
- npm run verify:punctuation-qg:p10
- node scripts/validate-punctuation-qg-certification-evidence.mjs reports/punctuation/punctuation-qg-p10-certification-manifest.json reports/punctuation/punctuation-qg-p10-verify.log