### PR TITLE
fix(punctuation): add sidebar panel to landing page

### DIFF
--- a/src/subjects/punctuation/components/PunctuationSetupScene.jsx
+++ b/src/subjects/punctuation/components/PunctuationSetupScene.jsx
@@ -21,8 +21,8 @@
 // testing (U9). The primary CTA carries `data-punctuation-cta`.
 //
 // U4 (refactor ui-consolidation): the mission dashboard is wrapped in the
-// shared `.setup-grid` / `.setup-main` / `.setup-content` rhythm (single-
-// column — no sidebar; see R3). The Bellstorm backdrop now paints via the
+// shared `.setup-grid` / `.setup-main` / `.setup-content` rhythm with a
+// right-hand sidebar (SetupSidePanel). The Bellstorm backdrop now paints via the
 // platform `HeroBackdrop` (cross-fade + pan) instead of a static `<img
 // srcSet>`, the round-length toggle is the platform `LengthPicker`, and
 // contrast tokens flow through `useSetupHeroContrast` so future darker
@@ -424,7 +424,7 @@ export function PunctuationSetupScene({ ui, actions, prefs, stats, learner, rewa
           )}
           body={(
             <>
-              <section className="punctuation-monster-row" data-section="monster-row" aria-label="Your monsters">
+              <section className="punctuation-monster-row" data-section="monster-row" aria-label="Monster star progress">
                 {dashboard.activeMonsters.map((monster) => (
                   <MonsterStarMeter monster={monster} key={monster.id} />
                 ))}

--- a/src/subjects/punctuation/components/PunctuationSetupScene.jsx
+++ b/src/subjects/punctuation/components/PunctuationSetupScene.jsx
@@ -54,6 +54,7 @@ import { Button } from '../../../platform/ui/Button.jsx';
 import { ProgressMeter } from '../../../platform/ui/ProgressMeter.jsx';
 import { StatCard } from '../../../platform/ui/StatCard.jsx';
 import { SubjectCompanionPanel } from '../../../platform/ui/SubjectCompanionPanel.jsx';
+import { SetupSidePanel } from '../../../platform/ui/SetupSidePanel.jsx';
 import { PracticeStage } from '../../../platform/ui/PracticeStage.jsx';
 
 // The 6 Phase 2 cluster mode ids + `guided` — the set that triggers the
@@ -379,29 +380,6 @@ export function PunctuationSetupScene({ ui, actions, prefs, stats, learner, rewa
               </div>
             </section>
 
-            {/* Monster row — 4 active monsters with star meters */}
-            <section className="punctuation-monster-row" data-section="monster-row" aria-label="Your monsters">
-              {dashboard.activeMonsters.map((monster) => (
-                <MonsterStarMeter monster={monster} key={monster.id} />
-              ))}
-            </section>
-
-            {/* Map link */}
-            <div data-section="map-link">
-              <button
-                type="button"
-                className="punctuation-map-link"
-                data-action="punctuation-open-map"
-                disabled={disabled}
-                onClick={() => {
-                  if (disabled) return;
-                  actions.dispatch('punctuation-open-map');
-                }}
-              >
-                Open Punctuation Map
-              </button>
-            </div>
-
             {/* Secondary practice drawer */}
             <section className="punctuation-secondary-drawer" data-section="secondary" aria-label="More practice options">
               <div className="punctuation-secondary-modes">
@@ -433,24 +411,62 @@ export function PunctuationSetupScene({ ui, actions, prefs, stats, learner, rewa
                 />
               </div>
             </section>
-
-            <SubjectCompanionPanel
-              subjectId="punctuation"
-              visible
-              monsters={dashboard.activeMonsters.map((m) => ({
-                name: punctuationMonsterDisplayName(m.id),
-                discovered: (m.displayStars ?? m.totalStars) > 0,
-              }))}
-              stats={[
-                { label: 'Due today', value: String(dueCount), tone: dueCount > 0 ? 'warn' : undefined },
-                { label: 'Wobbly', value: String(weakCount) },
-                { label: 'Grand Stars', value: String(grandStars) },
-              ]}
-              nextFocus={weakCount > 0 ? 'Wobbly spots need practice' : ''}
-              emptyState="Start practising to discover your first egg."
-            />
           </div>
         </section>
+
+        <SetupSidePanel
+          asideClassName="punctuation-setup-sidebar"
+          cardClassName="punctuation-setup-sidebar-card"
+          headTag="header"
+          ariaLabel="Your monsters"
+          head={(
+            <p className="eyebrow">Your monsters</p>
+          )}
+          body={(
+            <>
+              <section className="punctuation-monster-row" data-section="monster-row" aria-label="Your monsters">
+                {dashboard.activeMonsters.map((monster) => (
+                  <MonsterStarMeter monster={monster} key={monster.id} />
+                ))}
+              </section>
+
+              <SubjectCompanionPanel
+                subjectId="punctuation"
+                visible
+                monsters={dashboard.activeMonsters.map((m) => ({
+                  name: punctuationMonsterDisplayName(m.id),
+                  discovered: (m.displayStars ?? m.totalStars) > 0,
+                }))}
+                stats={[
+                  { label: 'Due today', value: String(dueCount), tone: dueCount > 0 ? 'warn' : undefined },
+                  { label: 'Wobbly', value: String(weakCount) },
+                  { label: 'Grand Stars', value: String(grandStars) },
+                ]}
+                nextFocus={weakCount > 0 ? 'Wobbly spots need practice' : ''}
+                emptyState="Start practising to discover your first egg."
+              />
+            </>
+          )}
+          footer={(
+            <button
+              type="button"
+              className="ss-bank-link punctuation-setup-sidebar-map-link"
+              data-action="punctuation-open-map"
+              data-section="map-link"
+              onClick={() => {
+                if (disabled) return;
+                actions.dispatch('punctuation-open-map');
+              }}
+              disabled={disabled}
+            >
+              <span className="ss-bank-link-body">
+                <span className="ss-bank-link-head">Open Punctuation Map</span>
+                <span className="ss-bank-link-sub">Explore all monsters and their habitats.</span>
+              </span>
+              <span className="ss-bank-link-arrow" aria-hidden="true">→</span>
+            </button>
+          )}
+        />
       </div>
     </section>
     </PracticeStage>

--- a/styles/app.css
+++ b/styles/app.css
@@ -5731,7 +5731,8 @@ button.chip,
   background: color-mix(in oklab, var(--brand-soft) 40%, var(--panel));
   border-color: color-mix(in oklab, var(--brand) 28%, var(--line));
 }
-.ss-bank-link:active { transform: translateY(1px); }
+.ss-bank-link:disabled { cursor: not-allowed; opacity: 0.64; }
+.ss-bank-link:active:not(:disabled) { transform: translateY(1px); }
 .ss-bank-link-body {
   display: flex; flex-direction: column; gap: 2px; min-width: 0;
 }
@@ -10691,30 +10692,7 @@ html { scroll-behavior: smooth; }
   font-weight: 600;
 }
 
-/* Map link */
-.punctuation-map-link {
-  appearance: none;
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 10px 16px;
-  border: 1px solid var(--line);
-  border-radius: var(--radius-sm);
-  background: var(--panel-soft);
-  color: var(--ink);
-  font-weight: 800;
-  cursor: pointer;
-  font-size: 0.95rem;
-}
-.punctuation-map-link:hover:not(:disabled),
-.punctuation-map-link:focus-visible {
-  border-color: var(--punctuation-accent);
-  box-shadow: 0 0 0 3px color-mix(in oklab, var(--punctuation-accent) 18%, transparent);
-}
-.punctuation-map-link:disabled {
-  cursor: not-allowed;
-  opacity: 0.64;
-}
+/* Punctuation sidebar map-link (inside SetupSidePanel footer) */
 
 /* Secondary practice drawer */
 .punctuation-secondary-drawer {

--- a/tests/punctuation-setup-hero-backdrop.test.js
+++ b/tests/punctuation-setup-hero-backdrop.test.js
@@ -150,8 +150,7 @@ test('punctuation Setup scene wraps the mission dashboard in .setup-grid / .setu
 
   const html = harness.render();
 
-  // `.setup-grid` is the collapsible grid-layout parent (single-column
-  // for Punctuation — no sidebar adopted this pass, see plan R3).
+  // `.setup-grid` is the two-column grid-layout parent (main + sidebar).
   assert.match(html, /<div class="setup-grid">/);
 
   // `.setup-main.punctuation-setup-main` — the second class is the
@@ -175,7 +174,7 @@ test('punctuation Setup scene wraps the mission dashboard in .setup-grid / .setu
   assert.match(html, /<div class="setup-content" data-section="hero">/);
 });
 
-test('punctuation Setup scene preserves every data-section landmark inside .setup-content', () => {
+test('punctuation Setup scene preserves every data-section landmark', () => {
   const harness = createPunctuationHarness();
   harness.dispatch('open-subject', { subjectId: 'punctuation' });
 
@@ -183,14 +182,22 @@ test('punctuation Setup scene preserves every data-section landmark inside .setu
 
   // Hero landmark sits on `.setup-content`.
   assert.match(html, /data-section="hero"/);
-  // Progress row.
+  // Progress row (in main column).
   assert.match(html, /data-section="progress-row"/);
-  // Monster row.
+  // Monster row (in sidebar).
   assert.match(html, /data-section="monster-row"/);
-  // Map link wrapper.
+  // Map link (in sidebar footer).
   assert.match(html, /data-section="map-link"/);
-  // Secondary drawer.
+  // Secondary drawer (in main column).
   assert.match(html, /data-section="secondary"/);
+
+  // Structural containment: monster-row and map-link live inside the sidebar.
+  const sidebarStart = html.indexOf('class="setup-side punctuation-setup-sidebar"');
+  assert.ok(sidebarStart > -1, 'sidebar aside exists');
+  const monsterRowPos = html.indexOf('data-section="monster-row"');
+  const mapLinkPos = html.indexOf('data-section="map-link"');
+  assert.ok(monsterRowPos > sidebarStart, 'monster-row is inside sidebar');
+  assert.ok(mapLinkPos > sidebarStart, 'map-link is inside sidebar');
 
   // Phase marker on the outer `<section>` wrapper.
   assert.match(html, /data-punctuation-phase="setup"/);


### PR DESCRIPTION
## Summary
- Adds `SetupSidePanel` to punctuation landing page, matching the 2-column layout used by grammar and spelling
- Moves monster star meters + `SubjectCompanionPanel` into the right-hand sidebar card
- Relocates "Open Punctuation Map" link into sidebar footer using shared `ss-bank-link` pattern
- All `data-section` landmarks preserved for test compatibility

## Test plan
- [x] 169 punctuation scene tests pass
- [x] 14 hero backdrop tests pass
- [x] 19 UI subject theme contract tests pass
- [x] 8 UI token contract tests pass
- [ ] Visual QA in browser confirms 2-column layout