### PR TITLE
fix(grammar): correct manualReviewOnly property path — top-level not answerSpec

### DIFF
--- a/scripts/audit-grammar-open-response-fairness.mjs
+++ b/scripts/audit-grammar-open-response-fairness.mjs
@@ -43,7 +43,7 @@ export function buildOpenResponseFairnessAudit(seeds = parseSeeds()) {
         && ['normalisedText', 'acceptedSet'].includes(kind)
         && isOpenPrompt(prompt)
         && acceptedCount < 3
-        && question.answerSpec?.manualReviewOnly !== true
+        && question.manualReviewOnly !== true
         && question.nonScored !== true
       ) {
         findings.push({ templateId: template.id, seed, inputType, kind, acceptedCount, nearMissCount, prompt });


### PR DESCRIPTION
## Summary
- Fixes manualReviewOnly check accessing wrong property (question.answerSpec vs question)
- Currently dead code due to kind filter, but correct for defence-in-depth

## Test plan
- [x] Fairness audit passes (0 findings)