### PR TITLE
[codex] Fix warn contrast token tracking

### DIFF
--- a/notes/ks2-mastery-design-baseline.md
+++ b/notes/ks2-mastery-design-baseline.md
@@ -1,0 +1,317 @@
+# ks2-mastery design baseline — CONSOLIDATED
+
+**Audit date**: 2026-05-01
+**Auditors**: @Designer-Opus + @Design-Opus-Worker (independent dual-pass, then reconciled)
+**Scope**: `~/Coding/ks2-mastery` HEAD as of 2026-05-01
+**Cross-reference**: `notes/design-standards.md`, `notes/designer-opus-pact.md`, `notes/agents-and-collaboration.md`
+
+This is the **locked** baseline that gates all future design work in `fol2/ks2-mastery`. Both auditors must publish the same content in their workspaces. Hard rule: **no token-touching change ships without referencing this doc**.
+
+---
+
+## 1. Repo / surface map
+
+```
+src/
+├─ app/              entry, AppProviders, App
+├─ platform/
+│  ├─ ui/            DESIGN-SYSTEM PRIMITIVES (Button, Card, EmptyState,
+│  │                 ErrorCard, LoadingSkeleton, ProgressMeter, StatCard,
+│  │                 SectionHeader, SubjectThemeScope, hero-*)
+│  ├─ react/         ErrorBoundary, useSubmitLock, useTtsStatus, chunk-load-*
+│  ├─ hubs/          admin-panel-frame
+│  └─ rewards/, game/, hero/, hubs/, ops/, runtime/, access/, events/, core/
+├─ subjects/
+│  ├─ grammar/       SessionScene, SetupScene, SummaryScene, TransferScene,
+│  │                 MiniTestReview, AnalyticsScene, CalibrationPanel,
+│  │                 ConceptBankScene, ConceptDetailModal, PracticeSurface
+│  ├─ punctuation/   SessionScene, SetupScene, SummaryScene, MapScene,
+│  │                 SkillDetailModal, PracticeSurface
+│  ├─ spelling/      (in-scope; not deep-audited this pass)
+│  └─ placeholders/
+├─ surfaces/
+│  ├─ auth/          AuthSurface, DemoExpiryBanner
+│  ├─ home/          HomeSurface, HeroQuestCard, HeroCampPanel,
+│  │                 MonsterMeadow, CodexSurface, CodexCard, CodexCreature*
+│  ├─ hubs/          AdminHubSurface, ParentHubSurface, AdminPanelFrame,
+│  │                 + ~20 admin section panels
+│  ├─ profile/       ProfileSettingsSurface
+│  ├─ shell/         TopNav, ToastShelf, MonsterCelebrationOverlay,
+│  │                 PersistenceBanner, SubjectBreadcrumb
+│  └─ subject/       SubjectRoute, SubjectRuntimeFallback, HeroTaskBanner
+
+styles/
+└─ app.css           13,562 lines — single source of CSS truth
+
+assets/
+├─ monsters/         403 MB source → 64 MB deployed (CDN)
+├─ regions/          308 MB source → 22 MB deployed (CDN)
+├─ app-icons/        1.2 MB
+└─ icons/            188 KB
+```
+
+**Asset binding (verified)**: `wrangler.jsonc` declares `"assets": { "directory": "./dist/public", "binding": "ASSETS" }`. Monster + region webps are served via Cloudflare ASSETS edge, NOT bundled into the JS bundle. Page-load weight (86 MB deployed across multi-resolution variants) is a separate optimisation track.
+
+---
+
+## 2. Token system — current state
+
+### Tokens that EXIST (don't break these)
+
+| Category | Tokens | Status |
+| --- | --- | --- |
+| Background / panel | `--bg`, `--bg-tint`, `--panel`, `--panel-soft`, `--panel-sunken` | ✅ |
+| Ink (text) | `--ink`, `--ink-2`, `--muted`, `--subtle` | ✅ |
+| Lines / borders | `--line`, `--line-soft`, `--line-strong` | ✅ |
+| Semantic colour | `--good[/-strong/-soft]`, `--warn[…]`, `--bad[…]` | ✅ |
+| Brand | `--brand`, `--brand-ink`, `--brand-soft` | ✅ |
+| Subject themes | 6 subjects × {accent, accentInk, accentSoft, accentBorder} via `.subject-theme[data-subject]`; mirrored in `src/platform/ui/subject-themes.js` | ✅ |
+| Radii | `--radius-xs/sm/md/lg/xl` (8 / 12 / 20 / 28 / 32 px) | ✅ |
+| Shadows | `--shadow-xs/-/lg/-glow` | ✅ |
+| Fonts | `--font-display` (Fraunces), `--font-sans` (Inter), `--font-serif`, `--font-mono` | ✅ |
+| Motion (partial) | `--ease-out`, `--ease-in-out`, `--dur-fast/-/-slow/-slower` (120 / 200 / 320 / 520 ms) | ⚠️ partial — see §3 motion gap |
+| Dark mode | full token override via `prefers-color-scheme: dark` AND `[data-theme="dark"]` | ✅ |
+
+### Tokens MISSING — BLOCKING gaps for child-facing standards
+
+| Category | Status | Severity |
+| --- | --- | --- |
+| **Spacing scale** (`--space-*`) | ❌ MISSING | **BLOCKING** |
+| **Type scale** (`--text-*`) | ❌ MISSING | **BLOCKING** |
+| **Heading scale** (`--text-h1..h6`) | ❌ MISSING (current usage shows semantic inversion — see §3) | **BLOCKING** |
+| **Tap-target minimum** (`--tap-min`) | ❌ MISSING | **BLOCKING** for KS2 |
+| **Motion `--dur-medium` (240 ms)** | ❌ MISSING (240 ms used 29× untokenised) | non-blocking but recommended |
+| **Focus-ring token** (`--focus-ring`) | ❌ MISSING (`--shadow-glow` does double duty) | nit |
+| **Z-index scale** | not audited this pass | TBD |
+
+The absence of spacing + type tokens means **every component re-decides its own spacing/sizing** → cross-surface drift by construction. §3 quantifies the drift.
+
+---
+
+## 3. Drift census (the rogue values)
+
+### Type scale — 82 unique font-size values (Designer-Opus count) / 30+ font-sizes with 0.01rem precision (Worker count)
+
+Sub-1rem (i.e. < 16 px @ 16 px base):
+```
+0.58em, 0.66, 0.68, 0.70, 0.72, 0.74, 0.75, 0.76, 0.78, 0.80,
+0.82, 0.83, 0.84, 0.85, 0.86, 0.87, 0.88, 0.92, 0.94, 0.95, 0.96, 0.98 rem
+```
+**22 distinct sub-1rem variants.** All violate the KS2 18 px minimum codified in `notes/design-standards.md`.
+
+#### 6-selector kill list (sub-12 px) — must ship in same PR as type scale
+| Line | Selector | Size | Action |
+| --- | --- | --- | --- |
+| `styles/app.css:464` | `.eyebrow` | 11 px | **Pattern replace (i)**: replace ALL-CAPS letter-spaced eyebrow with section-subhead pattern (16 px semibold normal case + optional coloured rule above). 11 px ALL-CAPS + 0.08em letter-spacing is anti-readability for primary-age. |
+| `styles/app.css:3434` | `.subject-grid .sc-status` | 10 px | Up-size to `--text-xs` (14 px); non-touch context |
+| `styles/app.css:4826` | `.mode-card .mc-badge` | 10 px | Up-size to `--text-xs` (14 px) |
+| `styles/app.css:4903` | `.post-mega-stat dt` | 11 px | Up-size to `--text-xs` (14 px) |
+| `styles/app.css:5060` | `.mc-badge-roadmap-label` | 9 px ← worst | Up-size to `--text-xs` (14 px) |
+| `styles/app.css:5178` | `.post-mega-coming-next-eyebrow` | 10 px | Up-size to `--text-xs` (14 px); also evaluate pattern replace |
+
+### Heading hierarchy — semantic inversion exists
+
+Current heading scale is gappy AND inverts in two places:
+- **3.2 → 1.45 rem jump** with no h2/h3 step
+- `subject-grid .subject-card h3` = 1.35 rem
+- `wb-word-group-head h2` = 1 rem ← **h3 visually larger than h2**
+
+Locked heading scale (ships in PR-C):
+```
+--text-h1: clamp(2rem, 4vw + 1rem, 3.2rem)     /* responsive cap */
+--text-h2: clamp(1.5rem, 2.4vw + 0.8rem, 2rem) /* responsive cap */
+--text-h3: 1.5rem
+--text-h4: 1.25rem
+--text-h5: 1.125rem
+--text-h6: 1rem  /* = 18px with body baseline 112.5%, meets KS2 floor */
+```
+Migrations forced into same PR:
+- `subject-card h3` 1.35rem → `var(--text-h3)` (1.5 rem)
+- `wb-word-group-head h2` 1rem → `var(--text-h2)` (capped clamp)
+
+### Spacing — 254 padding decls / 56 margin / 371 gap, all raw px or rem
+
+Worker's count of distinct px values: 25. Top non-scale offenders by frequency:
+- `10 px` × 143
+- `14 px` × 86
+- `6 px` × 83
+- `18 px` × 61
+- `2 px` × 41
+- `22 px` × 26
+
+**Locked spacing ladder** (ships in PR-B):
+```
+--space-0: 0
+--space-1: 4px
+--space-2: 8px
+--space-3: 12px
+--space-4: 16px
+--space-5: 20px
+--space-6: 24px
+--space-7: 32px
+--space-8: 48px
+```
+Defer `--space-9: 40px` until callsite migration genuinely needs it. The 32 → 48 jump is intentional luxe consistent with 8pt-system convention.
+
+### Colour — 166 unique hex values
+
+Reframed by Worker: many "rogues" are actually **token VALUES used as literals**, e.g.
+- `#3E6FA8` × 23 = `var(--brand)`
+- `#0F1620` × 16 = dark-theme `--bg`
+
+Severity drops from "blocking" to "high-leverage low-risk migration". Audit-and-convert is mechanical: PR-D ships a literal-to-token sweep.
+
+Sample of true rogues found in `.btn.warn / .good / .bad` and `.chip.*` (lines 524–556):
+```
+#b8dfca, #edd9ae, #f0c8c5, #9e6a19, #f4f6f8, #546171,
+#d9e0e7, #e8f1fb, #2f6fae, #bdd5ef
+```
+These resolve to existing tokens (`--good-strong`, `--warn-soft`, `--bad-strong`, etc.).
+
+### Motion — 124 tokenised transitions ✅, but the tail is rogue
+
+| Value | Count | Status |
+| --- | --- | --- |
+| 240 ms | × 29 | **untokenised; dominant** → introduce `--dur-medium: 240ms` |
+| 220 ms | × 8 | snap to `--dur` (200 ms) |
+| 360 ms | × 4 | snap to `--dur-slow` (320 ms) |
+| 420 ms | × 5 | snap to `--dur-slow` or `--dur-slower` |
+| 480 ms | × 3 | snap to `--dur-slower` (520 ms) |
+| 600 ms | × 3 | snap to `--dur-slower` |
+| 720 ms | × 5 | snap to `--dur-slower` |
+| 880 ms | × 3 | snap to `--dur-slower` |
+
+Specific multi-prop conflict to resolve:
+```css
+transition: border-color 200ms ease, box-shadow 200ms ease, transform 220ms var(--ease-out);
+```
+Same element, two durations (200 / 220), two easings (`ease` / `var(--ease-out)`). Visible micro-jank.
+
+### Tap targets — 27 explicit `min-height ≥ 44 px` declarations
+
+`.btn` default has **no min-height** — relies on padding alone. Estimated rendered height ≈ 38–40 px for `.btn` default, 32–34 px for `.btn.sm`. **Both violate WCAG 2.5.5 / our codified 44 px minimum** (`notes/design-standards.md` § Child-facing surfaces).
+Only `.btn.xl` correctly sets `min-height: 48px`. `.btn.lg` borderline.
+
+### `.btn.sm` callsite evidence (drives PR-A scope)
+
+| Surface | `.btn.sm` callsites | Child-facing? | Action |
+| --- | --- | --- | --- |
+| `GrammarMiniTestReview.jsx` | 1 | YES | migrate to `.btn` default |
+| `GrammarConceptBankScene.jsx` | 3 | YES | migrate to `.btn` default |
+| `PunctuationMapScene.jsx` | 1 | YES | migrate to `.btn` default |
+| `SpellingWordBankScene.jsx` | 2 | YES | migrate to `.btn` default |
+| `PatternQuestScene.jsx` | 1 | YES | migrate to `.btn` default |
+| `CodexCard.jsx` | 1 | YES (reward path) | migrate to `.btn` default |
+| `GrammarTransferScene.jsx` | 5 | NON-critical (Writing Try) | migrate for consistency |
+| Admin sections | 3+ | NO (admin only) | rename `.btn.sm` → `.btn.compact` is acceptable here |
+
+PR-A renames `.btn.sm` → `.btn.compact` in CSS with explicit comment, AND migrates child-facing callsites to default `.btn`.
+
+### Inline `style={{}}` — 20 src files (mostly fine)
+
+Sample-audited by Worker: most are intentional CSS-variable passthroughs (`Card.jsx --card-accent`, `LengthPicker --option-count`, `ProgressMeter --progress-value`). Rare literal violation: `ActionRow.jsx { gap: 12 }` — flag for fix in PR-B (spacing scale rollout).
+
+---
+
+## 4. State coverage — primitives strong, adoption uneven
+
+State primitives (`src/platform/ui/`) are well-built with correct a11y contracts:
+- `EmptyState` — `role="status" + aria-live="polite"`, three-part copy pattern (what / safe / action)
+- `ErrorCard` — `role="alert" + aria-live="polite"` (polite, not assertive — correct for mid-session non-blocking errors); hides error code from visible copy, surfaces as `data-error-code` attribute
+- `LoadingSkeleton` — `aria-label="Loading"`, visually-hidden screen-reader text, `prefers-reduced-motion` flattens to static placeholder
+- `Button` — **throws** if no visible label and no `aria-label` → fail-fast a11y contract; `busy` sets both `aria-busy` and `disabled`
+
+| Primitive | Adoption | Verdict |
+| --- | --- | --- |
+| `EmptyState` | 9 surfaces of ~50 (~18%) | ⚠️ partial |
+| `ErrorCard` | 5 surfaces (~10%) | ❌ under-used |
+| `LoadingSkeleton` | 3 surfaces (~6%) | ❌ **weakest state** |
+| `ErrorBoundary` | 1 (App.jsx global only) | ⚠️ no per-surface boundaries |
+| Offline detection | 4 files | ⚠️ minimal |
+
+### State matrix — components × {empty, loading, error, success, disabled, offline}
+Critical-path surfaces from pact §4 should achieve full state coverage by end of Wave 3 (PR-E + PR-F).
+
+**Critical-path adoption gaps to close in PR-E**:
+- `GrammarSessionScene`, `PunctuationSessionScene` (mastery flow critical)
+- `GrammarSummaryScene`, `PunctuationSummaryScene` (assessment + reward boundary)
+- `HeroQuestCard`, `MonsterMeadow`, `CodexSurface` (reward / progression critical)
+- `AuthSurface`, `HomeSurface` (onboarding / first-run critical)
+
+---
+
+## 5. A11y signal — overall positive but inconsistent
+
+| Signal | Count | Verdict |
+| --- | --- | --- |
+| `aria-label` | 191 | ✅ |
+| `aria-live` | 49 | ✅ |
+| `role=` | 143 | ✅ |
+| `prefers-reduced-motion` blocks | 36 | ✅ Strong |
+| `:focus-visible` rules | 38 | ✅ |
+| `.sr-only` / `.visually-hidden` utility | 1 def | ⚠️ verify pattern |
+| `PunctuationSessionScene` uses `role="radiogroup"`, `role="alert"`, `aria-describedby`, `aria-invalid` | yes | ✅ correct |
+
+**Conclusion**: standards-violations cluster at the **system-token level**, not at the a11y-attribute level. Migration is filling token gaps + raising adoption — not rebuilding a11y.
+
+**Open verifications (not in this baseline pass)**:
+- WCAG 2.2 AA contrast sweep
+- Manual keyboard traversal of critical paths
+- Flesch–Kincaid microcopy pass
+- Full per-surface state matrix (only critical paths sampled this pass)
+
+---
+
+## 6. Critical path verification (against pact §4)
+
+| Pact critical path | Surfaces to dual-pass | Notes |
+| --- | --- | --- |
+| (1) Core mastery flow | `GrammarSessionScene`, `PunctuationSessionScene` | Question → answer → feedback → next |
+| ~~(2) Assessment submission~~ | **MERGED into (1)** per Worker definitive read of `*SessionScene` | `GrammarMiniTestReview` = post-finish review, `GrammarTransferScene` = optional non-scored Writing Try — neither IS the assessment |
+| (3) Reward / progression | `MonsterCelebrationOverlay`, `MonsterMeadow`, `CodexSurface`, `CodexCard`, `CodexCreature*`, `HeroQuestCard` | Several distinct surfaces; dual-pass each |
+| (4) Onboarding / first-run | `AuthSurface`, `HomeSurface` first paint, first SubjectCard tap, first `Setup*Scene` impression | High SEND-cohort risk |
+
+**Non-critical (single-auditor sufficient)**: `GrammarTransferScene` (Writing Try), error-recovery, network-loss reconnect, secondary admin / settings paths.
+
+---
+
+## 7. Locked decisions
+
+- Spacing ladder `--space-{0..8}` = `0 / 4 / 8 / 12 / 16 / 20 / 24 / 32 / 48`; defer `--space-9: 40` until needed
+- Body baseline = `html { font-size: 112.5% }` (Option A) — makes 1 rem = 18 px base, all `rem`-based rules auto-comply
+- Type scale = `--text-{xs..4xl}` with `--text-base = 1.125rem (18 px)` floor on child-facing
+- Heading scale = h1/h2 `clamp()`, h3–h6 fixed; eliminates current 3.2 → 1.45 rem gap and h2/h3 inversion
+- Critical path (2) merged into (1); `GrammarTransferScene` = non-critical
+- `.btn.sm` → renamed to `.btn.compact` (admin-only) + child-facing callsites migrated to `.btn` default
+- Hex-rogue migration = incremental + one sweep PR for `--brand`/`--bg`/`--ink` literal cleanup
+- Onboarding scope = `AuthSurface` + `HomeSurface` first paint + first SubjectCard tap → SetupScene first impression
+- Kill list (6 selectors) ships in same PR as type scale
+- Motion `--dur-medium: 240ms` introduced; 220 / 360 / 420 / 480 / 600 / 720 / 880 ms snapped to nearest token
+- Per-surface `ErrorBoundary` = lift-and-place (existing component at `src/platform/react/ErrorBoundary.jsx`)
+
+## 8. PR sequence — locked (3 waves of 2-3 parallel PRs each)
+
+| Wave | PR | Lead spec | Reviewer | Bundle est |
+| --- | --- | --- | --- | --- |
+| 1 | **PR-A** tap-target token + `.btn` `min-height` + `.sm` migration | Designer-Opus | Worker | net-zero |
+| 1 | **PR-D** hex-literal sweep (`--brand`/`--bg`/`--ink` literals to tokens) | Worker | Designer-Opus | net-negative |
+| 2 | **PR-B** spacing scale (definitions only, no callsite migration) | Worker | Designer-Opus | small +ve |
+| 2 | **PR-C** type scale + body baseline + heading scale + 6-selector kill list (incl. `.eyebrow` pattern replace) | Worker | Designer-Opus | small ± |
+| 2 | **PR-G** motion token sweep (`--dur-medium: 240`, snap rogue tail) | Worker | Designer-Opus | net-negative |
+| 3 | **PR-E** state primitive adoption (Session / Setup / Summary scenes) | Worker | Designer-Opus | small +ve |
+| 3 | **PR-F** per-surface `ErrorBoundary` (lift-and-place around `Subject*PracticeSurface`) | Designer-Opus | Worker | small +ve |
+
+Wave gating: cannot start a wave until all PRs in the previous wave land or are decisively dropped.
+
+## 9. Open / pending
+
+- [ ] PR-A spec drafted by Designer-Opus, handed to @Codex-Coder.
+- [ ] PR-D spec drafted by Worker.
+- [ ] Wave 2 specs (B, C, G) drafted by Worker post-Wave-1.
+- [ ] Wave 3 specs (E by Worker, F by Designer-Opus) drafted post-Wave-2.
+- [ ] Page-load weight optimisation track (PNG → WebP/AVIF, asset preloading) — separate roadmap, not in baseline scope.
+- [ ] Future: WCAG 2.2 AA contrast sweep, keyboard traversal, Flesch–Kincaid microcopy pass.
+
+## 10. Revision log
+
+- 2026-05-01 — initial dual-pass + reconcile complete; baseline locked (DM thread: 67ac83e1 → 8904646f → 3b8dafb0 → ae2251bc → 75169f65 → 26d1f156 → 6feaec0d → acc7bdc9 → 44863d01 → de08f54e).

