### PR TITLE
Close Admin Hub smoke coverage gap

### DIFF
--- a/reports/admin-smoke/latest.json
+++ b/reports/admin-smoke/latest.json
@@ -1,11 +1,9 @@
 {
-  "ok": false,
-  "finishedAt": "2026-05-02T22:36:21.555Z",
+  "ok": true,
+  "finishedAt": "2026-05-02T22:43:04.526Z",
   "smokeType": "admin",
-  "failures": [
-    "ops-error-event status investigating"
-  ],
-  "stepCount": 9,
+  "failures": [],
+  "stepCount": 19,
   "steps": [
     {
       "step": "login",
@@ -42,6 +40,46 @@
     {
       "step": "ops-error-event ingest",
       "sequence": 9
+    },
+    {
+      "step": "ops-error-event status investigating",
+      "sequence": 10
+    },
+    {
+      "step": "ops-error-event status reopen",
+      "sequence": 11
+    },
+    {
+      "step": "debug-bundle",
+      "sequence": 12
+    },
+    {
+      "step": "denial-log",
+      "sequence": 13
+    },
+    {
+      "step": "account-search",
+      "sequence": 14
+    },
+    {
+      "step": "account-detail",
+      "sequence": 15
+    },
+    {
+      "step": "content-overview",
+      "sequence": 16
+    },
+    {
+      "step": "marketing-messages-list",
+      "sequence": 17
+    },
+    {
+      "step": "marketing-create",
+      "sequence": 18
+    },
+    {
+      "step": "marketing-archive",
+      "sequence": 19
     }
   ],
   "commit": "unknown"

--- a/reports/punctuation/punctuation-qg-p13-production-smoke.json
+++ b/reports/punctuation/punctuation-qg-p13-production-smoke.json
@@ -1,8 +1,8 @@
 {
   "ok": true,
   "origin": "https://ks2.eugnel.uk",
-  "accountId": "demo-VyVlzLhGErUa0Q",
-  "learnerId": "learner-demo-lFHiyHHuZNU8-w",
+  "accountId": "demo-HXWCvqbUBNEEYA",
+  "learnerId": "learner-demo-nkHuKEvW77m1Kw",
   "attestation": {
     "environment": "production",
     "releasePhase": "punctuation-qg-p13-live-serving",
@@ -12,9 +12,9 @@
     "workerCommitSha": "b7a6125966975bae14aaeea7050cf107ccdb40e6",
     "workerVersionId": null,
     "deploymentId": null,
-    "timestamp": "2026-05-02T21:53:40.211Z",
+    "timestamp": "2026-05-02T22:45:39.843Z",
     "authenticatedCoverage": true,
-    "adminHubCoverage": false
+    "adminHubCoverage": true
   },
   "punctuation": {
     "productionObserved": {
@@ -52,45 +52,46 @@
       "skillIds": [
         "apostrophe_contractions",
         "apostrophe_possession",
-        "fronted_adverbial",
+        "colon_list",
+        "comma_clarity",
         "list_commas",
         "sentence_endings"
       ],
       "items": [
         {
-          "itemId": "fx_se_choose_statement_forest",
+          "itemId": "cc_choose_before_cooking",
           "source": "fixed",
           "mode": "choose",
+          "skillIds": [
+            "comma_clarity"
+          ]
+        },
+        {
+          "itemId": "gen_sentence_endings_insert_3xypj9_6",
+          "source": "generated",
+          "mode": "insert",
           "skillIds": [
             "sentence_endings"
           ]
         },
         {
-          "itemId": "ac_insert_well_youre",
+          "itemId": "cc_fix_when_rain_stopped",
           "source": "fixed",
-          "mode": "insert",
-          "skillIds": [
-            "apostrophe_contractions"
-          ]
-        },
-        {
-          "itemId": "gen_apostrophe_contractions_fix_tdz6ot_7",
-          "source": "generated",
           "mode": "fix",
           "skillIds": [
-            "apostrophe_contractions"
+            "comma_clarity"
           ]
         },
         {
-          "itemId": "fa_transfer_after_lunch",
+          "itemId": "cl_transfer_trip",
           "source": "fixed",
           "mode": "transfer",
           "skillIds": [
-            "fronted_adverbial"
+            "colon_list"
           ]
         },
         {
-          "itemId": "gen_list_commas_combine_18t19w8_10",
+          "itemId": "gen_list_commas_combine_15sthm0_19",
           "source": "generated",
           "mode": "combine",
           "skillIds": [
@@ -98,7 +99,7 @@
           ]
         },
         {
-          "itemId": "gen_apostrophe_mix_paragraph_c6l9gp_12",
+          "itemId": "gen_apostrophe_mix_paragraph_d6g6dr_3",
           "source": "generated",
           "mode": "paragraph",
           "skillIds": [
@@ -130,6 +131,25 @@
       "rawWordHidden": true,
       "rawSentenceHidden": true,
       "promptTokenReturned": true
+    }
+  },
+  "adminHubEvidence": {
+    "hasEvidence": true,
+    "source": "reports/admin-smoke/latest.json",
+    "smokeType": "admin",
+    "finishedAt": "2026-05-02T22:43:04.526Z",
+    "commit": "unknown",
+    "stepCount": 19,
+    "requiredSteps": [
+      "admin-hub",
+      "debug-bundle",
+      "account-detail",
+      "content-overview"
+    ],
+    "redactionChecks": {
+      "learnerSupport": true,
+      "punctuationEvidence": true,
+      "releaseDiagnostics": true
     }
   }
 }

--- a/scripts/admin-ops-production-smoke.mjs
+++ b/scripts/admin-ops-production-smoke.mjs
@@ -542,8 +542,10 @@ export async function runSmoke({
         timeoutMs,
         body: {
           status: 'investigating',
-          requestId: investigateRequestId,
-          correlationId: investigateRequestId,
+          mutation: {
+            requestId: investigateRequestId,
+            correlationId: investigateRequestId,
+          },
         },
       });
       assertStepOk('ops-error-event status investigating', investigate);
@@ -558,9 +560,11 @@ export async function runSmoke({
         timeoutMs,
         body: {
           status: 'open',
-          requestId: openRequestId,
-          correlationId: openRequestId,
           expectedPreviousStatus: 'investigating',
+          mutation: {
+            requestId: openRequestId,
+            correlationId: openRequestId,
+          },
         },
       });
       assertStepOk('ops-error-event status reopen', reopen);
@@ -798,8 +802,10 @@ export async function runSmoke({
           body: {
             action: 'archived',
             expectedRowVersion: createdRowVersion,
-            requestId: archiveRequestId,
-            correlationId: archiveRequestId,
+            mutation: {
+              requestId: archiveRequestId,
+              correlationId: archiveRequestId,
+            },
           },
         });
         assertStepOk('marketing-archive', archive);
@@ -831,8 +837,10 @@ export async function runSmoke({
               body: {
                 action: 'archived',
                 expectedRowVersion: currentRowVersion,
-                requestId: retryArchiveRequestId,
-                correlationId: retryArchiveRequestId,
+                mutation: {
+                  requestId: retryArchiveRequestId,
+                  correlationId: retryArchiveRequestId,
+                },
               },
             });
             if (retryArchive.response.ok && retryArchive.payload?.ok !== false) {

--- a/src/platform/game/monster-visual-config.js
+++ b/src/platform/game/monster-visual-config.js
@@ -1,9 +1,18 @@
 import { MONSTER_ASSET_MANIFEST } from './monster-asset-manifest.js';
 import { MONSTER_ASSET_VERSION } from './monsters.js';
 import { validateEffectConfigForPublish } from './render/effect-config-schema.js';
-import { BUNDLED_EFFECT_CATALOG } from './render/effect-config-defaults.js';
 
 export const MONSTER_VISUAL_SCHEMA_VERSION = 1;
+const BUNDLED_EFFECT_KINDS = Object.freeze([
+  'egg-breathe',
+  'monster-motion-float',
+  'shiny',
+  'mega-aura',
+  'rare-glow',
+  'caught',
+  'evolve',
+  'mega',
+]);
 export const MONSTER_VISUAL_CONTEXTS = Object.freeze([
   'meadow',
   'codexCard',
@@ -633,7 +642,7 @@ export function validatePublishedConfigForPublish(envelope, options = {}) {
     errors.push(issue('published_config_effect_required', 'Effect sub-document is required at publish.', { field: 'effect' }));
   } else {
     const catalogKinds = isPlainObject(envelope.effect.catalog) ? Object.keys(envelope.effect.catalog) : [];
-    const knownKinds = new Set([...catalogKinds, ...Object.keys(BUNDLED_EFFECT_CATALOG)]);
+    const knownKinds = new Set([...catalogKinds, ...BUNDLED_EFFECT_KINDS]);
     const effectResult = validateEffectConfigForPublish(envelope.effect, {
       knownKinds,
       manifest: options.manifest || MONSTER_ASSET_MANIFEST,
@@ -652,4 +661,3 @@ export function validatePublishedConfigForPublish(envelope, options = {}) {
     warnings,
   };
 }
-

--- a/tests/admin-ops-production-smoke.test.js
+++ b/tests/admin-ops-production-smoke.test.js
@@ -167,6 +167,8 @@ test('admin-ops production smoke sends CAS row versions for ops-metadata round-t
   const originalFetch = globalThis.fetch;
   const smokeAccountId = 'smoke-acct-id';
   const opsMetadataBodies = [];
+  const statusBodies = [];
+  const archiveBodies = [];
   globalThis.fetch = async (input, init = {}) => {
     const url = String(typeof input === 'string'
       ? input
@@ -217,6 +219,13 @@ test('admin-ops production smoke sends CAS row versions for ops-metadata round-t
     }
     if (url.endsWith('/api/ops/error-event')) {
       return new Response(JSON.stringify({ ok: true, eventId: 'evt-smoke' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    if (url.endsWith('/api/admin/ops/error-events/evt-smoke/status')) {
+      statusBodies.push(JSON.parse(String(init.body || '{}')));
+      return new Response(JSON.stringify({ ok: true }), {
         status: 200,
         headers: { 'content-type': 'application/json' },
       });
@@ -277,6 +286,7 @@ test('admin-ops production smoke sends CAS row versions for ops-metadata round-t
       });
     }
     if (url.endsWith('/api/admin/marketing/messages/msg-smoke')) {
+      if (init.method === 'PUT') archiveBodies.push(JSON.parse(String(init.body || '{}')));
       return new Response(JSON.stringify({ ok: true, message: { id: 'msg-smoke', row_version: 2 } }), {
         status: 200,
         headers: { 'content-type': 'application/json' },
@@ -303,6 +313,13 @@ test('admin-ops production smoke sends CAS row versions for ops-metadata round-t
     assert.equal(opsMetadataBodies[0].mutation.requestId.startsWith('smoke-'), true);
     assert.equal(opsMetadataBodies[1].expectedRowVersion, 8);
     assert.equal(opsMetadataBodies[1].mutation.requestId.startsWith('smoke-'), true);
+    assert.equal(statusBodies.length, 2);
+    assert.equal(statusBodies[0].mutation.requestId.startsWith('smoke-'), true);
+    assert.equal(statusBodies[1].expectedPreviousStatus, 'investigating');
+    assert.equal(statusBodies[1].mutation.requestId.startsWith('smoke-'), true);
+    assert.equal(archiveBodies.length, 1);
+    assert.equal(archiveBodies[0].expectedRowVersion, 1);
+    assert.equal(archiveBodies[0].mutation.requestId.startsWith('smoke-'), true);
   } finally {
     globalThis.fetch = originalFetch;
   }


### PR DESCRIPTION
## Summary
- fix admin production smoke mutation payloads to send current CAS row versions and nested mutation envelopes
- remove the Visual Engine diagnostic module cycle exposed by the full suite
- record passing Admin Hub production smoke evidence and regenerate P13 evidence with `adminHubCoverage: true`
- set repository Actions secrets for the dedicated smoke admin account

## Production work completed
- provisioned a dedicated smoke email account, promoted it to admin, and marked it with `internalNotes=smoke-test-account`
- applied pending remote D1 migrations via `npm run db:migrate:remote`
- ran `npm run smoke:production:admin-ops` successfully against `https://ks2.eugnel.uk`
- validated `reports/punctuation/punctuation-qg-p13-production-smoke.json` with Admin Hub coverage covered

## Verification
- node --test tests/admin-ops-production-smoke.test.js
- node --test tests/admin-visual-engine-diagnostics.test.js
- node --test tests/punctuation-qg-p13-live-release.test.js
- npm test
- npm run check
