### PR TITLE
Reduce D1 subject command write amplification

### DIFF
--- a/docs/operations/capacity.md
+++ b/docs/operations/capacity.md
@@ -20,6 +20,23 @@ These artefacts can explain which Phase 2 path to take, but they cannot promote 
 | 60-learner stretch | Not certified — latest 60-learner preflight reached app load but failed bootstrap P95 (854.0 ms vs 750 ms ceiling). | Same evidence as classroom beta, with passing P95 wall time and zero 5xx across repeated runs. |
 | 100+ school-ready target | Not certified | Requires repeated 100+ learner runs, D1 row metrics, operational tail evidence, and a rollback/degrade drill. |
 
+## D1 Runtime Persistence Contract
+
+Normal subject commands persist source-of-truth state, not unbounded normal-operation history. A changed command may still write the learner's current subject state, the active or recent practice session, monster/reward game state, the command projection read model, the compact mutation receipt, and the learner revision. That is the persistence required for progress, reload, cross-device sync, stale-write protection, and reward correctness.
+
+The command path must not store full subject read-model payloads in `mutation_receipts.response_json`, and it must not append normal gameplay events into both `event_log` and `learner_activity_feed`. Subject command receipts use a compact replay contract: duplicate request IDs return `replayRequiresRefresh: true` plus mutation metadata, and the browser hydrates before applying the replay marker. Immediate command responses still include the full read model for the active UI update.
+
+`event_log` remains available for explicit admin or ops flows that intentionally append audit events, and the public ops error tables remain the home for real error reporting. `learner_activity_feed` is a rollout-drain table only for this path: old rows may still be read during the transition, but normal subject commands should not create new rows.
+
+Retention keeps the database bounded:
+
+- Non-admin `mutation_receipts`: 24 hours; `admin.*` receipts: 365 days.
+- `practice_sessions`: completed and abandoned sessions older than 30 days are pruned in 5000-row batches; active sessions are preserved for resume.
+- `learner_activity_feed`: rows older than 7 days are pruned in 5000-row batches.
+- `request_limits`, stale sessions, and admin request denials keep their existing bounded sweeps.
+
+Production cleanup must be code-first and backup-first: deploy code that stops future writes, smoke the live command path, take a remote D1 backup, then run bounded cleanup and record D1 `size_after` evidence. Do not drop `event_log` or `learner_activity_feed` while any deployed read path still references them.
+
 ## Standard Commands
 
 Local dry-run, no network:

