### PR TITLE
fix(punctuation): add token_variety facet label + derive TOTAL_REWARD_UNITS

### DIFF
--- a/shared/punctuation/marking.js
+++ b/shared/punctuation/marking.js
@@ -22,6 +22,7 @@ const FACET_LABELS = Object.freeze({
   terminal_punctuation: 'Terminal punctuation',
   single_sentence: 'One combined sentence',
   sentence_completeness: 'Complete sentence',
+  token_variety: 'Used different words',
   unwanted_punctuation: 'No duplicated punctuation outside the quote',
 });
 

--- a/src/subjects/punctuation/read-model.js
+++ b/src/subjects/punctuation/read-model.js
@@ -2,6 +2,7 @@ import { currentReleaseRewardEntries, projectPunctuationStars } from './star-pro
 import { stageFor, PUNCTUATION_STAR_THRESHOLDS, PUNCTUATION_GRAND_STAR_THRESHOLDS } from '../../platform/game/monsters.js';
 import {
   PUNCTUATION_CLIENT_SKILLS,
+  PUNCTUATION_CLIENT_REWARD_UNITS,
 } from './punctuation-manifest.js';
 import { PUNCTUATION_CURRENT_RELEASE_ID } from './service-contract.js';
 
@@ -9,7 +10,8 @@ export { PUNCTUATION_CLIENT_SKILLS };
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const CURRENT_RELEASE_ID = PUNCTUATION_CURRENT_RELEASE_ID;
-const TOTAL_REWARD_UNITS = 14;
+const TOTAL_REWARD_UNITS = new Set(PUNCTUATION_CLIENT_REWARD_UNITS.map((ru) => ru.rewardUnitId)).size;
+if (TOTAL_REWARD_UNITS !== 14) throw new Error(`TOTAL_REWARD_UNITS drift: expected 14, got ${TOTAL_REWARD_UNITS}`);
 const DAILY_TARGET_ATTEMPTS = 4;
 
 const ITEM_MODE_LABELS = Object.freeze({

--- a/src/subjects/punctuation/star-projection.js
+++ b/src/subjects/punctuation/star-projection.js
@@ -815,8 +815,9 @@ const GRAND_TIERS = Object.freeze([
   { threshold: 100, minMonsters: 3, minSecured: 14, minDeepSecured: 14, requireMixed: true  },
 ]);
 
-// Total reward units across all clusters.
-const TOTAL_REWARD_UNITS = 14;
+// Total reward units across all clusters (derived from manifest).
+const TOTAL_REWARD_UNITS = new Set(PUNCTUATION_CLIENT_REWARD_UNITS.map((ru) => ru.rewardUnitId)).size;
+if (TOTAL_REWARD_UNITS !== 14) throw new Error(`TOTAL_REWARD_UNITS drift: expected 14, got ${TOTAL_REWARD_UNITS}`);
 
 function computeGrandStars(progress, rewardUnitEntries) {
   const facetEntries = isPlainObject(progress.facets) ? progress.facets : {};


### PR DESCRIPTION
## Summary
- Adds missing `token_variety` entry to `FACET_LABELS` in `shared/punctuation/marking.js` with child-friendly label "Used different words" — previously the facet emitted by the marking engine fell back to the raw ID string.
- Derives `TOTAL_REWARD_UNITS` from the manifest (`PUNCTUATION_CLIENT_REWARD_UNITS`) in both `read-model.js` and `star-projection.js`, replacing the hardcoded `14`. A runtime assertion guards against silent drift if the manifest changes.

## Test plan
- [x] `node --test tests/punctuation-service.test.js tests/punctuation-p13-full-subject-quality.test.js tests/punctuation-golden-marking.test.js` — 34/34 pass
- [x] `npm run check` — clean exit