### PR TITLE
Record Hero Mode pA6 repo-side hold evidence

### DIFF
--- a/docs/plans/james/hero-mode/A/hero-pA6-live-rollout-log.md
+++ b/docs/plans/james/hero-mode/A/hero-pA6-live-rollout-log.md
@@ -1,0 +1,40 @@
+# Hero Mode pA6 - Live Rollout Log
+
+**Phase:** A6 (Production close-out, normalisation, or stop)
+**Date:** 2026-05-01
+**Status:** POPULATED - no widening executed; repo-side hold recorded
+**Contract:** `docs/plans/james/hero-mode/A/hero-mode-pA6.md`
+
+---
+
+## Rollout Timeline
+
+| Date/Time | Flag or Secret Changed | Population Affected | Operator | Smoke Result | Stop/Warning Conditions | Decision |
+|-----------|------------------------|---------------------|----------|--------------|-------------------------|----------|
+| 2026-05-01 16:46 UTC | None | No new production accounts widened by this branch; checked-in global Hero flags remain false; rollout-bucket path is effectively 0%; `HERO_INTERNAL_ACCOUNTS` secret exists but its size is not readable by this workflow | Codex worktree `hero-mode-pA6` | Production smoke not run; focused local resolver/safety tests passed | No live rollout evidence supplied; exact internal allowlist size not verified; A6 metric truth gap closed; owner and support approval evidence missing | HOLD AT CURRENT ROLLOUT PERCENTAGE |
+
+---
+
+## Evidence Boundary
+
+This log is intentionally not a normalisation log. It records the A6 release brake.
+
+- pA5 example/template rows are ignored.
+- No percentage rollout was executed by this branch.
+- No allowlist was widened by this branch.
+- The rollout-bucket path is effectively 0% from tracked vars and the observed secret-name list.
+- `HERO_INTERNAL_ACCOUNTS` is present, but its value and size are not readable by this workflow.
+- This is therefore a repo-side hold record, not a contract-complete production HOLD certification.
+- No production D1 export was supplied to the A6 extractor.
+- The current checked-in Worker vars keep global Hero flags off.
+
+---
+
+## Decision Key
+
+| Decision | Meaning |
+|----------|---------|
+| NORMALISE HERO MODE | Not supported by the available A6 evidence |
+| HOLD AT CURRENT ROLLOUT PERCENTAGE | Selected; do not widen until owners, support approval, live metrics, smoke, and rollback evidence exist |
+| ROLL BACK TO COHORT ONLY | Not selected; no live breach was observed by this branch |
+| KEEP DORMANT AND REWORK | Not selected; no serious product/privacy/economy architecture failure was observed by this branch |

--- a/docs/plans/james/hero-mode/A/hero-pA6-metrics-summary.md
+++ b/docs/plans/james/hero-mode/A/hero-pA6-metrics-summary.md
@@ -1,0 +1,127 @@
+# Hero Mode pA6 - Metrics Summary
+
+**Phase:** A6 (Production close-out, normalisation, or stop)
+**Date:** 2026-05-01
+**Status:** POPULATED FROM EMPTY SUPPLIED EXPORT - not live rollout evidence
+**Report:** `reports/hero/hero-pA6-metrics-report.json`
+
+---
+
+## Source Truth
+
+| Source | A6 role |
+|--------|---------|
+| `child_game_state` where `system_id = 'hero-mode'` | Authoritative Hero progress, economy, ledger, balance, Hero Pool, and Camp state |
+| `event_log` | Observational telemetry mirror only |
+| `child_subject_state` | Ready-subject and mastery/Star comparison source when pre/post snapshots exist |
+| `account_learner_memberships` | Account-to-learner join source |
+| support log export | Manual support/confusion/opt-out source |
+
+The A6 extractor does not reference conceptual Hero-only state tables. Metric source classification is explicit rather than inferred from registry presence.
+
+---
+
+## Source Counts
+
+Report evidence state:
+
+```txt
+no-live-export-supplied
+```
+
+| Source | Supplied rows |
+|--------|---------------|
+| `event_log` Hero rows | 0 |
+| `child_game_state` Hero rows | 0 |
+| `child_subject_state` rows | 0 |
+| `account_learner_memberships` rows | 0 |
+| support rows | 0 |
+
+Zero supplied rows do not prove zero production issues. They prove that no live production export was supplied to this A6 branch.
+
+For the same reason, privacy validation in the machine-readable report is `status: "not-evaluated"` with `passed: null`; it must not be read as a live privacy pass. When Hero event rows are supplied, malformed, missing, or non-object `event_json` payloads fail closed as privacy evaluation failures.
+
+---
+
+## Observability Classification
+
+| Classification | Count | Meaning |
+|----------------|-------|---------|
+| observed-live | 7 | Can be counted from live telemetry when exported |
+| schema-derived | 14 | Can be derived from current real platform state |
+| manual-support-log | 2 | Requires support or rollback evidence |
+| client-instrumented | 0 | No metric is currently treated as already instrumented client telemetry |
+| not-observable-yet | 11 | Must not be counted as covered without additional smoke, logs, or instrumentation |
+
+---
+
+## Launch Metrics
+
+| Metric | Classification | Current value | Decision note |
+|--------|----------------|---------------|---------------|
+| Eligible ready-subject learner count | schema-derived | 0 supplied rows | Requires production export before widening |
+| Exposed account count | schema-derived | 0 supplied rows | Requires production export or resolver classification export |
+| Hero Quest shown count | not-observable-yet | Not observable | Needs client telemetry or browser-smoke evidence |
+| Hero Quest start count | schema-derived | 0 supplied rows | Derived from Hero progress JSON when supplied |
+| Hero task start count | schema-derived | 0 supplied rows | Derived from Hero progress JSON when supplied |
+| Hero task completion count | observed-live | 0 supplied rows | event_log mirror only |
+| Daily Hero Quest completion count | schema-derived | 0 supplied rows | child_game_state authority, event_log mirror |
+| Claim success count | observed-live | 0 supplied rows | Current mirror is `hero.task.completed` |
+| Claim rejection count | not-observable-yet | Not observable | Rejections are not persisted in a queryable table |
+| Coin award count | schema-derived | 0 supplied rows | Authoritative economy ledger required |
+| Camp open count | not-observable-yet | Not observable | Client-only unless instrumented |
+| Camp invite/grow count | schema-derived | 0 supplied rows | Authoritative economy/Camp state required |
+| Hero route 4xx count | not-observable-yet | Not observable | Needs Workers request logs or persisted route-error telemetry |
+| Hero route 5xx count | not-observable-yet | Not observable | Needs Workers request logs or persisted route-error telemetry |
+
+---
+
+## Product Metrics
+
+| Metric | Classification | Current value | Decision note |
+|--------|----------------|---------------|---------------|
+| Start rate from shown | not-observable-yet | Not observable | Shown denominator is client-side |
+| Completion rate from server-started learner-days | schema-derived | 0/0 | Requires Hero progress export |
+| Next-day return rate | observed-live | 0/0 | Requires multi-day telemetry export |
+| Subject mix distribution | observed-live | `{}` | Requires task completion telemetry |
+| Task-intent mix | schema-derived | `{}` | Requires Hero progress JSON |
+| Abandonment point distribution | not-observable-yet | Not observable | Requires client/session instrumentation |
+| Parent/support confusion reports | manual-support-log | 0 supplied rows | No support log supplied |
+| Camp-before-learning ratio | observed-live | 0/0 | Requires Camp and daily completion telemetry |
+| Extra subject practice after daily coin cap | observed-live | 0 supplied rows | Requires telemetry after daily completion |
+| Warning-condition count | schema-derived | 0 from supplied rows | Not a live all-clear because live rows were not supplied |
+
+---
+
+## Safety Metrics
+
+| Metric | Classification | Current value | Gate impact |
+|--------|----------------|---------------|-------------|
+| Duplicate daily award | schema-derived | 0 from supplied rows | Needs live Hero state export |
+| Duplicate Camp debit | schema-derived | 0 from supplied rows | Needs live Hero state export |
+| Negative balance | schema-derived | 0 from supplied rows | Needs live Hero state export |
+| Dead CTA | not-observable-yet | Not observable | Needs browser smoke |
+| Claim without Worker-verified completion | schema-derived | 0 from supplied rows | Needs live Hero state and telemetry |
+| Raw child content | observed-live | Not evaluated | Needs live telemetry export; malformed or missing Hero `event_json` fails closed |
+| Subject Star/mastery drift attributable to Hero Mode | not-observable-yet | Not observable | Needs pre/post subject-state snapshots |
+| Exposure to excluded accounts | not-observable-yet | Not observable | Needs resolver classification export or named smoke accounts |
+| Rollback failure | manual-support-log | No rehearsal row supplied | Needs rollback rehearsal evidence |
+| Production 5xx spike attributable to Hero | not-observable-yet | Not observable | Needs Workers request logs or persisted route-error telemetry |
+
+---
+
+## Decision Impact
+
+The populated A6 report recommends:
+
+```txt
+HOLD AT CURRENT ROLLOUT PERCENTAGE
+```
+
+Reasons:
+
+- No supplied live Hero production export rows.
+- Safety blind spots still require smoke, logs, or manual evidence.
+- The metrics layer is now schema-accurate, but it has not yet been run against production data.
+
+Hero Mode must not be described as normalised from this metrics summary.

--- a/docs/plans/james/hero-mode/A/hero-pA6-metrics-summary.md
+++ b/docs/plans/james/hero-mode/A/hero-pA6-metrics-summary.md
@@ -39,7 +39,7 @@ no-live-export-supplied
 
 Zero supplied rows do not prove zero production issues. They prove that no live production export was supplied to this A6 branch.
 
-For the same reason, privacy validation in the machine-readable report is `status: "not-evaluated"` with `passed: null`; it must not be read as a live privacy pass. When Hero event rows are supplied, malformed, missing, or non-object `event_json` payloads fail closed as privacy evaluation failures.
+For the same reason, privacy validation in the machine-readable report is `status: "not-evaluated"` with `passed: null`; it must not be read as a live privacy pass. When Hero event rows are supplied, malformed, missing, or non-object `event_json` payloads fail closed as privacy evaluation failures. Malformed or non-object `child_game_state.state_json` rows also fail closed as authoritative state inspection failures.
 
 ---
 
