### PR TITLE
fix(grammar): HARD FAIL 8 — test raw prompt passes marking (not near-miss duplicate)

### DIFF
--- a/scripts/audit-grammar-content-quality.mjs
+++ b/scripts/audit-grammar-content-quality.mjs
@@ -216,22 +216,19 @@ export function buildGrammarContentQualityAudit(seeds = DEFAULT_SEEDS) {
         }
       }
 
-      // --- HARD FAIL 8: Raw prompt passes marking ---
+      // --- HARD FAIL 8: Raw prompt passes marking (constructed-response only) ---
       const constructedKinds = ['normalisedText', 'acceptedSet', 'punctuationPattern'];
-      if (question.answerSpec && constructedKinds.includes(question.answerSpec.kind)) {
-        const nearMiss8 = question.answerSpec.nearMiss;
-        if (Array.isArray(nearMiss8) && nearMiss8.length > 0) {
-          for (const nm of nearMiss8) {
-            const result = markByAnswerSpec(question.answerSpec, nm);
-            if (result.correct === true) {
-              hardFailures.push({
-                rule: 'raw-prompt-passes',
-                templateId: template.id,
-                seed,
-                detail: `Near-miss/raw value "${nm}" passes markByAnswerSpec — question is a no-op`,
-              });
-              break;
-            }
+      if (constructedKinds.includes(question.answerSpec?.kind)) {
+        const rawPromptText = stripHtml(question.stemHtml || '').trim();
+        if (rawPromptText) {
+          const rawResult = markByAnswerSpec(question.answerSpec, rawPromptText);
+          if (rawResult?.correct) {
+            hardFailures.push({
+              rule: 'raw-prompt-passes',
+              templateId: template.id,
+              seed,
+              detail: `Submitting the raw prompt text "${rawPromptText.slice(0, 80)}..." as an answer marks correct.`,
+            });
           }
         }
       }


### PR DESCRIPTION
## Summary
- HARD FAIL 8 was labelled 'raw-prompt-passes' but actually re-tested near-misses (identical to HARD FAIL 6)
- Now correctly tests whether submitting the stripped prompt text as an answer would mark correct
- This catches templates where the golden answer is accidentally embedded in the prompt

## Test plan
- [ ] Content-quality audit passes (or surfaces legitimate new findings)
- [ ] Tests pass