### PR TITLE
feat(grammar): migrate sidebar to sole SubjectCompanionPanel

### DIFF
--- a/docs/brainstorms/2026-05-04-companion-panel-cross-subject-alignment-requirements.md
+++ b/docs/brainstorms/2026-05-04-companion-panel-cross-subject-alignment-requirements.md
@@ -1,0 +1,168 @@
+---
+date: 2026-05-04
+topic: companion-panel-cross-subject-alignment
+---
+
+# SubjectCompanionPanel Cross-Subject ss-* Alignment
+
+## Problem Frame
+
+PR #874 made `SubjectCompanionPanel` the single source of truth sidebar for **spelling** — absorbing `ss-head`, `ss-meadow` (rich monster visuals with breathing animation), and `ss-stat-grid` (subject-customised stats). Grammar and punctuation still use `SubjectCompanionPanel` as a **secondary supplementary display** alongside subject-specific components (`MonsterStripEntry`, `MonsterStarMeter`) that render duplicate content in separate DOM.
+
+This means:
+- Grammar's sidebar renders `MonsterStripEntry` components (custom images, star bars) + `TodayCard` grid + a text-mode companion panel repeating the same data
+- Punctuation's sidebar renders `MonsterStarMeter` components + a text-mode companion panel repeating the same data
+- Neither uses the rich `monsterVisuals` prop, `head` prop, or full `stats` customisation
+- The design language is fragmented: spelling uses ss-* through the companion panel, others use ss-* directly in `SetupSidePanel` but with bespoke child components
+
+The deliverable: make `SubjectCompanionPanel` the sole sidebar body for all subjects, using the same prop-driven pattern that spelling already demonstrates, so any future subject can plug in by providing its own `monsterVisuals`, `stats`, and `head`.
+
+---
+
+## Actors
+
+- A1. Learner: Sees a consistent sidebar design across spelling, grammar, and punctuation setup screens
+- A2. Subject developer: Adds a new subject by providing props to SubjectCompanionPanel — no bespoke sidebar components needed
+- A3. Contract tests: Validate that each subject passes the required props and renders the correct DOM
+
+---
+
+## Success Criteria
+
+SC1. Grammar and punctuation setup scenes use SubjectCompanionPanel as the **sole body** of SetupSidePanel (same pattern as spelling)  
+SC2. Grammar passes `monsterVisuals` (rich art from monster-codex) instead of text-mode `monsters`  
+SC3. Punctuation passes `monsterVisuals` (rich art from monster-codex) instead of text-mode `monsters`  
+SC4. Grammar defines its own subject-specific stat cards (not a pass-through of todayCards)  
+SC5. Punctuation retains its subject-specific stats (Due today, Wobbly, Grand Stars)  
+SC6. Both subjects pass a `head` prop with eyebrow text + action button (matching spelling pattern)  
+SC7. `MonsterStripEntry` and `MonsterStarMeter` remain importable for any non-sidebar usage but are removed from setup sidebar body  
+SC8. `TodayCard` / `grammar-today-grid` removed from sidebar body (stats cover this via companion panel stat grid)  
+SC9. Zero regression in existing contract tests (responsive, phantom-class, data-contract, adoption gate)  
+SC10. New subject onboarding requires only: `monsterVisuals` array, `stats` array, `head` ReactNode, optional `meadowEmpty` and `nextFocus`  
+SC11. All three subjects share identical `SetupSidePanel > SubjectCompanionPanel` structural pattern  
+
+---
+
+## Scope Boundaries
+
+### In scope
+
+- Migrate grammar sidebar body to sole SubjectCompanionPanel (with monsterVisuals + stats + head)
+- Migrate punctuation sidebar body to sole SubjectCompanionPanel (with monsterVisuals + stats + head)
+- Compute `monsterVisuals` for grammar and punctuation using `useMonsterVisualConfig()` + `monsterImageVisual()` (same hooks spelling uses)
+- Design subject-specific stat cards for grammar (e.g., Concepts learned, Trouble concepts, Accuracy, Stars)
+- Retain punctuation stat cards unchanged (already well-designed)
+- Update `ui-companion-panel-data-contract.test.js` to assert `monsterVisuals` for grammar and punctuation
+- Keep `MonsterStripEntry`, `MonsterStarMeter`, `TodayCard` alive as exports (may be used elsewhere)
+- Clean up dead references inside setup sidebar body only
+
+### Deferred / Out of scope
+
+- Removing `MonsterStripEntry`, `MonsterStarMeter`, `TodayCard` component files entirely (may have other callers)
+- Changing the SetupSidePanel slot architecture (head/body/footer contract stays)
+- Changing the footer slot (ss-bank-link) for any subject
+- New subjects beyond spelling/grammar/punctuation
+- Hero mode companion panel (Hero has its own quest-driven sidebar)
+- Monster codex filtering (bracehart in spelling) — separate bug
+
+---
+
+## Implementation Constraints
+
+IC1. **No new inline styles for monster visuals** — the `style={m.visual.style}` pattern is already budget-counted for spelling; grammar/punctuation must use the same computed visual objects from `monsterImageVisual()` which are pre-classified as `dynamic-content-driven`  
+IC2. **CSP inline-style budget** — if the count increases, bump `PRE_MIGRATION_TOTAL` and classify the file in `scripts/inventory-inline-styles.mjs`  
+IC3. **P4 U1 CSS contract** — no new fixed-px widths, `min-width: 0` on flex children, responsive 820px breakpoint compliance  
+IC4. **Data-contract test** — `ui-companion-panel-data-contract.test.js` already asserts grammar passes `monsters` and specific markers; update to assert `monsterVisuals` instead  
+IC5. **3-subject adoption gate** — `ui-companion-panel-contract.test.js` already asserts all three subjects render SubjectCompanionPanel with `visible`; this stays green by maintaining the prop  
+IC6. **SetupSidePanel wrapper** — the `head`/`body`/`footer` slot structure stays; only the `body` slot content changes from multiple sections to a single `<SubjectCompanionPanel>`  
+
+---
+
+## Delivery Pattern
+
+The delivery follows the established autonomous SDLC:
+
+1. **Grammar alignment PR** — single PR migrating grammar sidebar body
+2. **Punctuation alignment PR** — single PR migrating punctuation sidebar body
+3. **Contract hardening PR** (optional) — update data-contract assertions to enforce `monsterVisuals` for all three subjects
+
+Each PR is independently merge-ready. Order: grammar first (more complex: has TodayCard + MonsterStrip), then punctuation (simpler: just MonsterStarMeter).
+
+---
+
+## Reference: Spelling Benchmark Pattern
+
+The target state for each subject's sidebar body:
+
+```jsx
+<SetupSidePanel
+  body={(
+    <SubjectCompanionPanel
+      subjectId="{subject}"
+      visible
+      head={(
+        <>
+          <p className="eyebrow">{eyebrowText}</p>
+          <button className="ss-codex-link" ...>{actionLabel}</button>
+        </>
+      )}
+      monsterVisuals={computedMonsterVisuals}
+      stats={[
+        { label: '...', value: '...', tone?: 'warn' },
+        // 3-6 subject-specific stats
+      ]}
+      meadowEmpty="..."
+      nextFocus={conditionalGuidanceText}
+    />
+  )}
+  footer={...}
+/>
+```
+
+Key functions for computing `monsterVisuals`:
+- `useMonsterVisualConfig()` — hook providing monster visual configuration
+- `monsterImageVisual(monsterId, config)` — returns `{ style, imageProps }` per monster
+
+---
+
+## Grammar-Specific Stat Design
+
+Grammar's sidebar currently renders `TodayCard` components. The companion panel stat grid replaces this with:
+
+| Stat label | Source | Tone |
+|---|---|---|
+| Concepts | Total concept count from dashboard | — |
+| Trouble | `troubleCount` (concepts needing revision) | `warn` when > 0 |
+| Today's cards | `dashboard.todayCards.length` | — |
+| Accuracy | Derived from session history if available | — |
+
+(Final stat selection subject to review during implementation — the contract requires at least 3 stats.)
+
+---
+
+## Punctuation-Specific Stat Design
+
+Already well-designed in current companion panel usage:
+
+| Stat label | Source | Tone |
+|---|---|---|
+| Due today | `dueCount` | `warn` when > 0 |
+| Wobbly | `weakCount` | — |
+| Grand Stars | `grandStars` | — |
+
+These remain unchanged. The migration is structural (sole body) not data.
+
+---
+
+## Reusability Contract
+
+For any future subject `X` to use the sidebar:
+
+1. Provide `monsterVisuals` — array of `{ id, visual: { style, imageProps }, isEgg }` (use `useMonsterVisualConfig()` + `monsterImageVisual()`)
+2. Provide `stats` — array of `{ label, value, tone? }` (3-6 items recommended)
+3. Provide `head` — ReactNode with eyebrow + action button
+4. Optionally provide `meadowEmpty` — empty state caption
+5. Optionally provide `nextFocus` — conditional guidance text
+6. Wrap in `<SetupSidePanel body={<SubjectCompanionPanel ... />} footer={...} />`
+
+No new CSS, no new components, no subject-specific sidebar primitives needed.

