### PR TITLE
fix(punctuation): cache P11 runtime indexes

### DIFF
--- a/scripts/punctuation-production-smoke.mjs
+++ b/scripts/punctuation-production-smoke.mjs
@@ -52,6 +52,12 @@ export const PUNCTUATION_DASH_POLICY_VARIANTS = Object.freeze([
   Object.freeze({ id: 'em-dash', label: 'em dash', mark: '—' }),
 ]);
 
+export const PUNCTUATION_DASH_ACCEPTANCE_SESSION_OPTIONS = Object.freeze({
+  mode: 'guided',
+  guidedSkillId: 'dash_clause',
+  roundLength: '6',
+});
+
 function isPlainObject(value) {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
@@ -575,7 +581,7 @@ async function smokePunctuationDashAcceptance({ origin, cookie, learnerId, revis
       learnerId,
       revision: currentRevision,
       label: `dashAcceptance.${variant.id}`,
-      sessionOptions: { mode: 'boundary', roundLength: '6' },
+      sessionOptions: PUNCTUATION_DASH_ACCEPTANCE_SESSION_OPTIONS,
       predicate: ({ source }) => Boolean(dashVariantAnswerFor(source, variant.mark)),
       answerForTarget: ({ source }) => {
         const typed = dashVariantAnswerFor(source, variant.mark);
@@ -583,6 +589,7 @@ async function smokePunctuationDashAcceptance({ origin, cookie, learnerId, revis
         return { typed };
       },
       expectedFeedbackKind: 'success',
+      maxAnsweredItems: 12,
     });
     currentRevision = result.revision;
     results.push({

--- a/shared/punctuation/service.js
+++ b/shared/punctuation/service.js
@@ -64,6 +64,21 @@ const SESSION_MODE_LABELS = Object.freeze({
   structure: 'Structure focus',
 });
 
+export const DEFAULT_PUNCTUATION_RUNTIME_MANIFEST = createPunctuationRuntimeManifest({
+  manifest: PUNCTUATION_CONTENT_MANIFEST,
+  generatedPerFamily: PRODUCTION_DEPTH,
+});
+
+export const DEFAULT_PUNCTUATION_CONTENT_INDEXES = createPunctuationContentIndexes(
+  DEFAULT_PUNCTUATION_RUNTIME_MANIFEST,
+);
+
+function indexesForManifest(manifest) {
+  return manifest === DEFAULT_PUNCTUATION_RUNTIME_MANIFEST
+    ? DEFAULT_PUNCTUATION_CONTENT_INDEXES
+    : createPunctuationContentIndexes(manifest);
+}
+
 function isPlainObject(value) {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
@@ -1271,11 +1286,8 @@ export function createPunctuationService({
   repository = createNoopRepository(),
   now = Date.now,
   random = Math.random,
-  manifest = createPunctuationRuntimeManifest({
-    manifest: PUNCTUATION_CONTENT_MANIFEST,
-    generatedPerFamily: PRODUCTION_DEPTH,
-  }),
-  indexes = createPunctuationContentIndexes(manifest),
+  manifest = DEFAULT_PUNCTUATION_RUNTIME_MANIFEST,
+  indexes = indexesForManifest(manifest),
 } = {}) {
   const clock = () => timestamp(now);
   const activeReleaseId = manifest.releaseId || PUNCTUATION_RELEASE_ID;

--- a/tests/punctuation-release-smoke.test.js
+++ b/tests/punctuation-release-smoke.test.js
@@ -7,6 +7,7 @@ import { createPunctuationRuntimeManifest, PRODUCTION_DEPTH } from '../shared/pu
 import { markPunctuationAnswer } from '../shared/punctuation/marking.js';
 import { SUBJECT_EXPOSURE_GATES } from '../src/platform/core/subject-availability.js';
 import {
+  PUNCTUATION_DASH_ACCEPTANCE_SESSION_OPTIONS,
   PUNCTUATION_DASH_POLICY_VARIANTS,
   PUNCTUATION_P2_LOCAL_RELEASE_MANIFEST_EXPECTATIONS,
   assertGeneratedActiveItemPolicy,
@@ -312,6 +313,24 @@ test('Punctuation P2 smoke helper builds accepted dash and Oxford-comma probes',
     answer: { typed: oxfordCommaAnswerFor(listSource) },
   });
   assert.equal(oxfordResult.correct, true);
+});
+
+test('Punctuation P11 smoke targets dash acceptance through guided dash practice', () => {
+  assert.deepEqual(PUNCTUATION_DASH_ACCEPTANCE_SESSION_OPTIONS, {
+    mode: 'guided',
+    guidedSkillId: 'dash_clause',
+    roundLength: '6',
+  });
+
+  const indexes = productionPunctuationIndexes();
+  const eligibleGuidedDashModes = new Set(
+    indexes.items
+      .filter((item) => item.skillIds?.includes('dash_clause') && Boolean(dashVariantAnswerFor(item, '-')))
+      .map((item) => item.mode),
+  );
+
+  assert.equal(eligibleGuidedDashModes.has('insert'), true);
+  assert.equal(eligibleGuidedDashModes.has('fix'), true);
 });
 
 test('Punctuation P2 smoke helper builds wrong generated answers with misconception evidence', () => {

--- a/tests/punctuation-service.test.js
+++ b/tests/punctuation-service.test.js
@@ -1,5 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 
 import {
   createPunctuationContentIndexes,
@@ -10,7 +11,12 @@ import {
 import { PUNCTUATION_EVENT_TYPES } from '../shared/punctuation/events.js';
 import { createPunctuationRuntimeManifest, PRODUCTION_DEPTH } from '../shared/punctuation/generators.js';
 import { createMemoryState, updateMemoryState } from '../shared/punctuation/scheduler.js';
-import { createPunctuationService, PunctuationServiceError } from '../shared/punctuation/service.js';
+import {
+  createPunctuationService,
+  DEFAULT_PUNCTUATION_CONTENT_INDEXES,
+  DEFAULT_PUNCTUATION_RUNTIME_MANIFEST,
+  PunctuationServiceError,
+} from '../shared/punctuation/service.js';
 import { projectPunctuationStars } from '../src/subjects/punctuation/star-projection.js';
 import {
   DEFAULT_PUNCTUATION_PREFS,
@@ -79,6 +85,28 @@ test('punctuation service default runtime bank exposes P11 expansion depth', () 
   assert.equal(stats.total, 1268);
   assert.equal(stats.fresh, 1268);
   assert.equal(stats.publishedRewardUnits, 14);
+});
+
+test('punctuation service keeps the default P11 runtime manifest and indexes cached', () => {
+  const fixedItems = DEFAULT_PUNCTUATION_RUNTIME_MANIFEST.items.filter((item) => item.source === 'fixed');
+  const generatedItems = DEFAULT_PUNCTUATION_RUNTIME_MANIFEST.items.filter((item) => item.source === 'generated');
+
+  assert.equal(Object.isFrozen(DEFAULT_PUNCTUATION_RUNTIME_MANIFEST), true);
+  assert.equal(fixedItems.length, 148);
+  assert.equal(generatedItems.length, 1120);
+  assert.equal(DEFAULT_PUNCTUATION_CONTENT_INDEXES.items.length, 1268);
+  assert.equal(DEFAULT_PUNCTUATION_CONTENT_INDEXES.publishedRewardUnits.length, 14);
+});
+
+test('punctuation service default path reuses cached P11 runtime indexes', () => {
+  const source = readFileSync(new URL('../shared/punctuation/service.js', import.meta.url), 'utf8');
+  const factoryStart = source.indexOf('export function createPunctuationService');
+  const factoryDefaults = source.slice(factoryStart, source.indexOf('  const clock =', factoryStart));
+
+  assert.match(factoryDefaults, /manifest\s*=\s*DEFAULT_PUNCTUATION_RUNTIME_MANIFEST/);
+  assert.match(factoryDefaults, /indexes\s*=\s*indexesForManifest\(manifest\)/);
+  assert.doesNotMatch(factoryDefaults, /createPunctuationRuntimeManifest\s*\(/);
+  assert.doesNotMatch(factoryDefaults, /createPunctuationContentIndexes\s*\(manifest\)/);
 });
 
 test('punctuation default Smart Practice uses a six-question round', () => {


### PR DESCRIPTION
## Summary
- cache the default P11 punctuation runtime manifest and content indexes at module scope, so normal Worker service construction no longer rebuilds the 1,268-item runtime on each default service instance
- keep custom manifest callers on the existing rebuild path by deriving indexes only when the caller supplies a non-default manifest
- stabilise the P11 production dash acceptance smoke by targeting guided `dash_clause` practice instead of broad `boundary` pool search

## Verification
- `node --test tests/punctuation-service.test.js tests/punctuation-release-smoke.test.js tests/worker-punctuation-runtime.test.js tests/build-public.test.js`
- `npm run verify:punctuation-qg:p11` — 12/12 gates, 68 logical gates, still reports `SOURCE_VERIFIED_PENDING_PRODUCT_ACCEPTANCE` because live smoke evidence is not yet recorded
- `npm run check`
- `npm test` — 19,594 tests, 19,588 passed, 0 failed, 6 skipped
- Independent engineering re-review: no blocking findings
- Independent contract re-review: hotfix is mergeable, but final P11 production certification remains blocked on live smoke/report evidence

## Contract Boundary
This is a hotfix and smoke-stabilisation PR after #817. It does not claim final P11 production certification.

Remaining certification work after deploy:
- rerun P11 production smoke against the deployed commit
- update `reports/punctuation/punctuation-qg-p11-product-acceptance.json` only after live smoke evidence is real and repeatable
- do not claim Admin Hub coverage unless an actual Admin Hub route/session is exercised; current smoke coverage is Parent Hub plus child/subject production flow
