### PR TITLE
docs(ui-refactor): record P5 blocker closure evidence

### DIFF
--- a/docs/plans/james/ui-refactor/ui-refactor-p5-completion-report.md
+++ b/docs/plans/james/ui-refactor/ui-refactor-p5-completion-report.md
@@ -2,14 +2,15 @@
 
 Date: 2026-05-02
 
-Status: completed for source, local verification, PR merge, and live production replay on `https://ks2.eugnel.uk`.
+Status: completed for source, local verification, PR merge, blocker follow-up, and live production replay on `https://ks2.eugnel.uk`.
 
 ## Scope Boundary
 
 - Source boundary: implemented on branch `ui-refactor` and merged through PR `#831`.
 - GitHub boundary: PR `#831` was squash-merged into `main` as `3e85fdb2ee819357559ac63f21e2e9cf9a6ea9e7`.
-- Production boundary: deployed from `main` commit `3e85fdb2ee819357559ac63f21e2e9cf9a6ea9e7` with Worker version `9cc7c30b-6c0b-4806-b782-c76f11ce7530`.
+- Production boundary: initially deployed from `main` commit `3e85fdb2ee819357559ac63f21e2e9cf9a6ea9e7` with Worker version `9cc7c30b-6c0b-4806-b782-c76f11ce7530`; blocker follow-ups were deployed through `main` commit `e0795100c167578eff96fa813ed060f12e203a6d` with Worker version `7d7e3afa-382b-410f-b623-a4e14c88f276`.
 - Screenshot-pack boundary: the P4 screenshot manifest is now explicit and the blocker follow-up commits all 12 named PNG entries as `captured`.
+- Redaction boundary: the dense Spelling production smoke now covers both start-session and submit-answer public read models, including forbidden-key scans after post-marking feedback.
 
 ## Implemented Changes
 
@@ -64,6 +65,11 @@ GitHub checks on PR `#831`:
 - GitGuardian Security Checks - passed.
 - `Chromium + mobile-390 golden paths` - skipped by path classification.
 
+Blocker follow-up verification:
+
+- PR `#837` closed the screenshot-pack and `audio.sessionId` blockers; GitHub `npm test + npm run check`, `npm run audit:client`, `npm run audit:punctuation-content`, and GitGuardian all passed.
+- PR `#838` closed the post-submit Spelling feedback redaction blocker; local `npm test` passed with 27,648 pass / 0 fail / 6 skipped, local `npm run check` passed, and GitHub `npm test + npm run check`, `npm run audit:client`, `npm run audit:punctuation-content`, and GitGuardian all passed.
+
 ## Production Evidence
 
 Deployment:
@@ -73,13 +79,14 @@ Deployment:
 - Source commit: `3e85fdb2ee819357559ac63f21e2e9cf9a6ea9e7`
 - Deploy client audit: passed, main bundle `188352 / 232000` bytes gzip.
 - Production bundle audit: passed for `https://ks2.eugnel.uk/` with 1 HTML-referenced bundle, 6 transitive chunks, 19 direct paths, 5/5 security-header checks, and 15/15 cache-split checks.
+- Blocker follow-up deployment: PR `#837` deployed Worker version `32c4f4cd-d4a2-4b17-8db2-38c9a15b3e23`; PR `#838` deployed Worker version `7d7e3afa-382b-410f-b623-a4e14c88f276` from source commit `e0795100c167578eff96fa813ed060f12e203a6d`. The final deploy client audit passed with main bundle `188340 / 232000` bytes gzip, and the production bundle audit passed again for `https://ks2.eugnel.uk/`.
 
 Smoke artefacts:
 
 - Bootstrap: `reports/ui-refactor/ui-refactor-p5-bootstrap-production-smoke-2026-05-02.json` (`ok: true`, HTTP 200, `bootstrapCapacity` present).
 - Grammar: `reports/ui-refactor/ui-refactor-p5-grammar-production-smoke-2026-05-02.json` (`ok: true`, release `grammar-qg-p14-2026-05-01`, session, mini-test, repair, summary, answer-spec families, and forbidden-key scans covered).
 - Punctuation: `reports/ui-refactor/ui-refactor-p5-punctuation-production-smoke-2026-05-02.json` (`ok: true`, release `punctuation-qg-p11-2026-05-01`, smart summary, generated incorrect path, dash/Oxford-comma acceptance, GPS review, parent evidence covered).
-- Spelling summary path: covered inside the punctuation smoke artefact through the one-word Spelling command path (`progressTotal: 1`, prompt token present). The blocker follow-up removes `audio.sessionId` from the public Spelling audio cue and locks the redaction contract with Worker tests; the dense-history production smoke must be re-run after that follow-up deploy.
+- Spelling dense path: `reports/ui-refactor/ui-refactor-p5-spelling-dense-production-smoke-2026-05-02.json` (`ok: true`, source commit `e0795100c167578eff96fa813ed060f12e203a6d`, finished `2026-05-02T22:17:14.684Z`, bootstrap capacity present, start-session and submit-answer both HTTP 200, no forbidden-key leak, `p95WallMs: 467.8` under the 750 ms gate).
 - Admin Visual Engine route: `reports/ui-refactor/ui-refactor-p5-admin-visual-engine-real-browser-evidence-2026-05-02.json` (`ok: true`) captured from an existing logged-in Chrome/CDP session against real production APIs. `/api/auth/session`, `/api/bootstrap`, and `/api/hubs/admin` returned HTTP 200, and the Visual Engine route rendered adapter, evidence, deployment, smoke-file, and diagnostic-only sections.
 - Admin Visual Engine screenshot: `output/playwright/ui-refactor-p5-production-2026-05-02/admin-visual-engine-real-cdp.png`.
 
