### PR TITLE
fix(grammar): preserve manualReviewOnly/nonScored in compactCase

### DIFF
--- a/scripts/generate-grammar-manual-expansion.mjs
+++ b/scripts/generate-grammar-manual-expansion.mjs
@@ -481,6 +481,8 @@ function compactCase(rawCase) {
     inputType: cleanText(sourceCase.inputType),
     questionType: cleanText(sourceCase.questionType),
     depthTier: cleanText(sourceCase.depthTier),
+    manualReviewOnly: rawCase?.manualReviewOnly === true ? true : undefined,
+    nonScored: rawCase?.nonScored === true ? true : undefined,
     promptText: cleanText(sourceCase.promptText),
     expectedAnswerSummary: cleanText(sourceCase.expectedAnswerSummary),
     feedbackLong: cleanText(sourceCase.feedbackLong),


### PR DESCRIPTION
## Summary
- compactCase now preserves manualReviewOnly and nonScored boolean flags from source data
- Makes caseTriggersFairnessFix guards functional (previously dead code due to field stripping)
- Defence-in-depth: if source data ever marks individual cases as non-scored, they'll be respected

## Test plan
- [x] Generated file regenerated (no output change — no source cases currently use these flags)
- [x] Fairness audit passes (0 findings, seeds 1..30)
- [x] grammar-qg-p10-evidence-artefacts tests pass (44/44)