### PR TITLE
docs(grammar): record P13 post-deploy certification

### DIFF
--- a/docs/plans/james/grammar/questions-generator/grammar-qg-p13-completion-report.md
+++ b/docs/plans/james/grammar/questions-generator/grammar-qg-p13-completion-report.md
@@ -1,7 +1,7 @@
 ---
 phase: grammar-qg-p13
 title: Grammar QG P13 — Runtime Certification Authority and Post-Deploy Production Certification
-certification_decision: CERTIFIED_PRE_DEPLOY
+certification_decision: CERTIFIED_POST_DEPLOY
 certification_phase: grammar-qg-p13
 final_content_release_id: grammar-qg-p11-2026-04-30
 content_release_unchanged: true
@@ -9,13 +9,11 @@ scoring_change: none
 mastery_change: none
 reward_change: none
 hero_mode_change: none
-post_deploy_smoke_evidence: pending-deployment
+post_deploy_smoke_evidence: reports/grammar/grammar-production-smoke-grammar-qg-p11-2026-04-30.json
 template_count: 78
 concept_count: 18
 inventory_item_count: 2340
-limitations:
-  - Production smoke evidence is pending deployment.
-  - Local release-gate evidence was captured on Node 24.2.0 / npm 11.6.3; CI evidence must still be green before merge.
+limitations: []
 ---
 
 # Grammar QG P13 — Runtime Certification Authority and Post-Deploy Production Certification
@@ -24,7 +22,7 @@ limitations:
 
 P13 keeps `grammar-qg-p11-2026-04-30` as the frozen content release and productionises the certification source. The learner-facing scheduler now uses a Worker-safe generated runtime status module derived from `reports/grammar/grammar-qg-p11-certification-status-map.json`; it no longer loads the historical P10 status map, uses Node `fs` or `require`, or creates an all-approved metadata fallback.
 
-Current decision: **CERTIFIED_PRE_DEPLOY**. Post-deploy certification remains pending until the deployed Worker is smoke-tested and the evidence JSON is committed or attached according to repository policy.
+Current decision: **CERTIFIED_POST_DEPLOY**. The live Worker at `https://ks2.eugnel.uk` has been deployed from `e3e214b57e1f86dd815da8b4fb858237aed3cefd`, production bundle audit passed, and post-deploy Grammar smoke evidence is committed at `reports/grammar/grammar-production-smoke-grammar-qg-p11-2026-04-30.json`.
 
 ## Contract Mapping
 
@@ -37,7 +35,7 @@ Current decision: **CERTIFIED_PRE_DEPLOY**. Post-deploy certification remains pe
 | Generated-source drift guard | Added `scripts/generate-grammar-qg-runtime-certification-status.mjs`; the validator regenerates expected source and fails on byte drift. |
 | Runtime authority validator | `scripts/validate-grammar-qg-certification-evidence.mjs` now checks manifest status map, runtime release ID, template count, per-template status/evidence parity, fail-closed unknown IDs and active P10 authority references. |
 | Manifest expected paths | `expectedOutputPaths` now names the canonical render inventory files, and the validator fails missing expected paths. |
-| Production smoke honesty | Report remains pre-deploy until `reports/grammar/grammar-production-smoke-grammar-qg-p11-2026-04-30.json` exists and passes validation. |
+| Production smoke honesty | Report moved to post-deploy only after `reports/grammar/grammar-production-smoke-grammar-qg-p11-2026-04-30.json` existed and passed validation. |
 | Rollback/blocklist notes | See the operating notes below. |
 
 ## Evidence Artefacts
@@ -52,7 +50,7 @@ Current decision: **CERTIFIED_PRE_DEPLOY**. Post-deploy certification remains pe
 | Marking matrix | `reports/grammar/grammar-qg-p11-marking-matrix.json` | 80 marking matrix entries |
 | Certification status map | `reports/grammar/grammar-qg-p11-certification-status-map.json` | runtime authority source |
 | Generated runtime source | `worker/src/subjects/grammar/certification-status.generated.js` | Worker-safe committed source |
-| Production smoke | `reports/grammar/grammar-production-smoke-grammar-qg-p11-2026-04-30.json` | pending deployment |
+| Production smoke | `reports/grammar/grammar-production-smoke-grammar-qg-p11-2026-04-30.json` | post-deploy pass |
 
 ## Release Gate
 
