### PR TITLE
fix(grammar): align fairness audit with Contract A nonScored exemption

### DIFF
--- a/scripts/audit-grammar-open-response-fairness.mjs
+++ b/scripts/audit-grammar-open-response-fairness.mjs
@@ -44,7 +44,7 @@ export function buildOpenResponseFairnessAudit(seeds = parseSeeds()) {
         && isOpenPrompt(prompt)
         && acceptedCount < 3
         && question.answerSpec?.manualReviewOnly !== true
-        && question.answerSpec?.nonScored !== true
+        && question.nonScored !== true
       ) {
         findings.push({ templateId: template.id, seed, inputType, kind, acceptedCount, nearMissCount, prompt });
       }

--- a/scripts/audit-grammar-open-response-fairness.mjs
+++ b/scripts/audit-grammar-open-response-fairness.mjs
@@ -44,6 +44,7 @@ export function buildOpenResponseFairnessAudit(seeds = parseSeeds()) {
         && isOpenPrompt(prompt)
         && acceptedCount < 3
         && question.answerSpec?.manualReviewOnly !== true
+        && question.answerSpec?.nonScored !== true
       ) {
         findings.push({ templateId: template.id, seed, inputType, kind, acceptedCount, nearMissCount, prompt });
       }


### PR DESCRIPTION
## Summary
- Adds nonScored check to the fairness audit, matching the generator's logic
- Aligns with Contract A.1 which says items "not manualReviewOnly / nonScored" are flaggable

## Test plan
- [ ] Fairness audit still passes (0 findings)
- [ ] No false negatives introduced (nonScored templates should be exempt)