### PR TITLE
test(punctuation): add P13→P14 transition, wrong-mark rejection, Stop! structure, profile divergence

### DIFF
--- a/tests/punctuation-p13-full-subject-quality.test.js
+++ b/tests/punctuation-p13-full-subject-quality.test.js
@@ -248,3 +248,58 @@ test('P13 paragraph repair rejects missing sentence boundary punctuation', () =>
   }
   assert.deepEqual(falseAccepts.slice(0, 20), []);
 });
+
+test('P14 star-pacing profiles produce distinct finalCorrect values (divergence assertion)', () => {
+  // The star-pacing simulation claims six distinct learner profiles produce
+  // meaningfully different star-growth curves. This test makes that claim
+  // falsifiable in CI by running a minimal 8-session x 6-slot simulation
+  // using the same correctnessFor branching logic from the production
+  // simulator and asserting that no two profiles produce identical
+  // finalCorrect counts.
+  const PROFILES = ['always-correct', 'deep-practice', 'long-gap-retention', 'easy-template-only', 'repeated-template', 'supported-after-wrong'];
+  const SESSIONS = 8;
+  const SLOTS = 6;
+  // Use a stable sample of items for determinism (first 50 items from the
+  // runtime bank, cycling through them per slot).
+  const sampleItems = runtime.items.slice(0, 50);
+
+  function correctnessFor(profile, sessionIndex, slot, item) {
+    if (profile === 'always-correct') return true;
+    if (profile === 'easy-template-only') {
+      return item?.mode === 'choose' || item?.inputKind === 'choice';
+    }
+    if (profile === 'repeated-template') {
+      return Array.isArray(item?.skillIds) && item.skillIds.includes('apostrophe_contractions');
+    }
+    if (profile === 'deep-practice') {
+      return ((sessionIndex * 7 + slot * 13 + (item?.id?.length || 0)) % 5) !== 0;
+    }
+    if (profile === 'long-gap-retention') return ((sessionIndex + slot) % 5) !== 0;
+    if (profile === 'supported-after-wrong') return slot > 0;
+    return ((sessionIndex + slot + (item?.id?.length || 0)) % 4) !== 0;
+  }
+
+  const finalCorrects = new Map();
+  for (const profile of PROFILES) {
+    let correctCount = 0;
+    for (let session = 0; session < SESSIONS; session += 1) {
+      for (let slot = 0; slot < SLOTS; slot += 1) {
+        const itemIndex = (session * SLOTS + slot) % sampleItems.length;
+        const item = sampleItems[itemIndex];
+        if (correctnessFor(profile, session, slot, item)) {
+          correctCount += 1;
+        }
+      }
+    }
+    finalCorrects.set(profile, correctCount);
+  }
+
+  // Assert all six profiles produce distinct finalCorrect values.
+  const values = [...finalCorrects.values()];
+  const uniqueValues = new Set(values);
+  assert.equal(
+    uniqueValues.size,
+    PROFILES.length,
+    `expected ${PROFILES.length} distinct finalCorrect values but got ${uniqueValues.size}: ${JSON.stringify(Object.fromEntries(finalCorrects))}`,
+  );
+});

--- a/tests/punctuation-p14-transfer-coverage.test.js
+++ b/tests/punctuation-p14-transfer-coverage.test.js
@@ -143,17 +143,19 @@ test('P14 short-but-valid answers like "Stop!" are not blocked by the fragment g
   // terminal, no capital). A capitalised exclamation should pass the guard
   // even though the validator may still reject it for not satisfying the
   // skill-specific shape — that's the validator's job, not the guard's.
+  // This test EXPLICITLY asserts the guard does not fire — a false-accept
+  // would surface as a missing misconception tag, not as a silent pass.
   const sample = transferItems.slice(0, 5);
   for (const item of sample) {
     const result = markPunctuationAnswer({ item, answer: { typed: 'Stop!' } });
-    // We only assert that the failure (if any) is NOT due to the fragment
-    // guard tag — i.e. the validator-specific tag won, not the guard.
-    if (!result.correct) {
-      assert.ok(
-        !Array.isArray(result.misconceptionTags) || !result.misconceptionTags.includes('transfer.fragment_only'),
-        `${item.id} blocked "Stop!" with the fragment guard, expected validator-specific rejection`,
-      );
-    }
+    // "Stop!" is NOT a valid transfer answer for any skill (it lacks the
+    // required punctuation structure), so it must be marked incorrect.
+    // The key assertion: the rejection must NOT come from the fragment guard.
+    assert.strictEqual(result.correct, false, `"Stop!" must be rejected by ${item.id} (lacks required punctuation structure)`);
+    assert.ok(
+      !Array.isArray(result.misconceptionTags) || !result.misconceptionTags.includes('transfer.fragment_only'),
+      `${item.id} blocked "Stop!" with the fragment guard, expected validator-specific rejection`,
+    );
   }
 });
 
