### PR TITLE
Record Hero pA8 dormant boundary closure

### DIFF
--- a/docs/plans/james/hero-mode/A/hero-pA8-final-decision.md
+++ b/docs/plans/james/hero-mode/A/hero-pA8-final-decision.md
@@ -1,0 +1,81 @@
+# Hero Mode pA8 - Final Decision
+
+**Phase:** A8 release boundary closure and A-series termination
+**Date:** 2026-05-02
+**Status:** FINAL - KEEP DORMANT UNTIL OWNED, full pA8 release execution incomplete
+**Contract:** `docs/plans/james/hero-mode/A/hero-mode-pA8.md`
+**Machine-readable evidence summary:** `reports/hero/hero-pA8-release-boundary.json`
+
+---
+
+## Selected Outcome
+
+```txt
+KEEP DORMANT UNTIL OWNED
+```
+
+Hero Mode is not normalised by this branch. It is not widened to a cohort or percentage rollout. A8 closes the pA7 unknown-boundary blocker by narrowing production exposure to a known zero-account boundary.
+
+---
+
+## What Is Complete
+
+1. `HERO_INTERNAL_ACCOUNTS` is no longer an unknown write-only exposure basis; it was rotated to a known empty JSON array.
+2. `HERO_EXTERNAL_ACCOUNTS` exists as a known empty JSON array.
+3. `HERO_EXCLUDED_ACCOUNTS` exists as a known empty JSON array.
+4. `HERO_EMERGENCY_DISABLED` exists, was rehearsed as `true`, and was restored to `false`.
+5. `HERO_ROLLOUT_PERCENT` exists as `0`.
+6. Checked-in global Hero flags remain false.
+7. Production Hero state rows remain 0.
+8. Production Hero event rows remain 0.
+9. Emergency-off hid Hero surfaces and rejected Hero commands with controlled non-500 responses.
+10. Post-rehearsal dormant state returned controlled flag-disabled responses.
+11. No real family account was widened, and no account remains widened after the temporary demo/test probes.
+12. A controlled production demo/test account probe was attempted, but it did not qualify as Stage 1 smoke because the read model had `ui.enabled=false` and zero tasks.
+13. A second controlled production demo/test account completed one Grammar session through the normal subject command path before temporary allowlisting, but it also did not qualify because Hero still returned `ui.enabled=false`, `ui.reason=no-eligible-subjects`, and zero tasks.
+14. No A9 is created.
+
+This is a complete dormant-boundary record. It is not a complete pA8 release execution, because the known-account production smoke did not pass.
+
+A8 did make production secret writes to force the pA7 unknown boundary into a known dormant state. That is narrower than strict full pA8 release execution and is recorded here as operational closure, not as normalisation evidence.
+
+---
+
+## Why Normalisation Is Not Allowed
+
+| Requirement | Status |
+|-------------|--------|
+| Production boundary known | PASS - known zero exposure |
+| Emergency brake works | PASS for dormant boundary |
+| Opt-out/exclusion works | Control exists; no excluded account supplied to exercise |
+| Known-account smoke passed | NOT RUN; controlled demo/test probes did not qualify |
+| Rollback rehearsal passed | PASS for dormant boundary only |
+| Small exposure produced no stop condition | NOT RUN |
+| Support load known and manageable | Zero supplied rows under no exposure; not a real exposure support load |
+| Product owner signs that Hero Mode helps rather than distracts | Not supplied for normalisation |
+
+Normalisation would require a new product release window, not another A-series phase.
+
+---
+
+## A-Series Termination
+
+A8 ends the A-series as a phase line, but it does not certify Hero Mode for widening or normalisation.
+
+Any future Hero Mode work must be one of:
+
+- a normal product release task with a named account and support window;
+- a bugfix for a concrete defect;
+- a product rework brief.
+
+It must not be A9.
+
+---
+
+## Review
+
+| Field | Value |
+|-------|-------|
+| Owner | James |
+| Review-by date | 2026-05-16 |
+| Specific reason for dormant decision | No known enabled account and owned live release window were supplied for the Stage 1 smoke after the boundary was made known zero |