@@ -99,7 +99,7 @@ For the same reason, privacy validation in the machine-readable report is `statu
 |--------|----------------|---------------|-------------|
 | Duplicate daily award | schema-derived | 0 from supplied rows | Needs live Hero state export |
 | Duplicate Camp debit | schema-derived | 0 from supplied rows | Needs live Hero state export |
-| Negative balance | schema-derived | 0 from supplied rows | Needs live Hero state export |
+| Negative balance | schema-derived | 0 from supplied rows | Needs live Hero state export; malformed Hero state fails closed as an inspection failure |
 | Dead CTA | not-observable-yet | Not observable | Needs browser smoke |
 | Claim without Worker-verified completion | schema-derived | 0 from supplied rows | Needs live Hero state and telemetry |
 | Raw child content | observed-live | Not evaluated | Needs live telemetry export; malformed or missing Hero `event_json` fails closed |

--- a/docs/plans/james/hero-mode/A/hero-pA6-preflight.md
+++ b/docs/plans/james/hero-mode/A/hero-pA6-preflight.md
@@ -1,0 +1,124 @@
+# Hero Mode pA6 - Preflight and Hold Note
+
+**Phase:** A6 (Production close-out, normalisation, or stop)
+**Date:** 2026-05-01
+**Status:** REPO-SIDE HOLD - metric correction complete; production hold boundary blocked
+**Contract:** `docs/plans/james/hero-mode/A/hero-mode-pA6.md`
+
+---
+
+## Outcome
+
+A6 cannot normalise Hero Mode from the evidence available in this worktree.
+
+The checked-in production config keeps the global Hero flags off:
+
+```txt
+HERO_MODE_SHADOW_ENABLED=false
+HERO_MODE_LAUNCH_ENABLED=false
+HERO_MODE_CHILD_UI_ENABLED=false
+HERO_MODE_PROGRESS_ENABLED=false
+HERO_MODE_ECONOMY_ENABLED=false
+HERO_MODE_CAMP_ENABLED=false
+```
+
+`HERO_ROLLOUT_PERCENT` is absent from the tracked Worker vars. A read-only Cloudflare secret-name check on 2026-05-01 also did not list `HERO_ROLLOUT_PERCENT` or `HERO_ROLLOUT_SALT`, so the rollout-bucket path is effectively 0% from the evidence visible to this branch.
+
+The same secret-name check did list `HERO_INTERNAL_ACCOUNTS`. Cloudflare does not expose secret values through this workflow, so this branch cannot verify the exact live internal allowlist size.
+
+No production rollout secret was changed by this branch. No live Hero production export was supplied. The pA5 rollout, metrics, support, and decision files remain template-era evidence and are not counted as live A6 evidence.
+
+The A6 decision is therefore:
+
+```txt
+HOLD AT CURRENT ROLLOUT PERCENTAGE
+```
+
+This is a release brake, not a product expansion.
+
+This is not a contract-complete production HOLD certification until an operator records the current `HERO_INTERNAL_ACCOUNTS` size or rotates it to a known value.
+
+---
+
+## Day 0 Checks
+
+| A6 entry or Day 0 requirement | Evidence | Status |
+|-------------------------------|----------|--------|
+| Resolver supports internal, external, percentage, excluded, emergency-off, global default, and none states | `node scripts/hero-pA5-rollout-resolver-evidence.mjs`: 9/9 scenarios passed | PASS |
+| Resolver precedence is emergency-off > excluded > internal > external > rollout-bucket > global-default > none | `node --test tests/hero-pA5-rollout-resolver.test.js tests/hero-pA5-safety-regression.test.js`: 44/44 passed | PASS |
+| Read-model and command route use the same resolver | Covered by `tests/hero-pA5-rollout-resolver.test.js` route consistency cases | PASS |
+| Emergency-off hides Hero surfaces and rejects commands without deleting Hero state | Covered by `tests/hero-pA5-safety-regression.test.js` rollback-preserves-state cases | PASS (local) |
+| Product, engineering, support, and daily-review owners exist | No named owners are recorded in this branch | BLOCKED |
+| Parent/support explanation approved for real families | pA4 support/explainer artefacts exist, but A6 has no fresh real-family approval evidence | BLOCKED |
+| Exact rollout percentage or allowlist size is known for HOLD | Rollout-bucket percentage is effectively 0%; `HERO_INTERNAL_ACCOUNTS` is present but its value/size is hidden | BLOCKED |
+| A5 rollout-control and safety tests pass | Focused local A5 resolver/safety tests passed on 2026-05-01 | PASS (focused local) |
+| Metric truth matches the real schema before widening | `scripts/hero-pA6-metrics-extract.mjs`, `tests/hero-pA6-metrics-extract.test.js`, and patched `scripts/hero-pA4-metrics-validator.mjs` | PASS |
+| pA5 template rows are not countable as live evidence | A6 docs and report explicitly ignore template-era rows | PASS |
+
+---
+
+## Metric Truth Correction
+
+A6 adds a schema-accurate extraction path:
+
+```txt
+scripts/hero-pA6-metrics-extract.mjs
+tests/hero-pA6-metrics-extract.test.js
+reports/hero/hero-pA6-metrics-report.json
+```
+
+The extractor uses these sources:
+
+```txt
+event_log
+child_game_state
+child_subject_state
+account_learner_memberships
+support_issues export when supplied
+```
+
+The authoritative Hero economy and Camp state source is:
+
+```txt
+child_game_state
+system_id = 'hero-mode'
+state_json = Hero progress/economy/Hero Pool JSON
+```
+
+`event_log` is treated as a telemetry mirror only. It is not treated as the source of truth for balances, ledger entries, daily awards, Camp spends, or Hero Pool ownership.
+
+The inherited pA4 metric mapping was also patched so it no longer points at conceptual Hero tables. Focused A6 tests now guard this.
+
+---
+
+## Current Evidence Boundary
+
+| Field | Value |
+|-------|-------|
+| Live rollout secret change executed by this branch | No |
+| Observed Hero secret names | `HERO_INTERNAL_ACCOUNTS` present; rollout percent/salt, external, excluded, and emergency secrets absent |
+| Repository-declared rollout-bucket percentage | 0% effective (`HERO_ROLLOUT_PERCENT` absent from tracked vars and secret-name list) |
+| Live internal allowlist size | Not verified; Cloudflare does not reveal secret values through this workflow |
+| Live production Hero export supplied | No |
+| `reports/hero/hero-pA6-metrics-report.json` event rows | 0 |
+| `reports/hero/hero-pA6-metrics-report.json` Hero state rows | 0 |
+| Support rows supplied to extractor | 0 |
+| Browser production smoke run | Not run in this branch |
+| Production normalisation supported | No |
+| Repo-side A6 outcome recorded | HOLD AT CURRENT ROLLOUT PERCENTAGE |
+| Contract-complete production HOLD supported | No; exact internal allowlist size is still blocked |
+
+---
+
+## Allowed Next Action
+
+To widen beyond this hold, the team needs all of the following before touching production exposure:
+
+1. Named product, engineering, support, and daily-review owners.
+2. An approved support/parent explanation for real families.
+3. A production export or live extraction run using `scripts/hero-pA6-metrics-extract.mjs`.
+4. The current `HERO_INTERNAL_ACCOUNTS` size recorded or the secret rotated to a known value.
+5. A production smoke account proving read model, command, claim, coins, and Camp behaviour.
+6. A real rollback rehearsal after the intended exposure state is reached.
+
+Until then, Hero Mode must not be described as normalised.

--- a/docs/plans/james/hero-mode/A/hero-pA6-production-decision.md
+++ b/docs/plans/james/hero-mode/A/hero-pA6-production-decision.md
@@ -1,0 +1,88 @@
+# Hero Mode pA6 - Production Decision
+
+**Phase:** A6 (Production close-out, normalisation, or stop)
+**Date:** 2026-05-01
+**Status:** REPO-SIDE HOLD RECORD - production hold boundary blocked
+**Contract:** `docs/plans/james/hero-mode/A/hero-mode-pA6.md`
+
+---
+
+## Decision
+
+```txt
+HOLD AT CURRENT ROLLOUT PERCENTAGE
+```
+
+Hero Mode is not normalised by this A6 branch. This is a repo-side hold record, not a contract-complete production HOLD certification.
+
+---
+
+## Why Hold
+
+The hold decision is based on the following real evidence:
+
+1. The pA5 rollout infrastructure exists, but pA5 live rollout evidence remains template-era or deferred.
+2. The checked-in production Worker vars keep global Hero flags off.
+3. No production rollout secret was changed by this branch.
+4. No live production Hero state, telemetry, support, or route-log export was supplied to the A6 extractor.
+5. The pA5 metric layer needed schema-truth correction before widening; A6 now supplies that correction.
+6. Product, support, engineering, and daily-review owners are not named in this branch.
+7. Local resolver/safety rehearsal passed, but production smoke and rollback rehearsal are still required before widening.
+8. A read-only Cloudflare secret-name check found `HERO_INTERNAL_ACCOUNTS` still present, but Cloudflare does not expose secret values through this workflow, so the exact live internal allowlist size is not verified.
+
+---
+
+## Exact Hold Boundary
+
+| Field | Value |
+|-------|-------|
+| Selected outcome | HOLD AT CURRENT ROLLOUT PERCENTAGE |
+| Rollout percentage changed by this branch | No |
+| Secret-name check | `node scripts/wrangler-oauth.mjs secret list` on 2026-05-01 |
+| Hero rollout percentage/salt secrets | `HERO_ROLLOUT_PERCENT` and `HERO_ROLLOUT_SALT` not present in the secret-name list |
+| Hero external/excluded/emergency secrets | `HERO_EXTERNAL_ACCOUNTS`, `HERO_EXCLUDED_ACCOUNTS`, and `HERO_EMERGENCY_DISABLED` not present in the secret-name list |
+| Internal allowlist secret | `HERO_INTERNAL_ACCOUNTS` present; value and size not readable by this workflow |
+| Repository-declared rollout-bucket percentage | 0% effective (`HERO_ROLLOUT_PERCENT` absent from tracked vars and absent from the observed secret-name list) |
+| Existing checked-in global Hero flags | false |
+| Exact live allowlist size | BLOCKED - `HERO_INTERNAL_ACCOUNTS` is present but its value is write-only/hidden |
+| A6 HOLD contract boundary | BLOCKED until an operator records the current `HERO_INTERNAL_ACCOUNTS` size or rotates it to a known value |
+| Live production export rows supplied | 0 |
+| Normalisation allowed | No |
+| Review-by date | 2026-05-15 |
+
+The review-by date is 14 calendar days after the A6 hold record, matching the A6 hold rule. The exact current production allowlist size is still required before this can be treated as a contract-complete A6 production HOLD.
+
+---
+
+## Required Actions Before Widening
+
+1. Name product, engineering, support, and daily-review owners.
+2. Confirm the family-facing support explanation is approved for real families.
+3. Record the current `HERO_INTERNAL_ACCOUNTS` allowlist size or rotate it to a known value.
+4. Run a real production extraction with `scripts/hero-pA6-metrics-extract.mjs`.
+5. Run production smoke for read model, command, claim, coins, and Camp.
+6. Rehearse production rollback after the intended exposure state is reached.
+7. Record support zeroes or issues in the support log.
+8. Revisit this decision no later than 2026-05-15.
+
+---
+
+## Outcome Options Not Selected
+
+| Outcome | Reason not selected |
+|---------|---------------------|
+| NORMALISE HERO MODE | No live rollout evidence, production metrics, production smoke, support owner sign-off, or production rollback rehearsal exists in this branch |
+| ROLL BACK TO COHORT ONLY | No live stop condition was observed by this branch |
+| KEEP DORMANT AND REWORK | No serious product, privacy, economy, or architecture failure was observed by this branch |
+
+---
+
+## Signatures
+
+| Role | Name | Date | Status |
+|------|------|------|--------|
+| Product owner | Not recorded | | REQUIRED BEFORE WIDENING |
+| Engineering owner | Not recorded | | REQUIRED BEFORE WIDENING |
+| Support owner | Not recorded | | REQUIRED BEFORE WIDENING |
+
+This decision is an engineering hold record from the A6 worktree. It does not replace product/support sign-off, and it does not certify the exact current production exposure until the `HERO_INTERNAL_ACCOUNTS` size is recorded or reset to a known value.

--- a/docs/plans/james/hero-mode/A/hero-pA6-rollback-evidence.md
+++ b/docs/plans/james/hero-mode/A/hero-pA6-rollback-evidence.md
@@ -1,0 +1,44 @@
+# Hero Mode pA6 - Rollback Rehearsal Evidence
+
+**Phase:** A6 (Production close-out, normalisation, or stop)
+**Date:** 2026-05-01
+**Status:** LOCAL REHEARSAL PASSED - production rehearsal still required before widening
+**Contract:** `docs/plans/james/hero-mode/A/hero-mode-pA6.md`
+
+---
+
+## Local Evidence
+
+| Check | Evidence | Result |
+|-------|----------|--------|
+| Emergency-off wins over all other classifications | `node scripts/hero-pA5-rollout-resolver-evidence.mjs` scenario S5 | PASS |
+| Excluded wins over internal allowlist | `node scripts/hero-pA5-rollout-resolver-evidence.mjs` scenario S4 | PASS |
+| 0 percent rollout admits no account by bucket | `node scripts/hero-pA5-rollout-resolver-evidence.mjs` scenario S8 | PASS |
+| Resolver precedence and bucket stability | `node --test tests/hero-pA5-rollout-resolver.test.js tests/hero-pA5-safety-regression.test.js` | PASS, 44/44 |
+| Emergency-off preserves dormant Hero state | `tests/hero-pA5-safety-regression.test.js` rollback-preserves-state group | PASS |
+
+---
+
+## Production Evidence Boundary
+
+This is not a production rollback rehearsal. No Cloudflare secret was changed and no live smoke account was exercised by this branch.
+
+The production rollback rehearsal still needs to prove:
+
+- Hero surfaces are hidden after rollback.
+- Hero command routes return controlled non-500 errors.
+- Hero state remains preserved in `child_game_state`.
+- Excluded accounts remain excluded.
+- Rollback does not require SQL repair or state deletion.
+
+---
+
+## A6 Gate Impact
+
+Local rollback evidence is sufficient to keep the code path eligible for a future controlled rollout. It is not sufficient to normalise Hero Mode.
+
+The selected A6 outcome remains:
+
+```txt
+HOLD AT CURRENT ROLLOUT PERCENTAGE
+```

--- a/docs/plans/james/hero-mode/A/hero-pA6-support-summary.md
+++ b/docs/plans/james/hero-mode/A/hero-pA6-support-summary.md
@@ -1,0 +1,60 @@
+# Hero Mode pA6 - Support Summary
+
+**Phase:** A6 (Production close-out, normalisation, or stop)
+**Date:** 2026-05-01
+**Status:** POPULATED FROM EMPTY SUPPLIED SUPPORT EXPORT - no live support log supplied
+**Contract:** `docs/plans/james/hero-mode/A/hero-mode-pA6.md`
+
+---
+
+## Support Ownership
+
+| Role | Name | Status |
+|------|------|--------|
+| Support owner | Not recorded in this branch | BLOCKED |
+| Daily review owner | Not recorded in this branch | BLOCKED |
+
+Support ownership must be named before any live A6 widening.
+
+---
+
+## Supplied Support Issue Log
+
+| Issue Date | Reporter | Category | Description | Resolution | Resolved By | Days to Resolve |
+|------------|----------|----------|-------------|------------|-------------|-----------------|
+| No supplied rows | | | No A6 production support log was supplied to this worktree | | | |
+
+---
+
+## Aggregate Summary
+
+| Category | Open | Resolved | Total | Evidence note |
+|----------|------|----------|-------|---------------|
+| comprehension | 0 | 0 | 0 | No support rows supplied; not proof of zero real parent confusion |
+| technical | 0 | 0 | 0 | No support rows supplied |
+| economy | 0 | 0 | 0 | No support rows supplied |
+| boundary | 0 | 0 | 0 | No support rows supplied |
+| opt-out | 0 | 0 | 0 | No support rows supplied |
+| **Total** | 0 | 0 | 0 | No support rows supplied; not proof of zero live support issues |
+
+## Evidence Blockers
+
+| Blocker | Status | Decision impact |
+|---------|--------|-----------------|
+| No A6 production support log supplied | BLOCKED | Hold; live support zeroes or issues must be recorded before widening |
+| Support owner not named | BLOCKED | Hold; support load is not owned |
+| Daily review owner not named | BLOCKED | Hold; live issue review cadence is not owned |
+
+---
+
+## Support Decision
+
+Support load is not understood from live evidence. The correct A6 action is to hold, not to widen.
+
+Before any Stage 1 live rollout, the team must record:
+
+1. Named support owner.
+2. Named daily review owner.
+3. Approved parent/support explanation for real families.
+4. Support-log capture path with zeroes recorded when no issues occur.
+5. Opt-out procedure tied to `HERO_EXCLUDED_ACCOUNTS` or an equivalent mechanism.

--- a/reports/hero/hero-pA6-metrics-report.json
+++ b/reports/hero/hero-pA6-metrics-report.json
@@ -1,6 +1,6 @@
 {
   "phase": "hero-mode-pA6",
-  "generatedAt": "2026-05-01T17:16:41.416Z",
+  "generatedAt": "2026-05-01T17:22:22.108Z",
   "evidenceState": "no-live-export-supplied",
   "dateRange": {
     "from": null,
@@ -36,6 +36,11 @@
     "violations": [],
     "parseFailures": [],
     "notEvaluatedRows": []
+  },
+  "stateInspection": {
+    "parseErrorCount": 0,
+    "failureCount": 0,
+    "failures": []
   },
   "metrics": [
     {
@@ -385,7 +390,7 @@
       "sourceTables": [
         "child_game_state"
       ],
-      "extraction": "Inspect economy.balance and ledger balanceAfter values in Hero progress JSON.",
+      "extraction": "Inspect economy.balance and ledger balanceAfter values in Hero progress JSON; malformed Hero state fails closed as an inspection failure.",
       "value": 0,
       "observableNow": true,
       "evidenceState": "no-live-export-supplied"

--- a/reports/hero/hero-pA6-metrics-report.json
+++ b/reports/hero/hero-pA6-metrics-report.json
@@ -1,0 +1,543 @@
+{
+  "phase": "hero-mode-pA6",
+  "generatedAt": "2026-05-01T17:16:41.416Z",
+  "evidenceState": "no-live-export-supplied",
+  "dateRange": {
+    "from": null,
+    "to": null
+  },
+  "sourceCounts": {
+    "eventLogRows": 0,
+    "heroStateRows": 0,
+    "childSubjectStateRows": 0,
+    "membershipRows": 0,
+    "supportRows": 0
+  },
+  "sourceTruth": {
+    "economyAuthority": "child_game_state.state_json where system_id='hero-mode'",
+    "eventLogRole": "telemetry mirror only",
+    "conceptualTablesAbsent": true,
+    "conceptualTableOffenders": []
+  },
+  "eventMirrorCounts": {
+    "taskCompleted": 0,
+    "dailyCompleted": 0,
+    "coinAwarded": 0,
+    "campEvents": 0
+  },
+  "privacy": {
+    "passed": null,
+    "status": "not-evaluated",
+    "rowsChecked": 0,
+    "violationCount": 0,
+    "parseErrorCount": 0,
+    "notEvaluatedCount": 0,
+    "failureCount": 0,
+    "violations": [],
+    "parseFailures": [],
+    "notEvaluatedRows": []
+  },
+  "metrics": [
+    {
+      "id": "pa6-launch-01",
+      "category": "launch",
+      "name": "eligible ready-subject learner count",
+      "sourceType": "schema-derived",
+      "sourceTables": [
+        "child_subject_state",
+        "account_learner_memberships"
+      ],
+      "extraction": "Count distinct learners with ready-subject state rows; final launchability still requires smoke proof.",
+      "value": 0,
+      "observableNow": true,
+      "evidenceState": "no-live-export-supplied"
+    },
+    {
+      "id": "pa6-launch-02",
+      "category": "launch",
+      "name": "exposed account count",
+      "sourceType": "schema-derived",
+      "sourceTables": [
+        "event_log",
+        "account_learner_memberships"
+      ],
+      "extraction": "Count distinct actor accounts from Hero telemetry and linked accounts for learners with Hero state.",
+      "value": 0,
+      "observableNow": true,
+      "evidenceState": "no-live-export-supplied"
+    },
+    {
+      "id": "pa6-launch-03",
+      "category": "launch",
+      "name": "Hero Quest shown count",
+      "sourceType": "not-observable-yet",
+      "sourceTables": [],
+      "extraction": "Requires client render telemetry or browser-smoke evidence; do not infer from registry presence.",
+      "value": null,
+      "observableNow": false,
+      "evidenceState": "not-observable-yet"
+    },
+    {
+      "id": "pa6-launch-04",
+      "category": "launch",
+      "name": "Hero Quest start count",
+      "sourceType": "schema-derived",
+      "sourceTables": [
+        "child_game_state"
+      ],
+      "extraction": "Count learner-days where Hero progress has firstStartedAt or at least one task started/completed.",
+      "value": 0,
+      "observableNow": true,
+      "evidenceState": "no-live-export-supplied"
+    },
+    {
+      "id": "pa6-launch-05",
+      "category": "launch",
+      "name": "Hero task start count",
+      "sourceType": "schema-derived",
+      "sourceTables": [
+        "child_game_state"
+      ],
+      "extraction": "Count Hero tasks with status started or completed in the authoritative progress JSON.",
+      "value": 0,
+      "observableNow": true,
+      "evidenceState": "no-live-export-supplied"
+    },
+    {
+      "id": "pa6-launch-06",
+      "category": "launch",
+      "name": "Hero task completion count",
+      "sourceType": "observed-live",
+      "sourceTables": [
+        "event_log"
+      ],
+      "extraction": "Count event_log rows where system_id='hero-mode' and event_type='hero.task.completed'.",
+      "value": 0,
+      "observableNow": true,
+      "evidenceState": "no-live-export-supplied"
+    },
+    {
+      "id": "pa6-launch-07",
+      "category": "launch",
+      "name": "daily Hero Quest completion count",
+      "sourceType": "schema-derived",
+      "sourceTables": [
+        "child_game_state",
+        "event_log"
+      ],
+      "extraction": "Use child_game_state daily.status=completed as authority, with event_log daily.completed as telemetry mirror.",
+      "value": 0,
+      "observableNow": true,
+      "evidenceState": "no-live-export-supplied"
+    },
+    {
+      "id": "pa6-launch-08",
+      "category": "launch",
+      "name": "claim success count",
+      "sourceType": "observed-live",
+      "sourceTables": [
+        "event_log"
+      ],
+      "extraction": "Current server mirror records successful claims as hero.task.completed events.",
+      "value": 0,
+      "observableNow": true,
+      "evidenceState": "no-live-export-supplied"
+    },
+    {
+      "id": "pa6-launch-09",
+      "category": "launch",
+      "name": "claim rejection count",
+      "sourceType": "not-observable-yet",
+      "sourceTables": [],
+      "extraction": "Current rejection paths are not persisted in a queryable production table.",
+      "value": null,
+      "observableNow": false,
+      "evidenceState": "not-observable-yet"
+    },
+    {
+      "id": "pa6-launch-10",
+      "category": "launch",
+      "name": "coin award count",
+      "sourceType": "schema-derived",
+      "sourceTables": [
+        "child_game_state"
+      ],
+      "extraction": "Count economy.ledger entries with type=daily-completion-award in Hero progress JSON.",
+      "value": 0,
+      "observableNow": true,
+      "evidenceState": "no-live-export-supplied"
+    },
+    {
+      "id": "pa6-launch-11",
+      "category": "launch",
+      "name": "Camp open count",
+      "sourceType": "not-observable-yet",
+      "sourceTables": [],
+      "extraction": "Camp screen opens are client-side only unless instrumented separately.",
+      "value": null,
+      "observableNow": false,
+      "evidenceState": "not-observable-yet"
+    },
+    {
+      "id": "pa6-launch-12",
+      "category": "launch",
+      "name": "Camp invite/grow count",
+      "sourceType": "schema-derived",
+      "sourceTables": [
+        "child_game_state",
+        "event_log"
+      ],
+      "extraction": "Use economy spending ledger and Hero Pool state as authority; use camp events as telemetry mirror.",
+      "value": 0,
+      "observableNow": true,
+      "evidenceState": "no-live-export-supplied"
+    },
+    {
+      "id": "pa6-launch-13",
+      "category": "launch",
+      "name": "Hero route 4xx count",
+      "sourceType": "not-observable-yet",
+      "sourceTables": [],
+      "extraction": "Requires Workers request logs or explicit persisted route-error telemetry.",
+      "value": null,
+      "observableNow": false,
+      "evidenceState": "not-observable-yet"
+    },
+    {
+      "id": "pa6-launch-14",
+      "category": "launch",
+      "name": "Hero route 5xx count",
+      "sourceType": "not-observable-yet",
+      "sourceTables": [],
+      "extraction": "Requires Workers request logs or explicit persisted route-error telemetry.",
+      "value": null,
+      "observableNow": false,
+      "evidenceState": "not-observable-yet"
+    },
+    {
+      "id": "pa6-product-01",
+      "category": "product",
+      "name": "start rate from shown",
+      "sourceType": "not-observable-yet",
+      "sourceTables": [],
+      "extraction": "The shown denominator requires client render telemetry. Use server-started counts only as a narrower decision substitute.",
+      "value": null,
+      "observableNow": false,
+      "evidenceState": "not-observable-yet"
+    },
+    {
+      "id": "pa6-product-02",
+      "category": "product",
+      "name": "completion rate from server-started learner-days",
+      "sourceType": "schema-derived",
+      "sourceTables": [
+        "child_game_state"
+      ],
+      "extraction": "daily.status=completed divided by learner-days with firstStartedAt or started/completed tasks.",
+      "value": {
+        "startedLearnerDays": 0,
+        "dailyCompletedStateCount": 0,
+        "rate": 0
+      },
+      "observableNow": true,
+      "evidenceState": "no-live-export-supplied"
+    },
+    {
+      "id": "pa6-product-03",
+      "category": "product",
+      "name": "next-day return rate",
+      "sourceType": "observed-live",
+      "sourceTables": [
+        "event_log"
+      ],
+      "extraction": "Approximate from distinct learner-date pairs in Hero telemetry.",
+      "value": {
+        "activeLearnerDays": 0,
+        "returnNextDayCount": 0,
+        "rate": 0
+      },
+      "observableNow": true,
+      "evidenceState": "no-live-export-supplied"
+    },
+    {
+      "id": "pa6-product-04",
+      "category": "product",
+      "name": "subject mix distribution",
+      "sourceType": "observed-live",
+      "sourceTables": [
+        "event_log"
+      ],
+      "extraction": "Count subject_id on hero.task.completed telemetry rows.",
+      "value": {},
+      "observableNow": true,
+      "evidenceState": "no-live-export-supplied"
+    },
+    {
+      "id": "pa6-product-05",
+      "category": "product",
+      "name": "task-intent mix",
+      "sourceType": "schema-derived",
+      "sourceTables": [
+        "child_game_state"
+      ],
+      "extraction": "Count current Hero task intent values in authoritative progress JSON.",
+      "value": {},
+      "observableNow": true,
+      "evidenceState": "no-live-export-supplied"
+    },
+    {
+      "id": "pa6-product-06",
+      "category": "product",
+      "name": "abandonment point distribution",
+      "sourceType": "not-observable-yet",
+      "sourceTables": [],
+      "extraction": "Requires client/session instrumentation beyond current Hero state and event mirror.",
+      "value": null,
+      "observableNow": false,
+      "evidenceState": "not-observable-yet"
+    },
+    {
+      "id": "pa6-product-07",
+      "category": "product",
+      "name": "parent/support confusion reports",
+      "sourceType": "manual-support-log",
+      "sourceTables": [],
+      "extraction": "Count support-log rows in category=comprehension.",
+      "value": 0,
+      "observableNow": true,
+      "evidenceState": "no-live-export-supplied"
+    },
+    {
+      "id": "pa6-product-08",
+      "category": "product",
+      "name": "Camp-before-learning ratio",
+      "sourceType": "observed-live",
+      "sourceTables": [
+        "event_log"
+      ],
+      "extraction": "Compare camp telemetry timestamps with daily.completed telemetry for the same learner-date.",
+      "value": {
+        "campEvents": 0,
+        "beforeLearning": 0,
+        "ratio": 0
+      },
+      "observableNow": true,
+      "evidenceState": "no-live-export-supplied"
+    },
+    {
+      "id": "pa6-product-09",
+      "category": "product",
+      "name": "extra subject practice after daily coin cap",
+      "sourceType": "observed-live",
+      "sourceTables": [
+        "event_log"
+      ],
+      "extraction": "Count task.completed telemetry after daily.completed for the same learner-date.",
+      "value": 0,
+      "observableNow": true,
+      "evidenceState": "no-live-export-supplied"
+    },
+    {
+      "id": "pa6-product-10",
+      "category": "product",
+      "name": "warning-condition count",
+      "sourceType": "schema-derived",
+      "sourceTables": [
+        "child_game_state",
+        "event_log"
+      ],
+      "extraction": "Derived from computed A6 warning checks plus manual support-log thresholds.",
+      "value": 0,
+      "observableNow": true,
+      "evidenceState": "no-live-export-supplied"
+    },
+    {
+      "id": "pa6-safety-01",
+      "category": "safety",
+      "name": "duplicate daily award",
+      "sourceType": "schema-derived",
+      "sourceTables": [
+        "child_game_state"
+      ],
+      "extraction": "Group daily-completion-award ledger entries by learner/date/quest/idempotency key.",
+      "value": 0,
+      "observableNow": true,
+      "evidenceState": "no-live-export-supplied"
+    },
+    {
+      "id": "pa6-safety-02",
+      "category": "safety",
+      "name": "duplicate Camp debit",
+      "sourceType": "schema-derived",
+      "sourceTables": [
+        "child_game_state"
+      ],
+      "extraction": "Group monster-invite and monster-grow ledger entries by learner/idempotency key.",
+      "value": 0,
+      "observableNow": true,
+      "evidenceState": "no-live-export-supplied"
+    },
+    {
+      "id": "pa6-safety-03",
+      "category": "safety",
+      "name": "negative balance",
+      "sourceType": "schema-derived",
+      "sourceTables": [
+        "child_game_state"
+      ],
+      "extraction": "Inspect economy.balance and ledger balanceAfter values in Hero progress JSON.",
+      "value": 0,
+      "observableNow": true,
+      "evidenceState": "no-live-export-supplied"
+    },
+    {
+      "id": "pa6-safety-04",
+      "category": "safety",
+      "name": "dead CTA",
+      "sourceType": "not-observable-yet",
+      "sourceTables": [],
+      "extraction": "Requires browser smoke or client instrumentation because dead navigation is not persisted.",
+      "value": null,
+      "observableNow": false,
+      "evidenceState": "not-observable-yet"
+    },
+    {
+      "id": "pa6-safety-05",
+      "category": "safety",
+      "name": "claim without Worker-verified completion",
+      "sourceType": "schema-derived",
+      "sourceTables": [
+        "child_game_state",
+        "event_log"
+      ],
+      "extraction": "Compare daily-award ledger entries with daily completion state and telemetry.",
+      "value": 0,
+      "observableNow": true,
+      "evidenceState": "no-live-export-supplied"
+    },
+    {
+      "id": "pa6-safety-06",
+      "category": "safety",
+      "name": "raw child content",
+      "sourceType": "observed-live",
+      "sourceTables": [
+        "event_log"
+      ],
+      "extraction": "Run recursive privacy validation against event_json payloads; fail closed on malformed, missing, or non-object payloads.",
+      "value": 0,
+      "observableNow": true,
+      "evidenceState": "no-live-export-supplied"
+    },
+    {
+      "id": "pa6-safety-07",
+      "category": "safety",
+      "name": "subject Star/mastery drift attributable to Hero Mode",
+      "sourceType": "not-observable-yet",
+      "sourceTables": [
+        "child_subject_state"
+      ],
+      "extraction": "Requires pre/post child_subject_state snapshots across the rollout window.",
+      "value": null,
+      "observableNow": false,
+      "evidenceState": "not-observable-yet"
+    },
+    {
+      "id": "pa6-safety-08",
+      "category": "safety",
+      "name": "exposure to excluded accounts",
+      "sourceType": "not-observable-yet",
+      "sourceTables": [],
+      "extraction": "Requires resolver classification export or named smoke accounts; do not infer from event presence alone.",
+      "value": null,
+      "observableNow": false,
+      "evidenceState": "not-observable-yet"
+    },
+    {
+      "id": "pa6-safety-09",
+      "category": "safety",
+      "name": "rollback failure",
+      "sourceType": "manual-support-log",
+      "sourceTables": [],
+      "extraction": "Recorded by rollback rehearsal evidence, not by normal Hero state rows.",
+      "value": null,
+      "observableNow": true,
+      "evidenceState": "not-observable-yet"
+    },
+    {
+      "id": "pa6-safety-10",
+      "category": "safety",
+      "name": "production 5xx spike attributable to Hero",
+      "sourceType": "not-observable-yet",
+      "sourceTables": [],
+      "extraction": "Requires Workers request logs or explicit persisted route-error telemetry.",
+      "value": null,
+      "observableNow": false,
+      "evidenceState": "not-observable-yet"
+    }
+  ],
+  "blindSpots": [
+    {
+      "id": "pa6-launch-03",
+      "name": "Hero Quest shown count",
+      "reason": "Requires client render telemetry or browser-smoke evidence; do not infer from registry presence."
+    },
+    {
+      "id": "pa6-launch-09",
+      "name": "claim rejection count",
+      "reason": "Current rejection paths are not persisted in a queryable production table."
+    },
+    {
+      "id": "pa6-launch-11",
+      "name": "Camp open count",
+      "reason": "Camp screen opens are client-side only unless instrumented separately."
+    },
+    {
+      "id": "pa6-launch-13",
+      "name": "Hero route 4xx count",
+      "reason": "Requires Workers request logs or explicit persisted route-error telemetry."
+    },
+    {
+      "id": "pa6-launch-14",
+      "name": "Hero route 5xx count",
+      "reason": "Requires Workers request logs or explicit persisted route-error telemetry."
+    },
+    {
+      "id": "pa6-product-01",
+      "name": "start rate from shown",
+      "reason": "The shown denominator requires client render telemetry. Use server-started counts only as a narrower decision substitute."
+    },
+    {
+      "id": "pa6-product-06",
+      "name": "abandonment point distribution",
+      "reason": "Requires client/session instrumentation beyond current Hero state and event mirror."
+    },
+    {
+      "id": "pa6-safety-04",
+      "name": "dead CTA",
+      "reason": "Requires browser smoke or client instrumentation because dead navigation is not persisted."
+    },
+    {
+      "id": "pa6-safety-07",
+      "name": "subject Star/mastery drift attributable to Hero Mode",
+      "reason": "Requires pre/post child_subject_state snapshots across the rollout window."
+    },
+    {
+      "id": "pa6-safety-08",
+      "name": "exposure to excluded accounts",
+      "reason": "Requires resolver classification export or named smoke accounts; do not infer from event presence alone."
+    },
+    {
+      "id": "pa6-safety-10",
+      "name": "production 5xx spike attributable to Hero",
+      "reason": "Requires Workers request logs or explicit persisted route-error telemetry."
+    }
+  ],
+  "decisionImpact": {
+    "recommendedOutcome": "HOLD AT CURRENT ROLLOUT PERCENTAGE",
+    "zeroToleranceBreaches": [],
+    "reasons": [
+      "No supplied live Hero production export rows; normalisation is not supported.",
+      "Safety blind spots still need smoke/log/manual evidence: pa6-safety-04, pa6-safety-07, pa6-safety-08, pa6-safety-10"
+    ]
+  }
+}

--- a/scripts/hero-pA4-metrics-validator.mjs
+++ b/scripts/hero-pA4-metrics-validator.mjs
@@ -27,8 +27,8 @@ export const REQUIRED_LAUNCH_METRICS = Object.freeze([
     name: 'cohort accounts enabled',
     canonicalMetric: null,
     extractionSource: 'server-extractable',
-    queryPattern: "SELECT COUNT(*) FROM cohort_members WHERE cohort_id = ? AND status = 'active'",
-    description: 'Count of learner accounts with Hero Mode cohort flag enabled',
+    queryPattern: "SELECT COUNT(DISTINCT m.account_id) FROM account_learner_memberships m JOIN child_game_state h ON h.learner_id = m.learner_id AND h.system_id = 'hero-mode'",
+    description: 'Count of accounts linked to learners with Hero Mode state; resolver allowlist or rollout export is still required for accounts with no state yet',
   },
   {
     id: 'launch-02',
@@ -90,9 +90,9 @@ export const REQUIRED_LAUNCH_METRICS = Object.freeze([
     id: 'launch-09',
     name: 'claim rejection count',
     canonicalMetric: null,
-    extractionSource: 'derived',
-    queryPattern: "SELECT COUNT(*) FROM event_log WHERE system_id = 'hero-mode' AND event_type = 'hero.task.rejected'",
-    description: 'Task claim rejections (stale write, revision conflict)',
+    extractionSource: 'not-observable-yet',
+    queryPattern: null,
+    description: 'Current rejection paths are not persisted in a queryable production table; do not infer from missing hero.task.rejected events.',
   },
   {
     id: 'launch-10',
@@ -194,9 +194,9 @@ export const REQUIRED_SAFETY_METRICS = Object.freeze([
     name: 'negative balance count',
     canonicalMetric: null,
     extractionSource: 'derived',
-    queryPattern: "SELECT COUNT(*) FROM hero_ledger WHERE balance < 0",
+    queryPattern: "SELECT learner_id, state_json FROM child_game_state WHERE system_id = 'hero-mode'",
     zeroTolerance: true,
-    description: 'Must be 0: ledger balance must never go negative',
+    description: 'Must be 0: parse Hero economy JSON and ensure balance and ledger balanceAfter values never go negative',
   },
   {
     id: 'safety-04',
@@ -212,18 +212,18 @@ export const REQUIRED_SAFETY_METRICS = Object.freeze([
     name: 'claim-without-completion count',
     canonicalMetric: null,
     extractionSource: 'derived',
-    queryPattern: "SELECT COUNT(*) FROM hero_ledger l LEFT JOIN event_log e ON l.source_event_id = e.id WHERE e.id IS NULL AND l.entry_type = 'daily-award'",
+    queryPattern: "SELECT learner_id, state_json FROM child_game_state WHERE system_id = 'hero-mode'",
     zeroTolerance: true,
-    description: 'Must be 0: coin award without corresponding task completion evidence',
+    description: 'Must be 0: parse daily award ledger entries and compare against Hero daily completion state plus event_log telemetry',
   },
   {
     id: 'safety-06',
     name: 'non-cohort exposure count',
     canonicalMetric: null,
     extractionSource: 'server-extractable',
-    queryPattern: "SELECT COUNT(*) FROM event_log WHERE system_id = 'hero-mode' AND learner_id NOT IN (SELECT learner_id FROM cohort_members WHERE cohort_id = ?)",
+    queryPattern: "SELECT DISTINCT actor_account_id, learner_id FROM event_log WHERE system_id = 'hero-mode' AND actor_account_id IS NOT NULL",
     zeroTolerance: true,
-    description: 'Must be 0: non-cohort learners must never see Hero Mode surfaces',
+    description: 'Must be 0 after joining observed accounts to the exported resolver classification; event presence alone is not enough',
   },
   {
     id: 'safety-07',
@@ -274,7 +274,7 @@ export const REQUIRED_SAFETY_METRICS = Object.freeze([
  *   valid: boolean,
  *   launchMetrics: Array<{id: string, name: string, mapped: boolean, extractionSource: string, reason?: string}>,
  *   safetyMetrics: Array<{id: string, name: string, mapped: boolean, extractionSource: string, reason?: string}>,
- *   summary: {total: number, mapped: number, serverExtractable: number, clientOnly: number, derived: number}
+ *   summary: {total: number, mapped: number, serverExtractable: number, clientOnly: number, derived: number, notObservableYet: number}
  * }}
  */
 export function validateMetricsMapping(metricsContract) {
@@ -285,12 +285,13 @@ export function validateMetricsMapping(metricsContract) {
     if (metric.canonicalMetric) {
       mapped = allCanonical.includes(metric.canonicalMetric);
     } else {
-      // Metrics without a canonical name are valid if they have a queryPattern,
-      // are derived from other metrics, or are classified as client-only (measured
-      // via browser telemetry rather than event_log).
+      // Metrics without a canonical name are valid if they have a real query
+      // path, are derived from other persisted sources, require browser
+      // telemetry, or are explicitly classified as not observable yet.
       mapped = metric.queryPattern !== null
         || metric.extractionSource === 'derived'
-        || metric.extractionSource === 'client-only';
+        || metric.extractionSource === 'client-only'
+        || metric.extractionSource === 'not-observable-yet';
     }
 
     const reason = !mapped
@@ -317,6 +318,7 @@ export function validateMetricsMapping(metricsContract) {
   const serverExtractable = allResults.filter(r => r.extractionSource === 'server-extractable').length;
   const clientOnly = allResults.filter(r => r.extractionSource === 'client-only').length;
   const derived = allResults.filter(r => r.extractionSource === 'derived').length;
+  const notObservableYet = allResults.filter(r => r.extractionSource === 'not-observable-yet').length;
 
   return {
     valid: allResults.every(r => r.mapped),
@@ -328,6 +330,7 @@ export function validateMetricsMapping(metricsContract) {
       serverExtractable,
       clientOnly,
       derived,
+      notObservableYet,
     },
   };
 }
@@ -386,6 +389,7 @@ function main() {
   console.log(`  Server-extractable: ${result.summary.serverExtractable}`);
   console.log(`  Client-only:        ${result.summary.clientOnly}`);
   console.log(`  Derived:            ${result.summary.derived}`);
+  console.log(`  Not observable yet: ${result.summary.notObservableYet}`);
 
   if (!result.valid) {
     console.log('\n[FAIL] Not all metrics are mapped:');
@@ -396,13 +400,21 @@ function main() {
     process.exit(1);
   }
 
-  console.log('\n[PASS] All 28 metrics are mapped to extraction sources.');
+  console.log('\n[PASS] All 28 metrics are classified to extraction sources or explicit observability gaps.');
 
   // Report client-only metrics (informational)
   const clientMetrics = [...result.launchMetrics, ...result.safetyMetrics].filter(m => m.extractionSource === 'client-only');
   if (clientMetrics.length > 0) {
     console.log(`\nClient-only metrics (${clientMetrics.length} — require browser telemetry, not event_log):`);
     for (const m of clientMetrics) {
+      console.log(`  - ${m.id}: ${m.name}`);
+    }
+  }
+
+  const notObservableMetrics = [...result.launchMetrics, ...result.safetyMetrics].filter(m => m.extractionSource === 'not-observable-yet');
+  if (notObservableMetrics.length > 0) {
+    console.log(`\nNot-observable-yet metrics (${notObservableMetrics.length} — no queryable production source yet):`);
+    for (const m of notObservableMetrics) {
       console.log(`  - ${m.id}: ${m.name}`);
     }
   }

--- a/scripts/hero-pA5-metrics-sanity-check.mjs
+++ b/scripts/hero-pA5-metrics-sanity-check.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 // Hero Mode pA5 — Metrics Sanity Check (U7)
 // Validates that all 34 required A5 metrics (14 launch + 10 product + 10 safety)
-// are derivable from existing infrastructure.
+// have registry/function mappings. This is not production evidence; pA6 uses
+// scripts/hero-pA6-metrics-extract.mjs for schema-accurate extraction.
 //
 // Usage: node scripts/hero-pA5-metrics-sanity-check.mjs
 //
@@ -207,7 +208,8 @@ function main() {
     process.exit(1);
   }
 
-  console.log('\n[PASS] All 34 metrics are mapped and validated.');
+  console.log('\n[PASS] All 34 metrics have registry/function mappings.');
+  console.log('[NOTE] Mapping coverage is not production evidence. Use hero-pA6-metrics-extract.mjs for schema-accurate live extraction.');
   process.exit(0);
 }
 

--- a/scripts/hero-pA6-metrics-extract.mjs
+++ b/scripts/hero-pA6-metrics-extract.mjs
@@ -1,0 +1,878 @@
+#!/usr/bin/env node
+// Hero Mode pA6 - schema-accurate production metrics extraction.
+// Reads exported platform rows and classifies every production metric by real
+// observability. event_log is telemetry only; Hero economy and Camp authority
+// come from child_game_state state_json for system_id='hero-mode'.
+
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { validateMetricPrivacyRecursive } from '../shared/hero/metrics-privacy.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_OUTPUT = resolve(__dirname, '../reports/hero/hero-pA6-metrics-report.json');
+
+export const PA6_SOURCE_TYPES = Object.freeze([
+  'observed-live',
+  'schema-derived',
+  'manual-support-log',
+  'client-instrumented',
+  'not-observable-yet',
+]);
+
+const FORBIDDEN_CONCEPTUAL_TABLES = /\b(cohort_members|hero_ledger)\b/i;
+
+export const HERO_READY_SUBJECT_IDS = Object.freeze(['spelling', 'grammar', 'punctuation']);
+
+export const PA6_METRIC_REGISTRY = Object.freeze([
+  {
+    id: 'pa6-launch-01',
+    category: 'launch',
+    name: 'eligible ready-subject learner count',
+    sourceType: 'schema-derived',
+    sourceTables: ['child_subject_state', 'account_learner_memberships'],
+    extraction: 'Count distinct learners with ready-subject state rows; final launchability still requires smoke proof.',
+  },
+  {
+    id: 'pa6-launch-02',
+    category: 'launch',
+    name: 'exposed account count',
+    sourceType: 'schema-derived',
+    sourceTables: ['event_log', 'account_learner_memberships'],
+    extraction: 'Count distinct actor accounts from Hero telemetry and linked accounts for learners with Hero state.',
+  },
+  {
+    id: 'pa6-launch-03',
+    category: 'launch',
+    name: 'Hero Quest shown count',
+    sourceType: 'not-observable-yet',
+    sourceTables: [],
+    extraction: 'Requires client render telemetry or browser-smoke evidence; do not infer from registry presence.',
+  },
+  {
+    id: 'pa6-launch-04',
+    category: 'launch',
+    name: 'Hero Quest start count',
+    sourceType: 'schema-derived',
+    sourceTables: ['child_game_state'],
+    extraction: 'Count learner-days where Hero progress has firstStartedAt or at least one task started/completed.',
+  },
+  {
+    id: 'pa6-launch-05',
+    category: 'launch',
+    name: 'Hero task start count',
+    sourceType: 'schema-derived',
+    sourceTables: ['child_game_state'],
+    extraction: 'Count Hero tasks with status started or completed in the authoritative progress JSON.',
+  },
+  {
+    id: 'pa6-launch-06',
+    category: 'launch',
+    name: 'Hero task completion count',
+    sourceType: 'observed-live',
+    sourceTables: ['event_log'],
+    extraction: "Count event_log rows where system_id='hero-mode' and event_type='hero.task.completed'.",
+  },
+  {
+    id: 'pa6-launch-07',
+    category: 'launch',
+    name: 'daily Hero Quest completion count',
+    sourceType: 'schema-derived',
+    sourceTables: ['child_game_state', 'event_log'],
+    extraction: 'Use child_game_state daily.status=completed as authority, with event_log daily.completed as telemetry mirror.',
+  },
+  {
+    id: 'pa6-launch-08',
+    category: 'launch',
+    name: 'claim success count',
+    sourceType: 'observed-live',
+    sourceTables: ['event_log'],
+    extraction: "Current server mirror records successful claims as hero.task.completed events.",
+  },
+  {
+    id: 'pa6-launch-09',
+    category: 'launch',
+    name: 'claim rejection count',
+    sourceType: 'not-observable-yet',
+    sourceTables: [],
+    extraction: 'Current rejection paths are not persisted in a queryable production table.',
+  },
+  {
+    id: 'pa6-launch-10',
+    category: 'launch',
+    name: 'coin award count',
+    sourceType: 'schema-derived',
+    sourceTables: ['child_game_state'],
+    extraction: 'Count economy.ledger entries with type=daily-completion-award in Hero progress JSON.',
+  },
+  {
+    id: 'pa6-launch-11',
+    category: 'launch',
+    name: 'Camp open count',
+    sourceType: 'not-observable-yet',
+    sourceTables: [],
+    extraction: 'Camp screen opens are client-side only unless instrumented separately.',
+  },
+  {
+    id: 'pa6-launch-12',
+    category: 'launch',
+    name: 'Camp invite/grow count',
+    sourceType: 'schema-derived',
+    sourceTables: ['child_game_state', 'event_log'],
+    extraction: 'Use economy spending ledger and Hero Pool state as authority; use camp events as telemetry mirror.',
+  },
+  {
+    id: 'pa6-launch-13',
+    category: 'launch',
+    name: 'Hero route 4xx count',
+    sourceType: 'not-observable-yet',
+    sourceTables: [],
+    extraction: 'Requires Workers request logs or explicit persisted route-error telemetry.',
+  },
+  {
+    id: 'pa6-launch-14',
+    category: 'launch',
+    name: 'Hero route 5xx count',
+    sourceType: 'not-observable-yet',
+    sourceTables: [],
+    extraction: 'Requires Workers request logs or explicit persisted route-error telemetry.',
+  },
+  {
+    id: 'pa6-product-01',
+    category: 'product',
+    name: 'start rate from shown',
+    sourceType: 'not-observable-yet',
+    sourceTables: [],
+    extraction: 'The shown denominator requires client render telemetry. Use server-started counts only as a narrower decision substitute.',
+  },
+  {
+    id: 'pa6-product-02',
+    category: 'product',
+    name: 'completion rate from server-started learner-days',
+    sourceType: 'schema-derived',
+    sourceTables: ['child_game_state'],
+    extraction: 'daily.status=completed divided by learner-days with firstStartedAt or started/completed tasks.',
+  },
+  {
+    id: 'pa6-product-03',
+    category: 'product',
+    name: 'next-day return rate',
+    sourceType: 'observed-live',
+    sourceTables: ['event_log'],
+    extraction: 'Approximate from distinct learner-date pairs in Hero telemetry.',
+  },
+  {
+    id: 'pa6-product-04',
+    category: 'product',
+    name: 'subject mix distribution',
+    sourceType: 'observed-live',
+    sourceTables: ['event_log'],
+    extraction: 'Count subject_id on hero.task.completed telemetry rows.',
+  },
+  {
+    id: 'pa6-product-05',
+    category: 'product',
+    name: 'task-intent mix',
+    sourceType: 'schema-derived',
+    sourceTables: ['child_game_state'],
+    extraction: 'Count current Hero task intent values in authoritative progress JSON.',
+  },
+  {
+    id: 'pa6-product-06',
+    category: 'product',
+    name: 'abandonment point distribution',
+    sourceType: 'not-observable-yet',
+    sourceTables: [],
+    extraction: 'Requires client/session instrumentation beyond current Hero state and event mirror.',
+  },
+  {
+    id: 'pa6-product-07',
+    category: 'product',
+    name: 'parent/support confusion reports',
+    sourceType: 'manual-support-log',
+    sourceTables: [],
+    extraction: 'Count support-log rows in category=comprehension.',
+  },
+  {
+    id: 'pa6-product-08',
+    category: 'product',
+    name: 'Camp-before-learning ratio',
+    sourceType: 'observed-live',
+    sourceTables: ['event_log'],
+    extraction: 'Compare camp telemetry timestamps with daily.completed telemetry for the same learner-date.',
+  },
+  {
+    id: 'pa6-product-09',
+    category: 'product',
+    name: 'extra subject practice after daily coin cap',
+    sourceType: 'observed-live',
+    sourceTables: ['event_log'],
+    extraction: 'Count task.completed telemetry after daily.completed for the same learner-date.',
+  },
+  {
+    id: 'pa6-product-10',
+    category: 'product',
+    name: 'warning-condition count',
+    sourceType: 'schema-derived',
+    sourceTables: ['child_game_state', 'event_log'],
+    extraction: 'Derived from computed A6 warning checks plus manual support-log thresholds.',
+  },
+  {
+    id: 'pa6-safety-01',
+    category: 'safety',
+    name: 'duplicate daily award',
+    sourceType: 'schema-derived',
+    sourceTables: ['child_game_state'],
+    extraction: 'Group daily-completion-award ledger entries by learner/date/quest/idempotency key.',
+  },
+  {
+    id: 'pa6-safety-02',
+    category: 'safety',
+    name: 'duplicate Camp debit',
+    sourceType: 'schema-derived',
+    sourceTables: ['child_game_state'],
+    extraction: 'Group monster-invite and monster-grow ledger entries by learner/idempotency key.',
+  },
+  {
+    id: 'pa6-safety-03',
+    category: 'safety',
+    name: 'negative balance',
+    sourceType: 'schema-derived',
+    sourceTables: ['child_game_state'],
+    extraction: 'Inspect economy.balance and ledger balanceAfter values in Hero progress JSON.',
+  },
+  {
+    id: 'pa6-safety-04',
+    category: 'safety',
+    name: 'dead CTA',
+    sourceType: 'not-observable-yet',
+    sourceTables: [],
+    extraction: 'Requires browser smoke or client instrumentation because dead navigation is not persisted.',
+  },
+  {
+    id: 'pa6-safety-05',
+    category: 'safety',
+    name: 'claim without Worker-verified completion',
+    sourceType: 'schema-derived',
+    sourceTables: ['child_game_state', 'event_log'],
+    extraction: 'Compare daily-award ledger entries with daily completion state and telemetry.',
+  },
+  {
+    id: 'pa6-safety-06',
+    category: 'safety',
+    name: 'raw child content',
+    sourceType: 'observed-live',
+    sourceTables: ['event_log'],
+    extraction: 'Run recursive privacy validation against event_json payloads; fail closed on malformed, missing, or non-object payloads.',
+  },
+  {
+    id: 'pa6-safety-07',
+    category: 'safety',
+    name: 'subject Star/mastery drift attributable to Hero Mode',
+    sourceType: 'not-observable-yet',
+    sourceTables: ['child_subject_state'],
+    extraction: 'Requires pre/post child_subject_state snapshots across the rollout window.',
+  },
+  {
+    id: 'pa6-safety-08',
+    category: 'safety',
+    name: 'exposure to excluded accounts',
+    sourceType: 'not-observable-yet',
+    sourceTables: [],
+    extraction: 'Requires resolver classification export or named smoke accounts; do not infer from event presence alone.',
+  },
+  {
+    id: 'pa6-safety-09',
+    category: 'safety',
+    name: 'rollback failure',
+    sourceType: 'manual-support-log',
+    sourceTables: [],
+    extraction: 'Recorded by rollback rehearsal evidence, not by normal Hero state rows.',
+  },
+  {
+    id: 'pa6-safety-10',
+    category: 'safety',
+    name: 'production 5xx spike attributable to Hero',
+    sourceType: 'not-observable-yet',
+    sourceTables: [],
+    extraction: 'Requires Workers request logs or explicit persisted route-error telemetry.',
+  },
+]);
+
+export function assertNoConceptualTables(registry = PA6_METRIC_REGISTRY) {
+  const offenders = [];
+  for (const metric of registry) {
+    const haystack = [
+      metric.extraction,
+      ...(metric.sourceTables || []),
+      metric.queryPattern,
+    ].filter(Boolean).join(' ');
+    if (FORBIDDEN_CONCEPTUAL_TABLES.test(haystack)) {
+      offenders.push(metric.id);
+    }
+  }
+  return {
+    ok: offenders.length === 0,
+    offenders,
+  };
+}
+
+function parseJsonMaybe(value) {
+  if (value == null || value === '') return null;
+  if (typeof value === 'object') return value;
+  if (typeof value !== 'string') return null;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}
+
+function parseEventJson(value) {
+  if (value == null || value === '') {
+    return { value: null, parseError: false };
+  }
+  if (typeof value === 'object') {
+    return { value, parseError: false };
+  }
+  if (typeof value !== 'string') {
+    return { value: null, parseError: true };
+  }
+
+  try {
+    const parsed = JSON.parse(value);
+    return {
+      value: parsed,
+      parseError: !parsed || typeof parsed !== 'object',
+    };
+  } catch {
+    return { value: null, parseError: true };
+  }
+}
+
+function normaliseCreatedAt(value) {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Date.parse(value);
+    if (Number.isFinite(parsed)) return parsed;
+    const numeric = Number(value);
+    if (Number.isFinite(numeric)) return numeric;
+  }
+  return null;
+}
+
+function dateKeyFromTimestamp(value) {
+  const ts = normaliseCreatedAt(value);
+  if (!Number.isFinite(ts)) return null;
+  return new Date(ts).toISOString().slice(0, 10);
+}
+
+function getRows(input, snakeName, camelName) {
+  const value = input?.[snakeName] || input?.[camelName] || [];
+  return Array.isArray(value) ? value : [];
+}
+
+export function parseEventRows(rawRows = []) {
+  return rawRows
+    .map((row) => {
+      const parsedEventJson = parseEventJson(row.event_json ?? row.eventJson);
+      return {
+        id: row.id || null,
+        learnerId: row.learner_id ?? row.learnerId ?? null,
+        subjectId: row.subject_id ?? row.subjectId ?? null,
+        systemId: row.system_id ?? row.systemId ?? null,
+        eventType: row.event_type ?? row.eventType ?? null,
+        eventJson: parsedEventJson.value,
+        eventJsonParseError: parsedEventJson.parseError,
+        createdAt: row.created_at ?? row.createdAt ?? null,
+        createdAtMs: normaliseCreatedAt(row.created_at ?? row.createdAt),
+        actorAccountId: row.actor_account_id ?? row.actorAccountId ?? null,
+      };
+    })
+    .filter((row) => row.systemId === 'hero-mode' || String(row.eventType || '').startsWith('hero.'));
+}
+
+export function parseHeroStateRows(rawRows = []) {
+  return rawRows
+    .filter((row) => (row.system_id ?? row.systemId) === 'hero-mode')
+    .map((row) => {
+      const rawState = parseJsonMaybe(row.state_json ?? row.stateJson) || {};
+      return {
+        learnerId: row.learner_id ?? row.learnerId ?? null,
+        updatedAt: row.updated_at ?? row.updatedAt ?? null,
+        updatedAtMs: normaliseCreatedAt(row.updated_at ?? row.updatedAt),
+        rawState,
+        economy: rawState.economy && typeof rawState.economy === 'object' ? rawState.economy : {},
+        heroPool: rawState.heroPool && typeof rawState.heroPool === 'object' ? rawState.heroPool : {},
+        daily: rawState.daily && typeof rawState.daily === 'object' ? rawState.daily : null,
+      };
+    });
+}
+
+function allTasksFromState(stateRow) {
+  const tasks = stateRow.daily?.tasks;
+  if (!tasks || typeof tasks !== 'object') return [];
+  return Object.values(tasks).filter((task) => task && typeof task === 'object');
+}
+
+function ledgerEntriesFromStates(stateRows) {
+  const entries = [];
+  for (const row of stateRows) {
+    const ledger = Array.isArray(row.economy?.ledger) ? row.economy.ledger : [];
+    for (const entry of ledger) {
+      if (!entry || typeof entry !== 'object') continue;
+      entries.push({
+        ...entry,
+        learnerId: entry.learnerId || row.learnerId,
+      });
+    }
+  }
+  return entries;
+}
+
+function countBy(rows, fn) {
+  const counts = {};
+  for (const row of rows) {
+    const key = fn(row);
+    if (!key) continue;
+    counts[key] = (counts[key] || 0) + 1;
+  }
+  return counts;
+}
+
+function countDuplicateGroups(keys) {
+  const counts = countBy(keys, (key) => key);
+  return Object.values(counts).filter((count) => count > 1).length;
+}
+
+function computePrivacy(events) {
+  const violations = [];
+  const parseFailures = [];
+  const notEvaluatedRows = [];
+  let checked = 0;
+  for (let i = 0; i < events.length; i++) {
+    if (events[i].eventJsonParseError) {
+      parseFailures.push({
+        rowIndex: i,
+        eventId: events[i].id,
+        reason: 'malformed-or-non-object-event-json',
+      });
+      continue;
+    }
+    const payload = events[i].eventJson;
+    if (!payload || typeof payload !== 'object') {
+      notEvaluatedRows.push({
+        rowIndex: i,
+        eventId: events[i].id,
+        reason: 'missing-event-json',
+      });
+      continue;
+    }
+    checked++;
+    const result = validateMetricPrivacyRecursive(payload);
+    if (!result.valid) {
+      violations.push({ rowIndex: i, eventId: events[i].id, violations: result.violations });
+    }
+  }
+  const failureCount = violations.length + parseFailures.length + notEvaluatedRows.length;
+  const status = events.length === 0
+    ? 'not-evaluated'
+    : (failureCount === 0 ? 'passed' : 'failed');
+  return {
+    passed: events.length === 0 ? null : failureCount === 0,
+    status,
+    rowsChecked: checked,
+    violationCount: violations.length,
+    parseErrorCount: parseFailures.length,
+    notEvaluatedCount: notEvaluatedRows.length,
+    failureCount,
+    violations,
+    parseFailures,
+    notEvaluatedRows,
+  };
+}
+
+function computeDateRange(events, stateRows) {
+  const timestamps = [
+    ...events.map((row) => row.createdAtMs),
+    ...stateRows.map((row) => row.updatedAtMs),
+  ].filter((ts) => Number.isFinite(ts));
+  if (timestamps.length === 0) return { from: null, to: null };
+  return {
+    from: new Date(Math.min(...timestamps)).toISOString(),
+    to: new Date(Math.max(...timestamps)).toISOString(),
+  };
+}
+
+function computeNextDayReturnRate(events) {
+  const byLearner = new Map();
+  for (const event of events) {
+    const day = event.eventJson?.data?.dateKey || event.eventJson?.dateKey || dateKeyFromTimestamp(event.createdAt);
+    if (!event.learnerId || !day) continue;
+    if (!byLearner.has(event.learnerId)) byLearner.set(event.learnerId, new Set());
+    byLearner.get(event.learnerId).add(day);
+  }
+
+  let activeLearnerDays = 0;
+  let returnNextDayCount = 0;
+  for (const daySet of byLearner.values()) {
+    const days = [...daySet].sort();
+    activeLearnerDays += days.length;
+    const lookup = new Set(days);
+    for (const day of days) {
+      const next = new Date(`${day}T00:00:00.000Z`);
+      next.setUTCDate(next.getUTCDate() + 1);
+      if (lookup.has(next.toISOString().slice(0, 10))) {
+        returnNextDayCount++;
+      }
+    }
+  }
+
+  return {
+    activeLearnerDays,
+    returnNextDayCount,
+    rate: activeLearnerDays > 0 ? returnNextDayCount / activeLearnerDays : 0,
+  };
+}
+
+function computeCampBeforeLearning(events) {
+  const completedAtByLearnerDate = new Map();
+  for (const event of events) {
+    if (event.eventType !== 'hero.daily.completed') continue;
+    const day = event.eventJson?.data?.dateKey || event.eventJson?.dateKey || dateKeyFromTimestamp(event.createdAt);
+    if (!event.learnerId || !day || !Number.isFinite(event.createdAtMs)) continue;
+    const key = `${event.learnerId}|${day}`;
+    const existing = completedAtByLearnerDate.get(key);
+    if (!Number.isFinite(existing) || event.createdAtMs < existing) {
+      completedAtByLearnerDate.set(key, event.createdAtMs);
+    }
+  }
+
+  const campEvents = events.filter((event) => (
+    event.eventType === 'hero.camp.monster.invited' ||
+    event.eventType === 'hero.camp.monster.grown'
+  ));
+  let beforeLearning = 0;
+  for (const event of campEvents) {
+    const day = dateKeyFromTimestamp(event.createdAt);
+    const completedAt = completedAtByLearnerDate.get(`${event.learnerId}|${day}`);
+    if (!Number.isFinite(completedAt) || event.createdAtMs < completedAt) {
+      beforeLearning++;
+    }
+  }
+
+  return {
+    campEvents: campEvents.length,
+    beforeLearning,
+    ratio: campEvents.length > 0 ? beforeLearning / campEvents.length : 0,
+  };
+}
+
+function computeExtraPracticeAfterCap(events) {
+  const completedAtByLearnerDate = new Map();
+  for (const event of events) {
+    if (event.eventType !== 'hero.daily.completed') continue;
+    const day = event.eventJson?.data?.dateKey || event.eventJson?.dateKey || dateKeyFromTimestamp(event.createdAt);
+    if (!event.learnerId || !day || !Number.isFinite(event.createdAtMs)) continue;
+    completedAtByLearnerDate.set(`${event.learnerId}|${day}`, event.createdAtMs);
+  }
+
+  let extraTaskCount = 0;
+  for (const event of events) {
+    if (event.eventType !== 'hero.task.completed') continue;
+    const day = event.eventJson?.data?.dateKey || event.eventJson?.dateKey || dateKeyFromTimestamp(event.createdAt);
+    const completedAt = completedAtByLearnerDate.get(`${event.learnerId}|${day}`);
+    if (Number.isFinite(completedAt) && event.createdAtMs > completedAt) {
+      extraTaskCount++;
+    }
+  }
+  return { extraTaskCount };
+}
+
+function buildValues({ events, stateRows, childSubjectRows, membershipRows, supportRows }) {
+  const ledgerEntries = ledgerEntriesFromStates(stateRows);
+  const dailyAwardEntries = ledgerEntries.filter((entry) => entry.type === 'daily-completion-award');
+  const campDebitEntries = ledgerEntries.filter((entry) => entry.type === 'monster-invite' || entry.type === 'monster-grow');
+  const taskCompletedEvents = events.filter((event) => event.eventType === 'hero.task.completed');
+  const dailyCompletedEvents = events.filter((event) => event.eventType === 'hero.daily.completed');
+  const coinAwardEvents = events.filter((event) => event.eventType === 'hero.coins.awarded');
+  const campEvents = events.filter((event) => (
+    event.eventType === 'hero.camp.monster.invited' ||
+    event.eventType === 'hero.camp.monster.grown'
+  ));
+
+  const readyLearnerIds = new Set(
+    childSubjectRows
+      .filter((row) => HERO_READY_SUBJECT_IDS.includes(row.subject_id ?? row.subjectId))
+      .map((row) => row.learner_id ?? row.learnerId)
+      .filter(Boolean),
+  );
+  const heroStateLearnerIds = new Set(stateRows.map((row) => row.learnerId).filter(Boolean));
+  const exposedAccountIds = new Set(events.map((event) => event.actorAccountId).filter(Boolean));
+  for (const row of membershipRows) {
+    const learnerId = row.learner_id ?? row.learnerId;
+    const accountId = row.account_id ?? row.accountId;
+    if (accountId && heroStateLearnerIds.has(learnerId)) exposedAccountIds.add(accountId);
+  }
+
+  let startedLearnerDays = 0;
+  let taskStartCount = 0;
+  let dailyCompletedStateCount = 0;
+  const taskIntentCounts = {};
+  for (const stateRow of stateRows) {
+    const tasks = allTasksFromState(stateRow);
+    const startedTasks = tasks.filter((task) => task.status === 'started' || task.status === 'completed');
+    if (stateRow.daily?.firstStartedAt || startedTasks.length > 0) {
+      startedLearnerDays++;
+    }
+    taskStartCount += startedTasks.length;
+    if (stateRow.daily?.status === 'completed') dailyCompletedStateCount++;
+    for (const task of tasks) {
+      if (task.intent) {
+        taskIntentCounts[task.intent] = (taskIntentCounts[task.intent] || 0) + 1;
+      }
+    }
+  }
+
+  const duplicateDailyAwardGroups = countDuplicateGroups(
+    dailyAwardEntries.map((entry) => (
+      entry.idempotencyKey ||
+      `${entry.learnerId || ''}|${entry.dateKey || ''}|${entry.questId || ''}|${entry.questFingerprint || ''}`
+    )),
+  );
+  const duplicateCampDebitGroups = countDuplicateGroups(
+    campDebitEntries.map((entry) => (
+      entry.idempotencyKey ||
+      `${entry.learnerId || ''}|${entry.type || ''}|${entry.monsterId || ''}|${entry.stageAfter ?? ''}|${entry.branch || ''}`
+    )),
+  );
+  const negativeBalanceCount = stateRows.filter((row) => typeof row.economy?.balance === 'number' && row.economy.balance < 0).length
+    + ledgerEntries.filter((entry) => typeof entry.balanceAfter === 'number' && entry.balanceAfter < 0).length;
+
+  const dailyCompleteKeys = new Set(dailyCompletedEvents.map((event) => {
+    const day = event.eventJson?.data?.dateKey || event.eventJson?.dateKey || dateKeyFromTimestamp(event.createdAt);
+    return `${event.learnerId || ''}|${day || ''}|${event.eventJson?.data?.questId || event.eventJson?.questId || ''}`;
+  }));
+  const claimWithoutCompletionCount = dailyAwardEntries.filter((entry) => {
+    const key = `${entry.learnerId || ''}|${entry.dateKey || ''}|${entry.questId || ''}`;
+    if (dailyCompleteKeys.has(key)) return false;
+    return !stateRows.some((row) => (
+      row.learnerId === entry.learnerId &&
+      row.daily?.dateKey === entry.dateKey &&
+      row.daily?.questId === entry.questId &&
+      row.daily?.status === 'completed'
+    ));
+  }).length;
+
+  const privacy = computePrivacy(events);
+  const nextDayReturn = computeNextDayReturnRate(events);
+  const campBeforeLearning = computeCampBeforeLearning(events);
+  const extraPractice = computeExtraPracticeAfterCap(events);
+  const supportConfusionCount = supportRows.filter((row) => (row.category || '').toLowerCase() === 'comprehension').length;
+
+  const warningCount = [
+    campBeforeLearning.ratio > 0.5,
+    supportConfusionCount > 3,
+    privacy.failureCount > 0,
+    negativeBalanceCount > 0,
+  ].filter(Boolean).length;
+
+  return {
+    'pa6-launch-01': readyLearnerIds.size,
+    'pa6-launch-02': exposedAccountIds.size,
+    'pa6-launch-03': null,
+    'pa6-launch-04': startedLearnerDays,
+    'pa6-launch-05': taskStartCount,
+    'pa6-launch-06': taskCompletedEvents.length,
+    'pa6-launch-07': dailyCompletedStateCount,
+    'pa6-launch-08': taskCompletedEvents.length,
+    'pa6-launch-09': null,
+    'pa6-launch-10': dailyAwardEntries.length,
+    'pa6-launch-11': null,
+    'pa6-launch-12': campDebitEntries.length,
+    'pa6-launch-13': null,
+    'pa6-launch-14': null,
+    'pa6-product-01': null,
+    'pa6-product-02': {
+      startedLearnerDays,
+      dailyCompletedStateCount,
+      rate: startedLearnerDays > 0 ? dailyCompletedStateCount / startedLearnerDays : 0,
+    },
+    'pa6-product-03': nextDayReturn,
+    'pa6-product-04': countBy(taskCompletedEvents, (event) => event.subjectId || event.eventJson?.data?.subjectId || 'unknown'),
+    'pa6-product-05': taskIntentCounts,
+    'pa6-product-06': null,
+    'pa6-product-07': supportConfusionCount,
+    'pa6-product-08': campBeforeLearning,
+    'pa6-product-09': extraPractice.extraTaskCount,
+    'pa6-product-10': warningCount,
+    'pa6-safety-01': duplicateDailyAwardGroups,
+    'pa6-safety-02': duplicateCampDebitGroups,
+    'pa6-safety-03': negativeBalanceCount,
+    'pa6-safety-04': null,
+    'pa6-safety-05': claimWithoutCompletionCount,
+    'pa6-safety-06': privacy.failureCount,
+    'pa6-safety-07': null,
+    'pa6-safety-08': null,
+    'pa6-safety-09': null,
+    'pa6-safety-10': null,
+    _privacy: privacy,
+    _eventMirrorCounts: {
+      taskCompleted: taskCompletedEvents.length,
+      dailyCompleted: dailyCompletedEvents.length,
+      coinAwarded: coinAwardEvents.length,
+      campEvents: campEvents.length,
+    },
+  };
+}
+
+export function buildA6MetricsReport(input = {}, options = {}) {
+  const events = parseEventRows(getRows(input, 'event_log', 'eventLog'));
+  const stateRows = parseHeroStateRows(getRows(input, 'child_game_state', 'childGameState'));
+  const childSubjectRows = getRows(input, 'child_subject_state', 'childSubjectState');
+  const membershipRows = getRows(input, 'account_learner_memberships', 'accountLearnerMemberships');
+  const supportRows = getRows(input, 'support_issues', 'supportIssues');
+  const conceptualCheck = assertNoConceptualTables();
+  const values = buildValues({ events, stateRows, childSubjectRows, membershipRows, supportRows });
+  const dateRange = computeDateRange(events, stateRows);
+  const sourceCounts = {
+    eventLogRows: events.length,
+    heroStateRows: stateRows.length,
+    childSubjectStateRows: childSubjectRows.length,
+    membershipRows: membershipRows.length,
+    supportRows: supportRows.length,
+  };
+  const suppliedRowCount = Object.values(sourceCounts).reduce((sum, count) => sum + count, 0);
+  const reportEvidenceState = suppliedRowCount === 0
+    ? 'no-live-export-supplied'
+    : 'computed-from-supplied-export';
+
+  const metrics = PA6_METRIC_REGISTRY.map((metric) => ({
+    ...metric,
+    value: values[metric.id],
+    observableNow: metric.sourceType !== 'not-observable-yet' && metric.sourceType !== 'client-instrumented',
+    evidenceState: values[metric.id] == null ? 'not-observable-yet' : reportEvidenceState,
+  }));
+
+  const notObservable = metrics.filter((metric) => metric.sourceType === 'not-observable-yet');
+  const clientInstrumented = metrics.filter((metric) => metric.sourceType === 'client-instrumented');
+
+  return {
+    phase: 'hero-mode-pA6',
+    generatedAt: options.generatedAt || new Date().toISOString(),
+    evidenceState: reportEvidenceState,
+    dateRange,
+    sourceCounts,
+    sourceTruth: {
+      economyAuthority: "child_game_state.state_json where system_id='hero-mode'",
+      eventLogRole: 'telemetry mirror only',
+      conceptualTablesAbsent: conceptualCheck.ok,
+      conceptualTableOffenders: conceptualCheck.offenders,
+    },
+    eventMirrorCounts: values._eventMirrorCounts,
+    privacy: values._privacy,
+    metrics,
+    blindSpots: [
+      ...notObservable.map((metric) => ({ id: metric.id, name: metric.name, reason: metric.extraction })),
+      ...clientInstrumented.map((metric) => ({ id: metric.id, name: metric.name, reason: metric.extraction })),
+    ],
+    decisionImpact: deriveDecisionImpact({ metrics, values, events, stateRows }),
+  };
+}
+
+function deriveDecisionImpact({ metrics, values, events, stateRows }) {
+  const zeroToleranceBreaches = [
+    ['duplicate-daily-award', values['pa6-safety-01']],
+    ['duplicate-camp-debit', values['pa6-safety-02']],
+    ['negative-balance', values['pa6-safety-03']],
+    ['claim-without-completion', values['pa6-safety-05']],
+    ['raw-child-content', values['pa6-safety-06']],
+  ].filter(([, value]) => typeof value === 'number' && value > 0);
+
+  const notObservableSafety = metrics
+    .filter((metric) => metric.category === 'safety' && metric.sourceType === 'not-observable-yet')
+    .map((metric) => metric.id);
+
+  let recommendation = 'HOLD AT CURRENT ROLLOUT PERCENTAGE';
+  const reasons = [];
+
+  if (zeroToleranceBreaches.length > 0) {
+    recommendation = 'ROLL BACK TO COHORT ONLY';
+    reasons.push(`Zero-tolerance breach(es): ${zeroToleranceBreaches.map(([name]) => name).join(', ')}`);
+  }
+  if (events.length === 0 && stateRows.length === 0) {
+    reasons.push('No supplied live Hero production export rows; normalisation is not supported.');
+  }
+  if (notObservableSafety.length > 0) {
+    reasons.push(`Safety blind spots still need smoke/log/manual evidence: ${notObservableSafety.join(', ')}`);
+  }
+  if (reasons.length === 0) {
+    reasons.push('Schema-derived checks supplied no stop-condition breach, but final rollout decision still needs owner sign-off.');
+  }
+
+  return {
+    recommendedOutcome: recommendation,
+    zeroToleranceBreaches: zeroToleranceBreaches.map(([name, count]) => ({ name, count })),
+    reasons,
+  };
+}
+
+export function parseArgs(argv) {
+  const args = {
+    input: null,
+    output: DEFAULT_OUTPUT,
+  };
+
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--input' && argv[i + 1]) {
+      args.input = resolve(argv[++i]);
+    } else if (arg.startsWith('--input=')) {
+      args.input = resolve(arg.slice('--input='.length));
+    } else if (arg === '--output' && argv[i + 1]) {
+      args.output = resolve(argv[++i]);
+    } else if (arg.startsWith('--output=')) {
+      args.output = resolve(arg.slice('--output='.length));
+    }
+  }
+
+  return args;
+}
+
+function readInput(path) {
+  if (!path) return {};
+  if (!existsSync(path)) {
+    throw new Error(`Input file not found: ${path}`);
+  }
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function writeOutput(report, outputPath) {
+  const outputDir = dirname(outputPath);
+  if (!existsSync(outputDir)) mkdirSync(outputDir, { recursive: true });
+  const tmpPath = `${outputPath}.tmp`;
+  writeFileSync(tmpPath, JSON.stringify(report, null, 2), 'utf8');
+  renameSync(tmpPath, outputPath);
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const input = readInput(args.input);
+  const report = buildA6MetricsReport(input);
+  writeOutput(report, args.output);
+  console.log(`Hero Mode pA6 metrics report written to ${args.output}`);
+  if (!report.sourceTruth.conceptualTablesAbsent) {
+    console.error(`Conceptual metric source(s) remain: ${report.sourceTruth.conceptualTableOffenders.join(', ')}`);
+    process.exit(1);
+  }
+}
+
+const _scriptUrl = fileURLToPath(import.meta.url);
+const _invokedAs = process.argv[1] ? resolve(process.argv[1]) : '';
+if (_scriptUrl === _invokedAs) {
+  main().catch((err) => {
+    console.error(err.message);
+    process.exit(1);
+  });
+}

--- a/scripts/hero-pA6-metrics-extract.mjs
+++ b/scripts/hero-pA6-metrics-extract.mjs
@@ -240,7 +240,7 @@ export const PA6_METRIC_REGISTRY = Object.freeze([
     name: 'negative balance',
     sourceType: 'schema-derived',
     sourceTables: ['child_game_state'],
-    extraction: 'Inspect economy.balance and ledger balanceAfter values in Hero progress JSON.',
+    extraction: 'Inspect economy.balance and ledger balanceAfter values in Hero progress JSON; malformed Hero state fails closed as an inspection failure.',
   },
   {
     id: 'pa6-safety-04',
@@ -318,17 +318,6 @@ export function assertNoConceptualTables(registry = PA6_METRIC_REGISTRY) {
   };
 }
 
-function parseJsonMaybe(value) {
-  if (value == null || value === '') return null;
-  if (typeof value === 'object') return value;
-  if (typeof value !== 'string') return null;
-  try {
-    return JSON.parse(value);
-  } catch {
-    return null;
-  }
-}
-
 function parseEventJson(value) {
   if (value == null || value === '') {
     return { value: null, parseError: false };
@@ -348,6 +337,31 @@ function parseEventJson(value) {
     };
   } catch {
     return { value: null, parseError: true };
+  }
+}
+
+function parseStateJson(value) {
+  if (value == null || value === '') {
+    return { value: {}, parseError: true };
+  }
+  if (typeof value === 'object') {
+    return {
+      value: value && !Array.isArray(value) ? value : {},
+      parseError: !value || Array.isArray(value),
+    };
+  }
+  if (typeof value !== 'string') {
+    return { value: {}, parseError: true };
+  }
+
+  try {
+    const parsed = JSON.parse(value);
+    return {
+      value: parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {},
+      parseError: !parsed || typeof parsed !== 'object' || Array.isArray(parsed),
+    };
+  } catch {
+    return { value: {}, parseError: true };
   }
 }
 
@@ -397,11 +411,13 @@ export function parseHeroStateRows(rawRows = []) {
   return rawRows
     .filter((row) => (row.system_id ?? row.systemId) === 'hero-mode')
     .map((row) => {
-      const rawState = parseJsonMaybe(row.state_json ?? row.stateJson) || {};
+      const parsedState = parseStateJson(row.state_json ?? row.stateJson);
+      const rawState = parsedState.value;
       return {
         learnerId: row.learner_id ?? row.learnerId ?? null,
         updatedAt: row.updated_at ?? row.updatedAt ?? null,
         updatedAtMs: normaliseCreatedAt(row.updated_at ?? row.updatedAt),
+        stateJsonParseError: parsedState.parseError,
         rawState,
         economy: rawState.economy && typeof rawState.economy === 'object' ? rawState.economy : {},
         heroPool: rawState.heroPool && typeof rawState.heroPool === 'object' ? rawState.heroPool : {},
@@ -591,6 +607,15 @@ function computeExtraPracticeAfterCap(events) {
 }
 
 function buildValues({ events, stateRows, childSubjectRows, membershipRows, supportRows }) {
+  const stateInspectionFailures = stateRows
+    .map((row, index) => ({ row, index }))
+    .filter(({ row }) => row.stateJsonParseError)
+    .map(({ row, index }) => ({
+      rowIndex: index,
+      learnerId: row.learnerId,
+      reason: 'malformed-or-non-object-state-json',
+    }));
+  const stateInspectionFailureCount = stateInspectionFailures.length;
   const ledgerEntries = ledgerEntriesFromStates(stateRows);
   const dailyAwardEntries = ledgerEntries.filter((entry) => entry.type === 'daily-completion-award');
   const campDebitEntries = ledgerEntries.filter((entry) => entry.type === 'monster-invite' || entry.type === 'monster-grow');
@@ -647,7 +672,8 @@ function buildValues({ events, stateRows, childSubjectRows, membershipRows, supp
       `${entry.learnerId || ''}|${entry.type || ''}|${entry.monsterId || ''}|${entry.stageAfter ?? ''}|${entry.branch || ''}`
     )),
   );
-  const negativeBalanceCount = stateRows.filter((row) => typeof row.economy?.balance === 'number' && row.economy.balance < 0).length
+  const negativeBalanceCount = stateInspectionFailureCount
+    + stateRows.filter((row) => typeof row.economy?.balance === 'number' && row.economy.balance < 0).length
     + ledgerEntries.filter((entry) => typeof entry.balanceAfter === 'number' && entry.balanceAfter < 0).length;
 
   const dailyCompleteKeys = new Set(dailyCompletedEvents.map((event) => {
@@ -718,6 +744,11 @@ function buildValues({ events, stateRows, childSubjectRows, membershipRows, supp
     'pa6-safety-09': null,
     'pa6-safety-10': null,
     _privacy: privacy,
+    _stateInspection: {
+      parseErrorCount: stateInspectionFailureCount,
+      failureCount: stateInspectionFailureCount,
+      failures: stateInspectionFailures,
+    },
     _eventMirrorCounts: {
       taskCompleted: taskCompletedEvents.length,
       dailyCompleted: dailyCompletedEvents.length,
@@ -772,6 +803,7 @@ export function buildA6MetricsReport(input = {}, options = {}) {
     },
     eventMirrorCounts: values._eventMirrorCounts,
     privacy: values._privacy,
+    stateInspection: values._stateInspection,
     metrics,
     blindSpots: [
       ...notObservable.map((metric) => ({ id: metric.id, name: metric.name, reason: metric.extraction })),

--- a/shared/hero/metrics-privacy.js
+++ b/shared/hero/metrics-privacy.js
@@ -14,6 +14,7 @@ export const PRIVACY_FORBIDDEN_FIELDS = Object.freeze([
   'answerText',
   'rawText',
   'childContent',
+  'childName',
 ]);
 
 const MAX_DEPTH = 50;

--- a/tests/hero-pA2-privacy-recursive.test.js
+++ b/tests/hero-pA2-privacy-recursive.test.js
@@ -198,7 +198,7 @@ describe('stripPrivacyFields', () => {
 
 describe('PRIVACY_FORBIDDEN_FIELDS', () => {
   it('contains all expected fields', () => {
-    const expected = ['rawAnswer', 'rawPrompt', 'childFreeText', 'childInput', 'answerText', 'rawText', 'childContent'];
+    const expected = ['rawAnswer', 'rawPrompt', 'childFreeText', 'childInput', 'answerText', 'rawText', 'childContent', 'childName'];
     assert.deepEqual([...PRIVACY_FORBIDDEN_FIELDS], expected);
   });
 

--- a/tests/hero-pA4-metrics-infrastructure.test.js
+++ b/tests/hero-pA4-metrics-infrastructure.test.js
@@ -30,7 +30,7 @@ describe('REQUIRED_LAUNCH_METRICS', () => {
   });
 
   it('each metric has a confidence classification (extractionSource)', () => {
-    const validSources = ['server-extractable', 'client-only', 'derived'];
+    const validSources = ['server-extractable', 'client-only', 'derived', 'not-observable-yet'];
     for (const m of REQUIRED_LAUNCH_METRICS) {
       assert.ok(
         validSources.includes(m.extractionSource),
@@ -73,7 +73,7 @@ describe('REQUIRED_SAFETY_METRICS', () => {
   });
 
   it('each metric has a confidence classification (extractionSource)', () => {
-    const validSources = ['server-extractable', 'client-only', 'derived'];
+    const validSources = ['server-extractable', 'client-only', 'derived', 'not-observable-yet'];
     for (const m of REQUIRED_SAFETY_METRICS) {
       assert.ok(
         validSources.includes(m.extractionSource),
@@ -127,7 +127,7 @@ describe('validateMetricsMapping', () => {
     const result = validateMetricsMapping({ ALL_HERO_METRICS });
     assert.equal(result.summary.total, 28);
     assert.equal(
-      result.summary.serverExtractable + result.summary.clientOnly + result.summary.derived,
+      result.summary.serverExtractable + result.summary.clientOnly + result.summary.derived + result.summary.notObservableYet,
       28,
     );
   });
@@ -142,7 +142,8 @@ describe('validateMetricsMapping', () => {
 
   it('reports unmapped metric when contract is empty', () => {
     const result = validateMetricsMapping({ ALL_HERO_METRICS: [] });
-    // Metrics with canonicalMetric will fail; those with queryPattern or derived still pass
+    // Metrics with canonicalMetric will fail; those with queryPattern, derived,
+    // client-only, or explicit not-observable-yet classifications still pass.
     const unmapped = [...result.launchMetrics, ...result.safetyMetrics].filter(m => !m.mapped);
     assert.ok(unmapped.length > 0, 'Expected some unmapped metrics with empty contract');
     assert.equal(result.valid, false);
@@ -228,13 +229,14 @@ describe('canonical metric cross-reference', () => {
     }
   });
 
-  it('metrics without canonicalMetric have alternative extraction (queryPattern, derived, or client-only)', () => {
+  it('metrics without canonicalMetric have an extraction path or explicit observability gap', () => {
     const allMetrics = [...REQUIRED_LAUNCH_METRICS, ...REQUIRED_SAFETY_METRICS];
     const withoutCanonical = allMetrics.filter(m => m.canonicalMetric === null);
     for (const m of withoutCanonical) {
       const hasAlternative = m.queryPattern !== null
         || m.extractionSource === 'derived'
-        || m.extractionSource === 'client-only';
+        || m.extractionSource === 'client-only'
+        || m.extractionSource === 'not-observable-yet';
       assert.ok(
         hasAlternative,
         `Metric ${m.id} has no canonicalMetric and no alternative extraction path`,

--- a/tests/hero-pA5-metrics-sanity.test.js
+++ b/tests/hero-pA5-metrics-sanity.test.js
@@ -155,8 +155,8 @@ describe('hero-pA5 metrics sanity — product signals', () => {
 
 // ── §8.1 Launch Metrics — 14 required ───────────────────────────────
 
-describe('hero-pA5 metrics sanity — launch metrics derivability', () => {
-  it('all 14 launch metrics are derivable from event counts', () => {
+describe('hero-pA5 metrics sanity — launch metric classification', () => {
+  it('all 14 launch metrics are classified without overclaiming event derivability', () => {
     // The pA5 contract requires 14 launch metrics. The pA4 validator defines
     // 18 (a superset). We verify the 14 required pA5 metrics exist within.
     const PA5_REQUIRED_LAUNCH_NAMES = [
@@ -199,12 +199,22 @@ describe('hero-pA5 metrics sanity — launch metrics derivability', () => {
       assert.ok(mappedId, `pA5 launch metric "${name}" has a mapping`);
       const metric = REQUIRED_LAUNCH_METRICS.find(m => m.id === mappedId);
       assert.ok(metric, `pA4 metric ${mappedId} exists for "${name}"`);
-      // Each metric has either a queryPattern or extractionSource
+      // Each metric has either a real query pattern or an explicit source
+      // classification. not-observable-yet metrics must not pretend to have an
+      // event_log query.
       assert.ok(
         metric.queryPattern || metric.extractionSource,
-        `metric ${mappedId} is derivable (has queryPattern or extractionSource)`,
+        `metric ${mappedId} is classified (has queryPattern or extractionSource)`,
       );
+      if (metric.extractionSource === 'not-observable-yet') {
+        assert.equal(metric.queryPattern, null, `metric ${mappedId} must not invent an event query`);
+      }
     }
+
+    const claimRejection = REQUIRED_LAUNCH_METRICS.find(m => m.id === 'launch-09');
+    assert.equal(claimRejection.extractionSource, 'not-observable-yet');
+    assert.equal(claimRejection.queryPattern, null);
+    assert.match(claimRejection.description, /not persisted/i);
   });
 });
 

--- a/tests/hero-pA6-deliverables-validation.test.js
+++ b/tests/hero-pA6-deliverables-validation.test.js
@@ -1,0 +1,83 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const ROOT = resolve(import.meta.dirname, '..');
+
+const REQUIRED_DOCS = [
+  'docs/plans/james/hero-mode/A/hero-pA6-preflight.md',
+  'docs/plans/james/hero-mode/A/hero-pA6-live-rollout-log.md',
+  'docs/plans/james/hero-mode/A/hero-pA6-metrics-summary.md',
+  'docs/plans/james/hero-mode/A/hero-pA6-support-summary.md',
+  'docs/plans/james/hero-mode/A/hero-pA6-rollback-evidence.md',
+  'docs/plans/james/hero-mode/A/hero-pA6-production-decision.md',
+];
+
+const REQUIRED_ARTEFACTS = [
+  'scripts/hero-pA6-metrics-extract.mjs',
+  'reports/hero/hero-pA6-metrics-report.json',
+];
+
+function read(relativePath) {
+  return readFileSync(resolve(ROOT, relativePath), 'utf8');
+}
+
+describe('Hero Mode pA6 deliverables', () => {
+  it('creates the required close-out artefacts', () => {
+    for (const path of [...REQUIRED_DOCS, ...REQUIRED_ARTEFACTS]) {
+      assert.ok(existsSync(resolve(ROOT, path)), `Missing pA6 artefact: ${path}`);
+    }
+  });
+
+  it('records one exact final decision and does not leave the outcome pending', () => {
+    const decision = read('docs/plans/james/hero-mode/A/hero-pA6-production-decision.md');
+    assert.ok(decision.includes('HOLD AT CURRENT ROLLOUT PERCENTAGE'));
+    assert.equal(decision.includes('[PENDING]'), false);
+    assert.equal(/NORMALISE HERO MODE[\s\S]*Selected outcome/i.test(decision), false);
+    assert.ok(decision.includes('Review-by date | 2026-05-15'));
+    assert.ok(decision.includes('Repository-declared rollout-bucket percentage | 0% effective'));
+    assert.ok(decision.includes('Secret-name check | `node scripts/wrangler-oauth.mjs secret list`'));
+    assert.ok(decision.includes('Exact live allowlist size | BLOCKED'));
+    assert.ok(decision.includes('A6 HOLD contract boundary | BLOCKED'));
+  });
+
+  it('keeps live rollout evidence honest rather than counting pA5 templates', () => {
+    const preflight = read('docs/plans/james/hero-mode/A/hero-pA6-preflight.md');
+    const rollout = read('docs/plans/james/hero-mode/A/hero-pA6-live-rollout-log.md');
+
+    assert.ok(preflight.includes('pA5 template rows are not countable as live evidence'));
+    assert.ok(preflight.includes('HERO_ROLLOUT_PERCENT` is absent from the tracked Worker vars'));
+    assert.ok(preflight.includes('HERO_INTERNAL_ACCOUNTS` is present but its value/size is hidden'));
+    assert.ok(rollout.includes('No new production accounts widened by this branch'));
+    assert.ok(rollout.includes('rollout-bucket path is effectively 0%'));
+    assert.ok(rollout.includes('HOLD AT CURRENT ROLLOUT PERCENTAGE'));
+    assert.ok(rollout.includes('not a contract-complete production HOLD certification'));
+    assert.equal(/normalised by this branch/i.test(rollout), false);
+  });
+
+  it('documents the schema-accurate metric boundary', () => {
+    const metrics = read('docs/plans/james/hero-mode/A/hero-pA6-metrics-summary.md');
+
+    assert.ok(metrics.includes("`child_game_state` where `system_id = 'hero-mode'`"));
+    assert.ok(metrics.includes('event_log` | Observational telemetry mirror only'));
+    assert.ok(metrics.includes('not-observable-yet | 11'));
+    assert.ok(metrics.includes('Zero supplied rows do not prove zero production issues'));
+    assert.ok(metrics.includes('no-live-export-supplied'));
+    assert.ok(metrics.includes('status: "not-evaluated"'));
+    assert.ok(metrics.includes('Hero route 5xx count'));
+    assert.ok(metrics.includes('Exposure to excluded accounts'));
+  });
+
+  it('requires owners and production rollback evidence before widening', () => {
+    const support = read('docs/plans/james/hero-mode/A/hero-pA6-support-summary.md');
+    const rollback = read('docs/plans/james/hero-mode/A/hero-pA6-rollback-evidence.md');
+    const decision = read('docs/plans/james/hero-mode/A/hero-pA6-production-decision.md');
+
+    assert.ok(support.includes('Support owner | Not recorded'));
+    assert.ok(support.includes('| **Total** | 0 | 0 | 0 | No support rows supplied; not proof of zero live support issues |'));
+    assert.ok(support.includes('## Evidence Blockers'));
+    assert.ok(rollback.includes('production rollback rehearsal still needs to prove'));
+    assert.ok(decision.includes('REQUIRED BEFORE WIDENING'));
+  });
+});

