### PR TITLE
docs: record P7 post-merge report closure

### DIFF
--- a/docs/plans/james/sys-hardening/A/sys-hardening-optimisation-p7-completion-report.md
+++ b/docs/plans/james/sys-hardening/A/sys-hardening-optimisation-p7-completion-report.md
@@ -1,7 +1,7 @@
 ---
 title: "System Hardening Optimisation P7 — Completion Report"
 type: completion-report
-status: ready-for-commit-pr-merge
+status: merged-operator-gated
 date: 2026-05-01
 phase: P7
 owner: james
@@ -20,9 +20,9 @@ source_context:
 
 ## Status
 
-P7 has passed independent review and is ready for commit, PR and merge. It is not ready for certification.
+P7 has passed independent review and was merged via PR #824 at `2026-05-01T23:04:26Z`. It is not ready for certification.
 
-Implementation evidence exists for a narrow bootstrap/D1 query-shape reduction. Post-change production diagnostic evidence does not exist yet because the code has not been committed, merged or deployed.
+Implementation evidence exists for a narrow bootstrap/D1 query-shape reduction. Post-change production diagnostic evidence does not exist yet because the deployed post-merge diagnostic and route-cost refresh have not been captured.
 
 ## Completed Artefacts
 
@@ -110,7 +110,7 @@ This branch must not be described as a 60-learner certification candidate until 
 
 ## Missing / Operator-Gated Evidence
 
-These P7 items remain blocked until after independent review, commit, PR merge and deploy:
+These P7 items remain blocked until a deployed post-merge diagnostic is run and captured:
 
 - post-change 60-learner production diagnostic;
 - redacted post-change tail correlation;

--- a/docs/plans/james/sys-hardening/A/sys-hardening-optimisation-p7-path-decision.md
+++ b/docs/plans/james/sys-hardening/A/sys-hardening-optimisation-p7-path-decision.md
@@ -21,7 +21,7 @@ source_context:
 
 Selected exit state: `p7-continuation-required`.
 
-P7 has a reviewed narrow implementation candidate and local query-count proof, but it has not yet produced a post-change production 60-learner diagnostic. The next step is commit/PR/merge, deploy, then the approved 60-learner run shape.
+P7 has a reviewed, merged narrow implementation candidate and local query-count proof, but it has not yet produced a post-change production 60-learner diagnostic. The next step is deployed-merge confirmation, then the approved 60-learner run shape.
 
 ## Required Questions
 
@@ -29,7 +29,7 @@ P7 has a reviewed narrow implementation candidate and local query-count proof, b
    Locally, yes for statement count. The focused production/demo public bootstrap test reduced the observed full-bootstrap query count from the P6 production shape of 11 to 9. The broader three-learner bounded GET/POST bootstrap budget also ratcheted from the previous measured 11 to 10. Production D1 duration has not yet been measured post-change.
 
 2. **Did the post-change 60-learner run pass the bootstrap P95 threshold?**
-   Not measured. The post-change production run is operator-gated until the code is reviewed, committed, merged and deployed.
+   Not measured. The post-change production run is operator-gated until the merged code is confirmed deployed and the diagnostic is captured.
 
 3. **Did Worker CPU become the new dominant blocker?**
    Unknown. No post-change production tail correlation exists yet.

--- a/docs/plans/james/sys-hardening/A/sys-hardening-optimisation-p7-post-change-run-report.md
+++ b/docs/plans/james/sys-hardening/A/sys-hardening-optimisation-p7-post-change-run-report.md
@@ -20,9 +20,9 @@ source_context:
 
 ## Run Boundary
 
-No post-change production 60-learner diagnostic has been run from this worktree.
+No post-change production 60-learner diagnostic has been captured for the merged PR #824 code.
 
-Reason: the P7 code is still uncommitted and not deployed. James required two independent reviews before commit, PR and merge; those review findings are closed. Running the approved production diagnostic before deployment would measure the old production code, not this P7 optimisation.
+Reason: PR #824 has merged after James's required independent reviews, but the deployed post-merge production diagnostic and route-cost refresh have not been run or captured. Running the approved production diagnostic before confirming the deployed merge would risk measuring the old production code, not this P7 optimisation.
 
 ## Local Post-Change Evidence
 


### PR DESCRIPTION
## Summary

- Update the P7 completion, post-change run and path-decision reports after PR #824 was merged.
- Replace stale pre-merge wording with the actual merged state and keep the production diagnostic / route-cost refresh as operator-gated.

## Verification

- `git diff --check` — passed.
- P7 report redaction/stale-wording scan — no matches.

## Boundary

Docs-only closure correction. This does not certify 60 learners and does not replace the deployed post-change diagnostic.