--- a/docs/plans/james/hero-mode/A/hero-pA8-known-account-smoke-evidence.md
+++ b/docs/plans/james/hero-mode/A/hero-pA8-known-account-smoke-evidence.md
@@ -1,0 +1,56 @@
+# Hero Mode pA8 - Known-Account Production Smoke Evidence
+
+**Phase:** A8 release boundary closure and A-series termination
+**Date:** 2026-05-02
+**Status:** NOT RUN - no safe enabled-account exposure after known dormant boundary
+
+---
+
+## Required Stage 1 Smoke
+
+The pA8 contract asked for one known enabled account to prove the production path:
+
+1. enabled Hero read model;
+2. non-cohort hidden;
+3. excluded account hidden;
+4. start task through `/api/hero/command`;
+5. launch through the normal subject command path;
+6. subject session completion under Worker authority;
+7. Worker-verified claim;
+8. single daily +100 Hero Coin award;
+9. duplicate claim blocked;
+10. Camp invite/grow succeeds or is calmly blocked;
+11. no subject Stars, mastery, or subject monster mutation;
+12. Hero metrics rows or precise non-observability;
+13. support log row or explicit zero.
+
+---
+
+## Actual A8 Evidence
+
+| Requirement | A8 result | Evidence |
+|-------------|-----------|----------|
+| Known enabled account | Not supplied | After Day 0, production exposure boundary is zero accounts |
+| Controlled demo/test allowlist probe | Not qualifying | Temporarily allowlisted one production demo/test account; read model returned status 200 but `ui.enabled=false` and task count 0 |
+| Controlled demo/test with Grammar subject state | Not qualifying | Created a fresh production demo/test account, completed one Grammar session through the normal subject command path, temporarily allowlisted it, and read Hero. Result: status 200, `ui.enabled=false`, `ui.reason=no-eligible-subjects`, task count 0 |
+| Enabled Hero read model | Not run | Running it would require widening an account |
+| Non-cohort hidden | PASS | Post-rehearsal demo/non-cohort read model returned 404 `hero_shadow_disabled` |
+| Excluded account hidden | Control present, no account in list | `HERO_EXCLUDED_ACCOUNTS` exists as a known empty JSON array |
+| Hero command controlled while disabled | PASS | Post-rehearsal demo command returned 404 `hero_launch_disabled`; emergency-off command returned controlled 403 `hero-unavailable` |
+| Subject completion, claim, coins, Camp | Not run | Requires a known enabled account and owned release window |
+| Metrics rows | Zero usage statement | Production `child_game_state` and `event_log` have 0 Hero rows |
+| Support log | Explicit zero supplied rows | No live family exposure after A8 rotation |
+
+---
+
+## Decision Impact
+
+This is not a smoke pass. It is the reason A8 cannot normalise or widen. The extra demo-with-Grammar-state probe shows that self-minting a production demo/test account during A8 still does not produce the known enabled account required by Stage 1.
+
+The full pA8 contract is not complete. The dormant-boundary decision is:
+
+```txt
+KEEP DORMANT UNTIL OWNED
+```
+
+Do not create A9 to chase this smoke. The next attempt needs a named product release window and a supplied known account.

