### PR TITLE
fix(hero): extract error code from nested response shape

### DIFF
--- a/src/platform/hero/hero-client.js
+++ b/src/platform/hero/hero-client.js
@@ -55,6 +55,18 @@ const STALE_WRITE_CODES = new Set([
 ]);
 
 // ---------------------------------------------------------------------------
+// Error code extraction — handles both flat and nested response shapes
+// ---------------------------------------------------------------------------
+
+function extractErrorCode(payload) {
+  if (!payload || typeof payload !== 'object') return '';
+  if (typeof payload.code === 'string' && payload.code) return payload.code;
+  if (payload.error && typeof payload.error === 'object' && typeof payload.error.code === 'string') return payload.error.code;
+  if (typeof payload.error === 'string' && payload.error) return payload.error;
+  return '';
+}
+
+// ---------------------------------------------------------------------------
 // JSON parsing helper (mirrors subject-command-client.js)
 // ---------------------------------------------------------------------------
 
@@ -181,7 +193,7 @@ export function createHeroModeClient({
     const responsePayload = await parseJson(response);
 
     if (!response.ok || responsePayload?.ok === false) {
-      const errorCode = responsePayload?.code || responsePayload?.error || '';
+      const errorCode = extractErrorCode(responsePayload);
       const heroError = new HeroModeClientError({
         code: errorCode,
         status: response.status,
@@ -266,7 +278,7 @@ export function createHeroModeClient({
     const responsePayload = await parseJson(response);
 
     // Auto-retry once on stale_write (revision conflict)
-    if (!response.ok && responsePayload?.code === 'stale_write') {
+    if (!response.ok && extractErrorCode(responsePayload) === 'stale_write') {
       if (typeof onStaleWrite === 'function') {
         onStaleWrite({
           error: new HeroModeClientError({
@@ -311,7 +323,7 @@ export function createHeroModeClient({
 
       if (!retryResponse.ok) {
         throw new HeroModeClientError({
-          code: retryPayload?.code || retryPayload?.error || 'hero_claim_failed',
+          code: extractErrorCode(retryPayload) || 'hero_claim_failed',
           status: retryResponse.status,
           retryable: false,
           payload: retryPayload,
@@ -323,7 +335,7 @@ export function createHeroModeClient({
 
     // Non-stale errors
     if (!response.ok || responsePayload?.ok === false) {
-      const errorCode = responsePayload?.code || responsePayload?.error || 'hero_claim_failed';
+      const errorCode = extractErrorCode(responsePayload) || 'hero_claim_failed';
       const heroError = new HeroModeClientError({
         code: errorCode,
         status: response.status,
@@ -394,7 +406,7 @@ export function createHeroModeClient({
     const responsePayload = await parseJson(response);
 
     if (!response.ok || responsePayload?.ok === false) {
-      const errorCode = responsePayload?.code || responsePayload?.error || 'hero_unlock_failed';
+      const errorCode = extractErrorCode(responsePayload) || 'hero_unlock_failed';
       const heroError = new HeroModeClientError({
         code: errorCode,
         status: response.status,
@@ -463,7 +475,7 @@ export function createHeroModeClient({
     const responsePayload = await parseJson(response);
 
     if (!response.ok || responsePayload?.ok === false) {
-      const errorCode = responsePayload?.code || responsePayload?.error || 'hero_evolve_failed';
+      const errorCode = extractErrorCode(responsePayload) || 'hero_evolve_failed';
       const heroError = new HeroModeClientError({
         code: errorCode,
         status: response.status,

--- a/src/platform/hero/hero-client.js
+++ b/src/platform/hero/hero-client.js
@@ -58,7 +58,7 @@ const STALE_WRITE_CODES = new Set([
 // Error code extraction — handles both flat and nested response shapes
 // ---------------------------------------------------------------------------
 
-function extractErrorCode(payload) {
+export function extractErrorCode(payload) {
   if (!payload || typeof payload !== 'object') return '';
   if (typeof payload.code === 'string' && payload.code) return payload.code;
   if (payload.error && typeof payload.error === 'object' && typeof payload.error.code === 'string') return payload.error.code;
@@ -131,7 +131,7 @@ export function createHeroModeClient({
     const payload = await parseJson(response);
     if (!response.ok || payload?.ok === false) {
       throw new HeroModeClientError({
-        code: payload?.code || payload?.error || '',
+        code: extractErrorCode(payload),
         status: response.status,
         payload,
       });

--- a/tests/hero-client-claim.test.js
+++ b/tests/hero-client-claim.test.js
@@ -244,6 +244,20 @@ describe('createHeroModeClient — claimTask error paths', () => {
     assert.equal(err.retryable, false);
   });
 
+  it('nested error shape { error: { code } } extracts code correctly', async () => {
+    const fakeFetch = createMockFetch([{
+      ok: false, status: 400, data: { ok: false, error: { code: 'hero_claim_task_not_in_quest', message: 'Task not found' } },
+    }]);
+    const client = createHeroModeClient({ ...defaultOpts(), fetch: fakeFetch });
+
+    const err = await client.claimTask(baseArgs).catch(e => e);
+
+    assert.ok(err instanceof HeroModeClientError);
+    assert.equal(err.code, 'hero_claim_task_not_in_quest');
+    assert.equal(err.status, 400);
+    assert.equal(err.retryable, false);
+  });
+
   it('network failure throws retryable HeroModeClientError', async () => {
     const calls = [];
     async function failingFetch(url, init) {

--- a/tests/hero-client-claim.test.js
+++ b/tests/hero-client-claim.test.js
@@ -258,6 +258,51 @@ describe('createHeroModeClient — claimTask error paths', () => {
     assert.equal(err.retryable, false);
   });
 
+  it('nested stale_write shape triggers auto-retry', async () => {
+    let revisionCallCount = 0;
+    const getLearnerRevision = () => {
+      revisionCallCount++;
+      return revisionCallCount === 1 ? 42 : 99;
+    };
+
+    const fakeFetch = createMockFetch([
+      { ok: false, status: 409, data: { ok: false, error: { code: 'stale_write' } } },
+      { ok: true, status: 200, data: { ok: true, heroClaim: { status: 'claimed' } } },
+    ]);
+
+    const client = createHeroModeClient({
+      ...defaultOpts(),
+      fetch: fakeFetch,
+      getLearnerRevision,
+      onStaleWrite: () => {},
+    });
+
+    const result = await client.claimTask(baseArgs);
+
+    assert.equal(fakeFetch.calls.length, 2, 'should retry once on nested stale_write');
+    assert.equal(fakeFetch.calls[1].body.expectedLearnerRevision, 99);
+    assert.deepStrictEqual(result, { ok: true, heroClaim: { status: 'claimed' } });
+  });
+
+  it('retry failure with nested error shape extracts code correctly', async () => {
+    const fakeFetch = createMockFetch([
+      { ok: false, status: 409, data: { ok: false, error: { code: 'stale_write' } } },
+      { ok: false, status: 400, data: { ok: false, error: { code: 'hero_claim_no_evidence', message: 'No evidence' } } },
+    ]);
+
+    const client = createHeroModeClient({
+      ...defaultOpts(),
+      fetch: fakeFetch,
+      onStaleWrite: () => {},
+    });
+
+    const err = await client.claimTask(baseArgs).catch(e => e);
+
+    assert.ok(err instanceof HeroModeClientError);
+    assert.equal(err.code, 'hero_claim_no_evidence');
+    assert.equal(err.retryable, false);
+  });
+
   it('network failure throws retryable HeroModeClientError', async () => {
     const calls = [];
     async function failingFetch(url, init) {

--- a/tests/hero-client.test.js
+++ b/tests/hero-client.test.js
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { createHeroModeClient, HeroModeClientError } from '../src/platform/hero/hero-client.js';
+import { createHeroModeClient, HeroModeClientError, extractErrorCode } from '../src/platform/hero/hero-client.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -447,5 +447,110 @@ describe('createHeroModeClient — factory validation', () => {
       () => createHeroModeClient({ fetch: 'not-a-function', getLearnerRevision: () => 0 }),
       /requires a fetch implementation/,
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractErrorCode — unit tests
+// ---------------------------------------------------------------------------
+
+describe('extractErrorCode', () => {
+  it('returns empty string for null/undefined', () => {
+    assert.equal(extractErrorCode(null), '');
+    assert.equal(extractErrorCode(undefined), '');
+  });
+
+  it('returns empty string for non-object', () => {
+    assert.equal(extractErrorCode('string'), '');
+    assert.equal(extractErrorCode(123), '');
+  });
+
+  it('extracts flat code string', () => {
+    assert.equal(extractErrorCode({ code: 'stale_write' }), 'stale_write');
+  });
+
+  it('extracts nested error.code string', () => {
+    assert.equal(extractErrorCode({ error: { code: 'hero_claim_no_evidence' } }), 'hero_claim_no_evidence');
+  });
+
+  it('flat code takes priority over nested error.code', () => {
+    assert.equal(extractErrorCode({ code: 'flat_code', error: { code: 'nested_code' } }), 'flat_code');
+  });
+
+  it('falls through to nested when flat code is empty string', () => {
+    assert.equal(extractErrorCode({ code: '', error: { code: 'nested_code' } }), 'nested_code');
+  });
+
+  it('extracts string error field', () => {
+    assert.equal(extractErrorCode({ error: 'hero-unavailable' }), 'hero-unavailable');
+  });
+
+  it('returns empty for non-string error.code (numeric)', () => {
+    assert.equal(extractErrorCode({ error: { code: 123 } }), '');
+  });
+
+  it('returns empty for error object without code field', () => {
+    assert.equal(extractErrorCode({ error: { message: 'failure' } }), '');
+  });
+
+  it('returns empty for null error field', () => {
+    assert.equal(extractErrorCode({ error: null }), '');
+  });
+
+  it('returns empty for empty object', () => {
+    assert.equal(extractErrorCode({}), '');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Nested error shape — readModel
+// ---------------------------------------------------------------------------
+
+describe('createHeroModeClient — readModel nested error shape', () => {
+  it('extracts code from nested { error: { code } } response', async () => {
+    const fakeFetch = mockFetch(403, { ok: false, error: { code: 'hero-unavailable', message: 'Hero blocked' } });
+    const client = createHeroModeClient({ ...defaultOpts(), fetch: fakeFetch });
+
+    const err = await client.readModel({ learnerId: 'abc' }).catch(e => e);
+
+    assert.ok(err instanceof HeroModeClientError);
+    assert.equal(err.code, 'hero-unavailable');
+    assert.equal(err.status, 403);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Nested error shape — startTask
+// ---------------------------------------------------------------------------
+
+describe('createHeroModeClient — startTask nested error shape', () => {
+  it('extracts code from nested { error: { code } } response', async () => {
+    const fakeFetch = mockFetch(400, { ok: false, error: { code: 'hero_task_not_launchable', message: 'Task not launchable' } });
+    const client = createHeroModeClient({ ...defaultOpts(), fetch: fakeFetch });
+
+    const err = await client.startTask({
+      learnerId: 'l', questId: 'q', questFingerprint: 'fp', taskId: 't', requestId: 'r',
+    }).catch(e => e);
+
+    assert.ok(err instanceof HeroModeClientError);
+    assert.equal(err.code, 'hero_task_not_launchable');
+    assert.equal(err.status, 400);
+  });
+
+  it('onStaleWrite fires when nested shape contains hero_quest_stale', async () => {
+    const fakeFetch = mockFetch(409, { ok: false, error: { code: 'hero_quest_stale' } });
+    const staleWrites = [];
+    const client = createHeroModeClient({
+      ...defaultOpts(),
+      fetch: fakeFetch,
+      onStaleWrite: (info) => staleWrites.push(info),
+    });
+
+    await client.startTask({
+      learnerId: 'l', questId: 'q', questFingerprint: 'fp', taskId: 't', requestId: 'r',
+    }).catch(() => {});
+
+    assert.equal(staleWrites.length, 1);
+    assert.equal(staleWrites[0].error.code, 'hero_quest_stale');
   });
 });


### PR DESCRIPTION
## Summary
- Server's claim rejection returns `{ ok: false, error: { code, message } }` (nested object) but `hero-client.js` extracted with `responsePayload?.code || responsePayload?.error` — yielding an Object instead of a string
- Added `extractErrorCode(payload)` helper handling both flat (`{ code }`) and nested (`{ error: { code } }`) response shapes
- Applied to all 5 error extraction sites across startTask, claimTask, unlockMonster, evolveMonster
- Added regression test for nested error shape

## Root cause
The inline `json()` calls in `worker/src/app.js:1564` return `{ error: { code } }` while thrown HttpErrors serialise to flat `{ code }` via `errorResponse()`. The client only handled the flat shape.

## Test plan
- [x] `node --test tests/hero-client.test.js` — 28 pass
- [x] `node --test tests/hero-client-claim.test.js` — 16 pass (includes new nested error test)
- [x] Syntax check passes