### PR TITLE
fix(test): V-003 — remove stale doc static check references

### DIFF
--- a/tests/punctuation-doc-static-checks.test.js
+++ b/tests/punctuation-doc-static-checks.test.js
@@ -22,6 +22,7 @@ const PLAN_DOC_PATH = resolve(
   'james',
   'punctuation',
   'questions-generator',
+  'archive',
   'punctuation-qg-p1.md',
 );
 const docContent = readFileSync(DOC_PATH, 'utf8');


### PR DESCRIPTION
## Summary
- Updated `PLAN_DOC_PATH` in `tests/punctuation-doc-static-checks.test.js` to point to the archived location of `punctuation-qg-p1.md` after it was moved to `archive/` in commit c9573688.
- The file was relocated from `docs/plans/james/punctuation/questions-generator/punctuation-qg-p1.md` to `docs/plans/james/punctuation/questions-generator/archive/punctuation-qg-p1.md`, causing the test to fail with ENOENT at module load time.

## Test plan
- [x] `node --test tests/punctuation-doc-static-checks.test.js` — all 11 tests pass
- [x] `node --test tests/punctuation-p13-full-subject-quality.test.js tests/punctuation-golden-marking.test.js tests/punctuation-p14-transfer-coverage.test.js` — all 24 regression tests pass