### PR TITLE
fix(punctuation): star-pacing simulator — exit-code gate + seed collision + profile fix

### DIFF
--- a/docs/plans/james/punctuation/questions-generator/p14/punctuation-p14-quality-hardening-report.md
+++ b/docs/plans/james/punctuation/questions-generator/p14/punctuation-p14-quality-hardening-report.md
@@ -23,7 +23,7 @@ Standing caveats (do NOT block FULL but must be disclosed alongside it):
 
 1. Round-2 document review F4 — the smoke validator's `attestation.releasePhase / runtimeItemCount / generatedFamilyDepths` mirror local imports for shape; the canonical worker-attested values flow through `punctuation.productionObserved` (release ID, runtime items, published reward units) and `smartSix.observedRuntimeStats`. The smoke output now carries an `_attestationSourceLegend` block flagging which sub-checks are client-asserted vs worker-attested.
 2. Round-2 document review F7 — release-ID namespace bump invalidates existing learner punctuation progress at deploy time. Comms must ship to parent + admin hubs **before** the production deploy, not after. See "Communications and rollout debt" section below.
-3. Round-2 document review F3 — Gate 6 inflation rule has been rewritten to be falsifiable (rule-version 3, normalised against the natural 6/4 = 1.5× round-length ratio). The canonical (always-correct) profile shows ratio 1.5 = natural, normalised 1.0 → no engine-level inflation. Two edge-case profiles (repeated-template, supported-after-wrong) breach the threshold and are surfaced as diagnostic findings — they do not flip Gate 6's roundLength but do warrant follow-up scheduler analysis.
+3. Round-2 document review F3 — Gate 6 inflation rule has been rewritten to be falsifiable (rule-version 3, normalised against the natural 6/4 = 1.5× round-length ratio). The canonical (always-correct) profile shows ratio 1.5 = natural, normalised 1.0 → no engine-level inflation. One edge-case profile (supported-after-wrong) breaches the threshold and is surfaced as a diagnostic finding — it does not flip Gate 6's roundLength but does warrant follow-up scheduler analysis.
 
 ## Pull request
 
@@ -163,16 +163,16 @@ Scheduler honesty (read-pass): `shared/punctuation/scheduler.js:240-269` `signat
 
 | Profile | 4q stars/correct | 6q stars/correct | Raw ratio | Normalised ratio | Inflation |
 | :--- | ---: | ---: | ---: | ---: | :--- |
-| **always-correct (canonical)** | (sim output) | (sim output) | 1.500 | 1.000 | none |
-| deep-practice | | | 1.510 | 1.007 | none |
-| long-gap-retention (7-day gap) | | | 1.500 | 1.000 | none |
-| easy-template-only (choose-only) | | | 1.500 | 1.000 | none |
-| repeated-template (apostrophe-only) | | | 1.909 | 1.273 | **diagnostic** |
-| supported-after-wrong | | | 1.667 | 1.111 | **diagnostic** |
+| **always-correct (canonical)** | 0.3125 | 0.2083 | 1.500 | 1.000 | none |
+| deep-practice | 0.3891 | 0.2597 | 1.498 | 0.999 | none |
+| long-gap-retention (7-day gap) | 0.3906 | 0.2604 | 1.500 | 1.000 | none |
+| easy-template-only (choose-only) | 1.2500 | 1.2500 | 1.000 | 0.667 | none |
+| repeated-template (apostrophe-only) | 5.0000 | 3.4483 | 1.450 | 0.967 | none |
+| supported-after-wrong | 0.4167 | 0.2500 | 1.667 | 1.111 | **diagnostic** |
 
 Source: `docs/plans/.../p14/punctuation-p14-star-pacing-simulation.json#/gate6Decision`.
 
-`gate6RoundLength: '4'` because the canonical profile sits exactly at the natural ratio (no inflation). Two diagnostic profiles exceed the 1.575 threshold (1.05 × natural); both are correctness-shaped edge cases, not engine inflation. They are reported in the simulation JSON's `diagnosticInflatedProfiles` block as scheduler-tuning input, not as a reason to flip skill-detail. See `PunctuationSkillDetailModal.jsx:170` (unchanged from P13).
+`gate6RoundLength: '4'` because the canonical profile sits exactly at the natural ratio (no inflation). One diagnostic profile (`supported-after-wrong`) exceeds the 1.575 threshold (1.05 × natural); it is a correctness-shaped edge case, not engine inflation. It is reported in the simulation JSON's `diagnosticInflatedProfiles` block as scheduler-tuning input, not as a reason to flip skill-detail. See `PunctuationSkillDetailModal.jsx:170` (unchanged from P13).
 
 ### Gate 7 — Star pacing simulator
 

--- a/docs/plans/james/punctuation/questions-generator/p14/punctuation-p14-star-pacing-simulation.json
+++ b/docs/plans/james/punctuation/questions-generator/p14/punctuation-p14-star-pacing-simulation.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "phase": "punctuation-qg-p14-star-pacing-simulation",
   "releaseId": "punctuation-qg-p14-3564-2026-05-04",