--- a/docs/plans/2026-05-31-001-perf-d1-write-amplification-hardening-plan.md
+++ b/docs/plans/2026-05-31-001-perf-d1-write-amplification-hardening-plan.md
@@ -1,0 +1,232 @@
+---
+title: "D1 Write-Amplification Hardening"
+type: perf
+status: active
+date: 2026-05-31
+---
+
+# D1 Write-Amplification Hardening
+
+## Summary
+
+Reduce Cloudflare D1 storage growth and per-command compute by changing normal gameplay writes from history/audit-heavy persistence to source-of-truth persistence only. Player progress, current sessions, rewards, and error reporting must remain intact; redundant normal-operation history, duplicate activity rows, and full response receipts should stop growing.
+
+---
+
+## Problem Frame
+
+The previous production quota incident was caused by `mutation_receipts.response_json` retaining full command responses, including large subject read models, until D1 reached the 500 MB limit. The later retention hotfix shortened the non-admin receipt window, but the same shape still exists: every subject command can write source state, session history, event history, derived activity rows, projection rows, a mutation receipt, rate-limit buckets for demo traffic, and revision rows.
+
+The latest read-only production check showed the current database is not near quota, but the growth pattern is still normal-gameplay data rather than error data:
+
+| Table | Current production signal | Concern |
+| --- | ---: | --- |
+| `event_log` | 6,904 rows, about 4.34 MB JSON | normal answer/session events are appended indefinitely |
+| `practice_sessions` | 1,432 rows | completed and abandoned sessions accumulate |
+| `learner_activity_feed` | 982 rows | duplicates a public subset of events |
+| `mutation_receipts` | 184 rows, about 2.06 MB JSON | still stores command response bodies during the retention window |
+| `ops_error_events` / occurrences / denials | 11 total rows | not the source of D1 growth |
+
+This plan treats error-only logging as valuable and normal-operation append history as the waste to remove.
+
+---
+
+## Requirements
+
+**Player Experience**
+
+- R1. Subject progress must survive reloads and cross-device sync through `child_subject_state`.
+- R2. Active practice state must survive reloads where the user is in the middle of a session.
+- R3. Rewards, stars, monster codex state, and celebration eligibility must remain correct through `child_game_state` and the command projection path.
+- R4. Existing command responses must keep returning the read models the client needs for the immediate UI update.
+
+**D1 Write Reduction**
+
+- R5. Normal subject commands must not persist full `subjectReadModel` payloads into `mutation_receipts.response_json`.
+- R6. Normal subject commands must not append public learner activity into both `event_log` and `learner_activity_feed`.
+- R7. Normal subject command event history must stop growing unless an event is needed for a live gameplay source of truth, admin audit, or error diagnosis.
+- R8. Completed or abandoned practice-session history must be bounded without deleting the active session needed for resume.
+- R9. Demo command protection must reduce repeated D1 rate-limit writes while preserving abuse protection.
+
+**Operations and Safety**
+
+- R10. `ops_error_events`, `ops_error_event_occurrences`, and `admin_request_denials` must continue to record real errors and access denials.
+- R11. Production cleanup must be backup-first and bounded; code must stop future writes before old normal-history rows are purged or tables are dropped.
+- R12. Capacity telemetry and tests must prove the new command path lowers `d1RowsWritten`, query count, and receipt payload bytes without hiding failures.
+- R13. Cloudflare deploy and D1 operations must keep using the repository OAuth-safe package scripts or `scripts/wrangler-oauth.mjs`.
+
+---
+
+## Key Technical Decisions
+
+- KTD1. Source-of-truth writes stay; normal history writes go. The application still writes current learner state, active session state, game state, revisions, and true error records. It stops writing append-only normal gameplay history where that history is not needed to reconstruct the current product experience.
+- KTD2. Compact idempotency replaces full response replay for subject commands. `mutation_receipts` should prove the request was applied and protect request-id reuse, but it should not store the whole read model. Duplicate command replay can return a compact replay response or force a client refresh, provided stale-write and retry semantics remain clear.
+- KTD3. Parent/admin history becomes derived or bounded. Parent Hub can continue showing recent sessions from `practice_sessions`, but long-lived activity timelines should not depend on an unbounded `event_log` or `learner_activity_feed`.
+- KTD4. Projection read models are kept because they remove hot-path reads. `learner_read_models` is small, bounded per learner, and improves command compute. It should remain unless implementation proves it is redundant after removing event persistence.
+- KTD5. Rate limiting should avoid D1 write fan-out on demo command traffic. The current demo command path consumes multiple D1 limiter buckets per command. The fix should collapse buckets or move low-risk counters to a cheaper boundary while preserving sensible abuse limits.
+- KTD6. Cleanup follows deployment, not the other way round. Dropping or purging tables before deployed code stops writing them risks data loss or runtime errors. The safe order is code first, deploy and smoke, remote backup, bounded cleanup, then optional drop migration.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TB
+  C["Subject command"] --> S["Persist source of truth"]
+  S --> CSS["child_subject_state"]
+  S --> PS["practice_sessions active / bounded recent"]
+  S --> CGS["child_game_state"]
+  S --> RM["learner_read_models projection"]
+  C --> MR["compact mutation_receipts metadata"]
+  C -. removed .-> EL["event_log normal events"]
+  C -. removed .-> AF["learner_activity_feed duplicate rows"]
+  E["Client/runtime error"] --> OEE["ops_error_events and occurrences"]
+  D["Admin/auth denial"] --> ARD["admin_request_denials"]
+```
+
+The command route remains stateful for the product. The change is not "no D1 writes"; it is "no D1 writes for redundant normal-operation history".
+
+---
+
+## Implementation Units
+
+### U1. Compact subject command receipts
+
+- **Goal:** Stop storing full command response bodies in subject-command `mutation_receipts`.
+- **Files:** `worker/src/repository.js`, `worker/src/mutation-repository.js`, `worker/src/subjects/command-contract.js`, `src/platform/runtime/subject-command-client.js`, `src/platform/core/repositories/api.js`.
+- **Pattern References:** `subject_content.put` already uses `receiptResponse` and `replayResponse` to compact stored receipt payloads while reconstructing live replay output.
+- **Test Scenarios:**
+  - `tests/worker-subject-runtime.test.js` verifies duplicate subject command request IDs remain idempotent and no longer store `subjectReadModel` in `response_json`.
+  - `tests/worker-query-budget.test.js` verifies the normal command path still returns the full response to the client but receipt payload bytes are bounded.
+  - Add a regression asserting stored subject-command receipt JSON is below a small cap for grammar, punctuation, and spelling commands.
+- **Verification:** Duplicate request with the same request ID returns a safe replay result; duplicate request with a different payload still returns `idempotency_reuse`.
+
+### U2. Remove duplicate learner activity feed writes
+
+- **Goal:** Stop writing `learner_activity_feed` from normal subject events and migrate Parent Hub activity away from the duplicate table.
+- **Files:** `worker/src/repository.js`, `worker/src/read-models/learner-read-models.js`, `src/platform/hubs/api.js`, `src/surfaces/hubs/ParentHubSurface.jsx`, `tests/worker-read-model-capacity.test.js`, `tests/worker-history-api.test.js`.
+- **Pattern References:** `readParentRecentSessions` already provides bounded recent practice history from `practice_sessions`.
+- **Test Scenarios:**
+  - Parent Hub loads without `learner_activity_feed` rows.
+  - Existing accounts with old activity rows do not break reads during the transition.
+  - Normal subject command writes no rows to `learner_activity_feed`.
+- **Verification:** Parent Hub remains usable and recent session display still works.
+
+### U3. Stop normal subject event-log persistence
+
+- **Goal:** Remove append-only normal command event writes while preserving data needed by rewards, projections, admin-only actions, and true error paths.
+- **Files:** `worker/src/repository.js`, `worker/src/subjects/spelling/commands.js`, `worker/src/projections/events.js`, `worker/src/projections/rewards.js`, `worker/src/row-transforms.js`, `tests/worker-projections.test.js`, `tests/worker-projection-hot-path-write.test.js`, `tests/worker-punctuation-runtime.test.js`, `tests/worker-grammar-subject-runtime.test.js`.
+- **Pattern References:** Command projection stores a bounded token ring in `learner_read_models`; current hot-path tests already assert zero `event_log` reads after the projection exists.
+- **Test Scenarios:**
+  - Spelling, grammar, punctuation, reading, arithmetic, and reasoning commands update subject state and rewards without inserting normal rows into `event_log`.
+  - Monster reward dedupe remains stable across repeated commands and reloads.
+  - Admin audit paths that intentionally append events still work or are explicitly moved to compact audit receipts.
+- **Verification:** Command response remains unchanged for the client while D1 row writes drop.
+
+### U4. Bound practice-session retention without harming resume
+
+- **Goal:** Keep active sessions and a small recent completed window while pruning completed/abandoned session history.
+- **Files:** `worker/src/repository.js`, `worker/src/cron/retention-sweep.js`, `worker/migrations`, `tests/worker-cron-retention-sweep.test.js`, `tests/worker-history-api.test.js`.
+- **Pattern References:** Existing cron sweeps use bounded `DELETE ... WHERE rowid IN (SELECT ... LIMIT ?)` for D1-safe retention.
+- **Test Scenarios:**
+  - Active sessions are never deleted by the retention sweep.
+  - Completed sessions older than the configured window are deleted in bounded batches.
+  - Parent recent sessions still returns the expected latest records.
+- **Verification:** Sweep is idempotent and safe on partial migrations.
+
+### U5. Collapse demo command rate-limit write fan-out
+
+- **Goal:** Reduce per-demo-command D1 limiter writes while retaining practical abuse protection.
+- **Files:** `worker/src/demo/sessions.js`, `worker/src/rate-limit.js`, `tests/worker-demo-session.test.js`, `tests/worker-rate-limit-ipv6-propagation.test.js`, `tests/worker-tts.test.js`.
+- **Pattern References:** `consumeRateLimit` centralises D1-backed limiter buckets and already has opportunistic cleanup.
+- **Test Scenarios:**
+  - A demo command consumes fewer limiter buckets than today.
+  - IPv6 /64 bucketing still applies.
+  - Rate-limit responses still include `Retry-After`.
+  - TTS and parent-hub demo limits keep their existing protections unless explicitly changed.
+- **Verification:** Production classroom demo probe shows lower command `queryCount` and `d1RowsWritten`.
+
+### U6. Stop authenticated GET account upserts
+
+- **Goal:** Avoid write-capable UPSERT work for authenticated read routes when the account row is unchanged.
+- **Files:** `worker/src/repository.js`, `worker/src/app.js`, `worker/src/auth.js`, `tests/worker-auth.test.js`, `tests/worker-bootstrap-capacity.test.js`, `tests/worker-query-budget.test.js`.
+- **Pattern References:** `auth.requireSession()` already reads `adult_accounts`; `ensureAccount()` should be create-or-repair only, not a per-request heartbeat.
+- **Test Scenarios:**
+  - Existing account GET `/api/bootstrap` does not write `adult_accounts.updated_at`.
+  - New or partial account sessions still get a usable account row.
+  - Platform role, account type, and selected learner behaviour remain unchanged.
+- **Verification:** Bootstrap remains `d1RowsWritten = 0`.
+
+### U7. Backup-first remote cleanup and optional table removal
+
+- **Goal:** Remove old redundant production data only after code stops future writes.
+- **Files:** `scripts/d1-backup.mjs`, `worker/src/cron/retention-sweep.js`, `worker/migrations`, `docs/operations/capacity.md`, `docs/plans/james/hotfixes`.
+- **Pattern References:** The previous D1 quota hotfix backed up remote D1 before bounded cleanup and recorded size evidence after each sweep.
+- **Test Scenarios:**
+  - Cleanup SQL is bounded and table-missing safe.
+  - A dry-run or read-only proof reports counts and byte estimates before destructive cleanup.
+  - Optional drop migration is only added for tables the deployed code no longer writes or reads.
+- **Verification:** Remote cleanup is backed by a timestamped SQL backup and post-cleanup `size_after` evidence.
+
+### U8. Capacity evidence and release verification
+
+- **Goal:** Prove the player experience is unchanged and D1 pressure is reduced before shipping.
+- **Files:** `tests/worker-query-budget.test.js`, `tests/worker-capacity-round1.test.js`, `tests/worker-read-model-capacity.test.js`, `tests/worker-cron-retention-sweep.test.js`, `scripts/classroom-load-test.mjs`, `docs/operations/capacity.md`.
+- **Pattern References:** `npm run capacity:classroom` and `meta.capacity` are the existing D1/compute evidence surfaces.
+- **Test Scenarios:**
+  - Focused unit tests cover command responses, replay, projections, parent hub reads, retention sweeps, and bootstrap capacity.
+  - `npm test` and `npm run check` pass before deploy.
+  - Production smoke creates a demo session, runs bootstrap, runs at least one subject command, and verifies no 5xx or capacity signals.
+- **Verification:** Report before/after values for `queryCount`, `d1RowsRead`, `d1RowsWritten`, response bytes, and D1 `size_after`.
+
+---
+
+## Scope Boundaries
+
+- This work does not remove persistence for learner progress, active gameplay state, monster rewards, account state, sessions needed for auth, or true error records.
+- This work does not promote any higher classroom capacity claim by itself; capacity status changes require separate evidence governance.
+- This work does not weaken same-origin checks, auth checks, stale-write handling, or admin audit requirements.
+- This work does not perform destructive production cleanup before the deployed code has stopped writing the target data.
+
+---
+
+## System-Wide Impact
+
+The change affects command persistence, parent hub history, demo protection, retention sweeps, and production operations. It should reduce D1 row writes and stored bytes on the highest-frequency route family, but it also changes replay and history assumptions. Tests must therefore cover both runtime state correctness and operational safety rather than only checking lower counts.
+
+---
+
+## Risks & Dependencies
+
+- **Idempotency replay drift:** Compact receipts may not replay byte-for-byte identical full responses. Mitigation: define a compact replay contract and refresh path, then test duplicate command retry behaviour.
+- **Reward dedupe regression:** Removing event persistence may expose hidden reliance on historical events. Mitigation: preserve projection token-ring behaviour and run dense command-loop tests.
+- **Parent Hub history loss:** Activity timeline may shrink or change source. Mitigation: keep recent sessions and make any removed activity-only UI explicit in tests.
+- **Cleanup risk:** Remote purge/drop operations are irreversible without backup. Mitigation: deploy code first, run `npm run db:backup:remote`, perform bounded cleanup, and capture post-cleanup proof.
+- **Rate-limit weakening:** Collapsing demo limiter buckets can open a small abuse window. Mitigation: keep an IP bucket plus one account/session bucket and verify IPv6 propagation tests.
+
+---
+
+## Acceptance Examples
+
+- AE1. Given a learner completes a grammar answer, when the command returns and the page reloads, then grammar progress and rewards remain visible, but no normal `grammar.answer-submitted` row is appended to `event_log`.
+- AE2. Given a command transport retry repeats the same request ID, when the stored compact receipt is found, then the server returns a safe replay result or refresh instruction without storing a full read model.
+- AE3. Given Parent Hub opens for a learner with no `learner_activity_feed` rows, when recent history loads, then recent sessions still display from bounded session data.
+- AE4. Given the daily retention sweep runs, when completed sessions and non-admin receipts are older than the configured window, then only bounded stale rows are deleted and active sessions remain.
+- AE5. Given a production demo classroom probe runs, when command capacity metadata is inspected, then `d1RowsWritten` and `queryCount` are lower than the current grammar command probe while status remains 200 and capacity signals remain empty.
+
+---
+
+## Documentation / Operational Notes
+
+Update `docs/operations/capacity.md` with the new persistence contract and any new cleanup command. Record production backup path, cleanup batches, final `size_after`, and live smoke evidence in a completion report under `docs/plans/james/hotfixes/` or the current system-hardening plan area.
+
+---
+
+## Sources / Research
+
+- `docs/plans/james/hotfixes/archive/4. d1-quota-receipt-retention-hotfix-0510/completion-report.md` documents the previous D1 quota root cause and backup-first cleanup pattern.
+- `worker/src/repository.js` owns `ensureAccount`, subject command mutation, subject runtime persistence, event-log writes, activity-feed writes, projection writes, and parent history reads.
+- `worker/src/cron/retention-sweep.js` contains bounded D1 retention patterns for receipts, request limits, sessions, and denials.
+- `worker/src/demo/sessions.js` shows the current multi-bucket demo command limiter.
+- `worker/src/read-models/learner-read-models.js` shows the small persisted projection and activity feed transforms.
+- `docs/operations/capacity.md` defines the current capacity telemetry and evidence gates.

--- a/docs/plans/james/hotfixes/22. d1-write-amplification-hardening/completion-report-2026-05-31.md
+++ b/docs/plans/james/hotfixes/22. d1-write-amplification-hardening/completion-report-2026-05-31.md
@@ -1,0 +1,84 @@
+# D1 write-amplification hardening completion report
+
+Date: 2026-05-31
+Production URL: `https://ks2.eugnel.uk`
+Branch: `codex/d1-write-amplification-hardening`
+Status: implementation locally verified and prepared for PR; production deployment and backup-first cleanup still require the release gate.
+
+## Root cause
+
+The D1 pressure was not caused by true error logging. It came from normal-operation write amplification on the subject-command hot path:
+
+- Subject command receipts could store full read-model payloads.
+- Normal gameplay events were written as append-only `event_log` history.
+- The same public activity signal could also be duplicated into `learner_activity_feed`.
+- Completed and abandoned `practice_sessions` were retained without a product-level bound.
+- Existing authenticated reads could still take a write-capable account path even when the account row was unchanged.
+
+This repeated the same class of problem as the earlier D1 quota incident: useful current state was mixed with large or redundant history, so ordinary play could grow D1 without a matching player-experience benefit.
+
+## Remediation
+
+- Kept source-of-truth player writes: `child_subject_state`, active/recent `practice_sessions`, `child_game_state`, `learner_read_models`, mutation revision metadata, and real error/audit records.
+- Changed subject command receipts to compact replay metadata. Duplicate request IDs now return `replayRequiresRefresh: true`; the browser hydrates before applying the replay marker.
+- Stopped normal subject commands from appending gameplay events to `event_log`.
+- Stopped normal subject commands from writing duplicate `learner_activity_feed` rows.
+- Preserved monster reward and replay dedupe through the projection read model's `recentEventTokens` ring.
+- Added retention sweeps for stale completed/abandoned `practice_sessions` and stale `learner_activity_feed` rows.
+- Collapsed demo command rate-limit fanout from four D1 buckets to two.
+- Changed `ensureAccount` to read-first and write only when a row is missing or materially changed.
+
+## Player experience contract
+
+This is not a no-write design. Changed gameplay commands still write the state needed for progress, resume, reload, rewards, cross-device sync, and stale-write protection. The removed writes are redundant normal-history writes and full response archives.
+
+Immediate command responses still return the full read model used by the UI. Only stored idempotency receipts are compact. On a duplicate replay, the client refreshes repositories before applying the compact replay marker, so the visible state remains current.
+
+## Local verification
+
+- `node --test tests/subject-command-client.test.js tests/worker-subject-runtime.test.js tests/worker-cron-retention-sweep.test.js tests/worker-query-budget.test.js tests/worker-projections.test.js tests/worker-projection-hot-path-read.test.js tests/worker-projection-hot-path-write.test.js tests/worker-demo-session.test.js`
+  - Result: 95 tests passed, 0 failed.
+  - Evidence included pure read `check-word-bank-drill` responses with `d1RowsWritten: 0`.
+  - Reward command coverage proved `child_game_state` and projection tokens update while `event_log` and `learner_activity_feed` stay unchanged.
+  - Compact subject command receipts were asserted below 512 bytes and without `subjectReadModel`.
+- `node --test tests/punctuation-release-smoke.test.js tests/server-spelling-engine-parity.test.js tests/worker-bootstrap-capacity.test.js tests/worker-grammar-subject-runtime.test.js`
+  - Result: 54 tests passed, 0 failed.
+  - Evidence covered legacy tests whose old assertions expected append-only gameplay history.
+- `npm test`
+  - Result: 111633 tests passed, 0 failed, 12 skipped.
+  - Log: `%TEMP%\ks2-npm-test-d1-hardening.log`.
+- `npm run check`
+  - Result: passed.
+  - Includes Worker dry-run deploy, client build, public-build assertion, Worker bundle build, and client bundle audit.
+  - Client bundle audit: 1285 public files, 6 chunks, main bundle 212142 / 232000 gzip bytes.
+- `git diff --check`
+  - Result: no whitespace errors.
+
+## Browser smoke
+
+- Harness: `node ./tests/helpers/browser-app-server.js --serve-only --port 0 --with-worker-api`.
+- Browser driver: `agent-browser --session ks2-d1-smoke-20260531`.
+- Flow: `/demo` -> Spelling -> start session -> submit an answer.
+- Result: the UI loaded, the Spelling session started, the answer submission returned feedback, and no page errors were reported by `agent-browser errors --clear`.
+- Local Worker evidence:
+  - Existing demo bootstrap after session creation returned `d1RowsWritten: 0`.
+  - `spelling.start-session` wrote 5 D1 rows: `child_subject_state`, `practice_sessions`, `learner_read_models`, compact `mutation_receipts`, and `learner_profiles` revision.
+  - `spelling.submit-answer` wrote the same 5 source-of-truth/projection/receipt/revision rows.
+  - The statement list for both commands contained no `event_log` write and no `learner_activity_feed` write.
+  - Local TTS returned the expected unavailable fallback in this harness; the UI continued with "Audio unavailable" and this is not part of the D1 write path.
+
+## Review closure
+
+Manual LFG review focused on the command receipt replay contract, source-of-truth persistence, removed history writes, retention safety, demo limiter fanout, and old tests that depended on `event_log`. No residual code changes were required after the verification fixes above.
+
+## Production cleanup gate
+
+Cleanup is intentionally not run before deployment. The safe order remains:
+
+1. Run `npm test`.
+2. Run `npm run check`.
+3. Deploy with `npm run deploy`.
+4. Smoke `https://ks2.eugnel.uk` with a logged-in or demo session.
+5. Take a remote D1 backup.
+6. Run bounded cleanup for stale receipts, stale completed/abandoned sessions, and stale activity feed rows.
+7. Record D1 `size_after`, row counts, and live smoke evidence here before closing the production ticket.

