### PR TITLE
Close P13 caveats

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -96,9 +96,8 @@ jobs:
         run: npm ci --no-audit --no-fund
 
       - name: Install Chromium
-        # `.npmrc` defaults `playwright_skip_browser_download=true` so
-        # `npm ci` above skipped the ~300 MB Chromium download. Install
-        # explicitly here — PR jobs need the browser available.
+        # Normal deploy/check paths skip Playwright browser downloads.
+        # Install explicitly here — PR jobs need the browser available.
         run: npx playwright install --with-deps chromium
 
       - name: Run Playwright (mobile-390)

--- a/.npmrc
+++ b/.npmrc
@@ -1,31 +1,7 @@
-# U5 (sys-hardening p1): skip Playwright browser download on `npm install`.
+# Project npm config intentionally stays empty.
 #
-# `@playwright/test` is a devDependency used only by the golden-path suite
-# under `tests/playwright/`. The deployed Cloudflare Worker never loads the
-# Playwright browser, so every install — including Cloudflare Wrangler
-# remote-build hosts which run `npm install` during `wrangler.jsonc` build
-# — previously risked downloading ~300 MB of Chromium binaries.
-#
-# Playwright honours `playwright_skip_browser_download=true` in `.npmrc`
-# as equivalent to the `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` environment
-# variable. Internally, npm exposes every `.npmrc` key as
-# `npm_config_<key>`, and Playwright's registry reader falls back to
-# `npm_config_<name>` when the plain env var is unset (see
-# `node_modules/playwright-core/lib/server/utils/env.js:getFromENV`).
-# Adopting the project-level `.npmrc` makes the skip the default on
-# every clone and build host, without each developer or CI job having
-# to remember the env var.
-#
-# Note: npm prints
-#   npm warn Unknown project config "playwright_skip_browser_download"
-# because the key isn't one of npm's built-in settings. The warning is
-# harmless — npm still exposes the key via `npm_config_*`, which is
-# what Playwright reads. If the warning becomes a hard error in a
-# future npm major, re-document the env-var approach in `AGENTS.md`
-# and `wrangler.jsonc`.
-#
-# Developers running the Playwright suite locally still need the
-# Chromium binary and can opt in explicitly:
-#   npx playwright install chromium
-# (See `docs/operations/capacity.md#playwright-test-suite`.)
-playwright_skip_browser_download=true
+# Do not add `playwright_skip_browser_download=true` here. npm 10+ warns
+# about unknown project config keys on every `npm run`, which makes release
+# gates noisy. Wrangler deploy/check paths set `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1`
+# inside `scripts/wrangler-oauth.mjs` before invoking Wrangler, so production
+# builds still skip Playwright browser downloads without npm warning noise.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@
 - These scripts route Wrangler through `scripts/wrangler-oauth.mjs`, which removes `CLOUDFLARE_API_TOKEN` from the child process so Wrangler uses the logged-in OAuth session.
 - Do not reintroduce raw `npx wrangler deploy`, raw remote D1 Wrangler commands, or scripts that depend on `CLOUDFLARE_API_TOKEN` unless the authentication strategy is intentionally changed and documented.
 - The `*:oauth` aliases are compatibility aliases only; the default scripts are already OAuth-safe.
-- The repo root `.npmrc` sets `playwright_skip_browser_download=true`, which Playwright honours as equivalent to the `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` environment variable. Every `npm install` — including the one Cloudflare Wrangler remote builds run — therefore skips the ~300 MB Chromium download by default. Developers who need the browser locally opt in with `npx playwright install chromium`. See `docs/operations/capacity.md#playwright-test-suite`.
+- The repo root `.npmrc` intentionally stays free of Playwright skip keys because npm warns on unknown project config. The Wrangler wrapper (`scripts/wrangler-oauth.mjs`) injects `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` for normal deploy/check paths, so production builds skip the ~300 MB Chromium download without npm warning noise. Developers who need the browser locally opt in with `npx playwright install chromium`. See `docs/operations/capacity.md#playwright-test-suite`.
 
 ## Verification
 