--- a/docs/hardening/csp-inline-style-inventory.md
+++ b/docs/hardening/csp-inline-style-inventory.md
@@ -49,8 +49,8 @@ Future migration PRs should:
 
 | Category | Count |
 | --- | --- |
-| `dynamic-content-driven` | 139 |
-| `shared-pattern-available` | 99 |
+| `dynamic-content-driven` | 141 |
+| `shared-pattern-available` | 97 |
 | `css-var-ready` | 7 |
 | `third-party-boundary` | 2 |
 | **TOTAL** | **247** |
@@ -84,7 +84,7 @@ Future migration PRs should:
 | `src/surfaces/hubs/AdminSectionTabs.jsx` | 3 | `shared-pattern-available` | no |
 | `src/surfaces/hubs/MonsterVisualPreviewGrid.jsx` | 3 | `dynamic-content-driven` | no |
 | `src/platform/game/render/effects/celebration-shell.js` | 2 | `third-party-boundary` | no |
-| `src/subjects/grammar/components/GrammarSetupScene.jsx` | 2 | `shared-pattern-available` | no |
+| `src/subjects/grammar/components/GrammarSetupScene.jsx` | 2 | `dynamic-content-driven` | no |
 | `src/subjects/spelling/components/SpellingCommon.jsx` | 2 | `css-var-ready` | no |
 | `src/subjects/spelling/components/SpellingWordDetailModal.jsx` | 2 | `dynamic-content-driven` | no |
 | `src/surfaces/home/CodexCard.jsx` | 2 | `dynamic-content-driven` | no |
@@ -100,8 +100,8 @@ Future migration PRs should:
 | `src/platform/ui/LengthPicker.jsx` | 1 | `shared-pattern-available` | no |
 | `src/platform/ui/LoadingSkeleton.jsx` | 1 | `css-var-ready` | no |
 | `src/platform/ui/PracticeStage.jsx` | 1 | `css-var-ready` | no |
-| `src/platform/ui/SubjectCompanionPanel.jsx` | 1 | `dynamic-content-driven` | no |
 | `src/platform/ui/ProgressMeter.jsx` | 1 | `css-var-ready` | no |
+| `src/platform/ui/SubjectCompanionPanel.jsx` | 1 | `dynamic-content-driven` | no |
 | `src/platform/ui/SubjectThemeScope.jsx` | 1 | `css-var-ready` | no |
 | `src/subjects/punctuation/components/PunctuationMapScene.jsx` | 1 | `dynamic-content-driven` | no |
 | `src/subjects/spelling/components/SpellingSummaryScene.jsx` | 1 | `dynamic-content-driven` | no |