--- a/docs/solutions/best-practices/d1-write-amplification-source-of-truth-contract-2026-05-31.md
+++ b/docs/solutions/best-practices/d1-write-amplification-source-of-truth-contract-2026-05-31.md
@@ -1,0 +1,76 @@
+---
+title: "D1 write amplification: keep source-of-truth state, not normal-operation history"
+date: 2026-05-31
+category: best-practices
+module: cloudflare-d1-capacity
+problem_type: best_practice
+component: database
+severity: high
+applies_when:
+  - "A hot path on Cloudflare D1 writes both current state and append-only normal-operation history"
+  - "Mutation receipts store full response payloads for idempotency replay"
+  - "A derived read model duplicates data already present in source-of-truth state"
+  - "A production D1 database is at risk of quota or write-pressure failures"
+tags:
+  - cloudflare-d1
+  - write-amplification
+  - mutation-receipts
+  - event-log
+  - retention
+  - source-of-truth
+related_components:
+  - worker/src/repository.js
+  - worker/src/cron/retention-sweep.js
+  - src/platform/runtime/subject-command-client.js
+---
+
+# D1 write amplification: keep source-of-truth state, not normal-operation history
+
+## Context
+
+The same failure mode can reappear after a quota hotfix if the hot path keeps writing large or duplicate normal-operation data. A previous production outage was caused by `mutation_receipts.response_json` retaining full subject command responses. Shortening receipt retention reduced the immediate database size, but the underlying shape remained risky: every command could write current state, event history, activity feed rows, projection rows, receipts, rate-limit buckets, and revision rows.
+
+The product does not need a permanent row for every normal answer/session event to preserve player experience. It needs current progress, active/resumable session state, reward state, a bounded projection token ring for dedupe, a compact idempotency receipt, and true error/audit records.
+
+## Guidance
+
+### 1. Separate player source of truth from operational history
+
+Keep writes that are needed to reload or sync the app:
+
+- `child_subject_state` for current subject state.
+- `practice_sessions` for active and recent bounded session history.
+- `child_game_state` for rewards and monster codex state.
+- `learner_read_models` for bounded projection state and dedupe tokens.
+- `learner_profiles.state_revision` for stale-write protection.
+
+Do not keep append-only normal gameplay history just because it is convenient for debugging or timeline rendering. If a row is not needed for current product behaviour, admin audit, or error diagnosis, it should be bounded, derived, or not written.
+
+### 2. Idempotency receipts should be proof, not replay archives
+
+`mutation_receipts` should prove that a request ID was applied and protect against request-id reuse. It should not store a full read model for every command. A compact replay response with `replayRequiresRefresh: true` is enough when the client can hydrate before applying the replay marker.
+
+### 3. Derived tables must have a drain plan
+
+Tables such as `learner_activity_feed` are useful only if they materially reduce read cost and stay bounded. If the normal write path stops using a derived table, keep old reads during rollout, add a bounded retention sweep, and only drop the table after every deployed read path no longer references it.
+
+### 4. Cleanup follows deployed code
+
+Never purge or drop a table before the deployed Worker stops writing the target rows. The safe order is:
+
+1. Deploy the low-write code.
+2. Smoke the live command and bootstrap paths.
+3. Take a remote D1 backup.
+4. Run bounded cleanup.
+5. Record D1 size and row-count evidence.
+6. Consider a drop migration only after reads and writes are both removed.
+
+## Verification
+
+Useful regression tests for this pattern:
+
+- Duplicate subject command request IDs return a compact replay and do not store `subjectReadModel` in `mutation_receipts.response_json`.
+- Reward-producing commands update `child_game_state` and projection tokens without appending normal `event_log` or `learner_activity_feed` rows.
+- Pure read commands report `d1RowsWritten = 0`.
+- Retention sweeps prune stale completed/abandoned sessions and activity rows, while preserving active sessions.
+- Bootstrap for existing authenticated accounts does not update account rows when nothing changed.