--- a/docs/plans/james/hero-mode/A/hero-pA8-live-rollout-log.md
+++ b/docs/plans/james/hero-mode/A/hero-pA8-live-rollout-log.md
@@ -1,0 +1,36 @@
+# Hero Mode pA8 - Live Rollout Log
+
+**Phase:** A8 release boundary closure and A-series termination
+**Date:** 2026-05-02
+**Status:** LIVE PRODUCTION BOUNDARY CLOSED - known dormant, no widening
+**Machine-readable evidence summary:** `reports/hero/hero-pA8-release-boundary.json`
+
+---
+
+## Rollout Timeline
+
+| Date/Time UTC | Flag or secret changed | Population affected | Operator | Smoke result | Stop/warning conditions | Decision |
+|---------------|------------------------|---------------------|----------|--------------|-------------------------|----------|
+| 2026-05-02 20:30-20:37 | Rotated `HERO_INTERNAL_ACCOUNTS=[]`; created `HERO_EXTERNAL_ACCOUNTS=[]`, `HERO_EXCLUDED_ACCOUNTS=[]`, `HERO_EMERGENCY_DISABLED=false`, `HERO_ROLLOUT_PERCENT=0`; temporarily set `HERO_EMERGENCY_DISABLED=true` for rehearsal, then restored `false` | Exposure narrowed to known zero accounts. No account remained widened after the rotation. | Codex on `hero-mode` using OAuth-safe Wrangler wrapper | Emergency-off rehearsal passed for dormant boundary: demo read model returned hidden Hero shape, command returned controlled 403; post-rehearsal dormant read model returned 404 `hero_shadow_disabled` and command returned 404 `hero_launch_disabled` | Known enabled-account smoke not run because there is no supplied known real/internal account for a safe release window. Live Hero state and event rows remain zero. | KEEP DORMANT UNTIL OWNED; full pA8 release execution incomplete |
+| 2026-05-02 20:44 | Temporarily allowlisted one controlled production demo/test account, then restored `HERO_INTERNAL_ACCOUNTS=[]` | One demo/test account was probed and then removed; no real family account widened | Codex on `hero-mode` using OAuth-safe Wrangler wrapper | Enabled read-model probe returned status 200, but `ui.enabled=false` and task count 0 | Not a valid Stage 1 known-account smoke target; do not normalise or widen | KEEP DORMANT UNTIL OWNED |
+| 2026-05-02 20:52-20:54 | Created controlled production demo/test accounts through existing smoke helpers; completed one Grammar session through the normal subject command path; temporarily allowlisted one prepared demo/test account, then restored `HERO_INTERNAL_ACCOUNTS=[]` | Demo/test accounts only. No real family account widened. | Codex on `hero-mode` using OAuth-safe Wrangler wrapper | Grammar production smoke passed, but the prepared demo/test Hero read model still returned status 200 with `ui.enabled=false`, `ui.reason=no-eligible-subjects`, and task count 0 | Still not a valid Stage 1 known-account smoke target; do not normalise or widen | KEEP DORMANT UNTIL OWNED |
+
+---
+
+## What Was Changed
+
+- `HERO_INTERNAL_ACCOUNTS` was rotated from unknown write-only state to a known empty JSON array.
+- `HERO_EXTERNAL_ACCOUNTS` was created as a known empty JSON array.
+- `HERO_EXCLUDED_ACCOUNTS` was created as a known empty JSON array.
+- `HERO_EMERGENCY_DISABLED` was created, rehearsed as `true`, and restored to `false`.
+- `HERO_ROLLOUT_PERCENT` was created as `0`.
+
+No global Hero flag was turned on. Controlled production demo/test accounts were temporarily allowlisted for non-qualifying probes and then removed. No real family account was added to an allowlist, and no account remains widened by A8.
+
+A8 did make production secret writes to force a known dormant boundary after the write-only pA7 state. That is a narrower operational closure than strict full pA8 release execution, because the known-account entry criterion was not available.
+
+---
+
+## Final Rollout Entry
+
+A8 records a dormant-boundary production decision, not a full pA8 smoke pass. The next Hero Mode work, if any, is not A9. It must be a normal product release window, bugfix, or product rework brief with a named owner and a supplied known account.