--- a/tests/hero-pA6-metrics-extract.test.js
+++ b/tests/hero-pA6-metrics-extract.test.js
@@ -185,6 +185,7 @@ describe('Hero Mode pA6 schema extraction', () => {
     assert.equal(report.privacy.status, 'not-evaluated');
     assert.equal(report.privacy.passed, null);
     assert.equal(report.privacy.failureCount, 0);
+    assert.equal(report.stateInspection.failureCount, 0);
     assert.equal(getMetric(report, 'pa6-safety-06').evidenceState, 'no-live-export-supplied');
     assert.ok(report.decisionImpact.reasons.some((reason) => reason.includes('No supplied live Hero production export rows')));
   });
@@ -285,6 +286,17 @@ describe('Hero Mode pA6 schema extraction', () => {
     assert.equal(report.privacy.parseErrorCount, 1);
     assert.equal(report.privacy.failureCount, 1);
     assert.equal(getMetric(report, 'pa6-safety-06').value, 1);
+    assert.equal(report.decisionImpact.recommendedOutcome, 'ROLL BACK TO COHORT ONLY');
+  });
+
+  it('fails closed when authoritative Hero state_json is malformed', () => {
+    const input = makeHealthyInput();
+    input.child_game_state[0].state_json = '{not valid json';
+
+    const report = buildA6MetricsReport(input);
+    assert.equal(report.stateInspection.failureCount, 1);
+    assert.equal(report.stateInspection.parseErrorCount, 1);
+    assert.equal(getMetric(report, 'pa6-safety-03').value, 1);
     assert.equal(report.decisionImpact.recommendedOutcome, 'ROLL BACK TO COHORT ONLY');
   });
 });

