### PR TITLE
fix(punctuation): rotate weak spots across sessions

### DIFF
--- a/shared/punctuation/scheduler.js
+++ b/shared/punctuation/scheduler.js
@@ -20,6 +20,7 @@ export const MIN_MS = 60 * 1000;
 
 const SMART_MODE_CYCLE = Object.freeze(['choose', 'insert', 'fix', 'transfer', 'combine', 'paragraph']);
 const GUIDED_MODE_CYCLE = Object.freeze(['choose', 'insert', 'fix']);
+const RECENT_ITEM_AVOIDANCE_WINDOW = 6;
 const CLUSTER_MODE = Object.freeze({
   endmarks: 'endmarks',
   apostrophe: 'apostrophe',
@@ -400,6 +401,24 @@ function recentSignatureSet(indexes, session = {}, progress = {}) {
   return signatures;
 }
 
+function recentItemSet(session = {}, progress = {}, limit = RECENT_ITEM_AVOIDANCE_WINDOW) {
+  const ids = new Set();
+  const sessionIds = Array.isArray(session?.recentItemIds) ? session.recentItemIds.slice(-limit) : [];
+  for (const itemId of sessionIds) {
+    if (typeof itemId === 'string' && itemId) ids.add(itemId);
+  }
+  const attempts = Array.isArray(progress?.attempts) ? progress.attempts.slice(-limit) : [];
+  for (const attempt of attempts) {
+    if (typeof attempt?.itemId === 'string' && attempt.itemId) ids.add(attempt.itemId);
+  }
+  return ids;
+}
+
+function avoidRecentItemRows(rows, recent) {
+  const freshRows = rows.filter((row) => !recent.has(row.item?.id));
+  return freshRows.length ? freshRows : rows;
+}
+
 function avoidRecentSignatureRows(rows, recentSignatures) {
   const freshRows = rows.filter((row) => {
     const signature = row.item?.variantSignature;
@@ -556,7 +575,7 @@ function selectMisconceptionRetry(indexes, progress, session, recentSignatures) 
 // --- End misconception retry helpers ---
 
 function weakRows(indexes, progress, session, now, maxWindow) {
-  const recent = new Set(Array.isArray(session?.recentItemIds) ? session.recentItemIds.slice(-6) : []);
+  const recent = recentItemSet(session, progress);
   const recentSignatures = recentSignatureSet(indexes, session, progress);
   const sessionSignatures = new Set(
     Array.isArray(session?.selectedSignatures) ? session.selectedSignatures : []
@@ -589,7 +608,7 @@ function weakRows(indexes, progress, session, now, maxWindow) {
   }
 
   const sortedRows = rows.sort((a, b) => b.priority - a.priority || a.order - b.order);
-  return avoidRecentSignatureRows(sortedRows, recentSignatures);
+  return avoidRecentItemRows(avoidRecentSignatureRows(sortedRows, recentSignatures), recent);
 }
 
 // --- Reason tag classification helpers ---

--- a/tests/punctuation-scheduler.test.js
+++ b/tests/punctuation-scheduler.test.js
@@ -118,6 +118,63 @@ test('weak mode avoids repeating a recent item when another weak alternative exi
   assert.equal(result.weakFocus.source, 'weak_facet');
 });
 
+test('weak mode avoids the last attempted item when a new session starts', () => {
+  const weakFacet = updateMemoryState(createMemoryState(), false, 0);
+  const items = [
+    {
+      id: 'weak_fixed_insert',
+      mode: 'insert',
+      skillIds: ['speech'],
+      clusterId: 'speech',
+      rewardUnitId: 'speech-core',
+      prompt: 'Add the missing punctuation.',
+      source: 'fixed',
+    },
+    {
+      id: 'weak_generated_insert',
+      mode: 'insert',
+      skillIds: ['speech'],
+      clusterId: 'speech',
+      rewardUnitId: 'speech-core',
+      prompt: 'Add the missing punctuation in another sentence.',
+      source: 'generated',
+      variantSignature: 'puncsig_recentalt',
+    },
+  ];
+  const indexes = {
+    items,
+    itemById: new Map(items.map((item) => [item.id, item])),
+    itemsByMode: new Map([['insert', items]]),
+    skillById: new Map([['speech', { id: 'speech', name: 'Direct speech', published: true }]]),
+  };
+
+  const result = selectPunctuationItem({
+    indexes,
+    progress: {
+      items: {},
+      facets: { 'speech::insert': weakFacet },
+      rewardUnits: {},
+      attempts: [
+        {
+          itemId: 'weak_fixed_insert',
+          mode: 'insert',
+          itemMode: 'insert',
+          skillIds: ['speech'],
+          correct: true,
+        },
+      ],
+      sessionsCompleted: 0,
+    },
+    session: { mode: 'weak', answeredCount: 0, recentItemIds: [] },
+    prefs: { mode: 'weak' },
+    now: 0,
+    random: () => 0,
+  });
+
+  assert.equal(result.item.id, 'weak_generated_insert');
+  assert.equal(result.weakFocus.source, 'weak_facet');
+});
+
 test('scheduler avoids recently seen generated variant signatures when alternatives exist', () => {
   const signatureItem = (id, variantSignature) => ({
     id,

--- a/tests/punctuation-service.test.js
+++ b/tests/punctuation-service.test.js
@@ -256,6 +256,31 @@ test('weak spots sessions target weak facets and record weak attempt metadata', 
   assert.equal(attempt.supportLevel, 0);
 });
 
+test('weak spots sessions rotate away from the item attempted in the previous session', () => {
+  const repository = makeRepository();
+  repository.writeData('learner-a', {
+    prefs: { mode: 'smart', roundLength: '1' },
+    progress: {
+      items: {},
+      facets: { 'speech::insert': updateMemoryState(createMemoryState(), false, 0) },
+      rewardUnits: {},
+      attempts: [],
+      sessionsCompleted: 0,
+    },
+  });
+  const service = createPunctuationService({ repository, now: () => 0, random: () => 0 });
+
+  const first = service.startSession('learner-a', { mode: 'weak', roundLength: '1' }).state;
+  assert.equal(first.session.currentItem.id, 'sp_insert_question');
+  service.submitAnswer('learner-a', first, correctAnswerFor(first.session.currentItem));
+
+  const second = service.startSession('learner-a', { mode: 'weak', roundLength: '1' }).state;
+  assert.notEqual(second.session.currentItem.id, first.session.currentItem.id);
+  assert.equal(second.session.currentItem.mode, 'insert');
+  assert.equal(second.session.weakFocus.skillId, 'speech');
+  assert.equal(second.session.weakFocus.source, 'weak_facet');
+});
+
 test('mixed transfer attempts update every included skill-by-mode facet', () => {
   const mixedTransfer = PUNCTUATION_CONTENT_MANIFEST.items.find((entry) => entry.id === 'sp_fa_transfer_at_last_speech');
   const manifest = {


### PR DESCRIPTION
## Summary
- carry recent attempted item IDs from stored progress into weak-spot selection
- avoid recently attempted weak rows when alternatives exist, so a fresh weak session does not keep serving the same item
- add scheduler and service regressions for the Tackle wobbly spots replay

## Verification
- node --test tests/punctuation-scheduler.test.js
- node --test tests/punctuation-service.test.js
- node --test tests/punctuation-release-smoke.test.js tests/punctuation-legacy-parity.test.js tests/punctuation-generators.test.js tests/punctuation-sibling-retry-lifecycle.test.js
- npm run verify:punctuation-qg:p10
- node --test tests/build-public.test.js
- npm run check
- npm test

## Manual acceptance replay
- seeded `speech::insert` as weak
- first weak session selected `sp_insert_question`
- after answering it, the next weak session selected `gen_speech_insert_1s7w6o3_1` with the same `speech::insert` weak focus