--- a/docs/operations/capacity.md
+++ b/docs/operations/capacity.md
@@ -714,18 +714,14 @@ Fresh clones must download the Chromium binary once:
 npx playwright install chromium
 ```
 
-The repo root `.npmrc` enforces the skip by default:
-
-```
-playwright_skip_browser_download=true
-```
-
-Playwright honours that key as equivalent to the
-`PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` environment variable, so every
-`npm install` — including the one Cloudflare Wrangler remote builds run —
-automatically skips the ~300 MB Chromium download. The deployed Worker never
-uses the Playwright browser, and developers who want it locally opt in with
-the `npx playwright install chromium` command above.
+The repo root `.npmrc` deliberately does not set Playwright skip keys because
+npm warns about unknown project config. Deploy and check commands go through
+`scripts/wrangler-oauth.mjs`, which injects
+`PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` before invoking Wrangler. That keeps
+production build paths from downloading the ~300 MB Chromium binary without
+adding npm warning noise. The deployed Worker never uses the Playwright
+browser, and developers who want it locally opt in with the
+`npx playwright install chromium` command above.
 
 ### Updating screenshot baselines
 

--- a/scripts/admin-ops-production-smoke.mjs
+++ b/scripts/admin-ops-production-smoke.mjs
@@ -268,6 +268,13 @@ function persistSmokeResult({ ok, failures, steps, rootDir }) {
     finishedAt: new Date().toISOString(),
     smokeType: 'admin',
     failures: Array.isArray(failures) ? failures.map(String) : [],
+    stepCount: Array.isArray(steps) ? steps.length : 0,
+    steps: Array.isArray(steps)
+      ? steps.map((entry) => ({
+        step: String(entry?.step || ''),
+        sequence: Number(entry?.sequence) || null,
+      }))
+      : [],
     commit,
   };
   writeFileSync(outputPath, JSON.stringify(payload, null, 2) + '\n');

--- a/scripts/deploy-punctuation-qg-p13-live.mjs
+++ b/scripts/deploy-punctuation-qg-p13-live.mjs
@@ -8,6 +8,7 @@ import { pathToFileURL } from 'node:url';
 const ROOT = resolve(new URL('..', import.meta.url).pathname);
 const OUT = 'reports/punctuation/punctuation-qg-p13-production-smoke.json';
 const DEPLOY_PREDEPLOY_OUT = '/tmp/ks2-punctuation-qg-p13-predeploy-evidence.json';
+const ADMIN_SMOKE_OUT = 'reports/admin-smoke/latest.json';
 
 function argValue(argv, ...names) {
   for (const name of names) {
@@ -60,6 +61,7 @@ function main(argv = process.argv) {
   const origin = argValue(argv, '--origin') || process.env.KS2_SMOKE_ORIGIN || 'https://ks2.eugnel.uk';
   const commitSha = argValue(argv, '--commit-sha') || process.env.GITHUB_SHA || process.env.WORKER_COMMIT_SHA || gitSha();
   const out = argValue(argv, '--out') || OUT;
+  const includeAdminHub = argv.includes('--admin-hub');
   if (!commitSha) {
     throw new Error('P13 live deploy requires a commit SHA. Pass --commit-sha, set GITHUB_SHA/WORKER_COMMIT_SHA, or run from a git checkout.');
   }
@@ -69,7 +71,11 @@ function main(argv = process.argv) {
   run(predeployCommandForDeploy());
   assertCleanGitTree();
   run('npm run deploy');
-  run(`node scripts/punctuation-qg-p13-live-smoke.mjs --env production --authenticated --origin ${origin} --commit-sha ${commitSha} --out ${out}`);
+  if (includeAdminHub) {
+    run('npm run smoke:production:admin-ops');
+  }
+  const adminHubArgs = includeAdminHub ? ` --admin-hub --admin-smoke-file ${ADMIN_SMOKE_OUT}` : '';
+  run(`node scripts/punctuation-qg-p13-live-smoke.mjs --env production --authenticated --origin ${origin} --commit-sha ${commitSha} --out ${out}${adminHubArgs}`);
   if (!existsSync(resolve(ROOT, out))) throw new Error(`Expected smoke artefact was not written: ${out}`);
   run(`node scripts/validate-punctuation-qg-p13-live-evidence.mjs ${out} --origin ${origin}`);
   console.log('\nPunctuation QG P13 is live-serving certified for the deployed production origin.');

--- a/scripts/punctuation-qg-p13-live-smoke.mjs
+++ b/scripts/punctuation-qg-p13-live-smoke.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import assert from 'node:assert/strict';
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
@@ -44,12 +44,66 @@ export function parseArgs(argv) {
     out: argValue(argv, '--out') || '',
     json: argv.includes('--json') || Boolean(argValue(argv, '--out')),
     adminHubCoverage: argv.includes('--admin-hub'),
+    adminSmokeFile: argValue(argv, '--admin-smoke-file') || 'reports/admin-smoke/latest.json',
   };
 }
 
-export function assertSupportedP13LiveSmokeOptions({ adminHubCoverage = false } = {}) {
-  if (adminHubCoverage) {
-    throw new Error('P13 live smoke cannot claim Admin Hub coverage because this smoke uses a demo session and does not fetch Admin Hub evidence.');
+const REQUIRED_ADMIN_SMOKE_STEPS = [
+  'admin-hub',
+  'debug-bundle',
+  'account-detail',
+  'content-overview',
+];
+
+function stepNamesForAdminSmoke(adminSmoke) {
+  return Array.isArray(adminSmoke?.steps)
+    ? adminSmoke.steps.map((entry) => String(entry?.step || '')).filter(Boolean)
+    : [];
+}
+
+export function buildAdminHubEvidenceFromSmoke(adminSmoke, { source = 'reports/admin-smoke/latest.json' } = {}) {
+  const stepNames = stepNamesForAdminSmoke(adminSmoke);
+  const missingSteps = REQUIRED_ADMIN_SMOKE_STEPS.filter((step) => !stepNames.includes(step));
+  if (adminSmoke?.ok !== true) {
+    throw new Error(`P13 Admin Hub coverage requires a passing admin production smoke artefact at ${source}.`);
+  }
+  if (adminSmoke?.smokeType !== 'admin') {
+    throw new Error(`P13 Admin Hub coverage requires an admin smoke artefact at ${source}.`);
+  }
+  if (missingSteps.length > 0) {
+    throw new Error(`P13 Admin Hub coverage artefact is missing required admin smoke steps: ${missingSteps.join(', ')}.`);
+  }
+
+  return {
+    hasEvidence: true,
+    source,
+    smokeType: adminSmoke.smokeType,
+    finishedAt: adminSmoke.finishedAt || null,
+    commit: adminSmoke.commit || null,
+    stepCount: Number(adminSmoke.stepCount || stepNames.length),
+    requiredSteps: REQUIRED_ADMIN_SMOKE_STEPS,
+    redactionChecks: {
+      learnerSupport: stepNames.includes('account-detail'),
+      punctuationEvidence: stepNames.includes('content-overview'),
+      releaseDiagnostics: stepNames.includes('debug-bundle'),
+    },
+  };
+}
+
+export function readAdminHubEvidenceForP13({ adminHubCoverage = false, adminSmokeFile = 'reports/admin-smoke/latest.json' } = {}) {
+  if (!adminHubCoverage) return null;
+  let adminSmoke;
+  try {
+    adminSmoke = JSON.parse(readFileSync(adminSmokeFile, 'utf8'));
+  } catch (error) {
+    throw new Error(`P13 Admin Hub coverage requires a readable admin smoke artefact at ${adminSmokeFile}: ${error?.message || error}`);
+  }
+  return buildAdminHubEvidenceFromSmoke(adminSmoke, { source: adminSmokeFile });
+}
+
+export function assertSupportedP13LiveSmokeOptions({ adminHubCoverage = false, adminHubEvidence = null } = {}) {
+  if (adminHubCoverage && adminHubEvidence?.hasEvidence !== true) {
+    throw new Error('P13 live smoke cannot claim Admin Hub coverage without a passing Admin Hub production smoke artefact.');
   }
 }
 
@@ -195,7 +249,8 @@ async function readParentHubPunctuationEvidence({ origin, cookie, learnerId }) {
 
 export async function runPunctuationQGP13LiveSmoke(options = {}) {
   const args = { ...parseArgs(process.argv), ...options };
-  assertSupportedP13LiveSmokeOptions(args);
+  const adminHubEvidence = readAdminHubEvidenceForP13(args);
+  assertSupportedP13LiveSmokeOptions({ ...args, adminHubEvidence });
   const expected = expectedPunctuationQGP13LiveManifest();
   const demo = await createDemoSession(args.origin);
   const bootstrap = await loadBootstrap(args.origin, demo.cookie, { expectedSession: demo.session });
@@ -266,6 +321,7 @@ export async function runPunctuationQGP13LiveSmoke(options = {}) {
         promptTokenReturned: spelling.hasPromptToken === true,
       },
     },
+    ...(adminHubEvidence ? { adminHubEvidence } : {}),
   };
 }
 

--- a/scripts/wrangler-oauth.mjs
+++ b/scripts/wrangler-oauth.mjs
@@ -10,6 +10,12 @@ if (!wranglerArgs.length) {
 const env = { ...process.env };
 const isWorkersBuild = env.WORKERS_CI === '1';
 
+// Keep deploy/check installs and Wrangler custom builds from downloading
+// Playwright browser binaries. This replaces the old `.npmrc`
+// `playwright_skip_browser_download=true` project config, which newer npm
+// versions warn about as an unknown key.
+env.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = env.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD || '1';
+
 if (!isWorkersBuild) {
   delete env.CLOUDFLARE_API_TOKEN;
 }

--- a/tests/punctuation-qg-p13-live-release.test.js
+++ b/tests/punctuation-qg-p13-live-release.test.js
@@ -9,6 +9,7 @@ import {
 } from '../scripts/deploy-punctuation-qg-p13-live.mjs';
 import {
   assertSupportedP13LiveSmokeOptions,
+  buildAdminHubEvidenceFromSmoke,
 } from '../scripts/punctuation-qg-p13-live-smoke.mjs';
 import {
   expectedPunctuationQGP13LiveManifest,
@@ -187,11 +188,11 @@ test('P13 predeploy verifier can write deploy-wrapper evidence outside the workt
   );
 });
 
-test('P13 live smoke cannot claim Admin Hub coverage without fetching Admin Hub evidence', () => {
+test('P13 live smoke cannot claim Admin Hub coverage without Admin Hub evidence', () => {
   assert.doesNotThrow(() => assertSupportedP13LiveSmokeOptions({ adminHubCoverage: false }));
   assert.throws(
     () => assertSupportedP13LiveSmokeOptions({ adminHubCoverage: true }),
-    /cannot claim Admin Hub coverage/,
+    /without a passing Admin Hub production smoke artefact/,
   );
 
   const expected = expectedPunctuationQGP13LiveManifest();
@@ -257,6 +258,118 @@ test('P13 live smoke cannot claim Admin Hub coverage without fetching Admin Hub 
   });
   assert.equal(result.ok, false);
   assert.match(result.errors.join('\n'), /adminHubEvidence/);
+});
+
+test('P13 live smoke can compose a passing Admin Hub smoke artefact into live evidence', () => {
+  const expected = expectedPunctuationQGP13LiveManifest();
+  const adminHubEvidence = buildAdminHubEvidenceFromSmoke({
+    ok: true,
+    smokeType: 'admin',
+    finishedAt: '2026-05-02T00:00:00.000Z',
+    commit: '2f8bb7d2542e5368202e2e8705af9a32588a4ef1',
+    stepCount: 14,
+    steps: [
+      { step: 'login', sequence: 1 },
+      { step: 'admin-hub', sequence: 2 },
+      { step: 'debug-bundle', sequence: 8 },
+      { step: 'account-detail', sequence: 11 },
+      { step: 'content-overview', sequence: 12 },
+    ],
+  }, { source: 'reports/admin-smoke/latest.json' });
+
+  assert.doesNotThrow(() => assertSupportedP13LiveSmokeOptions({
+    adminHubCoverage: true,
+    adminHubEvidence,
+  }));
+
+  const result = validatePunctuationQGP13LiveEvidence({
+    ok: true,
+    origin: 'https://ks2.eugnel.uk',
+    accountId: 'demo-sample',
+    learnerId: 'learner-demo-sample',
+    attestation: {
+      environment: 'production',
+      releasePhase: PUNCTUATION_QG_P13_LIVE_PHASE,
+      releaseId: expected.contentReleaseId,
+      runtimeItemCount: expected.runtimeItems,
+      generatedDepth: expected.productionDepth,
+      workerCommitSha: '2f8bb7d2542e5368202e2e8705af9a32588a4ef1',
+      timestamp: '2026-05-02T00:00:00.000Z',
+      authenticatedCoverage: true,
+      adminHubCoverage: true,
+    },
+    punctuation: {
+      productionObserved: {
+        releaseId: expected.contentReleaseId,
+        runtimeItems: expected.runtimeItems,
+        publishedRewardUnits: expected.publishedRewardUnits,
+      },
+      localReleaseManifestExpectation: {
+        fixedItems: expected.fixedItems,
+        generatedItems: expected.generatedItems,
+        generatedPerFamily: expected.productionDepth,
+        runtimeItems: expected.runtimeItems,
+        publishedRewardUnits: expected.publishedRewardUnits,
+      },
+      smartSix: {
+        summaryTotal: 6,
+        uniqueItems: 6,
+        immediateRepeats: 0,
+        generatedSeen: 1,
+        items: Array.from({ length: 6 }, (_, index) => ({
+          itemId: `sample-${index + 1}`,
+          source: 'generated',
+          mode: 'insert',
+          skillIds: ['speech'],
+        })),
+      },
+      parentHubEvidence: {
+        hasEvidence: true,
+        attempts: 6,
+        progressSnapshotsHasPunctuation: true,
+        redactionChecks: {
+          punctuationEvidence: true,
+          progressSnapshots: true,
+          misconceptionPatterns: true,
+        },
+      },
+    },
+    spelling: {
+      progressTotal: 1,
+      hasPromptToken: true,
+      redactionChecks: {
+        rawWordHidden: true,
+        rawSentenceHidden: true,
+        promptTokenReturned: true,
+      },
+    },
+    adminHubEvidence,
+  });
+  assert.equal(result.ok, true, result.errors.join('; '));
+});
+
+test('P13 Admin Hub evidence composition fails closed on incomplete admin smoke artefacts', () => {
+  assert.throws(
+    () => buildAdminHubEvidenceFromSmoke({
+      ok: true,
+      smokeType: 'admin',
+      steps: [{ step: 'admin-hub', sequence: 2 }],
+    }),
+    /missing required admin smoke steps/,
+  );
+  assert.throws(
+    () => buildAdminHubEvidenceFromSmoke({
+      ok: false,
+      smokeType: 'admin',
+      steps: [
+        { step: 'admin-hub', sequence: 2 },
+        { step: 'debug-bundle', sequence: 8 },
+        { step: 'account-detail', sequence: 11 },
+        { step: 'content-overview', sequence: 12 },
+      ],
+    }),
+    /passing admin production smoke/,
+  );
 });
 
 test('P13 package scripts write and validate the same live smoke artefact', () => {


### PR DESCRIPTION
## Summary
- remove the npm unknown-project-config warning source while preserving Playwright browser-download skips for Wrangler deploy/check paths
- make P13 Admin Hub coverage fail closed unless a passing admin production smoke artefact is present
- persist admin smoke step names so P13 evidence can trace Admin Hub coverage to real smoke steps
- wire `--admin-hub` deploy flow to run the admin production smoke before composing P13 live evidence

## Verification
- node --test tests/punctuation-qg-p13-live-release.test.js
- node --test tests/admin-ops-production-smoke.test.js
- npm run check
- no `Unknown project config` or `Unknown env config` matches in /tmp/ks2-check-no-npm-warning.log
- npm test

## Operational note
- Current shell has no `KS2_SMOKE_ACCOUNT_EMAIL` / `KS2_SMOKE_ACCOUNT_PASSWORD`, so the live Admin Hub production smoke is credential-gated until those env vars are supplied. The code path now fails closed instead of allowing a false Admin Hub claim.
- Removed local worktree `.worktrees/punctuation-p12-p13` and deleted local branch `punctuation-p13-production-smoke-evidence`.