--- a/tests/hero-pA6-metrics-extract.test.js
+++ b/tests/hero-pA6-metrics-extract.test.js
@@ -1,0 +1,290 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  PA6_METRIC_REGISTRY,
+  PA6_SOURCE_TYPES,
+  assertNoConceptualTables,
+  buildA6MetricsReport,
+} from '../scripts/hero-pA6-metrics-extract.mjs';
+import {
+  REQUIRED_LAUNCH_METRICS,
+  REQUIRED_SAFETY_METRICS,
+} from '../scripts/hero-pA4-metrics-validator.mjs';
+
+function getMetric(report, id) {
+  return report.metrics.find((metric) => metric.id === id);
+}
+
+function makeHealthyInput() {
+  const state = {
+    version: 3,
+    daily: {
+      dateKey: '2026-05-01',
+      questId: 'quest-1',
+      status: 'completed',
+      firstStartedAt: '2026-05-01T09:00:00.000Z',
+      tasks: {
+        task1: { taskId: 'task1', status: 'completed', intent: 'weak-repair', subjectId: 'spelling' },
+        task2: { taskId: 'task2', status: 'completed', intent: 'due-review', subjectId: 'grammar' },
+      },
+    },
+    economy: {
+      version: 1,
+      balance: 50,
+      lifetimeEarned: 100,
+      lifetimeSpent: 50,
+      ledger: [
+        {
+          entryId: 'award-1',
+          idempotencyKey: 'award-key-1',
+          type: 'daily-completion-award',
+          amount: 100,
+          balanceAfter: 100,
+          learnerId: 'learner-1',
+          dateKey: '2026-05-01',
+          questId: 'quest-1',
+        },
+        {
+          entryId: 'invite-1',
+          idempotencyKey: 'invite-key-1',
+          type: 'monster-invite',
+          amount: -50,
+          balanceAfter: 50,
+          learnerId: 'learner-1',
+          monsterId: 'glossbloom',
+          branch: 'b1',
+        },
+      ],
+    },
+    heroPool: {
+      monsters: {
+        glossbloom: { owned: true, stage: 0, branch: 'b1' },
+      },
+    },
+  };
+
+  return {
+    child_game_state: [
+      {
+        learner_id: 'learner-1',
+        system_id: 'hero-mode',
+        state_json: JSON.stringify(state),
+        updated_at: '2026-05-01T09:15:00.000Z',
+      },
+    ],
+    event_log: [
+      {
+        id: 'evt-task-1',
+        learner_id: 'learner-1',
+        subject_id: 'spelling',
+        system_id: 'hero-mode',
+        event_type: 'hero.task.completed',
+        event_json: JSON.stringify({ data: { questId: 'quest-1', taskId: 'task1', subjectId: 'spelling', dateKey: '2026-05-01' } }),
+        created_at: '2026-05-01T09:05:00.000Z',
+        actor_account_id: 'account-1',
+      },
+      {
+        id: 'evt-daily-1',
+        learner_id: 'learner-1',
+        subject_id: null,
+        system_id: 'hero-mode',
+        event_type: 'hero.daily.completed',
+        event_json: JSON.stringify({ data: { questId: 'quest-1', dateKey: '2026-05-01' } }),
+        created_at: '2026-05-01T09:10:00.000Z',
+        actor_account_id: 'account-1',
+      },
+      {
+        id: 'evt-coins-1',
+        learner_id: 'learner-1',
+        subject_id: null,
+        system_id: 'hero-mode',
+        event_type: 'hero.coins.awarded',
+        event_json: JSON.stringify({ questId: 'quest-1', dateKey: '2026-05-01', amount: 100, ledgerEntryId: 'award-1', balanceAfter: 100 }),
+        created_at: '2026-05-01T09:10:01.000Z',
+        actor_account_id: 'account-1',
+      },
+      {
+        id: 'evt-camp-1',
+        learner_id: 'learner-1',
+        subject_id: null,
+        system_id: 'hero-mode',
+        event_type: 'hero.camp.monster.invited',
+        event_json: JSON.stringify({ command: 'unlock-monster', monsterId: 'glossbloom', ledgerEntryId: 'invite-1' }),
+        created_at: '2026-05-01T09:20:00.000Z',
+        actor_account_id: 'account-1',
+      },
+    ],
+    child_subject_state: [
+      { learner_id: 'learner-1', subject_id: 'spelling' },
+      { learner_id: 'learner-2', subject_id: 'arithmetic' },
+    ],
+    account_learner_memberships: [
+      { account_id: 'account-1', learner_id: 'learner-1' },
+    ],
+    support_issues: [
+      { category: 'comprehension', status: 'resolved' },
+    ],
+  };
+}
+
+describe('Hero Mode pA6 metrics registry', () => {
+  it('classifies every metric with the A6 source truth vocabulary', () => {
+    assert.equal(PA6_METRIC_REGISTRY.length, 34);
+
+    for (const metric of PA6_METRIC_REGISTRY) {
+      assert.ok(PA6_SOURCE_TYPES.includes(metric.sourceType), `${metric.id} has invalid sourceType`);
+      assert.ok(['launch', 'product', 'safety'].includes(metric.category), `${metric.id} has invalid category`);
+      assert.equal(typeof metric.extraction, 'string');
+      assert.ok(metric.extraction.length > 0);
+    }
+  });
+
+  it('does not reference conceptual Hero tables in A6 or inherited pA4 metric patterns', () => {
+    const pa6Check = assertNoConceptualTables();
+    assert.equal(pa6Check.ok, true, `A6 offenders: ${pa6Check.offenders.join(', ')}`);
+
+    const inheritedPatterns = [...REQUIRED_LAUNCH_METRICS, ...REQUIRED_SAFETY_METRICS]
+      .map((metric) => metric.queryPattern || metric.description || '')
+      .join('\n');
+
+    assert.equal(/\b(cohort_members|hero_ledger)\b/i.test(inheritedPatterns), false);
+  });
+});
+
+describe('Hero Mode pA6 schema extraction', () => {
+  it('derives economy and Camp values from child_game_state, not telemetry-only mirrors', () => {
+    const report = buildA6MetricsReport(makeHealthyInput(), {
+      generatedAt: '2026-05-01T10:00:00.000Z',
+    });
+
+    assert.equal(report.sourceTruth.economyAuthority, "child_game_state.state_json where system_id='hero-mode'");
+    assert.equal(report.sourceTruth.eventLogRole, 'telemetry mirror only');
+    assert.equal(getMetric(report, 'pa6-launch-01').value, 1);
+    assert.equal(getMetric(report, 'pa6-launch-02').value, 1);
+    assert.equal(getMetric(report, 'pa6-launch-05').value, 2);
+    assert.equal(getMetric(report, 'pa6-launch-06').value, 1);
+    assert.equal(getMetric(report, 'pa6-launch-10').value, 1);
+    assert.equal(getMetric(report, 'pa6-launch-12').value, 1);
+    assert.equal(getMetric(report, 'pa6-safety-01').value, 0);
+    assert.equal(getMetric(report, 'pa6-safety-02').value, 0);
+    assert.equal(getMetric(report, 'pa6-safety-03').value, 0);
+    assert.equal(getMetric(report, 'pa6-safety-06').value, 0);
+    assert.equal(report.evidenceState, 'computed-from-supplied-export');
+    assert.equal(report.privacy.status, 'passed');
+    assert.equal(report.privacy.passed, true);
+    assert.equal(report.decisionImpact.recommendedOutcome, 'HOLD AT CURRENT ROLLOUT PERCENTAGE');
+  });
+
+  it('marks an empty export as not evaluated rather than a privacy pass', () => {
+    const report = buildA6MetricsReport({}, {
+      generatedAt: '2026-05-01T10:00:00.000Z',
+    });
+
+    assert.equal(report.evidenceState, 'no-live-export-supplied');
+    assert.equal(report.privacy.status, 'not-evaluated');
+    assert.equal(report.privacy.passed, null);
+    assert.equal(report.privacy.failureCount, 0);
+    assert.equal(getMetric(report, 'pa6-safety-06').evidenceState, 'no-live-export-supplied');
+    assert.ok(report.decisionImpact.reasons.some((reason) => reason.includes('No supplied live Hero production export rows')));
+  });
+
+  it('keeps client-only blind spots explicit instead of counting them as covered', () => {
+    const report = buildA6MetricsReport(makeHealthyInput());
+    const questShown = getMetric(report, 'pa6-launch-03');
+    const route5xx = getMetric(report, 'pa6-launch-14');
+
+    assert.equal(questShown.sourceType, 'not-observable-yet');
+    assert.equal(questShown.value, null);
+    assert.equal(route5xx.sourceType, 'not-observable-yet');
+    assert.equal(route5xx.value, null);
+    assert.ok(report.blindSpots.some((spot) => spot.id === 'pa6-launch-03'));
+  });
+
+  it('flags zero-tolerance safety breaches from authoritative Hero JSON', () => {
+    const input = makeHealthyInput();
+    const state = JSON.parse(input.child_game_state[0].state_json);
+    state.economy.balance = -1;
+    state.economy.ledger.push({
+      entryId: 'award-2',
+      idempotencyKey: 'award-key-1',
+      type: 'daily-completion-award',
+      amount: 100,
+      balanceAfter: 200,
+      learnerId: 'learner-1',
+      dateKey: '2026-05-01',
+      questId: 'quest-1',
+    });
+    input.child_game_state[0].state_json = JSON.stringify(state);
+
+    const report = buildA6MetricsReport(input);
+    assert.equal(getMetric(report, 'pa6-safety-01').value, 1);
+    assert.equal(getMetric(report, 'pa6-safety-03').value, 1);
+    assert.equal(report.decisionImpact.recommendedOutcome, 'ROLL BACK TO COHORT ONLY');
+  });
+
+  it('fails the raw-child-content safety metric when event_json contains forbidden child fields', () => {
+    const input = makeHealthyInput();
+    input.event_log.push({
+      id: 'evt-privacy-1',
+      learner_id: 'learner-1',
+      subject_id: 'spelling',
+      system_id: 'hero-mode',
+      event_type: 'hero.task.completed',
+      event_json: JSON.stringify({ data: { taskId: 'task2' }, rawAnswer: 'secret child text' }),
+      created_at: '2026-05-01T09:30:00.000Z',
+      actor_account_id: 'account-1',
+    });
+
+    const report = buildA6MetricsReport(input);
+    assert.equal(report.privacy.passed, false);
+    assert.equal(report.privacy.status, 'failed');
+    assert.equal(report.privacy.failureCount, 1);
+    assert.equal(getMetric(report, 'pa6-safety-06').value, 1);
+    assert.equal(report.decisionImpact.recommendedOutcome, 'ROLL BACK TO COHORT ONLY');
+  });
+
+  it('fails the raw-child-content safety metric for nested childName fields', () => {
+    const input = makeHealthyInput();
+    input.event_log.push({
+      id: 'evt-privacy-child-name',
+      learner_id: 'learner-1',
+      subject_id: 'grammar',
+      system_id: 'hero-mode',
+      event_type: 'hero.task.completed',
+      event_json: JSON.stringify({ data: { taskId: 'task3', learner: { childName: 'Private name' } } }),
+      created_at: '2026-05-01T09:31:00.000Z',
+      actor_account_id: 'account-1',
+    });
+
+    const report = buildA6MetricsReport(input);
+    assert.equal(report.privacy.passed, false);
+    assert.equal(report.privacy.failureCount, 1);
+    assert.equal(getMetric(report, 'pa6-safety-06').value, 1);
+    assert.ok(report.privacy.violations.some((violation) => (
+      Array.isArray(violation.violations) && violation.violations.includes('data.learner.childName')
+    )));
+  });
+
+  it('fails closed when a Hero event row has malformed event_json', () => {
+    const input = makeHealthyInput();
+    input.event_log.push({
+      id: 'evt-malformed-json',
+      learner_id: 'learner-1',
+      subject_id: 'grammar',
+      system_id: 'hero-mode',
+      event_type: 'hero.task.completed',
+      event_json: '{not valid json',
+      created_at: '2026-05-01T09:32:00.000Z',
+      actor_account_id: 'account-1',
+    });
+
+    const report = buildA6MetricsReport(input);
+    assert.equal(report.privacy.passed, false);
+    assert.equal(report.privacy.status, 'failed');
+    assert.equal(report.privacy.parseErrorCount, 1);
+    assert.equal(report.privacy.failureCount, 1);
+    assert.equal(getMetric(report, 'pa6-safety-06').value, 1);
+    assert.equal(report.decisionImpact.recommendedOutcome, 'ROLL BACK TO COHORT ONLY');
+  });
+});


