### PR TITLE
Add Grammar Bank confidence E2E regression

### DIFF
--- a/tests/playwright/grammar-golden-path.playwright.test.mjs
+++ b/tests/playwright/grammar-golden-path.playwright.test.mjs
@@ -303,6 +303,75 @@ test.describe('U9 Flow 2: Grammar Bank filter + concept detail + Practise 5', ()
     await applyDeterminism(page);
   });
 
+  test('Grammar Bank renders nested secure confidence ahead of coarse due status', async ({ page }) => {
+    const runtimeErrors = [];
+    page.on('pageerror', (error) => runtimeErrors.push(error?.message || String(error)));
+    page.on('console', (message) => {
+      if (message.type() === 'error') runtimeErrors.push(message.text());
+    });
+
+    await page.route('**/api/subjects/grammar/command', async (route) => {
+      const response = await route.fetch();
+      const contentType = response.headers()['content-type'] || '';
+      if (!contentType.includes('application/json')) {
+        await route.fulfill({ response });
+        return;
+      }
+
+      const json = await response.json();
+      const concepts = json?.subjectReadModel?.analytics?.concepts;
+      if (Array.isArray(concepts)) {
+        json.subjectReadModel.analytics.concepts = concepts.map((concept) => (
+          concept?.id === 'relative_clauses'
+            ? {
+              ...concept,
+              status: 'due',
+              confidence: {
+                ...(concept.confidence || {}),
+                label: 'secure',
+                sampleSize: 10,
+                intervalDays: 14,
+                distinctTemplates: 5,
+                recentMisses: 0,
+              },
+            }
+            : concept
+        ));
+      }
+
+      await route.fulfill({ response, json });
+    });
+
+    await seedFreshLearner(page);
+    await openGrammarDashboard(page);
+    await primeGrammarReadModel(page);
+
+    const bankCard = page.locator('[data-action="grammar-open-concept-bank"]').first();
+    await expect(bankCard).toBeVisible();
+    await bankCard.click();
+
+    const bankRoot = page.locator('[data-grammar-phase-root="bank"]');
+    await expect(bankRoot).toBeVisible({ timeout: 15_000 });
+
+    const relativeClausesCard = page.locator('.grammar-bank-card[data-concept-id="relative_clauses"]');
+    await expect(relativeClausesCard).toBeVisible();
+    await expect(relativeClausesCard).toHaveAttribute('data-status-label', 'secure');
+    await expect(relativeClausesCard.locator('.grammar-bank-card-status-chip')).toHaveText('Secure');
+    await expect(relativeClausesCard).not.toContainText('Trouble spot');
+
+    const secureChip = page.locator('[data-action="grammar-concept-bank-filter"][data-value="secure"]');
+    await secureChip.click();
+    await expect(secureChip).toHaveAttribute('aria-pressed', 'true');
+    await expect(relativeClausesCard).toBeVisible();
+
+    const troubleChip = page.locator('[data-action="grammar-concept-bank-filter"][data-value="trouble"]');
+    await troubleChip.click();
+    await expect(troubleChip).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.locator('.grammar-bank-card[data-concept-id="relative_clauses"]')).toHaveCount(0);
+
+    expect(runtimeErrors, 'Grammar Bank confidence regression should not emit browser errors').toEqual([]);
+  });
+
   test('Grammar Bank filter affects visible cards, modal Esc closes with focus return, Practise 5 starts focused round', async ({ page }, testInfo) => {
     await seedFreshLearner(page);
     await openGrammarDashboard(page);

--- a/tests/playwright/shared.mjs
+++ b/tests/playwright/shared.mjs
@@ -66,9 +66,9 @@ const SCREENSHOT_DETERMINISM_CSS = `
 .grammar-hero > img,
 /* U5/U6/U7 (refactor ui-consolidation) — the three Punctuation scenes
    (Setup, Session, Summary, Map) all paint via the platform HeroBackdrop.
-   Hiding the `background-image` paints on HeroBackdrop layers so
+   Hiding the background-image paints on HeroBackdrop layers so
    deterministic screenshot diffs do not see per-phase bellstorm variance.
-   The `data-hero-layer="true"` anchors match every adopter wrapper. */
+   The data-hero-layer="true" anchors match every adopter wrapper. */
 .punctuation-hero-backdrop [data-hero-layer="true"],
 .punctuation-session-hero [data-hero-layer="true"],
 .punctuation-summary-hero [data-hero-layer="true"],
@@ -738,19 +738,26 @@ export async function returnToGrammarDashboard(page) {
  * populated in memory.
  */
 export async function primeGrammarReadModel(page) {
-  // Dashboard's round-length <select> dispatches
-  // `grammar-set-round-length` which the module routes to a
-  // `save-prefs` Worker command. The response carries the full read
-  // model; `applyRemoteReadModel` then hydrates the subject UI with
-  // transferLane.prompts.
-  const lengthSelect = page.locator('.grammar-round-controls select').first();
-  await expect(lengthSelect).toBeVisible({ timeout: 10_000 });
-  const initial = await lengthSelect.inputValue();
-  const options = await lengthSelect.evaluate((el) => Array.from(el.options).map((o) => o.value));
-  const other = options.find((v) => v !== initial) || options[0];
+  // Dashboard's round-length control dispatches `grammar-set-round-length`,
+  // which the module routes to a `save-prefs` Worker command. The response
+  // carries the full read model; `applyRemoteReadModel` then hydrates the
+  // subject UI with transferLane.prompts. The control used to be a <select>;
+  // it is now the platform LengthPicker radio-button group.
+  const lengthOptions = page.locator('[data-action="grammar-set-round-length"][data-pref="roundLength"]');
+  await expect(lengthOptions.first()).toBeVisible({ timeout: 10_000 });
+  const optionCount = await lengthOptions.count();
+  const optionValues = [];
+  let initial = '';
+  for (let i = 0; i < optionCount; i += 1) {
+    const option = lengthOptions.nth(i);
+    const value = await option.getAttribute('value');
+    if (value) optionValues.push(value);
+    if ((await option.getAttribute('aria-checked')) === 'true') initial = value || '';
+  }
+  const other = optionValues.find((value) => value !== initial) || optionValues[0];
   if (!other) return;
   // Toggle to a different length to trigger save-prefs.
-  await lengthSelect.selectOption(other);
+  await lengthOptions.filter({ hasText: new RegExp(`^${other}$`) }).first().click();
   // Wait for the command to complete. We watch for a response pattern
   // via the network - any grammar command response suffices.
   await page.waitForResponse(
@@ -762,7 +769,7 @@ export async function primeGrammarReadModel(page) {
   });
   // Flip back to the original value for a clean baseline.
   if (initial !== other) {
-    await lengthSelect.selectOption(initial);
+    await lengthOptions.filter({ hasText: new RegExp(`^${initial}$`) }).first().click();
     await page.waitForResponse(
       (resp) => resp.url().includes('/api/subjects/grammar/command') && resp.status() === 200,
       { timeout: 10_000 },


### PR DESCRIPTION
## Summary
- Add a Playwright regression that forces a Grammar Bank concept to carry nested secure confidence with coarse due status and verifies the card/filter behaviour stays Secure.
- Update the shared Grammar E2E read-model priming helper for the current LengthPicker round-length control.

## Verification
- npx playwright test tests/playwright/grammar-golden-path.playwright.test.mjs -g "nested secure confidence" --project desktop-1440
- npx playwright test tests/playwright/grammar-golden-path.playwright.test.mjs -g "nested secure confidence" --project mobile-390
- node --test tests/grammar-ui-model.test.js tests/spelling-view-model.test.js tests/react-spelling-surface.test.js
- node --test tests/punctuation-view-model.test.js tests/punctuation-map-phase.test.js
- node --test tests/reading-content-contract.test.js tests/reading-subject-registry.test.js tests/reading-session-interface.test.js tests/worker-reading-runtime.test.js
- npm run check
- npm run deploy
- npm run smoke:production:grammar
- npm test (pre-push hook): 109219 tests, 0 failed, 12 skipped
