### PR TITLE
fix(punctuation): rotate weak retry siblings

### DIFF
--- a/shared/punctuation/scheduler.js
+++ b/shared/punctuation/scheduler.js
@@ -542,7 +542,7 @@ function consecutiveMisconceptionFailures(progress, tag) {
   return count;
 }
 
-function selectMisconceptionRetry(indexes, progress, session, recentSignatures) {
+function selectMisconceptionRetry(indexes, progress, session, recentSignatures, recentItems = new Set()) {
   const retriedMisconceptions = new Set(
     Array.isArray(session?.retriedMisconceptions) ? session.retriedMisconceptions : []
   );
@@ -564,7 +564,8 @@ function selectMisconceptionRetry(indexes, progress, session, recentSignatures) 
   const ranked = rankMisconceptionCandidates(candidates, missedAttempt);
   if (!ranked.length) return null;
 
-  const best = ranked[0];
+  const nonRecentRanked = ranked.filter((entry) => !recentItems.has(entry.item?.id));
+  const best = (nonRecentRanked.length ? nonRecentRanked : ranked)[0];
   return {
     item: clone(best.item),
     reason: REASON_TAGS.MISCONCEPTION_RETRY,
@@ -738,7 +739,8 @@ export function selectPunctuationItem({
 
   // --- Misconception retry (applies to all modes) ---
   const recentSignaturesForRetry = recentSignatureSet(indexes, session, progress);
-  const misconceptionResult = selectMisconceptionRetry(indexes, progress, session, recentSignaturesForRetry);
+  const recentItemsForRetry = recentItemSet(session, progress);
+  const misconceptionResult = selectMisconceptionRetry(indexes, progress, session, recentSignaturesForRetry, recentItemsForRetry);
   if (misconceptionResult) {
     return {
       item: misconceptionResult.item,

--- a/tests/punctuation-scheduler.test.js
+++ b/tests/punctuation-scheduler.test.js
@@ -175,6 +175,82 @@ test('weak mode avoids the last attempted item when a new session starts', () =>
   assert.equal(result.weakFocus.source, 'weak_facet');
 });
 
+test('misconception retry avoids repeating the last fixed sibling across weak sessions', () => {
+  const missed = {
+    id: 'missed_insert',
+    mode: 'insert',
+    skillIds: ['speech'],
+    clusterId: 'speech',
+    rewardUnitId: 'speech-core',
+    misconceptionTags: ['speech.quote_missing'],
+  };
+  const recentSibling = {
+    id: 'recent_transfer',
+    mode: 'transfer',
+    skillIds: ['speech'],
+    clusterId: 'speech',
+    rewardUnitId: 'speech-core',
+    misconceptionTags: ['speech.quote_missing'],
+  };
+  const freshSibling = {
+    id: 'fresh_fix',
+    mode: 'fix',
+    skillIds: ['speech'],
+    clusterId: 'speech',
+    rewardUnitId: 'speech-core',
+    misconceptionTags: ['speech.quote_missing'],
+  };
+  const items = [missed, recentSibling, freshSibling];
+  const indexes = {
+    items,
+    itemById: new Map(items.map((item) => [item.id, item])),
+    itemsByMode: new Map([
+      ['insert', [missed]],
+      ['transfer', [recentSibling]],
+      ['fix', [freshSibling]],
+    ]),
+    itemsBySkill: new Map([['speech', items]]),
+    itemsByRewardUnit: new Map([['speech-core', items]]),
+    skillById: new Map([['speech', { id: 'speech', name: 'Direct speech', published: true }]]),
+  };
+
+  const result = selectPunctuationItem({
+    indexes,
+    progress: {
+      items: {},
+      facets: {},
+      rewardUnits: {},
+      attempts: [
+        {
+          itemId: missed.id,
+          mode: missed.mode,
+          itemMode: missed.mode,
+          skillIds: missed.skillIds,
+          rewardUnitId: missed.rewardUnitId,
+          misconceptionTags: missed.misconceptionTags,
+          correct: false,
+        },
+        {
+          itemId: recentSibling.id,
+          mode: recentSibling.mode,
+          itemMode: recentSibling.mode,
+          skillIds: recentSibling.skillIds,
+          rewardUnitId: recentSibling.rewardUnitId,
+          correct: true,
+        },
+      ],
+      sessionsCompleted: 0,
+    },
+    session: { mode: 'weak', answeredCount: 0, recentItemIds: [] },
+    prefs: { mode: 'weak' },
+    now: 0,
+    random: () => 0,
+  });
+
+  assert.equal(result.reason, REASON_TAGS.MISCONCEPTION_RETRY);
+  assert.equal(result.item.id, freshSibling.id);
+});
+
 test('scheduler avoids recently seen generated variant signatures when alternatives exist', () => {
   const signatureItem = (id, variantSignature) => ({
     id,

--- a/tests/punctuation-service.test.js
+++ b/tests/punctuation-service.test.js
@@ -281,6 +281,38 @@ test('weak spots sessions rotate away from the item attempted in the previous se
   assert.equal(second.session.weakFocus.source, 'weak_facet');
 });
 
+test('weak spots sessions rotate misconception retry siblings across new sessions', () => {
+  const repository = makeRepository();
+  repository.writeData('learner-a', {
+    prefs: { mode: 'smart', roundLength: '1' },
+    progress: {
+      items: { sp_insert_question: updateMemoryState(createMemoryState(), false, 0) },
+      facets: { 'speech::insert': updateMemoryState(createMemoryState(), false, 0) },
+      rewardUnits: {},
+      attempts: [
+        {
+          itemId: 'sp_insert_question',
+          mode: 'insert',
+          itemMode: 'insert',
+          skillIds: ['speech'],
+          rewardUnitId: 'speech-core',
+          misconceptionTags: ['speech.quote_missing', 'speech.reporting_comma_missing'],
+          correct: false,
+          timestamp: 0,
+        },
+      ],
+      sessionsCompleted: 0,
+    },
+  });
+  const service = createPunctuationService({ repository, now: () => 0, random: () => 0 });
+
+  const first = service.startSession('learner-a', { mode: 'weak', roundLength: '1' }).state;
+  service.submitAnswer('learner-a', first, correctAnswerFor(first.session.currentItem));
+
+  const second = service.startSession('learner-a', { mode: 'weak', roundLength: '1' }).state;
+  assert.notEqual(second.session.currentItem.id, first.session.currentItem.id);
+});
+
 test('mixed transfer attempts update every included skill-by-mode facet', () => {
   const mixedTransfer = PUNCTUATION_CONTENT_MANIFEST.items.find((entry) => entry.id === 'sp_fa_transfer_at_last_speech');
   const manifest = {


### PR DESCRIPTION
## Summary
- avoid recently attempted fixed-item siblings in misconception retry selection
- add scheduler and service regressions for repeated weak-session retry loops

## Verification
- node --test tests/punctuation-scheduler.test.js
- node --test tests/punctuation-service.test.js
- npm test
- npm run check
- npm run verify:punctuation-qg:p10

## Acceptance replay
- local deterministic replay: seeded speech insert miss, first weak retry sibling, then second weak session rotated away from the first weak item