--- a/docs/plans/james/hero-mode/A/hero-pA8-metrics-summary.md
+++ b/docs/plans/james/hero-mode/A/hero-pA8-metrics-summary.md
@@ -1,0 +1,42 @@
+# Hero Mode pA8 - Metrics Summary
+
+**Phase:** A8 release boundary closure and A-series termination
+**Date:** 2026-05-02
+**Status:** LIVE PRODUCTION ZERO-USAGE STATEMENT
+
+---
+
+## Source Truth
+
+| Source | A8 role | Result |
+|--------|---------|--------|
+| `child_game_state` where `system_id='hero-mode'` | Authoritative Hero state, economy, ledger, Camp | 0 rows |
+| `event_log` where `system_id='hero-mode'` | Observational Hero telemetry mirror | 0 rows |
+| Cloudflare Worker secret-name list | Exposure-control presence only | Internal, external, excluded, emergency-off, and rollout-percent controls present |
+| Secret rotations | Exposure count truth | Internal/external/excluded lists rotated or created as empty arrays; rollout percent set to 0 |
+| Production demo checks | Boundary behaviour | Emergency-off hides read model and rejects command; dormant state returns flag-disabled responses; prepared demo/test account still has no Hero-eligible subjects |
+
+---
+
+## Population Context
+
+| Metric | Live value | Evidence note |
+|--------|------------|---------------|
+| Adult accounts | 176 | D1 read-only count after A8 demo checks |
+| Real accounts | 5 | D1 read-only count |
+| Demo accounts | 171 | D1 read-only count |
+| Known Hero-exposed accounts | 0 | Secret rotation to empty internal/external allowlists and rollout percent 0 |
+| Hero state rows | 0 | D1 read-only count |
+| Hero event rows | 0 | D1 read-only count |
+
+---
+
+## Metrics Decision
+
+There are no live Hero usage rows to summarise. That is now an honest zero-usage statement under a known zero-exposure boundary, not an unknown hold.
+
+The metrics support the final decision:
+
+```txt
+KEEP DORMANT UNTIL OWNED
+```

--- a/docs/plans/james/hero-mode/A/hero-pA8-release-command-centre.md
+++ b/docs/plans/james/hero-mode/A/hero-pA8-release-command-centre.md
@@ -1,0 +1,52 @@
+# Hero Mode pA8 - Release Command Centre
+
+**Phase:** A8 release boundary closure and A-series termination
+**Date:** 2026-05-02
+**Status:** LIVE PRODUCTION BOUNDARY CLOSED - known dormant, no widening
+**Contract:** `docs/plans/james/hero-mode/A/hero-mode-pA8.md`
+**Machine-readable evidence summary:** `reports/hero/hero-pA8-release-boundary.json`
+
+---
+
+## Owner Register
+
+| Role | Named owner | Status | Boundary |
+|------|-------------|--------|----------|
+| Product owner | James | RECORDED FOR DORMANT DECISION | Must supply the next product release window and known account before any exposure |
+| Engineering owner | Codex on branch `hero-mode` | REPO-SIDE IMPLEMENTATION/PR ONLY | Completed boundary closure artefacts and live operational checks |
+| Support owner | James | RECORDED FOR DORMANT DECISION | No live family watch window is active while exposure is zero |
+| Daily review owner | James | RECORDED FOR DORMANT DECISION | Review is only needed before a future owned release window |
+| Rollback operator | James/Codex operator using OAuth-safe Wrangler scripts | REHEARSED FOR DORMANT BOUNDARY | Emergency-off set true, verified, then restored false |
+
+---
+
+## Current Live Exposure Boundary
+
+Observed and changed with live production Cloudflare OAuth-safe commands on 2026-05-02.
+
+| Field | Live boundary |
+|-------|---------------|
+| `HERO_INTERNAL_ACCOUNTS` | Rotated to a reviewed empty JSON array; known count 0 |
+| `HERO_EXTERNAL_ACCOUNTS` | Created as a reviewed empty JSON array; known count 0 |
+| `HERO_ROLLOUT_PERCENT` | Created as `0`; rollout-bucket exposure 0 percent |
+| `HERO_ROLLOUT_SALT` | Absent; unnecessary while rollout percentage is 0 |
+| `HERO_EXCLUDED_ACCOUNTS` | Created as a reviewed empty JSON array; opt-out/exclusion path present, known count 0 |
+| `HERO_EMERGENCY_DISABLED` | Created and restored to `false` after rehearsal |
+| Checked-in global Hero flags | All six `HERO_MODE_*_ENABLED` flags are `false` in `wrangler.jsonc` |
+| Production Hero state rows | 0 rows in `child_game_state` where `system_id='hero-mode'` |
+| Production Hero event rows | 0 rows in `event_log` where `system_id='hero-mode'` |
+| Exposed production accounts | 0 known accounts after rotation |
+
+A8 closes the pA7 blocker by replacing the write-only unknown internal allowlist with a known empty allowlist. This narrows exposure. It does not leave any account widened.
+
+Because no known enabled account was supplied, A8 could not execute the full release-smoke path. The production secret writes recorded here are operational boundary-closure side effects, not evidence that the full pA8 release execution completed.
+
+---
+
+## Day 0 Decision
+
+```txt
+KEEP DORMANT UNTIL OWNED
+```
+
+Reason: the production exposure boundary is now known, emergency-off and exclusion controls exist, and rollback hiding was rehearsed. No named known real/internal account and owned release window were supplied for the enabled-account smoke, so A8 must not normalise, widen, or create A9.