--- a/notes/specs/PR-D-hex-literal-sweep-spec.md
+++ b/notes/specs/PR-D-hex-literal-sweep-spec.md
@@ -1,0 +1,252 @@
+# PR-D — Hex literal sweep · v2 (scoped to `.btn.warn` / `.chip.warn` dark-mode contrast fix)
+
+> **Scope note**: keeping the "Hex literal sweep" name for traceability against baseline §3 (Colour) and the original Wave-1 PR sequence. **Actual PR substance is the 2-line dark-mode WCAG contrast fix.** Broader rogue cleanup deferred to PR-D2 (border tokens) in Wave 2 — see baseline §8.
+
+**Spec author**: @Design-Opus-Worker
+**Spec reviewer**: @Designer-Opus (✅ signed off — see revision log §10)
+**Implementation owner**: @Codex-Coder
+**Wave**: 1 (parallel with PR-A)
+**Severity**: 🔴 **BLOCKING** — fixes WCAG 2.2 AA dark-mode contrast violation on warn semantic surfaces.
+**Status**: SPEC READY for handoff
+
+---
+
+## 1. Goal
+
+Replace hex-literal usages in `styles/app.css` that are **functionally identical** to existing design tokens with `var(--token)` references — converting lazy-paste literals into token references AND fixing two latent dark-mode contrast bugs.
+
+This PR ships **no visual change in light mode** (substitutions resolve to identical RGB). In dark mode it fixes the `.btn.warn` / `.chip.warn` foreground-on-background contrast issue caused by hardcoded light-theme orange text.
+
+---
+
+## 2. Why (evidence)
+
+### 2.1 Reframing the original "166 unique hex / 76 single-use" finding
+Baseline §3 colour census reported 166 unique hex values with ~135 considered "rogue". After context-filtering, the actual rogue surface is **much smaller**:
+
+| Filtered scope | Count |
+| --- | --- |
+| Hex literals in `styles/app.css` (raw) | 166 unique |
+| Removed: `:root` / dark / subject-theme **definition** blocks | -83 |
+| Removed: `var(--token, #literal)` **defensive fallback** patterns | (~7 lines) |
+| Removed: `color-mix(in oklab, #LIGHT-VALUE %, #DARK-BG)` cross-theme **inputs** by design | (~12 lines) |
+| Removed: comments referencing colours | (~5 lines) |
+| Removed: decorative linear-gradient palettes (intentional fixed colours) | (~6 lines) |
+| **High-confidence substitution candidates** | **2** |
+| Per-callsite-review candidates | ~9 |
+
+**The "lazy-paste rogue" pattern barely exists in this codebase.** Most hex literals are intentional (definitions, fallbacks, gradient palettes, cross-theme color-mix inputs). PR-D's real value pivots from "rogue cleanup" to **dark-mode contrast bug fix + establishing the audit-and-convert pipeline** for future incremental cleanup.
+
+### 2.2 The two real dark-mode bugs
+
+`styles/app.css:526` and `styles/app.css:552`:
+
+```css
+.btn.warn { background: var(--warn-soft); border-color: #edd9ae; color: #9e6a19; }
+.chip.warn { background: var(--warn-soft); color: #9e6a19; border-color: #edd9ae; }
+```
+
+The `color: #9e6a19` is the literal value of `--warn-strong` in **light theme only**. There is **no dark-mode override** for these selectors.
+
+**Light mode** (`--warn-strong: #9E6A19`):
+- Foreground: `#9e6a19` (dark warm orange)
+- Background: `var(--warn-soft)` = `#FBEFD9` (cream)
+- Contrast ratio ≈ **6.27 : 1** ✅ WCAG AA
+
+**Dark mode** (`--warn-strong: #F1C081`):
+- Foreground: `#9e6a19` (UNCHANGED — the literal isn't theme-aware)
+- Background: `var(--warn-soft)` = `color-mix(in oklab, #D08A2C 22%, #0F1620)` ≈ `#3D2E1A` (dark warm)
+- Contrast ratio ≈ **2.4 : 1** ❌ **FAILS WCAG AA (requires ≥ 4.5:1 for body, ≥ 3:1 for UI)**
+
+This is a real WCAG 2.2 AA violation in dark mode. Substituting `color: #9e6a19` → `color: var(--warn-strong)` makes the foreground theme-aware:
+- Light: `#9E6A19` (identical to current — no visual regression)
+- Dark: `#F1C081` (light warm orange) on dark warm-soft → contrast ≈ **5.8 : 1** ✅
+
+`.chip.warn` follows the same pattern.
+
+### 2.3 Pact / standards reference
+- `notes/design-standards.md` § Accessibility a11y baseline: WCAG 2.2 AA — contrast ≥ 4.5:1 for body. The current `.btn.warn` / `.chip.warn` color violates this in dark mode.
+- `notes/ks2-mastery-design-baseline.md` § 3 Colour: hex-as-token-literal framing.
+
+---
+
+## 3. Scope (exhaustive)
+
+### 3.1 — Two BLOCKING substitutions (dark-mode contrast bug fix)
+
+**File**: `styles/app.css`
+
+| Line | Selector | Change |
+| --- | --- | --- |
+| 526 | `.btn.warn` | `color: #9e6a19` → `color: var(--warn-strong)` |
+| 552 | `.chip.warn` | `color: #9e6a19` → `color: var(--warn-strong)` |
+
+After change:
+
+```css
+.btn.warn { background: var(--warn-soft); border-color: #edd9ae; color: var(--warn-strong); }
+.chip.warn { background: var(--warn-soft); color: var(--warn-strong); border-color: #edd9ae; }
+```
+
+`border-color: #edd9ae` stays untouched in this PR (deferred to PR-D2 — needs a `--warn-border` token introduction, which is a system-level design call rather than a substitution).
+
+### 3.2 — Out of scope for PR-D (deferred to PR-D2)
+
+Documented for traceability — these are real rogues but require design judgment beyond mechanical substitution:
+
+| Pattern | Count | Why deferred |
+| --- | --- | --- |
+| `.btn.good` / `.chip.good` `border-color: #b8dfca` | × 14 | Needs new `--good-border` token; theme-aware introduction = system-level decision |
+| `.btn.warn` / `.chip.warn` `border-color: #edd9ae` | × 9 | Needs new `--warn-border` token |
+| `.btn.bad` / `.chip.bad` `border-color: #f0c8c5` | × 4 | Needs new `--bad-border` token |
+| `#1d2b3a` setting `--mode-card-title` (L4596, L4700) | × 2 | L4700 is `[data-text-tone="dark"]` intentional fixed-ink override; L4596 needs scope confirmation |
+| `#FFFFFF` in decorative linear-gradients | × 6 | Gradient palettes are design choices; per-callsite review needed |
+| `#3E6FA8` literal usages | × 25 | Mostly legitimate (definitions, var-fallbacks, color-mix inputs across themes); ambiguous between `--brand` and `--inklet` token |
+| `#B8873F` literal usages | × 8 | Mostly legitimate (definitions, color-mix); needs design call |
+
+**Note for Designer-Opus**: PR-D2 is a future spec that introduces the three border tokens (`--good-border`, `--warn-border`, `--bad-border`) and consolidates the 27 border literals. Bundle estimate: net-negative (3 token definitions × 2 themes = 6 lines added; 27 literal usages × ~8 bytes saved = -216 bytes raw, -130 bytes gzip est.). Worth it.
+
+### 3.3 — Substitution rules (for future PRs in this lineage)
+
+Document the rules so PR-D2..N follow the same discipline:
+
+1. **Skip definitions** — `:root`, `[data-theme="dark"]`, `@media (prefers-color-scheme: dark)`, `.subject-theme[data-subject="*"]` blocks define tokens; literals there ARE the source of truth.
+2. **Skip `var()` fallbacks** — `var(--token, #fallback)` is a defensive pattern; the literal is the safety net, do not remove.
+3. **Skip cross-theme color-mix inputs** — when a dark-mode rule does `color-mix(in oklab, #LIGHT-COLOUR 22%, #DARK-BG)`, the light colour is intentionally fixed (the substitution would self-reference the dark-theme token and break the cascade).
+4. **Skip comments**.
+5. **Skip decorative gradient palettes** — fixed colour design choices, not theme-tracking.
+6. **Substitute when**: literal exactly matches a token's value in the cascade scope AND substitution preserves intent (or fixes a theme-awareness bug).
+7. **For ambiguous literals** (multiple tokens share value, e.g. `#3E6FA8` = `--brand` and `--inklet`): per-callsite semantic review required — choose the token that matches the surrounding selector's intent.
+
+---
+
+## 4. Verification
+
+### 4.1 Unit / parser tests
+- No new tests required for 2-line CSS substitution.
+- Existing visual regression suite (if any Playwright screenshot-snapshot tests) should pass unchanged in light mode.
+
+### 4.2 Build / bundle checks
+- `npm run check` passes.
+- `npm test` passes.
+- CSS bundle delta: `dist/public/styles/app.css` size before / after — expect **net-zero** or **+8 bytes** (`#9e6a19` is 7 chars, `var(--warn-strong)` is 18 chars; 2 substitutions × 11 chars added ≈ +22 bytes raw, gzip-equivalent likely ≤ +10 bytes since both forms compress).
+- JS bundle delta: 0 bytes (no JS change).
+
+### 4.3 Critical-path / dark-mode contrast verification (BLOCKING)
+
+**REQUIRED — Playwright assertion (CI-durable, catches regressions)**:
+
+Add a Playwright test that:
+1. Renders a surface containing `.btn.warn` AND `.chip.warn` (or two separate surfaces).
+2. In light theme: asserts `getComputedStyle(el).color` resolves to RGB equivalent of `var(--warn-strong)` light value (`#9E6A19` → `rgb(158, 106, 25)`).
+3. Toggles to dark theme via `[data-theme="dark"]` attribute on the root element.
+4. Re-asserts `getComputedStyle(el).color` resolves to RGB equivalent of `var(--warn-strong)` dark value (`#F1C081` → `rgb(241, 192, 129)`).
+5. The assertion is on the COMPUTED colour tracking the token across themes — proves substitution succeeded AND prevents future regression if anyone re-introduces a literal here.
+
+Sketch:
+```js
+test('warn surfaces foreground tracks --warn-strong token in both themes', async ({ page }) => {
+  await page.goto('/some-route-with-warn-surface');
+  // Light theme baseline
+  const lightColor = await page.evaluate(() => getComputedStyle(document.querySelector('.btn.warn')).color);
+  expect(lightColor).toBe('rgb(158, 106, 25)');  // --warn-strong light
+  // Toggle to dark
+  await page.evaluate(() => document.documentElement.setAttribute('data-theme', 'dark'));
+  const darkColor = await page.evaluate(() => getComputedStyle(document.querySelector('.btn.warn')).color);
+  expect(darkColor).toBe('rgb(241, 192, 129)');  // --warn-strong dark
+  // Repeat for .chip.warn
+});
+```
+
+Where `.btn.warn` / `.chip.warn` actually render in the app (find callsites first):
+```bash
+grep -rn "btn[^\"']*warn\|chip[^\"']*warn" src --include="*.jsx"
+```
+Pick one surface per selector for the test fixture.
+
+**OPTIONAL but recommended — light/dark screenshot pair for PR description**:
+
+Useful for human reviewer eyeball; not durable. Capture before/after for one `.btn.warn` and one `.chip.warn` callsite in both themes. Add to PR body inline.
+
+### 4.4 Regression check
+- `.btn.warn` / `.chip.warn` foreground colour in light mode IS `#9E6A19` (same as `--warn-strong` light value). Substitution preserves byte-identical visual.
+- No other selector references `#9e6a19` for it to drift.
+
+---
+
+## 5. A11y impact
+
+**Positive**:
+- Fixes WCAG 2.2 AA contrast violation for `.btn.warn` / `.chip.warn` in dark mode (estimated ~2.4:1 → ~5.8:1).
+- Aligns with `notes/design-standards.md` § Accessibility a11y baseline (≥ 4.5:1 body contrast).
+- No keyboard / screen-reader / motion impact.
+
+**Risk**:
+- None. Light mode unchanged; dark mode strictly improves.
+
+---
+
+## 6. Bundle impact
+
+| Item | Direction | Magnitude |
+| --- | --- | --- |
+| 2 × `#9e6a19` (7 chars) → `var(--warn-strong)` (18 chars) | + | ~22 bytes raw, ~+8 bytes gzip est. |
+
+**Net estimate**: ≈ +8 bytes gzip, negligible against the 1,506-byte JS-bundle headroom (and CSS bundle is separate from JS bundle anyway).
+
+PR-D2 (border tokens + 27 literal consolidation) is the bundle-banking PR — that one nets ~−130 bytes.
+
+---
+
+## 7. Dissent log (alternatives considered + rejected)
+
+### Rejected: ship the original "broad sweep" of all 166 hex literals
+Reason: filter analysis revealed most hex literals are intentional (definitions, var-fallbacks, gradient palettes, cross-theme color-mix). Naive `sed` replace would have introduced regressions. Surgical scope (2 lines) reflects the actual rogue surface.
+
+### Rejected: include border-colour rogues (`#b8dfca`, `#edd9ae`, `#f0c8c5`) in this PR
+Reason: substitution-without-token doesn't apply (these aren't existing token values). Token introduction is a system-level decision deserving its own PR. PR-D2 will handle.
+
+### Rejected: substitute `#1d2b3a` → `var(--ink)` for `--mode-card-title` (L4596, L4700)
+Reason: L4700 is inside `.mode-card[data-text-tone="dark"]` where the design intentionally pins a dark ink colour regardless of theme. Substitution would change semantics (introduce theme-awareness where the design wants theme-static). L4596 needs scope confirmation. Both deferred to PR-D2.
+
+### Rejected: substitute `#FFFFFF` → `var(--panel)` in linear-gradients (6 occurrences)
+Reason: gradients are decorative palette choices, not theme-tracking surfaces. `#FFFFFF` in a gradient stop expresses "white at this stop", not "the panel surface colour"; these meanings differ in dark mode. Skip without explicit per-callsite design call.
+
+### Rejected: defer entire PR-D until PR-D2 token additions are designed
+Reason: the 2 dark-mode contrast fixes are real WCAG violations. Shipping them now (Wave 1) closes a child-facing a11y gap immediately. Bundling into a larger PR delays the fix unnecessarily.
+
+---
+
+## 8. Acceptance criteria (binary)
+
+- [ ] `styles/app.css:526` `.btn.warn` colour changed from `#9e6a19` to `var(--warn-strong)`.
+- [ ] `styles/app.css:552` `.chip.warn` colour changed from `#9e6a19` to `var(--warn-strong)`.
+- [ ] No other CSS / JS / JSX changes in this PR.
+- [ ] `npm run check` passes.
+- [ ] `npm test` passes.
+- [ ] Playwright theme-tracking assertion added (REQUIRED — see §4.3); passes in CI.
+- [ ] Light/dark screenshot pair in PR description (OPTIONAL but recommended).
+- [ ] Bundle delta reported: ≤ +20 bytes gzip.
+- [ ] PR description references this spec doc + baseline doc § 3 Colour.
+- [ ] Reviewer (Designer-Opus) sign-off on contrast verification.
+
+---
+
+## 9. Handoff metadata
+
+- Spec drafted: 2026-05-01
+- Implementation owner: @Codex-Coder
+- Spec reviewer (approved before implementation): @Designer-Opus ✅ (DM 70dc8693)
+- Spec reviewer (must approve PR before merge): @Codex-Reviewer
+- Final design sign-off: @Designer-Opus
+- Follow-up: **PR-D2** introduces `--good-border`, `--warn-border`, `--bad-border` tokens and consolidates the 27 border literals (`#b8dfca` × 14, `#edd9ae` × 9, `#f0c8c5` × 4). **Scheduled for Wave 2** alongside other token-introduction PRs (B / C / G). Estimated bundle impact: ~−130 bytes gzip.
+
+## 10. Revision log
+
+- **v1** (2026-05-01) — initial draft, scope reframed via context-filter analysis (§2.1). Sent for review (DM b47f8acb).
+- **v2** (2026-05-01) — Designer-Opus sign-off (DM 70dc8693) with three conditional edits applied:
+  1. Severity retag: mixed 🟡+🔴 → single 🔴 BLOCKING (warn-surface contrast is the entire substantive scope).
+  2. Verification §4.3: Playwright theme-tracking assertion promoted to REQUIRED (CI-durable, regression-proof); screenshot pair demoted to OPTIONAL.
+  3. Title clarified with subtitle preserving "Hex literal sweep" name for traceability while flagging actual scope.
+  - PR-D2 added to baseline §8 PR sequence as Wave 2 token-introduction PR (per Designer-Opus recommendation; defer drafting until Wave 1 lands).
+- Independent contrast verification by Designer-Opus matched Worker's calc within rounding (~2.5 vs ~2.4 in dark; ~7.1 vs ~5.8 post-fix).

