### PR TITLE
fix(spelling): remove duplicate companion panel + guard hero double-claim

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1014,6 +1014,11 @@ async function heroClaimTask({ questId, questFingerprint, taskId, practiceSessio
   const learnerId = appState.learners?.selectedId;
   if (!learnerId || !questId || !taskId) return null;
 
+  // In-flight guard: if a claim is already pending for this taskId, skip the
+  // duplicate call. This prevents the 400 `hero_claim_stale_or_expired` errors
+  // caused by React effects or event handlers firing twice in rapid succession.
+  if (heroUi.pendingClaimKey === taskId) return null;
+
   const requestId = `hero-claim-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 
   patchHeroUi({

--- a/src/subjects/spelling/components/SpellingSetupScene.jsx
+++ b/src/subjects/spelling/components/SpellingSetupScene.jsx
@@ -6,7 +6,6 @@ import { useSetupHeroContrast } from './useSetupHeroContrast.js';
 import { Button } from '../../../platform/ui/Button.jsx';
 import { LengthPicker } from '../../../platform/ui/LengthPicker.jsx';
 import { SetupSidePanel } from '../../../platform/ui/SetupSidePanel.jsx';
-import { SubjectCompanionPanel } from '../../../platform/ui/SubjectCompanionPanel.jsx';
 import { SubjectThemeScope } from '../../../platform/ui/SubjectThemeScope.jsx';
 import {
   BOSS_DEFAULT_ROUND_LENGTH,
@@ -492,20 +491,6 @@ export function SpellingSetupScene({
           <>
             <SetupMeadow codex={codex} repositories={repositories} />
             <SetupStatGrid stats={stats} />
-            <SubjectCompanionPanel
-              subjectId="spelling"
-              visible
-              monsters={(Array.isArray(codex) ? codex : [])
-                .filter((e) => e?.progress?.caught)
-                .map((e) => ({ name: e.monster?.name || e.monster?.id || '?', discovered: true }))}
-              stats={[
-                { label: 'Secure', value: String(stats.secure ?? 0) },
-                { label: 'Due today', value: String(stats.due ?? 0), tone: 'warn' },
-                { label: 'Weak spots', value: String(stats.trouble ?? 0) },
-              ]}
-              nextFocus={stats.trouble > 0 ? 'Trouble words need attention' : ''}
-              emptyState="Catch your first monster to see companion info."
-            />
           </>
         )}
         footer={(

--- a/src/subjects/spelling/module.js
+++ b/src/subjects/spelling/module.js
@@ -127,7 +127,6 @@ export const spellingModule = {
   visualAdapter: createReadySubjectVisualAdapter('spelling', {
     setup: { component: 'SpellingSetupScene', primaryAction: 'spelling-start' },
     sessionHud: { component: 'SessionHUD', adapter: 'SpellingSessionScene' },
-    companionPanel: { component: 'SubjectCompanionPanel', dataSource: 'codex+stats' },
     practiceStage: { component: 'PracticeStage', adopted: true },
     summaryFrame: { component: 'SessionSummaryFrame', adapter: 'SpellingSummaryFrameAdapter' },
   }),

--- a/tests/ui-companion-panel-contract.test.js
+++ b/tests/ui-companion-panel-contract.test.js
@@ -190,11 +190,7 @@ test('SubjectCompanionPanel: imports SectionHeader from platform/ui', () => {
 // 3-subject adoption gate: spelling, punctuation, grammar
 // ---------------------------------------------------------------
 
-test('SubjectCompanionPanel: adopted by all three ready subjects', () => {
-  const spellingSource = readFileSync(
-    path.join(rootDir, 'src/subjects/spelling/components/SpellingSetupScene.jsx'),
-    'utf8',
-  );
+test('SubjectCompanionPanel: adopted by punctuation and grammar subjects', () => {
   const punctuationSource = readFileSync(
     path.join(rootDir, 'src/subjects/punctuation/components/PunctuationSetupScene.jsx'),
     'utf8',
@@ -203,14 +199,12 @@ test('SubjectCompanionPanel: adopted by all three ready subjects', () => {
     path.join(rootDir, 'src/subjects/grammar/components/GrammarSetupScene.jsx'),
     'utf8',
   );
-  assert.match(spellingSource, /SubjectCompanionPanel/);
   assert.match(punctuationSource, /SubjectCompanionPanel/);
   assert.match(grammarSource, /SubjectCompanionPanel/);
 });
 
 test('P4 U5: ready-subject setup call-sites make the companion panel visible', () => {
   const subjects = [
-    ['spelling', 'src/subjects/spelling/components/SpellingSetupScene.jsx'],
     ['punctuation', 'src/subjects/punctuation/components/PunctuationSetupScene.jsx'],
     ['grammar', 'src/subjects/grammar/components/GrammarSetupScene.jsx'],
   ];

--- a/tests/ui-companion-panel-data-contract.test.js
+++ b/tests/ui-companion-panel-data-contract.test.js
@@ -59,11 +59,6 @@ function absoluteSpecifier(relativePath) {
 test('ready subject companion panels map subject-owned data into real panel inputs', () => {
   const contracts = [
     {
-      subject: 'spelling',
-      path: 'src/subjects/spelling/components/SpellingSetupScene.jsx',
-      markers: ['codex', 'stats.secure', 'stats.due', 'stats.trouble', 'Trouble words need attention'],
-    },
-    {
       subject: 'grammar',
       path: 'src/subjects/grammar/components/GrammarSetupScene.jsx',
       markers: ['dashboard.monsterStrip', 'dashboard.todayCards', 'troubleCount', 'Trouble concepts need revision'],

--- a/tests/ui-p3-guardrails.test.js
+++ b/tests/ui-p3-guardrails.test.js
@@ -174,11 +174,11 @@ test('P3 ratchet: all 3 summary scenes import SessionSummaryFrame', () => {
 });
 
 // ────────────────────────────────────────────────────────────────────
-// 7. SubjectCompanionPanel adoption: all 3 setup scenes.
+// 7. SubjectCompanionPanel adoption: grammar + punctuation setup scenes.
+//    Spelling uses SetupMeadow + SetupStatGrid (approved design).
 // ────────────────────────────────────────────────────────────────────
-test('P3 ratchet: all 3 setup scenes import SubjectCompanionPanel', () => {
+test('P3 ratchet: grammar and punctuation setup scenes import SubjectCompanionPanel', () => {
   const setups = [
-    'src/subjects/spelling/components/SpellingSetupScene.jsx',
     'src/subjects/grammar/components/GrammarSetupScene.jsx',
     'src/subjects/punctuation/components/PunctuationSetupScene.jsx',
   ];

--- a/tests/ui-subject-visual-adapter-contract.test.js
+++ b/tests/ui-subject-visual-adapter-contract.test.js
@@ -23,7 +23,9 @@ test('ready subjects expose a complete SubjectVisualAdapter', () => {
       assert.ok(subject.visualAdapter.sections[section], `${subjectId} missing ${section}`);
     }
     assert.equal(subject.visualAdapter.sections.summaryFrame.component, 'SessionSummaryFrame');
-    assert.equal(subject.visualAdapter.sections.companionPanel.component, 'SubjectCompanionPanel');
+    if (subjectId !== 'spelling') {
+      assert.equal(subject.visualAdapter.sections.companionPanel.component, 'SubjectCompanionPanel');
+    }
   }
 });
 

--- a/tests/ui-visual-journey-ready-subjects.test.js
+++ b/tests/ui-visual-journey-ready-subjects.test.js
@@ -62,7 +62,10 @@ test('ready subject journeys expose setup, session HUD, summary, and home return
     const session = stripLineComments(source(subject.session));
     const summary = source(subject.summary);
 
-    assert.match(setup, /<SubjectCompanionPanel[\s\S]*\svisible/);
+    // Spelling uses SetupMeadow + SetupStatGrid instead of SubjectCompanionPanel
+    if (subject.id !== 'spelling') {
+      assert.match(setup, /<SubjectCompanionPanel[\s\S]*\svisible/);
+    }
     assert.ok(setup.includes(subject.startAction), `${subject.id} setup must expose start action`);
     assert.match(session, /<SessionHUD[\s\S]*subjectId=/);
     assert.doesNotMatch(session, /Question\s+\{[^}]*\}\s+of\s+\{[^}]*\}/);


### PR DESCRIPTION
## Summary
- Remove `SubjectCompanionPanel` from spelling setup sidebar — it duplicated data already shown by `SetupMeadow` + `SetupStatGrid` (approved design) and incorrectly showed grammar/punctuation monsters (Bracehart etc) in the spelling context
- Add in-flight guard to `heroClaimTask` preventing duplicate 400 errors when React effects fire twice rapidly

## Test plan
- [ ] Spelling sidebar shows only meadow + stat grid (no companion panel)
- [ ] Grammar/punctuation monsters no longer appear in spelling sidebar
- [ ] Hero Mode claim doesn't fire duplicate requests (no 400 `hero_claim_stale_or_expired` spam)
- [ ] Existing companion-panel tests pass (updated for spelling removal)
- [ ] No regression in grammar/punctuation companion panels