### PR TITLE
fix(ui-refactor): redact spelling feedback answers

### DIFF
--- a/tests/server-spelling-engine-parity.test.js
+++ b/tests/server-spelling-engine-parity.test.js
@@ -9,6 +9,7 @@ import { resolveRuntimeSnapshot } from '../src/subjects/spelling/content/model.j
 import { createServerSpellingEngine, SPELLING_SERVER_AUTHORITY } from '../worker/src/subjects/spelling/engine.js';
 import { createWorkerRepositoryServer } from './helpers/worker-server.js';
 import { installMemoryStorage } from './helpers/memory-storage.js';
+import { FORBIDDEN_SPELLING_READ_MODEL_KEYS } from './helpers/forbidden-keys.mjs';
 
 function makeSeededRandom(seed = 1) {
   let value = seed >>> 0;
@@ -51,6 +52,22 @@ function seedAccountLearner(DB, { accountId = 'adult-a', learnerId = 'learner-a'
     INSERT INTO account_learner_memberships (account_id, learner_id, role, sort_index, created_at, updated_at)
     VALUES (?, ?, 'owner', 0, ?, ?)
   `).run(accountId, learnerId, now, now);
+}
+
+function assertNoForbiddenObjectKeys(value, forbiddenKeys, label, path = label) {
+  if (!value || typeof value !== 'object') return;
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => assertNoForbiddenObjectKeys(item, forbiddenKeys, label, `${path}[${index}]`));
+    return;
+  }
+  for (const [key, child] of Object.entries(value)) {
+    assert.equal(
+      forbiddenKeys.includes(key),
+      false,
+      `${path}.${key} exposed a server-only field.`,
+    );
+    assertNoForbiddenObjectKeys(child, forbiddenKeys, label, `${path}.${key}`);
+  }
 }
 
 async function postCommand(server, {
@@ -350,6 +367,44 @@ test('worker spelling command route starts, submits, continues, and completes se
       WHERE learner_id = 'learner-a' AND subject_id = 'spelling' AND status = 'completed'
     `).get().count;
     assert.equal(completedCount, 1);
+  } finally {
+    server.close();
+  }
+});
+
+test('worker spelling command route redacts answer fields from public feedback', async () => {
+  const server = createWorkerRepositoryServer();
+  seedAccountLearner(server.DB);
+
+  try {
+    let step = await postCommand(server, {
+      command: 'start-session',
+      requestId: 'spell-feedback-redaction-start',
+      expectedLearnerRevision: 0,
+      payload: {
+        mode: 'single',
+        slug: 'possess',
+        length: 1,
+      },
+    });
+    assert.equal(step.response.status, 200);
+
+    step = await postCommand(server, {
+      command: 'submit-answer',
+      requestId: 'spell-feedback-redaction-submit',
+      expectedLearnerRevision: 1,
+      payload: { answer: 'ks2-dense-smoke-wrong-answer' },
+    });
+    assert.equal(step.response.status, 200);
+    assert.equal(step.body.subjectReadModel.phase, 'session');
+    assert.ok(step.body.subjectReadModel.feedback);
+    assert.equal(step.body.subjectReadModel.feedback.answer, undefined);
+    assert.equal(step.body.subjectReadModel.feedback.attemptedAnswer, undefined);
+    assertNoForbiddenObjectKeys(
+      step.body.subjectReadModel,
+      FORBIDDEN_SPELLING_READ_MODEL_KEYS,
+      'workerSpelling.feedback',
+    );
   } finally {
     server.close();
   }

--- a/worker/src/subjects/spelling/read-models.js
+++ b/worker/src/subjects/spelling/read-models.js
@@ -33,6 +33,42 @@ function safeSession(session) {
   };
 }
 
+function safeStringArray(value) {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item) => typeof item === 'string');
+}
+
+function safeFeedback(feedback) {
+  if (!feedback || typeof feedback !== 'object' || Array.isArray(feedback)) return null;
+  const safe = {
+    kind: typeof feedback.kind === 'string' ? feedback.kind : 'info',
+    headline: typeof feedback.headline === 'string' ? feedback.headline : '',
+    body: typeof feedback.body === 'string' ? feedback.body : '',
+    footer: typeof feedback.footer === 'string' ? feedback.footer : '',
+    familyWords: safeStringArray(feedback.familyWords),
+  };
+
+  if (
+    !safe.headline
+    && !safe.body
+    && !safe.footer
+    && !safe.familyWords.length
+    && !feedback.persistenceWarning
+  ) {
+    return null;
+  }
+
+  if (
+    feedback.persistenceWarning
+    && typeof feedback.persistenceWarning === 'object'
+    && !Array.isArray(feedback.persistenceWarning)
+  ) {
+    safe.persistenceWarning = cloneSerialisable(feedback.persistenceWarning) || null;
+  }
+
+  return safe;
+}
+
 export function buildSpellingReadModel({
   learnerId,
   state,
@@ -51,7 +87,7 @@ export function buildSpellingReadModel({
     phase: safeState.phase || 'dashboard',
     awaitingAdvance: Boolean(safeState.awaitingAdvance),
     session,
-    feedback: safeState.feedback || null,
+    feedback: safeFeedback(safeState.feedback),
     summary: safeState.summary || null,
     error: typeof safeState.error === 'string' ? safeState.error : '',
     prefs: cloneSerialisable(prefs) || {},


### PR DESCRIPTION
## Summary
- redact answer and attemptedAnswer from the public Worker spelling feedback read model
- add a Worker command-route regression that submits a wrong spelling answer and scans the public read model with the production spelling forbidden-key oracle

## Verification
- node --test tests/server-spelling-engine-parity.test.js
- node --test tests/spelling-dense-history-smoke.test.js
- npm test
- npm run check