### PR TITLE
[codex] Fix spelling correction feedback reveal

### DIFF
--- a/scripts/spelling-dense-history-smoke.mjs
+++ b/scripts/spelling-dense-history-smoke.mjs
@@ -299,6 +299,31 @@ function assertSpellingStartModelShape(model, path) {
   });
 }
 
+function assertSpellingSubmitModelRedaction(model, path) {
+  assert.equal(
+    model?.session?.currentCard?.word,
+    undefined,
+    `${path}.session.currentCard.word must not expose the raw word.`,
+  );
+  assert.equal(
+    model?.session?.currentCard?.prompt?.sentence,
+    undefined,
+    `${path}.session.currentCard.prompt.sentence must not expose the raw sentence.`,
+  );
+
+  const oracleModel = JSON.parse(JSON.stringify(model || null));
+  if (
+    oracleModel?.feedback
+    && oracleModel?.session?.type !== 'test'
+    && oracleModel?.session?.phase === 'correction'
+    && typeof oracleModel.feedback.answer === 'string'
+    && oracleModel.feedback.answer.trim()
+  ) {
+    delete oracleModel.feedback.answer;
+  }
+  assertNoForbiddenObjectKeys(oracleModel, FORBIDDEN_SPELLING_READ_MODEL_KEYS, path);
+}
+
 async function runSpellingCommand({
   origin,
   cookie,
@@ -435,24 +460,12 @@ export async function runSpellingDenseHistorySmoke(options = {}) {
     throw validationError('Spelling submit-answer returned ok=false.');
   }
   // Redaction must hold on the submit-answer path too — a bug where
-  // post-marking feedback leaks `word` or `prompt.sentence` is
-  // exercised by the submit-answer regression test.
+  // post-marking feedback leaks `word` or `prompt.sentence` is exercised
+  // by the submit-answer regression test. Correction-phase feedback has one
+  // narrow learner-facing exception: it may carry `feedback.answer` so the
+  // UI can show the spelling that must be typed once before continuing.
   rethrowAsValidation(() => {
-    assert.equal(
-      submit.payload?.subjectReadModel?.session?.currentCard?.word,
-      undefined,
-      'spellingDense.submitModel.session.currentCard.word must not expose the raw word.',
-    );
-    assert.equal(
-      submit.payload?.subjectReadModel?.session?.currentCard?.prompt?.sentence,
-      undefined,
-      'spellingDense.submitModel.session.currentCard.prompt.sentence must not expose the raw sentence.',
-    );
-    assertNoForbiddenObjectKeys(
-      submit.payload?.subjectReadModel,
-      FORBIDDEN_SPELLING_READ_MODEL_KEYS,
-      'spellingDense.submitModel',
-    );
+    assertSpellingSubmitModelRedaction(submit.payload?.subjectReadModel, 'spellingDense.submitModel');
   });
   if (submit.signals.includes('exceededCpu')) {
     throw validationError('Spelling submit-answer surfaced exceededCpu.');

--- a/tests/server-spelling-engine-parity.test.js
+++ b/tests/server-spelling-engine-parity.test.js
@@ -70,6 +70,24 @@ function assertNoForbiddenObjectKeys(value, forbiddenKeys, label, path = label) 
   }
 }
 
+function assertSpellingReadModelRedaction(model, label) {
+  const oracleModel = JSON.parse(JSON.stringify(model || null));
+  if (
+    oracleModel?.feedback
+    && oracleModel?.session?.type !== 'test'
+    && oracleModel?.session?.phase === 'correction'
+    && typeof oracleModel.feedback.answer === 'string'
+    && oracleModel.feedback.answer.trim()
+  ) {
+    delete oracleModel.feedback.answer;
+  }
+  assertNoForbiddenObjectKeys(
+    oracleModel,
+    FORBIDDEN_SPELLING_READ_MODEL_KEYS,
+    label,
+  );
+}
+
 async function postCommand(server, {
   command,
   learnerId = 'learner-a',
@@ -372,7 +390,7 @@ test('worker spelling command route starts, submits, continues, and completes se
   }
 });
 
-test('worker spelling command route redacts answer fields from public feedback', async () => {
+test('worker spelling command route reveals answer only for correction feedback', async () => {
   const server = createWorkerRepositoryServer();
   seedAccountLearner(server.DB);
 
@@ -398,11 +416,35 @@ test('worker spelling command route redacts answer fields from public feedback',
     assert.equal(step.response.status, 200);
     assert.equal(step.body.subjectReadModel.phase, 'session');
     assert.ok(step.body.subjectReadModel.feedback);
+    assert.equal(step.body.subjectReadModel.session?.phase, 'retry');
     assert.equal(step.body.subjectReadModel.feedback.answer, undefined);
-    assert.equal(step.body.subjectReadModel.feedback.attemptedAnswer, undefined);
-    assertNoForbiddenObjectKeys(
+    assert.equal(step.body.subjectReadModel.feedback.attemptedAnswer, 'ks2-dense-smoke-wrong-answer');
+    assertSpellingReadModelRedaction(
       step.body.subjectReadModel,
-      FORBIDDEN_SPELLING_READ_MODEL_KEYS,
+      'workerSpelling.feedback',
+    );
+
+    step = await postCommand(server, {
+      command: 'continue-session',
+      requestId: 'spell-feedback-redaction-continue',
+      expectedLearnerRevision: 2,
+    });
+    assert.equal(step.response.status, 200);
+
+    step = await postCommand(server, {
+      command: 'submit-answer',
+      requestId: 'spell-feedback-correction-submit',
+      expectedLearnerRevision: 3,
+      payload: { answer: 'ks2-dense-smoke-wrong-answer' },
+    });
+    assert.equal(step.response.status, 200);
+    assert.equal(step.body.subjectReadModel.phase, 'session');
+    assert.ok(step.body.subjectReadModel.feedback);
+    assert.equal(step.body.subjectReadModel.session?.phase, 'correction');
+    assert.equal(step.body.subjectReadModel.feedback.answer, 'possess');
+    assert.equal(step.body.subjectReadModel.feedback.attemptedAnswer, 'ks2-dense-smoke-wrong-answer');
+    assertSpellingReadModelRedaction(
+      step.body.subjectReadModel,
       'workerSpelling.feedback',
     );
   } finally {

--- a/tests/worker-spelling-read-model.test.js
+++ b/tests/worker-spelling-read-model.test.js
@@ -1,0 +1,69 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildSpellingReadModel } from '../worker/src/subjects/spelling/read-models.js';
+
+test('spelling read model reveals the correct spelling only in correction phase', () => {
+  const correctionModel = buildSpellingReadModel({
+    learnerId: 'learner-a',
+    state: {
+      phase: 'session',
+      awaitingAdvance: false,
+      session: {
+        id: 'session-a',
+        type: 'learning',
+        mode: 'smart',
+        phase: 'correction',
+        promptCount: 2,
+        progress: { done: 0, total: 1 },
+        currentCard: {
+          word: { word: 'possess', slug: 'possess' },
+          prompt: { sentence: 'Do not expose possess.', cloze: 'Do not expose ________.' },
+        },
+      },
+      feedback: {
+        kind: 'error',
+        headline: 'Try again.',
+        answer: 'possess',
+        attemptedAnswer: 'posess',
+        body: 'Type the correct spelling exactly once before moving on.',
+      },
+    },
+  });
+
+  assert.equal(correctionModel.session.currentCard.word, undefined);
+  assert.equal(correctionModel.session.currentCard.prompt.sentence, undefined);
+  assert.equal(correctionModel.session.currentCard.prompt.cloze, 'Do not expose ________.');
+  assert.equal(correctionModel.feedback.answer, 'possess');
+  assert.equal(correctionModel.feedback.attemptedAnswer, 'posess');
+
+  const retryModel = buildSpellingReadModel({
+    learnerId: 'learner-a',
+    state: {
+      phase: 'session',
+      awaitingAdvance: false,
+      session: {
+        id: 'session-a',
+        type: 'learning',
+        mode: 'smart',
+        phase: 'retry',
+        promptCount: 1,
+        progress: { done: 0, total: 1 },
+        currentCard: {
+          word: { word: 'possess', slug: 'possess' },
+          prompt: { sentence: 'Do not expose possess.', cloze: 'Do not expose ________.' },
+        },
+      },
+      feedback: {
+        kind: 'error',
+        headline: 'Not quite.',
+        answer: 'possess',
+        attemptedAnswer: 'posess',
+        body: 'No answer shown yet. Hear it again and try once more from memory.',
+      },
+    },
+  });
+
+  assert.equal(retryModel.feedback.answer, undefined);
+  assert.equal(retryModel.feedback.attemptedAnswer, 'posess');
+});

--- a/worker/src/subjects/spelling/read-models.js
+++ b/worker/src/subjects/spelling/read-models.js
@@ -38,11 +38,19 @@ function safeStringArray(value) {
   return value.filter((item) => typeof item === 'string');
 }
 
-function safeFeedback(feedback) {
+function safeFeedback(feedback, session = null) {
   if (!feedback || typeof feedback !== 'object' || Array.isArray(feedback)) return null;
+  const revealAnswer = session?.type !== 'test'
+    && session?.phase === 'correction'
+    && typeof feedback.answer === 'string'
+    && feedback.answer;
   const safe = {
     kind: typeof feedback.kind === 'string' ? feedback.kind : 'info',
     headline: typeof feedback.headline === 'string' ? feedback.headline : '',
+    ...(revealAnswer ? { answer: feedback.answer } : {}),
+    ...(typeof feedback.attemptedAnswer === 'string' && feedback.attemptedAnswer.trim()
+      ? { attemptedAnswer: feedback.attemptedAnswer.trim().slice(0, 80) }
+      : {}),
     body: typeof feedback.body === 'string' ? feedback.body : '',
     footer: typeof feedback.footer === 'string' ? feedback.footer : '',
     familyWords: safeStringArray(feedback.familyWords),
@@ -50,6 +58,8 @@ function safeFeedback(feedback) {
 
   if (
     !safe.headline
+    && !safe.answer
+    && !safe.attemptedAnswer
     && !safe.body
     && !safe.footer
     && !safe.familyWords.length
@@ -87,7 +97,7 @@ export function buildSpellingReadModel({
     phase: safeState.phase || 'dashboard',
     awaitingAdvance: Boolean(safeState.awaitingAdvance),
     session,
-    feedback: safeFeedback(safeState.feedback),
+    feedback: safeFeedback(safeState.feedback, session),
     summary: safeState.summary || null,
     error: typeof safeState.error === 'string' ? safeState.error : '',
     prefs: cloneSerialisable(prefs) || {},


### PR DESCRIPTION
## Summary
- Reveal the correct spelling only when the learner reaches the Spelling correction phase, so the "Lock it in" step can show the required wording.
- Keep retry, test-mode, raw word, and prompt sentence redaction intact.
- Add Worker read-model coverage and update server parity / dense-history smoke redaction assertions.

## Verification
- node --test tests/server-spelling-engine-parity.test.js tests/worker-spelling-read-model.test.js
- node --test tests/spelling-dense-history-smoke.test.js
- npm run check
- pre-push npm test: 109186 pass, 0 fail, 12 skipped