--- a/docs/plans/james/hero-mode/A/hero-pA8-rollback-evidence.md
+++ b/docs/plans/james/hero-mode/A/hero-pA8-rollback-evidence.md
@@ -1,0 +1,27 @@
+# Hero Mode pA8 - Rollback Evidence
+
+**Phase:** A8 release boundary closure and A-series termination
+**Date:** 2026-05-02
+**Status:** EMERGENCY-OFF REHEARSAL PASSED FOR DORMANT BOUNDARY
+
+---
+
+## Evidence Collected
+
+| Check | Evidence | Result |
+|-------|----------|--------|
+| Emergency-off control exists | `HERO_EMERGENCY_DISABLED` secret name present after A8 | PASS |
+| Emergency-off can be enabled | Secret temporarily set to `true` during rehearsal | PASS |
+| Read model hides Hero under emergency-off | Production demo session received status 200 with `hero.heroEnabled=false` and `hero.ui.enabled=false` | PASS |
+| Hero command rejected under emergency-off | Production demo `/api/hero/command` returned controlled 403 `hero-unavailable` | PASS |
+| Emergency-off can be restored | Secret restored to `false` after rehearsal | PASS |
+| Dormant boundary restored | Post-rehearsal read model returned 404 `hero_shadow_disabled`; command returned 404 `hero_launch_disabled` | PASS |
+| State preserved | Hero state rows stayed 0; Hero event rows stayed 0 | PASS |
+
+---
+
+## Boundary
+
+This rehearsal proves the emergency brake exists and hides/rejects Hero while the release is dormant. It does not prove re-enablement of an existing exposed cohort with balances or Hero Pool state, because A8 deliberately ended with zero exposed accounts and zero Hero rows.
+
+That limitation blocks widening and normalisation, but it does not block the final dormant decision.