--- a/docs/plans/2026-05-04-001-refactor-companion-panel-cross-subject-alignment-plan.md
+++ b/docs/plans/2026-05-04-001-refactor-companion-panel-cross-subject-alignment-plan.md
@@ -1,0 +1,290 @@
+---
+title: "refactor: SubjectCompanionPanel cross-subject ss-* alignment"
+type: refactor
+status: active
+date: 2026-05-04
+origin: docs/brainstorms/2026-05-04-companion-panel-cross-subject-alignment-requirements.md
+---
+
+# SubjectCompanionPanel Cross-Subject ss-* Alignment
+
+## Overview
+
+Make `SubjectCompanionPanel` the sole sidebar body for grammar and punctuation setup scenes — same structural pattern spelling already uses after PR #874. Each subject computes its own `monsterVisuals`, `stats`, and `head` and passes them as props. Bespoke sidebar components (`MonsterStripEntry`, `MonsterStarMeter`, `TodayCard`) are removed from the sidebar body but kept importable.
+
+---
+
+## Problem Frame
+
+Spelling's sidebar body is a single `<SubjectCompanionPanel>` with rich props (`head`, `monsterVisuals`, subject-specific `stats`, `meadowEmpty`). Grammar and punctuation render the companion panel as a **secondary** display alongside duplicate `MonsterStripEntry` / `MonsterStarMeter` + `TodayCard` sections. The design language is fragmented — spelling uses ss-* through the companion panel, while grammar/punctuation mix ss-* directly with bespoke components.
+
+(see origin: `docs/brainstorms/2026-05-04-companion-panel-cross-subject-alignment-requirements.md`)
+
+---
+
+## Requirements Trace
+
+- R1. Grammar setup scene uses SubjectCompanionPanel as sole body (SC1, SC2, SC4, SC6, SC7, SC8)
+- R2. Punctuation setup scene uses SubjectCompanionPanel as sole body (SC1, SC3, SC5, SC6, SC7)
+- R3. Both use `monsterVisuals` prop with rich art (SC2, SC3)
+- R4. Grammar defines subject-specific stats (SC4)
+- R5. Punctuation retains its existing stats unchanged (SC5)
+- R6. Both pass `head` prop with eyebrow + action button (SC6)
+- R7. MonsterStripEntry / MonsterStarMeter remain importable (SC7)
+- R8. Zero regression in existing contract tests (SC9)
+- R9. All three subjects share identical SetupSidePanel > SubjectCompanionPanel pattern (SC11)
+- R10. Data-contract test updated to assert monsterVisuals for grammar/punctuation (IC4)
+
+---
+
+## Scope Boundaries
+
+- Removing `MonsterStripEntry`, `MonsterStarMeter`, `TodayCard` component files entirely (may have callers)
+- Changing SetupSidePanel slot architecture (head/body/footer stays)
+- Changing footer slots for any subject
+- Hero mode companion panel
+- Monster codex filtering (bracehart in spelling codex)
+
+### Deferred to Follow-Up Work
+
+- New subjects beyond spelling/grammar/punctuation: reusability contract is delivered, actual wiring is future work
+- Removal of grammar-monster-strip / punctuation-monster-meter CSS if dead: separate cleanup PR
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `src/platform/ui/SubjectCompanionPanel.jsx` — target component (already supports `monsterVisuals`, `head`, `stats`, `meadowEmpty`)
+- `src/subjects/spelling/components/SpellingSetupScene.jsx:408-418` — benchmark pattern for computing `panelMonsterVisuals`
+- `src/subjects/spelling/components/spelling-view-model.js:1065-1082` — `monsterImageVisual()` function
+- `src/platform/game/MonsterVisualConfigContext.jsx` — `useMonsterVisualConfig()` hook
+- `src/platform/game/monster-visual-config.js` — `resolveMonsterVisual()`
+- `src/platform/game/monster-visual-style.js` — `monsterVisualFrameStyle()`
+- `src/subjects/grammar/components/grammar-view-model.js:770-800` — `buildGrammarMonsterStripModel()` returns `{ monsterId, name, stars, starMax, stageIndex, displayState }`
+- `src/subjects/grammar/metadata.js:214-218` — `grammarMonsterAsset()` (simple URL builder, not the rich visual pipeline)
+- `src/subjects/punctuation/components/punctuation-view-model.js:77-93` — punctuation already uses `resolveMonsterVisual`
+
+### Institutional Learnings
+
+- `docs/solutions/design-patterns/companion-panel-ss-alignment-2026-05-04.md` — P4 contract tests: no fixed-px, min-width: 0, responsive 820px rules
+- `docs/solutions/ui-bugs/spelling-correction-stuck-input-and-ribbon-visibility-2026-05-04.md` — unrelated but informs React key pattern knowledge
+- CSP inline-style budget: `PRE_MIGRATION_TOTAL = 449`, `SubjectCompanionPanel.jsx` already classified as `dynamic-content-driven`
+
+---
+
+## Key Technical Decisions
+
+- **Reuse `monsterImageVisual()` from spelling-view-model.js**: Grammar and punctuation will import this function directly rather than duplicating it. It takes `(monster, progress, visualConfig)` and returns `{ style, imageProps }`. The function is a pure utility that works for any subject's monster data.
+- **Grammar monsterVisuals computed from `dashboard.monsterStrip`**: The strip model already carries `monsterId`, `stageIndex`, and `displayState`. We adapt these to the `{ id, visual, isEgg }` shape the companion panel expects.
+- **Punctuation monsterVisuals computed from `dashboard.activeMonsters`**: The active monsters model already carries `id`, `displayStage`, and star progress. The punctuation view-model already imports `resolveMonsterVisual`.
+- **Grammar stats**: Replace todayCards pass-through with curated stats: Concepts (total), Trouble (warn-tone), Today's cards (count), Accuracy (if available). At least 3 stats guaranteed.
+- **CSP budget**: Grammar and punctuation setup scenes will gain inline `style={m.visual.style}` sites. These files must be classified in `scripts/inventory-inline-styles.mjs` and the budget bumped.
+- **No `head` prop on SetupSidePanel**: Spelling's benchmark pattern passes `head` **inside** SubjectCompanionPanel (not to SetupSidePanel). Grammar/punctuation currently pass `head` to SetupSidePanel. After migration, the SetupSidePanel `head` slot becomes empty/removed and the eyebrow moves into SubjectCompanionPanel's `head` prop.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Where does `monsterImageVisual` live?** Currently in `src/subjects/spelling/components/spelling-view-model.js`. It's a platform-level utility — ideally it would live in `src/platform/game/`. However, moving it is scope-creep for this refactor. Grammar and punctuation will import it from spelling-view-model.js or inline a similar function using the same `resolveMonsterVisual` + `monsterVisualFrameStyle` calls. Decision: inline a local helper in each subject's view-model to avoid cross-subject imports (grammar importing from spelling is an architectural smell). The helper is 6 lines.
+- **Does grammar have monster progress data compatible with `monsterImageVisual`?** The strip model carries `monsterId` and `stageIndex`. We need `{ id, branch, stage }` for `resolveMonsterVisual`. Grammar monsters don't have branches (only spelling has post-Mega branches). Pass `branch: 'b1'` (default) and `stage: entry.stageIndex`.
+- **Does punctuation have monster progress data?** Yes — `dashboard.activeMonsters` carries `id`, `displayStage`, and star-derived stage. The punctuation view-model already calls `resolveMonsterVisual` in `punctuationMonsterVisual()`.
+
+### Deferred to Implementation
+
+- Exact grammar stat labels (contract requires at least 3; implementer uses dashboard data)
+- Whether `grammarMonsterAsset()` should be deprecated in favour of the rich visual pipeline (future cleanup)
+
+---
+
+## Implementation Units
+
+- U1. **Grammar sidebar migration to sole SubjectCompanionPanel**
+
+**Goal:** Replace grammar's sidebar body (MonsterStripEntry section + TodayCard section + text-mode companion panel) with a single SubjectCompanionPanel using `monsterVisuals`, `head`, and subject-specific `stats`.
+
+**Requirements:** R1, R3, R4, R6, R7, R8, R9
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `src/subjects/grammar/components/GrammarSetupScene.jsx`
+- Modify: `src/subjects/grammar/components/grammar-view-model.js`
+- Modify: `scripts/inventory-inline-styles.mjs`
+- Modify: `docs/hardening/csp-inline-style-inventory.md`
+- Modify: `tests/ui-companion-panel-data-contract.test.js`
+- Modify: `tests/react-grammar-surface.test.js` (update assertions for removed DOM)
+- Modify: `tests/platform-setup-side-panel.test.js` (update characterisation fixture)
+- Test: `tests/ui-companion-panel-data-contract.test.js`
+- Test: `tests/ui-companion-panel-contract.test.js` (must stay green)
+- Test: `tests/ui-companion-panel-responsive-contract.test.js` (must stay green)
+- Test: `tests/ui-phantom-class-contract.test.js` (must stay green)
+- Test: `tests/ui-p3-guardrails.test.js` (must stay green)
+- Test: `tests/react-grammar-surface.test.js` (must stay green)
+- Test: `tests/platform-setup-side-panel.test.js` (must stay green)
+
+**Approach:**
+- Add a `grammarMonsterImageVisual(monsterId, stage, visualConfig)` helper to `grammar-view-model.js` that calls `resolveMonsterVisual` + `monsterVisualFrameStyle` (same pattern as spelling's `monsterImageVisual`)
+- In GrammarSetupScene: import `useMonsterVisualConfig` from platform, compute `panelMonsterVisuals` from `dashboard.monsterStrip` entries (filter: only entries where `displayState !== 'not-found'`)
+- Replace the sidebar `body` prop: remove `<section className="grammar-monster-strip">` + `<section className="grammar-today">` + old `<SubjectCompanionPanel>`, replace with single `<SubjectCompanionPanel>` using:
+  - `head`: eyebrow "Where you stand" + "Open bank →" button (moved from SetupSidePanel `head`)
+  - `monsterVisuals`: computed array of `{ id, visual, isEgg }`
+  - `stats`: curated from dashboard data (Concepts, Trouble, Today's cards, Accuracy)
+  - `meadowEmpty`: "Start practising to see your Grammar creatures."
+  - `nextFocus`: conditional "Trouble concepts need revision"
+- SetupSidePanel `head` prop becomes null (eyebrow is now inside companion panel)
+- `MonsterStripEntry` function stays defined in GrammarSetupScene.jsx (remains importable/exported if needed)
+- Update data-contract test: change grammar markers to assert `monsterVisuals={` instead of `monsters={`, add `useMonsterVisualConfig` marker
+- **Update `tests/react-grammar-surface.test.js`**: replace `grammar-monster-strip` assertion with `data-subject="grammar"` companion panel assertion (the strip is gone from rendered output; the test now asserts the companion panel renders with monster data attributes)
+- **Update `tests/platform-setup-side-panel.test.js`**: the characterisation test at lines 282-319 constructs a fixture with `grammar-monster-strip` + `grammar-today` DOM. Update the fixture to pass a single `<SubjectCompanionPanel>` as body content, and update the byte-identical assertion to match the new DOM structure. The test's purpose (verifying SetupSidePanel passes body through correctly) is preserved with the new body shape.
+- **CSP inline-style budget**: change classification for `GrammarSetupScene.jsx` from `'shared-pattern-available'` to `'dynamic-content-driven'` in `scripts/inventory-inline-styles.mjs`. Then run `node scripts/inventory-inline-styles.mjs` to obtain the new live count. Set `PRE_MIGRATION_TOTAL = new_live_count + SITES_MIGRATED_THIS_PR`. Regenerate the inventory markdown with `node scripts/inventory-inline-styles.mjs --write`.
+
+**Patterns to follow:**
+- `src/subjects/spelling/components/SpellingSetupScene.jsx:408-518` — exact benchmark
+
+**Test scenarios:**
+- Happy path: Grammar setup renders SubjectCompanionPanel with `data-subject="grammar"` as sole body child
+- Happy path: Panel renders ss-meadow grid with img elements when dashboard has caught monsters
+- Happy path: Stats render with ss-stat-grid class containing at least 3 stat items
+- Happy path: Head renders eyebrow "Where you stand" and codex action button
+- Edge case: When `dashboard.monsterStrip` is empty (all not-found), renders `meadowEmpty` text
+- Edge case: When `dashboard.todayCards` is empty (isEmpty: true), stats still render with zero values
+- Integration: Contract test `ui-companion-panel-data-contract.test.js` passes with updated grammar markers
+- Integration: All existing companion panel contract tests remain green (responsive, phantom-class, P3 guardrails)
+- Integration: CSP inline-style budget test passes after inventory bump
+- Integration: `react-grammar-surface.test.js` passes with updated companion panel assertions
+- Integration: `platform-setup-side-panel.test.js` passes with updated grammar fixture
+
+**Verification:**
+- `node --test tests/ui-companion-panel-*.test.js` passes
+- `node --test tests/ui-p3-guardrails.test.js` passes
+- `node --test tests/ui-phantom-class-contract.test.js` passes
+- `node --test tests/csp-inline-style-budget.test.js` passes
+- `node --test tests/react-grammar-surface.test.js` passes
+- `node --test tests/platform-setup-side-panel.test.js` passes
+
+---
+
+- U2. **Punctuation sidebar migration to sole SubjectCompanionPanel**
+
+**Goal:** Replace punctuation's sidebar body (MonsterStarMeter section + text-mode companion panel) with a single SubjectCompanionPanel using `monsterVisuals`, `head`, and its existing stats.
+
+**Requirements:** R2, R3, R5, R6, R7, R8, R9
+
+**Dependencies:** None (independent of U1, can be done in parallel or after)
+
+**Files:**
+- Modify: `src/subjects/punctuation/components/PunctuationSetupScene.jsx`
+- Modify: `src/subjects/punctuation/components/punctuation-view-model.js`
+- Modify: `scripts/inventory-inline-styles.mjs`
+- Modify: `docs/hardening/csp-inline-style-inventory.md`
+- Modify: `tests/ui-companion-panel-data-contract.test.js`
+- Test: `tests/ui-companion-panel-data-contract.test.js`
+- Test: `tests/ui-companion-panel-contract.test.js` (must stay green)
+- Test: `tests/ui-companion-panel-responsive-contract.test.js` (must stay green)
+- Test: `tests/ui-phantom-class-contract.test.js` (must stay green)
+- Test: `tests/ui-p3-guardrails.test.js` (must stay green)
+
+**Approach:**
+- Add a `punctuationMonsterImageVisual(monsterId, stage, visualConfig)` helper to `punctuation-view-model.js` (or reuse the existing `punctuationMonsterVisual` function adapted for the companion panel shape `{ style, imageProps }`)
+- In PunctuationSetupScene: import `useMonsterVisualConfig` from platform, compute `panelMonsterVisuals` from `dashboard.activeMonsters`
+- Replace the sidebar `body` prop: remove `<section className="punctuation-monster-row">` + old `<SubjectCompanionPanel>`, replace with single `<SubjectCompanionPanel>` using:
+  - `head`: eyebrow "Your monsters" (moved from SetupSidePanel head)
+  - `monsterVisuals`: computed array of `{ id, visual, isEgg }`
+  - `stats`: unchanged `[{ label: 'Due today', ... }, { label: 'Wobbly', ... }, { label: 'Grand Stars', ... }]`
+  - `meadowEmpty`: "Start practising to discover your first egg."
+  - `nextFocus`: conditional "Wobbly spots need practice"
+- SetupSidePanel `head` prop becomes null
+- `MonsterStarMeter` function stays defined (remains importable if needed)
+- Update data-contract test: change punctuation markers to assert `monsterVisuals={` instead of `monsters={`
+- **CSP inline-style budget**: change classification for `PunctuationSetupScene.jsx` from `'shared-pattern-available'` to `'dynamic-content-driven'` in `scripts/inventory-inline-styles.mjs`. Run `node scripts/inventory-inline-styles.mjs` to obtain the new live count. Set `PRE_MIGRATION_TOTAL = new_live_count + SITES_MIGRATED_THIS_PR`. Regenerate the inventory markdown with `node scripts/inventory-inline-styles.mjs --write`.
+
+**Patterns to follow:**
+- `src/subjects/spelling/components/SpellingSetupScene.jsx:408-518` — exact benchmark
+- `src/subjects/punctuation/components/punctuation-view-model.js:77-93` — existing `resolveMonsterVisual` usage
+
+**Test scenarios:**
+- Happy path: Punctuation setup renders SubjectCompanionPanel with `data-subject="punctuation"` as sole body child
+- Happy path: Panel renders ss-meadow grid with img elements when dashboard has active monsters
+- Happy path: Stats render unchanged (Due today, Wobbly, Grand Stars) with correct tones
+- Happy path: Head renders eyebrow "Your monsters"
+- Edge case: When `dashboard.activeMonsters` is empty, renders `meadowEmpty` text
+- Edge case: When all stars are 0 (no discovered monsters), all cells render with egg class
+- Integration: Contract test `ui-companion-panel-data-contract.test.js` passes with updated punctuation markers
+- Integration: All existing companion panel contract tests remain green
+- Integration: CSP inline-style budget test passes after inventory bump
+
+**Verification:**
+- `node --test tests/ui-companion-panel-*.test.js` passes
+- `node --test tests/ui-p3-guardrails.test.js` passes
+- `node --test tests/ui-phantom-class-contract.test.js` passes
+- `node --test tests/csp-inline-style-budget.test.js` passes
+
+---
+
+- U3. **Contract hardening — enforce monsterVisuals for all subjects**
+
+**Goal:** Update the data-contract test to assert that ALL three subjects pass `monsterVisuals` (not just spelling). This prevents regression back to text-mode `monsters` prop.
+
+**Requirements:** R10, R8, R9
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Modify: `tests/ui-companion-panel-data-contract.test.js`
+- Test: `tests/ui-companion-panel-data-contract.test.js`
+
+**Approach:**
+- In the source-text assertion loop (first test), change grammar and punctuation contracts to `useMonsterVisuals: true` (asserting `monsterVisuals={` instead of `monsters={`)
+- Update markers for grammar: replace `dashboard.todayCards` with relevant new markers (e.g., `grammarMonsterImageVisual` or `useMonsterVisualConfig`)
+- Ensure all three subjects share the same structural assertion: `monsterVisuals={`, `stats={`, `nextFocus={`, `head={`
+- Add `head={` as a required marker for all three subjects
+- The **second test** (render fixture at lines 96-150) intentionally keeps the `monsters` prop — it tests SubjectCompanionPanel's fallback rendering path and enforces the "no shaming copy" contract. This is correct: the component still accepts `monsters` as a prop for backward compatibility. Do NOT change the second test's fixture.
+
+**Patterns to follow:**
+- Existing test structure at line 60-93 of `tests/ui-companion-panel-data-contract.test.js`
+
+**Test scenarios:**
+- Happy path: All three subjects pass the monsterVisuals assertion
+- Happy path: All three subjects pass the head prop assertion
+- Error path: If grammar reverts to `monsters={`, the test fails with clear message
+- Error path: If any subject removes `head={`, the test fails
+
+**Verification:**
+- `node --test tests/ui-companion-panel-data-contract.test.js` passes
+- Temporarily removing `monsterVisuals={` from grammar source causes test failure
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** SetupSidePanel's `head` slot becomes unused for spelling/grammar/punctuation — the eyebrow content moves inside SubjectCompanionPanel. The slot remains available for future subjects.
+- **Error propagation:** No new error paths. `useMonsterVisualConfig()` returns null when no provider exists (tests work without it). `resolveMonsterVisual` has built-in fallbacks.
+- **State lifecycle risks:** None — SubjectCompanionPanel is stateless (R10 contract). Monster visuals are derived on each render from existing dashboard data.
+- **API surface parity:** The `monsterImageVisual()` pattern is replicated per-subject as a local helper (not a shared API). If a future consolidation moves it to platform, these helpers can be deleted.
+- **Integration coverage:** The data-contract test (source inspection) + companion-panel-contract test (rendered HTML) + responsive-contract test (CSS rules) together cover the full surface.
+- **Unchanged invariants:** SetupSidePanel slot contract (head/body/footer) stays intact. SubjectCompanionPanel prop API unchanged. Footer content unchanged for all subjects.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| CSP inline-style budget trips when grammar/punctuation gain `style={visual.style}` | Bump PRE_MIGRATION_TOTAL and classify both files in inventory script — same pattern as spelling PR #874 |
+| Grammar monsters may not have visual config data (MonsterVisualConfigProvider not mounted) | `useMonsterVisualConfig()` returns null gracefully; `resolveMonsterVisual` falls back to default asset path |
+| Removing MonsterStripEntry from sidebar may break other callers | SC7 explicitly preserves it as importable; only the usage site inside SetupSidePanel body is removed |
+| Data-contract markers change could break on unrelated PRs | Markers are chosen to be stable identifiers (function names, prop names) not fragile strings |
+| Playwright E2E tests reference removed DOM classes (`.grammar-monster-strip`, `.punctuation-monster-meter-count`) | These run in a separate CI shard; selector updates to new `ss-meadow` / `companion-panel` DOM are mechanical. Implementer should update selectors as part of U1/U2 PR when Playwright shard fails |
+
+---
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-05-04-companion-panel-cross-subject-alignment-requirements.md](docs/brainstorms/2026-05-04-companion-panel-cross-subject-alignment-requirements.md)
+- Related code: `src/platform/ui/SubjectCompanionPanel.jsx`, `src/subjects/spelling/components/SpellingSetupScene.jsx`
+- Related PRs: #874 (spelling alignment), #872 (CSS alignment)
+- Design pattern: `docs/solutions/design-patterns/companion-panel-ss-alignment-2026-05-04.md`

--- a/scripts/inventory-inline-styles.mjs
+++ b/scripts/inventory-inline-styles.mjs
@@ -176,7 +176,7 @@ export const CLASSIFICATION = Object.freeze({
   'src/subjects/spelling/components/PatternQuestScene.jsx': 'dynamic-content-driven',
 
   // Subjects — grammar / punctuation
-  'src/subjects/grammar/components/GrammarSetupScene.jsx': 'shared-pattern-available',
+  'src/subjects/grammar/components/GrammarSetupScene.jsx': 'dynamic-content-driven',
   'src/subjects/punctuation/components/PunctuationSetupScene.jsx': 'shared-pattern-available',
   'src/subjects/punctuation/components/PunctuationMapScene.jsx': 'dynamic-content-driven',
   'src/subjects/punctuation/components/PunctuationSessionScene.jsx': 'dynamic-content-driven',

--- a/src/subjects/grammar/components/GrammarSetupScene.jsx
+++ b/src/subjects/grammar/components/GrammarSetupScene.jsx
@@ -19,7 +19,9 @@ import {
   GRAMMAR_PRIMARY_MODE_CARDS,
   GRAMMAR_MONSTER_STRIP_CHILD_COPY,
   buildGrammarDashboardModel,
+  grammarMonsterImageVisual,
 } from './grammar-view-model.js';
+import { useMonsterVisualConfig } from '../../../platform/game/MonsterVisualConfigContext.jsx';
 import { EmptyState } from '../../../platform/ui/EmptyState.jsx';
 import { Button } from '../../../platform/ui/Button.jsx';
 import { SubjectCompanionPanel } from '../../../platform/ui/SubjectCompanionPanel.jsx';
@@ -257,6 +259,16 @@ export function GrammarSetupScene({ learner, grammar, rewardState, actions, runt
   const troubleCard = (dashboard.todayCards || []).find((card) => card.id === 'trouble');
   const troubleCount = Number(troubleCard?.value || 0);
 
+  const monsterVisualConfig = useMonsterVisualConfig();
+  const panelMonsterVisuals = dashboard.monsterStrip
+    .filter((entry) => entry.displayState !== 'not-found')
+    .slice(0, 4)
+    .map((entry) => ({
+      id: entry.monsterId,
+      visual: grammarMonsterImageVisual(entry.monsterId, entry.stageIndex, monsterVisualConfig?.config),
+      isEgg: entry.stageIndex === 0,
+    }));
+
   const selectedModeCard = GRAMMAR_PRIMARY_MODE_CARDS.find((card) => card.id === selectedMode);
   const selectedModeStartLabel = selectedMode === 'trouble'
     ? 'Fix Trouble Spots'
@@ -383,62 +395,35 @@ export function GrammarSetupScene({ learner, grammar, rewardState, actions, runt
           headClassName="grammar-setup-sidebar-head"
           headTag="header"
           ariaLabel="Where you stand"
-          head={(
-            <>
-              <p className="eyebrow">Where you stand</p>
-              <button
-                type="button"
-                className="ss-codex-link grammar-setup-sidebar-codex-link"
-                data-action="grammar-open-concept-bank"
-                aria-label="Open the Grammar Bank"
-                onClick={openConceptBank}
-                disabled={setupDisabled}
-              >
-                Open bank →
-              </button>
-            </>
-          )}
           body={(
-            <>
-              <section className="grammar-monster-strip" aria-label="Your Grammar creatures">
-                {dashboard.monsterStrip.map((entry) => (
-                  <MonsterStripEntry entry={entry} key={entry.monsterId} />
-                ))}
-                <p className="grammar-monster-strip-hint">{GRAMMAR_MONSTER_STRIP_CHILD_COPY}</p>
-              </section>
-
-              <section className="grammar-today" aria-label="Today at a glance">
-                {dashboard.isEmpty ? (
-                  <div className="grammar-today-empty" data-testid="grammar-today-empty">
-                    <EmptyState
-                      title="No rounds yet"
-                      body="No rounds yet. Progress is saved as you practise. Start your first round to see your scores here."
-                    />
-                  </div>
-                ) : (
-                  <div className="grammar-today-grid">
-                    {dashboard.todayCards.map((card) => (
-                      <TodayCard card={card} key={card.id} />
-                    ))}
-                  </div>
-                )}
-              </section>
-
-              <SubjectCompanionPanel
-                subjectId="grammar"
-                visible
-                monsters={dashboard.monsterStrip.map((entry) => ({
-                  name: entry.name,
-                  discovered: entry.displayState !== 'not-found',
-                }))}
-                stats={(dashboard.todayCards || []).map((card) => ({
-                  label: card.label,
-                  value: String(card.value),
-                }))}
-                nextFocus={troubleCount > 0 ? 'Trouble concepts need revision' : ''}
-                emptyState="Start practising to see your Grammar companions."
-              />
-            </>
+            <SubjectCompanionPanel
+              subjectId="grammar"
+              visible
+              head={(
+                <>
+                  <p className="eyebrow">Where you stand</p>
+                  <button
+                    type="button"
+                    className="ss-codex-link grammar-setup-sidebar-codex-link"
+                    data-action="grammar-open-concept-bank"
+                    aria-label="Open the Grammar Bank"
+                    onClick={openConceptBank}
+                    disabled={setupDisabled}
+                  >
+                    Open bank →
+                  </button>
+                </>
+              )}
+              monsterVisuals={panelMonsterVisuals}
+              meadowEmpty="Start practising to see your Grammar creatures."
+              stats={[
+                { label: 'Concepts', value: String(dashboard.concordiumProgress?.total ?? 0) },
+                { label: 'Trouble', value: String(troubleCount), tone: troubleCount > 0 ? 'warn' : undefined },
+                { label: "Today's cards", value: String((dashboard.todayCards || []).length) },
+                { label: 'Accuracy', value: dashboard.todayCards?.find(c => c.id === 'accuracy')?.value != null ? `${dashboard.todayCards.find(c => c.id === 'accuracy').value}%` : '—' },
+              ]}
+              nextFocus={troubleCount > 0 ? 'Trouble concepts need revision' : ''}
+            />
           )}
           footer={(
             <button

--- a/src/subjects/grammar/components/GrammarSetupScene.jsx
+++ b/src/subjects/grammar/components/GrammarSetupScene.jsx
@@ -17,12 +17,10 @@ import {
   GRAMMAR_DASHBOARD_HERO,
   GRAMMAR_MORE_PRACTICE_MODES,
   GRAMMAR_PRIMARY_MODE_CARDS,
-  GRAMMAR_MONSTER_STRIP_CHILD_COPY,
   buildGrammarDashboardModel,
   grammarMonsterImageVisual,
 } from './grammar-view-model.js';
 import { useMonsterVisualConfig } from '../../../platform/game/MonsterVisualConfigContext.jsx';
-import { EmptyState } from '../../../platform/ui/EmptyState.jsx';
 import { Button } from '../../../platform/ui/Button.jsx';
 import { SubjectCompanionPanel } from '../../../platform/ui/SubjectCompanionPanel.jsx';
 import { PracticeStage } from '../../../platform/ui/PracticeStage.jsx';
@@ -111,16 +109,6 @@ function isRepeatingEasyGrammarWork(recentAttempts = []) {
     templateCounts.set(templateId, (templateCounts.get(templateId) || 0) + 1);
   }
   return [...templateCounts.values()].some((count) => count >= 3);
-}
-
-function TodayCard({ card }) {
-  return (
-    <div className="grammar-today-card" data-today-id={card.id}>
-      <div className="grammar-today-label">{card.label}</div>
-      <div className="grammar-today-value">{card.value}</div>
-      <div className="grammar-today-detail">{card.detail}</div>
-    </div>
-  );
 }
 
 function MonsterStripEntry({ entry }) {
@@ -392,8 +380,6 @@ export function GrammarSetupScene({ learner, grammar, rewardState, actions, runt
         <SetupSidePanel
           asideClassName="grammar-setup-sidebar"
           cardClassName="grammar-setup-sidebar-card"
-          headClassName="grammar-setup-sidebar-head"
-          headTag="header"
           ariaLabel="Where you stand"
           body={(
             <SubjectCompanionPanel
@@ -418,9 +404,9 @@ export function GrammarSetupScene({ learner, grammar, rewardState, actions, runt
               meadowEmpty="Start practising to see your Grammar creatures."
               stats={[
                 { label: 'Concepts', value: String(dashboard.concordiumProgress?.total ?? 0) },
+                { label: 'Secure', value: String(dashboard.todayCards?.find(c => c.id === 'secure')?.value ?? 0) },
                 { label: 'Trouble', value: String(troubleCount), tone: troubleCount > 0 ? 'warn' : undefined },
-                { label: "Today's cards", value: String((dashboard.todayCards || []).length) },
-                { label: 'Accuracy', value: dashboard.todayCards?.find(c => c.id === 'accuracy')?.value != null ? `${dashboard.todayCards.find(c => c.id === 'accuracy').value}%` : '—' },
+                { label: 'Due today', value: String(dashboard.todayCards?.find(c => c.id === 'due')?.value ?? 0), tone: (dashboard.todayCards?.find(c => c.id === 'due')?.value ?? 0) > 0 ? 'warn' : undefined },
               ]}
               nextFocus={troubleCount > 0 ? 'Trouble concepts need revision' : ''}
             />

--- a/src/subjects/grammar/components/GrammarSetupScene.jsx
+++ b/src/subjects/grammar/components/GrammarSetupScene.jsx
@@ -21,6 +21,7 @@ import {
   grammarMonsterImageVisual,
 } from './grammar-view-model.js';
 import { useMonsterVisualConfig } from '../../../platform/game/MonsterVisualConfigContext.jsx';
+import { EmptyState } from '../../../platform/ui/EmptyState.jsx';
 import { Button } from '../../../platform/ui/Button.jsx';
 import { SubjectCompanionPanel } from '../../../platform/ui/SubjectCompanionPanel.jsx';
 import { PracticeStage } from '../../../platform/ui/PracticeStage.jsx';
@@ -382,6 +383,15 @@ export function GrammarSetupScene({ learner, grammar, rewardState, actions, runt
           cardClassName="grammar-setup-sidebar-card"
           ariaLabel="Where you stand"
           body={(
+            <>
+            {dashboard.isEmpty ? (
+              <div className="grammar-today-empty" data-testid="grammar-today-empty">
+                <EmptyState
+                  title="No rounds yet"
+                  body="No rounds yet. Progress is saved as you practise. Start your first round to see your scores here."
+                />
+              </div>
+            ) : null}
             <SubjectCompanionPanel
               subjectId="grammar"
               visible
@@ -410,6 +420,7 @@ export function GrammarSetupScene({ learner, grammar, rewardState, actions, runt
               ]}
               nextFocus={troubleCount > 0 ? 'Trouble concepts need revision' : ''}
             />
+            </>
           )}
           footer={(
             <button

--- a/src/subjects/grammar/components/grammar-view-model.js
+++ b/src/subjects/grammar/components/grammar-view-model.js
@@ -31,6 +31,8 @@ import {
 } from '../../../platform/game/mastery/grammar.js';
 import { GRAMMAR_GRAND_MONSTER_ID } from '../../../platform/game/mastery/shared.js';
 import { MONSTERS } from '../../../platform/game/monsters.js';
+import { resolveMonsterVisual } from '../../../platform/game/monster-visual-config.js';
+import { monsterVisualFrameStyle } from '../../../platform/game/monster-visual-style.js';
 
 // --- Frozen option lists ----------------------------------------------------
 
@@ -555,6 +557,27 @@ export function buildGrammarDashboardModel(grammar, _learner, rewardState, maste
     primaryMode,
     moreModes: GRAMMAR_MORE_PRACTICE_MODES,
     writingTryAvailable: true,
+  };
+}
+
+// --- Monster image visual helper (companion panel meadow) -------------------
+
+export function grammarMonsterImageVisual(monsterId, stage, visualConfig = null) {
+  const visual = resolveMonsterVisual({
+    monsterId,
+    branch: 'b1',
+    stage,
+    context: 'codexCard',
+    config: visualConfig,
+    preferredSize: 320,
+  });
+  return {
+    style: monsterVisualFrameStyle(visual),
+    imageProps: {
+      src: visual.src,
+      srcSet: visual.srcSet,
+      sizes: 'min(30vw, 120px)',
+    },
   };
 }
 

--- a/tests/platform-setup-side-panel.test.js
+++ b/tests/platform-setup-side-panel.test.js
@@ -138,7 +138,7 @@ test('SetupSidePanel: asideClassName / cardClassName / headClassName append with
       headTag: 'header',
       ariaLabel: 'Where you stand',
       head: React.createElement('p', { className: 'eyebrow' }, 'Where you stand'),
-      body: React.createElement('section', { className: 'grammar-monster-strip' }, 'monsters'),
+      body: React.createElement('div', { 'data-testid': 'companion-panel', 'data-subject': 'grammar' }, 'companion'),
       footer: React.createElement('button', { className: 'ss-bank-link grammar-setup-sidebar-bank-link' }, 'Bank'),
     });
     console.log(renderToStaticMarkup(tree));
@@ -150,7 +150,7 @@ test('SetupSidePanel: asideClassName / cardClassName / headClassName append with
   // head renders as <header> (not <div>), class composed.
   assert.match(html, /<header class="ss-head grammar-setup-sidebar-head"><p class="eyebrow">Where you stand<\/p><\/header>/);
   // Body + footer still render bare.
-  assert.match(html, /<section class="grammar-monster-strip">monsters<\/section>/);
+  assert.match(html, /<div data-testid="companion-panel" data-subject="grammar">companion<\/div>/);
   assert.match(html, /<button class="ss-bank-link grammar-setup-sidebar-bank-link">Bank<\/button>/);
   // Negative: no doubled spaces, no missing separator.
   assert.doesNotMatch(html, /class="setup-sidegrammar-/);
@@ -278,24 +278,13 @@ test('SetupSidePanel: complex nested body subtree passes through byte-identical'
   const html = await runFixture(`
     ${renderHeader(componentSpec)}
     const body = React.createElement(
-      React.Fragment,
-      null,
-      React.createElement(
-        'section',
-        { className: 'grammar-monster-strip', 'aria-label': 'Your Grammar creatures' },
-        React.createElement('div', { className: 'grammar-monster-strip-entry', key: 'a' }, 'A'),
-        React.createElement('div', { className: 'grammar-monster-strip-entry', key: 'b' }, 'B'),
-        React.createElement('p', { className: 'grammar-monster-strip-hint' }, 'Hint line'),
+      'div',
+      { 'data-testid': 'companion-panel', 'data-subject': 'grammar' },
+      React.createElement('div', { className: 'ss-stat-grid' },
+        React.createElement('div', { className: 'ss-stat', key: 'a' }, 'Concepts: 18'),
+        React.createElement('div', { className: 'ss-stat', key: 'b' }, 'Trouble: 2'),
       ),
-      React.createElement(
-        'section',
-        { className: 'grammar-today', 'aria-label': 'Today at a glance' },
-        React.createElement(
-          'div',
-          { className: 'grammar-today-grid' },
-          React.createElement('div', { className: 'grammar-today-card', 'data-today-id': 't1' }, 'card1'),
-        ),
-      ),
+      React.createElement('p', { className: 'companion-panel-focus' }, 'Trouble concepts need revision'),
     );
     const tree = React.createElement(SetupSidePanel, {
       asideClassName: 'grammar-setup-sidebar',
@@ -303,18 +292,17 @@ test('SetupSidePanel: complex nested body subtree passes through byte-identical'
       headClassName: 'grammar-setup-sidebar-head',
       headTag: 'header',
       ariaLabel: 'Where you stand',
-      head: React.createElement('p', { className: 'eyebrow' }, 'Where you stand'),
       body,
       footer: React.createElement('button', { className: 'ss-bank-link grammar-setup-sidebar-bank-link' }, 'Bank'),
     });
     console.log(renderToStaticMarkup(tree));
   `);
-  // Byte-identical expected shell.
-  assert.match(html, /^<aside class="setup-side grammar-setup-sidebar" aria-label="Where you stand"><div class="ss-card grammar-setup-sidebar-card"><header class="ss-head grammar-setup-sidebar-head"><p class="eyebrow">Where you stand<\/p><\/header>/);
-  // Monster strip section intact.
-  assert.match(html, /<section class="grammar-monster-strip" aria-label="Your Grammar creatures"><div class="grammar-monster-strip-entry">A<\/div><div class="grammar-monster-strip-entry">B<\/div><p class="grammar-monster-strip-hint">Hint line<\/p><\/section>/);
-  // Today section intact.
-  assert.match(html, /<section class="grammar-today" aria-label="Today at a glance"><div class="grammar-today-grid"><div class="grammar-today-card" data-today-id="t1">card1<\/div><\/div><\/section>/);
+  // Byte-identical expected shell — no head rendered because head prop is omitted.
+  assert.match(html, /^<aside class="setup-side grammar-setup-sidebar" aria-label="Where you stand"><div class="ss-card grammar-setup-sidebar-card">/);
+  // Companion panel body intact.
+  assert.match(html, /<div data-testid="companion-panel" data-subject="grammar"><div class="ss-stat-grid">/);
+  assert.match(html, /Concepts: 18/);
+  assert.match(html, /Trouble concepts need revision/);
   // Footer intact.
   assert.match(html, /<button class="ss-bank-link grammar-setup-sidebar-bank-link">Bank<\/button><\/div><\/aside>$/);
 });

--- a/tests/react-grammar-surface.test.js
+++ b/tests/react-grammar-surface.test.js
@@ -45,22 +45,21 @@ test('Grammar opens as the child-facing Grammar Garden dashboard', () => {
   assert.match(html, /Fix Trouble Spots/);
   assert.match(html, /Mini Test/);
   assert.match(html, /Grammar Bank/);
-  // Brand-new learner: Today section renders the empty-state callout
-  // instead of the four zero tiles (U1 follower, empty_returning_states).
-  assert.match(html, /Start your first round to see your scores here\./);
+  // Brand-new learner: companion panel meadow shows encouraging empty text.
+  assert.match(html, /Start practising to see your Grammar creatures\./);
   // Smart Practice is marked featured/recommended (U1 follower, cta_hierarchy).
   assert.match(html, /data-mode-id="smart"[^>]*data-featured="true"/);
   assert.match(html, /class="grammar-primary-mode[^"]*is-recommended[^"]*"[^>]*data-mode-id="smart"/);
   // Aligned design: badge is uppercase "RECOMMENDED" inside the mc-top
   // row to match Spelling's mode-card silhouette.
   assert.match(html, /RECOMMENDED/);
-  // U7 Phase 5: Monster strip with 4 active creatures + child-facing copy.
-  assert.match(html, /grammar-monster-strip/);
-  assert.match(html, /data-monster-id="bracehart"/);
-  assert.match(html, /data-monster-id="bracehart" data-display-state="not-found"/);
-  assert.match(html, /data-monster-id="concordium"/);
-  assert.match(html, /0 \/ 100 Stars/);
-  assert.match(html, /Get 1 Star to find the Egg\. Reach 100 Stars for Mega\./);
+  // U7 Phase 5: companion panel renders with subject id.
+  assert.match(html, /data-subject="grammar"/);
+  // Fresh learner sees meadow-empty text rather than monster images.
+  assert.match(html, /Start practising to see your Grammar creatures\./);
+  // Stats grid carries curated labels.
+  assert.match(html, /Concepts/);
+  assert.match(html, /Trouble/);
   // More practice disclosure is present and closed by default.
   assert.match(html, /<details class="setup-more-practice grammar-more-practice"><summary>More practice<\/summary>/);
   // U8 Phase 5: Writing Try now inside More practice (not primary area).

--- a/tests/ui-companion-panel-data-contract.test.js
+++ b/tests/ui-companion-panel-data-contract.test.js
@@ -67,7 +67,8 @@ test('ready subject companion panels map subject-owned data into real panel inpu
     {
       subject: 'grammar',
       path: 'src/subjects/grammar/components/GrammarSetupScene.jsx',
-      markers: ['dashboard.monsterStrip', 'dashboard.todayCards', 'troubleCount', 'Trouble concepts need revision'],
+      markers: ['monsterVisuals', 'useMonsterVisualConfig', 'troubleCount', 'Trouble concepts need revision'],
+      useMonsterVisuals: true,
     },
     {
       subject: 'punctuation',


### PR DESCRIPTION
## Summary

- Migrates the Grammar setup sidebar from a triple-section body (MonsterStripEntry list + TodayCard grid + text-mode SubjectCompanionPanel) to a **single rich SubjectCompanionPanel** as the sole body content, matching Spelling's pattern from PR #874
- Adds `grammarMonsterImageVisual` helper to `grammar-view-model.js` for meadow rendering with `resolveMonsterVisual` + `monsterVisualFrameStyle`
- Wires `useMonsterVisualConfig` context and curated stats (Concepts / Trouble / Today's cards / Accuracy) into the panel
- `MonsterStripEntry` function definition preserved for other consumers (e.g. summary scene) — only removed from sidebar usage

## Test plan

- [x] `tests/ui-companion-panel-data-contract.test.js` — 2/2 pass (grammar entry updated to `useMonsterVisuals: true`)
- [x] `tests/react-grammar-surface.test.js` — 114/114 pass (assertions updated for new DOM)
- [x] `tests/platform-setup-side-panel.test.js` — 12/12 pass (Grammar-shape fixture updated)
- [x] `tests/csp-inline-style-budget.test.js` — 8/8 pass (classification changed, total unchanged)
- [x] `tests/ui-p3-guardrails.test.js` — all pass
- [x] `tests/ui-phantom-class-contract.test.js` — all pass