@@ -72,7 +70,17 @@ npm run smoke:production:grammar -- \
   --out=reports/grammar/grammar-production-smoke-grammar-qg-p11-2026-04-30.json
 ```
 
-The report can move to `CERTIFIED_POST_DEPLOY` only after that smoke evidence proves the production endpoint is reachable, the Worker serves `grammar-qg-p11-2026-04-30`, item creation and selected/constructed answer submission work, read models update, semantic cue assertions pass and client-facing payloads do not leak answer internals.
+This report moved to `CERTIFIED_POST_DEPLOY` after the smoke evidence proved the production endpoint is reachable, the Worker serves `grammar-qg-p11-2026-04-30`, item creation and selected/constructed answer submission work, read models update, semantic cue assertions pass and client-facing payloads do not leak answer internals.
+
+## Post-Deploy Hardening
+
+The first post-deploy smoke runs found three live read-model issues before certification was claimed:
+
+1. Summary read models exposed `sessionId`; fixed in PR #798.
+2. Faded support contrast exposed the server-only `nearMiss` key; fixed in PR #801 by projecting `commonMixUp`.
+3. Prompt cue metadata was generated but dropped by the Worker read-model allow-list; fixed in PR #802 by projecting learner-facing cue fields through fail-closed allow-lists.
+
+All three fixes were merged, deployed, and covered by the final production smoke evidence.
 
 ## Rollback And Blocklist Notes
 
@@ -102,5 +110,13 @@ Focused P13 gates are implemented in `tests/grammar-qg-p13-runtime-certification
 | `npm run check` | Node v24.2.0 / npm 11.6.3, branch `codex/grammar-qg-p13-runtime-certification` | Passed. Wrangler dry-run completed after `npm run build`, `npm run assert:build-public`, and `npm run audit:client`. |
 | `git diff --check` | Working tree | Passed. |
 | `npm test` | Node v24.2.0 / npm 11.6.3, branch `codex/grammar-qg-p13-runtime-certification` | Passed: 16,240 tests; 16,234 passed; 0 failed; 6 skipped. |
+| PR #802 GitHub CI | `codex/grammar-focus-cue-read-model-hotfix` | Passed: `npm test + npm run check`, `npm run audit:client`, `npm run audit:punctuation-content`, path classification and GitGuardian. |
+| `npm run deploy` | `e3e214b57e1f86dd815da8b4fb858237aed3cefd` | Passed. Cloudflare Worker version `85604165-1e04-4ad9-b278-5959abdcdb9a`; production bundle audit passed for `https://ks2.eugnel.uk/`. |
+| `npm run smoke:production:grammar -- --json --evidence-origin=post-deploy --expected-release=grammar-qg-p11-2026-04-30 --out=reports/grammar/grammar-production-smoke-grammar-qg-p11-2026-04-30.json` | Production `https://ks2.eugnel.uk`, commit `e3e214b57e1f86dd815da8b4fb858237aed3cefd` | Passed. Evidence `ok: true`; all answer-spec families covered; target-sentence and noun-phrase cue assertions passed; forbidden-key scan passed. |
+| `npx -y node@22 --test tests/grammar-qg-p5-report-validation.test.js` | Branch `codex/grammar-qg-p13-post-deploy-certification` | Passed: 5 tests, 0 failed. The missing-evidence regression now uses an isolated temporary root so it remains valid after the real smoke evidence file is committed. |
+| `npm run verify:grammar-qg-production-release` | Branch `codex/grammar-qg-p13-post-deploy-certification` | Passed. This revalidated the full P11 chain, P13 runtime authority, semantic prompt-cue audit (`totalChecked: 2340`) and post-deploy report/evidence consistency. |
+| `npm test` | Branch `codex/grammar-qg-p13-post-deploy-certification` | Passed: 16,274 tests; 16,268 passed; 0 failed; 6 skipped. |
+| `npm run check` | Branch `codex/grammar-qg-p13-post-deploy-certification` | Passed. Wrangler dry-run completed after build, public asset assertion and client bundle audit. |
+| `git diff --check` | Branch `codex/grammar-qg-p13-post-deploy-certification` | Passed. |
 
-Post-deploy smoke is not yet present, no production deployment was performed from this branch, and this report deliberately does not claim post-deploy certification. Before merge, GitHub CI must rerun on the pushed PR branch and remain green. After deployment, production smoke must write `reports/grammar/grammar-production-smoke-grammar-qg-p11-2026-04-30.json` before this report can move to `CERTIFIED_POST_DEPLOY`.
+Post-deploy production certification is complete for `grammar-qg-p11-2026-04-30`.