@@ -87,7 +94,7 @@ Smoke artefacts:
 
 Production evidence proves the deployed source commit and the smoke/browser routes listed above. It does not claim pixel-perfect visual correctness beyond the captured Admin Visual Engine screenshot and the explicitly present screenshot artefacts.
 
-The P4 screenshot pack now remains strict: all 12 named PNGs are committed, all manifest entries are `captured`, and the verifier plus contract test fail future missing-file or omitted-entry regressions.
+The P4 screenshot pack now remains strict: all 12 named PNGs are committed, all manifest entries are `captured`, and the verifier plus contract test fail future missing-file or omitted-entry regressions. The public Spelling read model also remains strict: post-submit feedback no longer exposes `answer` or `attemptedAnswer`, and the Worker command-route test scans the public read model with the production Spelling forbidden-key oracle.
 
 ## Non-Goals Preserved
 
@@ -100,4 +107,4 @@ The P4 screenshot pack now remains strict: all 12 named PNGs are committed, all 
 
 ## Closure
 
-P5 closes the Visual Engine operating contract. Future UI work should move into named product streams rather than another generic UI-refactor phase.
+P5 closes the Visual Engine operating contract and the reviewer-raised blocker follow-ups. Future UI work should move into named product streams rather than another generic UI-refactor phase.

--- a/reports/ui-refactor/ui-refactor-p5-spelling-dense-production-smoke-2026-05-02.json
+++ b/reports/ui-refactor/ui-refactor-p5-spelling-dense-production-smoke-2026-05-02.json
@@ -1,0 +1,114 @@
+{
+  "ok": true,
+  "reportMeta": {
+    "commit": "e0795100c167578eff96fa813ed060f12e203a6d",
+    "environment": "production",
+    "origin": "https://ks2.eugnel.uk",
+    "authMode": "unknown",
+    "learners": null,
+    "bootstrapBurst": null,
+    "rounds": null,
+    "startedAt": "2026-05-02T22:17:13.372Z",
+    "finishedAt": "2026-05-02T22:17:14.684Z",
+    "evidenceSchemaVersion": 3,
+    "provenance": {
+      "workflowRunUrl": "unknown",
+      "workflowName": "unknown",
+      "gitSha": "e0795100c167578eff96fa813ed060f12e203a6d",
+      "dirtyTreeFlag": false,
+      "thresholdConfigHash": "none",
+      "loadDriverVersion": "0.1.0",
+      "operator": "jamesto",
+      "rawLogArtifactPath": "none"
+    }
+  },
+  "summary": {
+    "ok": true,
+    "startedAt": "2026-05-02T22:17:13.372Z",
+    "finishedAt": "2026-05-02T22:17:14.684Z",
+    "origin": "https://ks2.eugnel.uk",
+    "learnerId": "learner-demo-nh7f1EgGZW_kiA",
+    "totalRequests": 2,
+    "endpoints": {
+      "POST /api/subjects/spelling/command": {
+        "count": 2,
+        "p50WallMs": 467.8,
+        "p95WallMs": 467.8,
+        "maxResponseBytes": 4348
+      }
+    },
+    "signals": {},
+    "bootstrap": {
+      "capacity": {
+        "version": 4,
+        "mode": "public-bounded",
+        "practiceSessions": {
+          "returned": 0,
+          "bounded": true,
+          "atOrAboveRecentLimit": false,
+          "atOrAboveMaximumLimit": false
+        },
+        "eventLog": {
+          "returned": 0,
+          "bounded": true,
+          "atOrAboveRecentLimit": false
+        }
+      }
+    },
+    "commands": [
+      {
+        "command": "start-session",
+        "status": 200,
+        "wallMs": 467.8,
+        "responseBytes": 4106,
+        "signals": [],
+        "serverCapacity": {
+          "requestId": "req_04106d433d6256ac5e58527b",
+          "queryCount": 22,
+          "d1RowsRead": 133,
+          "d1RowsWritten": 16,
+          "serverWallMs": 249,
+          "responseBytes": 3887,
+          "signals": []
+        },
+        "requestId": "req_5450827e2d4d409ccc3e6958"
+      },
+      {
+        "command": "submit-answer",
+        "status": 200,
+        "wallMs": 257.2,
+        "responseBytes": 4348,
+        "signals": [],
+        "serverCapacity": {
+          "requestId": "req_94c57488d4d04643547bd168",
+          "queryCount": 18,
+          "d1RowsRead": 20,
+          "d1RowsWritten": 13,
+          "serverWallMs": 172,
+          "responseBytes": 4142,
+          "signals": []
+        },
+        "requestId": "req_9bf2d208ca803a470bea19cb"
+      }
+    ],
+    "failures": []
+  },
+  "failures": [],
+  "thresholds": {
+    "maxP95Ms": {
+      "configured": 750,
+      "observed": 467.8,
+      "passed": true
+    }
+  },
+  "safety": {
+    "mode": "production-spelling-dense-smoke",
+    "origin": "https://ks2.eugnel.uk",
+    "authMode": "unknown"
+  },
+  "redaction": {
+    "version": "capacity-diagnostics-redaction-v1",
+    "requestIds": "sha256:24",
+    "rawRequestIdsPersisted": false
+  }
+}


### PR DESCRIPTION
## Summary
- add the final production Spelling dense smoke evidence after the blocker follow-up deploy
- update the P5 completion report so it records PR #837, PR #838, final Worker version, and the closed redaction/screenshot blockers

## Verification
- production smoke: npm run smoke:production:spelling-dense -- --origin https://ks2.eugnel.uk --require-bootstrap-capacity --output reports/ui-refactor/ui-refactor-p5-spelling-dense-production-smoke-2026-05-02.json
- JSON parse check for reports/ui-refactor/ui-refactor-p5-spelling-dense-production-smoke-2026-05-02.json