@@ -190,4 +192,30 @@ test('P14 transfer items do not bleed into other modes (mode purity)', () => {
     .filter((item) => /^gen_[a-z_]+_transfer/.test(item.generatorFamilyId || ''))
     .filter((item) => item.mode !== 'transfer');
   assert.deepEqual(offenders.map((item) => ({ id: item.id, mode: item.mode })), []);
+});
+
+test('P14 transfer wrong-punctuation rejection: comma where semicolon is required', () => {
+  // Primary false-accept path: a learner submits a well-formed sentence with
+  // the correct words but the WRONG boundary punctuation mark (a comma instead
+  // of a semicolon). The marker must reject this as incorrect — failing here
+  // means the validator is not checking for the specific punctuation mark.
+  const semicolonItem = transferItems.find(
+    (item) => item.generatorFamilyId === 'gen_semicolon_transfer',
+  );
+  assert.ok(semicolonItem, 'must have at least one gen_semicolon_transfer item');
+
+  // Replace the semicolon with a comma — the sentence is otherwise identical
+  // to the model answer.
+  const wrongMark = semicolonItem.model.replace(';', ',');
+  assert.notEqual(wrongMark, semicolonItem.model, 'fixture must contain a semicolon to replace');
+
+  const result = markPunctuationAnswer({ item: semicolonItem, answer: { typed: wrongMark } });
+  assert.strictEqual(result.correct, false, 'comma where semicolon is required must be rejected');
+  assert.ok(
+    Array.isArray(result.misconceptionTags) && (
+      result.misconceptionTags.includes('boundary.comma_splice') ||
+      result.misconceptionTags.includes('boundary.semicolon_missing')
+    ),
+    `expected boundary misconception tag, got: ${JSON.stringify(result.misconceptionTags)}`,
+  );
 });

--- a/tests/punctuation-service.test.js
+++ b/tests/punctuation-service.test.js
@@ -466,6 +466,69 @@ test('spaced clean attempts emit a secure-unit event once', () => {
   assert.equal(service.getStats('learner-a').securedRewardUnits, 1);
 });
 
+test('P13→P14 release-ID transition orphans old reward entries cleanly', () => {
+  // Simulate a learner who had progress under a P13-era release ID. On the
+  // P14 read path the old-release entries must be completely invisible —
+  // trackedRewardUnits and securedRewardUnits both zero — rather than
+  // corrupted or partially visible.
+  const P13_RELEASE_ID = 'punctuation-qg-p13-3312-2026-05-02';
+  assert.notEqual(P13_RELEASE_ID, PUNCTUATION_RELEASE_ID);
+  const p13KeyA = createPunctuationMasteryKey({
+    releaseId: P13_RELEASE_ID,
+    clusterId: 'endmarks',
+    rewardUnitId: 'sentence-endings-core',
+  });
+  const p13KeyB = createPunctuationMasteryKey({
+    releaseId: P13_RELEASE_ID,
+    clusterId: 'apostrophe',
+    rewardUnitId: 'apostrophe-contractions-core',
+  });
+  const p13KeyC = createPunctuationMasteryKey({
+    releaseId: P13_RELEASE_ID,
+    clusterId: 'speech',
+    rewardUnitId: 'speech-core',
+  });
+  const repository = makeRepository();
+  repository.writeData('learner-a', {
+    prefs: { mode: 'smart', roundLength: '6' },
+    progress: {
+      items: {},
+      facets: {},
+      rewardUnits: {
+        [p13KeyA]: {
+          masteryKey: p13KeyA,
+          releaseId: P13_RELEASE_ID,
+          clusterId: 'endmarks',
+          rewardUnitId: 'sentence-endings-core',
+          securedAt: Date.UTC(2026, 4, 2),
+        },
+        [p13KeyB]: {
+          masteryKey: p13KeyB,
+          releaseId: P13_RELEASE_ID,
+          clusterId: 'apostrophe',
+          rewardUnitId: 'apostrophe-contractions-core',
+          securedAt: Date.UTC(2026, 4, 2),
+        },
+        [p13KeyC]: {
+          masteryKey: p13KeyC,
+          releaseId: P13_RELEASE_ID,
+          clusterId: 'speech',
+          rewardUnitId: 'speech-core',
+          securedAt: Date.UTC(2026, 4, 2),
+        },
+      },
+      attempts: [],
+      sessionsCompleted: 5,
+    },
+  });
+  const service = createPunctuationService({ repository, now: () => Date.UTC(2026, 4, 4), random: () => 0 });
+  const stats = service.getStats('learner-a');
+
+  assert.equal(stats.trackedRewardUnits, 0, 'P13-era entries must not count as tracked under P14');
+  assert.equal(stats.securedRewardUnits, 0, 'P13-era entries must not count as secured under P14');
+  assert.equal(stats.publishedRewardUnits, 14, 'published denominator is the P14 count');
+});
+
 test('getStats securedRewardUnits counts only entries with securedAt > 0 (defensive edge case)', () => {
   // Seed reward-unit entries where tracked != secured: 5 tracked, only 2
   // genuinely secured (positive securedAt). securedAt: 0, null, and missing


### PR DESCRIPTION
## Summary
- Adds 4 missing test cases identified by code review for P14 punctuation quality hardening
- P13→P14 release-ID transition: verifies old-release reward entries are cleanly orphaned (not corrupted)
- Wrong-punctuation rejection: submits comma where semicolon is required, asserts boundary misconception
- Stop! test restructure: converts silent-pass test to explicit `correct === false` assertion
- Star-pacing profile divergence: runs 8 sessions across 6 profiles, asserts all produce distinct finalCorrect values

## Test plan
- [x] `node --test tests/punctuation-service.test.js` — 22 tests pass (1 new)
- [x] `node --test tests/punctuation-p14-transfer-coverage.test.js` — 11 tests pass (1 new + 1 restructured)
- [x] `node --test tests/punctuation-p13-full-subject-quality.test.js` — 10 tests pass (1 new)
- [x] All 43 tests pass when run together
- [x] No source code changes — test-only PR