### PR TITLE
Fix Grammar production smoke manual-review fixture

### DIFF
--- a/scripts/grammar-production-smoke.mjs
+++ b/scripts/grammar-production-smoke.mjs
@@ -98,9 +98,9 @@ export const GRAMMAR_ANSWER_SPEC_FAMILY_SMOKE_ITEMS = Object.freeze([
     templateId: 'build_noun_phrase',
     seed: 0,
     response: Object.freeze({
-      part1: 'The tall',
-      part2: 'captain',
-      part3: 'with curly hair',
+      part1: 'The careful',
+      part2: 'detective',
+      part3: 'with a silver badge',
     }),
   }),
 ]);

--- a/tests/grammar-production-smoke.test.js
+++ b/tests/grammar-production-smoke.test.js
@@ -36,6 +36,36 @@ function readItemFromQuestion(question) {
   };
 }
 
+function optionValues(options) {
+  return new Set((Array.isArray(options) ? options : []).map((option) => (
+    Array.isArray(option) ? option[0] : (typeof option === 'string' ? option : option?.value)
+  )));
+}
+
+function assertFixtureResponseUsesVisibleInputs(question, response) {
+  const spec = question?.inputSpec || {};
+  if (spec.type === 'multi') {
+    for (const field of spec.fields || []) {
+      const value = response?.[field.key];
+      assert.ok(
+        optionValues(field.options).has(value),
+        `${question.templateId}.${field.key} response must use a visible option`,
+      );
+    }
+    return;
+  }
+  if (spec.type === 'table_choice') {
+    const globalOptions = optionValues(spec.columns);
+    for (const row of spec.rows || []) {
+      const allowed = Array.isArray(row.options) && row.options.length ? optionValues(row.options) : globalOptions;
+      assert.ok(
+        allowed.has(response?.[row.key]),
+        `${question.templateId}.${row.key} response must use a visible option`,
+      );
+    }
+  }
+}
+
 test('Grammar production smoke answers from the production-visible option set', () => {
   const question = smokeQuestion();
   assert.equal(question.templateId, 'qg_modal_verb_explain');
@@ -212,6 +242,7 @@ test('Grammar production smoke has visible-data probes for every answer-spec fam
     const question = createGrammarQuestion({ templateId: fixture.templateId, seed: fixture.seed });
     const readItem = readItemFromQuestion(question);
     const response = visibleResponseForAnswerSpecFamily(readItem);
+    assertFixtureResponseUsesVisibleInputs(question, response);
     const result = evaluateGrammarQuestion(question, response);
     if (fixture.family === 'manualReviewOnly') {
       assert.equal(result.correct, false, fixture.family);


### PR DESCRIPTION
## Summary
- updates the Grammar production smoke manual-review fixture to use the visible `build_noun_phrase` seed 0 options
- adds a regression guard that multi/table smoke fixture responses must come from production-visible inputs

## Verification
- `node --test tests/grammar-production-smoke.test.js`
- `npm run smoke:production:grammar -- --json --evidence-origin post-deploy --release-id=grammar-qg-p14-2026-05-01 --out=/tmp/grammar-production-smoke-grammar-qg-p14-2026-05-01-fixed-fixture.json`

## Note
This is a verification-script fix only. The P14 Worker release is already deployed as version `438a4bc4-836e-46c4-b035-ac724f32189b`; the corrected smoke passed against `https://ks2.eugnel.uk`.