### PR TITLE
fix(punctuation): V-002 — source audit multi-skill counting note

### DIFF
--- a/docs/plans/james/punctuation/questions-generator/p14/punctuation-p14-quality-hardening-report.md
+++ b/docs/plans/james/punctuation/questions-generator/p14/punctuation-p14-quality-hardening-report.md
@@ -75,6 +75,8 @@ Transfer-mode item count by published skill (Gate 4 floor ≥ 12, aim 18). Value
 
 Every published skill exceeds the 12-floor; minimum observed is 19, hyphen and list_commas top out at 21.
 
+Note: the per-skill values sum to 278, which exceeds the unique transfer-item count of 276 (`counts.transferItems`). This is because 2 transfer items serve multiple skills and are counted under each skill they belong to. The discrepancy is documented explicitly in the source-audit JSON via `transferBySkillSum` and `_transferCountingNote`.
+
 ## Gates
 
 ### Gate 1 — Source / runtime identity

--- a/docs/plans/james/punctuation/questions-generator/p14/punctuation-p14-source-audit.json
+++ b/docs/plans/james/punctuation/questions-generator/p14/punctuation-p14-source-audit.json
@@ -30,6 +30,8 @@
     "bullet_points": 19,
     "hyphen": 21
   },
+  "transferBySkillSum": 278,
+  "_transferCountingNote": "transferBySkill values sum to 278 which exceeds counts.transferItems (276) because 2 items serve multiple skills and are counted under each.",
   "gates": {
     "gate1SourceIdentity": {
       "ok": true,

--- a/scripts/audit-punctuation-qg-p14-source.mjs
+++ b/scripts/audit-punctuation-qg-p14-source.mjs
@@ -179,6 +179,12 @@ function audit() {
       bankFamilyCount: Object.keys(GENERATED_TEMPLATE_BANK).length,
     },
     transferBySkill,
+    transferBySkillSum: Object.values(transferBySkill).reduce((a, b) => a + b, 0),
+    _transferCountingNote:
+      `transferBySkill values sum to ${Object.values(transferBySkill).reduce((a, b) => a + b, 0)}`
+      + ` which exceeds counts.transferItems (${transfer.length}) because`
+      + ` ${Object.values(transferBySkill).reduce((a, b) => a + b, 0) - transfer.length}`
+      + ` items serve multiple skills and are counted under each.`,
     gates: {
       gate1SourceIdentity: {
         ok: manifest.items.length === fixed.length + generated.length


### PR DESCRIPTION
## Summary
- Add `transferBySkillSum` (278) and `_transferCountingNote` fields to the P14 source-audit JSON, making the discrepancy between per-skill sum and unique item count self-documenting.
- Update the audit script (`scripts/audit-punctuation-qg-p14-source.mjs`) to emit both fields dynamically.
- Add an explanatory paragraph in the quality-hardening report (Gate 4 section) noting that 2 items serve multiple skills.

## Test plan
- [ ] Verify `node scripts/audit-punctuation-qg-p14-source.mjs` output includes `transferBySkillSum` and `_transferCountingNote`
- [ ] Confirm the stored JSON matches the script output shape
- [ ] Read the report Gate 4 section and confirm the note is clear