### PR TITLE
Fix Hero provider read model projection

### DIFF
--- a/tests/hero-p4-read-model.test.js
+++ b/tests/hero-p4-read-model.test.js
@@ -48,6 +48,36 @@ function makeSubjectReadModels() {
   };
 }
 
+function makeProductionSplitSubjectReadModels() {
+  return {
+    grammar: {
+      data: {
+        prefs: { mode: 'smart' },
+        mastery: {},
+        recentAttempts: [],
+      },
+      ui: {
+        stats: {
+          concepts: {
+            total: 18,
+            weak: 2,
+            due: 1,
+            secured: 4,
+            learning: 6,
+            new: 5,
+          },
+        },
+        analytics: {
+          concepts: [
+            { id: 'relative_clauses', status: 'weak', confidence: { label: 'needs-repair' } },
+            { id: 'pronouns_cohesion', status: 'secured', confidence: { label: 'secure' } },
+          ],
+        },
+      },
+    },
+  };
+}
+
 function buildV4(overrides = {}) {
   return buildHeroShadowReadModel({
     learnerId: 'learner-1',
@@ -128,6 +158,23 @@ function buildProgressState(model, overrides = {}) {
 }
 
 // ── V5 shape: economy enabled ─────────────────────────────────────────
+
+test('providers prefer production ui_json signals over storage data_json', () => {
+  const model = buildHeroShadowReadModel({
+    learnerId: 'learner-1',
+    accountId: 'account-1',
+    subjectReadModels: makeProductionSplitSubjectReadModels(),
+    now: Date.now(),
+    env: BASE_ENV,
+  });
+
+  assert.deepEqual(
+    model.eligibleSubjects.map((entry) => entry.subjectId),
+    ['grammar'],
+  );
+  assert.equal(model.ui.reason, 'enabled');
+  assert.ok(model.dailyQuest.tasks.some((task) => task.subjectId === 'grammar'));
+});
 
 test('economy enabled → version 5, economy block present with correct balance', () => {
   const model = buildV5();

--- a/worker/src/hero/launch.js
+++ b/worker/src/hero/launch.js
@@ -120,7 +120,10 @@ export async function resolveHeroStartTaskCommand({ body, repository, env, now, 
     }
   }
 
-  const subjectReadModels = await repository.readHeroSubjectReadModels(learnerId);
+  const subjectReadModels = await repository.readHeroSubjectReadModels(learnerId, {
+    accountId: callerAccountId,
+    now,
+  });
   const heroReadModel = buildHeroShadowReadModel({
     learnerId,
     accountId: callerAccountId || '',
@@ -194,6 +197,17 @@ export async function resolveHeroStartTaskCommand({ body, repository, env, now, 
     }
 
     // Different Hero taskId → conflict
+    if (activeSession.launchRequestId && activeSession.launchRequestId === requestId) {
+      throw new ConflictError('The same mutation request id was reused for a different payload.', {
+        code: 'idempotency_reuse',
+        retryable: false,
+        kind: 'subject_command.hero.start-task',
+        scopeType: 'learner',
+        scopeId: learnerId,
+        requestId,
+        correlationId,
+      });
+    }
     throw new ConflictError('A different Hero task is already active.', {
       code: 'hero_active_session_conflict',
       activeSession: {

--- a/worker/src/hero/read-model.js
+++ b/worker/src/hero/read-model.js
@@ -67,6 +67,51 @@ function buildCapabilityRegistry(tasks) {
   return registry;
 }
 
+function hasHeroProviderSignals(value) {
+  if (!value || typeof value !== 'object') return false;
+  return Boolean(
+    value.stats
+    || value.analytics
+    || value.availability
+    || value.postMega
+    || value.postMastery
+  );
+}
+
+function selectProviderReadModel(entry) {
+  if (!entry || typeof entry !== 'object') return entry;
+  if ('data' in entry || 'ui' in entry) {
+    if (hasHeroProviderSignals(entry.ui)) return entry.ui;
+    return entry.data || entry.ui || null;
+  }
+  return entry;
+}
+
+function detectActiveHeroSession(subjectReadModels) {
+  for (const subjectId of HERO_READY_SUBJECT_IDS) {
+    const entry = subjectReadModels[subjectId];
+    if (!entry || typeof entry !== 'object') continue;
+    const ui = 'ui' in entry ? entry.ui : null;
+    if (!ui || typeof ui !== 'object') continue;
+    const session = ui.session;
+    if (!session || typeof session !== 'object') continue;
+    const heroCtx = session.heroContext;
+    if (!heroCtx || typeof heroCtx !== 'object') continue;
+    if (heroCtx.source !== 'hero-mode') continue;
+    return {
+      subjectId,
+      questId: heroCtx.questId || null,
+      questFingerprint: heroCtx.questFingerprint || null,
+      taskId: heroCtx.taskId || null,
+      intent: heroCtx.intent || null,
+      launcher: heroCtx.launcher || null,
+      launchRequestId: heroCtx.launchRequestId || null,
+      status: 'in-progress',
+    };
+  }
+  return null;
+}
+
 /**
  * Derive the ui.reason code from the flag hierarchy and task state.
  */
@@ -155,16 +200,15 @@ export function buildHeroShadowReadModel({
 
   // 1. Run each provider via the provider registry.
   //    subjectReadModels is keyed by subjectId. Each value is either:
-  //    - { data, ui } (P2 expanded shape from repository), or
+  //    - { data, ui } (repository shape: storage data plus read-model UI), or
   //    - a raw data object (P0/P1 compat from unit tests).
-  //    Providers always receive the data portion only.
+  //    Production stores provider-readable signals in ui_json, while data_json
+  //    remains the subject engine's storage shape. Prefer ui_json when it has
+  //    Hero-readable signals, then fall back to data_json for older fixtures.
   const subjectSnapshots = {};
   for (const subjectId of HERO_READY_SUBJECT_IDS) {
     const entry = subjectReadModels[subjectId] || null;
-    // Support both { data, ui } (P2) and raw data object (P0 compat)
-    const readModel = entry && typeof entry === 'object' && 'data' in entry
-      ? entry.data
-      : entry;
+    const readModel = selectProviderReadModel(entry);
     const snapshot = runProvider(subjectId, readModel);
     if (snapshot) {
       subjectSnapshots[subjectId] = snapshot;
@@ -173,6 +217,7 @@ export function buildHeroShadowReadModel({
 
   // 2. Resolve eligibility
   const eligibility = resolveEligibility(subjectSnapshots);
+  const activeHeroSession = detectActiveHeroSession(subjectReadModels);
 
   // 3. Build eligible snapshots for the scheduler
   const eligibleSnapshots = eligibility.eligible.map((entry) => {
@@ -186,7 +231,9 @@ export function buildHeroShadowReadModel({
     dateKey,
     timezone: HERO_DEFAULT_TIMEZONE,
     schedulerVersion: HERO_P2_SCHEDULER_VERSION,
-    contentReleaseFingerprint: null,
+    contentReleaseFingerprint: activeHeroSession?.launchRequestId
+      ? `active:${activeHeroSession.subjectId}:${activeHeroSession.taskId}:${activeHeroSession.launchRequestId}`
+      : null,
   });
 
   // 5. Schedule shadow quest
@@ -285,30 +332,9 @@ export function buildHeroShadowReadModel({
     copyVersion: HERO_P2_COPY_VERSION,
   };
 
-  // 10. Detect active Hero session from ui_json.
-  //     Inspect each subject's ui field for session.heroContext.source === 'hero-mode'.
-  let activeHeroSession = null;
-  for (const subjectId of HERO_READY_SUBJECT_IDS) {
-    const entry = subjectReadModels[subjectId];
-    if (!entry || typeof entry !== 'object') continue;
-    const ui_data = 'ui' in entry ? entry.ui : null;
-    if (!ui_data || typeof ui_data !== 'object') continue;
-    const session = ui_data.session;
-    if (!session || typeof session !== 'object') continue;
-    const heroCtx = session.heroContext;
-    if (!heroCtx || typeof heroCtx !== 'object') continue;
-    if (heroCtx.source !== 'hero-mode') continue;
-    activeHeroSession = {
-      subjectId,
-      questId: heroCtx.questId || null,
-      questFingerprint: heroCtx.questFingerprint || null,
-      taskId: heroCtx.taskId || null,
-      intent: heroCtx.intent || null,
-      launcher: heroCtx.launcher || null,
-      status: 'in-progress',
-    };
-    break;
-  }
+  // 10. Active Hero session detection is resolved before scheduling so a
+  // launched task can move subsequent quest identity without hiding the
+  // existing session from conflict/idempotency handling.
 
   // 11. If progress is NOT enabled, return v3 shape unchanged.
   if (!progressEnabled) {

--- a/worker/src/hero/routes.js
+++ b/worker/src/hero/routes.js
@@ -87,11 +87,15 @@ export async function handleHeroReadModel({
   //    caller without membership receives a 403 before any data read.
   await repository.requireLearnerReadAccess(session.accountId, learnerId);
 
+  const nowTs = typeof now === 'function' ? now() : Date.now();
+
   // 4. Load per-subject read models for the learner.
-  //    This is the P0 minimal path: we read raw child_subject_state and
-  //    pass each subject's data object directly to the provider. The
-  //    providers are designed to handle null/empty gracefully.
-  const subjectReadModels = await repository.readHeroSubjectReadModels(learnerId);
+  //    This uses the same public read-model projection as bootstrap so Hero
+  //    sees provider-readable subject signals rather than raw storage slots.
+  const subjectReadModels = await repository.readHeroSubjectReadModels(learnerId, {
+    accountId: session.accountId,
+    now: nowTs,
+  });
 
   // 4b. P3 U7: load progress bundle for the v4 read model when progress enabled.
   const progressFlagEnabled = envFlagEnabled(resolvedEnv.HERO_MODE_PROGRESS_ENABLED);
@@ -103,7 +107,6 @@ export async function handleHeroReadModel({
 
   // 5. Assemble the shadow read model (v3, v4, v5, or v6: pass accountId and env for
   //    quest fingerprint and the HERO_MODE_CHILD_UI_ENABLED gate).
-  const nowTs = typeof now === 'function' ? now() : Date.now();
   const result = buildHeroShadowReadModel({
     learnerId,
     accountId: session.accountId || '',
@@ -137,4 +140,3 @@ export async function handleHeroReadModel({
 
   return json({ ok: true, hero: responseHero });
 }
-

--- a/worker/src/repository.js
+++ b/worker/src/repository.js
@@ -9641,20 +9641,36 @@ export function createWorkerRepository({ env = {}, now = Date.now, capacity = nu
       return requireLearnerReadAccess(db, accountId, learnerId);
     },
     // Hero Mode P0/P2: read per-subject read-model data for the hero
-    // providers. Reads `child_subject_state` rows and returns both
-    // parsed `data` (data_json) and `ui` (ui_json) objects keyed by
-    // subject_id. Providers consume the `data` field unchanged.
+    // providers. Reads `child_subject_state` rows and returns raw storage
+    // data plus the public subject read model keyed by subject_id. Production
+    // Hero providers need derived read-model signals (stats, analytics,
+    // availability), not the subject engine's storage shape.
     // P2 active session detection inspects `ui` for heroContext.
-    async readHeroSubjectReadModels(learnerId) {
+    async readHeroSubjectReadModels(learnerId, { accountId = '', now = Date.now() } = {}) {
       const rows = await all(db, `
         SELECT subject_id, data_json, ui_json
         FROM child_subject_state
         WHERE learner_id = ?
       `, [learnerId]);
       const result = {};
+      const spellingContent = accountId && rows.some((row) => row.subject_id === 'spelling')
+        ? await readSpellingRuntimeContentBundle(db, accountId, 'spelling')
+        : null;
       for (const row of rows) {
-        const data = safeJsonParse(row.data_json, null);
-        const ui = safeJsonParse(row.ui_json, null);
+        const rawRecord = subjectStateRowToRecord(row);
+        const publicRecord = accountId
+          ? await publicSubjectStateRowToRecord(row, {
+            spellingContentSnapshot: spellingContent?.snapshot || null,
+            now,
+          })
+          : rawRecord;
+        const data = rawRecord.data || null;
+        const ui = publicRecord.ui
+          ? {
+            ...publicRecord.ui,
+            session: rawRecord.ui?.session || publicRecord.ui.session || null,
+          }
+          : rawRecord.ui || null;
         if (data || ui) {
           result[row.subject_id] = { data, ui };
         }


### PR DESCRIPTION
## Summary
- use the public subject read-model projection for Hero provider signals instead of raw subject storage JSON
- preserve raw active session heroContext for Hero active-session and idempotency handling
- add regression coverage for production split data/ui subject read models

## Verification
- npm test
- npm run check