### PR TITLE
style(companion-panel): align to ss-* design language

### DIFF
--- a/src/platform/ui/SubjectCompanionPanel.jsx
+++ b/src/platform/ui/SubjectCompanionPanel.jsx
@@ -28,8 +28,8 @@ export function SubjectCompanionPanel({
         <section className="companion-panel-monsters">
           <SectionHeader title="Monsters" level={3} />
           <ul className="companion-panel-monster-list">
-            {monsters.map((m) => (
-              <li key={m.name} data-discovered={m.discovered ? 'true' : 'false'}>
+            {monsters.map((m, idx) => (
+              <li key={m.name || idx} data-discovered={m.discovered ? 'true' : 'false'}>
                 <span className="companion-panel-monster-glyph" aria-hidden="true">{m.name?.[0]?.toUpperCase() || '?'}</span>
                 <span className="companion-panel-monster-name">{m.name}</span>
               </li>

--- a/src/platform/ui/SubjectCompanionPanel.jsx
+++ b/src/platform/ui/SubjectCompanionPanel.jsx
@@ -29,7 +29,10 @@ export function SubjectCompanionPanel({
           <SectionHeader title="Monsters" level={3} />
           <ul className="companion-panel-monster-list">
             {monsters.map((m) => (
-              <li key={m.name} data-discovered={m.discovered ? 'true' : 'false'}>{m.name}</li>
+              <li key={m.name} data-discovered={m.discovered ? 'true' : 'false'}>
+                <span className="companion-panel-monster-glyph" aria-hidden="true">{m.name?.[0]?.toUpperCase() || '?'}</span>
+                <span className="companion-panel-monster-name">{m.name}</span>
+              </li>
             ))}
           </ul>
         </section>

--- a/styles/app.css
+++ b/styles/app.css
@@ -13664,8 +13664,8 @@ html { scroll-behavior: smooth; }
 .companion-panel-monster-glyph {
   display: grid;
   place-items: center;
-  width: 28px;
-  height: 28px;
+  width: 1.75rem;
+  height: 1.75rem;
   border-radius: 50%;
   background: color-mix(in oklab, var(--subject-accent-soft, var(--line-soft)) 60%, transparent);
   font-family: var(--font-serif);
@@ -13699,6 +13699,7 @@ html { scroll-behavior: smooth; }
   flex-direction: column;
   align-items: flex-start;
   gap: 2px;
+  min-width: 0;
   padding: 12px 14px;
   border: 1px solid var(--line-soft);
   border-radius: 14px;
@@ -13780,6 +13781,9 @@ html { scroll-behavior: smooth; }
   .action-row .btn,
   .home-hero-scene-actions .btn {
     width: 100%;
+  }
+  .companion-panel-stat {
+    flex-direction: column;
   }
 }
 

--- a/styles/app.css
+++ b/styles/app.css
@@ -13630,8 +13630,8 @@ html { scroll-behavior: smooth; }
 }
 .companion-panel-monster-list {
   display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(52px, 1fr));
   gap: 8px;
-  min-width: 0;
   margin: 0;
   padding: 0;
   list-style: none;
@@ -13646,48 +13646,80 @@ html { scroll-behavior: smooth; }
 }
 .companion-panel-monster-list li {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  padding: 8px 10px;
+  justify-content: center;
+  gap: 4px;
+  aspect-ratio: 1 / 1;
+  padding: 8px;
   border: 1px solid var(--line-soft);
-  border-radius: var(--radius-sm);
-  background: var(--panel);
+  border-radius: 14px;
+  background: var(--panel-soft);
+  color: var(--ink);
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-align: center;
+  overflow: hidden;
+}
+.companion-panel-monster-glyph {
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: color-mix(in oklab, var(--subject-accent-soft, var(--line-soft)) 60%, transparent);
+  font-family: var(--font-serif);
+  font-size: 1rem;
+  font-weight: 600;
   color: var(--ink);
 }
+.companion-panel-monster-name {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  line-height: 1.1;
+}
 .companion-panel-monster-list li[data-discovered="false"] {
-  color: var(--muted);
-  background: color-mix(in oklab, var(--panel) 78%, var(--line-soft));
+  opacity: 0.45;
+}
+.companion-panel-monster-list li[data-discovered="false"] .companion-panel-monster-glyph {
+  background: var(--line-soft);
 }
 .companion-panel-dl {
   display: grid;
-  gap: 8px;
-  min-width: 0;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
   margin: 0;
+  padding: 0;
 }
 .companion-panel-stat {
   display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 12px;
-  min-width: 0;
-  padding: 8px 10px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  padding: 12px 14px;
   border: 1px solid var(--line-soft);
-  border-radius: var(--radius-sm);
-  background: var(--panel);
+  border-radius: 14px;
+  background: var(--panel-soft);
 }
 .companion-panel-stat dt {
-  color: var(--muted);
+  font-size: 0.78rem;
   font-weight: 700;
+  color: var(--muted);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 .companion-panel-stat dd {
   margin: 0;
-  color: var(--ink);
-  font-weight: 800;
-  text-align: right;
+  font-family: var(--font-serif);
+  font-size: 1.6rem;
+  font-weight: 500;
+  letter-spacing: -0.015em;
 }
 .companion-panel-stat[data-tone="warn"] {
-  border-color: color-mix(in oklab, var(--subject-accent, var(--brand)) 34%, var(--line));
+  border-color: var(--warn-soft, var(--line-soft));
 }
 .companion-panel-focus {
   padding-top: 10px;
@@ -13729,8 +13761,7 @@ html { scroll-behavior: smooth; }
   }
   .session-hud-title,
   .session-hud-status,
-  .session-summary-frame-progress-item,
-  .companion-panel-stat {
+  .session-summary-frame-progress-item {
     align-items: flex-start;
     flex-direction: column;
   }
@@ -13749,6 +13780,17 @@ html { scroll-behavior: smooth; }
   .action-row .btn,
   .home-hero-scene-actions .btn {
     width: 100%;
+  }
+}
+
+@media (max-width: 400px) {
+  .companion-panel-dl {
+    grid-template-columns: 1fr;
+  }
+  .companion-panel-stat {
+    flex-direction: row;
+    align-items: baseline;
+    justify-content: space-between;
   }
 }
 

--- a/styles/app.css
+++ b/styles/app.css
@@ -13630,7 +13630,7 @@ html { scroll-behavior: smooth; }
 }
 .companion-panel-monster-list {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(52px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(64px, 1fr));
   gap: 8px;
   margin: 0;
   padding: 0;

--- a/tests/ui-companion-panel-contract.test.js
+++ b/tests/ui-companion-panel-contract.test.js
@@ -158,8 +158,8 @@ test('SubjectCompanionPanel: monsters render as ul/li with discovered attribute'
     console.log(renderToStaticMarkup(tree));
   `);
   assert.match(html, /<ul class="companion-panel-monster-list">/);
-  assert.match(html, /<li data-discovered="true">Grammox<\/li>/);
-  assert.match(html, /<li data-discovered="false">Syntaxon<\/li>/);
+  assert.match(html, /<li data-discovered="true">.*?Grammox.*?<\/li>/);
+  assert.match(html, /<li data-discovered="false">.*?Syntaxon.*?<\/li>/);
 });
 
 // ---------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Align `SubjectCompanionPanel` stats to the approved `ss-stat-grid` design: 2-column grid, stacked label/value, uppercase label typography, serif value font, 14px border-radius
- Align monster list to `ss-meadow`-style grid cells with square aspect ratio, circular glyph initial, and ellipsised name
- Add responsive fallback (single-column at <400px)
- No prop API changes; all 3 subjects (spelling, grammar, punctuation) inherit the alignment automatically

## Test plan
- [ ] Visual check: companion panel stats match ss-stat-grid appearance
- [ ] Visual check: monster cells display as square grid with circular glyph
- [ ] Responsive: stats collapse to single row on narrow viewports
- [ ] No regression: existing `data-testid="companion-panel"` and `data-discovered` attributes preserved
- [ ] Build passes (CSS + JSX syntax valid)