### PR TITLE
fix(grammar): correct surfaceKeyFor focusCue serialisation

### DIFF
--- a/scripts/audit-grammar-qg-p19-smart-practice.mjs
+++ b/scripts/audit-grammar-qg-p19-smart-practice.mjs
@@ -307,7 +307,7 @@ function visibleOptions(inputSpec) {
 function surfaceKeyFor(question, serialised) {
   const promptText = String(serialised?.promptText || '');
   const optionsBlob = JSON.stringify(visibleOptions(serialised?.inputSpec) || null);
-  const focusCue = String(serialised?.focusCue || '');
+  const focusCue = JSON.stringify(serialised?.focusCue ?? '');
   return crypto.createHash('sha1').update(`${promptText}|${optionsBlob}|${focusCue}`).digest('hex');
 }
 


### PR DESCRIPTION
## Summary
- Fixes surfaceKeyFor() using String() on an object (always produces "[object Object]")
- Now uses JSON.stringify to preserve discriminating focusCue data in surface deduplication

## Test plan
- [ ] Smart-practice audit still passes (0 failures, 0 advisories)
- [ ] No behaviour change for templates without focusCue