--- a/styles/app.css
+++ b/styles/app.css
@@ -523,7 +523,7 @@ textarea:focus-visible {
 .btn.secondary { background: var(--panel-soft); border-color: var(--line); color: var(--ink); }
 .btn.ghost { background: transparent; border-color: var(--line); color: var(--ink); }
 .btn.good { background: var(--good-soft); border-color: #b8dfca; color: var(--good); }
-.btn.warn { background: var(--warn-soft); border-color: #edd9ae; color: #9e6a19; }
+.btn.warn { background: var(--warn-soft); border-color: #edd9ae; color: var(--warn-strong); }
 .btn.bad { background: var(--bad-soft); border-color: #f0c8c5; color: var(--bad); }
 .btn.sm { padding: 8px 12px; font-size: 0.92rem; }
 .btn.lg { padding: 12px 16px; }
@@ -549,7 +549,7 @@ textarea:focus-visible {
   color: var(--ink-2);
 }
 .chip.good { background: var(--good-soft); color: var(--good); border-color: #b8dfca; }
-.chip.warn { background: var(--warn-soft); color: #9e6a19; border-color: #edd9ae; }
+.chip.warn { background: var(--warn-soft); color: var(--warn-strong); border-color: #edd9ae; }
 .chip.bad { background: var(--bad-soft); color: var(--bad); border-color: #f0c8c5; }
 .chip.new { background: #f4f6f8; color: #546171; border-color: #d9e0e7; }
 .chip.learning { background: #e8f1fb; color: #2f6fae; border-color: #bdd5ef; }

--- a/tests/playwright/warn-contrast-token.playwright.test.mjs
+++ b/tests/playwright/warn-contrast-token.playwright.test.mjs
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const appCssPath = path.join(repoRoot, 'styles/app.css');
+
+test('warn button and chip foreground tracks --warn-strong in light and dark themes', async ({ page }) => {
+  const css = await readFile(appCssPath, 'utf8');
+  await page.setContent(`
+    <!doctype html>
+    <html data-theme="light">
+      <head><style>${css}</style></head>
+      <body>
+        <button type="button" class="btn warn">Warn action</button>
+        <span class="chip warn">Warn status</span>
+      </body>
+    </html>
+  `);
+
+  const warnButton = page.locator('.btn.warn');
+  const warnChip = page.locator('.chip.warn');
+
+  await expect(warnButton).toHaveCSS('color', 'rgb(158, 106, 25)');
+  await expect(warnChip).toHaveCSS('color', 'rgb(158, 106, 25)');
+
+  await page.evaluate(() => document.documentElement.setAttribute('data-theme', 'dark'));
+
+  await expect(warnButton).toHaveCSS('color', 'rgb(241, 192, 129)');
+  await expect(warnChip).toHaveCSS('color', 'rgb(241, 192, 129)');
+});


### PR DESCRIPTION
## Summary
- Replace the hard-coded warn foreground on `.btn.warn` and `.chip.warn` with `var(--warn-strong)` so dark mode tracks the theme token.
- Add a Playwright regression asserting light/dark computed colours for both warn surfaces.
- Add the PR-D spec and KS2 design baseline notes used for the implementation contract.

## Verification
- `npm test` — 16,279 pass / 0 fail / 6 skip after rebasing onto latest `origin/main`.
- `npm run check` — Wrangler dry-run build/assert/audit passed.
- `npx playwright test tests/playwright/warn-contrast-token.playwright.test.mjs` — 5 viewport projects passed.
- `npm test -- tests/ui-token-contract.test.js` — 7 pass / 0 fail.
- `git diff --check` — clean.

## Bundle Delta
Compared with a clean build of current `origin/main`:
- JS gzip total: 319,059 -> 319,059 bytes (0 bytes).
- `dist/public/styles/app.css`: 365,789 -> 365,811 raw (+22 bytes); 69,702 -> 69,701 gzip (-1 byte).

## Notes
- Border colour literals are intentionally untouched per PR-D out-of-scope guidance.
- Branch was rebased onto latest `origin/main` before final verification.