### PR TITLE
fix(grammar): escape pipe chars in smart-practice markdown table

### DIFF
--- a/scripts/audit-grammar-qg-p19-smart-practice.mjs
+++ b/scripts/audit-grammar-qg-p19-smart-practice.mjs
@@ -556,7 +556,7 @@ function renderMarkdown(audit) {
         ? `templateId=${failure.templateId} (count=${failure.count})`
         : failure.kind === 'duplicate-surface'
           ? `surfaceKey=${failure.surfaceKey.slice(0, 12)}… (count=${failure.count})`
-          : JSON.stringify(failure);
+          : JSON.stringify(failure).replace(/\|/g, '\\|');
       lines.push(`| ${failure.profile} | ${failure.seed} | ${failure.kind} | ${detail} |`);
     }
     if (audit.failures.length > 50) lines.push(`| … | … | … | (${audit.failures.length - 50} additional rows omitted) |`);


### PR DESCRIPTION
## Summary
- Escapes | characters in JSON.stringify output within markdown failure table
- Prevents broken table rendering if failure details contain pipe characters

## Test plan
- [ ] Smart-practice audit passes
- [ ] Markdown output valid