--- a/docs/plans/james/hero-mode/A/hero-pA8-support-summary.md
+++ b/docs/plans/james/hero-mode/A/hero-pA8-support-summary.md
@@ -1,0 +1,43 @@
+# Hero Mode pA8 - Support Summary
+
+**Phase:** A8 release boundary closure and A-series termination
+**Date:** 2026-05-02
+**Status:** EXPLICIT ZERO LIVE FAMILY SUPPORT ROWS - no widening
+
+---
+
+## Support Ownership
+
+| Role | Name | Status |
+|------|------|--------|
+| Support owner | James | Recorded for dormant decision |
+| Daily review owner | James | Recorded for dormant decision |
+
+No live family support window was opened because A8 ended with zero exposed accounts.
+
+---
+
+## Supplied Support Issue Log
+
+| Issue Date | Reporter | Category | Description | Resolution | Owner |
+|------------|----------|----------|-------------|------------|-------|
+| 2026-05-02 | A8 branch evidence | all categories | No live Hero support rows were supplied. Production Hero state rows and event rows are both 0 after the boundary was narrowed to zero exposed accounts. | Keep dormant until a named owner supplies a release window and known account. | James |
+
+---
+
+## Aggregate Summary
+
+| Category | Open | Resolved | Total | Evidence note |
+|----------|------|----------|-------|---------------|
+| comprehension | 0 | 0 | 0 | No live family exposure after A8 rotation |
+| technical | 0 | 0 | 0 | No live family exposure after A8 rotation |
+| economy | 0 | 0 | 0 | No live family exposure after A8 rotation |
+| boundary | 0 | 0 | 0 | Exposure boundary is known zero |
+| opt-out | 0 | 0 | 0 | Exclusion control exists; list count is 0 |
+| **Total** | 0 | 0 | 0 | Explicit zero supplied rows under dormant state |
+
+---
+
+## Support Decision
+
+Support is not ready for wider family exposure because no live watch window or known-account smoke was supplied. Support is sufficient for the A8 dormant decision because no family is newly exposed.