-  "generatedAt": "2026-05-04T07:49:30.107Z",
+  "generatedAt": "2026-05-04T10:40:36.056Z",
   "sessionsPerProfile": 80,
   "profiles": [
     {
@@ -44,13 +44,13 @@
         "label": "Always-correct learner",
         "stageReachedAt": {
           "Egg found": 1,
-          "Hatched": 2,
-          "Growing": 10
+          "Hatched": 3,
+          "Growing": 9
         },
         "finalStars": {
           "pealark": 40,
           "curlune": 40,
-          "claspin": 36,
+          "claspin": 40,
           "grand": 100
         },
         "finalAttempts": 320,
@@ -61,14 +61,14 @@
           {
             "session": 1,
             "itemsServed": 4,
-            "uniqueModes": 1,
+            "uniqueModes": 4,
             "uniqueSkills": 4,
             "correctCount": 4,
-            "maxDirectStars": 7,
+            "maxDirectStars": 5,
             "stage": "Egg found",
             "stars": {
-              "pealark": 2,
-              "curlune": 7,
+              "pealark": 5,
+              "curlune": 5,
               "claspin": 0,
               "grand": 100
             }
@@ -76,7 +76,7 @@
           {
             "session": 21,
             "itemsServed": 4,
-            "uniqueModes": 1,
+            "uniqueModes": 4,
             "uniqueSkills": 3,
             "correctCount": 4,
             "maxDirectStars": 40,
@@ -84,29 +84,29 @@
             "stars": {
               "pealark": 40,
               "curlune": 40,
-              "claspin": 26,
+              "claspin": 27,
               "grand": 100
             }
           },
           {
             "session": 41,
             "itemsServed": 4,
-            "uniqueModes": 1,
-            "uniqueSkills": 4,
+            "uniqueModes": 4,
+            "uniqueSkills": 2,
             "correctCount": 4,
             "maxDirectStars": 40,
             "stage": "Growing",
             "stars": {
               "pealark": 40,
               "curlune": 40,
-              "claspin": 35,
+              "claspin": 40,
               "grand": 100
             }
           },
           {
             "session": 61,
             "itemsServed": 4,
-            "uniqueModes": 1,
+            "uniqueModes": 4,
             "uniqueSkills": 4,
             "correctCount": 4,
             "maxDirectStars": 40,
@@ -114,22 +114,22 @@
             "stars": {
               "pealark": 40,
               "curlune": 40,
-              "claspin": 36,
+              "claspin": 40,
               "grand": 100
             }
           },
           {
             "session": 80,
             "itemsServed": 4,
-            "uniqueModes": 1,
-            "uniqueSkills": 3,
+            "uniqueModes": 4,
+            "uniqueSkills": 4,
             "correctCount": 4,
             "maxDirectStars": 40,
             "stage": "Growing",
             "stars": {
               "pealark": 40,
               "curlune": 40,
-              "claspin": 36,
+              "claspin": 40,
               "grand": 100
             }
           }
@@ -141,23 +141,119 @@
         "stageReachedAt": {
           "Egg found": 1,
           "Hatched": 4,
-          "Growing": 17
+          "Growing": 11
         },
         "finalStars": {
           "pealark": 40,
           "curlune": 40,
-          "claspin": 31,
+          "claspin": 40,
           "grand": 100
         },
         "finalAttempts": 320,
-        "finalCorrect": 249,
-        "starsPerCorrect": 0.4016,
+        "finalCorrect": 257,
+        "starsPerCorrect": 0.3891,
         "sessionCount": 80,
         "samples": [
           {
             "session": 1,
             "itemsServed": 4,
-            "uniqueModes": 1,
+            "uniqueModes": 4,
+            "uniqueSkills": 3,
+            "correctCount": 3,
+            "maxDirectStars": 7,
+            "stage": "Egg found",
+            "stars": {
+              "pealark": 7,
+              "curlune": 1,
+              "claspin": 0,
+              "grand": 100
+            }
+          },
+          {
+            "session": 21,
+            "itemsServed": 4,
+            "uniqueModes": 4,
+            "uniqueSkills": 4,
+            "correctCount": 4,
+            "maxDirectStars": 40,
+            "stage": "Growing",
+            "stars": {
+              "pealark": 40,
+              "curlune": 40,
+              "claspin": 17,
+              "grand": 100
+            }
+          },
+          {
+            "session": 41,
+            "itemsServed": 4,
+            "uniqueModes": 4,
+            "uniqueSkills": 4,
+            "correctCount": 1,
+            "maxDirectStars": 40,
+            "stage": "Growing",
+            "stars": {
+              "pealark": 40,
+              "curlune": 40,
+              "claspin": 40,
+              "grand": 100
+            }
+          },
+          {
+            "session": 61,
+            "itemsServed": 4,
+            "uniqueModes": 4,
+            "uniqueSkills": 3,
+            "correctCount": 2,
+            "maxDirectStars": 40,
+            "stage": "Growing",
+            "stars": {
+              "pealark": 40,
+              "curlune": 40,
+              "claspin": 40,
+              "grand": 100
+            }
+          },
+          {
+            "session": 80,
+            "itemsServed": 4,
+            "uniqueModes": 4,
+            "uniqueSkills": 4,
+            "correctCount": 3,
+            "maxDirectStars": 40,
+            "stage": "Growing",
+            "stars": {
+              "pealark": 40,
+              "curlune": 40,
+              "claspin": 40,
+              "grand": 100
+            }
+          }
+        ]
+      },
+      {
+        "profileId": "long-gap-retention",
+        "label": "Long-gap retention learner (returns at 7-day intervals; misses 1-in-5)",
+        "stageReachedAt": {
+          "Egg found": 1,
+          "Hatched": 2,
+          "Growing": 7
+        },
+        "finalStars": {
+          "pealark": 40,
+          "curlune": 40,
+          "claspin": 40,
+          "grand": 100
+        },
+        "finalAttempts": 320,
+        "finalCorrect": 256,
+        "starsPerCorrect": 0.3906,
+        "sessionCount": 80,
+        "samples": [
+          {
+            "session": 1,
+            "itemsServed": 4,
+            "uniqueModes": 4,
             "uniqueSkills": 4,
             "correctCount": 3,
             "maxDirectStars": 6,
@@ -172,22 +268,22 @@
           {
             "session": 21,
             "itemsServed": 4,
-            "uniqueModes": 1,
+            "uniqueModes": 4,
             "uniqueSkills": 4,
-            "correctCount": 4,
-            "maxDirectStars": 39,
+            "correctCount": 3,
+            "maxDirectStars": 40,
             "stage": "Growing",
             "stars": {
-              "pealark": 38,
-              "curlune": 39,
-              "claspin": 28,
+              "pealark": 40,
+              "curlune": 40,
+              "claspin": 19,
               "grand": 100
             }
           },
           {
             "session": 41,
             "itemsServed": 4,
-            "uniqueModes": 1,
+            "uniqueModes": 4,
             "uniqueSkills": 3,
             "correctCount": 3,
             "maxDirectStars": 40,
@@ -195,72 +291,167 @@
             "stars": {
               "pealark": 40,
               "curlune": 40,
-              "claspin": 31,
+              "claspin": 36,
               "grand": 100
             }
           },
           {
             "session": 61,
             "itemsServed": 4,
-            "uniqueModes": 1,
-            "uniqueSkills": 4,
+            "uniqueModes": 4,
+            "uniqueSkills": 3,
             "correctCount": 3,
             "maxDirectStars": 40,
             "stage": "Growing",
             "stars": {
               "pealark": 40,
               "curlune": 40,
-              "claspin": 31,
+              "claspin": 40,
               "grand": 100
             }
           },
           {
             "session": 80,
             "itemsServed": 4,
-            "uniqueModes": 1,
+            "uniqueModes": 4,
             "uniqueSkills": 4,
-            "correctCount": 2,
+            "correctCount": 3,
             "maxDirectStars": 40,
             "stage": "Growing",
             "stars": {
               "pealark": 40,
               "curlune": 40,
-              "claspin": 31,
+              "claspin": 40,
               "grand": 100
             }
           }
         ]
       },
       {
-        "profileId": "long-gap-retention",
-        "label": "Long-gap retention learner (returns at 7-day intervals; misses 1-in-5)",
+        "profileId": "easy-template-only",
+        "label": "Easy-template-only learner (correct only on multiple-choice items)",
         "stageReachedAt": {
           "Egg found": 1,
-          "Hatched": 5,
-          "Growing": 15
+          "Hatched": 6,
+          "Growing": 38
         },
         "finalStars": {
           "pealark": 40,
           "curlune": 40,
-          "claspin": 31,
+          "claspin": 29,
           "grand": 100
         },
         "finalAttempts": 320,
-        "finalCorrect": 256,
-        "starsPerCorrect": 0.3906,
+        "finalCorrect": 80,
+        "starsPerCorrect": 1.25,
         "sessionCount": 80,
         "samples": [
           {
             "session": 1,
             "itemsServed": 4,
-            "uniqueModes": 1,
+            "uniqueModes": 4,
             "uniqueSkills": 4,
-            "correctCount": 3,
-            "maxDirectStars": 5,
+            "correctCount": 1,
+            "maxDirectStars": 4,
             "stage": "Egg found",
             "stars": {
-              "pealark": 5,
-              "curlune": 1,
+              "pealark": 1,
+              "curlune": 4,
+              "claspin": 0,
+              "grand": 100
+            }
+          },
+          {
+            "session": 21,
+            "itemsServed": 4,
+            "uniqueModes": 4,
+            "uniqueSkills": 4,
+            "correctCount": 1,
+            "maxDirectStars": 24,
+            "stage": "Hatched",
+            "stars": {
+              "pealark": 19,
+              "curlune": 24,
+              "claspin": 13,
+              "grand": 100
+            }
+          },
+          {
+            "session": 41,
+            "itemsServed": 4,
+            "uniqueModes": 4,
+            "uniqueSkills": 4,
+            "correctCount": 1,
+            "maxDirectStars": 37,
+            "stage": "Growing",
+            "stars": {
+              "pealark": 24,
+              "curlune": 37,
+              "claspin": 21,
+              "grand": 100
+            }
+          },
+          {
+            "session": 61,
+            "itemsServed": 4,
+            "uniqueModes": 4,
+            "uniqueSkills": 4,
+            "correctCount": 1,
+            "maxDirectStars": 40,
+            "stage": "Growing",
+            "stars": {
+              "pealark": 33,
+              "curlune": 40,
+              "claspin": 27,
+              "grand": 100
+            }
+          },
+          {
+            "session": 80,
+            "itemsServed": 4,
+            "uniqueModes": 4,
+            "uniqueSkills": 4,
+            "correctCount": 1,
+            "maxDirectStars": 40,
+            "stage": "Growing",
+            "stars": {
+              "pealark": 40,
+              "curlune": 40,
+              "claspin": 29,
+              "grand": 100
+            }
+          }
+        ]
+      },
+      {
+        "profileId": "repeated-template",
+        "label": "Repeated-template learner (correct only on apostrophe-contractions skill)",
+        "stageReachedAt": {
+          "Egg found": 1,
+          "Hatched": 28
+        },
+        "finalStars": {
+          "pealark": 10,
+          "curlune": 10,
+          "claspin": 34,
+          "grand": 100
+        },
+        "finalAttempts": 320,
+        "finalCorrect": 20,
+        "starsPerCorrect": 5,
+        "sessionCount": 80,
+        "samples": [
+          {
+            "session": 1,
+            "itemsServed": 4,
+            "uniqueModes": 4,
+            "uniqueSkills": 4,
+            "correctCount": 1,
+            "maxDirectStars": 2,
+            "stage": "Egg found",
+            "stars": {
+              "pealark": 1,
+              "curlune": 2,
               "claspin": 2,
               "grand": 100
             }
@@ -268,8 +459,104 @@
           {
             "session": 21,
             "itemsServed": 4,
-            "uniqueModes": 1,
+            "uniqueModes": 4,
+            "uniqueSkills": 4,
+            "correctCount": 0,
+            "maxDirectStars": 12,
+            "stage": "Egg found",
+            "stars": {
+              "pealark": 10,
+              "curlune": 10,
+              "claspin": 12,
+              "grand": 100
+            }
+          },
+          {
+            "session": 41,
+            "itemsServed": 4,
+            "uniqueModes": 4,
+            "uniqueSkills": 3,
+            "correctCount": 0,
+            "maxDirectStars": 24,
+            "stage": "Hatched",
+            "stars": {
+              "pealark": 10,
+              "curlune": 10,
+              "claspin": 24,
+              "grand": 100
+            }
+          },
+          {
+            "session": 61,
+            "itemsServed": 4,
+            "uniqueModes": 4,
+            "uniqueSkills": 4,
+            "correctCount": 0,
+            "maxDirectStars": 29,
+            "stage": "Hatched",
+            "stars": {
+              "pealark": 10,
+              "curlune": 10,
+              "claspin": 29,
+              "grand": 100
+            }
+          },
+          {
+            "session": 80,
+            "itemsServed": 4,
+            "uniqueModes": 4,
+            "uniqueSkills": 4,
+            "correctCount": 0,
+            "maxDirectStars": 34,
+            "stage": "Hatched",
+            "stars": {
+              "pealark": 10,
+              "curlune": 10,
+              "claspin": 34,
+              "grand": 100
+            }
+          }
+        ]
+      },
+      {
+        "profileId": "supported-after-wrong",
+        "label": "Supported-after-wrong learner (first-slot fails, rest succeed)",
+        "stageReachedAt": {
+          "Egg found": 1,
+          "Hatched": 3,
+          "Growing": 11
+        },
+        "finalStars": {
+          "pealark": 40,
+          "curlune": 40,
+          "claspin": 38,
+          "grand": 100
+        },
+        "finalAttempts": 320,
+        "finalCorrect": 240,
+        "starsPerCorrect": 0.4167,
+        "sessionCount": 80,
+        "samples": [
+          {
+            "session": 1,
+            "itemsServed": 4,
+            "uniqueModes": 4,
             "uniqueSkills": 2,
+            "correctCount": 3,
+            "maxDirectStars": 5,
+            "stage": "Egg found",
+            "stars": {
+              "pealark": 0,
+              "curlune": 5,
+              "claspin": 3,
+              "grand": 100
+            }
+          },
+          {
+            "session": 21,
+            "itemsServed": 4,
+            "uniqueModes": 4,
+            "uniqueSkills": 4,
             "correctCount": 3,
             "maxDirectStars": 40,
             "stage": "Growing",
@@ -283,22 +570,7 @@
           {
             "session": 41,
             "itemsServed": 4,
-            "uniqueModes": 1,
-            "uniqueSkills": 2,
-            "correctCount": 3,
-            "maxDirectStars": 40,
-            "stage": "Growing",
-            "stars": {
-              "pealark": 40,
-              "curlune": 40,
-              "claspin": 31,
-              "grand": 100
-            }
-          },
-          {
-            "session": 61,
-            "itemsServed": 4,
-            "uniqueModes": 1,
+            "uniqueModes": 4,
             "uniqueSkills": 3,
             "correctCount": 3,
             "maxDirectStars": 40,
@@ -306,97 +578,16 @@
             "stars": {
               "pealark": 40,
               "curlune": 40,
-              "claspin": 31,
-              "grand": 100
-            }
-          },
-          {
-            "session": 80,
-            "itemsServed": 4,
-            "uniqueModes": 1,
-            "uniqueSkills": 4,
-            "correctCount": 3,
-            "maxDirectStars": 40,
-            "stage": "Growing",
-            "stars": {
-              "pealark": 40,
-              "curlune": 40,
-              "claspin": 31,
-              "grand": 100
-            }
-          }
-        ]
-      },
-      {
-        "profileId": "easy-template-only",
-        "label": "Easy-template-only learner (correct only on multiple-choice items)",
-        "stageReachedAt": {
-          "Egg found": 1,
-          "Hatched": 5,
-          "Growing": 14
-        },
-        "finalStars": {
-          "pealark": 40,
-          "curlune": 40,
-          "claspin": 36,
-          "grand": 100
-        },
-        "finalAttempts": 320,
-        "finalCorrect": 320,
-        "starsPerCorrect": 0.3125,
-        "sessionCount": 80,
-        "samples": [
-          {
-            "session": 1,
-            "itemsServed": 4,
-            "uniqueModes": 1,
-            "uniqueSkills": 4,
-            "correctCount": 4,
-            "maxDirectStars": 5,
-            "stage": "Egg found",
-            "stars": {
-              "pealark": 5,
-              "curlune": 2,
-              "claspin": 2,
-              "grand": 100
-            }
-          },
-          {
-            "session": 21,
-            "itemsServed": 4,
-            "uniqueModes": 1,
-            "uniqueSkills": 2,
-            "correctCount": 4,
-            "maxDirectStars": 40,
-            "stage": "Growing",
-            "stars": {
-              "pealark": 40,
-              "curlune": 40,
-              "claspin": 31,
-              "grand": 100
-            }
-          },
-          {
-            "session": 41,
-            "itemsServed": 4,
-            "uniqueModes": 1,
-            "uniqueSkills": 3,
-            "correctCount": 4,
-            "maxDirectStars": 40,
-            "stage": "Growing",
-            "stars": {
-              "pealark": 40,
-              "curlune": 40,
-              "claspin": 36,
+              "claspin": 33,
               "grand": 100
             }
           },
           {
             "session": 61,
             "itemsServed": 4,
-            "uniqueModes": 1,
+            "uniqueModes": 4,
             "uniqueSkills": 4,
-            "correctCount": 4,
+            "correctCount": 3,
             "maxDirectStars": 40,
             "stage": "Growing",
             "stars": {
@@ -409,168 +600,7 @@
           {
             "session": 80,
             "itemsServed": 4,
-            "uniqueModes": 1,
-            "uniqueSkills": 4,
-            "correctCount": 4,
-            "maxDirectStars": 40,
-            "stage": "Growing",
-            "stars": {
-              "pealark": 40,
-              "curlune": 40,
-              "claspin": 36,
-              "grand": 100
-            }
-          }
-        ]
-      },
-      {
-        "profileId": "repeated-template",
-        "label": "Repeated-template learner (correct only on apostrophe-contractions skill)",
-        "stageReachedAt": {
-          "Egg found": 1,
-          "Hatched": 20
-        },
-        "finalStars": {
-          "pealark": 10,
-          "curlune": 10,
-          "claspin": 28,
-          "grand": 100
-        },
-        "finalAttempts": 320,
-        "finalCorrect": 22,
-        "starsPerCorrect": 4.5455,
-        "sessionCount": 80,
-        "samples": [
-          {
-            "session": 1,
-            "itemsServed": 4,
-            "uniqueModes": 1,
-            "uniqueSkills": 4,
-            "correctCount": 0,
-            "maxDirectStars": 2,
-            "stage": "Egg found",
-            "stars": {
-              "pealark": 2,
-              "curlune": 2,
-              "claspin": 0,
-              "grand": 100
-            }
-          },
-          {
-            "session": 21,
-            "itemsServed": 4,
-            "uniqueModes": 1,
-            "uniqueSkills": 4,
-            "correctCount": 1,
-            "maxDirectStars": 16,
-            "stage": "Hatched",
-            "stars": {
-              "pealark": 10,
-              "curlune": 10,
-              "claspin": 16,
-              "grand": 100
-            }
-          },
-          {
-            "session": 41,
-            "itemsServed": 4,
-            "uniqueModes": 1,
-            "uniqueSkills": 3,
-            "correctCount": 0,
-            "maxDirectStars": 23,
-            "stage": "Hatched",
-            "stars": {
-              "pealark": 10,
-              "curlune": 10,
-              "claspin": 23,
-              "grand": 100
-            }
-          },
-          {
-            "session": 61,
-            "itemsServed": 4,
-            "uniqueModes": 1,
-            "uniqueSkills": 3,
-            "correctCount": 0,
-            "maxDirectStars": 26,
-            "stage": "Hatched",
-            "stars": {
-              "pealark": 10,
-              "curlune": 10,
-              "claspin": 26,
-              "grand": 100
-            }
-          },
-          {
-            "session": 80,
-            "itemsServed": 4,
-            "uniqueModes": 1,
-            "uniqueSkills": 4,
-            "correctCount": 0,
-            "maxDirectStars": 28,
-            "stage": "Hatched",
-            "stars": {
-              "pealark": 10,
-              "curlune": 10,
-              "claspin": 28,
-              "grand": 100
-            }
-          }
-        ]
-      },
-      {
-        "profileId": "supported-after-wrong",
-        "label": "Supported-after-wrong learner (first-slot fails, rest succeed)",
-        "stageReachedAt": {
-          "Egg found": 1,
-          "Hatched": 4,
-          "Growing": 13
-        },
-        "finalStars": {
-          "pealark": 40,
-          "curlune": 40,
-          "claspin": 32,
-          "grand": 100
-        },
-        "finalAttempts": 320,
-        "finalCorrect": 240,
-        "starsPerCorrect": 0.4167,
-        "sessionCount": 80,
-        "samples": [
-          {
-            "session": 1,
-            "itemsServed": 4,
-            "uniqueModes": 1,
-            "uniqueSkills": 4,
-            "correctCount": 3,
-            "maxDirectStars": 3,
-            "stage": "Egg found",
-            "stars": {
-              "pealark": 2,
-              "curlune": 3,
-              "claspin": 2,
-              "grand": 100
-            }
-          },
-          {
-            "session": 21,
-            "itemsServed": 4,
-            "uniqueModes": 1,
-            "uniqueSkills": 4,
-            "correctCount": 3,
-            "maxDirectStars": 40,
-            "stage": "Growing",
-            "stars": {
-              "pealark": 31,
-              "curlune": 40,
-              "claspin": 26,
-              "grand": 100
-            }
-          },
-          {
-            "session": 41,
-            "itemsServed": 4,
-            "uniqueModes": 1,
+            "uniqueModes": 4,
             "uniqueSkills": 3,
             "correctCount": 3,
             "maxDirectStars": 40,
@@ -578,37 +608,7 @@
             "stars": {
               "pealark": 40,
               "curlune": 40,
-              "claspin": 31,
-              "grand": 100
-            }
-          },
-          {
-            "session": 61,
-            "itemsServed": 4,
-            "uniqueModes": 1,
-            "uniqueSkills": 4,
-            "correctCount": 3,
-            "maxDirectStars": 40,
-            "stage": "Growing",
-            "stars": {
-              "pealark": 40,
-              "curlune": 40,
-              "claspin": 32,
-              "grand": 100
-            }
-          },
-          {
-            "session": 80,
-            "itemsServed": 4,
-            "uniqueModes": 1,
-            "uniqueSkills": 3,
-            "correctCount": 3,
-            "maxDirectStars": 40,
-            "stage": "Growing",
-            "stars": {
-              "pealark": 40,
-              "curlune": 40,
-              "claspin": 32,
+              "claspin": 38,
               "grand": 100
             }
           }
@@ -618,8 +618,8 @@
     "summary": {
       "alwaysCorrectStageReachedAt": {
         "Egg found": 1,
-        "Hatched": 2,
-        "Growing": 10
+        "Hatched": 3,
+        "Growing": 9
       }
     }
   },
@@ -632,12 +632,12 @@
         "stageReachedAt": {
           "Egg found": 1,
           "Hatched": 2,
-          "Growing": 8
+          "Growing": 6
         },
         "finalStars": {
           "pealark": 40,
           "curlune": 40,
-          "claspin": 36,
+          "claspin": 40,
           "grand": 100
         },
         "finalAttempts": 480,
@@ -648,7 +648,7 @@
           {
             "session": 1,
             "itemsServed": 6,
-            "uniqueModes": 1,
+            "uniqueModes": 6,
             "uniqueSkills": 6,
             "correctCount": 6,
             "maxDirectStars": 10,
@@ -663,7 +663,22 @@
           {
             "session": 21,
             "itemsServed": 6,
-            "uniqueModes": 1,
+            "uniqueModes": 6,
+            "uniqueSkills": 7,
+            "correctCount": 6,
+            "maxDirectStars": 40,
+            "stage": "Growing",
+            "stars": {
+              "pealark": 40,
+              "curlune": 40,
+              "claspin": 27,
+              "grand": 100
+            }
+          },
+          {
+            "session": 41,
+            "itemsServed": 6,
+            "uniqueModes": 6,
             "uniqueSkills": 5,
             "correctCount": 6,
             "maxDirectStars": 40,
@@ -671,14 +686,14 @@
             "stars": {
               "pealark": 40,
               "curlune": 40,
-              "claspin": 34,
+              "claspin": 40,
               "grand": 100
             }
           },
           {
-            "session": 41,
+            "session": 61,
             "itemsServed": 6,
-            "uniqueModes": 1,
+            "uniqueModes": 6,
             "uniqueSkills": 6,
             "correctCount": 6,
             "maxDirectStars": 40,
@@ -686,37 +701,22 @@
             "stars": {
               "pealark": 40,
               "curlune": 40,
-              "claspin": 36,
-              "grand": 100
-            }
-          },
-          {
-            "session": 61,
-            "itemsServed": 6,
-            "uniqueModes": 1,
-            "uniqueSkills": 5,
-            "correctCount": 6,
-            "maxDirectStars": 40,
-            "stage": "Growing",
-            "stars": {
-              "pealark": 40,
-              "curlune": 40,
-              "claspin": 36,
+              "claspin": 40,
               "grand": 100
             }
           },
           {
             "session": 80,
             "itemsServed": 6,
-            "uniqueModes": 1,
-            "uniqueSkills": 4,
+            "uniqueModes": 6,
+            "uniqueSkills": 6,
             "correctCount": 6,
             "maxDirectStars": 40,
             "stage": "Growing",
             "stars": {
               "pealark": 40,
               "curlune": 40,
-              "claspin": 36,
+              "claspin": 40,
               "grand": 100
             }
           }
@@ -728,30 +728,30 @@
         "stageReachedAt": {
           "Egg found": 1,
           "Hatched": 3,
-          "Growing": 13
+          "Growing": 7
         },
         "finalStars": {
           "pealark": 40,
           "curlune": 40,
-          "claspin": 32,
+          "claspin": 40,
           "grand": 100
         },
         "finalAttempts": 480,
-        "finalCorrect": 376,
-        "starsPerCorrect": 0.266,
+        "finalCorrect": 385,
+        "starsPerCorrect": 0.2597,
         "sessionCount": 80,
         "samples": [
           {
             "session": 1,
             "itemsServed": 6,
-            "uniqueModes": 1,
-            "uniqueSkills": 5,
-            "correctCount": 3,
-            "maxDirectStars": 4,
+            "uniqueModes": 6,
+            "uniqueSkills": 6,
+            "correctCount": 5,
+            "maxDirectStars": 7,
             "stage": "Egg found",
             "stars": {
-              "pealark": 2,
-              "curlune": 4,
+              "pealark": 7,
+              "curlune": 3,
               "claspin": 2,
               "grand": 100
             }
@@ -759,60 +759,60 @@
           {
             "session": 21,
             "itemsServed": 6,
-            "uniqueModes": 1,
+            "uniqueModes": 6,
             "uniqueSkills": 5,
-            "correctCount": 4,
-            "maxDirectStars": 40,
-            "stage": "Growing",
-            "stars": {
-              "pealark": 40,
-              "curlune": 35,
-              "claspin": 27,
-              "grand": 100
-            }
-          },
-          {
-            "session": 41,
-            "itemsServed": 6,
-            "uniqueModes": 1,
-            "uniqueSkills": 4,
-            "correctCount": 4,
-            "maxDirectStars": 40,
-            "stage": "Growing",
-            "stars": {
-              "pealark": 40,
-              "curlune": 40,
-              "claspin": 32,
-              "grand": 100
-            }
-          },
-          {
-            "session": 61,
-            "itemsServed": 6,
-            "uniqueModes": 1,
-            "uniqueSkills": 6,
-            "correctCount": 6,
-            "maxDirectStars": 40,
-            "stage": "Growing",
-            "stars": {
-              "pealark": 40,
-              "curlune": 40,
-              "claspin": 32,
-              "grand": 100
-            }
-          },
-          {
-            "session": 80,
-            "itemsServed": 6,
-            "uniqueModes": 1,
-            "uniqueSkills": 4,
             "correctCount": 5,
             "maxDirectStars": 40,
             "stage": "Growing",
             "stars": {
               "pealark": 40,
               "curlune": 40,
-              "claspin": 32,
+              "claspin": 25,
+              "grand": 100
+            }
+          },
+          {
+            "session": 41,
+            "itemsServed": 6,
+            "uniqueModes": 6,
+            "uniqueSkills": 4,
+            "correctCount": 6,
+            "maxDirectStars": 40,
+            "stage": "Growing",
+            "stars": {
+              "pealark": 40,
+              "curlune": 40,
+              "claspin": 39,
+              "grand": 100
+            }
+          },
+          {
+            "session": 61,
+            "itemsServed": 6,
+            "uniqueModes": 6,
+            "uniqueSkills": 7,
+            "correctCount": 4,
+            "maxDirectStars": 40,
+            "stage": "Growing",
+            "stars": {
+              "pealark": 40,
+              "curlune": 40,
+              "claspin": 40,
+              "grand": 100
+            }
+          },
+          {
+            "session": 80,
+            "itemsServed": 6,
+            "uniqueModes": 6,
+            "uniqueSkills": 5,
+            "correctCount": 6,
+            "maxDirectStars": 40,
+            "stage": "Growing",
+            "stars": {
+              "pealark": 40,
+              "curlune": 40,
+              "claspin": 40,
               "grand": 100
             }
           }
@@ -823,13 +823,13 @@
         "label": "Long-gap retention learner (returns at 7-day intervals; misses 1-in-5)",
         "stageReachedAt": {
           "Egg found": 1,
-          "Hatched": 3,
-          "Growing": 10
+          "Hatched": 2,
+          "Growing": 6
         },
         "finalStars": {
           "pealark": 40,
           "curlune": 40,
-          "claspin": 33,
+          "claspin": 40,
           "grand": 100
         },
         "finalAttempts": 480,
@@ -840,37 +840,52 @@
           {
             "session": 1,
             "itemsServed": 6,
-            "uniqueModes": 1,
+            "uniqueModes": 6,
             "uniqueSkills": 6,
             "correctCount": 4,
-            "maxDirectStars": 6,
+            "maxDirectStars": 9,
             "stage": "Egg found",
             "stars": {
-              "pealark": 6,
-              "curlune": 3,
-              "claspin": 2,
+              "pealark": 3,
+              "curlune": 9,
+              "claspin": 0,
               "grand": 100
             }
           },
           {
             "session": 21,
             "itemsServed": 6,
-            "uniqueModes": 1,
-            "uniqueSkills": 6,
+            "uniqueModes": 6,
+            "uniqueSkills": 5,
             "correctCount": 4,
             "maxDirectStars": 40,
             "stage": "Growing",
             "stars": {
               "pealark": 40,
               "curlune": 40,
-              "claspin": 30,
+              "claspin": 21,
               "grand": 100
             }
           },
           {
             "session": 41,
             "itemsServed": 6,
-            "uniqueModes": 1,
+            "uniqueModes": 6,
+            "uniqueSkills": 5,
+            "correctCount": 4,
+            "maxDirectStars": 40,
+            "stage": "Growing",
+            "stars": {
+              "pealark": 40,
+              "curlune": 40,
+              "claspin": 36,
+              "grand": 100
+            }
+          },
+          {
+            "session": 61,
+            "itemsServed": 6,
+            "uniqueModes": 6,
             "uniqueSkills": 6,
             "correctCount": 4,
             "maxDirectStars": 40,
@@ -878,29 +893,14 @@
             "stars": {
               "pealark": 40,
               "curlune": 40,
-              "claspin": 33,
-              "grand": 100
-            }
-          },
-          {
-            "session": 61,
-            "itemsServed": 6,
-            "uniqueModes": 1,
-            "uniqueSkills": 4,
-            "correctCount": 4,
-            "maxDirectStars": 40,
-            "stage": "Growing",
-            "stars": {
-              "pealark": 40,
-              "curlune": 40,
-              "claspin": 33,
+              "claspin": 40,
               "grand": 100
             }
           },
           {
             "session": 80,
             "itemsServed": 6,
-            "uniqueModes": 1,
+            "uniqueModes": 6,
             "uniqueSkills": 5,
             "correctCount": 5,
             "maxDirectStars": 40,
@@ -908,7 +908,7 @@
             "stars": {
               "pealark": 40,
               "curlune": 40,
-              "claspin": 33,
+              "claspin": 40,
               "grand": 100
             }
           }
@@ -919,92 +919,92 @@
         "label": "Easy-template-only learner (correct only on multiple-choice items)",
         "stageReachedAt": {
           "Egg found": 1,
-          "Hatched": 2,
-          "Growing": 8
+          "Hatched": 5,
+          "Growing": 53
         },
         "finalStars": {
           "pealark": 40,
           "curlune": 40,
-          "claspin": 36,
+          "claspin": 31,
           "grand": 100
         },
         "finalAttempts": 480,
-        "finalCorrect": 480,
-        "starsPerCorrect": 0.2083,
+        "finalCorrect": 80,
+        "starsPerCorrect": 1.25,
         "sessionCount": 80,
         "samples": [
           {
             "session": 1,
             "itemsServed": 6,
-            "uniqueModes": 1,
+            "uniqueModes": 6,
             "uniqueSkills": 5,
-            "correctCount": 6,
-            "maxDirectStars": 10,
+            "correctCount": 1,
+            "maxDirectStars": 4,
             "stage": "Egg found",
             "stars": {
-              "pealark": 10,
-              "curlune": 2,
-              "claspin": 2,
+              "pealark": 3,
+              "curlune": 4,
+              "claspin": 1,
               "grand": 100
             }
           },
           {
             "session": 21,
             "itemsServed": 6,
-            "uniqueModes": 1,
-            "uniqueSkills": 6,
-            "correctCount": 6,
-            "maxDirectStars": 40,
-            "stage": "Growing",
+            "uniqueModes": 6,
+            "uniqueSkills": 7,
+            "correctCount": 1,
+            "maxDirectStars": 25,
+            "stage": "Hatched",
             "stars": {
-              "pealark": 40,
-              "curlune": 40,
-              "claspin": 34,
+              "pealark": 25,
+              "curlune": 14,
+              "claspin": 19,
               "grand": 100
             }
           },
           {
             "session": 41,
             "itemsServed": 6,
-            "uniqueModes": 1,
+            "uniqueModes": 6,
             "uniqueSkills": 6,
-            "correctCount": 6,
-            "maxDirectStars": 40,
-            "stage": "Growing",
+            "correctCount": 1,
+            "maxDirectStars": 31,
+            "stage": "Hatched",
             "stars": {
-              "pealark": 40,
-              "curlune": 40,
-              "claspin": 36,
+              "pealark": 31,
+              "curlune": 28,
+              "claspin": 24,
               "grand": 100
             }
           },
           {
             "session": 61,
             "itemsServed": 6,
-            "uniqueModes": 1,
-            "uniqueSkills": 3,
-            "correctCount": 6,
-            "maxDirectStars": 40,
+            "uniqueModes": 6,
+            "uniqueSkills": 7,
+            "correctCount": 1,
+            "maxDirectStars": 38,
             "stage": "Growing",
             "stars": {
-              "pealark": 40,
-              "curlune": 40,
-              "claspin": 36,
+              "pealark": 35,
+              "curlune": 38,
+              "claspin": 29,
               "grand": 100
             }
           },
           {
             "session": 80,
             "itemsServed": 6,
-            "uniqueModes": 1,
+            "uniqueModes": 6,
             "uniqueSkills": 5,
-            "correctCount": 6,
+            "correctCount": 1,
             "maxDirectStars": 40,
             "stage": "Growing",
             "stars": {
               "pealark": 40,
               "curlune": 40,
-              "claspin": 36,
+              "claspin": 31,
               "grand": 100
             }
           }
@@ -1015,91 +1015,92 @@
         "label": "Repeated-template learner (correct only on apostrophe-contractions skill)",
         "stageReachedAt": {
           "Egg found": 1,
-          "Hatched": 7
+          "Hatched": 13,
+          "Growing": 62
         },
         "finalStars": {
           "pealark": 10,
           "curlune": 10,
-          "claspin": 29,
+          "claspin": 37,
           "grand": 100
         },
         "finalAttempts": 480,
-        "finalCorrect": 42,
-        "starsPerCorrect": 2.381,
+        "finalCorrect": 29,
+        "starsPerCorrect": 3.4483,
         "sessionCount": 80,
         "samples": [
           {
             "session": 1,
             "itemsServed": 6,
-            "uniqueModes": 1,
-            "uniqueSkills": 4,
-            "correctCount": 0,
-            "maxDirectStars": 4,
+            "uniqueModes": 6,
+            "uniqueSkills": 7,
+            "correctCount": 1,
+            "maxDirectStars": 3,
             "stage": "Egg found",
             "stars": {
-              "pealark": 4,
-              "curlune": 2,
-              "claspin": 0,
+              "pealark": 3,
+              "curlune": 3,
+              "claspin": 2,
               "grand": 100
             }
           },
           {
             "session": 21,
             "itemsServed": 6,
-            "uniqueModes": 1,
-            "uniqueSkills": 5,
-            "correctCount": 0,
-            "maxDirectStars": 26,
+            "uniqueModes": 6,
+            "uniqueSkills": 6,
+            "correctCount": 1,
+            "maxDirectStars": 25,
             "stage": "Hatched",
             "stars": {
               "pealark": 10,
               "curlune": 10,
-              "claspin": 26,
+              "claspin": 25,
               "grand": 100
             }
           },
           {
             "session": 41,
             "itemsServed": 6,
-            "uniqueModes": 1,
-            "uniqueSkills": 6,
-            "correctCount": 1,
-            "maxDirectStars": 27,
+            "uniqueModes": 6,
+            "uniqueSkills": 5,
+            "correctCount": 0,
+            "maxDirectStars": 30,
             "stage": "Hatched",
             "stars": {
               "pealark": 10,
               "curlune": 10,
-              "claspin": 27,
+              "claspin": 30,
               "grand": 100
             }
           },
           {
             "session": 61,
             "itemsServed": 6,
-            "uniqueModes": 1,
-            "uniqueSkills": 4,
-            "correctCount": 0,
-            "maxDirectStars": 29,
+            "uniqueModes": 6,
+            "uniqueSkills": 7,
+            "correctCount": 1,
+            "maxDirectStars": 33,
             "stage": "Hatched",
             "stars": {
               "pealark": 10,
               "curlune": 10,
-              "claspin": 29,
+              "claspin": 33,
               "grand": 100
             }
           },
           {
             "session": 80,
             "itemsServed": 6,
-            "uniqueModes": 1,
-            "uniqueSkills": 5,
-            "correctCount": 1,
-            "maxDirectStars": 29,
-            "stage": "Hatched",
+            "uniqueModes": 6,
+            "uniqueSkills": 7,
+            "correctCount": 0,
+            "maxDirectStars": 37,
+            "stage": "Growing",
             "stars": {
               "pealark": 10,
               "curlune": 10,
-              "claspin": 29,
+              "claspin": 37,
               "grand": 100
             }
           }
@@ -1110,13 +1111,13 @@
         "label": "Supported-after-wrong learner (first-slot fails, rest succeed)",
         "stageReachedAt": {
           "Egg found": 1,
-          "Hatched": 3,
-          "Growing": 8
+          "Hatched": 2,
+          "Growing": 6
         },
         "finalStars": {
           "pealark": 40,
           "curlune": 40,
-          "claspin": 34,
+          "claspin": 38,
           "grand": 100
         },
         "finalAttempts": 480,
@@ -1127,37 +1128,22 @@
           {
             "session": 1,
             "itemsServed": 6,
-            "uniqueModes": 1,
-            "uniqueSkills": 6,
+            "uniqueModes": 6,
+            "uniqueSkills": 4,
             "correctCount": 5,
-            "maxDirectStars": 6,
+            "maxDirectStars": 12,
             "stage": "Egg found",
             "stars": {
-              "pealark": 5,
-              "curlune": 6,
-              "claspin": 2,
+              "pealark": 12,
+              "curlune": 2,
+              "claspin": 1,
               "grand": 100
             }
           },
           {
             "session": 21,
             "itemsServed": 6,
-            "uniqueModes": 1,
-            "uniqueSkills": 5,
-            "correctCount": 5,
-            "maxDirectStars": 40,
-            "stage": "Growing",
-            "stars": {
-              "pealark": 40,
-              "curlune": 40,
-              "claspin": 29,
-              "grand": 100
-            }
-          },
-          {
-            "session": 41,
-            "itemsServed": 6,
-            "uniqueModes": 1,
+            "uniqueModes": 6,
             "uniqueSkills": 6,
             "correctCount": 5,
             "maxDirectStars": 40,
@@ -1165,14 +1151,14 @@
             "stars": {
               "pealark": 40,
               "curlune": 40,
-              "claspin": 34,
+              "claspin": 23,
               "grand": 100
             }
           },
           {
-            "session": 61,
+            "session": 41,
             "itemsServed": 6,
-            "uniqueModes": 1,
+            "uniqueModes": 6,
             "uniqueSkills": 5,
             "correctCount": 5,
             "maxDirectStars": 40,
@@ -1180,22 +1166,37 @@
             "stars": {
               "pealark": 40,
               "curlune": 40,
-              "claspin": 34,
+              "claspin": 26,
               "grand": 100
             }
           },
           {
-            "session": 80,
+            "session": 61,
             "itemsServed": 6,
-            "uniqueModes": 1,
-            "uniqueSkills": 3,
+            "uniqueModes": 6,
+            "uniqueSkills": 6,
             "correctCount": 5,
             "maxDirectStars": 40,
             "stage": "Growing",
             "stars": {
               "pealark": 40,
               "curlune": 40,
-              "claspin": 34,
+              "claspin": 33,
+              "grand": 100
+            }
+          },
+          {
+            "session": 80,
+            "itemsServed": 6,
+            "uniqueModes": 6,
+            "uniqueSkills": 5,
+            "correctCount": 5,
+            "maxDirectStars": 40,
+            "stage": "Growing",
+            "stars": {
+              "pealark": 40,
+              "curlune": 40,
+              "claspin": 38,
               "grand": 100
             }
           }
@@ -1206,7 +1207,7 @@
       "alwaysCorrectStageReachedAt": {
         "Egg found": 1,
         "Hatched": 2,
-        "Growing": 8
+        "Growing": 6
       }
     }
   },
@@ -1218,10 +1219,9 @@
     "naturalRatio": 1.5,
     "inflationThreshold": 1.575,
     "diagnosticInflatedProfiles": [
-      "repeated-template",
       "supported-after-wrong"
     ],
-    "diagnosticNote": "Profiles repeated-template, supported-after-wrong show ratio above the threshold but are NOT decision-bearing — investigate as engine/scheduler tuning input, not as a reason to change roundLength.",
+    "diagnosticNote": "Profiles supported-after-wrong show ratio above the threshold but are NOT decision-bearing — investigate as engine/scheduler tuning input, not as a reason to change roundLength.",
     "perProfile": [
       {
         "profileId": "always-correct",
@@ -1233,10 +1233,10 @@
       },
       {
         "profileId": "deep-practice",
-        "starsPerCorrect4": 0.4016,
-        "starsPerCorrect6": 0.266,
-        "ratio": 1.51,
-        "normalisedRatio": 1.007,
+        "starsPerCorrect4": 0.3891,
+        "starsPerCorrect6": 0.2597,
+        "ratio": 1.498,
+        "normalisedRatio": 0.999,
         "inflated": false
       },
       {
@@ -1249,19 +1249,19 @@
       },
       {
         "profileId": "easy-template-only",
-        "starsPerCorrect4": 0.3125,
-        "starsPerCorrect6": 0.2083,
-        "ratio": 1.5,
-        "normalisedRatio": 1,
+        "starsPerCorrect4": 1.25,
+        "starsPerCorrect6": 1.25,
+        "ratio": 1,
+        "normalisedRatio": 0.667,
         "inflated": false
       },
       {
         "profileId": "repeated-template",
-        "starsPerCorrect4": 4.5455,
-        "starsPerCorrect6": 2.381,
-        "ratio": 1.909,
-        "normalisedRatio": 1.273,
-        "inflated": true
+        "starsPerCorrect4": 5,
+        "starsPerCorrect6": 3.4483,
+        "ratio": 1.45,
+        "normalisedRatio": 0.967,
+        "inflated": false
       },
       {
         "profileId": "supported-after-wrong",
@@ -1274,13 +1274,13 @@
     ],
     "stages4": {
       "Egg found": 1,
-      "Hatched": 2,
-      "Growing": 10
+      "Hatched": 3,
+      "Growing": 9
     },
     "stages6": {
       "Egg found": 1,
       "Hatched": 2,
-      "Growing": 8
+      "Growing": 6
     }
   }
 }

--- a/scripts/simulate-punctuation-qg-p14-star-pacing.mjs
+++ b/scripts/simulate-punctuation-qg-p14-star-pacing.mjs
@@ -20,6 +20,7 @@
 
 import { writeFileSync, mkdirSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { PUNCTUATION_CONTENT_INDEXES } from '../shared/punctuation/content.js';
 import { selectPunctuationItem } from '../shared/punctuation/scheduler.js';
@@ -53,6 +54,14 @@ const PROFILES = Object.freeze([
   { id: 'supported-after-wrong', label: 'Supported-after-wrong learner (first-slot fails, rest succeed)', gapDays: 1 },
 ]);
 
+function hashCode(str) {
+  let hash = 0;
+  for (let i = 0; i < str.length; i += 1) {
+    hash = ((hash << 5) - hash + str.charCodeAt(i)) | 0;
+  }
+  return hash >>> 0;
+}
+
 function makeRng(seed) {
   let state = seed >>> 0;
   return () => {
@@ -70,7 +79,9 @@ function correctnessFor(profile, sessionIndex, slot, item) {
   if (profile === 'easy-template-only') {
     // Only `choose`-mode items (the easiest answer surface) succeed; typed
     // surfaces fail, simulating a learner who avoids open production.
-    return item?.mode === 'choose' || item?.inputKind === 'choice';
+    // Note: check ONLY item.mode — inputKind is an internal property that may
+    // match more broadly and collapse this profile's trace into always-correct.
+    return item?.mode === 'choose';
   }
   if (profile === 'repeated-template') {
     // Strong on apostrophe_contractions only; wrong on every other skill.
@@ -237,6 +248,7 @@ function runSession({
     selectedSignatures: [],
     currentItemId: null,
     selectionReason: null,
+    answeredCount: 0,
   };
   const slotItems = [];
   // adv-r2-006: profileGapMs replaces the implicit DAY_MS cadence, letting
@@ -267,6 +279,7 @@ function runSession({
     });
     session.recentItemIds.push(item.id);
     session.currentItemId = item.id;
+    session.answeredCount += 1;
     if (item.variantSignature) session.selectedSignatures.push(item.variantSignature);
   }
   return slotItems;
@@ -275,7 +288,7 @@ function runSession({
 function simulateProfile({ profile, roundLength, prefs }) {
   const profileMeta = PROFILES.find((p) => p.id === profile);
   const profileGapMs = (profileMeta?.gapDays ?? 1) * DAY_MS;
-  const rng = makeRng(roundLength * 1000 + profile.length);
+  const rng = makeRng(hashCode(profile) * 31 + roundLength);
   const progressState = { items: {}, facets: {}, rewardUnits: {}, attempts: [] };
   const recentItemIds = [];
   const sessionRecords = [];
@@ -472,8 +485,27 @@ function main() {
   } else {
     process.stdout.write(`${json}\n`);
   }
+
+  // Gate 6 exit-code enforcement: CI must catch inflation violations.
+  const perProfile = decision.perProfile || [];
+  const canonical = perProfile.find((p) => p.profileId === 'always-correct');
+  if (canonical?.inflated) {
+    process.stderr.write(
+      `GATE 6 FAIL: canonical profile (always-correct) shows inflation — ` +
+      `normalised ratio ${canonical.normalisedRatio} exceeds threshold.\n`
+    );
+    process.exitCode = 1;
+  }
+  const decisionBearingInflated = perProfile.filter((p) => p.inflated);
+  if (decisionBearingInflated.length > 0 && !canonical?.inflated) {
+    process.stderr.write(
+      `GATE 6 WARNING: ${decisionBearingInflated.length} profile(s) show inflation ` +
+      `(${decisionBearingInflated.map((p) => p.profileId).join(', ')}). ` +
+      `Canonical profile is clean — no exit-code failure, but investigate.\n`
+    );
+  }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (resolve(fileURLToPath(import.meta.url)) === resolve(process.argv[1])) {
   main();
 }


### PR DESCRIPTION
## Summary

- **Exit-code gating**: simulator now exits non-zero when the canonical `always-correct` profile triggers Gate 6 inflation, enabling CI to catch violations automatically
- **RNG seed collision**: replaced `profile.length`-based seed with `hashCode(profile)` string hash — fixes identical seeds for `long-gap-retention` and `easy-template-only` (both 18-char IDs)
- **easy-template-only profile**: removed overly-broad `inputKind === 'choice'` fallback and added `session.answeredCount` tracking so the scheduler's mode rotation fires — profile now correctly fails on non-choose items (finalCorrect 80 vs always-correct 320/480)

Also fixes the `import.meta.url` entrypoint guard for Windows compatibility via `fileURLToPath`.

## Gate 6 table impact

| Profile | Old ratio | New ratio | Status |
| :--- | ---: | ---: | :--- |
| always-correct | 1.500 | 1.500 | unchanged |
| deep-practice | 1.510 | 1.498 | unchanged |
| long-gap-retention | 1.500 | 1.500 | unchanged |
| easy-template-only | 1.500 | 1.000 | **fixed** (was collapsed into always-correct) |
| repeated-template | 1.909 | 1.450 | no longer diagnostic (below threshold) |
| supported-after-wrong | 1.667 | 1.667 | unchanged (diagnostic) |

Decision unchanged: `gate6RoundLength: '4'`.

## Test plan

- [x] Simulator exits 0 (no inflation on canonical profile)
- [x] `easy-template-only` shows `finalCorrect: 80` — distinct from `always-correct` (320 at RL4, 480 at RL6)
- [x] Diagnostic warning printed for `supported-after-wrong` but no exit failure
- [x] Stored simulation JSON and report table updated with new values