### PR TITLE
Close UI refactor P5 operating contract

### DIFF
--- a/docs/expansion-readiness.md
+++ b/docs/expansion-readiness.md
@@ -88,6 +88,7 @@ Arithmetic should only be considered complete when all of the following are true
 
 - it plugs into the new conformance suite
 - it plugs into the new golden-path smoke harness
+- it exposes a ready `SubjectVisualAdapter` as defined in `docs/subject-visual-adapter-contract.md`, while Reading and Reasoning remain unavailable adapters until their production engines exist
 - it persists through the generic repository collections
 - it publishes domain events through the existing event runtime
 - it exposes a subject-owned analytics snapshot

--- a/docs/plans/james/ui-refactor/ui-refactor-p4-completion-report.md
+++ b/docs/plans/james/ui-refactor/ui-refactor-p4-completion-report.md
@@ -2,12 +2,12 @@
 
 Date: 2026-05-01
 
-Status: source, local build, deployed smoke, and live production screenshot evidence captured for `https://ks2.eugnel.uk`. P4 has no remaining production-evidence blocker. P5/P6 is not claimed because no `ui-refactor-p5.md` or `ui-refactor-p6.md` contract exists in this repository.
+Status: source, local build, and deployed smoke evidence captured for `https://ks2.eugnel.uk`. P4 has no remaining production-smoke blocker. The committed screenshot pack proves only the screenshot files present in this repository; missing screenshot paths in the production visual evidence manifest are explicitly downgraded and are not bundled-image claims. P5 is tracked separately by `ui-refactor-p5.md`; this P4 report does not claim P5 delivery.
 
 ## Scope Boundary
 
 - Source boundary: implemented and verified in local worktree `.worktrees/ui-refactor-p4` on branch `ui-refactor-p4`, then production evidence/fix work continued in `.worktrees/ui-refactor-p4-production-evidence-clean`.
-- GitHub boundary: P4 source was merged through PR `#815`; this report now also records the follow-up production-evidence closure and Admin Visual Engine routing fix.
+- GitHub boundary: P4 source was merged through PR `#815`; the follow-up production-evidence closure and Admin Visual Engine routing fix were merged through PR `#823`.
 - ZIP boundary: no ZIP snapshot was used as the source of truth after these edits; verification is from the local source checkout.
 - Production boundary: deployed smoke 2026-05-01 against `https://ks2.eugnel.uk` passed; screenshot evidence was captured from an isolated production demo session plus a logged-in admin browser session.
 
@@ -78,7 +78,9 @@ Known non-failing output:
 
 ## Production Evidence
 
-Production evidence: production-proven for the P4 surfaces in scope.
+Production smoke evidence: production-smoke-proven for the P4 surfaces covered by the recorded smoke files.
+
+Screenshot-pack evidence: screenshot-pack-proven only for committed screenshot files that are present in this repository. The current committed pack contains `01-home.png`; the other screenshot entries in `reports/ui-refactor/ui-refactor-p4-production-visual-evidence-2026-05-01.json` are marked `omitted` with durable non-claim reasons because their PNG files are not present in the lean source bundle.
 
 Deployed smoke and screenshot evidence was captured on 2026-05-01 for `https://ks2.eugnel.uk`:
 
