### PR TITLE
fix(grammar): correct eligible pool count for focus-concept profiles

### DIFF
--- a/scripts/audit-grammar-qg-p19-smart-practice.mjs
+++ b/scripts/audit-grammar-qg-p19-smart-practice.mjs
@@ -315,7 +315,7 @@ function eligibleTemplateIds(profile) {
   const concepts = new Set(Object.keys(profile.mastery?.concepts || {}));
   if (concepts.size === 0) return GRAMMAR_TEMPLATE_METADATA.length;
   return GRAMMAR_TEMPLATE_METADATA.filter((template) => {
-    if (!Array.isArray(template.skillIds) || template.skillIds.length === 0) return true;
+    if (!Array.isArray(template.skillIds) || template.skillIds.length === 0) return !profile.focusConceptId;
     if (profile.focusConceptId) return template.skillIds.includes(profile.focusConceptId);
     return template.skillIds.some((id) => concepts.has(id));
   }).length;


### PR DESCRIPTION
## Summary
- eligibleTemplateIds now excludes templates without skillIds when a focusConceptId is set
- Aligns with the real scheduler's focusAwarePool filtering logic
- Prevents false failure reports if a concept's template pool is small

## Test plan
- [ ] Smart-practice audit still passes
- [ ] focusConcept profile eligible count now matches real scheduler behaviour