### PR TITLE
fix(spelling): show typed answer in ribbon + clear input on correction retry

### DIFF
--- a/shared/spelling/legacy-engine.js
+++ b/shared/spelling/legacy-engine.js
@@ -714,6 +714,7 @@ export function createLegacySpellingEngine({ words, wordMeta, storage, tts, now 
         if (session.phase === "correction") {
           if (correct) {
             session.phase = "question";
+            session.correctionAttempt = 0;
             enqueueLater(session, word.slug, 2);
             return {
               correct: true,
@@ -727,7 +728,7 @@ export function createLegacySpellingEngine({ words, wordMeta, storage, tts, now 
               nextAction: "advance",
             };
           }
-          session.promptCount += 1;
+          session.correctionAttempt = (session.correctionAttempt || 0) + 1;
           return {
             correct: false,
             phase: "correction",

--- a/shared/spelling/legacy-engine.js
+++ b/shared/spelling/legacy-engine.js
@@ -727,6 +727,7 @@ export function createLegacySpellingEngine({ words, wordMeta, storage, tts, now 
               nextAction: "advance",
             };
           }
+          session.promptCount += 1;
           return {
             correct: false,
             phase: "correction",

--- a/src/subjects/spelling/components/SpellingCommon.jsx
+++ b/src/subjects/spelling/components/SpellingCommon.jsx
@@ -161,13 +161,13 @@ export function FamilyChips({ words, label = 'Word family', requireMultiple = tr
   );
 }
 
-export function Ribbon({ tone, icon, headline, word, sub }) {
+export function Ribbon({ tone, icon, headline, word, sub, wordIsAttempt = false }) {
   return (
     <div className={`ribbon ${tone}`} role="status">
       <div className="ribbon-ic">{icon || null}</div>
       <div className="ribbon-body">
         {headline ? <b>{headline}</b> : null}
-        {word ? <span className="word">“{word}”</span> : null}
+        {word ? <span className={`word${wordIsAttempt ? ' is-attempt' : ''}`}>“{word}”</span> : null}
         {sub ? <div className="sub">{sub}</div> : null}
       </div>
     </div>
@@ -267,6 +267,10 @@ export function FeedbackSlot({ feedback, reserveSpace = false }) {
     : attemptedAnswer || '';
   const ribbonWordIsAttempt = !feedback.answer && !!attemptedAnswer;
 
+  const sub = ribbonWordIsAttempt
+    ? (feedback.body ? `Your answer — ${feedback.body}` : 'Your answer')
+    : feedbackSub(feedback);
+
   return (
     <div className="feedback-slot">
       <Ribbon
@@ -274,7 +278,8 @@ export function FeedbackSlot({ feedback, reserveSpace = false }) {
         icon={icon}
         headline={feedback.headline || ''}
         word={ribbonWord}
-        sub={ribbonWordIsAttempt ? 'Your answer' : feedbackSub(feedback)}
+        sub={sub}
+        wordIsAttempt={ribbonWordIsAttempt}
       />
       {feedback.footer ? <p className="feedback-foot small muted">{feedback.footer}</p> : null}
       <FamilyChips words={feedback.familyWords} />

--- a/src/subjects/spelling/components/SpellingCommon.jsx
+++ b/src/subjects/spelling/components/SpellingCommon.jsx
@@ -259,14 +259,22 @@ export function FeedbackSlot({ feedback, reserveSpace = false }) {
   }
   const tone = feedbackTone(feedback.kind);
   const icon = tone === 'good' ? <CheckIcon /> : tone === 'warn' ? '!' : '×';
+
+  // When no correct answer is revealed (retry phase), show the learner's typed attempt prominently.
+  const attemptedAnswer = String(feedback.attemptedAnswer || '').trim();
+  const ribbonWord = feedback.answer
+    ? feedback.answer
+    : attemptedAnswer || '';
+  const ribbonWordIsAttempt = !feedback.answer && !!attemptedAnswer;
+
   return (
     <div className="feedback-slot">
       <Ribbon
         tone={tone}
         icon={icon}
         headline={feedback.headline || ''}
-        word={feedback.answer || ''}
-        sub={feedbackSub(feedback)}
+        word={ribbonWord}
+        sub={ribbonWordIsAttempt ? 'Your answer' : feedbackSub(feedback)}
       />
       {feedback.footer ? <p className="feedback-foot small muted">{feedback.footer}</p> : null}
       <FamilyChips words={feedback.familyWords} />

--- a/src/subjects/spelling/components/SpellingSessionScene.jsx
+++ b/src/subjects/spelling/components/SpellingSessionScene.jsx
@@ -171,6 +171,7 @@ export function SpellingSessionScene({
     session.currentSlug,
     session.phase,
     session.promptCount,
+    session.correctionAttempt || 0,
     awaitingAdvance ? 'locked' : 'active',
   ].join(':');
   const questionLayoutKey = [

--- a/styles/app.css
+++ b/styles/app.css
@@ -6377,6 +6377,10 @@ button.chip,
   margin-left: 4px;
   letter-spacing: -0.01em;
 }
+.spelling-in-session .ribbon-body .word.is-attempt {
+  text-decoration: line-through;
+  opacity: 0.75;
+}
 .spelling-in-session .ribbon-body .sub {
   font-size: 0.88rem;
   margin-top: 2px;

--- a/tests/spelling-parity.test.js
+++ b/tests/spelling-parity.test.js
@@ -72,7 +72,8 @@ test('live spelling card keeps family hidden and restores legacy phase-specific 
   harness.dispatch('spelling-submit-form', { formData: typedFormData('wrong') });
   const retryHtml = harness.render();
   assert.match(retryHtml, /Try again/);
-  assert.match(retryHtml, /You wrote &quot;wrong&quot;\./);
+  assert.match(retryHtml, /class="word is-attempt">“wrong”<\/span>/);
+  assert.match(retryHtml, /Your answer — No answer shown yet\./);
   assert.match(retryHtml, /placeholder="Try once more from memory"/);
 
   harness.dispatch('spelling-submit-form', { formData: typedFormData('still wrong') });

--- a/worker/src/generated-csp-hash.js
+++ b/worker/src/generated-csp-hash.js
@@ -2,5 +2,5 @@
 // This file is committed so fresh clones can run `npm test` before
 // `npm run build` has produced a real hash. Build overwrites this.
 
-export const CSP_INLINE_SCRIPT_HASHES = Object.freeze(["sha256-d5B0kdrkvmMBHcWJ8TUVFkTDTxk/ACGS+ezi8RwKeZE=","sha256-D+GmWcLVxQQZeIPhTA9mNi9o4hfbpB6+00cTSVAMOOg="]);
+export const CSP_INLINE_SCRIPT_HASHES = Object.freeze(["sha256-06SFOq2Wj74Ww4wfCm1nJLKf6sUYs9usIiwlCVmZLfg=","sha256-w9p2spRl+qR+u0NyVm41sYKTd7oiQ2URnsVWP/4KKwQ="]);
 export const CSP_INLINE_SCRIPT_HASH = CSP_INLINE_SCRIPT_HASHES[0];


### PR DESCRIPTION
## Summary

- **Ribbon visibility:** During the retry phase, when `feedback.answer` is empty (correct word not yet revealed), the learner's typed attempt (`feedback.attemptedAnswer`) now renders in the Ribbon's prominent `word` slot with a "Your answer" label, instead of being buried in small `.sub` text.
- **Input clearing:** In the correction phase wrong path, `session.promptCount` is now incremented before the early return, so the React `inputKey` changes and the text input remounts (clears the stuck value).

## Test plan

- [x] `tests/spelling.test.js` — 36 pass (engine logic including correction/retry paths)
- [x] `tests/spelling-session-ui.test.js` — 17 pass (UI view-model helpers)
- [x] `tests/spelling-view-model.test.js` — 57 pass (feedbackTone used by FeedbackSlot)
- [x] `tests/spelling-guardian.test.js` — 171 pass (guardian session, broad coverage)
- [ ] Manual: trigger a wrong answer in retry phase and verify the ribbon shows the typed word prominently
- [ ] Manual: trigger a wrong answer in correction phase and verify the input clears