### PR DESCRIPTION
## Summary

- Add the Hero Mode pA6 close-out artefacts: preflight, live rollout log, metrics summary, support summary, rollback evidence, production decision, and generated metrics report.
- Add a schema-accurate pA6 metrics extractor that treats `child_game_state.state_json` as the Hero economy/Camp authority and `event_log` as telemetry only.
- Correct inherited pA4/pA5 metric evidence wording so registry coverage is not presented as production evidence, and stale/conceptual Hero tables are not used as metric sources.
- Fail closed on uninspectable production evidence: malformed/missing Hero `event_json` fails privacy evaluation, and malformed/non-object Hero `state_json` becomes a zero-tolerance state inspection failure.

## Production Decision Boundary

This PR records `HOLD AT CURRENT ROLLOUT PERCENTAGE` as a repo-side pA6 decision record. It does not normalise Hero Mode, widen rollout, or certify production hold completeness.

Read-only Cloudflare secret-name evidence shows `HERO_INTERNAL_ACCOUNTS` is present, while `HERO_ROLLOUT_PERCENT`, `HERO_ROLLOUT_SALT`, `HERO_EXTERNAL_ACCOUNTS`, `HERO_EXCLUDED_ACCOUNTS`, and `HERO_EMERGENCY_DISABLED` are not listed. Because Cloudflare secrets are value-hidden, this branch cannot verify the exact `HERO_INTERNAL_ACCOUNTS` allowlist size. The docs therefore mark the production HOLD boundary as blocked until an operator records that size or rotates it to a known value.

