### PR TITLE
fix(spelling): prioritise completion-tail review words

### DIFF
--- a/legacy/spelling-engine.source.js
+++ b/legacy/spelling-engine.source.js
@@ -283,6 +283,28 @@
     var bucketWeights = { urgent: 7, fragile: 5, due: 4, new: 3, growing: 2, secure: 0.7 };
     var selected = [];
 
+    var completionTail = available.filter(function (word) {
+      var p = progressFor(profileId, word.slug);
+      return p.attempts > 0 && p.stage > 0 && p.stage < SECURE_STAGE;
+    });
+    if (completionTail.length && completionTail.length <= target) {
+      completionTail.sort(function (a, b) {
+        var aProgress = progressFor(profileId, a.slug);
+        var bProgress = progressFor(profileId, b.slug);
+        if (aProgress.stage !== bProgress.stage) return aProgress.stage - bProgress.stage;
+        if (aProgress.dueDay !== bProgress.dueDay) return aProgress.dueDay - bProgress.dueDay;
+        return a.slug < b.slug ? -1 : a.slug > b.slug ? 1 : 0;
+      });
+      for (var tailIndex = 0; tailIndex < completionTail.length; tailIndex++) {
+        selected.push(completionTail[tailIndex]);
+      }
+      var completionTailSlugs = Object.create(null);
+      for (var slugIndex = 0; slugIndex < completionTail.length; slugIndex++) {
+        completionTailSlugs[completionTail[slugIndex].slug] = true;
+      }
+      available = available.filter(function (word) { return !completionTailSlugs[word.slug]; });
+    }
+
     while (selected.length < target && available.length) {
       var bucketChoices = Object.keys(bucketWeights).map(function (name) {
         var baseWeight = bucketWeights[name];

--- a/shared/spelling/legacy-engine.js
+++ b/shared/spelling/legacy-engine.js
@@ -317,6 +317,28 @@ export function createLegacySpellingEngine({ words, wordMeta, storage, tts, now 
         var bucketWeights = { urgent: 7, fragile: 5, due: 4, new: 3, growing: 2, secure: 0.7 };
         var selected = [];
 
+        var completionTail = available.filter(function (word) {
+          var p = getProgressFromStore(profileId, word.slug, store);
+          return p.attempts > 0 && p.stage > 0 && p.stage < SECURE_STAGE;
+        });
+        if (completionTail.length && completionTail.length <= target) {
+          completionTail.sort(function (a, b) {
+            var aProgress = getProgressFromStore(profileId, a.slug, store);
+            var bProgress = getProgressFromStore(profileId, b.slug, store);
+            if (aProgress.stage !== bProgress.stage) return aProgress.stage - bProgress.stage;
+            if (aProgress.dueDay !== bProgress.dueDay) return aProgress.dueDay - bProgress.dueDay;
+            return a.slug < b.slug ? -1 : a.slug > b.slug ? 1 : 0;
+          });
+          for (var tailIndex = 0; tailIndex < completionTail.length; tailIndex++) {
+            selected.push(completionTail[tailIndex]);
+          }
+          var completionTailSlugs = Object.create(null);
+          for (var slugIndex = 0; slugIndex < completionTail.length; slugIndex++) {
+            completionTailSlugs[completionTail[slugIndex].slug] = true;
+          }
+          available = available.filter(function (word) { return !completionTailSlugs[word.slug]; });
+        }
+
         while (selected.length < target && available.length) {
           var bucketChoices = Object.keys(bucketWeights).map(function (name) {
             var baseWeight = bucketWeights[name];

--- a/tests/spelling.test.js
+++ b/tests/spelling.test.js
@@ -763,6 +763,64 @@ test('smartBucket routes secure-stage words with historical wrongs to fragile be
   assert.deepEqual(result.session.uniqueWords, [fragileSlug]);
 });
 
+test('Smart Review fallback prioritises not-yet-secure historical-wrong words over secure fragile review', () => {
+  const now = () => Date.UTC(2026, 3, 30);
+  const today = Math.floor(now() / (24 * 60 * 60 * 1000));
+  const learnerId = 'learner-nelson-tail';
+  const targetSlugs = ['apparent', 'privilege'];
+  const storage = installMemoryStorage();
+  const repositories = createLocalPlatformRepositories({ storage });
+  const y56Words = WORDS.filter((word) => word.spellingPool === 'core' && word.year === '5-6');
+
+  const progress = Object.fromEntries(y56Words.map((word) => {
+    const blocking = targetSlugs.includes(word.slug);
+    return [word.slug, blocking
+      ? {
+          stage: 3,
+          attempts: 4,
+          correct: 3,
+          wrong: 1,
+          dueDay: today + 2,
+          lastDay: today - 5,
+          lastResult: 'correct',
+        }
+      : {
+          stage: 4,
+          attempts: 6,
+          correct: 5,
+          wrong: 1,
+          dueDay: today + 30,
+          lastDay: today - 7,
+          lastResult: 'correct',
+        }];
+  }));
+  repositories.subjectStates.writeData(learnerId, 'spelling', { progress });
+
+  const service = createSpellingService({
+    repository: createSpellingPersistence({ repositories, now }),
+    now,
+    random: makeSeededRandom(1),
+    tts: {
+      speak() {},
+      stop() {},
+      warmup() {},
+    },
+  });
+
+  const started = service.startSession(learnerId, {
+    mode: 'trouble',
+    yearFilter: 'y5-6',
+    length: 10,
+  });
+
+  assert.equal(started.ok, true);
+  assert.equal(started.state.feedback?.headline, 'Trouble drill fell back to Smart Review.');
+  assert.ok(
+    targetSlugs.every((slug) => started.state.session.uniqueWords.includes(slug)),
+    `expected completion-tail words in session: ${started.state.session.uniqueWords.join(', ')}`,
+  );
+});
+
 // ----- U8: Storage-failure warning surface (Smart Review path) -----------------
 //
 // Goal: when localStorage.setItem throws during a Smart Review submit, the


### PR DESCRIPTION
## Summary
- prioritise already-started but not-yet-secure Smart Review words before secure historical-wrong review items
- keep the legacy weighted selector for the rest of the round once completion-tail words are included
- add a Nelson-shaped Years 5-6 regression covering Trouble Drill fallback into Smart Review

## Verification
- Nelson production snapshot replay locally includes `apparent` and `privilege` in the fallback round
- `node --test tests/spelling.test.js tests/server-spelling-engine-parity.test.js tests/spelling-parity.test.js`
- `npm test`
- `npm run check`