### PR TITLE
Optimise cached startup bootstrap

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,8 @@
 import {
+  canUseCachedRepositoryStartup,
   createCredentialFetch,
   createRepositoriesForBrowserRuntime,
+  refreshCachedRepositoryStartup,
 } from './platform/app/bootstrap.js';
 import { createAppController } from './platform/app/create-app-controller.js';
 import { createRoot } from 'react-dom/client';
@@ -272,7 +274,10 @@ if (!boot.repositories) {
 const repositories = boot.repositories;
 globalThis.KS2_AUTH_SESSION = boot.session;
 const subjectExposureGates = normaliseSubjectExposureGates(boot.session.subjectExposureGates);
-await repositories.hydrate();
+const canStartFromCachedRepositories = canUseCachedRepositoryStartup(repositories);
+if (!canStartFromCachedRepositories) {
+  await repositories.hydrate();
+}
 
 const services = {
   arithmetic: null,
@@ -1509,6 +1514,14 @@ const controller = createAppController({
   },
 });
 store = controller.store;
+if (canStartFromCachedRepositories) {
+  const scheduleCachedRefresh = typeof globalThis.setTimeout === 'function'
+    ? globalThis.setTimeout.bind(globalThis)
+    : (fn) => queueMicrotask(fn);
+  scheduleCachedRefresh(() => {
+    refreshCachedRepositoryStartup({ repositories, store });
+  }, 0);
+}
 const buildUpdateDetector = createBuildUpdateDetector({
   loadedBuildId: resolveClientBuildId(),
   fetchFn: credentialFetch,

--- a/src/platform/app/bootstrap.js
+++ b/src/platform/app/bootstrap.js
@@ -55,6 +55,30 @@ export function createCredentialFetch(fetchFn = (input, init) => globalThis.fetc
   };
 }
 
+export function canUseCachedRepositoryStartup(repositories) {
+  return Boolean(
+    repositories?.kind === 'api'
+    && typeof repositories.hasCachedRemoteState === 'function'
+    && repositories.hasCachedRemoteState(),
+  );
+}
+
+export async function refreshCachedRepositoryStartup({
+  repositories,
+  store,
+  log = globalThis.console,
+} = {}) {
+  if (!repositories || typeof repositories.hydrate !== 'function') return false;
+  try {
+    await repositories.hydrate({ cacheScope: 'startup-cache-refresh' });
+    store?.reloadFromRepositories?.({ preserveRoute: true });
+    return true;
+  } catch (error) {
+    log?.warn?.('Remote bootstrap refresh failed after cached startup.', error);
+    return false;
+  }
+}
+
 export function createLocalOnlySession() {
   return createAuthRequiredSession({ error: 'auth-required' });
 }

--- a/src/platform/core/repositories/api.js
+++ b/src/platform/core/repositories/api.js
@@ -2452,6 +2452,9 @@ export function createApiPlatformRepositories({
       await hydrateRemoteState(options);
       return undefined;
     },
+    hasCachedRemoteState() {
+      return hasCacheFallback(cache, pendingOperations);
+    },
     async flush() {
       await processPendingQueue();
       const snapshot = persistenceChannel.read();

--- a/tests/app-controller.test.js
+++ b/tests/app-controller.test.js
@@ -3,9 +3,11 @@ import assert from 'node:assert/strict';
 import React from 'react';
 
 import {
+  canUseCachedRepositoryStartup,
   createCredentialFetch,
   createRepositoriesForBrowserRuntime,
   localCodexReviewLearnerIdFromUrl,
+  refreshCachedRepositoryStartup,
   reviewLearnerIdFromMode,
   shouldOpenLocalCodexReview,
 } from '../src/platform/app/bootstrap.js';
@@ -223,6 +225,110 @@ test('browser bootstrap uses cached repositories when the auth session endpoint 
   assert.equal(persistence.mode, 'degraded');
   assert.equal(persistence.trustedState, 'local-cache');
   assert.equal(persistence.lastError.code, 'exceeded_cpu');
+});
+
+test('browser startup can render cached repositories before remote bootstrap refresh', async () => {
+  const storage = installMemoryStorage();
+  writeCachedApiState(storage, 'adult-cache');
+  const calls = [];
+  const credentialFetch = async (input) => {
+    calls.push(input);
+    if (input === '/api/auth/session') {
+      return jsonResponse(true, {
+        session: {
+          accountId: 'adult-cache',
+          provider: 'password',
+        },
+        account: {
+          platformRole: 'parent',
+          repoRevision: 9,
+        },
+      });
+    }
+    if (input === '/api/bootstrap') {
+      return jsonResponse(true, {
+        ok: true,
+        learners: {
+          byId: {
+            'learner-remote': {
+              id: 'learner-remote',
+              name: 'Remote Learner',
+              yearGroup: 'Y5',
+            },
+          },
+          allIds: ['learner-remote'],
+          selectedId: 'learner-remote',
+        },
+        subjectStates: {},
+        practiceSessions: [],
+        gameState: {},
+        eventLog: [],
+        monsterVisualConfig: null,
+      });
+    }
+    throw new Error(`Unexpected request: ${input}`);
+  };
+
+  const boot = await createRepositoriesForBrowserRuntime({
+    location: new URL('https://ks2.example.test/'),
+    storage,
+    credentialFetch,
+  });
+
+  assert.deepEqual(calls, ['/api/auth/session']);
+  assert.equal(canUseCachedRepositoryStartup(boot.repositories), true);
+
+  const controller = createAppController({
+    repositories: boot.repositories,
+    session: boot.session,
+  });
+  assert.equal(controller.store.getState().learners.selectedId, 'learner-cache');
+
+  const reloadCalls = [];
+  const reloadFromRepositories = controller.store.reloadFromRepositories.bind(controller.store);
+  controller.store.reloadFromRepositories = (options) => {
+    reloadCalls.push(options);
+    return reloadFromRepositories(options);
+  };
+
+  const refreshed = await refreshCachedRepositoryStartup({
+    repositories: boot.repositories,
+    store: controller.store,
+    log: { warn() {} },
+  });
+
+  assert.equal(refreshed, true);
+  assert.deepEqual(calls, ['/api/auth/session', '/api/bootstrap']);
+  assert.deepEqual(reloadCalls, [{ preserveRoute: true }]);
+  assert.equal(controller.store.getState().learners.selectedId, 'learner-remote');
+});
+
+test('cached repository startup refresh degrades silently when bootstrap is unavailable', async () => {
+  const warnings = [];
+  let reloadCount = 0;
+  const refreshed = await refreshCachedRepositoryStartup({
+    repositories: {
+      kind: 'api',
+      async hydrate() {
+        throw new Error('bootstrap unavailable');
+      },
+    },
+    store: {
+      reloadFromRepositories() {
+        reloadCount += 1;
+      },
+    },
+    log: {
+      warn(message, error) {
+        warnings.push({ message, error });
+      },
+    },
+  });
+
+  assert.equal(refreshed, false);
+  assert.equal(reloadCount, 0);
+  assert.equal(warnings.length, 1);
+  assert.equal(warnings[0].message, 'Remote bootstrap refresh failed after cached startup.');
 });
 
 test('browser bootstrap does not use cached repositories for explicit unauthenticated responses', async () => {


### PR DESCRIPTION
## Summary
- render returning learners from cached remote state before waiting on bootstrap
- refresh cached startup in the background and preserve the current route
- expose a repository cache-availability signal and cover success/failure refresh paths

## Verification
- npm test
- npm run check
- pre-push npm test