### PR TITLE
Certify Grammar QG P14 post-deploy evidence

### DIFF
--- a/docs/plans/james/grammar/questions-generator/grammar-qg-p14-completion-report.md
+++ b/docs/plans/james/grammar/questions-generator/grammar-qg-p14-completion-report.md
@@ -2,10 +2,9 @@
 phase: grammar-qg-p14
 certification_phase: grammar-qg-p14
 final_content_release_id: grammar-qg-p14-2026-05-01
-certification_decision: CERTIFIED_PRE_DEPLOY
-post_deploy_smoke_evidence: pending
+certification_decision: CERTIFIED_POST_DEPLOY
+post_deploy_smoke_evidence: reports/grammar/grammar-production-smoke-grammar-qg-p14-2026-05-01.json
 limitations:
-  - Post-deploy production smoke must run after the P14 release is deployed to https://ks2.eugnel.uk.
   - Depth effectiveness needs production telemetry over time; this report certifies release safety and local depth simulations only.
 ---
 
@@ -13,7 +12,7 @@ limitations:
 
 ## Decision
 
-P14 is complete for pre-deploy release review under `grammar-qg-p14-2026-05-01`.
+P14 is complete for post-deploy production release certification under `grammar-qg-p14-2026-05-01`.
 
 The active Grammar QG pool now has 110 templates, 3,300 render-inventory items, 2,496 unique learner-visible surfaces and 1,622 unique prompt texts across seeds 1..30. Quality evidence records 106 approved + 4 approved_with_limitation templates, 0 blocked templates, 33 adult-review decisions, 2,190 distractor audit items with 0 S0/S1 failures, 0 P14 selected-response surface-cue flags, and 120 marking matrix entries.
 
@@ -32,7 +31,7 @@ The distractor audit still records heuristic surface-cue warnings on prior-pool 
 | U6 click-path learner surface audit | Done | `reports/grammar/grammar-qg-p14-learner-surface-audit.json`, `.md` |
 | U7 distractor rationale | Done | `reports/grammar/grammar-qg-p14-distractor-audit.json`; P14 templates have 0 likely surface-cue flags, and all 33 active review-required templates have `adultReviewDecision` entries in the quality register |
 | U8 repetition/depth telemetry | Done | session depth, duplicate count, unique template/concept counts, low-diversity exposure, elapsed-by-depth, and abandonment-by-template/input read-model fields |
-| U9 release certification chain | Done pre-deploy | P14 manifest, render inventory, quality register, distractor audit, marking matrix, status map, runtime source |
+| U9 release certification chain | Done post-deploy | P14 manifest, render inventory, quality register, distractor audit, marking matrix, status map, runtime source, and production smoke evidence |
 
 ## Artefacts
 
@@ -55,10 +54,12 @@ Non-priority concepts keep their existing P1-P13 coverage and are not expanded i
 
 ## Post-Deploy Smoke
 
-This report is intentionally `CERTIFIED_PRE_DEPLOY`. After merge and deployment, run:
+The P14 release is `CERTIFIED_POST_DEPLOY`. Production smoke evidence is committed at `reports/grammar/grammar-production-smoke-grammar-qg-p14-2026-05-01.json`.
 
 ```bash
-npm run smoke:production:grammar -- --json --evidence-origin post-deploy --release-id=grammar-qg-p14-2026-05-01 --out=reports/grammar/grammar-production-smoke-grammar-qg-p14-2026-05-01.json
+npm run smoke:production:grammar -- --json --evidence-origin=post-deploy --expected-release=grammar-qg-p14-2026-05-01 --out=reports/grammar/grammar-production-smoke-grammar-qg-p14-2026-05-01.json
 ```
 
-Then rerun `npm run verify:grammar-qg-production-release` and update this report only if the production evidence passes.
+The smoke passed against `https://ks2.eugnel.uk` with `ok: true`, `environment: production`, `contentReleaseId: grammar-qg-p14-2026-05-01`, and passing item-creation, answer-submission, read-model, answer-leak, semantic-cue, prompt-cue, read-aloud and release-ID assertions. It covered the exact, multi-field, normalised-text, punctuation-pattern, accepted-set and manual-review-only answer-spec families.
+
+Depth effectiveness still needs production telemetry over time. That is a measurement limitation, not a release blocker.


### PR DESCRIPTION
## Summary
- Move the P14 completion report from pre-deploy to post-deploy certification.
- Link the committed production smoke evidence for grammar-qg-p14-2026-05-01.
- Keep the remaining depth-effectiveness telemetry limitation explicit.

## Verification
- npm run verify:grammar-qg-production-release