--- a/reports/hero/hero-pA8-release-boundary.json
+++ b/reports/hero/hero-pA8-release-boundary.json
@@ -1,0 +1,161 @@
+{
+  "phase": "hero-mode-pA8",
+  "status": "live-production-dormant-boundary-recorded-full-pa8-contract-incomplete",
+  "generatedAt": "2026-05-02T20:54:26Z",
+  "evidenceCodeBaseline": "9a91db991d0dfacff834cbf4c4a7bf20683e0883",
+  "productionOrigin": "https://ks2.eugnel.uk",
+  "contract": "docs/plans/james/hero-mode/A/hero-mode-pA8.md",
+  "sourceCommandDetail": "Exact secret names, D1 read-only queries, and package-script commands are listed. Inline production probe scripts are summarised rather than replayable because they carried short-lived session cookies and demo account identifiers.",
+  "sourceCommands": [
+    "node scripts/wrangler-oauth.mjs secret list",
+    "printf '[]' | node scripts/wrangler-oauth.mjs secret put HERO_INTERNAL_ACCOUNTS",
+    "printf '[]' | node scripts/wrangler-oauth.mjs secret put HERO_EXTERNAL_ACCOUNTS",
+    "printf '[]' | node scripts/wrangler-oauth.mjs secret put HERO_EXCLUDED_ACCOUNTS",
+    "printf 'false' | node scripts/wrangler-oauth.mjs secret put HERO_EMERGENCY_DISABLED",
+    "printf '0' | node scripts/wrangler-oauth.mjs secret put HERO_ROLLOUT_PERCENT",
+    "printf 'true' | node scripts/wrangler-oauth.mjs secret put HERO_EMERGENCY_DISABLED",
+    "node --input-type=module <production demo emergency-off read-model and command rehearsal>",
+    "printf 'false' | node scripts/wrangler-oauth.mjs secret put HERO_EMERGENCY_DISABLED",
+    "node --input-type=module <production demo dormant-boundary read-model and command check>",
+    "node --input-type=module <create production demo session, temporarily set HERO_INTERNAL_ACCOUNTS to that demo account, read /api/hero/read-model, then restore HERO_INTERNAL_ACCOUNTS=[]>",
+    "node --input-type=module <production demo dormant-boundary read-model check after restoring HERO_INTERNAL_ACCOUNTS=[]>",
+    "npm run smoke:production:grammar -- --json --timeout-ms 30000",
+    "node --input-type=module <create production demo session, complete one Grammar session through subject command path, temporarily set HERO_INTERNAL_ACCOUNTS to that demo account, read /api/hero/read-model, then restore HERO_INTERNAL_ACCOUNTS=[]>",
+    "node scripts/wrangler-oauth.mjs d1 execute ks2-mastery-db --remote --json --command \"SELECT COUNT(*) AS hero_state_rows FROM child_game_state WHERE system_id='hero-mode';\"",
+    "node scripts/wrangler-oauth.mjs d1 execute ks2-mastery-db --remote --json --command \"SELECT COUNT(*) AS hero_event_rows FROM event_log WHERE system_id='hero-mode';\"",
+    "node scripts/wrangler-oauth.mjs d1 execute ks2-mastery-db --remote --json --command \"SELECT COUNT(*) AS adult_accounts, SUM(CASE WHEN account_type = 'demo' THEN 0 ELSE 1 END) AS real_accounts, SUM(CASE WHEN account_type = 'demo' THEN 1 ELSE 0 END) AS demo_accounts FROM adult_accounts;\""
+  ],
+  "productionBoundary": {
+    "observedAt": "2026-05-02T20:37:42Z",
+    "valuesReadable": false,
+    "knownByRotation": true,
+    "secretNamesPresent": {
+      "HERO_INTERNAL_ACCOUNTS": true,
+      "HERO_EXTERNAL_ACCOUNTS": true,
+      "HERO_ROLLOUT_PERCENT": true,
+      "HERO_ROLLOUT_SALT": false,
+      "HERO_EXCLUDED_ACCOUNTS": true,
+      "HERO_EMERGENCY_DISABLED": true
+    },
+    "knownCounts": {
+      "internalAllowlistAccountCount": 0,
+      "externalAllowlistAccountCount": 0,
+      "excludedAccountCount": 0,
+      "rolloutPercent": 0
+    },
+    "currentIntendedValues": {
+      "HERO_INTERNAL_ACCOUNTS": "known empty JSON array",
+      "HERO_EXTERNAL_ACCOUNTS": "known empty JSON array",
+      "HERO_EXCLUDED_ACCOUNTS": "known empty JSON array",
+      "HERO_EMERGENCY_DISABLED": "false",
+      "HERO_ROLLOUT_PERCENT": "0"
+    },
+    "temporaryDemoProbeAllowlisting": true,
+    "realFamilyWideningByThisBranch": false,
+    "permanentWideningByThisBranch": false,
+    "remainingWidenedAccounts": 0,
+    "knownExposureBoundary": true,
+    "exposedAccountCount": 0
+  },
+  "checkedInHeroFlags": {
+    "HERO_MODE_SHADOW_ENABLED": "false",
+    "HERO_MODE_LAUNCH_ENABLED": "false",
+    "HERO_MODE_CHILD_UI_ENABLED": "false",
+    "HERO_MODE_PROGRESS_ENABLED": "false",
+    "HERO_MODE_ECONOMY_ENABLED": "false",
+    "HERO_MODE_CAMP_ENABLED": "false"
+  },
+  "productionD1Counts": {
+    "adultAccounts": 176,
+    "realAccounts": 5,
+    "demoAccounts": 171,
+    "heroStateRows": 0,
+    "heroEventRows": 0
+  },
+  "emergencyOffRehearsal": {
+    "ranAt": "2026-05-02T20:36:31Z",
+    "temporarySecretValue": "true",
+    "restoredSecretValue": "false",
+    "demoSession": {
+      "status": 201,
+      "cookieIssued": true,
+      "demo": true
+    },
+    "session": {
+      "status": 200,
+      "learnerPresent": true
+    },
+    "readModelWhileEmergencyOff": {
+      "status": 200,
+      "heroEnabled": false,
+      "uiEnabled": false
+    },
+    "commandWhileEmergencyOff": {
+      "status": 403,
+      "controlledNon500": true,
+      "error": "hero-unavailable"
+    },
+    "statePreserved": {
+      "heroStateRowsBefore": 0,
+      "heroStateRowsAfter": 0,
+      "heroEventRowsBefore": 0,
+      "heroEventRowsAfter": 0
+    },
+    "result": "pass-for-dormant-boundary"
+  },
+  "postRehearsalDormantCheck": {
+    "ranAt": "2026-05-02T20:37:03Z",
+    "readModelStatus": 404,
+    "readModelCode": "hero_shadow_disabled",
+    "commandStatus": 404,
+    "commandCode": "hero_launch_disabled",
+    "commandControlledNon500": true
+  },
+  "knownAccountSmoke": {
+    "result": "not-run",
+    "reason": "After pA8 Day 0 rotation the known production exposure boundary is zero accounts. No named real/internal account was supplied for a safe enabled-account smoke. A controlled production demo/test account was temporarily allowlisted, but its Hero read model had ui.enabled=false and zero tasks. A second production-safe demo/test account completed a Grammar session through the normal subject command path before temporary allowlisting; its Hero read model still had ui.enabled=false, ui.reason=no-eligible-subjects, and zero tasks. Neither probe is a valid Stage 1 smoke target.",
+    "wideningAllowed": false
+  },
+  "controlledDemoAllowlistProbe": {
+    "ranAt": "2026-05-02T20:44:11Z",
+    "temporaryInternalAllowlistCount": 1,
+    "restoredInternalAllowlistCount": 0,
+    "readModelStatus": 200,
+    "uiEnabled": false,
+    "questPresent": true,
+    "taskCount": 0,
+    "result": "not-a-valid-known-account-smoke"
+  },
+  "controlledDemoWithGrammarStateProbe": {
+    "ranAt": "2026-05-02T20:53:21Z",
+    "temporaryInternalAllowlistCount": 1,
+    "restoredInternalAllowlistCount": 0,
+    "subjectPreparation": "completed one production Grammar session through the normal subject command path on a controlled demo/test account",
+    "readModelStatus": 200,
+    "uiEnabled": false,
+    "uiReason": "no-eligible-subjects",
+    "taskCount": 0,
+    "eligibleSubjects": [],
+    "result": "not-a-valid-known-account-smoke"
+  },
+  "supportPosture": {
+    "supportOwner": "James",
+    "dailyReviewOwner": "James",
+    "supportRowsSupplied": 0,
+    "explicitZeroRecorded": true,
+    "optOutControlPresent": true,
+    "optOutCount": 0,
+    "readyForWidening": false
+  },
+  "decision": {
+    "selectedOutcome": "KEEP DORMANT UNTIL OWNED",
+    "contractComplete": false,
+    "dormantBoundaryRecorded": true,
+    "normalisationAllowed": false,
+    "wideningAllowed": false,
+    "aSeriesTerminated": true,
+    "reviewBy": "2026-05-16",
+    "owner": "James",
+    "reason": "The release boundary is now known and dormant, emergency-off and exclusion controls exist, rollback hiding was rehearsed without state loss, and live Hero rows remain zero. Full pA8 release execution is incomplete because no valid known enabled account smoke passed; the honest production decision is to keep Hero Mode dormant until a named owner supplies the account and release window."
+  }
+}


### PR DESCRIPTION
## Summary
- records the Hero Mode pA8 production exposure boundary as known zero after rotating the write-only pA7 allowlist state
- documents emergency-off rehearsal, exclusion/rollout controls, zero Hero state/event rows, support zeroes, and the final KEEP DORMANT UNTIL OWNED decision
- records that controlled demo/test probes did not qualify as Stage 1 known-account smoke, so this is not normalisation or widening evidence

## Verification
- npm test (passed earlier in this worktree before final doc-only evidence edits)
- npm run check (passed earlier in this worktree before final doc-only evidence edits)
- npm run verify:hero-pA7 (passed earlier in this worktree)
- node -e "JSON.parse(require('fs').readFileSync('reports/hero/hero-pA8-release-boundary.json','utf8')); console.log('pA8-json-ok')"
- git diff --cached --check before commit

## Review
- Independent contract review: valid dormant-boundary closure and A-series termination; no release/widening/normalisation approval.
- Independent code/evidence hygiene review: initial temporary-allowlist wording blocker fixed; no remaining blocker for a dormant-boundary-record PR.

## Production Decision
KEEP DORMANT UNTIL OWNED. Full pA8 release execution remains incomplete because no valid known enabled account smoke passed.