--- a/src/main.js
+++ b/src/main.js
@@ -559,6 +559,9 @@ const subjectCommands = createSubjectCommandClient({
   onCommandApplied: ({ learnerId, subjectId, response }) => {
     repositories.runtime?.applySubjectCommandResult?.({ learnerId, subjectId, response });
   },
+  onReplayRefresh: async () => {
+    await repositories.hydrate({ cacheScope: 'subject-command-replay' });
+  },
 });
 
 // ---------------------------------------------------------------------------

--- a/src/platform/runtime/subject-command-client.js
+++ b/src/platform/runtime/subject-command-client.js
@@ -118,6 +118,7 @@ export function createSubjectCommandClient({
   fetch: fetchFn = (input, init) => globalThis.fetch(input, init),
   getLearnerRevision = () => 0,
   onCommandApplied = () => {},
+  onReplayRefresh = null,
   onStaleWrite = null,
   retryAttempts = 2,
   retryDelayMs = 250,
@@ -261,6 +262,21 @@ export function createSubjectCommandClient({
 
         throw error;
       }
+    }
+
+    if (
+      responsePayload?.replayRequiresRefresh === true
+      && responsePayload?.mutation?.replayed === true
+      && typeof onReplayRefresh === 'function'
+    ) {
+      await onReplayRefresh({
+        learnerId: cleanLearnerId,
+        subjectId: cleanSubjectId,
+        command: cleanCommand,
+        payload: snapshotCommandPayload(payloadSnapshot),
+        requestId,
+        response: responsePayload,
+      });
     }
 
     onCommandApplied({

--- a/tests/hero-p5-boundaries.test.js
+++ b/tests/hero-p5-boundaries.test.js
@@ -113,8 +113,11 @@ describe('Hero P5 — vocabulary boundaries', () => {
 // ── Structural boundary tests ────────────────────────────────────────
 
 describe('Hero P5 — structural boundaries', () => {
-  it('No new D1 migration files were added for P5 camp', () => {
-    // P5 camp must NOT add new migration files — it stores state in existing hero_progress JSON
+  it('No D1 migrations add Hero Camp storage', () => {
+    // P5 camp must NOT add dedicated schema — it stores state in existing
+    // hero_progress JSON. Later unrelated migrations may exist, so this guard
+    // checks the migration content rather than assuming the global migration
+    // number never advances.
     const migrationsDir = join(ROOT, 'worker', 'migrations');
     let files;
     try {
@@ -123,13 +126,19 @@ describe('Hero P5 — structural boundaries', () => {
       // No migrations directory — that is acceptable
       files = [];
     }
-    // The highest known pre-P5 migration is 0015 (Admin Console P7 incidents).
-    // Anything above means Hero Camp specifically added new tables.
-    const p5Migrations = files.filter(f => {
-      const match = f.match(/^(\d+)/);
-      return match && parseInt(match[1], 10) > 15;
-    });
-    assert.equal(p5Migrations.length, 0, `P5 added new migrations: ${p5Migrations.join(', ')}`);
+    const violations = [];
+    for (const file of files) {
+      const sql = readFileSync(join(migrationsDir, file), 'utf8').toLowerCase();
+      if (
+        /\bcreate\s+table\b[\s\S]*\bhero_camp\b/.test(sql)
+        || /\bcreate\s+index\b[\s\S]*\bhero_camp\b/.test(sql)
+        || /\bhero_camp\b/.test(sql)
+        || /\bcamp_state\b/.test(sql)
+      ) {
+        violations.push(file);
+      }
+    }
+    assert.equal(violations.length, 0, `Hero Camp added dedicated D1 schema: ${violations.join(', ')}`);
   });
 
   it('camp.js does not read from event_log table (event mirror is not authority)', () => {

--- a/tests/punctuation-release-smoke.test.js
+++ b/tests/punctuation-release-smoke.test.js
@@ -436,11 +436,11 @@ test('Punctuation release smoke completes a gated demo action through Worker com
       FROM practice_sessions
       WHERE learner_id = ? AND subject_id = 'punctuation' AND status = 'completed'
     `).get(demo.learnerId).count, 1);
-    assert.ok(server.DB.db.prepare(`
+    assert.equal(server.DB.db.prepare(`
       SELECT COUNT(*) AS count
       FROM event_log
       WHERE learner_id = ? AND subject_id = 'punctuation'
-    `).get(demo.learnerId).count >= 1);
+    `).get(demo.learnerId).count, 0);
 
     const beforeReplayCounts = punctuationMutationCounts(server, {
       ...demo,

--- a/tests/server-spelling-engine-parity.test.js
+++ b/tests/server-spelling-engine-parity.test.js
@@ -526,7 +526,7 @@ test('worker spelling command route keeps core practice available while capacity
       FROM event_log
       WHERE learner_id = 'learner-a' AND subject_id = 'spelling'
     `).get().count;
-    assert.ok(eventCount > 0);
+    assert.equal(eventCount, 0);
   } finally {
     server.close();
   }

--- a/tests/subject-command-client.test.js
+++ b/tests/subject-command-client.test.js
@@ -108,6 +108,48 @@ test('subject command client retries transient server failures with the same req
   assert.equal(revision, 8);
 });
 
+test('subject command client refreshes repositories for compact replay responses', async () => {
+  const calls = [];
+  const fetch = async (input, init = {}) => {
+    const body = JSON.parse(init.body);
+    calls.push(['fetch', body.requestId]);
+    return new Response(JSON.stringify({
+      ok: true,
+      replayRequiresRefresh: true,
+      mutation: {
+        requestId: body.requestId,
+        expectedRevision: body.expectedLearnerRevision,
+        appliedRevision: body.expectedLearnerRevision + 1,
+        replayed: true,
+      },
+    }), { status: 200, headers: { 'content-type': 'application/json' } });
+  };
+  const commands = createSubjectCommandClient({
+    fetch,
+    getLearnerRevision: () => 3,
+    onReplayRefresh: async ({ learnerId, subjectId, command, requestId }) => {
+      calls.push(['refresh', learnerId, subjectId, command, requestId]);
+    },
+    onCommandApplied: ({ response }) => {
+      calls.push(['applied', response.mutation?.requestId]);
+    },
+  });
+
+  const response = await commands.send({
+    subjectId: 'spelling',
+    learnerId: 'learner-a',
+    command: 'start-session',
+    requestId: 'cmd-compact-replay',
+  });
+
+  assert.equal(response.replayRequiresRefresh, true);
+  assert.deepEqual(calls, [
+    ['fetch', 'cmd-compact-replay'],
+    ['refresh', 'learner-a', 'spelling', 'start-session', 'cmd-compact-replay'],
+    ['applied', 'cmd-compact-replay'],
+  ]);
+});
+
 test('subject command client freezes expected revision across transport retries', async () => {
   let revision = 12;
   const commandBodies = [];

--- a/tests/worker-bootstrap-capacity.test.js
+++ b/tests/worker-bootstrap-capacity.test.js
@@ -393,10 +393,13 @@ test('P7 public demo bootstrap reuses authenticated account snapshot and ratchet
     assert.equal(payload.bootstrapCapacity.mode, 'public-bounded');
 
     const queryLog = server.DB.takeQueryLog();
+    const adultAccountReads = queryLog.filter((entry) => (
+      entry.operation === 'first' && /^\s*SELECT \* FROM adult_accounts WHERE id = \?/i.test(entry.sql)
+    ));
     assert.equal(
-      queryLog.some((entry) => entry.operation === 'first' && /^\s*SELECT \* FROM adult_accounts WHERE id = \?/i.test(entry.sql)),
-      false,
-      'bootstrap should reuse ensureAccount() row instead of re-reading the adult account',
+      adultAccountReads.length,
+      1,
+      'bootstrap should perform only the ensureAccount() idempotence read for the adult account',
     );
     assert.equal(
       queryLog.some((entry) => entry.operation === 'first' && /SELECT id, account_type, demo_expires_at\s+FROM adult_accounts\s+WHERE id = \?/i.test(entry.sql)),

--- a/tests/worker-cron-retention-sweep.test.js
+++ b/tests/worker-cron-retention-sweep.test.js
@@ -214,6 +214,24 @@ test('sweepLearnerActivityFeed prunes stale duplicate activity rows', async () =
   }
 });
 
+test('sweepLearnerActivityFeed uses the updated_at retention index', async () => {
+  const db = createMigratedSqliteD1Database();
+  try {
+    const plan = db.db.prepare(`
+      EXPLAIN QUERY PLAN
+      SELECT rowid
+      FROM learner_activity_feed
+      WHERE updated_at < ?
+      LIMIT ?
+    `).all(0, 5000);
+    const detail = plan.map((row) => row.detail).join('\n');
+    assert.match(detail, /idx_learner_activity_feed_updated/);
+    assert.doesNotMatch(detail, /SCAN learner_activity_feed\b/);
+  } finally {
+    db.close();
+  }
+});
+
 test('U11 runRetentionSweeps aggregates per-sweep deletion counts', async () => {
   const db = createMigratedSqliteD1Database();
   try {

--- a/tests/worker-cron-retention-sweep.test.js
+++ b/tests/worker-cron-retention-sweep.test.js
@@ -10,7 +10,11 @@ import { createMigratedSqliteD1Database } from './helpers/sqlite-d1.js';
 import {
   MUTATION_RECEIPT_RETENTION_MS,
   REQUEST_LIMITS_RETENTION_MS,
+  PRACTICE_SESSION_RETENTION_MS,
+  LEARNER_ACTIVITY_FEED_RETENTION_MS,
   sweepMutationReceipts,
+  sweepPracticeSessions,
+  sweepLearnerActivityFeed,
   sweepRequestLimits,
   sweepStaleSessions,
   runRetentionSweeps,
@@ -82,6 +86,35 @@ function seedRequestLimit(db, { limiterKey, windowStartedAt }) {
   `).run(limiterKey, windowStartedAt, windowStartedAt);
 }
 
+function seedLearner(db, { id = 'learner-a', now = 1 } = {}) {
+  db.db.prepare(`
+    INSERT OR IGNORE INTO learner_profiles (
+      id, name, year_group, avatar_color, goal, daily_minutes, created_at, updated_at, state_revision
+    )
+    VALUES (?, 'Learner A', 'Y5', '#3E6FA8', 'sats', 15, ?, ?, 0)
+  `).run(id, now, now);
+}
+
+function seedPracticeSession(db, { id, learnerId = 'learner-a', status, updatedAt }) {
+  db.db.prepare(`
+    INSERT INTO practice_sessions (
+      id, learner_id, subject_id, session_kind, status,
+      session_state_json, summary_json, created_at, updated_at, updated_by_account_id
+    )
+    VALUES (?, ?, 'spelling', 'smart', ?, '{}', '{}', ?, ?, NULL)
+  `).run(id, learnerId, status, updatedAt, updatedAt);
+}
+
+function seedActivityFeed(db, { id, learnerId = 'learner-a', updatedAt }) {
+  db.db.prepare(`
+    INSERT INTO learner_activity_feed (
+      id, learner_id, subject_id, activity_type, activity_json,
+      source_event_id, created_at, updated_at
+    )
+    VALUES (?, ?, 'spelling', 'reward', '{}', NULL, ?, ?)
+  `).run(id, learnerId, updatedAt, updatedAt);
+}
+
 function rowCount(db, sql, params = []) {
   return Number(db.db.prepare(sql).get(...params)?.count || 0);
 }
@@ -145,23 +178,64 @@ test('U11 sweepStaleSessions removes expired sessions whose revision is below cu
   }
 });
 
+test('sweepPracticeSessions prunes old completed and abandoned sessions but keeps active resume state', async () => {
+  const db = createMigratedSqliteD1Database();
+  try {
+    const now = 1_700_000_000_000;
+    seedLearner(db, { now });
+    seedPracticeSession(db, { id: 'old-completed', status: 'completed', updatedAt: now - PRACTICE_SESSION_RETENTION_MS - 1 });
+    seedPracticeSession(db, { id: 'old-abandoned', status: 'abandoned', updatedAt: now - PRACTICE_SESSION_RETENTION_MS - 2 });
+    seedPracticeSession(db, { id: 'old-active', status: 'active', updatedAt: now - PRACTICE_SESSION_RETENTION_MS - 3 });
+    seedPracticeSession(db, { id: 'fresh-completed', status: 'completed', updatedAt: now - 1000 });
+
+    const result = await sweepPracticeSessions(db, now);
+    assert.equal(result.deleted, 2);
+    const remaining = db.db.prepare('SELECT id FROM practice_sessions ORDER BY id').all().map((row) => row.id);
+    assert.deepEqual(remaining, ['fresh-completed', 'old-active']);
+  } finally {
+    db.close();
+  }
+});
+
+test('sweepLearnerActivityFeed prunes stale duplicate activity rows', async () => {
+  const db = createMigratedSqliteD1Database();
+  try {
+    const now = 1_700_000_000_000;
+    seedLearner(db, { now });
+    seedActivityFeed(db, { id: 'old-activity', updatedAt: now - LEARNER_ACTIVITY_FEED_RETENTION_MS - 1 });
+    seedActivityFeed(db, { id: 'fresh-activity', updatedAt: now - 1000 });
+
+    const result = await sweepLearnerActivityFeed(db, now);
+    assert.equal(result.deleted, 1);
+    const remaining = db.db.prepare('SELECT id FROM learner_activity_feed ORDER BY id').all().map((row) => row.id);
+    assert.deepEqual(remaining, ['fresh-activity']);
+  } finally {
+    db.close();
+  }
+});
+
 test('U11 runRetentionSweeps aggregates per-sweep deletion counts', async () => {
   const db = createMigratedSqliteD1Database();
   try {
     const now = 1_700_000_000_000;
     seedAdultAccount(db, { id: 'adult-a', now });
     seedOpsMetadata(db, { accountId: 'adult-a', now, statusRevision: 3 });
+    seedLearner(db, { now });
     seedMutationReceipt(db, { requestId: 'req-old', appliedAt: now - MUTATION_RECEIPT_RETENTION_MS - 1 });
     seedRequestLimit(db, { limiterKey: 'old', windowStartedAt: now - REQUEST_LIMITS_RETENTION_MS - 1 });
     seedSession(db, { id: 'sess-stale', accountId: 'adult-a', expiresAt: now - 1, revisionAtIssue: 0 });
+    seedPracticeSession(db, { id: 'practice-old', status: 'completed', updatedAt: now - PRACTICE_SESSION_RETENTION_MS - 1 });
+    seedActivityFeed(db, { id: 'activity-old', updatedAt: now - LEARNER_ACTIVITY_FEED_RETENTION_MS - 1 });
 
     const result = await runRetentionSweeps(db, now);
-    assert.equal(result.totalDeleted, 3);
+    assert.equal(result.totalDeleted, 5);
     const byName = Object.create(null);
     for (const entry of result.completed) byName[entry.sweep] = entry.deleted;
     assert.equal(byName.mutation_receipts, 1);
     assert.equal(byName.request_limits, 1);
     assert.equal(byName.account_sessions, 1);
+    assert.equal(byName.practice_sessions, 1);
+    assert.equal(byName.learner_activity_feed, 1);
   } finally {
     db.close();
   }

--- a/tests/worker-demo-session.test.js
+++ b/tests/worker-demo-session.test.js
@@ -397,7 +397,7 @@ test('demo commands and Parent Hub reads are rate limited by session', async () 
   const sessionId = server.DB.db.prepare('SELECT id FROM account_sessions WHERE account_id = ?').get(accountId)?.id;
   assert.ok(sessionId);
 
-  await seedRateLimit(server, 'demo-command-session', sessionId, 120);
+  await seedRateLimit(server, 'demo-command-account-session', `${accountId}:${sessionId}`, 120);
   const commandResponse = await postJson(server, '/api/subjects/spelling/command', {
     command: 'check-word-bank-drill',
     learnerId,

--- a/tests/worker-grammar-subject-runtime.test.js
+++ b/tests/worker-grammar-subject-runtime.test.js
@@ -187,7 +187,7 @@ test('worker subject runtime starts Grammar trouble drills against weak concepts
   assert.ok(result.subjectReadModel.session.currentItem.skillIds.includes('adverbials'));
 });
 
-test('Grammar command route persists subject state, practice session, and events', async () => {
+test('Grammar command route persists subject state, practice session, and response events', async () => {
   const DB = createMigratedSqliteD1Database();
   const app = createWorkerApp({ now: () => 1_777_000_000_000 });
   const sample = readGrammarLegacyOracle().templates.find((template) => template.id === 'question_mark_select');
@@ -243,7 +243,7 @@ test('Grammar command route persists subject state, practice session, and events
   assert.equal(data.mastery.concepts.sentence_functions.attempts, 1);
   assert.equal(data.mastery.concepts.speech_punctuation.attempts, 1);
   assert.equal(DB.db.prepare("SELECT COUNT(*) AS count FROM practice_sessions WHERE subject_id = 'grammar'").get().count, 1);
-  assert.equal(DB.db.prepare("SELECT COUNT(*) AS count FROM event_log WHERE subject_id = 'grammar' AND event_type = 'grammar.answer-submitted'").get().count, 1);
+  assert.equal(DB.db.prepare("SELECT COUNT(*) AS count FROM event_log WHERE subject_id = 'grammar' AND event_type = 'grammar.answer-submitted'").get().count, 0);
 
   const summary = await postCommand(app, DB, {
     command: 'continue-session',
@@ -309,7 +309,7 @@ test('Grammar command route saves manual-review-only responses without scored ev
   assert.equal(data.mastery.concepts.noun_phrases?.attempts || 0, 0);
   assert.equal(data.retryQueue.length, 0);
   assert.equal(DB.db.prepare("SELECT COUNT(*) AS count FROM event_log WHERE subject_id = 'grammar' AND event_type = 'grammar.answer-submitted'").get().count, 0);
-  assert.equal(DB.db.prepare("SELECT COUNT(*) AS count FROM event_log WHERE subject_id = 'grammar' AND event_type = 'grammar.manual-review-saved'").get().count, 1);
+  assert.equal(DB.db.prepare("SELECT COUNT(*) AS count FROM event_log WHERE subject_id = 'grammar' AND event_type = 'grammar.manual-review-saved'").get().count, 0);
 
   DB.close();
 });

--- a/tests/worker-projections.test.js
+++ b/tests/worker-projections.test.js
@@ -147,14 +147,21 @@ test('spelling command projection applies monster rewards and returns celebratio
 
     assert.ok(secureSubmit, 'the fourth round should emit a secure-word event');
     assert.ok(secureSubmit.body.domainEvents.some((event) => event.type === 'spelling.word-secured'));
-    assert.ok(secureSubmit.body.reactionEvents.some((event) => (
+    const caughtRewardEvent = secureSubmit.body.reactionEvents.find((event) => (
       event.type === 'reward.monster'
       && event.kind === 'caught'
       && event.monsterId === 'inklet'
-    )));
+    ));
+    assert.ok(caughtRewardEvent);
     assert.ok(secureSubmit.body.toastEvents.some((event) => event.monsterId === 'inklet'));
     assert.equal(secureSubmit.body.projections.rewards.systemId, 'monster-codex');
     assert.ok(secureSubmit.body.projections.rewards.state.inklet.mastered.includes('possess'));
+    const rewardCapacity = secureSubmit.body.meta?.capacity;
+    assert.ok(rewardCapacity, 'reward command response must include capacity metadata');
+    assert.ok(
+      rewardCapacity.d1RowsWritten <= 6,
+      `reward command should avoid duplicate history writes; got ${rewardCapacity.d1RowsWritten}`,
+    );
 
     const gameRow = harness.DB.db.prepare(`
       SELECT state_json
@@ -164,12 +171,12 @@ test('spelling command projection applies monster rewards and returns celebratio
     const gameState = JSON.parse(gameRow.state_json);
     assert.ok(gameState.inklet.mastered.includes('possess'));
 
-    const rewardCount = harness.DB.db.prepare(`
+    const rewardHistoryCount = harness.DB.db.prepare(`
       SELECT COUNT(*) AS count
       FROM event_log
       WHERE learner_id = 'learner-a' AND event_type = 'reward.monster'
     `).get().count;
-    assert.equal(rewardCount, 1);
+    assert.equal(rewardHistoryCount, 0);
     const readModelRow = harness.DB.db.prepare(`
       SELECT model_json, source_revision
       FROM learner_read_models
@@ -180,17 +187,18 @@ test('spelling command projection applies monster rewards and returns celebratio
     const readModel = JSON.parse(readModelRow.model_json);
     assert.equal(readModel.rewards.systemId, 'monster-codex');
     assert.ok(readModel.rewards.state.inklet.mastered.includes('possess'));
+    assert.ok(readModel.recentEventTokens.includes(caughtRewardEvent.id));
     assert.ok(readModelRow.source_revision >= secureSubmit.body.mutation.appliedRevision);
 
     const replay = await harness.postRaw(secureSubmit.requestBody);
     assert.equal(replay.response.status, 200);
     assert.equal(replay.body.mutation.replayed, true);
-    const rewardCountAfterReplay = harness.DB.db.prepare(`
+    const rewardHistoryCountAfterReplay = harness.DB.db.prepare(`
       SELECT COUNT(*) AS count
       FROM event_log
       WHERE learner_id = 'learner-a' AND event_type = 'reward.monster'
     `).get().count;
-    assert.equal(rewardCountAfterReplay, rewardCount);
+    assert.equal(rewardHistoryCountAfterReplay, rewardHistoryCount);
   } finally {
     harness.close();
   }
@@ -262,7 +270,19 @@ test('spelling command projection emits requested monster celebration replays on
         AND id LIKE 'reward.monster.replay:%'
       ORDER BY created_at ASC, id ASC
     `).all();
-    assert.deepEqual(replayRows.map((row) => row.id), firstReplayEvents.map((event) => event.id));
+    assert.deepEqual(replayRows.map((row) => row.id), []);
+
+    const readModelRow = harness.DB.db.prepare(`
+      SELECT model_json
+      FROM learner_read_models
+      WHERE learner_id = 'learner-a'
+        AND model_key = 'command.projection.v1'
+    `).get();
+    const readModel = JSON.parse(readModelRow.model_json);
+    assert.deepEqual(
+      firstReplayEvents.map((event) => readModel.recentEventTokens.includes(event.id)),
+      [true, true],
+    );
 
     const secondCompletion = await completePossessRound(harness);
     assert.equal(

--- a/tests/worker-read-model-capacity.test.js
+++ b/tests/worker-read-model-capacity.test.js
@@ -54,7 +54,8 @@ test('capacity read-model migration creates indexed summary and activity stores'
         'idx_learner_read_models_key_updated',
         'idx_learner_activity_feed_source_event',
         'idx_learner_activity_feed_learner_created',
-        'idx_learner_activity_feed_subject_created'
+        'idx_learner_activity_feed_subject_created',
+        'idx_learner_activity_feed_updated'
       )
     ORDER BY name
   `).all();
@@ -64,6 +65,7 @@ test('capacity read-model migration creates indexed summary and activity stores'
     'idx_learner_activity_feed_learner_created',
     'idx_learner_activity_feed_source_event',
     'idx_learner_activity_feed_subject_created',
+    'idx_learner_activity_feed_updated',
     'idx_learner_read_models_key_updated',
   ]);
 

--- a/tests/worker-subject-runtime.test.js
+++ b/tests/worker-subject-runtime.test.js
@@ -386,6 +386,16 @@ test('worker subject command route validates auth, same-origin, and handler avai
   const replayPayload = await replay.json();
   assert.equal(replay.status, 200);
   assert.equal(replayPayload.mutation.replayed, true);
+  assert.equal(replayPayload.replayRequiresRefresh, true);
+  assert.equal(replayPayload.subjectReadModel, undefined);
+  const storedReceipt = DB.db.prepare('SELECT response_json FROM mutation_receipts WHERE request_id = ?').get('cmd-2');
+  assert.ok(storedReceipt, 'subject command receipt must be stored');
+  assert.ok(storedReceipt.response_json.length < 512, `receipt response should be compact, saw ${storedReceipt.response_json.length} bytes`);
+  const storedReplay = JSON.parse(storedReceipt.response_json);
+  assert.equal(storedReplay.replayRequiresRefresh, true);
+  assert.equal(storedReplay.subjectId, 'spelling');
+  assert.equal(storedReplay.command, 'start-session');
+  assert.equal(storedReplay.subjectReadModel, undefined);
 
   const missing = await app.fetch(new Request('https://repo.test/api/subjects/spelling/command', {
     method: 'POST',
@@ -479,7 +489,7 @@ test('subject command replay requires current learner write access', async () =>
   DB.close();
 });
 
-test('subject command writes roll back as one D1 batch without a transaction feature flag', async () => {
+test('subject command keeps runtime events in projection memory without appending event_log rows', async () => {
   const DB = createMigratedSqliteD1Database();
   delete DB.supportsSqlTransactions;
   const runtime = createSubjectRuntime({
@@ -535,10 +545,12 @@ test('subject command writes roll back as one D1 batch without a transaction fea
     }),
   }), env, {});
 
-  assert.equal(response.status, 500);
-  assert.equal(DB.db.prepare('SELECT state_revision FROM learner_profiles WHERE id = ?').get('learner-a').state_revision, 0);
-  assert.equal(DB.db.prepare('SELECT COUNT(*) AS count FROM child_subject_state WHERE learner_id = ?').get('learner-a').count, 0);
-  assert.equal(DB.db.prepare('SELECT COUNT(*) AS count FROM mutation_receipts WHERE request_id = ?').get('cmd-atomic-failure').count, 0);
+  assert.equal(response.status, 200, await response.text());
+  assert.equal(DB.db.prepare('SELECT state_revision FROM learner_profiles WHERE id = ?').get('learner-a').state_revision, 1);
+  assert.equal(DB.db.prepare('SELECT COUNT(*) AS count FROM child_subject_state WHERE learner_id = ?').get('learner-a').count, 1);
+  assert.equal(DB.db.prepare('SELECT COUNT(*) AS count FROM event_log WHERE id = ?').get('bad-event').count, 0);
+  assert.equal(DB.db.prepare('SELECT COUNT(*) AS count FROM learner_activity_feed').get().count, 0);
+  assert.equal(DB.db.prepare('SELECT COUNT(*) AS count FROM mutation_receipts WHERE request_id = ?').get('cmd-atomic-failure').count, 1);
 
   DB.close();
 });

--- a/worker/migrations/0016_activity_feed_retention_index.sql
+++ b/worker/migrations/0016_activity_feed_retention_index.sql
@@ -1,0 +1,5 @@
+-- Support bounded learner_activity_feed retention sweeps without scanning the
+-- full table. The table is a rollout-drain store on the subject-command path,
+-- so cleanup must be indexed by the same timestamp predicate used by cron.
+CREATE INDEX IF NOT EXISTS idx_learner_activity_feed_updated
+  ON learner_activity_feed(updated_at);

--- a/worker/src/cron/retention-sweep.js
+++ b/worker/src/cron/retention-sweep.js
@@ -25,6 +25,10 @@ export const MUTATION_RECEIPT_MAX_DELETE_BATCH = 5000;
 export const REQUEST_LIMITS_RETENTION_MS = 24 * 60 * 60 * 1000; // 24 hours
 export const REQUEST_LIMITS_MAX_DELETE_BATCH = 5000;
 export const ACCOUNT_SESSIONS_MAX_DELETE_BATCH = 5000;
+export const PRACTICE_SESSION_RETENTION_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+export const PRACTICE_SESSIONS_MAX_DELETE_BATCH = 5000;
+export const LEARNER_ACTIVITY_FEED_RETENTION_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+export const LEARNER_ACTIVITY_FEED_MAX_DELETE_BATCH = 5000;
 // P3 U4: request denials retention — 14-day rolling window.
 export const REQUEST_DENIALS_RETENTION_MS = 14 * 24 * 60 * 60 * 1000; // 14 days
 export const REQUEST_DENIALS_MAX_DELETE_BATCH = 5000;
@@ -142,6 +146,51 @@ export async function sweepStaleSessions(db, now = Date.now()) {
 }
 
 /**
+ * Prune old completed or abandoned practice sessions while preserving active
+ * sessions for in-progress resume. Parent Hub recent history is intentionally
+ * bounded; the source-of-truth subject state remains in child_subject_state.
+ */
+export async function sweepPracticeSessions(db, now = Date.now()) {
+  const cutoff = Math.max(0, Number(now) || 0) - PRACTICE_SESSION_RETENTION_MS;
+  try {
+    const result = await run(db, `
+      DELETE FROM practice_sessions
+      WHERE rowid IN (
+        SELECT rowid FROM practice_sessions
+        WHERE status IN ('completed', 'abandoned')
+          AND updated_at < ?
+        LIMIT ?
+      )
+    `, [cutoff, PRACTICE_SESSIONS_MAX_DELETE_BATCH]);
+    return { deleted: Math.max(0, Number(result?.meta?.changes) || 0) };
+  } catch (error) {
+    return swallowMissingTable(error, 'practice_sessions');
+  }
+}
+
+/**
+ * Prune the duplicate public activity feed after the command path stops
+ * writing new rows. Old rows remain available briefly during rollout, then
+ * drain without touching source-of-truth progress or error records.
+ */
+export async function sweepLearnerActivityFeed(db, now = Date.now()) {
+  const cutoff = Math.max(0, Number(now) || 0) - LEARNER_ACTIVITY_FEED_RETENTION_MS;
+  try {
+    const result = await run(db, `
+      DELETE FROM learner_activity_feed
+      WHERE rowid IN (
+        SELECT rowid FROM learner_activity_feed
+        WHERE updated_at < ?
+        LIMIT ?
+      )
+    `, [cutoff, LEARNER_ACTIVITY_FEED_MAX_DELETE_BATCH]);
+    return { deleted: Math.max(0, Number(result?.meta?.changes) || 0) };
+  } catch (error) {
+    return swallowMissingTable(error, 'learner_activity_feed');
+  }
+}
+
+/**
  * P3 U4: prune stale request denials. 14-day rolling window, bounded-
  * delete (5000-row cap), `swallowMissingTable` pattern. The table may
  * not exist on instances that have not yet applied migration 0013.
@@ -164,7 +213,7 @@ export async function sweepRequestDenials(db, now = Date.now()) {
 }
 
 /**
- * Run all four sweeps sequentially and return an aggregated summary.
+ * Run all retention sweeps sequentially and return an aggregated summary.
  * A sweep failure aborts the remainder so the failure surfaces in the
  * cron's error telemetry; partial successes are reported via the
  * `completed` array.
@@ -177,6 +226,10 @@ export async function runRetentionSweeps(db, now = Date.now()) {
   completed.push({ sweep: 'request_limits', ...requestLimits });
   const sessions = await sweepStaleSessions(db, now);
   completed.push({ sweep: 'account_sessions', ...sessions });
+  const practiceSessions = await sweepPracticeSessions(db, now);
+  completed.push({ sweep: 'practice_sessions', ...practiceSessions });
+  const activityFeed = await sweepLearnerActivityFeed(db, now);
+  completed.push({ sweep: 'learner_activity_feed', ...activityFeed });
   const denials = await sweepRequestDenials(db, now);
   completed.push({ sweep: 'admin_request_denials', ...denials });
   return {

--- a/worker/src/demo/sessions.js
+++ b/worker/src/demo/sessions.js
@@ -132,14 +132,14 @@ function demoSessionIdentifier(session = {}) {
   return cleanText(session.sessionId || session.sessionHash || session.accountId) || 'unknown-demo-session';
 }
 
-export async function protectDemoSubjectCommand({ env, request, session, command, now = Date.now(), capacity = null } = {}) {
+export async function protectDemoSubjectCommand({ env, request, session, now = Date.now(), capacity = null } = {}) {
   if (!session?.demo) return;
   // U3 round 1 (P1 #03): wrap the D1 handle when a capacity collector
   // is supplied so every rate-limit query and the demo-active guard are
   // counted. Previously 5+ queries per command bypassed the proxy.
   const db = requireDatabaseWithCapacity(env, capacity);
   await requireActiveDemoAccount(db, session.accountId, now);
-  const commandType = cleanText(`${command?.subjectId || 'subject'}:${command?.command || 'unknown'}`);
+  const accountSession = `${session.accountId}:${demoSessionIdentifier(session)}`;
   await enforceDemoRateLimit(db, [
     {
       bucket: 'demo-command-ip',
@@ -147,19 +147,9 @@ export async function protectDemoSubjectCommand({ env, request, session, command
       limit: DEMO_LIMITS.commandIp,
     },
     {
-      bucket: 'demo-command-account',
-      identifier: session.accountId,
-      limit: DEMO_LIMITS.commandAccount,
-    },
-    {
-      bucket: 'demo-command-session',
-      identifier: demoSessionIdentifier(session),
+      bucket: 'demo-command-account-session',
+      identifier: accountSession,
       limit: DEMO_LIMITS.commandSession,
-    },
-    {
-      bucket: 'demo-command-type',
-      identifier: `${session.accountId}:${commandType}`,
-      limit: DEMO_LIMITS.commandType,
     },
   ], now, 'Too many demo practice requests. Please wait a few minutes and try again.');
 }

--- a/worker/src/repository.js
+++ b/worker/src/repository.js
@@ -628,20 +628,65 @@ function storeMutationReceiptStatement(db, {
   `, exists ? guardedExistsParams(params, exists) : guardedParams(params, guard));
 }
 
+function subjectCommandReceiptResponse(response = {}, {
+  learnerId = null,
+  subjectId = null,
+  command = null,
+} = {}) {
+  const mutation = response?.mutation && typeof response.mutation === 'object' && !Array.isArray(response.mutation)
+    ? response.mutation
+    : {};
+  return {
+    receiptVersion: 1,
+    replayRequiresRefresh: true,
+    learnerId: response?.learnerId || learnerId || mutation.scopeId || null,
+    subjectId: response?.subjectId || subjectId || null,
+    command: response?.command || command || null,
+    changed: response?.changed !== false,
+    mutation,
+  };
+}
+
 async function ensureAccount(db, session, nowTs) {
-  const platformRole = normalisePlatformRole(session?.platformRole);
-  // U6 queryCount budget: RETURNING * folds the post-write SELECT into
-  // the UPSERT so per-command ensureAccount runs a single query.
+  const existing = await first(db, 'SELECT * FROM adult_accounts WHERE id = ?', [session.accountId]);
+  const sessionPlatformRole = typeof session?.platformRole === 'string' && session.platformRole
+    ? normalisePlatformRole(session.platformRole)
+    : null;
+  if (!existing) {
+    return first(db, `
+      INSERT INTO adult_accounts (id, email, display_name, platform_role, selected_learner_id, created_at, updated_at)
+      VALUES (?, ?, ?, ?, NULL, ?, ?)
+      RETURNING *
+    `, [
+      session.accountId,
+      session.email || null,
+      session.displayName || null,
+      sessionPlatformRole || 'parent',
+      nowTs,
+      nowTs,
+    ]);
+  }
+
+  const nextEmail = session?.email || existing.email || null;
+  const nextDisplayName = session?.displayName || existing.display_name || null;
+  const nextPlatformRole = sessionPlatformRole || existing.platform_role || 'parent';
+  if (
+    (existing.email || null) === nextEmail
+    && (existing.display_name || null) === nextDisplayName
+    && (existing.platform_role || 'parent') === nextPlatformRole
+  ) {
+    return existing;
+  }
+
   return first(db, `
-    INSERT INTO adult_accounts (id, email, display_name, platform_role, selected_learner_id, created_at, updated_at)
-    VALUES (?, ?, ?, ?, NULL, ?, ?)
-    ON CONFLICT(id) DO UPDATE SET
-      email = COALESCE(excluded.email, adult_accounts.email),
-      display_name = COALESCE(excluded.display_name, adult_accounts.display_name),
-      platform_role = COALESCE(excluded.platform_role, adult_accounts.platform_role),
-      updated_at = excluded.updated_at
+    UPDATE adult_accounts
+    SET email = ?,
+        display_name = ?,
+        platform_role = ?,
+        updated_at = ?
+    WHERE id = ?
     RETURNING *
-  `, [session.accountId, session.email, session.displayName, platformRole, nowTs, nowTs]);
+  `, [nextEmail, nextDisplayName, nextPlatformRole, nowTs, session.accountId]);
 }
 
 // listMembershipRows, getMembership, requireLearnerWriteAccess,
@@ -7724,8 +7769,14 @@ function uniqueStringList(value) {
     .filter((entry) => typeof entry === 'string' && entry))];
 }
 
-async function readLearnerEventLogEvents(db, accountId, learnerId, { ids = [], eventTypes = [] } = {}) {
-  await requireLearnerWriteAccess(db, accountId, learnerId);
+async function readLearnerEventLogEvents(db, accountId, learnerId, {
+  ids = [],
+  eventTypes = [],
+  skipAccessCheck = false,
+} = {}) {
+  if (!skipAccessCheck) {
+    await requireLearnerWriteAccess(db, accountId, learnerId);
+  }
   const safeIds = uniqueStringList(ids);
   const safeEventTypes = uniqueStringList(eventTypes);
   if (!safeIds.length && !safeEventTypes.length) return [];
@@ -7792,6 +7843,8 @@ function guardedWhere(guard) {
 function buildSubjectRuntimePersistencePlan(db, accountId, learnerId, subjectId, runtime, nowTs, {
   guard = null,
   includeCapacityReadModels = true,
+  persistEventLog = true,
+  persistActivityFeed = true,
   // U6: caller passes the projection input it already loaded so the
   // persisted token ring inherits the prior `recentEventTokens` set and
   // any non-v1 fields from a newer writer are preserved rather than
@@ -7932,38 +7985,40 @@ function buildSubjectRuntimePersistencePlan(db, accountId, learnerId, subjectId,
     event.subjectId = event.subjectId || subjectId;
     event.createdAt = createdAt;
     persistedEvents.push(event);
-    const eventParams = [
-      id,
-      event.learnerId,
-      event.subjectId || null,
-      event.systemId || null,
-      eventType,
-      JSON.stringify(event),
-      createdAt,
-      accountId,
-    ];
-    statements.push(bindStatement(db, `
-      INSERT INTO event_log (id, learner_id, subject_id, system_id, event_type, event_json, created_at, actor_account_id)
-      ${guardedValueSource(eventParams.length, guard)}
-      ON CONFLICT(id) DO UPDATE SET
-        learner_id = excluded.learner_id,
-        subject_id = excluded.subject_id,
-        system_id = excluded.system_id,
-        event_type = excluded.event_type,
-        event_json = excluded.event_json,
-        created_at = excluded.created_at,
-        actor_account_id = excluded.actor_account_id
-    `, guardedParams(eventParams, guard)));
-    const activityRow = activityFeedRowFromEventRecord(event, {
-      id,
-      learnerId: event.learnerId,
-      subjectId: event.subjectId || null,
-      systemId: event.systemId || null,
-      eventType,
-      createdAt,
-      now: nowTs,
-    });
-    if (includeCapacityReadModels) {
+    if (persistEventLog) {
+      const eventParams = [
+        id,
+        event.learnerId,
+        event.subjectId || null,
+        event.systemId || null,
+        eventType,
+        JSON.stringify(event),
+        createdAt,
+        accountId,
+      ];
+      statements.push(bindStatement(db, `
+        INSERT INTO event_log (id, learner_id, subject_id, system_id, event_type, event_json, created_at, actor_account_id)
+        ${guardedValueSource(eventParams.length, guard)}
+        ON CONFLICT(id) DO UPDATE SET
+          learner_id = excluded.learner_id,
+          subject_id = excluded.subject_id,
+          system_id = excluded.system_id,
+          event_type = excluded.event_type,
+          event_json = excluded.event_json,
+          created_at = excluded.created_at,
+          actor_account_id = excluded.actor_account_id
+      `, guardedParams(eventParams, guard)));
+    }
+    if (includeCapacityReadModels && persistActivityFeed) {
+      const activityRow = activityFeedRowFromEventRecord(event, {
+        id,
+        learnerId: event.learnerId,
+        subjectId: event.subjectId || null,
+        systemId: event.systemId || null,
+        eventType,
+        createdAt,
+        now: nowTs,
+      });
       const activityStatement = bindLearnerActivityFeedUpsertStatement(db, activityRow, { guard });
       if (activityStatement) statements.push(activityStatement);
     }
@@ -8287,11 +8342,12 @@ async function runSubjectCommandMutation(db, {
         nowTs,
         {
           guard: attemptGuard,
-          // When includeProjection is false we still need capacity read
-          // models for the rest of the persistence plan (subject state,
-          // practice session, event log, activity feed); the plan only
-          // omits the projection read-model write itself.
+          // When includeProjection is false we still persist source-of-truth
+          // state and receipts. Normal event/activity history remains off on
+          // the subject command hot path.
           includeCapacityReadModels,
+          persistEventLog: false,
+          persistActivityFeed: false,
           projectionContext: includeProjection ? freshProjectionContext : null,
           skipProjectionReadModelWrite: !includeProjection,
           currentActiveSessionId: freshRuntimeWrite.previousActiveSessionId || null,
@@ -8306,7 +8362,11 @@ async function runSubjectCommandMutation(db, {
       scopeId: command.learnerId,
       mutationKind: kind,
       requestHash,
-      response: attemptResponse,
+      response: subjectCommandReceiptResponse(attemptResponse, {
+        learnerId: command.learnerId,
+        subjectId: command.subjectId,
+        command: command.command,
+      }),
       correlationId: nextMutation.correlationId,
       appliedAt: nowTs,
     }, { guard: attemptGuard }));

--- a/worker/src/subjects/spelling/commands.js
+++ b/worker/src/subjects/spelling/commands.js
@@ -54,7 +54,10 @@ async function replayContextEvents(context, learnerId) {
   const replayRequests = await context.repository.readLearnerEventLogEvents(
     context.session.accountId,
     learnerId,
-    { eventTypes: [MONSTER_CELEBRATION_REPLAY_REQUEST_TYPE] },
+    {
+      eventTypes: [MONSTER_CELEBRATION_REPLAY_REQUEST_TYPE],
+      skipAccessCheck: true,
+    },
   );
   const { sourceIds, replayIds } = monsterCelebrationReplayReferenceIds(replayRequests, {
     learnerId,
@@ -65,7 +68,10 @@ async function replayContextEvents(context, learnerId) {
   const referenceEvents = await context.repository.readLearnerEventLogEvents(
     context.session.accountId,
     learnerId,
-    { ids: referenceIds },
+    {
+      ids: referenceIds,
+      skipAccessCheck: true,
+    },
   );
   return [...replayRequests, ...referenceEvents];
 }


### PR DESCRIPTION
# D1 write-amplification hardening completion report

Date: 2026-05-31
Production URL: `https://ks2.eugnel.uk`
Branch: `codex/d1-write-amplification-hardening`
Status: implementation locally verified and prepared for PR; production deployment and backup-first cleanup still require the release gate.

## Root cause

The D1 pressure was not caused by true error logging. It came from normal-operation write amplification on the subject-command hot path:

- Subject command receipts could store full read-model payloads.
- Normal gameplay events were written as append-only `event_log` history.
- The same public activity signal could also be duplicated into `learner_activity_feed`.
- Completed and abandoned `practice_sessions` were retained without a product-level bound.
- Existing authenticated reads could still take a write-capable account path even when the account row was unchanged.

This repeated the same class of problem as the earlier D1 quota incident: useful current state was mixed with large or redundant history, so ordinary play could grow D1 without a matching player-experience benefit.

## Remediation

- Kept source-of-truth player writes: `child_subject_state`, active/recent `practice_sessions`, `child_game_state`, `learner_read_models`, mutation revision metadata, and real error/audit records.
- Changed subject command receipts to compact replay metadata. Duplicate request IDs now return `replayRequiresRefresh: true`; the browser hydrates before applying the replay marker.
- Stopped normal subject commands from appending gameplay events to `event_log`.
- Stopped normal subject commands from writing duplicate `learner_activity_feed` rows.
- Preserved monster reward and replay dedupe through the projection read model's `recentEventTokens` ring.
- Added retention sweeps for stale completed/abandoned `practice_sessions` and stale `learner_activity_feed` rows.
- Collapsed demo command rate-limit fanout from four D1 buckets to two.
- Changed `ensureAccount` to read-first and write only when a row is missing or materially changed.

## Player experience contract

This is not a no-write design. Changed gameplay commands still write the state needed for progress, resume, reload, rewards, cross-device sync, and stale-write protection. The removed writes are redundant normal-history writes and full response archives.

Immediate command responses still return the full read model used by the UI. Only stored idempotency receipts are compact. On a duplicate replay, the client refreshes repositories before applying the compact replay marker, so the visible state remains current.

## Local verification

- `node --test tests/subject-command-client.test.js tests/worker-subject-runtime.test.js tests/worker-cron-retention-sweep.test.js tests/worker-query-budget.test.js tests/worker-projections.test.js tests/worker-projection-hot-path-read.test.js tests/worker-projection-hot-path-write.test.js tests/worker-demo-session.test.js`
  - Result: 95 tests passed, 0 failed.
  - Evidence included pure read `check-word-bank-drill` responses with `d1RowsWritten: 0`.
  - Reward command coverage proved `child_game_state` and projection tokens update while `event_log` and `learner_activity_feed` stay unchanged.
  - Compact subject command receipts were asserted below 512 bytes and without `subjectReadModel`.
- `node --test tests/punctuation-release-smoke.test.js tests/server-spelling-engine-parity.test.js tests/worker-bootstrap-capacity.test.js tests/worker-grammar-subject-runtime.test.js`
  - Result: 54 tests passed, 0 failed.
  - Evidence covered legacy tests whose old assertions expected append-only gameplay history.
- `npm test`
  - Result: 111633 tests passed, 0 failed, 12 skipped.
  - Log: `%TEMP%\ks2-npm-test-d1-hardening.log`.
- `npm run check`
  - Result: passed.
  - Includes Worker dry-run deploy, client build, public-build assertion, Worker bundle build, and client bundle audit.
  - Client bundle audit: 1285 public files, 6 chunks, main bundle 212142 / 232000 gzip bytes.
- `git diff --check`
  - Result: no whitespace errors.

## Browser smoke

- Harness: `node ./tests/helpers/browser-app-server.js --serve-only --port 0 --with-worker-api`.
- Browser driver: `agent-browser --session ks2-d1-smoke-20260531`.
- Flow: `/demo` -> Spelling -> start session -> submit an answer.
- Result: the UI loaded, the Spelling session started, the answer submission returned feedback, and no page errors were reported by `agent-browser errors --clear`.
- Local Worker evidence:
  - Existing demo bootstrap after session creation returned `d1RowsWritten: 0`.
  - `spelling.start-session` wrote 5 D1 rows: `child_subject_state`, `practice_sessions`, `learner_read_models`, compact `mutation_receipts`, and `learner_profiles` revision.
  - `spelling.submit-answer` wrote the same 5 source-of-truth/projection/receipt/revision rows.
  - The statement list for both commands contained no `event_log` write and no `learner_activity_feed` write.
  - Local TTS returned the expected unavailable fallback in this harness; the UI continued with "Audio unavailable" and this is not part of the D1 write path.

## Review closure

Manual LFG review focused on the command receipt replay contract, source-of-truth persistence, removed history writes, retention safety, demo limiter fanout, and old tests that depended on `event_log`. No residual code changes were required after the verification fixes above.

## Production cleanup gate

Cleanup is intentionally not run before deployment. The safe order remains:

1. Run `npm test`.
2. Run `npm run check`.
3. Deploy with `npm run deploy`.
4. Smoke `https://ks2.eugnel.uk` with a logged-in or demo session.
5. Take a remote D1 backup.
6. Run bounded cleanup for stale receipts, stale completed/abandoned sessions, and stale activity feed rows.
7. Record D1 `size_after`, row counts, and live smoke evidence here before closing the production ticket.
