### PR TITLE
docs(grammar): record P18 post-deploy certification

### DIFF
--- a/docs/plans/james/grammar/questions-generator/grammar-qg-p18-completion-report.md
+++ b/docs/plans/james/grammar/questions-generator/grammar-qg-p18-completion-report.md
@@ -2,7 +2,7 @@
 phase: grammar-qg-p18
 certification_phase: grammar-qg-p18
 final_content_release_id: grammar-qg-p18-2026-05-02
-certification_decision: CERTIFIED_PRE_DEPLOY
+certification_decision: CERTIFIED_POST_DEPLOY
 ---
 
 # Grammar QG P18 Completion Report
@@ -36,7 +36,7 @@ P18 promotes the combined P15-P18 manual expansion pack into the live Grammar qu
 | P16/P17/P18 answer safety and distractor quality | Done | `reports/grammar/grammar-qg-p18-distractor-audit.json`, `reports/grammar/grammar-qg-p18-marking-matrix.json` |
 | P18 semantic prompt-cue/read-aloud safety | Done | `reports/grammar/grammar-qg-p18-semantic-prompt-cue-audit.json`, `tests/grammar-qg-p10-prompt-cue-contract.test.js` |
 | Runtime certification authority | Done | `reports/grammar/grammar-qg-p18-certification-status-map.json`, `worker/src/subjects/grammar/certification-status.generated.js` |
-| Production release gate | Pre-deploy done | `reports/grammar/grammar-qg-p18-certification-manifest.json`, `npm run verify:grammar-qg-production-release` |
+| Production release gate | Done | `reports/grammar/grammar-qg-p18-certification-manifest.json`, `npm run verify:grammar-qg-production-release`, `reports/grammar/grammar-production-smoke-grammar-qg-p18-2026-05-02.json` |
 
 Manual expansion promotion is authorised by the P18 release evidence, not by a blanket human review claim. The source pack is marked `certified_scheduler_ready`; runtime generation fails closed if that status regresses, and `npm run verify:grammar-qg-production-release` byte-checks `worker/src/subjects/grammar/manual-expansion.generated.js` against the certified source. Adult-review decisions in the quality register cover the templates flagged by the distractor audit; the remaining approved templates are promoted by automated oracle, render, semantic, marking, and runtime-certification evidence.
 
@@ -54,6 +54,7 @@ Manual expansion promotion is authorised by the P18 release evidence, not by a b
 | Semantic prompt-cue audit | `reports/grammar/grammar-qg-p18-semantic-prompt-cue-audit.json` |
 | Learner surface audit | `reports/grammar/grammar-qg-p18-learner-surface-audit.json` |
 | Star-pacing simulation | `reports/grammar/grammar-qg-p18-star-pacing-simulation.json` |
+| Production smoke | `reports/grammar/grammar-production-smoke-grammar-qg-p18-2026-05-02.json` |
 | Runtime certification source | `worker/src/subjects/grammar/certification-status.generated.js` |
 
 ## Oracle Windows
@@ -71,10 +72,16 @@ The release keeps per-family oracle windows explicit rather than claiming a unif
 
 ## Production State
 
-Current decision is `CERTIFIED_PRE_DEPLOY`. After merge and deployment, run:
+Current decision is `CERTIFIED_POST_DEPLOY`.
 
-```sh
-npm run smoke:production:grammar -- --json --evidence-origin=post-deploy --expected-release=grammar-qg-p18-2026-05-02 --out=reports/grammar/grammar-production-smoke-grammar-qg-p18-2026-05-02.json
-```
+| Check | Result |
+| --- | --- |
+| PR merge | `#842` merged into `main` at `e2013cf0861dee47e19cc79f38584bed9a6920b6` |
+| Latest deployed checkout | `c504ee3a32064c5e4114de9246c673de1baa4582` |
+| Deploy command | `npm run deploy` |
+| Cloudflare Worker version | `23313fbe-0d5f-467a-bbd2-9ac45c2c61f8` |
+| Production bundle audit | Passed for `https://ks2.eugnel.uk/` |
+| Production smoke | Passed at `2026-05-02T23:00:28.572Z` |
+| Production content release | `grammar-qg-p18-2026-05-02` |
 
-When that production smoke passes against `https://ks2.eugnel.uk`, update this report to `CERTIFIED_POST_DEPLOY` and commit the smoke evidence.
+The post-deploy smoke used a production demo-session fixture, verified normal round creation/submission/read-model update, mini-test behaviour, repair support, answer-leak guards, semantic prompt-cue/read-aloud assertions, and confirmed the live `contentReleaseId` is `grammar-qg-p18-2026-05-02`.