@@ -88,12 +90,12 @@ Deployed smoke and screenshot evidence was captured on 2026-05-01 for `https://k
 - Grammar production smoke: `reports/ui-refactor/ui-refactor-p4-grammar-production-smoke-2026-05-01.json` (`ok: true`, release `grammar-qg-p14-2026-05-01`, deployed source commit `91dcbabd9b948a8b53c1231c692eb04ff2e8b4fa`, finished `2026-05-01T22:45:26.783Z`).
 - Punctuation production smoke: `reports/ui-refactor/ui-refactor-p4-punctuation-production-smoke-2026-05-01.json` (`ok: true`, release `punctuation-qg-p11-2026-05-01`, deployed source commit `91dcbabd9b948a8b53c1231c692eb04ff2e8b4fa`, finished `2026-05-01T22:45:38.946Z`; `adminHubCoverage: false` because admin credentials are not part of that script).
 - Visual production evidence manifest: `reports/ui-refactor/ui-refactor-p4-production-visual-evidence-2026-05-01.json`.
-- Screenshot artifacts: Home, Spelling setup/session/feedback/summary, Grammar setup/session/summary, Punctuation setup/session/summary, and Admin Visual Engine under `output/playwright/ui-refactor-p4-production-2026-05-01/`.
+- Screenshot artifacts: Home is present under `output/playwright/ui-refactor-p4-production-2026-05-01/01-home.png`. Spelling setup/session/feedback/summary, Grammar setup/session/summary, Punctuation setup/session/summary, and Admin Visual Engine were named in the original manifest but are not present in this committed evidence pack, so P5 treats them as not proven from supplied artefacts.
 
 Residual blockers:
 
 - None for P4 production evidence after the follow-up fixes.
-- No `ui-refactor-p5.md` or `ui-refactor-p6.md` contract exists in this repository, so this report cannot truthfully claim P5/P6 delivery. It closes P4 plus the production-evidence follow-up only.
+- This report cannot truthfully claim P5/P6 delivery. It closes P4 plus the production-evidence follow-up only.
 
 ## Non-Goals
 

--- a/docs/subject-expansion.md
+++ b/docs/subject-expansion.md
@@ -39,6 +39,8 @@ Punctuation is now the first production non-Spelling subject using this path. It
 
 The browser shell has since moved to a single React root. Subject presentation flows through `SubjectRoute` and React practice components.
 
+Visual Engine v1 adds one more presentation contract for every registered subject: `SubjectVisualAdapter`, documented in `docs/subject-visual-adapter-contract.md`. A production-ready subject should expose ready adapter sections for setup, session HUD, companion panel, practice stage, and summary frame through its subject module. Placeholder subjects such as Reading, Reasoning, and Arithmetic may expose unavailable adapters, but they must not gain production practice controls or browser scoring engines from the visual adapter alone.
+
 The full-lockdown baseline adds one more production rule: a new public subject must not ship its production engine as a browser runtime. The React component may render controls, local form state, and returned read models, but session creation, marking, scheduling, progress mutation, and reward projection should be owned by Worker subject commands before the subject is treated as production-ready.
 
 ## Thin-slice reference contract

--- a/docs/subject-visual-adapter-contract.md
+++ b/docs/subject-visual-adapter-contract.md
@@ -1,0 +1,9 @@
+# Subject Visual Adapter Contract
+
+Visual Engine v1 exposes a read-only `SubjectVisualAdapter` metadata shape for every registered subject.
+
+Ready subjects (`spelling`, `grammar`, `punctuation`) declare how their setup scene, session HUD, companion panel, practice stage, and summary frame map into the shared Visual Engine primitives.
+
+Placeholder subjects (`reading`, `reasoning`, `arithmetic`) declare the same sections as unavailable. They must not expose production practice controls, Worker command handlers, or browser-only subject engines until a subject-specific launch contract makes them ready.
+
+The adapter is display metadata. Subject-owned learning logic, marking, scheduling, rewards, Stars, and Worker command handling remain in the subject modules and services.

--- a/reports/ui-refactor/ui-refactor-p4-production-visual-evidence-2026-05-01.json
+++ b/reports/ui-refactor/ui-refactor-p4-production-visual-evidence-2026-05-01.json
@@ -4,10 +4,28 @@
   "capturedAt": "2026-05-01T22:48:25Z",
   "deployment": {
     "versionId": "0bc250a8-1224-476c-a534-c383814527f8",
+    "sourceCommit": "91dcbabd9b948a8b53c1231c692eb04ff2e8b4fa",
     "productionBundleAudit": "passed",
     "appBundleGzipBytes": 230865,
     "appBundleBudgetBytes": 232000
   },
+  "smokeFiles": [
+    {
+      "name": "bootstrap",
+      "status": "present",
+      "path": "reports/ui-refactor/ui-refactor-p4-bootstrap-production-smoke-2026-05-01.json"
+    },
+    {
+      "name": "grammar",
+      "status": "present",
+      "path": "reports/ui-refactor/ui-refactor-p4-grammar-production-smoke-2026-05-01.json"
+    },
+    {
+      "name": "punctuation",
+      "status": "present",
+      "path": "reports/ui-refactor/ui-refactor-p4-punctuation-production-smoke-2026-05-01.json"
+    }
+  ],
   "sessions": {
     "subjectScreenshots": "isolated production demo sessions created through /api/demo/session; Spelling summary used a deterministic one-word single drill request on the production command path",
     "adminScreenshot": "logged-in production admin browser session via bb-browser"
@@ -20,59 +38,70 @@
     },
     {
       "name": "spelling-setup",
-      "status": "captured",
-      "path": "output/playwright/ui-refactor-p4-production-2026-05-01/02-spelling-setup.png"
+      "status": "omitted",
+      "path": "output/playwright/ui-refactor-p4-production-2026-05-01/02-spelling-setup.png",
+      "reason": "The lean source bundle does not contain this PNG, so P5 treats it as not screenshot-pack-proven from committed artefacts."
     },
     {
       "name": "spelling-session",
-      "status": "captured",
-      "path": "output/playwright/ui-refactor-p4-production-2026-05-01/03-spelling-session.png"
+      "status": "omitted",
+      "path": "output/playwright/ui-refactor-p4-production-2026-05-01/03-spelling-session.png",
+      "reason": "The lean source bundle does not contain this PNG, so P5 treats it as not screenshot-pack-proven from committed artefacts."
     },
     {
       "name": "spelling-feedback",
-      "status": "captured",
-      "path": "output/playwright/ui-refactor-p4-production-2026-05-01/04-spelling-feedback.png"
+      "status": "omitted",
+      "path": "output/playwright/ui-refactor-p4-production-2026-05-01/04-spelling-feedback.png",
+      "reason": "The lean source bundle does not contain this PNG, so P5 treats it as not screenshot-pack-proven from committed artefacts."
     },
     {
       "name": "spelling-summary",
-      "status": "captured",
+      "status": "omitted",
       "path": "output/playwright/ui-refactor-p4-production-2026-05-01/04-spelling-summary.png",
+      "reason": "The lean source bundle does not contain this PNG, so P5 treats it as not screenshot-pack-proven from committed artefacts.",
       "detail": "Captured after the remote command response fix preserved the live summary read model returned by the Worker."
     },
     {
       "name": "grammar-setup",
-      "status": "captured",
-      "path": "output/playwright/ui-refactor-p4-production-2026-05-01/05-grammar-setup.png"
+      "status": "omitted",
+      "path": "output/playwright/ui-refactor-p4-production-2026-05-01/05-grammar-setup.png",
+      "reason": "The lean source bundle does not contain this PNG, so P5 treats it as not screenshot-pack-proven from committed artefacts."
     },
     {
       "name": "grammar-session",
-      "status": "captured",
-      "path": "output/playwright/ui-refactor-p4-production-2026-05-01/06-grammar-session.png"
+      "status": "omitted",
+      "path": "output/playwright/ui-refactor-p4-production-2026-05-01/06-grammar-session.png",
+      "reason": "The lean source bundle does not contain this PNG, so P5 treats it as not screenshot-pack-proven from committed artefacts."
     },
     {
       "name": "grammar-summary",
-      "status": "captured",
-      "path": "output/playwright/ui-refactor-p4-production-2026-05-01/07-grammar-summary.png"
+      "status": "omitted",
+      "path": "output/playwright/ui-refactor-p4-production-2026-05-01/07-grammar-summary.png",
+      "reason": "The lean source bundle does not contain this PNG, so P5 treats it as not screenshot-pack-proven from committed artefacts."
     },
     {
       "name": "punctuation-setup",
-      "status": "captured",
-      "path": "output/playwright/ui-refactor-p4-production-2026-05-01/08-punctuation-setup.png"
+      "status": "omitted",
+      "path": "output/playwright/ui-refactor-p4-production-2026-05-01/08-punctuation-setup.png",
+      "reason": "The lean source bundle does not contain this PNG, so P5 treats it as not screenshot-pack-proven from committed artefacts."
     },
     {
       "name": "punctuation-session",
-      "status": "captured",
-      "path": "output/playwright/ui-refactor-p4-production-2026-05-01/09-punctuation-session.png"
+      "status": "omitted",
+      "path": "output/playwright/ui-refactor-p4-production-2026-05-01/09-punctuation-session.png",
+      "reason": "The lean source bundle does not contain this PNG, so P5 treats it as not screenshot-pack-proven from committed artefacts."
     },
     {
       "name": "punctuation-summary",
-      "status": "captured",
-      "path": "output/playwright/ui-refactor-p4-production-2026-05-01/10-punctuation-summary.png"
+      "status": "omitted",
+      "path": "output/playwright/ui-refactor-p4-production-2026-05-01/10-punctuation-summary.png",
+      "reason": "The lean source bundle does not contain this PNG, so P5 treats it as not screenshot-pack-proven from committed artefacts."
     },
     {
       "name": "admin-visual-engine",
-      "status": "captured",
-      "path": "output/playwright/ui-refactor-p4-production-2026-05-01/11-admin-visual-engine.png"
+      "status": "omitted",
+      "path": "output/playwright/ui-refactor-p4-production-2026-05-01/11-admin-visual-engine.png",
+      "reason": "The lean source bundle does not contain this PNG, so P5 treats it as not screenshot-pack-proven from committed artefacts."
     }
   ],
   "discoveredFixes": [

--- a/scripts/verify-ui-refactor-visual-evidence.mjs
+++ b/scripts/verify-ui-refactor-visual-evidence.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const DEFAULT_MANIFEST = path.join(
+  rootDir,
+  'reports/ui-refactor/ui-refactor-p4-production-visual-evidence-2026-05-01.json',
+);
+
+function hasDurableReason(entry) {
+  return typeof entry.reason === 'string' && entry.reason.trim().length >= 12;
+}
+
+function validateExternal(entry) {
+  const failures = [];
+
+  if (!hasDurableReason(entry)) {
+    failures.push('external screenshot entries require a durable reason');
+  }
+
+  if (
+    typeof entry.url !== 'string'
+    && typeof entry.externalUrl !== 'string'
+    && typeof entry.evidenceUrl !== 'string'
+  ) {
+    failures.push('external screenshot entries require url, externalUrl, or evidenceUrl');
+  }
+
+  return failures;
+}
+
+function validateOmitted(entry) {
+  return hasDurableReason(entry)
+    ? []
+    : ['omitted screenshot entries require a durable reason'];
+}
+
+export function verifyUiRefactorVisualEvidence(manifestPath = DEFAULT_MANIFEST, options = {}) {
+  const baseDir = options.baseDir ?? rootDir;
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  const screenshots = Array.isArray(manifest.screenshots) ? manifest.screenshots : [];
+  const failures = [];
+
+  if (screenshots.length === 0) {
+    failures.push('manifest must contain screenshots[] entries');
+  }
+
+  screenshots.forEach((entry, index) => {
+    const label = entry.name ?? `screenshots[${index}]`;
+    const status = String(entry.status ?? '').toLowerCase();
+
+    if (status === 'external') {
+      validateExternal(entry).forEach((failure) => failures.push(`${label}: ${failure}`));
+      return;
+    }
+
+    if (status === 'omitted') {
+      validateOmitted(entry).forEach((failure) => failures.push(`${label}: ${failure}`));
+      return;
+    }
+
+    if (typeof entry.path !== 'string' || entry.path.trim().length === 0) {
+      failures.push(`${label}: captured screenshot entries require path`);
+      return;
+    }
+
+    const screenshotPath = path.isAbsolute(entry.path)
+      ? entry.path
+      : path.join(baseDir, entry.path);
+
+    if (!existsSync(screenshotPath)) {
+      failures.push(`${label}: missing screenshot file ${entry.path}`);
+    }
+  });
+
+  return {
+    ok: failures.length === 0,
+    manifestPath,
+    screenshotCount: screenshots.length,
+    failures,
+  };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const manifestPath = process.argv[2] ? path.resolve(process.argv[2]) : DEFAULT_MANIFEST;
+  const result = verifyUiRefactorVisualEvidence(manifestPath);
+
+  if (!result.ok) {
+    console.error(`UI refactor visual evidence verification failed for ${manifestPath}`);
+    for (const failure of result.failures) {
+      console.error(`- ${failure}`);
+    }
+    process.exitCode = 1;
+  } else {
+    console.log(
+      `UI refactor visual evidence verified: ${result.screenshotCount} screenshot entries checked.`,
+    );
+  }
+}

--- a/src/platform/ui/subject-visual-adapter.js
+++ b/src/platform/ui/subject-visual-adapter.js
@@ -1,0 +1,58 @@
+export const SUBJECT_VISUAL_ADAPTER_SECTIONS = Object.freeze([
+  'setup',
+  'sessionHud',
+  'companionPanel',
+  'practiceStage',
+  'summaryFrame',
+]);
+
+function freezeSectionMap(sections) {
+  const next = {};
+  for (const section of SUBJECT_VISUAL_ADAPTER_SECTIONS) {
+    next[section] = Object.freeze({ ...(sections?.[section] || {}) });
+  }
+  return Object.freeze(next);
+}
+
+export function createReadySubjectVisualAdapter(subjectId, sections = {}) {
+  return Object.freeze({
+    kind: 'SubjectVisualAdapter',
+    subjectId,
+    status: 'ready',
+    productionPracticeAvailable: true,
+    sections: freezeSectionMap(sections),
+  });
+}
+
+export function createPlaceholderSubjectVisualAdapter(subjectId, label) {
+  return Object.freeze({
+    kind: 'SubjectVisualAdapter',
+    subjectId,
+    status: 'unavailable',
+    productionPracticeAvailable: false,
+    unavailableCopy: `${label || 'This subject'} is not ready for practice yet.`,
+    sections: freezeSectionMap({
+      setup: { mode: 'placeholder', primaryAction: 'unavailable-info' },
+      sessionHud: { mode: 'placeholder', available: false },
+      companionPanel: { mode: 'placeholder', available: false },
+      practiceStage: { mode: 'placeholder', available: false },
+      summaryFrame: { mode: 'placeholder', available: false },
+    }),
+  });
+}
+
+export function isSubjectVisualAdapter(candidate) {
+  return Boolean(
+    candidate
+    && candidate.kind === 'SubjectVisualAdapter'
+    && typeof candidate.subjectId === 'string'
+    && (candidate.status === 'ready' || candidate.status === 'unavailable')
+    && typeof candidate.productionPracticeAvailable === 'boolean'
+    && SUBJECT_VISUAL_ADAPTER_SECTIONS.every((section) => (
+      candidate.sections
+      && candidate.sections[section]
+      && typeof candidate.sections[section] === 'object'
+      && !Array.isArray(candidate.sections[section])
+    )),
+  );
+}

--- a/src/subjects/grammar/components/GrammarSessionScene.jsx
+++ b/src/subjects/grammar/components/GrammarSessionScene.jsx
@@ -411,7 +411,6 @@ function MiniTestStatus({ miniTest, pending, runtimeReadOnly, answerFormId }) {
     <div className="grammar-mini-test-panel" aria-label="Mini-test status">
       <div className="grammar-mini-test-meta">
         <span className="chip good">Timed test</span>
-        <span className="chip">Question {currentIndex + 1} of {Math.max(1, questions.length)}</span>
         <span className="chip">{answered} saved</span>
         <span className={`chip ${remainingMs <= 60_000 ? 'warn' : ''}`}>Time left {formatMiniTestTime(remainingMs)}</span>
       </div>

--- a/src/subjects/grammar/components/GrammarSummaryScene.jsx
+++ b/src/subjects/grammar/components/GrammarSummaryScene.jsx
@@ -187,6 +187,13 @@ function GrammarSummaryFrameAdapter({
           disabled: Boolean(disabled),
           onClick: () => actions.dispatch('grammar-open-analytics'),
         },
+        {
+          label: 'Back to dashboard',
+          dataAction: 'grammar-back',
+          variant: 'ghost',
+          disabled: Boolean(disabled),
+          onClick: () => actions.dispatch('grammar-back'),
+        },
       ]
     : [
         ...(missedConceptId ? [{
@@ -210,6 +217,13 @@ function GrammarSummaryFrameAdapter({
           ariaLabel: 'Open adult report',
           disabled: Boolean(disabled),
           onClick: () => actions.dispatch('grammar-open-analytics'),
+        },
+        {
+          label: 'Back to dashboard',
+          dataAction: 'grammar-back',
+          variant: 'ghost',
+          disabled: Boolean(disabled),
+          onClick: () => actions.dispatch('grammar-back'),
         },
       ];
   return (

--- a/src/subjects/grammar/module.js
+++ b/src/subjects/grammar/module.js
@@ -8,6 +8,7 @@ import {
 } from './metadata.js';
 import { normaliseGrammarSpeechRate } from './speech.js';
 import { dropSessionEphemeralFields } from '../../platform/core/subject-contract.js';
+import { createReadySubjectVisualAdapter } from '../../platform/ui/subject-visual-adapter.js';
 import {
   shouldDelayMonsterCelebrations,
   subjectSessionEnded,
@@ -342,6 +343,13 @@ export const grammarModule = {
   icon: 'speech',
   available: true,
   reactPractice: true,
+  visualAdapter: createReadySubjectVisualAdapter(GRAMMAR_SUBJECT_ID, {
+    setup: { component: 'GrammarSetupScene', primaryAction: 'grammar-start' },
+    sessionHud: { component: 'SessionHUD', adapter: 'GrammarSessionScene' },
+    companionPanel: { component: 'SubjectCompanionPanel', dataSource: 'monsterStrip+todayCards' },
+    practiceStage: { component: 'PracticeStage', adopted: true },
+    summaryFrame: { component: 'SessionSummaryFrame', adapter: 'GrammarSummaryFrameAdapter' },
+  }),
   initState() {
     return normaliseGrammarReadModel();
   },

--- a/src/subjects/placeholders/module-factory.js
+++ b/src/subjects/placeholders/module-factory.js
@@ -1,4 +1,5 @@
 import { createElement } from 'react';
+import { createPlaceholderSubjectVisualAdapter } from '../../platform/ui/subject-visual-adapter.js';
 
 function PlaceholderPracticeComponent({ subject }) {
   const meta = subject || {};
@@ -47,6 +48,7 @@ export function createPlaceholderSubject(meta) {
   return {
     ...meta,
     available: false,
+    visualAdapter: createPlaceholderSubjectVisualAdapter(meta.id, meta.name),
     initState() {
       return {
         placeholder: true,

--- a/src/subjects/punctuation/module.js
+++ b/src/subjects/punctuation/module.js
@@ -11,6 +11,7 @@ import {
 } from './service-contract.js';
 import { PUNCTUATION_SETUP_ROUND_LENGTH_OPTIONS } from './components/punctuation-view-model.js';
 import { SUBJECT_EXPOSURE_GATES } from '../../platform/core/subject-availability.js';
+import { createReadySubjectVisualAdapter } from '../../platform/ui/subject-visual-adapter.js';
 
 function applyTransition(context, transition) {
   if (!transition) return true;
@@ -70,6 +71,13 @@ export const punctuationModule = {
   available: true,
   exposureGate: SUBJECT_EXPOSURE_GATES.punctuation,
   reactPractice: true,
+  visualAdapter: createReadySubjectVisualAdapter('punctuation', {
+    setup: { component: 'PunctuationSetupScene', primaryAction: 'punctuation-start' },
+    sessionHud: { component: 'SessionHUD', adapter: 'PunctuationSessionScene' },
+    companionPanel: { component: 'SubjectCompanionPanel', dataSource: 'activeMonsters+stats' },
+    practiceStage: { component: 'PracticeStage', adopted: true },
+    summaryFrame: { component: 'SessionSummaryFrame', adapter: 'PunctuationSummaryFrameAdapter' },
+  }),
   initState() {
     return createInitialPunctuationState();
   },

--- a/src/subjects/spelling/module.js
+++ b/src/subjects/spelling/module.js
@@ -1,5 +1,6 @@
 import { monsterSummaryFromSpellingAnalytics } from '../../platform/game/monster-system.js';
 import { dropSessionEphemeralFields } from '../../platform/core/subject-contract.js';
+import { createReadySubjectVisualAdapter } from '../../platform/ui/subject-visual-adapter.js';
 import { monsterBranchOverrideForLearner } from '../../platform/game/learner-monster-branch-overrides.js';
 import { createInitialSpellingState, isMegaSafeMode, isPostMasteryMode } from './service-contract.js';
 import {
@@ -123,6 +124,13 @@ export const spellingModule = {
   icon: 'pen',
   available: true,
   reactPractice: true,
+  visualAdapter: createReadySubjectVisualAdapter('spelling', {
+    setup: { component: 'SpellingSetupScene', primaryAction: 'spelling-start' },
+    sessionHud: { component: 'SessionHUD', adapter: 'SpellingSessionScene' },
+    companionPanel: { component: 'SubjectCompanionPanel', dataSource: 'codex+stats' },
+    practiceStage: { component: 'PracticeStage', adopted: true },
+    summaryFrame: { component: 'SessionSummaryFrame', adapter: 'SpellingSummaryFrameAdapter' },
+  }),
   initState() {
     return createInitialSpellingState();
   },

--- a/src/surfaces/hubs/AdminVisualEngineSection.jsx
+++ b/src/surfaces/hubs/AdminVisualEngineSection.jsx
@@ -2,9 +2,11 @@ import React from 'react';
 import { AdminPanelFrame } from './AdminPanelFrame.jsx';
 import { SectionHeader } from '../../platform/ui/SectionHeader.jsx';
 import { SUBJECT_THEMES, SUBJECT_IDS } from '../../platform/ui/subject-themes.js';
+import { SUBJECTS } from '../../platform/core/subject-registry.js';
 import { MONSTER_ASSET_MANIFEST } from '../../platform/game/monster-asset-manifest.js';
 import { BUNDLED_MONSTER_VISUAL_CONFIG, MONSTER_VISUAL_CONTEXTS, MONSTER_VISUAL_MOTION_PROFILE_OPTIONS } from '../../platform/game/monster-visual-config.js';
 import { MONSTERS, MONSTERS_BY_SUBJECT } from '../../platform/game/monsters.js';
+import visualEvidenceManifest from '../../../reports/ui-refactor/ui-refactor-p4-production-visual-evidence-2026-05-01.json';
 
 // U8: Read-only diagnostic panel for admin inspection of subject theme tokens,
 // monster asset availability, and visual engine configuration.
@@ -47,11 +49,39 @@ function getMotionProfiles() {
   return profiles;
 }
 
+function evidenceRows(manifest) {
+  return (Array.isArray(manifest?.screenshots) ? manifest.screenshots : []).map((entry) => ({
+    name: entry.name || 'unknown',
+    status: entry.status || 'unknown',
+    path: entry.path || entry.externalUrl || entry.url || entry.evidenceUrl || 'not supplied',
+    reason: entry.reason || '',
+  }));
+}
+
+function smokeRows(manifest) {
+  return (Array.isArray(manifest?.smokeFiles) ? manifest.smokeFiles : []).map((entry) => ({
+    name: entry.name || 'unknown',
+    status: entry.status || 'unknown',
+    path: entry.path || 'not supplied',
+  }));
+}
+
+function evidenceStatusCounts(rows) {
+  return rows.reduce((counts, row) => {
+    counts[row.status] = (counts[row.status] || 0) + 1;
+    return counts;
+  }, {});
+}
+
 export function AdminVisualEngineSection() {
   const placeholders = detectPlaceholderAssets(MONSTER_ASSET_MANIFEST);
   const missingAlt = detectMissingAltText(MONSTER_ASSET_MANIFEST);
   const motionProfiles = getMotionProfiles();
   const totalAssets = MONSTER_ASSET_MANIFEST.assets.length;
+  const evidence = evidenceRows(visualEvidenceManifest);
+  const evidenceCounts = evidenceStatusCounts(evidence);
+  const smokes = smokeRows(visualEvidenceManifest);
+  const deployment = visualEvidenceManifest.deployment || {};
 
   return (
     <AdminPanelFrame
@@ -161,6 +191,109 @@ export function AdminVisualEngineSection() {
         <p><strong>Schema version:</strong> {BUNDLED_MONSTER_VISUAL_CONFIG.schemaVersion}</p>
         <p><strong>Manifest hash:</strong> <code>{BUNDLED_MONSTER_VISUAL_CONFIG.manifestHash}</code></p>
       </div>
+
+      {/* Visual Adapter Contract */}
+      <SectionHeader
+        eyebrow="Operating Contract"
+        title="Subject Visual Adapters"
+        level={3}
+        data-testid="section-visual-adapters"
+      />
+      <table className="admin-table" data-testid="visual-adapter-table">
+        <thead>
+          <tr>
+            <th>Subject</th>
+            <th>Status</th>
+            <th>Setup</th>
+            <th>Companion input</th>
+            <th>Summary frame</th>
+          </tr>
+        </thead>
+        <tbody>
+          {SUBJECTS.map((subject) => {
+            const adapter = subject.visualAdapter || {};
+            const sections = adapter.sections || {};
+            return (
+              <tr key={subject.id} data-subject={subject.id} data-visual-adapter-status={adapter.status || 'missing'}>
+                <td><strong>{subject.name}</strong></td>
+                <td>{adapter.status || 'missing'}</td>
+                <td><code>{sections.setup?.component || sections.setup?.mode || 'not supplied'}</code></td>
+                <td><code>{sections.companionPanel?.dataSource || sections.companionPanel?.mode || 'not supplied'}</code></td>
+                <td><code>{sections.summaryFrame?.component || sections.summaryFrame?.mode || 'not supplied'}</code></td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+
+      {/* Evidence Pack Status */}
+      <SectionHeader
+        eyebrow="Evidence"
+        title="Visual Evidence Pack"
+        level={3}
+        statusChip={<span className="chip" data-testid="visual-evidence-status-chip">{`${evidenceCounts.captured || 0} present / ${evidenceCounts.omitted || 0} omitted / ${evidenceCounts.external || 0} external`}</span>}
+        data-testid="section-visual-evidence-pack"
+      />
+      <table className="admin-table" data-testid="visual-evidence-table">
+        <thead>
+          <tr>
+            <th>Screenshot</th>
+            <th>Status</th>
+            <th>Path or evidence</th>
+            <th>Reason</th>
+          </tr>
+        </thead>
+        <tbody>
+          {evidence.map((row) => (
+            <tr key={row.name} data-screenshot={row.name} data-screenshot-status={row.status}>
+              <td>{row.name}</td>
+              <td>{row.status}</td>
+              <td><code>{row.path}</code></td>
+              <td>{row.reason || 'present in committed evidence pack'}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <table className="admin-table" data-testid="visual-evidence-deployment-table">
+        <thead>
+          <tr>
+            <th>Origin</th>
+            <th>Captured</th>
+            <th>Deployment version</th>
+            <th>Source commit</th>
+            <th>Bundle audit</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr data-testid="visual-evidence-deployment-row">
+            <td><code>{visualEvidenceManifest.origin || 'not supplied'}</code></td>
+            <td><code>{visualEvidenceManifest.capturedAt || 'not supplied'}</code></td>
+            <td><code>{deployment.versionId || 'not supplied'}</code></td>
+            <td><code>{deployment.sourceCommit || 'not supplied'}</code></td>
+            <td>{deployment.productionBundleAudit || 'not supplied'}</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <table className="admin-table" data-testid="visual-smoke-files-table">
+        <thead>
+          <tr>
+            <th>Smoke</th>
+            <th>Status</th>
+            <th>Path</th>
+          </tr>
+        </thead>
+        <tbody>
+          {smokes.map((row) => (
+            <tr key={row.name} data-smoke={row.name} data-smoke-status={row.status}>
+              <td>{row.name}</td>
+              <td>{row.status}</td>
+              <td><code>{row.path}</code></td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
 
       {/* Motion Profiles */}
       <SectionHeader

--- a/tests/admin-visual-engine-diagnostics.test.js
+++ b/tests/admin-visual-engine-diagnostics.test.js
@@ -177,6 +177,8 @@ test('AdminVisualEngineSection uses SectionHeader primitive for diagnostic categ
     'section-monster-assets',
     'section-placeholders',
     'section-stage-assignments',
+    'section-visual-adapters',
+    'section-visual-evidence-pack',
     'section-motion-profiles',
     'section-alt-text',
   ];
@@ -186,6 +188,31 @@ test('AdminVisualEngineSection uses SectionHeader primitive for diagnostic categ
       `Expected SectionHeader with data-testid="${testId}"`
     );
   }
+});
+
+test('P5 U5: AdminVisualEngineSection displays adapter and evidence-pack status rows', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { AdminVisualEngineSection } from ${absoluteSpecifier('src/surfaces/hubs/AdminVisualEngineSection.jsx')};
+    const markup = renderToStaticMarkup(React.createElement(AdminVisualEngineSection));
+    console.log(markup);
+  `);
+
+  assert.ok(html.includes('data-testid="visual-adapter-table"'));
+  assert.ok(html.includes('data-testid="visual-evidence-table"'));
+  assert.ok(html.includes('data-testid="visual-evidence-deployment-table"'));
+  assert.ok(html.includes('data-testid="visual-smoke-files-table"'));
+  assert.ok(html.includes('data-visual-adapter-status="ready"'));
+  assert.ok(html.includes('data-visual-adapter-status="unavailable"'));
+  assert.ok(html.includes('data-screenshot="home"'));
+  assert.ok(html.includes('data-screenshot-status="captured"'));
+  assert.ok(html.includes('data-screenshot-status="omitted"'));
+  assert.ok(html.includes('data-smoke="bootstrap"'));
+  assert.ok(html.includes('0bc250a8-1224-476c-a534-c383814527f8'));
+  assert.ok(html.includes('91dcbabd9b948a8b53c1231c692eb04ff2e8b4fa'));
+  assert.ok(html.includes('2026-05-01T22:48:25Z'));
+  assert.ok(html.includes('0 external'));
 });
 
 // ---------- Test 5: Section renders within admin hub tab registry ---------- //

