### PR TITLE
fix(punctuation): align setup panel layout with grammar/spelling

### DIFF
--- a/src/subjects/punctuation/components/PunctuationSetupScene.jsx
+++ b/src/subjects/punctuation/components/PunctuationSetupScene.jsx
@@ -313,7 +313,7 @@ export function PunctuationSetupScene({ ui, actions, prefs, stats, learner, rewa
   return (
     <PracticeStage subjectId="punctuation" scene="setup" backdrop="punctuation-map" motion="calm">
     <section
-      className="card border-top punctuation-surface punctuation-setup-scene punctuation-mission-dashboard"
+      className="punctuation-surface punctuation-setup-scene punctuation-mission-dashboard"
       data-punctuation-phase="setup"
     >
       <div className="setup-grid">

--- a/styles/app.css
+++ b/styles/app.css
@@ -10525,8 +10525,7 @@ html { scroll-behavior: smooth; }
    mirrors the Spelling Setup's hero pattern, adapted for Bellstorm Coast. */
 
 .punctuation-mission-dashboard {
-  display: grid;
-  gap: 20px;
+  display: block;
 }
 
 /* --- U4 (refactor ui-consolidation): platform hero engine adoption ------- */
@@ -10540,7 +10539,33 @@ html { scroll-behavior: smooth; }
 .punctuation-setup-main {
   min-height: auto;
   overflow: visible;
-  view-transition-name: none;
+  view-transition-name: punctuation-hero-card;
+}
+
+/* Punctuation sidebar — mirrors Grammar's sidebar structure. */
+.punctuation-setup-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.punctuation-setup-sidebar .punctuation-setup-sidebar-card {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg, 28px);
+  box-shadow: var(--shadow);
+  padding: 20px;
+  view-transition-name: punctuation-metrics-card;
+}
+.punctuation-setup-sidebar .ss-head {
+  margin-bottom: 12px;
+}
+.punctuation-setup-sidebar .ss-head .eyebrow {
+  margin: 0;
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--muted);
+  font-weight: 700;
 }
 
 /* KS2 44×44 tap-target floor for the platform `LengthPicker` adopted on


### PR DESCRIPTION
## Summary
- Removes `card border-top` wrapper classes from punctuation landing — these added double-padding/border not present on grammar/spelling
- Changes `.punctuation-mission-dashboard` from `display: grid` to `display: block` (matching `.grammar-dashboard`)
- Adds `.punctuation-setup-sidebar` CSS rules (card radius, padding, head styling) matching grammar's sidebar structure
- Sets subject-specific `view-transition-name` values to avoid collision with spelling

## Test plan
- [x] 169 punctuation scene tests pass
- [x] 14 hero backdrop tests pass
- [x] 27 UI contract tests pass
- [ ] Visual QA confirms layout matches grammar/spelling two-column pattern