### PR TITLE
docs(grammar): fix stale profile count in smart-practice audit comment

### DIFF
--- a/scripts/audit-grammar-qg-p19-smart-practice.mjs
+++ b/scripts/audit-grammar-qg-p19-smart-practice.mjs
@@ -2,8 +2,8 @@
 /**
  * Grammar QG P19 — Contract D smart-practice simulator.
  *
- * Replays buildGrammarPracticeQueue across 8 learner profiles × 30 seeds
- * (>= 200 sessions) and asserts that a normal 5-question smart round does
+ * Replays buildGrammarPracticeQueue across 11 learner profiles × 30 seeds
+ * (330 sessions) and asserts that a normal 5-question smart round does
  * not contain duplicate template IDs or duplicate learner-visible surfaces
  * when the active template pool can avoid it. Reports concept / question-
  * type / constructed-selected / support-surface / repeated-surface metrics.


### PR DESCRIPTION
## Summary
- Updates header comment from "8 learner profiles × 30 seeds (>= 200 sessions)" to "11 learner profiles × 30 seeds (330 sessions)"
- Comment was stale after 4 Contract D.4 profiles were added

## Test plan
- [ ] Smart-practice audit still passes