--- a/tests/home-hero-no-duplicate-primary.test.js
+++ b/tests/home-hero-no-duplicate-primary.test.js
@@ -52,6 +52,10 @@ function countPrimaryLearnerCtas(html) {
   );
 }
 
+function countPrimaryButtons(html) {
+  return countMatches(html, /<button\b(?=[^>]*class="btn primary xl")[^>]*>/g);
+}
+
 test.after(() => {
   cleanupHomeSurfaceRenderer();
 });
@@ -94,4 +98,60 @@ test('HomeSurface renders subject cards exactly once for zero, one, three and si
       );
     }
   }
+});
+
+test('P5 U2: HomeSurface hero operating states keep one primary learner action', () => {
+  const states = [
+    ['no-ready-subject', []],
+    ['one-ready-subject', SUBJECTS.slice(0, 1)],
+    ['three-ready-subjects', SUBJECTS.slice(0, 3)],
+    ['six-registered-three-ready', SUBJECTS],
+    ['hero-disabled', SUBJECTS.slice(0, 3), { enabled: false, status: 'idle' }],
+    ['hero-shadow-hold', SUBJECTS.slice(0, 3), { enabled: true, status: 'loading' }],
+    ['persistence-degraded', SUBJECTS.slice(0, 3), { enabled: false, status: 'idle' }, { mode: 'degraded', label: 'Sync degraded' }],
+    ['read-only-learner-context', SUBJECTS.slice(0, 3), { enabled: false, status: 'idle' }, { mode: 'read-only', label: 'Read-only' }, { canOpenParentHub: false }],
+  ];
+
+  for (const [
+    name,
+    subjects,
+    hero = { enabled: false, status: 'idle' },
+    persistence = { mode: 'local-only', label: 'Local-only' },
+    permissions = { canOpenParentHub: true },
+  ] of states) {
+    const html = renderHomeSurfaceStandalone({
+      model: {
+        ...modelWithSubjects(subjects),
+        hero,
+        persistence,
+        permissions,
+      },
+    });
+    assert.equal(countPrimaryLearnerCtas(html), 1, `${name} must have exactly one open-subject primary CTA`);
+    assert.equal(countMatches(html, /data-scene="home-hero"/g), 1);
+    assert.equal(countMatches(html, /class="subject-grid"/g), 1);
+  }
+});
+
+test('P5 U2: active Hero Quest branch has one primary action and does not hide subject cards', () => {
+  const html = renderHomeSurfaceStandalone({
+    model: {
+      ...modelWithSubjects(SUBJECTS),
+      hero: {
+        enabled: true,
+        status: 'idle',
+        canStart: true,
+        canContinue: false,
+        nextTask: { taskId: 'hero-task-1', subjectId: 'spelling', childLabel: 'Spelling round' },
+        effortPlanned: 6,
+        completedTaskIds: [],
+        eligibleSubjects: ['spelling', 'grammar', 'punctuation'],
+        lockedSubjects: [],
+      },
+    },
+  });
+
+  assert.equal(countPrimaryButtons(html), 1);
+  assert.equal(countMatches(html, /class="subject-card/g), SUBJECTS.length);
+  assert.doesNotMatch(html, /Hero Coins|Hero Camp/);
 });

--- a/tests/ui-companion-panel-data-contract.test.js
+++ b/tests/ui-companion-panel-data-contract.test.js
@@ -1,0 +1,146 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function source(relativePath) {
+  return readFileSync(path.join(rootDir, relativePath), 'utf8');
+}
+
+function nodePaths() {
+  return [
+    path.join(rootDir, 'node_modules'),
+    ...String(process.env.NODE_PATH || '').split(path.delimiter),
+  ].filter((entry) => entry && existsSync(entry));
+}
+
+async function renderFixture(entrySource) {
+  const tmpDir = await mkdtemp(path.join(tmpdir(), 'ks2-companion-data-'));
+  const entryPath = path.join(tmpDir, 'entry.jsx');
+  const bundlePath = path.join(tmpDir, 'entry.cjs');
+  try {
+    await writeFile(entryPath, entrySource);
+    await build({
+      absWorkingDir: rootDir,
+      entryPoints: [entryPath],
+      outfile: bundlePath,
+      bundle: true,
+      platform: 'node',
+      format: 'cjs',
+      target: ['node24'],
+      jsx: 'automatic',
+      jsxImportSource: 'react',
+      loader: { '.js': 'jsx' },
+      nodePaths: nodePaths(),
+      logLevel: 'silent',
+    });
+    return execFileSync(process.execPath, [bundlePath], {
+      cwd: rootDir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
+function absoluteSpecifier(relativePath) {
+  return JSON.stringify(path.join(rootDir, relativePath));
+}
+
+test('ready subject companion panels map subject-owned data into real panel inputs', () => {
+  const contracts = [
+    {
+      subject: 'spelling',
+      path: 'src/subjects/spelling/components/SpellingSetupScene.jsx',
+      markers: ['codex', 'stats.secure', 'stats.due', 'stats.trouble', 'Trouble words need attention'],
+    },
+    {
+      subject: 'grammar',
+      path: 'src/subjects/grammar/components/GrammarSetupScene.jsx',
+      markers: ['dashboard.monsterStrip', 'dashboard.todayCards', 'troubleCount', 'Trouble concepts need revision'],
+    },
+    {
+      subject: 'punctuation',
+      path: 'src/subjects/punctuation/components/PunctuationSetupScene.jsx',
+      markers: ['dashboard.activeMonsters', 'dueCount', 'weakCount', 'grandStars', 'Wobbly spots need practice'],
+    },
+  ];
+
+  for (const contract of contracts) {
+    const text = source(contract.path);
+    const panel = text.match(/<SubjectCompanionPanel[\s\S]*?\/>/)?.[0] || '';
+    assert.match(panel, new RegExp(`subjectId="${contract.subject}"`));
+    assert.match(panel, /\svisible(?:\s|>|$|=)/);
+    assert.match(panel, /monsters=\{/);
+    assert.match(panel, /stats=\{/);
+    assert.match(panel, /nextFocus=\{/);
+    for (const marker of contract.markers) {
+      assert.ok(panel.includes(marker), `${contract.subject} companion panel must include ${marker}`);
+    }
+  }
+});
+
+test('ready subject companion panel data renders subject-owned stats without shaming empty states', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { SubjectCompanionPanel } from ${absoluteSpecifier('src/platform/ui/SubjectCompanionPanel.jsx')};
+    const fixtures = [
+      ['spelling', [{ name: 'Codex', discovered: true }], [
+        { label: 'Secure', value: '12', tone: 'good' },
+        { label: 'Due', value: '3', tone: 'warn' },
+        { label: 'Trouble', value: '1', tone: 'warn' },
+      ], 'Try the next due word.'],
+      ['grammar', [{ name: 'Grammox', discovered: true }], [
+        { label: 'Confidence', value: 'steady', tone: 'good' },
+        { label: 'Trouble concepts', value: '2', tone: 'warn' },
+      ], 'Revise noun phrases.'],
+      ['punctuation', [{ name: 'Comma Egg', discovered: true }], [
+        { label: 'Due', value: '4', tone: 'warn' },
+        { label: 'Wobbly', value: '2', tone: 'warn' },
+        { label: 'Grand Stars', value: '1', tone: 'good' },
+      ], 'Practise wobbly spots.'],
+    ];
+    const rendered = fixtures.map(([subjectId, monsters, stats, nextFocus]) => renderToStaticMarkup(
+      <SubjectCompanionPanel
+        subjectId={subjectId}
+        monsters={monsters}
+        stats={stats}
+        nextFocus={nextFocus}
+        emptyState="No discoveries yet. Start a short round when you are ready."
+        visible
+      />
+    ));
+    rendered.push(renderToStaticMarkup(
+      <SubjectCompanionPanel
+        subjectId="grammar"
+        monsters={[]}
+        stats={[]}
+        emptyState="No discoveries yet. Start a short round when you are ready."
+        visible
+      />
+    ));
+    console.log(rendered.join('\\n---\\n'));
+  `);
+
+  for (const subjectId of ['spelling', 'grammar', 'punctuation']) {
+    assert.match(html, new RegExp(`data-subject="${subjectId}"`));
+  }
+  for (const label of ['Secure', 'Due', 'Trouble', 'Confidence', 'Trouble concepts', 'Wobbly', 'Grand Stars']) {
+    assert.match(html, new RegExp(`<dt>${label}</dt>`));
+  }
+  assert.match(html, /Try the next due word\./);
+  assert.match(html, /Revise noun phrases\./);
+  assert.match(html, /Practise wobbly spots\./);
+  assert.match(html, /No discoveries yet\. Start a short round when you are ready\./);
+  assert.doesNotMatch(html, /failed|weak|bad|behind|lost/i);
+});

--- a/tests/ui-companion-panel-responsive-contract.test.js
+++ b/tests/ui-companion-panel-responsive-contract.test.js
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+test('companion panel CSS is mobile-safe and cannot force fixed-width overflow', () => {
+  const css = readFileSync(path.join(rootDir, 'styles/app.css'), 'utf8');
+  const companionBlock = css.slice(css.indexOf('.companion-panel {'), css.indexOf('.home-hero-scene {'));
+
+  assert.match(companionBlock, /\.companion-panel\s*\{[\s\S]*min-width:\s*0;/);
+  assert.match(companionBlock, /\.companion-panel-monster-list\s*\{[\s\S]*min-width:\s*0;/);
+  assert.match(companionBlock, /\.companion-panel-stat\s*\{[\s\S]*min-width:\s*0;/);
+  assert.match(css, /@media\s*\(max-width:\s*820px\)\s*\{[\s\S]*\.companion-panel-stat\s*\{[\s\S]*flex-direction:\s*column;/);
+  assert.doesNotMatch(companionBlock, /width:\s*\d+px|min-width:\s*\d+px/);
+});

--- a/tests/ui-subject-visual-adapter-contract.test.js
+++ b/tests/ui-subject-visual-adapter-contract.test.js
@@ -1,0 +1,60 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { SUBJECTS } from '../src/platform/core/subject-registry.js';
+import {
+  SUBJECT_VISUAL_ADAPTER_SECTIONS,
+  isSubjectVisualAdapter,
+} from '../src/platform/ui/subject-visual-adapter.js';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+test('ready subjects expose a complete SubjectVisualAdapter', () => {
+  for (const subjectId of ['spelling', 'grammar', 'punctuation']) {
+    const subject = SUBJECTS.find((entry) => entry.id === subjectId);
+    assert.ok(subject, `${subjectId} must be registered`);
+    assert.equal(isSubjectVisualAdapter(subject.visualAdapter), true);
+    assert.equal(subject.visualAdapter.status, 'ready');
+    assert.equal(subject.visualAdapter.productionPracticeAvailable, true);
+    for (const section of SUBJECT_VISUAL_ADAPTER_SECTIONS) {
+      assert.ok(subject.visualAdapter.sections[section], `${subjectId} missing ${section}`);
+    }
+    assert.equal(subject.visualAdapter.sections.summaryFrame.component, 'SessionSummaryFrame');
+    assert.equal(subject.visualAdapter.sections.companionPanel.component, 'SubjectCompanionPanel');
+  }
+});
+
+test('placeholder subjects expose unavailable adapters without production practice controls', () => {
+  for (const subjectId of ['reading', 'reasoning', 'arithmetic']) {
+    const subject = SUBJECTS.find((entry) => entry.id === subjectId);
+    assert.ok(subject, `${subjectId} must be registered`);
+    assert.equal(isSubjectVisualAdapter(subject.visualAdapter), true);
+    assert.equal(subject.visualAdapter.status, 'unavailable');
+    assert.equal(subject.visualAdapter.productionPracticeAvailable, false);
+    assert.equal(subject.visualAdapter.sections.setup.primaryAction, 'unavailable-info');
+  }
+});
+
+test('placeholder adapter module does not import Worker command handlers or browser engines', () => {
+  const source = readFileSync(path.join(rootDir, 'src/subjects/placeholders/module-factory.js'), 'utf8');
+  const importLines = source.split('\n').filter((line) => line.trim().startsWith('import ')).join('\n');
+  assert.doesNotMatch(importLines, /subject-command|worker\/src|startSession|submitAnswer/);
+  assert.doesNotMatch(source, /handleAction\([^)]*\)\s*\{[\s\S]*dispatch|handleAction\([^)]*\)\s*\{[\s\S]*startSession/);
+  assert.match(source, /createPlaceholderSubjectVisualAdapter/);
+});
+
+test('subject expansion documentation references the visual adapter contract', () => {
+  const source = readFileSync(path.join(rootDir, 'docs/subject-visual-adapter-contract.md'), 'utf8');
+  assert.match(source, /SubjectVisualAdapter/);
+  assert.match(source, /Placeholder subjects/);
+  assert.match(source, /must not expose production practice controls/);
+
+  const expansion = readFileSync(path.join(rootDir, 'docs/subject-expansion.md'), 'utf8');
+  const readiness = readFileSync(path.join(rootDir, 'docs/expansion-readiness.md'), 'utf8');
+  assert.match(expansion, /SubjectVisualAdapter/);
+  assert.match(expansion, /docs\/subject-visual-adapter-contract\.md/);
+  assert.match(readiness, /SubjectVisualAdapter/);
+});

--- a/tests/ui-summary-no-duplicate-actions.test.js
+++ b/tests/ui-summary-no-duplicate-actions.test.js
@@ -3,14 +3,60 @@
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
 import { readFileSync } from 'node:fs';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
 
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
 function source(relativePath) {
   return readFileSync(path.join(rootDir, relativePath), 'utf8');
+}
+
+function nodePaths() {
+  return [
+    path.join(rootDir, 'node_modules'),
+    ...String(process.env.NODE_PATH || '').split(path.delimiter),
+  ].filter((entry) => entry && existsSync(entry));
+}
+
+async function renderFixture(entrySource) {
+  const tmpDir = await mkdtemp(path.join(tmpdir(), 'ks2-summary-actions-'));
+  const entryPath = path.join(tmpDir, 'entry.jsx');
+  const bundlePath = path.join(tmpDir, 'entry.cjs');
+  try {
+    await writeFile(entryPath, entrySource);
+    await build({
+      absWorkingDir: rootDir,
+      entryPoints: [entryPath],
+      outfile: bundlePath,
+      bundle: true,
+      platform: 'node',
+      format: 'cjs',
+      target: ['node24'],
+      jsx: 'automatic',
+      jsxImportSource: 'react',
+      loader: { '.js': 'jsx' },
+      nodePaths: nodePaths(),
+      logLevel: 'silent',
+    });
+    return execFileSync(process.execPath, [bundlePath], {
+      cwd: rootDir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
+function absoluteSpecifier(relativePath) {
+  return JSON.stringify(path.join(rootDir, relativePath));
 }
 
 test('P4 U4 summary scenes do not render legacy and shared action clusters together', () => {
@@ -60,4 +106,169 @@ test('P4 U4 summary scenes do not render legacy and shared action clusters toget
       );
     }
   }
+});
+
+test('P5 U4 summary scenes keep one primary action through SessionSummaryFrame', () => {
+  const scenes = [
+    ['Spelling', 'src/subjects/spelling/components/SpellingSummaryScene.jsx'],
+    ['Grammar', 'src/subjects/grammar/components/GrammarSummaryScene.jsx'],
+    ['Punctuation', 'src/subjects/punctuation/components/PunctuationSummaryScene.jsx'],
+  ];
+
+  for (const [name, relativePath] of scenes) {
+    const text = source(relativePath);
+    assert.equal(
+      (text.match(/nextPrimaryAction=\{nextPrimaryAction\}/g) || []).length,
+      1,
+      `${name} summary should pass exactly one primary action prop`,
+    );
+    assert.match(text, /secondaryActions=\{secondaryActions\}/);
+    assert.doesNotMatch(text, /className="btn primary xl"/);
+    assert.doesNotMatch(text, /summary frame computes rewards|compute.*Stars|write.*mastery/i);
+  }
+});
+
+test('P5 U4 Boss Dictation summary remains Mega-safe with no drill actions', () => {
+  const text = source('src/subjects/spelling/components/SpellingSummaryScene.jsx');
+  const bossBranch = text.slice(text.indexOf('isBossSummary'), text.indexOf('isPatternQuestSummary'));
+  assert.match(text, /isBossSummary/);
+  assert.match(text, /SummaryBossMissList/);
+  assert.doesNotMatch(bossBranch, /spelling-drill-all|spelling-drill-single|Drill all/);
+});
+
+test('P5 U4 summary outcome variants render one primary action through the shared frame', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { SessionSummaryFrame } from ${absoluteSpecifier('src/platform/ui/SessionSummaryFrame.jsx')};
+    const variants = [
+      ['spelling-boss', 'spelling', 'secure', 'Boss Dictation complete', 'spelling-back'],
+      ['grammar-mini-test', 'grammar', 'review-complete', 'Mini-test complete', 'grammar-back'],
+      ['grammar-repair', 'grammar', 'needs-practice', 'Repair round complete', 'grammar-repair-start'],
+      ['grammar-smart', 'grammar', 'improving', 'Smart grammar complete', 'grammar-smart-start'],
+      ['punctuation-smart', 'punctuation', 'improving', 'Smart punctuation complete', 'punctuation-start'],
+      ['punctuation-guided', 'punctuation', 'needs-practice', 'Guided punctuation complete', 'punctuation-start-guided'],
+      ['punctuation-gps', 'punctuation', 'secure', 'GPS challenge complete', 'punctuation-back'],
+    ];
+    const rendered = variants.map(([id, subjectId, outcome, title, dataAction]) => renderToStaticMarkup(
+      <SessionSummaryFrame
+        subjectId={subjectId}
+        outcome={outcome}
+        title={title}
+        highlights={['Result returned by the subject summary model']}
+        misconceptions={id.includes('repair') || id.includes('guided') ? ['Review target'] : []}
+        progressDelta={[]}
+        nextPrimaryAction={{ label: 'Continue', dataAction, onClick: () => {} }}
+        secondaryActions={[{ label: 'Back to dashboard', dataAction: subjectId + '-back', variant: 'ghost', onClick: () => {} }]}
+      />
+    ));
+    console.log(rendered.join('\\n---\\n'));
+  `);
+
+  const frames = html.split('\n---\n');
+  assert.equal(frames.length, 7);
+  for (const frame of frames) {
+    assert.equal((frame.match(/class="btn primary/g) || []).length, 1);
+    assert.match(frame, /class="session-summary-frame"/);
+    assert.doesNotMatch(frame, /spelling-drill-all|spelling-drill-single|Drill all/);
+    assert.doesNotMatch(frame, /compute.*Stars|write.*mastery|Hero Coins|Hero Camp/i);
+  }
+});
+
+test('P5 U4 actual ready-subject summary scenes render one primary action per branch', async () => {
+  const html = await renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { SpellingSummaryScene } from ${absoluteSpecifier('src/subjects/spelling/components/SpellingSummaryScene.jsx')};
+    import { GrammarSummaryScene } from ${absoluteSpecifier('src/subjects/grammar/components/GrammarSummaryScene.jsx')};
+    import { PunctuationSummaryScene } from ${absoluteSpecifier('src/subjects/punctuation/components/PunctuationSummaryScene.jsx')};
+
+    const learner = { id: 'learner-p5', name: 'Ava' };
+    const actions = { dispatch() {}, openWordBank() {} };
+    const spellingActions = { dispatch() {}, openWordBank() {} };
+    const spellingBoss = {
+      summary: {
+        mode: 'boss',
+        totalWords: 2,
+        correct: 1,
+        mistakes: [{ slug: 'receive', word: 'receive' }],
+        cards: [
+          { label: 'Answered', value: '2' },
+          { label: 'Correct', value: '1' },
+        ],
+        message: 'Boss complete',
+      },
+      pendingCommand: '',
+    };
+    const grammarRegular = {
+      summary: { answered: 5, correct: 4, trouble: 1, mistakes: [{ conceptId: 'noun_phrases' }] },
+      pendingCommand: '',
+      projections: { rewards: { state: {} } },
+      analytics: { concepts: [{ id: 'noun_phrases', status: 'weak' }] },
+    };
+    const grammarMini = {
+      summary: {
+        mode: 'satsset',
+        totalMarks: 2,
+        miniTestReview: {
+          questions: [
+            { item: { skillIds: ['noun_phrases'], prompt: 'Pick the noun phrase.' }, marked: { result: { correct: false } } },
+            { item: { skillIds: ['verbs'], prompt: 'Pick the verb.' }, marked: { result: { correct: true } } },
+          ],
+        },
+      },
+      pendingCommand: '',
+      projections: { rewards: { state: {} } },
+    };
+    const punctuationSmart = {
+      summary: {
+        total: 5,
+        correct: 4,
+        accuracy: 80,
+        focus: ['commas-in-lists'],
+        skillsExercised: ['commas-in-lists'],
+        message: 'Smart round complete.',
+      },
+      pendingCommand: '',
+      stats: { due: 1 },
+      rewardState: {},
+    };
+    const punctuationGps = {
+      summary: {
+        total: 3,
+        correct: 3,
+        accuracy: 100,
+        focus: [],
+        skillsExercised: ['speech-punctuation'],
+        message: 'GPS challenge complete.',
+        gps: { reviewItems: [{ itemId: 'gps-1', misconceptionTags: [] }] },
+      },
+      pendingCommand: '',
+      stats: { due: 0 },
+      rewardState: {},
+    };
+
+    const frames = [
+      renderToStaticMarkup(<SpellingSummaryScene learner={learner} ui={spellingBoss} accent="#335577" actions={spellingActions} />),
+      renderToStaticMarkup(<GrammarSummaryScene grammar={grammarRegular} rewardState={{}} actions={actions} learner={learner} runtimeReadOnly={false} />),
+      renderToStaticMarkup(<GrammarSummaryScene grammar={grammarMini} rewardState={{}} actions={actions} learner={learner} runtimeReadOnly={false} />),
+      renderToStaticMarkup(<PunctuationSummaryScene ui={punctuationSmart} actions={actions} rewardState={{}} />),
+      renderToStaticMarkup(<PunctuationSummaryScene ui={punctuationGps} actions={actions} rewardState={{}} />),
+    ];
+    console.log(frames.join('\\n---\\n'));
+  `);
+
+  const frames = html.split('\n---\n');
+  assert.equal(frames.length, 5);
+  for (const frame of frames) {
+    assert.equal((frame.match(/class="btn primary/g) || []).length, 1);
+    assert.equal((frame.match(/data-session-summary-frame/g) || []).length, 1);
+    assert.doesNotMatch(frame, /Hero Coins|Hero Camp|write mastery|compute Stars/i);
+  }
+
+  assert.doesNotMatch(frames[0], /spelling-drill-all|spelling-drill-single|Drill all/);
+  assert.match(frames[1], /data-action="grammar-practise-missed"/);
+  assert.match(frames[2], /data-action="grammar-practise-missed"/);
+  assert.match(frames[3], /data-action="punctuation-start"/);
+  assert.match(frames[4], /data-action="punctuation-start"/);
 });

--- a/tests/ui-visual-evidence-pack.test.js
+++ b/tests/ui-visual-evidence-pack.test.js
@@ -1,0 +1,100 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { verifyUiRefactorVisualEvidence } from '../scripts/verify-ui-refactor-visual-evidence.mjs';
+
+function writeManifest(dir, screenshots) {
+  const manifestPath = path.join(dir, 'visual-evidence.json');
+  writeFileSync(
+    manifestPath,
+    JSON.stringify(
+      {
+        ok: true,
+        origin: 'https://ks2.eugnel.uk',
+        screenshots,
+      },
+      null,
+      2,
+    ),
+  );
+  return manifestPath;
+}
+
+function createFixtureDir() {
+  return mkdtempSync(path.join(tmpdir(), 'ks2-ui-visual-evidence-'));
+}
+
+test('visual evidence verifier passes when captured screenshots are present', () => {
+  const dir = createFixtureDir();
+  mkdirSync(path.join(dir, 'output'), { recursive: true });
+  writeFileSync(path.join(dir, 'output/present.png'), 'png');
+
+  const manifestPath = writeManifest(dir, [
+    {
+      name: 'home',
+      status: 'captured',
+      path: 'output/present.png',
+    },
+  ]);
+
+  const result = verifyUiRefactorVisualEvidence(manifestPath, { baseDir: dir });
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.failures, []);
+});
+
+test('visual evidence verifier fails when a captured screenshot path is missing', () => {
+  const dir = createFixtureDir();
+  const manifestPath = writeManifest(dir, [
+    {
+      name: 'grammar-session',
+      status: 'captured',
+      path: 'output/missing.png',
+    },
+  ]);
+
+  const result = verifyUiRefactorVisualEvidence(manifestPath, { baseDir: dir });
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.failures, [
+    'grammar-session: missing screenshot file output/missing.png',
+  ]);
+});
+
+test('visual evidence verifier accepts external screenshots with durable evidence links', () => {
+  const dir = createFixtureDir();
+  const manifestPath = writeManifest(dir, [
+    {
+      name: 'admin-visual-engine',
+      status: 'external',
+      externalUrl: 'https://evidence.example/admin-visual-engine.png',
+      reason: 'Stored in a durable external review evidence pack.',
+    },
+  ]);
+
+  const result = verifyUiRefactorVisualEvidence(manifestPath, { baseDir: dir });
+  assert.equal(result.ok, true);
+});
+
+test('visual evidence verifier accepts omitted screenshots only with durable reasons', () => {
+  const dir = createFixtureDir();
+  const manifestPath = writeManifest(dir, [
+    {
+      name: 'spelling-summary',
+      status: 'omitted',
+      reason: 'Lean ZIP did not include this screenshot, so no bundled-image claim is made.',
+    },
+    {
+      name: 'punctuation-summary',
+      status: 'omitted',
+      reason: '',
+    },
+  ]);
+
+  const result = verifyUiRefactorVisualEvidence(manifestPath, { baseDir: dir });
+  assert.equal(result.ok, false);
+  assert.deepEqual(result.failures, [
+    'punctuation-summary: omitted screenshot entries require a durable reason',
+  ]);
+});

--- a/tests/ui-visual-journey-ready-subjects.test.js
+++ b/tests/ui-visual-journey-ready-subjects.test.js
@@ -1,0 +1,87 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function source(relativePath) {
+  return readFileSync(path.join(rootDir, relativePath), 'utf8');
+}
+
+function count(sourceText, pattern) {
+  return (sourceText.match(pattern) || []).length;
+}
+
+function stripLineComments(sourceText) {
+  return sourceText
+    .split('\n')
+    .filter((line) => !line.trim().startsWith('//') && !line.trim().startsWith('*'))
+    .join('\n');
+}
+
+test('Home to recommended subject route has one primary CTA and no duplicate setup route', () => {
+  const home = source('src/surfaces/home/HomeSurface.jsx');
+  assert.match(home, /selectTodaysBestRound/);
+  assert.equal(count(home, /dataAction="open-subject"/g), 1);
+  assert.match(home, /data-subject-id=\{ctaSubjectId\}/);
+  assert.match(home, /actions\.openSubject\(ctaSubjectId\)/);
+});
+
+test('ready subject journeys expose setup, session HUD, summary, and home return actions', () => {
+  const subjects = [
+    {
+      id: 'spelling',
+      setup: 'src/subjects/spelling/components/SpellingSetupScene.jsx',
+      session: 'src/subjects/spelling/components/SpellingSessionScene.jsx',
+      summary: 'src/subjects/spelling/components/SpellingSummaryScene.jsx',
+      startAction: 'spelling-start',
+      backAction: 'spelling-back',
+    },
+    {
+      id: 'grammar',
+      setup: 'src/subjects/grammar/components/GrammarSetupScene.jsx',
+      session: 'src/subjects/grammar/components/GrammarSessionScene.jsx',
+      summary: 'src/subjects/grammar/components/GrammarSummaryScene.jsx',
+      startAction: 'grammar-start',
+      backAction: 'grammar-back',
+    },
+    {
+      id: 'punctuation',
+      setup: 'src/subjects/punctuation/components/PunctuationSetupScene.jsx',
+      session: 'src/subjects/punctuation/components/PunctuationSessionScene.jsx',
+      summary: 'src/subjects/punctuation/components/PunctuationSummaryScene.jsx',
+      startAction: 'punctuation-start',
+      backAction: 'punctuation-back',
+    },
+  ];
+
+  for (const subject of subjects) {
+    const setup = source(subject.setup);
+    const session = stripLineComments(source(subject.session));
+    const summary = source(subject.summary);
+
+    assert.match(setup, /<SubjectCompanionPanel[\s\S]*\svisible/);
+    assert.ok(setup.includes(subject.startAction), `${subject.id} setup must expose start action`);
+    assert.match(session, /<SessionHUD[\s\S]*subjectId=/);
+    assert.doesNotMatch(session, /Question\s+\{[^}]*\}\s+of\s+\{[^}]*\}/);
+    assert.match(summary, /<SessionSummaryFrame[\s\S]*nextPrimaryAction=\{nextPrimaryAction\}/);
+    assert.ok(summary.includes(subject.backAction), `${subject.id} summary must expose a return or next route`);
+  }
+});
+
+test('ready subject journey contract is backed by Worker summary read-model preservation tests', () => {
+  const spellingRemote = source('tests/spelling-remote-actions.test.js');
+  const spellingHydration = source('tests/spelling-remote-sync-hydration.test.js');
+
+  assert.match(
+    spellingRemote,
+    /remote spelling command response applies the live summary read model after repository reload/,
+  );
+  assert.match(spellingRemote, /subjectReadModel:\s*\{\s*phase:\s*'summary'/);
+  assert.match(
+    spellingHydration,
+    /applyCommandResponse preserves postMastery cache when follow-up response lacks postMastery/,
+  );
+});


### PR DESCRIPTION
## Summary
- adds the SubjectVisualAdapter contract for ready and placeholder subjects
- extends Admin Visual Engine diagnostics with adapter, evidence, deployment, and smoke metadata
- locks P5 UI contracts for hero actions, journeys, companion panels, summaries, and screenshot-pack evidence

## Verification
- npm test: 21543 tests, 21537 pass, 0 fail, 6 skipped
- npm run check: dry-run deploy passed; client bundle 188356 / 232000 bytes gzip
- node --test tests/ui-production-evidence-contract.test.js tests/ui-visual-evidence-pack.test.js tests/home-hero-no-duplicate-primary.test.js tests/ui-visual-journey-ready-subjects.test.js tests/ui-session-hud-contract.test.js tests/ui-session-hud-adapter-render.test.js tests/ui-companion-panel-contract.test.js tests/ui-companion-panel-data-contract.test.js tests/ui-companion-panel-responsive-contract.test.js tests/ui-summary-engine-contract.test.js tests/ui-summary-no-duplicate-actions.test.js tests/admin-visual-engine-diagnostics.test.js tests/ui-subject-visual-adapter-contract.test.js tests/csp-inline-style-budget.test.js tests/bundle-byte-budget.test.js: 89/89 pass
- node scripts/verify-ui-refactor-visual-evidence.mjs
- git diff --check HEAD~1..HEAD

## Review
- independent code review: no blockers after Admin Visual Engine metadata fix
- independent contract review: U2/U4/U5/U6 closed; U7 remains pending until PR merge, production deploy, and completion report