### PR TITLE
perf(ci): 30 shards + concurrency for <60s CI target (#876)

### DIFF
--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -1,13 +1,13 @@
-# CI Speed Optimisation U1: Shard node tests into 10 parallel matrix jobs.
+# CI Speed Optimisation: Shard node tests into 30 parallel matrix jobs.
 #
-# The 626-file Node test suite is split across 10 shards using
-# `node --test --test-shard=N/10` (built-in since Node 22). Each shard
-# runs in its own GitHub Actions matrix cell, reducing wall-clock from
-# ~700s (single job) to < 60s.
+# The 626-file Node test suite is split across 30 shards using
+# `node --test --test-shard=N/30 --test-concurrency=2`. Each shard
+# runs ~21 files in parallel (2 at a time) in its own GitHub Actions
+# matrix cell, targeting < 60s wall-clock.
 #
 # Structure:
 #  1. `changes`        — docs-only classification (skip shards on trivial PRs)
-#  2. `test` (×10)     — parallel sharded test execution
+#  2. `test` (×30)     — parallel sharded test execution
 #  3. `wrangler-check` — deploy dry-run (schema-drift canary, auth-less)
 #  4. `ci-gate`        — fan-in gate for branch protection
 #
@@ -62,12 +62,12 @@ jobs:
     needs: changes
     if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.docs_only != 'true' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 7
+    timeout-minutes: 4
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
-        total: [15]
+        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]
+        total: [30]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -79,7 +79,7 @@ jobs:
       - name: Install dependencies
         run: npm ci --no-audit --no-fund
       - name: Run tests (shard ${{ matrix.shard }}/${{ matrix.total }})
-        run: node ./scripts/run-node-tests.mjs --test-shard=${{ matrix.shard }}/${{ matrix.total }}
+        run: node ./scripts/run-node-tests.mjs --test-shard=${{ matrix.shard }}/${{ matrix.total }} --test-concurrency 2
 
   wrangler-check:
     name: Wrangler deploy dry-run


### PR DESCRIPTION
## Summary
- Increases shard count from 15 to 30 (~21 files/shard vs 42)
- Adds `--test-concurrency=2` for intra-shard parallelism
- Reduces timeout-minutes from 7 to 4 (tighter for smaller shards)
- Targets R3: < 60s total CI wall-clock

## Context
Round 1 (PR #875) established the sharding architecture but achieved ~5 min
due to shard imbalance. This round addresses the imbalance by doubling
shards and adding file-level concurrency.

## Contract
`docs/contracts/ci-speed-optimisation.md` — R3 delivery

## Expected impact
- Max shard time: 293s (15 shards) → ~60s (30 shards + 2x concurrency)
- Billable minutes: 30 × ~60s = 30 min (vs 15 × ~5min = 75 min — cheaper)

## Test plan
- [ ] All 30 shards pass
- [ ] Max shard wall-clock < 60s
- [ ] Total CI wall-clock < 60s from push to all-green
- [ ] `tests/ci-shard-coverage.test.js` still passes