### PR TITLE
Reduce D1 history and grammar payload pressure

### DIFF
--- a/src/subjects/grammar/module.js
+++ b/src/subjects/grammar/module.js
@@ -127,6 +127,39 @@ function setGrammarError(context, message, { learnerId = selectedLearnerId(conte
   }));
 }
 
+function mergeGrammarReadModelPatch(current, incoming, learnerId) {
+  if (!incoming || typeof incoming !== 'object' || Array.isArray(incoming)) {
+    return normaliseGrammarReadModel(current, learnerId);
+  }
+  if (incoming.readModelPatch !== true) {
+    return normaliseGrammarReadModel(incoming, learnerId);
+  }
+
+  const base = normaliseGrammarReadModel(current, learnerId);
+  const merged = {
+    ...base,
+    ...incoming,
+    content: {
+      ...base.content,
+      ...(incoming.content && typeof incoming.content === 'object' && !Array.isArray(incoming.content)
+        ? incoming.content
+        : {}),
+    },
+    analytics: Object.prototype.hasOwnProperty.call(incoming, 'analytics')
+      ? incoming.analytics
+      : base.analytics,
+    capabilities: Object.prototype.hasOwnProperty.call(incoming, 'capabilities')
+      ? incoming.capabilities
+      : base.capabilities,
+    transferLane: Object.prototype.hasOwnProperty.call(incoming, 'transferLane')
+      ? incoming.transferLane
+      : base.transferLane,
+    bank: Object.prototype.hasOwnProperty.call(incoming, 'bank') ? incoming.bank : base.bank,
+    ui: Object.prototype.hasOwnProperty.call(incoming, 'ui') ? incoming.ui : base.ui,
+  };
+  return normaliseGrammarReadModel(merged, learnerId);
+}
+
 function applyRemoteReadModel(context, response, { learnerId } = {}) {
   if (!learnerId) return;
   const responseLearnerId = String(response?.subjectReadModel?.learnerId || learnerId);
@@ -137,11 +170,11 @@ function applyRemoteReadModel(context, response, { learnerId } = {}) {
     context.store.pushToasts(response.projections.rewards.toastEvents);
   }
   if (response?.subjectReadModel) {
-    updateGrammarUiForLearner(context, learnerId, {
-      ...normaliseGrammarReadModel(response.subjectReadModel, learnerId),
+    updateGrammarUiForLearner(context, learnerId, (current) => ({
+      ...mergeGrammarReadModelPatch(current, response.subjectReadModel, learnerId),
       pendingCommand: '',
       error: '',
-    });
+    }));
   } else if (isSelectedLearner) {
     context.store.reloadFromRepositories?.({ preserveRoute: true });
   }

--- a/tests/grammar-engine-validation.test.js
+++ b/tests/grammar-engine-validation.test.js
@@ -19,7 +19,10 @@ import {
   grammarTemplateGeneratorFamilyId,
   serialiseGrammarQuestion,
 } from '../worker/src/subjects/grammar/content.js';
-import { buildGrammarReadModel } from '../worker/src/subjects/grammar/read-models.js';
+import {
+  buildGrammarCommandReadModel,
+  buildGrammarReadModel,
+} from '../worker/src/subjects/grammar/read-models.js';
 import {
   readGrammarLegacyOracle,
   readGrammarQuestionGeneratorBaseline,
@@ -163,6 +166,58 @@ test('Grammar attempt history stores generated variant metadata but keeps read m
   assert.equal(readModel.analytics.recentAttempts[0].response, undefined);
   assert.equal(readModel.analytics.recentAttempts[0].result.answerText, undefined);
   assertNoForbiddenGrammarReadModelKeys(readModel, 'grammar.variantMetadataReadModel');
+});
+
+test('Grammar command read models omit heavy stable fields until the user opens summary surfaces', () => {
+  const state = createInitialGrammarState();
+  state.phase = 'session';
+  state.prefs = { mode: 'smart', roundLength: 5 };
+  state.transferEvidence = {
+    'storm-scene': {
+      latest: {
+        writing: 'A short piece of saved writing.',
+        selfAssessment: [{ key: 'sentence-variety', checked: true }],
+        savedAt: 1_777_000_000_000,
+      },
+      history: [],
+      updatedAt: 1_777_000_000_000,
+    },
+  };
+
+  const full = buildGrammarReadModel({ learnerId: 'learner-a', state, now: 1_777_000_000_000 });
+  const compact = buildGrammarCommandReadModel({
+    command: 'start-session',
+    learnerId: 'learner-a',
+    state,
+    now: 1_777_000_000_000,
+  });
+
+  assert.equal(compact.readModelPatch, true);
+  assert.equal(compact.analytics, undefined);
+  assert.equal(compact.capabilities, undefined);
+  assert.equal(compact.transferLane, undefined);
+  assert.ok(JSON.stringify(compact).length < JSON.stringify(full).length / 2);
+
+  const transferPatch = buildGrammarCommandReadModel({
+    command: 'save-transfer-evidence',
+    learnerId: 'learner-a',
+    state,
+    now: 1_777_000_000_000,
+  });
+  assert.equal(transferPatch.readModelPatch, true);
+  assert.ok(transferPatch.transferLane?.evidence?.length >= 1);
+  assert.equal(transferPatch.analytics, undefined);
+
+  const summaryModel = buildGrammarCommandReadModel({
+    command: 'end-session',
+    learnerId: 'learner-a',
+    state,
+    now: 1_777_000_000_000,
+  });
+  assert.equal(summaryModel.readModelPatch, undefined);
+  assert.ok(Array.isArray(summaryModel.analytics?.concepts));
+  assert.ok(summaryModel.capabilities?.enabledModes?.length > 0);
+  assert.ok(summaryModel.transferLane);
 });
 
 test('Grammar engine rejects empty answers before mastery is mutated', () => {

--- a/tests/react-grammar-surface.test.js
+++ b/tests/react-grammar-surface.test.js
@@ -1439,6 +1439,93 @@ test('Grammar command responses are pinned to the learner that sent them', async
   assert.equal(celebrations.length, 0);
 });
 
+test('Grammar compact command responses patch active session fields without dropping stable dashboard data', async () => {
+  const context = {
+    appState: {
+      learners: { selectedId: 'learner-a' },
+      subjectUi: {
+        grammar: normaliseGrammarReadModel({
+          learnerId: 'learner-a',
+          analytics: {
+            concepts: [{ id: 'clauses', status: 'due', attempts: 7, correct: 5 }],
+          },
+          capabilities: {
+            aiEnrichment: { enabled: false, nonScored: true, kinds: ['explanation'] },
+          },
+          transferLane: {
+            mode: 'non-scored',
+            limits: { maxPrompts: 4, historyPerPrompt: 2, writingCapChars: 2000 },
+            prompts: [{ id: 'storm-scene', title: 'Storm scene', brief: 'Write a scene.' }],
+            evidence: [{
+              promptId: 'storm-scene',
+              latest: {
+                writing: 'Saved writing.',
+                selfAssessment: [{ key: 'sentence-variety', checked: true }],
+                savedAt: 1_777_000_000_000,
+                source: 'transfer-lane',
+              },
+              history: [],
+              updatedAt: 1_777_000_000_000,
+            }],
+          },
+        }, 'learner-a'),
+      },
+    },
+    runtimeReadOnly: false,
+    subjectCommands: {
+      async send() {
+        return {
+          subjectReadModel: {
+            readModelPatch: true,
+            learnerId: 'learner-a',
+            subjectId: 'grammar',
+            version: 1,
+            authority: 'server',
+            phase: 'session',
+            awaitingAdvance: false,
+            session: { id: 'compact-session', mode: 'smart', currentItem: null },
+            feedback: null,
+            summary: null,
+            prefs: { mode: 'smart', roundLength: 5 },
+            stats: { concepts: { total: 30, due: 1, weak: 0, secured: 0 } },
+            aiEnrichment: { status: 'idle' },
+            projections: null,
+            error: '',
+          },
+        };
+      },
+    },
+    store: {
+      getState() { return context.appState; },
+      updateSubjectUi(subjectId, updater) {
+        const previous = context.appState.subjectUi[subjectId] || {};
+        const next = typeof updater === 'function' ? updater(previous) : { ...previous, ...updater };
+        context.appState = {
+          ...context.appState,
+          subjectUi: {
+            ...context.appState.subjectUi,
+            [subjectId]: next,
+          },
+        };
+      },
+    },
+  };
+
+  grammarModule.handleAction('grammar-start', context);
+  await Promise.resolve();
+  await Promise.resolve();
+
+  const grammar = context.appState.subjectUi.grammar;
+  const clauses = grammar.analytics.concepts.find((concept) => concept.id === 'clauses');
+  assert.equal(grammar.pendingCommand, '');
+  assert.equal(grammar.phase, 'session');
+  assert.equal(grammar.session.id, 'compact-session');
+  assert.equal(clauses.status, 'due');
+  assert.equal(clauses.attempts, 7);
+  assert.equal(grammar.capabilities.aiEnrichment.enabled, false);
+  assert.equal(grammar.transferLane.evidence[0].latest.writing, 'Saved writing.');
+});
+
 test('Grammar remote command defers monster celebrations until session end', async () => {
   const calls = [];
   const context = {

--- a/tests/worker-cron-retention-sweep.test.js
+++ b/tests/worker-cron-retention-sweep.test.js
@@ -12,9 +12,13 @@ import {
   REQUEST_LIMITS_RETENTION_MS,
   PRACTICE_SESSION_RETENTION_MS,
   LEARNER_ACTIVITY_FEED_RETENTION_MS,
+  EVENT_LOG_RECENT_EVENTS_PER_LEARNER,
+  EVENT_LOG_MAX_DELETE_BATCH,
+  EVENT_LOG_CANDIDATE_EVENT_SCAN_LIMIT,
   sweepMutationReceipts,
   sweepPracticeSessions,
   sweepLearnerActivityFeed,
+  sweepEventLog,
   sweepRequestLimits,
   sweepStaleSessions,
   runRetentionSweeps,
@@ -113,6 +117,20 @@ function seedActivityFeed(db, { id, learnerId = 'learner-a', updatedAt }) {
     )
     VALUES (?, ?, 'spelling', 'reward', '{}', NULL, ?, ?)
   `).run(id, learnerId, updatedAt, updatedAt);
+}
+
+function seedEventLog(db, {
+  id,
+  learnerId = 'learner-a',
+  createdAt,
+  eventType = 'grammar.answer-submitted',
+} = {}) {
+  db.db.prepare(`
+    INSERT INTO event_log (
+      id, learner_id, subject_id, system_id, event_type, event_json, created_at, actor_account_id
+    )
+    VALUES (?, ?, 'grammar', NULL, ?, '{}', ?, NULL)
+  `).run(id, learnerId, eventType, createdAt);
 }
 
 function rowCount(db, sql, params = []) {
@@ -232,6 +250,85 @@ test('sweepLearnerActivityFeed uses the updated_at retention index', async () =>
   }
 });
 
+test('sweepEventLog prunes old high-history rows while preserving each learner latest 200 events', async () => {
+  const db = createMigratedSqliteD1Database();
+  try {
+    const now = 1_700_000_000_000;
+    seedLearner(db, { id: 'learner-a', now });
+    seedLearner(db, { id: 'learner-b', now });
+    for (let index = 0; index < EVENT_LOG_RECENT_EVENTS_PER_LEARNER + 5; index += 1) {
+      seedEventLog(db, {
+        id: `event-a-${String(index).padStart(3, '0')}`,
+        learnerId: 'learner-a',
+        createdAt: now + index,
+      });
+    }
+    for (let index = 0; index < 3; index += 1) {
+      seedEventLog(db, {
+        id: `event-b-${index}`,
+        learnerId: 'learner-b',
+        createdAt: now + index,
+      });
+    }
+
+    const result = await sweepEventLog(db, now);
+    assert.equal(result.deleted, 5);
+    assert.equal(rowCount(db, "SELECT COUNT(*) AS count FROM event_log WHERE learner_id='learner-a'"), EVENT_LOG_RECENT_EVENTS_PER_LEARNER);
+    assert.equal(rowCount(db, "SELECT COUNT(*) AS count FROM event_log WHERE learner_id='learner-b'"), 3);
+    const oldestKept = db.db.prepare(`
+      SELECT id FROM event_log
+      WHERE learner_id = 'learner-a'
+      ORDER BY created_at ASC, id ASC
+      LIMIT 1
+    `).get();
+    assert.equal(oldestKept.id, 'event-a-005');
+  } finally {
+    db.close();
+  }
+});
+
+test('sweepEventLog uses the learner/created index for bounded deletes', async () => {
+  const db = createMigratedSqliteD1Database();
+  try {
+    const plan = db.db.prepare(`
+      EXPLAIN QUERY PLAN
+      SELECT rowid
+      FROM event_log
+      WHERE learner_id = ?
+        AND created_at < ?
+      LIMIT ?
+    `).all('learner-a', 0, EVENT_LOG_MAX_DELETE_BATCH);
+    const detail = plan.map((row) => row.detail).join('\n');
+    assert.match(detail, /idx_event_log_learner_created/);
+    assert.doesNotMatch(detail, /SCAN event_log\b/);
+  } finally {
+    db.close();
+  }
+});
+
+test('sweepEventLog candidate scan stays bounded on the created_at index', async () => {
+  const db = createMigratedSqliteD1Database();
+  try {
+    const plan = db.db.prepare(`
+      EXPLAIN QUERY PLAN
+      SELECT learner_id
+      FROM (
+        SELECT learner_id
+        FROM event_log
+        WHERE learner_id IS NOT NULL
+        ORDER BY created_at ASC
+        LIMIT ?
+      )
+      GROUP BY learner_id
+      LIMIT ?
+    `).all(EVENT_LOG_CANDIDATE_EVENT_SCAN_LIMIT, 50);
+    const detail = plan.map((row) => row.detail).join('\n');
+    assert.match(detail, /idx_event_log_created/);
+  } finally {
+    db.close();
+  }
+});
+
 test('U11 runRetentionSweeps aggregates per-sweep deletion counts', async () => {
   const db = createMigratedSqliteD1Database();
   try {
@@ -244,9 +341,15 @@ test('U11 runRetentionSweeps aggregates per-sweep deletion counts', async () => 
     seedSession(db, { id: 'sess-stale', accountId: 'adult-a', expiresAt: now - 1, revisionAtIssue: 0 });
     seedPracticeSession(db, { id: 'practice-old', status: 'completed', updatedAt: now - PRACTICE_SESSION_RETENTION_MS - 1 });
     seedActivityFeed(db, { id: 'activity-old', updatedAt: now - LEARNER_ACTIVITY_FEED_RETENTION_MS - 1 });
+    for (let index = 0; index < EVENT_LOG_RECENT_EVENTS_PER_LEARNER + 1; index += 1) {
+      seedEventLog(db, {
+        id: `event-old-${index}`,
+        createdAt: now + index,
+      });
+    }
 
     const result = await runRetentionSweeps(db, now);
-    assert.equal(result.totalDeleted, 5);
+    assert.equal(result.totalDeleted, 6);
     const byName = Object.create(null);
     for (const entry of result.completed) byName[entry.sweep] = entry.deleted;
     assert.equal(byName.mutation_receipts, 1);
@@ -254,6 +357,7 @@ test('U11 runRetentionSweeps aggregates per-sweep deletion counts', async () => 
     assert.equal(byName.account_sessions, 1);
     assert.equal(byName.practice_sessions, 1);
     assert.equal(byName.learner_activity_feed, 1);
+    assert.equal(byName.event_log, 1);
   } finally {
     db.close();
   }

--- a/tests/worker-grammar-subject-runtime.test.js
+++ b/tests/worker-grammar-subject-runtime.test.js
@@ -101,21 +101,10 @@ test('worker subject runtime registers Grammar command handlers', async () => {
   assert.equal(result.subjectReadModel.session.currentItem.templateId, 'fronted_adverbial_choose');
   assert.equal(result.subjectReadModel.session.currentItem.evaluate, undefined);
   assert.equal(result.subjectReadModel.session.currentItem.promptText.includes('<'), false);
-  assert.deepEqual(result.subjectReadModel.capabilities.enabledModes.map((mode) => mode.id), [
-    'learn',
-    'smart',
-    'satsset',
-    'trouble',
-    'surgery',
-    'builder',
-    'worked',
-    'faded',
-  ]);
-  assert.equal(result.subjectReadModel.capabilities.lockedModes.some((mode) => mode.id === 'trouble'), false);
-  assert.equal(result.subjectReadModel.capabilities.lockedModes.some((mode) => mode.id === 'surgery'), false);
-  assert.equal(result.subjectReadModel.capabilities.lockedModes.some((mode) => mode.id === 'builder'), false);
-  assert.equal(result.subjectReadModel.capabilities.lockedModes.some((mode) => mode.id === 'worked'), false);
-  assert.equal(result.subjectReadModel.capabilities.lockedModes.some((mode) => mode.id === 'faded'), false);
+  assert.equal(result.subjectReadModel.readModelPatch, true);
+  assert.equal(result.subjectReadModel.capabilities, undefined);
+  assert.equal(result.subjectReadModel.analytics, undefined);
+  assert.equal(result.subjectReadModel.transferLane, undefined);
 });
 
 test('worker subject runtime starts Grammar trouble drills against weak concepts', async () => {
@@ -441,7 +430,8 @@ test('Grammar command route accepts trouble drill mode', async () => {
   assert.equal(start.body.subjectReadModel.phase, 'session');
   assert.equal(start.body.subjectReadModel.session.mode, 'trouble');
   assert.equal(start.body.subjectReadModel.session.type, 'trouble-drill');
-  assert.equal(start.body.subjectReadModel.capabilities.lockedModes.some((mode) => mode.id === 'trouble'), false);
+  assert.equal(start.body.subjectReadModel.readModelPatch, true);
+  assert.equal(start.body.subjectReadModel.capabilities, undefined);
 
   DB.close();
 });
@@ -674,7 +664,8 @@ test('Grammar command route accepts sentence surgery mode', async () => {
   assert.equal(start.body.subjectReadModel.session.mode, 'surgery');
   assert.equal(start.body.subjectReadModel.session.type, 'sentence-surgery');
   assert.match(start.body.subjectReadModel.session.currentItem.questionType, /^(fix|rewrite)$/);
-  assert.equal(start.body.subjectReadModel.capabilities.lockedModes.some((mode) => mode.id === 'surgery'), false);
+  assert.equal(start.body.subjectReadModel.readModelPatch, true);
+  assert.equal(start.body.subjectReadModel.capabilities, undefined);
 
   DB.close();
 });
@@ -823,7 +814,8 @@ test('Grammar command route accepts sentence builder mode', async () => {
   assert.equal(start.body.subjectReadModel.session.type, 'sentence-builder');
   assert.equal(start.body.subjectReadModel.session.focusConceptId, '');
   assert.match(start.body.subjectReadModel.session.currentItem.questionType, /^(build|rewrite)$/);
-  assert.equal(start.body.subjectReadModel.capabilities.lockedModes.some((mode) => mode.id === 'builder'), false);
+  assert.equal(start.body.subjectReadModel.readModelPatch, true);
+  assert.equal(start.body.subjectReadModel.capabilities, undefined);
 
   DB.close();
 });
@@ -852,7 +844,8 @@ test('Grammar command route accepts worked example mode with concept guidance', 
   assert.equal(start.body.subjectReadModel.session.supportLevel, 2);
   assert.equal(start.body.subjectReadModel.session.supportGuidance.kind, 'worked');
   assert.ok(start.body.subjectReadModel.session.supportGuidance.workedExample.exampleResponse);
-  assert.equal(start.body.subjectReadModel.capabilities.lockedModes.some((mode) => mode.id === 'worked'), false);
+  assert.equal(start.body.subjectReadModel.readModelPatch, true);
+  assert.equal(start.body.subjectReadModel.capabilities, undefined);
 
   DB.close();
 });
@@ -881,7 +874,8 @@ test('Grammar command route accepts faded guidance mode without current-answer l
   assert.equal(start.body.subjectReadModel.session.supportGuidance.kind, 'faded');
   assert.equal(start.body.subjectReadModel.session.currentItem.solutionLines, undefined);
   assert.equal(start.body.subjectReadModel.session.supportGuidance.workedExample, undefined);
-  assert.equal(start.body.subjectReadModel.capabilities.lockedModes.some((mode) => mode.id === 'faded'), false);
+  assert.equal(start.body.subjectReadModel.readModelPatch, true);
+  assert.equal(start.body.subjectReadModel.capabilities, undefined);
 
   DB.close();
 });
@@ -1004,11 +998,24 @@ test('Grammar read model exposes evidence analytics for misconceptions and quest
   });
 
   assert.equal(submit.response.status, 200, JSON.stringify(submit.body));
-  assert.equal(submit.body.subjectReadModel.analytics.progressSnapshot.trackedConcepts, 1);
-  assert.equal(submit.body.subjectReadModel.analytics.misconceptionPatterns[0].id, 'fronted_adverbial_confusion');
-  assert.equal(submit.body.subjectReadModel.analytics.questionTypeSummary[0].id, 'choose');
-  assert.equal(submit.body.subjectReadModel.analytics.questionTypeSummary[0].wrong, 1);
-  assert.equal(submit.body.subjectReadModel.analytics.recentActivity[0].misconception, 'fronted_adverbial_confusion');
+  assert.equal(submit.body.subjectReadModel.readModelPatch, true);
+  assert.equal(submit.body.subjectReadModel.analytics, undefined);
+
+  const end = await postCommand(app, DB, {
+    command: 'end-session',
+    learnerId: 'learner-a',
+    requestId: 'grammar-evidence-end',
+    expectedLearnerRevision: 2,
+    payload: {},
+  });
+
+  assert.equal(end.response.status, 200, JSON.stringify(end.body));
+  assert.equal(end.body.subjectReadModel.readModelPatch, undefined);
+  assert.equal(end.body.subjectReadModel.analytics.progressSnapshot.trackedConcepts, 1);
+  assert.equal(end.body.subjectReadModel.analytics.misconceptionPatterns[0].id, 'fronted_adverbial_confusion');
+  assert.equal(end.body.subjectReadModel.analytics.questionTypeSummary[0].id, 'choose');
+  assert.equal(end.body.subjectReadModel.analytics.questionTypeSummary[0].wrong, 1);
+  assert.equal(end.body.subjectReadModel.analytics.recentActivity[0].misconception, 'fronted_adverbial_confusion');
 
   DB.close();
 });

--- a/worker/src/cron/retention-sweep.js
+++ b/worker/src/cron/retention-sweep.js
@@ -29,6 +29,12 @@ export const PRACTICE_SESSION_RETENTION_MS = 30 * 24 * 60 * 60 * 1000; // 30 day
 export const PRACTICE_SESSIONS_MAX_DELETE_BATCH = 5000;
 export const LEARNER_ACTIVITY_FEED_RETENTION_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 export const LEARNER_ACTIVITY_FEED_MAX_DELETE_BATCH = 5000;
+// Keep the bounded history needed by bootstrap and projection fallback without
+// letting long-play learners turn event_log into an unbounded archive.
+export const EVENT_LOG_RECENT_EVENTS_PER_LEARNER = 200;
+export const EVENT_LOG_MAX_DELETE_BATCH = 5000;
+export const EVENT_LOG_LEARNER_SCAN_LIMIT = 50;
+export const EVENT_LOG_CANDIDATE_EVENT_SCAN_LIMIT = 500;
 // P3 U4: request denials retention — 14-day rolling window.
 export const REQUEST_DENIALS_RETENTION_MS = 14 * 24 * 60 * 60 * 1000; // 14 days
 export const REQUEST_DENIALS_MAX_DELETE_BATCH = 5000;
@@ -191,6 +197,73 @@ export async function sweepLearnerActivityFeed(db, now = Date.now()) {
 }
 
 /**
+ * Prune old normal gameplay events by count, not by wall-clock age. The
+ * product reads only a bounded recent window from event_log: public bootstrap
+ * returns recent public events, and projection fallback reads the latest 200
+ * learner events. Source-of-truth progress/reward state lives in state tables.
+ *
+ * The implementation intentionally avoids a correlated "count newer rows"
+ * predicate. That shape explodes into millions of row comparisons for heavy
+ * learners. Instead it:
+ *   1. picks a small batch of learners with the oldest event rows;
+ *   2. uses the learner/created index to find each learner's 200th newest row;
+ *   3. deletes only older rows, capped across the sweep.
+ */
+export async function sweepEventLog(db, now = Date.now()) {
+  try {
+    const candidates = await db.prepare(`
+      SELECT learner_id
+      FROM (
+        SELECT learner_id
+        FROM event_log
+        WHERE learner_id IS NOT NULL
+        ORDER BY created_at ASC
+        LIMIT ?
+      )
+      GROUP BY learner_id
+      LIMIT ?
+    `).bind(EVENT_LOG_CANDIDATE_EVENT_SCAN_LIMIT, EVENT_LOG_LEARNER_SCAN_LIMIT).all();
+    const learnerRows = Array.isArray(candidates?.results) ? candidates.results : [];
+    let remaining = EVENT_LOG_MAX_DELETE_BATCH;
+    let deleted = 0;
+
+    for (const row of learnerRows) {
+      if (remaining <= 0) break;
+      const learnerId = String(row?.learner_id || '').trim();
+      if (!learnerId) continue;
+
+      const cutoff = await db.prepare(`
+        SELECT created_at
+        FROM event_log
+        WHERE learner_id = ?
+        ORDER BY created_at DESC, id DESC
+        LIMIT 1 OFFSET ?
+      `).bind(learnerId, EVENT_LOG_RECENT_EVENTS_PER_LEARNER - 1).first();
+      const cutoffCreatedAt = Number(cutoff?.created_at);
+      if (!Number.isFinite(cutoffCreatedAt)) continue;
+
+      const result = await run(db, `
+        DELETE FROM event_log
+        WHERE rowid IN (
+          SELECT rowid
+          FROM event_log
+          WHERE learner_id = ?
+            AND created_at < ?
+          LIMIT ?
+        )
+      `, [learnerId, cutoffCreatedAt, remaining]);
+      const changed = Math.max(0, Number(result?.meta?.changes) || 0);
+      deleted += changed;
+      remaining -= changed;
+    }
+
+    return { deleted };
+  } catch (error) {
+    return swallowMissingTable(error, 'event_log');
+  }
+}
+
+/**
  * P3 U4: prune stale request denials. 14-day rolling window, bounded-
  * delete (5000-row cap), `swallowMissingTable` pattern. The table may
  * not exist on instances that have not yet applied migration 0013.
@@ -230,6 +303,8 @@ export async function runRetentionSweeps(db, now = Date.now()) {
   completed.push({ sweep: 'practice_sessions', ...practiceSessions });
   const activityFeed = await sweepLearnerActivityFeed(db, now);
   completed.push({ sweep: 'learner_activity_feed', ...activityFeed });
+  const eventLog = await sweepEventLog(db, now);
+  completed.push({ sweep: 'event_log', ...eventLog });
   const denials = await sweepRequestDenials(db, now);
   completed.push({ sweep: 'admin_request_denials', ...denials });
   return {

--- a/worker/src/subjects/grammar/commands.js
+++ b/worker/src/subjects/grammar/commands.js
@@ -3,7 +3,7 @@ import { combineCommandEvents } from '../../projections/events.js';
 import { buildCommandProjectionReadModel } from '../../projections/read-models.js';
 import { projectGrammarRewards } from '../../projections/rewards.js';
 import { createServerGrammarEngine } from './engine.js';
-import { buildGrammarReadModel } from './read-models.js';
+import { buildGrammarCommandReadModel } from './read-models.js';
 import { GRAMMAR_CONTENT_RELEASE_ID } from './content.js';
 import { resolveProjectionInput } from '../projection-input.js';
 import {
@@ -226,7 +226,8 @@ export function createGrammarCommandHandlers({ now, random } = {}) {
     return {
       learnerId: command.learnerId,
       changed: result.changed,
-      subjectReadModel: buildGrammarReadModel({
+      subjectReadModel: buildGrammarCommandReadModel({
+        command: command.command,
         learnerId: command.learnerId,
         state: result.state,
         projections,

--- a/worker/src/subjects/grammar/read-models.js
+++ b/worker/src/subjects/grammar/read-models.js
@@ -994,6 +994,71 @@ export function buildGrammarReadModel({
   };
 }
 
+const GRAMMAR_FULL_COMMAND_READ_MODEL_COMMANDS = new Set([
+  'end-session',
+  'finish-mini-test',
+  'reset-learner',
+]);
+
+const GRAMMAR_TRANSFER_COMMAND_READ_MODEL_COMMANDS = new Set([
+  'save-transfer-evidence',
+  'reset-learner',
+]);
+
+function compactGrammarCommandReadModel(readModel, command) {
+  if (!readModel || typeof readModel !== 'object' || Array.isArray(readModel)) return readModel;
+  if (GRAMMAR_FULL_COMMAND_READ_MODEL_COMMANDS.has(command)) return readModel;
+
+  const compact = {
+    readModelPatch: true,
+    subjectId: readModel.subjectId,
+    learnerId: readModel.learnerId,
+    version: readModel.version,
+    authority: readModel.authority,
+    content: {
+      releaseId: readModel.content?.releaseId || '',
+      conceptCount: readModel.content?.conceptCount || 0,
+      templateCount: readModel.content?.templateCount || 0,
+    },
+    phase: readModel.phase,
+    awaitingAdvance: readModel.awaitingAdvance,
+    session: readModel.session,
+    feedback: readModel.feedback,
+    summary: readModel.summary,
+    prefs: readModel.prefs,
+    stats: readModel.stats,
+    aiEnrichment: readModel.aiEnrichment,
+    projections: readModel.projections,
+    error: readModel.error,
+  };
+
+  if (GRAMMAR_TRANSFER_COMMAND_READ_MODEL_COMMANDS.has(command)) {
+    compact.transferLane = readModel.transferLane;
+  }
+
+  return compact;
+}
+
+export function buildGrammarCommandReadModel({
+  command,
+  learnerId,
+  state,
+  projections = null,
+  now = Date.now(),
+  aiEnrichment = null,
+} = {}) {
+  return compactGrammarCommandReadModel(
+    buildGrammarReadModel({
+      learnerId,
+      state,
+      projections,
+      now,
+      aiEnrichment,
+    }),
+    command,
+  );
+}
+
 // U7 non-scored transfer writing lane read-model projection. The prompt
 // catalogue is delivered from the Worker via this read model so the React
 // surface does not import worker/src/subjects/grammar/transfer-prompts.js


### PR DESCRIPTION
## Summary
- add bounded event_log retention so old learner history cannot grow without limit
- compact grammar command responses into client-merged read-model patches while preserving full reads for summary, reset, and transfer-save paths
- add regression coverage for the retention sweep, compact grammar responses, and React merge behaviour

## Verification
- npm test -- tests/worker-cron-retention-sweep.test.js
- npm test -- tests/grammar-engine-validation.test.js
- npm test -- tests/react-grammar-surface.test.js
- npm test -- tests/worker-grammar-subject-runtime.test.js
- npm test
- npm run check
- npm run deploy
- production /api/version buildId 6549b29d
- production capacity smoke: reports/capacity/d1-reassess-20260531-post-6549b29d.json

## Production notes
- remote D1 backup created at backups/d1/ks2-mastery-db-remote-2026-05-31T10-30-51-597Z.sql before cleanup
- remote D1 size reduced from 23,814,144 bytes to about 10,502,144 bytes after stale feed/session cleanup and bounded event_log pruning
- deployed Worker version 9133e1f9-5885-497d-86b4-676e6be56a94