## Independent Reviews

Engineering code review: all P0-P2 engineering findings are resolved after fail-closing malformed `event_json` and `state_json` evidence paths.

Contract review: support-summary and empty-export evidence issues are resolved. One production contract blocker remains intentionally documented: pA6 is not contract-complete as a production HOLD until the live internal allowlist size is known or reset.

## Verification

- `node --test tests/hero-pA6-metrics-extract.test.js tests/hero-pA6-deliverables-validation.test.js tests/hero-pA2-privacy-recursive.test.js tests/hero-pA4-metrics-infrastructure.test.js tests/hero-pA5-metrics-sanity.test.js` — 71/71 pass
- `node scripts/hero-pA4-metrics-validator.mjs`
- `node scripts/hero-pA5-metrics-sanity-check.mjs`
- `node scripts/hero-pA6-metrics-extract.mjs --output reports/hero/hero-pA6-metrics-report.json`
- `node scripts/hero-pA5-rollout-resolver-evidence.mjs` — 9/9 pass
- `node --test tests/hero-pA5-rollout-resolver.test.js tests/hero-pA5-safety-regression.test.js` — 44/44 pass
- `node scripts/wrangler-oauth.mjs secret list` — read-only secret-name check
- `npm test` — 16,294 pass / 0 fail / 6 skipped
- `npm run check` — pass
- `git diff --check` — pass