### PR TITLE
fix(punctuation): Windows-compatible entrypoint guard in P14 audit scripts

### DIFF
--- a/scripts/audit-punctuation-qg-p14-session-variety.mjs
+++ b/scripts/audit-punctuation-qg-p14-session-variety.mjs
@@ -22,6 +22,7 @@
 
 import { writeFileSync, mkdirSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { markPunctuationAnswer } from '../shared/punctuation/marking.js';
 import { createPunctuationService } from '../shared/punctuation/service.js';
@@ -361,6 +362,6 @@ function main() {
   process.exitCode = report.overallOk ? 0 : 1;
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (resolve(fileURLToPath(import.meta.url)) === resolve(process.argv[1])) {
   main();
 }

--- a/scripts/audit-punctuation-qg-p14-source.mjs
+++ b/scripts/audit-punctuation-qg-p14-source.mjs
@@ -17,6 +17,7 @@
 
 import { writeFileSync, mkdirSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { PUNCTUATION_CONTENT_MANIFEST } from '../shared/punctuation/content.js';
 import {
@@ -246,6 +247,6 @@ function main() {
   process.exitCode = allGatesOk ? 0 : 1;
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (resolve(fileURLToPath(import.meta.url)) === resolve(process.argv[1])) {
   main();
 }


### PR DESCRIPTION
## Summary
- Replace broken `import.meta.url === \`file://${process.argv[1]}\`` entrypoint guard with cross-platform `resolve(fileURLToPath(import.meta.url)) === resolve(process.argv[1])` in both P14 audit scripts.
- On Windows, `import.meta.url` produces `file:///C:/path` (forward slashes, triple-slash protocol) while `process.argv[1]` produces `C:\path` (backslashes, no protocol), so the old guard never matched and `main()` never executed.
- The sibling script `simulate-punctuation-qg-p14-star-pacing.mjs` already used the correct pattern.

## Test plan
- [x] `node scripts/audit-punctuation-qg-p14-source.mjs` exits 0 on Windows