### PR TITLE
[codex] Fix Grammar Bank confidence labels

### DIFF
--- a/src/subjects/grammar/components/grammar-view-model.js
+++ b/src/subjects/grammar/components/grammar-view-model.js
@@ -584,10 +584,11 @@ export function grammarMonsterImageVisual(monsterId, stage, visualConfig = null,
 // --- Grammar Bank model builder ---------------------------------------------
 
 function childLabelForConcept(concept) {
-  // Analytics concept shape carries an internal `confidenceLabel` after the
-  // Worker projects it. Older fixtures may only carry a coarse `status` —
-  // `'new' | 'learning' | 'weak' | 'due' | 'secured'`. We map status → label
-  // so the bank renders a child label even on first boot.
+  // Analytics concept shape carries the canonical nested `confidence.label`.
+  // Older fixtures may only carry `confidenceLabel`, or just a coarse
+  // `status` — `'new' | 'learning' | 'weak' | 'due' | 'secured'`. We map
+  // status → label only as a last-resort first-boot fallback.
+  if (isGrammarConfidenceLabel(concept?.confidence?.label)) return concept.confidence.label;
   if (typeof concept?.confidenceLabel === 'string') return concept.confidenceLabel;
   switch (concept?.status) {
     case 'secured': return 'secure';

--- a/tests/grammar-ui-model.test.js
+++ b/tests/grammar-ui-model.test.js
@@ -687,6 +687,28 @@ test('U8 view-model: buildGrammarBankModel filter=trouble narrows to needs-repai
   }
 });
 
+test('U8 view-model: buildGrammarBankModel uses nested confidence label before coarse status', () => {
+  const grammar = {
+    analytics: {
+      concepts: [
+        {
+          id: 'relative_clauses',
+          confidence: { label: 'secure', sampleSize: 12, intervalDays: 14, distinctTemplates: 4, recentMisses: 0 },
+          status: 'due',
+          name: 'Relative clauses',
+        },
+      ],
+    },
+  };
+
+  const model = buildGrammarBankModel(grammar, { statusFilter: 'secure' });
+  const card = model.cards.find((entry) => entry.id === 'relative_clauses');
+
+  assert.ok(card, 'secure confidence concept remains in the secure filter even when coarse status is due');
+  assert.equal(card.label, 'secure');
+  assert.equal(card.childLabel, 'Secure');
+});
+
 test('U8 view-model: buildGrammarBankModel search clause narrows to matching concepts', () => {
   const model = buildGrammarBankModel({}, { query: 'clause' });
   assert.ok(model.cards.length >= 2);


### PR DESCRIPTION
## Summary
- Fix Grammar Bank child label resolution to prefer nested confidence.label before legacy labels or coarse status fields.
- Add regression coverage for secure concepts that also have due coarse status.

## Verification
- node --test tests/grammar-ui-model.test.js
- npm test
- npm run check
- node --test tests/worker-admin-ops-mutations-lifecycle.test.js