--- a/reports/grammar/grammar-production-smoke-grammar-qg-p11-2026-04-30.json
+++ b/reports/grammar/grammar-production-smoke-grammar-qg-p11-2026-04-30.json
@@ -1,0 +1,86 @@
+{
+  "ok": true,
+  "releaseId": "grammar-qg-p11-2026-04-30",
+  "evidenceOrigin": "post-deploy",
+  "environment": "production",
+  "deployedUrl": "https://ks2.eugnel.uk",
+  "origin": "post-deploy",
+  "contentReleaseId": "grammar-qg-p11-2026-04-30",
+  "testedTemplateIds": [
+    "qg_modal_verb_explain",
+    "fronted_adverbial_choose",
+    "qg_modal_verb_explain",
+    "qg_subject_object_classify_table",
+    "tense_rewrite",
+    "fix_fronted_adverbial",
+    "combine_clauses_rewrite",
+    "build_noun_phrase",
+    "identify_words_in_sentence",
+    "qg_p4_voice_roles_transfer"
+  ],
+  "answerSpecFamiliesCovered": [
+    "exact",
+    "multiField",
+    "normalisedText",
+    "punctuationPattern",
+    "acceptedSet",
+    "manualReviewOnly"
+  ],
+  "command": "npm run smoke:production:grammar -- --json --evidence-origin=post-deploy --expected-release=grammar-qg-p11-2026-04-30 --out=reports/grammar/grammar-production-smoke-grammar-qg-p11-2026-04-30.json",
+  "learnerFixtureType": "demo-session",
+  "itemCreationResult": {
+    "ok": true,
+    "detail": "templateId=qg_modal_verb_explain, answered=1"
+  },
+  "answerSubmissionResult": {
+    "ok": true,
+    "detail": "templateId=qg_modal_verb_explain, answered=1"
+  },
+  "readModelUpdateResult": {
+    "ok": true,
+    "detail": "templateId=qg_modal_verb_explain, answered=1"
+  },
+  "noAnswerLeakAssertion": {
+    "ok": true,
+    "detail": "checked via assertNoForbiddenGrammarReadModelKeys in each phase"
+  },
+  "semanticCueAssertion": {
+    "ok": true,
+    "detail": "targetSentence=identify_words_in_sentence, nounPhrase=qg_p4_voice_roles_transfer"
+  },
+  "promptCueAssertion": {
+    "ok": true,
+    "detail": "targetSentence=identify_words_in_sentence, nounPhrase=qg_p4_voice_roles_transfer"
+  },
+  "readAloudAssertion": {
+    "ok": true,
+    "detail": "targetSentence=identify_words_in_sentence, nounPhrase=qg_p4_voice_roles_transfer"
+  },
+  "releaseIdAssertion": {
+    "ok": true,
+    "detail": "contentReleaseId=grammar-qg-p11-2026-04-30"
+  },
+  "normalRoundResult": {
+    "ok": true,
+    "detail": "templateId=qg_modal_verb_explain, answered=1"
+  },
+  "miniTestResult": {
+    "ok": true,
+    "detail": "answered=1, reviewSize=8"
+  },
+  "repairResult": {
+    "ok": true,
+    "detail": "supportKind=faded, aiKind=explanation"
+  },
+  "cueAssertionResult": {
+    "ok": true,
+    "detail": "targetSentence=identify_words_in_sentence, nounPhrase=qg_p4_voice_roles_transfer"
+  },
+  "forbiddenKeyScanResult": {
+    "ok": true,
+    "detail": "checked via assertNoForbiddenGrammarReadModelKeys in each phase"
+  },
+  "failureDetails": null,
+  "timestamp": "2026-04-30T22:04:37.543Z",
+  "commitSha": "e3e214b57e1f86dd815da8b4fb858237aed3cefd"
+}

--- a/tests/grammar-qg-p5-report-validation.test.js
+++ b/tests/grammar-qg-p5-report-validation.test.js
@@ -1,5 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -108,6 +110,7 @@ test('report claiming post-deploy smoke passed without evidence file fails', () 
   const deepSeeds = Array.from({ length: 30 }, (_, i) => i + 1);
   const audit = buildGrammarQuestionGeneratorAudit({ seeds, deepSeeds });
   const contentQuality = buildGrammarContentQualityAudit(seeds);
+  const missingEvidenceRoot = mkdtempSync(path.join(tmpdir(), 'grammar-qg-p5-report-'));
 
   // Build a report that claims post-deploy smoke passed
   const report = buildValidMockReport(audit, contentQuality)
@@ -117,7 +120,7 @@ test('report claiming post-deploy smoke passed without evidence file fails', () 
     );
 
   const result = validateGrammarCompletionReport(report, {
-    rootDir: ROOT_DIR,
+    rootDir: missingEvidenceRoot,
     seeds,
     deepSeeds,
     auditOverride: audit,


### PR DESCRIPTION
## Summary
- moves Grammar QG P13 to CERTIFIED_POST_DEPLOY after the deployed Worker passed production Grammar smoke
- commits the post-deploy smoke evidence for grammar-qg-p11-2026-04-30
- fixes the P5 report-validation fixture so the missing-evidence regression stays isolated now that real evidence exists

## Verification
- npx -y node@22 --test tests/grammar-qg-p5-report-validation.test.js
- npm run verify:grammar-qg-production-release
- npm test
- npm run check
- git diff --check

## Production Evidence
- Deployed Worker commit: e3e214b57e1f86dd815da8b4fb858237aed3cefd
- Worker version: 85604165-1e04-4ad9-b278-5959abdcdb9a
- Production smoke evidence: reports/grammar/grammar-production-smoke-grammar-qg-p11-2026-04-30.json