--- a/reports/grammar/grammar-production-smoke-grammar-qg-p18-2026-05-02.json
+++ b/reports/grammar/grammar-production-smoke-grammar-qg-p18-2026-05-02.json
@@ -1,0 +1,86 @@
+{
+  "ok": true,
+  "releaseId": "grammar-qg-p18-2026-05-02",
+  "evidenceOrigin": "post-deploy",
+  "environment": "production",
+  "deployedUrl": "https://ks2.eugnel.uk",
+  "origin": "post-deploy",
+  "contentReleaseId": "grammar-qg-p18-2026-05-02",
+  "testedTemplateIds": [
+    "qg_modal_verb_explain",
+    "fronted_adverbial_choose",
+    "qg_modal_verb_explain",
+    "qg_subject_object_classify_table",
+    "tense_rewrite",
+    "fix_fronted_adverbial",
+    "combine_clauses_rewrite",
+    "build_noun_phrase",
+    "identify_words_in_sentence",
+    "qg_p4_voice_roles_transfer"
+  ],
+  "answerSpecFamiliesCovered": [
+    "exact",
+    "multiField",
+    "normalisedText",
+    "punctuationPattern",
+    "acceptedSet",
+    "manualReviewOnly"
+  ],
+  "command": "npm run smoke:production:grammar -- --json --evidence-origin=post-deploy --expected-release=grammar-qg-p18-2026-05-02 --out=reports/grammar/grammar-production-smoke-grammar-qg-p18-2026-05-02.json",
+  "learnerFixtureType": "demo-session",
+  "itemCreationResult": {
+    "ok": true,
+    "detail": "templateId=qg_modal_verb_explain, answered=1"
+  },
+  "answerSubmissionResult": {
+    "ok": true,
+    "detail": "templateId=qg_modal_verb_explain, answered=1"
+  },
+  "readModelUpdateResult": {
+    "ok": true,
+    "detail": "templateId=qg_modal_verb_explain, answered=1"
+  },
+  "noAnswerLeakAssertion": {
+    "ok": true,
+    "detail": "checked via assertNoForbiddenGrammarReadModelKeys in each phase"
+  },
+  "semanticCueAssertion": {
+    "ok": true,
+    "detail": "targetSentence=identify_words_in_sentence, nounPhrase=qg_p4_voice_roles_transfer"
+  },
+  "promptCueAssertion": {
+    "ok": true,
+    "detail": "targetSentence=identify_words_in_sentence, nounPhrase=qg_p4_voice_roles_transfer"
+  },
+  "readAloudAssertion": {
+    "ok": true,
+    "detail": "targetSentence=identify_words_in_sentence, nounPhrase=qg_p4_voice_roles_transfer"
+  },
+  "releaseIdAssertion": {
+    "ok": true,
+    "detail": "contentReleaseId=grammar-qg-p18-2026-05-02"
+  },
+  "normalRoundResult": {
+    "ok": true,
+    "detail": "templateId=qg_modal_verb_explain, answered=1"
+  },
+  "miniTestResult": {
+    "ok": true,
+    "detail": "answered=1, reviewSize=8"
+  },
+  "repairResult": {
+    "ok": true,
+    "detail": "supportKind=faded, aiKind=explanation"
+  },
+  "cueAssertionResult": {
+    "ok": true,
+    "detail": "targetSentence=identify_words_in_sentence, nounPhrase=qg_p4_voice_roles_transfer"
+  },
+  "forbiddenKeyScanResult": {
+    "ok": true,
+    "detail": "checked via assertNoForbiddenGrammarReadModelKeys in each phase"
+  },
+  "failureDetails": null,
+  "timestamp": "2026-05-02T23:00:28.572Z",
+  "commitSha": "c504ee3a32064c5e4114de9246c673de1baa4582"
+}


### PR DESCRIPTION
## Summary
- records Grammar QG P18 as CERTIFIED_POST_DEPLOY
- adds the production smoke evidence for grammar-qg-p18-2026-05-02
- links the live deploy version, production bundle audit, and release smoke result in the completion report

## Verification
- npm run smoke:production:grammar -- --json --evidence-origin=post-deploy --expected-release=grammar-qg-p18-2026-05-02 --out=reports/grammar/grammar-production-smoke-grammar-qg-p18-2026-05-02.json
- node scripts/validate-grammar-qg-certification-evidence.mjs reports/grammar/grammar-qg-p18-certification-manifest.json docs/plans/james/grammar/questions-generator/grammar-qg-p18-completion-report.md --expected-release=grammar-qg-p18-2026-05-02
- npm run verify:grammar-qg-production-release