### PR TITLE
Reduce Cloudflare D1 and compute pressure

### DIFF
--- a/docs/operations/capacity.md
+++ b/docs/operations/capacity.md
@@ -153,7 +153,12 @@ Add any combination of the following to `npm run capacity:classroom`. Each flag 
 - `--max-network-failures <count>` — fail if network-level failures exceed `<count>`.
 - `--max-bootstrap-p95-ms <ms>` — fail if `/api/bootstrap` P95 wall time exceeds `<ms>`.
 - `--max-command-p95-ms <ms>` — fail if subject-command P95 wall time exceeds `<ms>`.
+- `--max-bootstrap-server-p95-ms <ms>` — fail if `/api/bootstrap` server-side P95 wall time exceeds `<ms>`.
+- `--max-command-server-p95-ms <ms>` — fail if subject-command server-side P95 wall time exceeds `<ms>`.
+- `--max-bootstrap-d1-rows-written <count>` — fail if bootstrap writes to D1 above `<count>`; the normal production expectation is `0`.
+- `--max-command-d1-rows-written <count>` — fail if a subject command writes more D1 rows than the configured cap.
 - `--max-response-bytes <bytes>` — fail if any endpoint's maximum response bytes exceed `<bytes>`.
+- `--max-command-response-bytes <bytes>` — fail if subject-command maximum response bytes exceed `<bytes>`.
 - `--require-zero-signals` — fail if any `exceededCpu`, `d1Overloaded`, `d1DailyLimit`, `rateLimited`, `networkFailure`, or `server5xx` signal is observed.
 - `--confirm-high-production-load` — required by operators before running `--production` at classroom or stretch scale (learners ≥ 20 or bootstrap-burst ≥ 20). Enforced by `validateClassroomLoadOptions`: a production run that exceeds the high-load threshold and omits this flag is rejected with a clear error.
 
@@ -169,7 +174,7 @@ The `capacity:classroom:release-gate` package script bakes the recommended defau
 npm run capacity:classroom:release-gate -- --production --origin https://ks2.eugnel.uk --confirm-production-load --confirm-high-production-load --demo-sessions --learners 30 --bootstrap-burst 20 --rounds 1
 ```
 
-The release-gate script is equivalent to `capacity:classroom` with `--max-5xx 0 --max-network-failures 0 --max-bootstrap-p95-ms 1000 --max-command-p95-ms 750 --max-response-bytes 600000 --require-zero-signals` prepended. Any additional arguments you supply on the command line layer on top — but they cannot repeat a threshold already baked in (duplicate-flag rejection), and they cannot choose `--dry-run` (threshold-vs-dry-run rejection).
+The release-gate script is equivalent to `capacity:classroom` with `--max-5xx 0 --max-network-failures 0 --max-bootstrap-p95-ms 1000 --max-command-p95-ms 500 --max-bootstrap-server-p95-ms 250 --max-command-server-p95-ms 250 --max-bootstrap-d1-rows-written 0 --max-command-d1-rows-written 5 --max-response-bytes 600000 --max-command-response-bytes 20000 --require-zero-signals` prepended. Any additional arguments you supply on the command line layer on top — but they cannot repeat a threshold already baked in (duplicate-flag rejection), and they cannot choose `--dry-run` (threshold-vs-dry-run rejection).
 
 ### Probe bootstrap flags
 

--- a/docs/operations/capacity.md
+++ b/docs/operations/capacity.md
@@ -174,7 +174,7 @@ The `capacity:classroom:release-gate` package script bakes the recommended defau
 npm run capacity:classroom:release-gate -- --production --origin https://ks2.eugnel.uk --confirm-production-load --confirm-high-production-load --demo-sessions --learners 30 --bootstrap-burst 20 --rounds 1
 ```
 
-The release-gate script is equivalent to `capacity:classroom` with `--max-5xx 0 --max-network-failures 0 --max-bootstrap-p95-ms 1000 --max-command-p95-ms 500 --max-bootstrap-server-p95-ms 250 --max-command-server-p95-ms 250 --max-bootstrap-d1-rows-written 0 --max-command-d1-rows-written 5 --max-response-bytes 600000 --max-command-response-bytes 20000 --require-zero-signals` prepended. Any additional arguments you supply on the command line layer on top — but they cannot repeat a threshold already baked in (duplicate-flag rejection), and they cannot choose `--dry-run` (threshold-vs-dry-run rejection).
+The release-gate script is equivalent to `capacity:classroom` with `--max-5xx 0 --max-network-failures 0 --max-bootstrap-p95-ms 1000 --max-command-p95-ms 500 --max-bootstrap-server-p95-ms 250 --max-command-server-p95-ms 250 --max-bootstrap-d1-rows-written 0 --max-command-d1-rows-written 12 --max-response-bytes 600000 --max-command-response-bytes 20000 --require-zero-signals` prepended. Any additional arguments you supply on the command line layer on top — but they cannot repeat a threshold already baked in (duplicate-flag rejection), and they cannot choose `--dry-run` (threshold-vs-dry-run rejection).
 
 ### Probe bootstrap flags
 
@@ -411,7 +411,7 @@ Do not claim classroom or school readiness from Free-tier limits alone.
 
 ### Admin ops console KPI endpoint
 
-`GET /api/admin/ops/kpi` runs 7 live `COUNT(*)` queries against `adult_accounts`, `learner_profiles`, `practice_sessions`, `event_log`, `mutation_receipts` plus 1 read against `admin_kpi_metrics`. Cost is bounded by the 3 new indexes added in migration `0010` (`idx_event_log_created`, `idx_practice_sessions_updated`, `idx_mutation_receipts_applied`); `EXPLAIN QUERY PLAN` verifies index usage.
+`GET /api/admin/ops/kpi` runs 7 live `COUNT(*)` queries against `adult_accounts`, `learner_profiles`, `practice_sessions`, `event_log`, `mutation_receipts` plus 1 read against `admin_kpi_metrics`. Event and mutation counts remain bounded by the retained migration `0010` indexes (`idx_event_log_created`, `idx_mutation_receipts_applied`). Migration `0019` removes the global `practice_sessions(updated_at)` index because it amplified every player session write; practice-session engagement remains a manual admin diagnostic rather than a player hot-path dependency.
 
 The endpoint is manual-refresh only (no polling). Current KS2 scale keeps per-refresh cost well under the D1 Free-tier 10ms CPU budget. Re-evaluate if `event_log` exceeds ~500K rows — at that point consider a pre-aggregated `admin_kpi_metrics`-style counter for the windowed totals in place of live COUNTs.
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "check": "node ./scripts/wrangler-oauth.mjs deploy --dry-run",
     "check:oauth": "npm run check",
     "capacity:classroom": "node ./scripts/classroom-load-test.mjs",
-    "capacity:classroom:release-gate": "node ./scripts/classroom-load-test.mjs --max-5xx 0 --max-network-failures 0 --max-bootstrap-p95-ms 1000 --max-command-p95-ms 750 --max-response-bytes 600000 --require-zero-signals",
+    "capacity:classroom:release-gate": "node ./scripts/classroom-load-test.mjs --max-5xx 0 --max-network-failures 0 --max-bootstrap-p95-ms 1000 --max-command-p95-ms 500 --max-bootstrap-server-p95-ms 250 --max-command-server-p95-ms 250 --max-bootstrap-d1-rows-written 0 --max-command-d1-rows-written 5 --max-response-bytes 600000 --max-command-response-bytes 20000 --require-zero-signals",
     "capacity:local-worker": "node ./scripts/capacity-local-worker.mjs",
     "capacity:plan-60-diagnostic": "node ./scripts/plan-60-learner-diagnostic.mjs",
     "capacity:plan-route-costs": "node ./scripts/plan-route-cost-diagnostic.mjs",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "check": "node ./scripts/wrangler-oauth.mjs deploy --dry-run",
     "check:oauth": "npm run check",
     "capacity:classroom": "node ./scripts/classroom-load-test.mjs",
-    "capacity:classroom:release-gate": "node ./scripts/classroom-load-test.mjs --max-5xx 0 --max-network-failures 0 --max-bootstrap-p95-ms 1000 --max-command-p95-ms 500 --max-bootstrap-server-p95-ms 250 --max-command-server-p95-ms 250 --max-bootstrap-d1-rows-written 0 --max-command-d1-rows-written 5 --max-response-bytes 600000 --max-command-response-bytes 20000 --require-zero-signals",
+    "capacity:classroom:release-gate": "node ./scripts/classroom-load-test.mjs --max-5xx 0 --max-network-failures 0 --max-bootstrap-p95-ms 1000 --max-command-p95-ms 500 --max-bootstrap-server-p95-ms 250 --max-command-server-p95-ms 250 --max-bootstrap-d1-rows-written 0 --max-command-d1-rows-written 12 --max-response-bytes 600000 --max-command-response-bytes 20000 --require-zero-signals",
     "capacity:local-worker": "node ./scripts/capacity-local-worker.mjs",
     "capacity:plan-60-diagnostic": "node ./scripts/plan-60-learner-diagnostic.mjs",
     "capacity:plan-route-costs": "node ./scripts/plan-route-cost-diagnostic.mjs",

--- a/reports/capacity/evidence/2026-05-31-item1-bootstrap-tail-r1.json
+++ b/reports/capacity/evidence/2026-05-31-item1-bootstrap-tail-r1.json
@@ -1,0 +1,1858 @@
+{
+  "ok": true,
+  "dryRun": false,
+  "plan": {
+    "mode": "production",
+    "origin": "https://ks2.eugnel.uk",
+    "virtualLearners": [
+      {
+        "index": 0,
+        "label": "learner-01"
+      },
+      {
+        "index": 1,
+        "label": "learner-02"
+      },
+      {
+        "index": 2,
+        "label": "learner-03"
+      },
+      {
+        "index": 3,
+        "label": "learner-04"
+      },
+      {
+        "index": 4,
+        "label": "learner-05"
+      }
+    ],
+    "scenarios": [
+      {
+        "name": "cold-bootstrap-burst",
+        "requests": 5,
+        "concurrency": 5,
+        "endpoint": "GET /api/bootstrap"
+      },
+      {
+        "name": "human-paced-grammar-round",
+        "learners": 5,
+        "rounds": 1,
+        "pacingMs": 0,
+        "commandsPerRound": 3,
+        "endpoint": "POST /api/subjects/grammar/command"
+      }
+    ],
+    "expectedRequests": 30,
+    "safety": {
+      "productionRequiresConfirmation": true,
+      "productionRequiresAuth": true,
+      "localFixtureRequiresDemoSessions": true
+    }
+  },
+  "summary": {
+    "ok": true,
+    "totalRequests": 30,
+    "expectedRequests": 30,
+    "statusCounts": {
+      "200": 25,
+      "201": 5
+    },
+    "endpointStatus": {
+      "POST /api/demo/session 201": 5,
+      "GET /api/bootstrap 200": 10,
+      "POST /api/subjects/grammar/command 200": 15
+    },
+    "endpoints": {
+      "POST /api/demo/session": {
+        "phase": "setup",
+        "count": 5,
+        "p50WallMs": 183.4,
+        "p95WallMs": 643.9,
+        "maxWallMs": 643.9,
+        "p50ResponseBytes": 155,
+        "p95ResponseBytes": 155,
+        "maxResponseBytes": 155,
+        "topTailSamples": [
+          {
+            "scenario": "demo-session-setup",
+            "virtualLearner": "learner-01",
+            "status": 201,
+            "ok": true,
+            "wallMs": 643.9,
+            "responseBytes": 155,
+            "clientRequestId": "req_d42c56b6cafb83df367dbe4a",
+            "serverRequestId": "req_d42c56b6cafb83df367dbe4a"
+          },
+          {
+            "scenario": "demo-session-setup",
+            "virtualLearner": "learner-02",
+            "status": 201,
+            "ok": true,
+            "wallMs": 214.1,
+            "responseBytes": 155,
+            "clientRequestId": "req_464cd90d00af49c8ae5c566f",
+            "serverRequestId": "req_464cd90d00af49c8ae5c566f"
+          },
+          {
+            "scenario": "demo-session-setup",
+            "virtualLearner": "learner-04",
+            "status": 201,
+            "ok": true,
+            "wallMs": 183.4,
+            "responseBytes": 155,
+            "clientRequestId": "req_35860750eb06779cac8c1ea7",
+            "serverRequestId": "req_35860750eb06779cac8c1ea7"
+          },
+          {
+            "scenario": "demo-session-setup",
+            "virtualLearner": "learner-03",
+            "status": 201,
+            "ok": true,
+            "wallMs": 160.4,
+            "responseBytes": 155,
+            "clientRequestId": "req_a38bb90230472be753f90fb4",
+            "serverRequestId": "req_a38bb90230472be753f90fb4"
+          },
+          {
+            "scenario": "demo-session-setup",
+            "virtualLearner": "learner-05",
+            "status": 201,
+            "ok": true,
+            "wallMs": 158.9,
+            "responseBytes": 155,
+            "clientRequestId": "req_cf631087bace8ed4deb727f3",
+            "serverRequestId": "req_cf631087bace8ed4deb727f3"
+          }
+        ]
+      },
+      "GET /api/bootstrap": {
+        "phase": "bootstrap",
+        "count": 10,
+        "p50WallMs": 173.2,
+        "p95WallMs": 745.2,
+        "maxWallMs": 745.2,
+        "p50ResponseBytes": 2448,
+        "p95ResponseBytes": 2448,
+        "maxResponseBytes": 2448,
+        "queryCount": 9,
+        "queryCountP50": 9,
+        "queryCountP95": 9,
+        "queryCountMax": 9,
+        "d1RowsRead": 7,
+        "d1RowsReadP50": 7,
+        "d1RowsReadP95": 7,
+        "d1RowsReadMax": 7,
+        "d1RowsWritten": 0,
+        "d1RowsWrittenP50": 0,
+        "d1RowsWrittenP95": 0,
+        "d1RowsWrittenMax": 0,
+        "serverWallMsP50": 104,
+        "serverWallMsP95": 203,
+        "serverWallMsMax": 203,
+        "serverResponseBytesP50": 1818,
+        "serverResponseBytesP95": 1818,
+        "serverResponseBytesMax": 1818,
+        "bootstrapModes": {
+          "selected-learner-bounded": 10
+        },
+        "bootstrapCapacityModes": {
+          "public-bounded": 10
+        },
+        "bootstrapCapacityVersions": {
+          "4": 10
+        },
+        "subjectStatesBounded": {
+          "false": 10
+        },
+        "topTailSamples": [
+          {
+            "scenario": "cold-bootstrap-burst",
+            "virtualLearner": "learner-03",
+            "status": 200,
+            "ok": true,
+            "wallMs": 745.2,
+            "responseBytes": 2447,
+            "clientRequestId": "req_d054748b902c6ee904143cb5",
+            "serverRequestId": "req_d054748b902c6ee904143cb5",
+            "queryCount": 9,
+            "d1RowsRead": 7,
+            "d1RowsWritten": 0,
+            "serverWallMs": 76,
+            "serverResponseBytes": 1818,
+            "bootstrapMode": "selected-learner-bounded",
+            "bootstrapCapacityMode": "public-bounded",
+            "bootstrapCapacityVersion": 4
+          },
+          {
+            "scenario": "initial-bootstrap",
+            "virtualLearner": "learner-02",
+            "status": 200,
+            "ok": true,
+            "wallMs": 256.9,
+            "responseBytes": 2448,
+            "clientRequestId": "req_e8e78710f48c0a9f24ddedd1",
+            "serverRequestId": "req_e8e78710f48c0a9f24ddedd1",
+            "queryCount": 9,
+            "d1RowsRead": 7,
+            "d1RowsWritten": 0,
+            "serverWallMs": 203,
+            "serverResponseBytes": 1818,
+            "bootstrapMode": "selected-learner-bounded",
+            "bootstrapCapacityMode": "public-bounded",
+            "bootstrapCapacityVersion": 4
+          },
+          {
+            "scenario": "cold-bootstrap-burst",
+            "virtualLearner": "learner-05",
+            "status": 200,
+            "ok": true,
+            "wallMs": 223.9,
+            "responseBytes": 2448,
+            "clientRequestId": "req_bd48495180519ac37d435828",
+            "serverRequestId": "req_bd48495180519ac37d435828",
+            "queryCount": 9,
+            "d1RowsRead": 7,
+            "d1RowsWritten": 0,
+            "serverWallMs": 130,
+            "serverResponseBytes": 1818,
+            "bootstrapMode": "selected-learner-bounded",
+            "bootstrapCapacityMode": "public-bounded",
+            "bootstrapCapacityVersion": 4
+          },
+          {
+            "scenario": "cold-bootstrap-burst",
+            "virtualLearner": "learner-04",
+            "status": 200,
+            "ok": true,
+            "wallMs": 217.7,
+            "responseBytes": 2448,
+            "clientRequestId": "req_5a655611a55c2e34114fbff9",
+            "serverRequestId": "req_5a655611a55c2e34114fbff9",
+            "queryCount": 9,
+            "d1RowsRead": 7,
+            "d1RowsWritten": 0,
+            "serverWallMs": 140,
+            "serverResponseBytes": 1818,
+            "bootstrapMode": "selected-learner-bounded",
+            "bootstrapCapacityMode": "public-bounded",
+            "bootstrapCapacityVersion": 4
+          },
+          {
+            "scenario": "cold-bootstrap-burst",
+            "virtualLearner": "learner-02",
+            "status": 200,
+            "ok": true,
+            "wallMs": 194.5,
+            "responseBytes": 2448,
+            "clientRequestId": "req_00ffb5533c5ea42c834c194f",
+            "serverRequestId": "req_00ffb5533c5ea42c834c194f",
+            "queryCount": 9,
+            "d1RowsRead": 7,
+            "d1RowsWritten": 0,
+            "serverWallMs": 135,
+            "serverResponseBytes": 1818,
+            "bootstrapMode": "selected-learner-bounded",
+            "bootstrapCapacityMode": "public-bounded",
+            "bootstrapCapacityVersion": 4
+          },
+          {
+            "scenario": "initial-bootstrap",
+            "virtualLearner": "learner-01",
+            "status": 200,
+            "ok": true,
+            "wallMs": 173.2,
+            "responseBytes": 2448,
+            "clientRequestId": "req_e1a3ed6b540e2a83410b0245",
+            "serverRequestId": "req_e1a3ed6b540e2a83410b0245",
+            "queryCount": 9,
+            "d1RowsRead": 7,
+            "d1RowsWritten": 0,
+            "serverWallMs": 104,
+            "serverResponseBytes": 1818,
+            "bootstrapMode": "selected-learner-bounded",
+            "bootstrapCapacityMode": "public-bounded",
+            "bootstrapCapacityVersion": 4
+          },
+          {
+            "scenario": "cold-bootstrap-burst",
+            "virtualLearner": "learner-01",
+            "status": 200,
+            "ok": true,
+            "wallMs": 157.2,
+            "responseBytes": 2448,
+            "clientRequestId": "req_959b71383d04faa233d4250f",
+            "serverRequestId": "req_959b71383d04faa233d4250f",
+            "queryCount": 9,
+            "d1RowsRead": 7,
+            "d1RowsWritten": 0,
+            "serverWallMs": 112,
+            "serverResponseBytes": 1818,
+            "bootstrapMode": "selected-learner-bounded",
+            "bootstrapCapacityMode": "public-bounded",
+            "bootstrapCapacityVersion": 4
+          },
+          {
+            "scenario": "initial-bootstrap",
+            "virtualLearner": "learner-04",
+            "status": 200,
+            "ok": true,
+            "wallMs": 144.8,
+            "responseBytes": 2448,
+            "clientRequestId": "req_a575bbabea3674708f6538d4",
+            "serverRequestId": "req_a575bbabea3674708f6538d4",
+            "queryCount": 9,
+            "d1RowsRead": 7,
+            "d1RowsWritten": 0,
+            "serverWallMs": 102,
+            "serverResponseBytes": 1818,
+            "bootstrapMode": "selected-learner-bounded",
+            "bootstrapCapacityMode": "public-bounded",
+            "bootstrapCapacityVersion": 4
+          },
+          {
+            "scenario": "initial-bootstrap",
+            "virtualLearner": "learner-03",
+            "status": 200,
+            "ok": true,
+            "wallMs": 142.1,
+            "responseBytes": 2447,
+            "clientRequestId": "req_dad9d159d02179d92b137d4c",
+            "serverRequestId": "req_dad9d159d02179d92b137d4c",
+            "queryCount": 9,
+            "d1RowsRead": 7,
+            "d1RowsWritten": 0,
+            "serverWallMs": 94,
+            "serverResponseBytes": 1818,
+            "bootstrapMode": "selected-learner-bounded",
+            "bootstrapCapacityMode": "public-bounded",
+            "bootstrapCapacityVersion": 4
+          },
+          {
+            "scenario": "initial-bootstrap",
+            "virtualLearner": "learner-05",
+            "status": 200,
+            "ok": true,
+            "wallMs": 137.7,
+            "responseBytes": 2447,
+            "clientRequestId": "req_f1ac7c3383b7c4529cf6c5c0",
+            "serverRequestId": "req_f1ac7c3383b7c4529cf6c5c0",
+            "queryCount": 9,
+            "d1RowsRead": 7,
+            "d1RowsWritten": 0,
+            "serverWallMs": 94,
+            "serverResponseBytes": 1818,
+            "bootstrapMode": "selected-learner-bounded",
+            "bootstrapCapacityMode": "public-bounded",
+            "bootstrapCapacityVersion": 4
+          }
+        ]
+      },
+      "POST /api/subjects/grammar/command": {
+        "phase": "command",
+        "count": 15,
+        "p50WallMs": 192.6,
+        "p95WallMs": 226.2,
+        "maxWallMs": 226.2,
+        "p50ResponseBytes": 5035,
+        "p95ResponseBytes": 17231,
+        "maxResponseBytes": 17231,
+        "queryCount": 18,
+        "queryCountP50": 16,
+        "queryCountP95": 18,
+        "queryCountMax": 18,
+        "d1RowsRead": 19,
+        "d1RowsReadP50": 18,
+        "d1RowsReadP95": 19,
+        "d1RowsReadMax": 19,
+        "d1RowsWritten": 16,
+        "d1RowsWrittenP50": 15,
+        "d1RowsWrittenP95": 16,
+        "d1RowsWrittenMax": 16,
+        "serverWallMsP50": 144,
+        "serverWallMsP95": 172,
+        "serverWallMsMax": 172,
+        "serverResponseBytesP50": 4829,
+        "serverResponseBytesP95": 17024,
+        "serverResponseBytesMax": 17024,
+        "topTailSamples": [
+          {
+            "scenario": "human-paced-grammar-round",
+            "virtualLearner": "learner-01",
+            "status": 200,
+            "ok": true,
+            "wallMs": 226.2,
+            "responseBytes": 4101,
+            "clientRequestId": "req_cae5d268bc9a4b7ffac1c115",
+            "serverRequestId": "req_cae5d268bc9a4b7ffac1c115",
+            "queryCount": 18,
+            "d1RowsRead": 13,
+            "d1RowsWritten": 16,
+            "serverWallMs": 172,
+            "serverResponseBytes": 3883
+          },
+          {
+            "scenario": "human-paced-grammar-round",
+            "virtualLearner": "learner-02",
+            "status": 200,
+            "ok": true,
+            "wallMs": 220,
+            "responseBytes": 4100,
+            "clientRequestId": "req_26b90f95863a11292e3f43f2",
+            "serverRequestId": "req_26b90f95863a11292e3f43f2",
+            "queryCount": 18,
+            "d1RowsRead": 13,
+            "d1RowsWritten": 16,
+            "serverWallMs": 167,
+            "serverResponseBytes": 3882
+          },
+          {
+            "scenario": "human-paced-grammar-round",
+            "virtualLearner": "learner-03",
+            "status": 200,
+            "ok": true,
+            "wallMs": 218.5,
+            "responseBytes": 4100,
+            "clientRequestId": "req_5e0699eab75bd15a442f7bb6",
+            "serverRequestId": "req_5e0699eab75bd15a442f7bb6",
+            "queryCount": 18,
+            "d1RowsRead": 13,
+            "d1RowsWritten": 16,
+            "serverWallMs": 159,
+            "serverResponseBytes": 3882
+          },
+          {
+            "scenario": "human-paced-grammar-round",
+            "virtualLearner": "learner-04",
+            "status": 200,
+            "ok": true,
+            "wallMs": 205.8,
+            "responseBytes": 4103,
+            "clientRequestId": "req_84fd0ec8cc374c86b902359d",
+            "serverRequestId": "req_84fd0ec8cc374c86b902359d",
+            "queryCount": 18,
+            "d1RowsRead": 13,
+            "d1RowsWritten": 16,
+            "serverWallMs": 154,
+            "serverResponseBytes": 3885
+          },
+          {
+            "scenario": "human-paced-grammar-round",
+            "virtualLearner": "learner-01",
+            "status": 200,
+            "ok": true,
+            "wallMs": 205.5,
+            "responseBytes": 17225,
+            "clientRequestId": "req_0ae04b01dfedde69061a2842",
+            "serverRequestId": "req_0ae04b01dfedde69061a2842",
+            "queryCount": 16,
+            "d1RowsRead": 19,
+            "d1RowsWritten": 15,
+            "serverWallMs": 149,
+            "serverResponseBytes": 17018
+          },
+          {
+            "scenario": "human-paced-grammar-round",
+            "virtualLearner": "learner-04",
+            "status": 200,
+            "ok": true,
+            "wallMs": 204,
+            "responseBytes": 5039,
+            "clientRequestId": "req_d9e7cc7cc56e89b20252251b",
+            "serverRequestId": "req_d9e7cc7cc56e89b20252251b",
+            "queryCount": 15,
+            "d1RowsRead": 18,
+            "d1RowsWritten": 13,
+            "serverWallMs": 155,
+            "serverResponseBytes": 4833
+          },
+          {
+            "scenario": "human-paced-grammar-round",
+            "virtualLearner": "learner-05",
+            "status": 200,
+            "ok": true,
+            "wallMs": 203.8,
+            "responseBytes": 4103,
+            "clientRequestId": "req_0db65905dfe0f47dab22512f",
+            "serverRequestId": "req_0db65905dfe0f47dab22512f",
+            "queryCount": 18,
+            "d1RowsRead": 13,
+            "d1RowsWritten": 16,
+            "serverWallMs": 154,
+            "serverResponseBytes": 3885
+          },
+          {
+            "scenario": "human-paced-grammar-round",
+            "virtualLearner": "learner-05",
+            "status": 200,
+            "ok": true,
+            "wallMs": 192.6,
+            "responseBytes": 17231,
+            "clientRequestId": "req_f0860a49516a4e35ac9ee452",
+            "serverRequestId": "req_f0860a49516a4e35ac9ee452",
+            "queryCount": 16,
+            "d1RowsRead": 19,
+            "d1RowsWritten": 15,
+            "serverWallMs": 138,
+            "serverResponseBytes": 17024
+          },
+          {
+            "scenario": "human-paced-grammar-round",
+            "virtualLearner": "learner-04",
+            "status": 200,
+            "ok": true,
+            "wallMs": 192.1,
+            "responseBytes": 17231,
+            "clientRequestId": "req_71d99b2ebf065fa61c7884e5",
+            "serverRequestId": "req_71d99b2ebf065fa61c7884e5",
+            "queryCount": 16,
+            "d1RowsRead": 19,
+            "d1RowsWritten": 15,
+            "serverWallMs": 138,
+            "serverResponseBytes": 17024
+          },
+          {
+            "scenario": "human-paced-grammar-round",
+            "virtualLearner": "learner-01",
+            "status": 200,
+            "ok": true,
+            "wallMs": 191.4,
+            "responseBytes": 5035,
+            "clientRequestId": "req_a26d7f40e7abe241246a6b7a",
+            "serverRequestId": "req_a26d7f40e7abe241246a6b7a",
+            "queryCount": 15,
+            "d1RowsRead": 18,
+            "d1RowsWritten": 13,
+            "serverWallMs": 144,
+            "serverResponseBytes": 4829
+          }
+        ]
+      }
+    },
+    "phases": {
+      "setup": {
+        "phase": "setup",
+        "count": 5,
+        "p50WallMs": 183.4,
+        "p95WallMs": 643.9,
+        "maxWallMs": 643.9,
+        "p50ResponseBytes": 155,
+        "p95ResponseBytes": 155,
+        "maxResponseBytes": 155
+      },
+      "bootstrap": {
+        "phase": "bootstrap",
+        "count": 10,
+        "p50WallMs": 173.2,
+        "p95WallMs": 745.2,
+        "maxWallMs": 745.2,
+        "p50ResponseBytes": 2448,
+        "p95ResponseBytes": 2448,
+        "maxResponseBytes": 2448,
+        "queryCount": 9,
+        "queryCountP50": 9,
+        "queryCountP95": 9,
+        "queryCountMax": 9,
+        "d1RowsRead": 7,
+        "d1RowsReadP50": 7,
+        "d1RowsReadP95": 7,
+        "d1RowsReadMax": 7,
+        "d1RowsWritten": 0,
+        "d1RowsWrittenP50": 0,
+        "d1RowsWrittenP95": 0,
+        "d1RowsWrittenMax": 0,
+        "serverWallMsP50": 104,
+        "serverWallMsP95": 203,
+        "serverWallMsMax": 203,
+        "serverResponseBytesP50": 1818,
+        "serverResponseBytesP95": 1818,
+        "serverResponseBytesMax": 1818,
+        "bootstrapModes": {
+          "selected-learner-bounded": 10
+        },
+        "bootstrapCapacityModes": {
+          "public-bounded": 10
+        },
+        "bootstrapCapacityVersions": {
+          "4": 10
+        },
+        "subjectStatesBounded": {
+          "false": 10
+        }
+      },
+      "command": {
+        "phase": "command",
+        "count": 15,
+        "p50WallMs": 192.6,
+        "p95WallMs": 226.2,
+        "maxWallMs": 226.2,
+        "p50ResponseBytes": 5035,
+        "p95ResponseBytes": 17231,
+        "maxResponseBytes": 17231,
+        "queryCount": 18,
+        "queryCountP50": 16,
+        "queryCountP95": 18,
+        "queryCountMax": 18,
+        "d1RowsRead": 19,
+        "d1RowsReadP50": 18,
+        "d1RowsReadP95": 19,
+        "d1RowsReadMax": 19,
+        "d1RowsWritten": 16,
+        "d1RowsWrittenP50": 15,
+        "d1RowsWrittenP95": 16,
+        "d1RowsWrittenMax": 16,
+        "serverWallMsP50": 144,
+        "serverWallMsP95": 172,
+        "serverWallMsMax": 172,
+        "serverResponseBytesP50": 4829,
+        "serverResponseBytesP95": 17024,
+        "serverResponseBytesMax": 17024
+      }
+    },
+    "scenarios": {
+      "demo-session-setup": {
+        "phase": "setup",
+        "count": 5,
+        "p50WallMs": 183.4,
+        "p95WallMs": 643.9,
+        "maxWallMs": 643.9,
+        "p50ResponseBytes": 155,
+        "p95ResponseBytes": 155,
+        "maxResponseBytes": 155
+      },
+      "initial-bootstrap": {
+        "phase": "bootstrap",
+        "count": 5,
+        "p50WallMs": 144.8,
+        "p95WallMs": 256.9,
+        "maxWallMs": 256.9,
+        "p50ResponseBytes": 2448,
+        "p95ResponseBytes": 2448,
+        "maxResponseBytes": 2448,
+        "queryCount": 9,
+        "queryCountP50": 9,
+        "queryCountP95": 9,
+        "queryCountMax": 9,
+        "d1RowsRead": 7,
+        "d1RowsReadP50": 7,
+        "d1RowsReadP95": 7,
+        "d1RowsReadMax": 7,
+        "d1RowsWritten": 0,
+        "d1RowsWrittenP50": 0,
+        "d1RowsWrittenP95": 0,
+        "d1RowsWrittenMax": 0,
+        "serverWallMsP50": 102,
+        "serverWallMsP95": 203,
+        "serverWallMsMax": 203,
+        "serverResponseBytesP50": 1818,
+        "serverResponseBytesP95": 1818,
+        "serverResponseBytesMax": 1818,
+        "bootstrapModes": {
+          "selected-learner-bounded": 5
+        },
+        "bootstrapCapacityModes": {
+          "public-bounded": 5
+        },
+        "bootstrapCapacityVersions": {
+          "4": 5
+        },
+        "subjectStatesBounded": {
+          "false": 5
+        }
+      },
+      "cold-bootstrap-burst": {
+        "phase": "bootstrap",
+        "count": 5,
+        "p50WallMs": 217.7,
+        "p95WallMs": 745.2,
+        "maxWallMs": 745.2,
+        "p50ResponseBytes": 2448,
+        "p95ResponseBytes": 2448,
+        "maxResponseBytes": 2448,
+        "queryCount": 9,
+        "queryCountP50": 9,
+        "queryCountP95": 9,
+        "queryCountMax": 9,
+        "d1RowsRead": 7,
+        "d1RowsReadP50": 7,
+        "d1RowsReadP95": 7,
+        "d1RowsReadMax": 7,
+        "d1RowsWritten": 0,
+        "d1RowsWrittenP50": 0,
+        "d1RowsWrittenP95": 0,
+        "d1RowsWrittenMax": 0,
+        "serverWallMsP50": 130,
+        "serverWallMsP95": 140,
+        "serverWallMsMax": 140,
+        "serverResponseBytesP50": 1818,
+        "serverResponseBytesP95": 1818,
+        "serverResponseBytesMax": 1818,
+        "bootstrapModes": {
+          "selected-learner-bounded": 5
+        },
+        "bootstrapCapacityModes": {
+          "public-bounded": 5
+        },
+        "bootstrapCapacityVersions": {
+          "4": 5
+        },
+        "subjectStatesBounded": {
+          "false": 5
+        }
+      },
+      "human-paced-grammar-round": {
+        "phase": "command",
+        "count": 15,
+        "p50WallMs": 192.6,
+        "p95WallMs": 226.2,
+        "maxWallMs": 226.2,
+        "p50ResponseBytes": 5035,
+        "p95ResponseBytes": 17231,
+        "maxResponseBytes": 17231,
+        "queryCount": 18,
+        "queryCountP50": 16,
+        "queryCountP95": 18,
+        "queryCountMax": 18,
+        "d1RowsRead": 19,
+        "d1RowsReadP50": 18,
+        "d1RowsReadP95": 19,
+        "d1RowsReadMax": 19,
+        "d1RowsWritten": 16,
+        "d1RowsWrittenP50": 15,
+        "d1RowsWrittenP95": 16,
+        "d1RowsWrittenMax": 16,
+        "serverWallMsP50": 144,
+        "serverWallMsP95": 172,
+        "serverWallMsMax": 172,
+        "serverResponseBytesP50": 4829,
+        "serverResponseBytesP95": 17024,
+        "serverResponseBytesMax": 17024
+      }
+    },
+    "signals": {},
+    "failures": []
+  },
+  "measurements": [
+    {
+      "scenario": "demo-session-setup",
+      "virtualLearner": "learner-01",
+      "method": "POST",
+      "endpoint": "/api/demo/session",
+      "status": 201,
+      "ok": true,
+      "wallMs": 643.9,
+      "responseBytes": 155,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_d42c56b6cafb83df367dbe4a",
+      "serverRequestId": "req_d42c56b6cafb83df367dbe4a",
+      "capacity": null
+    },
+    {
+      "scenario": "demo-session-setup",
+      "virtualLearner": "learner-02",
+      "method": "POST",
+      "endpoint": "/api/demo/session",
+      "status": 201,
+      "ok": true,
+      "wallMs": 214.1,
+      "responseBytes": 155,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_464cd90d00af49c8ae5c566f",
+      "serverRequestId": "req_464cd90d00af49c8ae5c566f",
+      "capacity": null
+    },
+    {
+      "scenario": "demo-session-setup",
+      "virtualLearner": "learner-03",
+      "method": "POST",
+      "endpoint": "/api/demo/session",
+      "status": 201,
+      "ok": true,
+      "wallMs": 160.4,
+      "responseBytes": 155,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_a38bb90230472be753f90fb4",
+      "serverRequestId": "req_a38bb90230472be753f90fb4",
+      "capacity": null
+    },
+    {
+      "scenario": "demo-session-setup",
+      "virtualLearner": "learner-04",
+      "method": "POST",
+      "endpoint": "/api/demo/session",
+      "status": 201,
+      "ok": true,
+      "wallMs": 183.4,
+      "responseBytes": 155,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_35860750eb06779cac8c1ea7",
+      "serverRequestId": "req_35860750eb06779cac8c1ea7",
+      "capacity": null
+    },
+    {
+      "scenario": "demo-session-setup",
+      "virtualLearner": "learner-05",
+      "method": "POST",
+      "endpoint": "/api/demo/session",
+      "status": 201,
+      "ok": true,
+      "wallMs": 158.9,
+      "responseBytes": 155,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_cf631087bace8ed4deb727f3",
+      "serverRequestId": "req_cf631087bace8ed4deb727f3",
+      "capacity": null
+    },
+    {
+      "scenario": "initial-bootstrap",
+      "virtualLearner": "learner-01",
+      "method": "GET",
+      "endpoint": "/api/bootstrap",
+      "status": 200,
+      "ok": true,
+      "wallMs": 173.2,
+      "responseBytes": 2448,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_e1a3ed6b540e2a83410b0245",
+      "serverRequestId": "req_e1a3ed6b540e2a83410b0245",
+      "capacity": {
+        "requestId": "req_e1a3ed6b540e2a83410b0245",
+        "queryCount": 9,
+        "d1RowsRead": 7,
+        "d1RowsWritten": 0,
+        "serverWallMs": 104,
+        "responseBytes": 1818,
+        "signals": [],
+        "bootstrapMode": "selected-learner-bounded",
+        "bootstrapCapacity": {
+          "version": 4,
+          "mode": "public-bounded",
+          "limits": {
+            "activeSessionsPerLearner": 1,
+            "recentSessionsPerLearner": 5,
+            "recentEventsPerLearner": 50
+          },
+          "learners": {
+            "returned": 1
+          },
+          "practiceSessions": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false,
+            "atOrAboveMaximumLimit": false
+          },
+          "eventLog": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false
+          },
+          "subjectStatesBounded": false
+        },
+        "projectionFallback": null
+      }
+    },
+    {
+      "scenario": "initial-bootstrap",
+      "virtualLearner": "learner-02",
+      "method": "GET",
+      "endpoint": "/api/bootstrap",
+      "status": 200,
+      "ok": true,
+      "wallMs": 256.9,
+      "responseBytes": 2448,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_e8e78710f48c0a9f24ddedd1",
+      "serverRequestId": "req_e8e78710f48c0a9f24ddedd1",
+      "capacity": {
+        "requestId": "req_e8e78710f48c0a9f24ddedd1",
+        "queryCount": 9,
+        "d1RowsRead": 7,
+        "d1RowsWritten": 0,
+        "serverWallMs": 203,
+        "responseBytes": 1818,
+        "signals": [],
+        "bootstrapMode": "selected-learner-bounded",
+        "bootstrapCapacity": {
+          "version": 4,
+          "mode": "public-bounded",
+          "limits": {
+            "activeSessionsPerLearner": 1,
+            "recentSessionsPerLearner": 5,
+            "recentEventsPerLearner": 50
+          },
+          "learners": {
+            "returned": 1
+          },
+          "practiceSessions": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false,
+            "atOrAboveMaximumLimit": false
+          },
+          "eventLog": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false
+          },
+          "subjectStatesBounded": false
+        },
+        "projectionFallback": null
+      }
+    },
+    {
+      "scenario": "initial-bootstrap",
+      "virtualLearner": "learner-03",
+      "method": "GET",
+      "endpoint": "/api/bootstrap",
+      "status": 200,
+      "ok": true,
+      "wallMs": 142.1,
+      "responseBytes": 2447,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_dad9d159d02179d92b137d4c",
+      "serverRequestId": "req_dad9d159d02179d92b137d4c",
+      "capacity": {
+        "requestId": "req_dad9d159d02179d92b137d4c",
+        "queryCount": 9,
+        "d1RowsRead": 7,
+        "d1RowsWritten": 0,
+        "serverWallMs": 94,
+        "responseBytes": 1818,
+        "signals": [],
+        "bootstrapMode": "selected-learner-bounded",
+        "bootstrapCapacity": {
+          "version": 4,
+          "mode": "public-bounded",
+          "limits": {
+            "activeSessionsPerLearner": 1,
+            "recentSessionsPerLearner": 5,
+            "recentEventsPerLearner": 50
+          },
+          "learners": {
+            "returned": 1
+          },
+          "practiceSessions": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false,
+            "atOrAboveMaximumLimit": false
+          },
+          "eventLog": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false
+          },
+          "subjectStatesBounded": false
+        },
+        "projectionFallback": null
+      }
+    },
+    {
+      "scenario": "initial-bootstrap",
+      "virtualLearner": "learner-04",
+      "method": "GET",
+      "endpoint": "/api/bootstrap",
+      "status": 200,
+      "ok": true,
+      "wallMs": 144.8,
+      "responseBytes": 2448,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_a575bbabea3674708f6538d4",
+      "serverRequestId": "req_a575bbabea3674708f6538d4",
+      "capacity": {
+        "requestId": "req_a575bbabea3674708f6538d4",
+        "queryCount": 9,
+        "d1RowsRead": 7,
+        "d1RowsWritten": 0,
+        "serverWallMs": 102,
+        "responseBytes": 1818,
+        "signals": [],
+        "bootstrapMode": "selected-learner-bounded",
+        "bootstrapCapacity": {
+          "version": 4,
+          "mode": "public-bounded",
+          "limits": {
+            "activeSessionsPerLearner": 1,
+            "recentSessionsPerLearner": 5,
+            "recentEventsPerLearner": 50
+          },
+          "learners": {
+            "returned": 1
+          },
+          "practiceSessions": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false,
+            "atOrAboveMaximumLimit": false
+          },
+          "eventLog": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false
+          },
+          "subjectStatesBounded": false
+        },
+        "projectionFallback": null
+      }
+    },
+    {
+      "scenario": "initial-bootstrap",
+      "virtualLearner": "learner-05",
+      "method": "GET",
+      "endpoint": "/api/bootstrap",
+      "status": 200,
+      "ok": true,
+      "wallMs": 137.7,
+      "responseBytes": 2447,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_f1ac7c3383b7c4529cf6c5c0",
+      "serverRequestId": "req_f1ac7c3383b7c4529cf6c5c0",
+      "capacity": {
+        "requestId": "req_f1ac7c3383b7c4529cf6c5c0",
+        "queryCount": 9,
+        "d1RowsRead": 7,
+        "d1RowsWritten": 0,
+        "serverWallMs": 94,
+        "responseBytes": 1818,
+        "signals": [],
+        "bootstrapMode": "selected-learner-bounded",
+        "bootstrapCapacity": {
+          "version": 4,
+          "mode": "public-bounded",
+          "limits": {
+            "activeSessionsPerLearner": 1,
+            "recentSessionsPerLearner": 5,
+            "recentEventsPerLearner": 50
+          },
+          "learners": {
+            "returned": 1
+          },
+          "practiceSessions": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false,
+            "atOrAboveMaximumLimit": false
+          },
+          "eventLog": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false
+          },
+          "subjectStatesBounded": false
+        },
+        "projectionFallback": null
+      }
+    },
+    {
+      "scenario": "cold-bootstrap-burst",
+      "virtualLearner": "learner-01",
+      "method": "GET",
+      "endpoint": "/api/bootstrap",
+      "status": 200,
+      "ok": true,
+      "wallMs": 157.2,
+      "responseBytes": 2448,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_959b71383d04faa233d4250f",
+      "serverRequestId": "req_959b71383d04faa233d4250f",
+      "capacity": {
+        "requestId": "req_959b71383d04faa233d4250f",
+        "queryCount": 9,
+        "d1RowsRead": 7,
+        "d1RowsWritten": 0,
+        "serverWallMs": 112,
+        "responseBytes": 1818,
+        "signals": [],
+        "bootstrapMode": "selected-learner-bounded",
+        "bootstrapCapacity": {
+          "version": 4,
+          "mode": "public-bounded",
+          "limits": {
+            "activeSessionsPerLearner": 1,
+            "recentSessionsPerLearner": 5,
+            "recentEventsPerLearner": 50
+          },
+          "learners": {
+            "returned": 1
+          },
+          "practiceSessions": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false,
+            "atOrAboveMaximumLimit": false
+          },
+          "eventLog": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false
+          },
+          "subjectStatesBounded": false
+        },
+        "projectionFallback": null
+      }
+    },
+    {
+      "scenario": "cold-bootstrap-burst",
+      "virtualLearner": "learner-02",
+      "method": "GET",
+      "endpoint": "/api/bootstrap",
+      "status": 200,
+      "ok": true,
+      "wallMs": 194.5,
+      "responseBytes": 2448,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_00ffb5533c5ea42c834c194f",
+      "serverRequestId": "req_00ffb5533c5ea42c834c194f",
+      "capacity": {
+        "requestId": "req_00ffb5533c5ea42c834c194f",
+        "queryCount": 9,
+        "d1RowsRead": 7,
+        "d1RowsWritten": 0,
+        "serverWallMs": 135,
+        "responseBytes": 1818,
+        "signals": [],
+        "bootstrapMode": "selected-learner-bounded",
+        "bootstrapCapacity": {
+          "version": 4,
+          "mode": "public-bounded",
+          "limits": {
+            "activeSessionsPerLearner": 1,
+            "recentSessionsPerLearner": 5,
+            "recentEventsPerLearner": 50
+          },
+          "learners": {
+            "returned": 1
+          },
+          "practiceSessions": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false,
+            "atOrAboveMaximumLimit": false
+          },
+          "eventLog": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false
+          },
+          "subjectStatesBounded": false
+        },
+        "projectionFallback": null
+      }
+    },
+    {
+      "scenario": "cold-bootstrap-burst",
+      "virtualLearner": "learner-03",
+      "method": "GET",
+      "endpoint": "/api/bootstrap",
+      "status": 200,
+      "ok": true,
+      "wallMs": 745.2,
+      "responseBytes": 2447,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_d054748b902c6ee904143cb5",
+      "serverRequestId": "req_d054748b902c6ee904143cb5",
+      "capacity": {
+        "requestId": "req_d054748b902c6ee904143cb5",
+        "queryCount": 9,
+        "d1RowsRead": 7,
+        "d1RowsWritten": 0,
+        "serverWallMs": 76,
+        "responseBytes": 1818,
+        "signals": [],
+        "bootstrapMode": "selected-learner-bounded",
+        "bootstrapCapacity": {
+          "version": 4,
+          "mode": "public-bounded",
+          "limits": {
+            "activeSessionsPerLearner": 1,
+            "recentSessionsPerLearner": 5,
+            "recentEventsPerLearner": 50
+          },
+          "learners": {
+            "returned": 1
+          },
+          "practiceSessions": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false,
+            "atOrAboveMaximumLimit": false
+          },
+          "eventLog": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false
+          },
+          "subjectStatesBounded": false
+        },
+        "projectionFallback": null
+      }
+    },
+    {
+      "scenario": "cold-bootstrap-burst",
+      "virtualLearner": "learner-04",
+      "method": "GET",
+      "endpoint": "/api/bootstrap",
+      "status": 200,
+      "ok": true,
+      "wallMs": 217.7,
+      "responseBytes": 2448,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_5a655611a55c2e34114fbff9",
+      "serverRequestId": "req_5a655611a55c2e34114fbff9",
+      "capacity": {
+        "requestId": "req_5a655611a55c2e34114fbff9",
+        "queryCount": 9,
+        "d1RowsRead": 7,
+        "d1RowsWritten": 0,
+        "serverWallMs": 140,
+        "responseBytes": 1818,
+        "signals": [],
+        "bootstrapMode": "selected-learner-bounded",
+        "bootstrapCapacity": {
+          "version": 4,
+          "mode": "public-bounded",
+          "limits": {
+            "activeSessionsPerLearner": 1,
+            "recentSessionsPerLearner": 5,
+            "recentEventsPerLearner": 50
+          },
+          "learners": {
+            "returned": 1
+          },
+          "practiceSessions": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false,
+            "atOrAboveMaximumLimit": false
+          },
+          "eventLog": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false
+          },
+          "subjectStatesBounded": false
+        },
+        "projectionFallback": null
+      }
+    },
+    {
+      "scenario": "cold-bootstrap-burst",
+      "virtualLearner": "learner-05",
+      "method": "GET",
+      "endpoint": "/api/bootstrap",
+      "status": 200,
+      "ok": true,
+      "wallMs": 223.9,
+      "responseBytes": 2448,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_bd48495180519ac37d435828",
+      "serverRequestId": "req_bd48495180519ac37d435828",
+      "capacity": {
+        "requestId": "req_bd48495180519ac37d435828",
+        "queryCount": 9,
+        "d1RowsRead": 7,
+        "d1RowsWritten": 0,
+        "serverWallMs": 130,
+        "responseBytes": 1818,
+        "signals": [],
+        "bootstrapMode": "selected-learner-bounded",
+        "bootstrapCapacity": {
+          "version": 4,
+          "mode": "public-bounded",
+          "limits": {
+            "activeSessionsPerLearner": 1,
+            "recentSessionsPerLearner": 5,
+            "recentEventsPerLearner": 50
+          },
+          "learners": {
+            "returned": 1
+          },
+          "practiceSessions": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false,
+            "atOrAboveMaximumLimit": false
+          },
+          "eventLog": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false
+          },
+          "subjectStatesBounded": false
+        },
+        "projectionFallback": null
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-01",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 226.2,
+      "responseBytes": 4101,
+      "code": null,
+      "message": "",
+      "requestId": "req_d6127c8cd79bd992660e9100",
+      "clientRequestId": "req_cae5d268bc9a4b7ffac1c115",
+      "serverRequestId": "req_cae5d268bc9a4b7ffac1c115",
+      "capacity": {
+        "requestId": "req_cae5d268bc9a4b7ffac1c115",
+        "queryCount": 18,
+        "d1RowsRead": 13,
+        "d1RowsWritten": 16,
+        "serverWallMs": 172,
+        "responseBytes": 3883,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "miss-rehydrated"
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-01",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 205.5,
+      "responseBytes": 17225,
+      "code": null,
+      "message": "",
+      "requestId": "req_be667c6f7636aff3749f0292",
+      "clientRequestId": "req_0ae04b01dfedde69061a2842",
+      "serverRequestId": "req_0ae04b01dfedde69061a2842",
+      "capacity": {
+        "requestId": "req_0ae04b01dfedde69061a2842",
+        "queryCount": 16,
+        "d1RowsRead": 19,
+        "d1RowsWritten": 15,
+        "serverWallMs": 149,
+        "responseBytes": 17018,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "hit"
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-01",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 191.4,
+      "responseBytes": 5035,
+      "code": null,
+      "message": "",
+      "requestId": "req_23b9ce2f07fb1398c62130bf",
+      "clientRequestId": "req_a26d7f40e7abe241246a6b7a",
+      "serverRequestId": "req_a26d7f40e7abe241246a6b7a",
+      "capacity": {
+        "requestId": "req_a26d7f40e7abe241246a6b7a",
+        "queryCount": 15,
+        "d1RowsRead": 18,
+        "d1RowsWritten": 13,
+        "serverWallMs": 144,
+        "responseBytes": 4829,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "hit"
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-02",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 220,
+      "responseBytes": 4100,
+      "code": null,
+      "message": "",
+      "requestId": "req_f4fcfc3d75ca3b97651c1f84",
+      "clientRequestId": "req_26b90f95863a11292e3f43f2",
+      "serverRequestId": "req_26b90f95863a11292e3f43f2",
+      "capacity": {
+        "requestId": "req_26b90f95863a11292e3f43f2",
+        "queryCount": 18,
+        "d1RowsRead": 13,
+        "d1RowsWritten": 16,
+        "serverWallMs": 167,
+        "responseBytes": 3882,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "miss-rehydrated"
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-02",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 184.3,
+      "responseBytes": 17224,
+      "code": null,
+      "message": "",
+      "requestId": "req_bb44d40dcb5ec4ee02e289f6",
+      "clientRequestId": "req_06f85b3116d497ba01b79818",
+      "serverRequestId": "req_06f85b3116d497ba01b79818",
+      "capacity": {
+        "requestId": "req_06f85b3116d497ba01b79818",
+        "queryCount": 16,
+        "d1RowsRead": 19,
+        "d1RowsWritten": 15,
+        "serverWallMs": 135,
+        "responseBytes": 17017,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "hit"
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-02",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 185.1,
+      "responseBytes": 5031,
+      "code": null,
+      "message": "",
+      "requestId": "req_2f51281dffb3d5a43c52d086",
+      "clientRequestId": "req_eb8499d207661cdfe141d277",
+      "serverRequestId": "req_eb8499d207661cdfe141d277",
+      "capacity": {
+        "requestId": "req_eb8499d207661cdfe141d277",
+        "queryCount": 15,
+        "d1RowsRead": 18,
+        "d1RowsWritten": 13,
+        "serverWallMs": 136,
+        "responseBytes": 4825,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "hit"
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-03",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 218.5,
+      "responseBytes": 4100,
+      "code": null,
+      "message": "",
+      "requestId": "req_24e26eec6a74a33c50cc99fb",
+      "clientRequestId": "req_5e0699eab75bd15a442f7bb6",
+      "serverRequestId": "req_5e0699eab75bd15a442f7bb6",
+      "capacity": {
+        "requestId": "req_5e0699eab75bd15a442f7bb6",
+        "queryCount": 18,
+        "d1RowsRead": 13,
+        "d1RowsWritten": 16,
+        "serverWallMs": 159,
+        "responseBytes": 3882,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "miss-rehydrated"
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-03",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 185.9,
+      "responseBytes": 17224,
+      "code": null,
+      "message": "",
+      "requestId": "req_8b88aff44914d9a303e8b42c",
+      "clientRequestId": "req_aa9fec570dad4384421f3cd2",
+      "serverRequestId": "req_aa9fec570dad4384421f3cd2",
+      "capacity": {
+        "requestId": "req_aa9fec570dad4384421f3cd2",
+        "queryCount": 16,
+        "d1RowsRead": 19,
+        "d1RowsWritten": 15,
+        "serverWallMs": 138,
+        "responseBytes": 17017,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "hit"
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-03",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 176.4,
+      "responseBytes": 5031,
+      "code": null,
+      "message": "",
+      "requestId": "req_5cacbb6a2c8fc4edae4b662e",
+      "clientRequestId": "req_77c14c15427c51d24e504e03",
+      "serverRequestId": "req_77c14c15427c51d24e504e03",
+      "capacity": {
+        "requestId": "req_77c14c15427c51d24e504e03",
+        "queryCount": 15,
+        "d1RowsRead": 18,
+        "d1RowsWritten": 13,
+        "serverWallMs": 130,
+        "responseBytes": 4825,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "hit"
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-04",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 205.8,
+      "responseBytes": 4103,
+      "code": null,
+      "message": "",
+      "requestId": "req_85a9e94239fdc551ff060ae4",
+      "clientRequestId": "req_84fd0ec8cc374c86b902359d",
+      "serverRequestId": "req_84fd0ec8cc374c86b902359d",
+      "capacity": {
+        "requestId": "req_84fd0ec8cc374c86b902359d",
+        "queryCount": 18,
+        "d1RowsRead": 13,
+        "d1RowsWritten": 16,
+        "serverWallMs": 154,
+        "responseBytes": 3885,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "miss-rehydrated"
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-04",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 192.1,
+      "responseBytes": 17231,
+      "code": null,
+      "message": "",
+      "requestId": "req_1303a007fa278c765f48b789",
+      "clientRequestId": "req_71d99b2ebf065fa61c7884e5",
+      "serverRequestId": "req_71d99b2ebf065fa61c7884e5",
+      "capacity": {
+        "requestId": "req_71d99b2ebf065fa61c7884e5",
+        "queryCount": 16,
+        "d1RowsRead": 19,
+        "d1RowsWritten": 15,
+        "serverWallMs": 138,
+        "responseBytes": 17024,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "hit"
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-04",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 204,
+      "responseBytes": 5039,
+      "code": null,
+      "message": "",
+      "requestId": "req_e7018ac0e41ee2ee5eea65ed",
+      "clientRequestId": "req_d9e7cc7cc56e89b20252251b",
+      "serverRequestId": "req_d9e7cc7cc56e89b20252251b",
+      "capacity": {
+        "requestId": "req_d9e7cc7cc56e89b20252251b",
+        "queryCount": 15,
+        "d1RowsRead": 18,
+        "d1RowsWritten": 13,
+        "serverWallMs": 155,
+        "responseBytes": 4833,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "hit"
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-05",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 203.8,
+      "responseBytes": 4103,
+      "code": null,
+      "message": "",
+      "requestId": "req_60bd3bca7a162fb185aea085",
+      "clientRequestId": "req_0db65905dfe0f47dab22512f",
+      "serverRequestId": "req_0db65905dfe0f47dab22512f",
+      "capacity": {
+        "requestId": "req_0db65905dfe0f47dab22512f",
+        "queryCount": 18,
+        "d1RowsRead": 13,
+        "d1RowsWritten": 16,
+        "serverWallMs": 154,
+        "responseBytes": 3885,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "miss-rehydrated"
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-05",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 192.6,
+      "responseBytes": 17231,
+      "code": null,
+      "message": "",
+      "requestId": "req_b2dad783f20adf27c3b51901",
+      "clientRequestId": "req_f0860a49516a4e35ac9ee452",
+      "serverRequestId": "req_f0860a49516a4e35ac9ee452",
+      "capacity": {
+        "requestId": "req_f0860a49516a4e35ac9ee452",
+        "queryCount": 16,
+        "d1RowsRead": 19,
+        "d1RowsWritten": 15,
+        "serverWallMs": 138,
+        "responseBytes": 17024,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "hit"
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-05",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 179.6,
+      "responseBytes": 5039,
+      "code": null,
+      "message": "",
+      "requestId": "req_091f2ba1779d5fd1890b68f0",
+      "clientRequestId": "req_6e8efd5dee7afc2acd7be59b",
+      "serverRequestId": "req_6e8efd5dee7afc2acd7be59b",
+      "capacity": {
+        "requestId": "req_6e8efd5dee7afc2acd7be59b",
+        "queryCount": 15,
+        "d1RowsRead": 18,
+        "d1RowsWritten": 13,
+        "serverWallMs": 135,
+        "responseBytes": 4833,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "hit"
+      }
+    }
+  ],
+  "startedAt": "2026-05-31T11:55:41.984Z",
+  "finishedAt": "2026-05-31T11:55:47.924Z",
+  "sessionSourceMode": "demo-sessions",
+  "thresholds": {
+    "max5xx": {
+      "configured": 0,
+      "observed": 0,
+      "passed": true
+    },
+    "maxNetworkFailures": {
+      "configured": 0,
+      "observed": 0,
+      "passed": true
+    },
+    "maxResponseBytes": {
+      "configured": 600000,
+      "observed": 17231,
+      "passed": true
+    },
+    "requireZeroSignals": {
+      "configured": true,
+      "observed": 0,
+      "passed": true
+    },
+    "configured": true,
+    "violations": [],
+    "limits": {
+      "max5xx": 0,
+      "maxNetworkFailures": 0,
+      "maxBootstrapP95Ms": null,
+      "maxCommandP95Ms": null,
+      "maxResponseBytes": 600000,
+      "requireZeroSignals": true,
+      "requireBootstrapCapacity": false
+    }
+  },
+  "failures": [],
+  "safety": {
+    "mode": "production",
+    "origin": "https://ks2.eugnel.uk",
+    "learners": 5,
+    "bootstrapBurst": 5,
+    "demoSessions": true,
+    "authMode": "demo-sessions",
+    "confirmedVia": [
+      "production-load"
+    ]
+  },
+  "diagnostics": {
+    "classification": {
+      "kind": "diagnostic",
+      "certificationEligible": false,
+      "reasons": [
+        "non-p6-30-learner-gate-shape",
+        "missing-pinned-threshold-config"
+      ],
+      "targetTier": null,
+      "runShape": {
+        "mode": "production",
+        "origin": "https://ks2.eugnel.uk",
+        "originClass": "production",
+        "learners": 5,
+        "bootstrapBurst": 5,
+        "rounds": 1,
+        "sessionSourceMode": "demo-sessions",
+        "releaseGateShape": false
+      },
+      "shapeEligible": false,
+      "thresholdEligible": true,
+      "evidenceComplete": true
+    },
+    "evidenceLane": {
+      "matrix": "p1-evidence-attribution",
+      "lane": "diagnostic-alternate-run-shape",
+      "diagnosticOnly": true,
+      "certificationCandidate": false,
+      "requiresUniqueOutputPath": true,
+      "reasons": [
+        "non-p6-30-learner-gate-shape",
+        "missing-pinned-threshold-config"
+      ]
+    },
+    "runShape": {
+      "mode": "production",
+      "origin": "https://ks2.eugnel.uk",
+      "originClass": "production",
+      "learners": 5,
+      "bootstrapBurst": 5,
+      "rounds": 1,
+      "sessionSourceMode": "demo-sessions",
+      "releaseGateShape": false
+    },
+    "endpointInventory": {
+      "hasBootstrapMetrics": true,
+      "hasCommandMetrics": true,
+      "bootstrapEndpointKeys": [
+        "GET /api/bootstrap"
+      ],
+      "commandEndpointKeys": [
+        "POST /api/subjects/grammar/command"
+      ]
+    },
+    "thresholdConfig": {
+      "configPath": null,
+      "tier": null,
+      "minEvidenceSchemaVersion": null,
+      "hash": "none"
+    },
+    "thresholdViolations": []
+  },
+  "reportMeta": {
+    "commit": "eb9cb8f7558d1384e9f5a28674ac213c42b4194b",
+    "environment": "production",
+    "origin": "https://ks2.eugnel.uk",
+    "authMode": "demo-sessions",
+    "learners": 5,
+    "bootstrapBurst": 5,
+    "rounds": 1,
+    "startedAt": "2026-05-31T11:55:41.984Z",
+    "finishedAt": "2026-05-31T11:55:47.924Z",
+    "evidenceSchemaVersion": 3,
+    "provenance": {
+      "workflowRunUrl": "unknown",
+      "workflowName": "unknown",
+      "gitSha": "eb9cb8f7558d1384e9f5a28674ac213c42b4194b",
+      "dirtyTreeFlag": false,
+      "thresholdConfigHash": "none",
+      "loadDriverVersion": "0.1.0",
+      "operator": "fol2h",
+      "rawLogArtifactPath": "none"
+    }
+  },
+  "redaction": {
+    "version": "capacity-diagnostics-redaction-v1",
+    "requestIds": "sha256:24",
+    "rawRequestIdsPersisted": false
+  }
+}

--- a/reports/capacity/evidence/2026-05-31-item1-bootstrap-tail-r2.json
+++ b/reports/capacity/evidence/2026-05-31-item1-bootstrap-tail-r2.json
@@ -1,0 +1,1858 @@
+{
+  "ok": true,
+  "dryRun": false,
+  "plan": {
+    "mode": "production",
+    "origin": "https://ks2.eugnel.uk",
+    "virtualLearners": [
+      {
+        "index": 0,
+        "label": "learner-01"
+      },
+      {
+        "index": 1,
+        "label": "learner-02"
+      },
+      {
+        "index": 2,
+        "label": "learner-03"
+      },
+      {
+        "index": 3,
+        "label": "learner-04"
+      },
+      {
+        "index": 4,
+        "label": "learner-05"
+      }
+    ],
+    "scenarios": [
+      {
+        "name": "cold-bootstrap-burst",
+        "requests": 5,
+        "concurrency": 5,
+        "endpoint": "GET /api/bootstrap"
+      },
+      {
+        "name": "human-paced-grammar-round",
+        "learners": 5,
+        "rounds": 1,
+        "pacingMs": 0,
+        "commandsPerRound": 3,
+        "endpoint": "POST /api/subjects/grammar/command"
+      }
+    ],
+    "expectedRequests": 30,
+    "safety": {
+      "productionRequiresConfirmation": true,
+      "productionRequiresAuth": true,
+      "localFixtureRequiresDemoSessions": true
+    }
+  },
+  "summary": {
+    "ok": true,
+    "totalRequests": 30,
+    "expectedRequests": 30,
+    "statusCounts": {
+      "200": 25,
+      "201": 5
+    },
+    "endpointStatus": {
+      "POST /api/demo/session 201": 5,
+      "GET /api/bootstrap 200": 10,
+      "POST /api/subjects/grammar/command 200": 15
+    },
+    "endpoints": {
+      "POST /api/demo/session": {
+        "phase": "setup",
+        "count": 5,
+        "p50WallMs": 196.4,
+        "p95WallMs": 237.6,
+        "maxWallMs": 237.6,
+        "p50ResponseBytes": 155,
+        "p95ResponseBytes": 155,
+        "maxResponseBytes": 155,
+        "topTailSamples": [
+          {
+            "scenario": "demo-session-setup",
+            "virtualLearner": "learner-01",
+            "status": 201,
+            "ok": true,
+            "wallMs": 237.6,
+            "responseBytes": 155,
+            "clientRequestId": "req_357fea8e2da09eed0dc1823c",
+            "serverRequestId": "req_357fea8e2da09eed0dc1823c"
+          },
+          {
+            "scenario": "demo-session-setup",
+            "virtualLearner": "learner-04",
+            "status": 201,
+            "ok": true,
+            "wallMs": 204.4,
+            "responseBytes": 155,
+            "clientRequestId": "req_a3d9b886942cfabd66a35167",
+            "serverRequestId": "req_a3d9b886942cfabd66a35167"
+          },
+          {
+            "scenario": "demo-session-setup",
+            "virtualLearner": "learner-02",
+            "status": 201,
+            "ok": true,
+            "wallMs": 196.4,
+            "responseBytes": 155,
+            "clientRequestId": "req_dc322f8dc1c29c001dce5523",
+            "serverRequestId": "req_dc322f8dc1c29c001dce5523"
+          },
+          {
+            "scenario": "demo-session-setup",
+            "virtualLearner": "learner-03",
+            "status": 201,
+            "ok": true,
+            "wallMs": 159.7,
+            "responseBytes": 155,
+            "clientRequestId": "req_52d3f57ab7baaa523deba9ae",
+            "serverRequestId": "req_52d3f57ab7baaa523deba9ae"
+          },
+          {
+            "scenario": "demo-session-setup",
+            "virtualLearner": "learner-05",
+            "status": 201,
+            "ok": true,
+            "wallMs": 155.7,
+            "responseBytes": 155,
+            "clientRequestId": "req_5f2757eb4807b7f87b8ed583",
+            "serverRequestId": "req_5f2757eb4807b7f87b8ed583"
+          }
+        ]
+      },
+      "GET /api/bootstrap": {
+        "phase": "bootstrap",
+        "count": 10,
+        "p50WallMs": 167.2,
+        "p95WallMs": 221.6,
+        "maxWallMs": 221.6,
+        "p50ResponseBytes": 2447,
+        "p95ResponseBytes": 2448,
+        "maxResponseBytes": 2448,
+        "queryCount": 9,
+        "queryCountP50": 9,
+        "queryCountP95": 9,
+        "queryCountMax": 9,
+        "d1RowsRead": 7,
+        "d1RowsReadP50": 7,
+        "d1RowsReadP95": 7,
+        "d1RowsReadMax": 7,
+        "d1RowsWritten": 0,
+        "d1RowsWrittenP50": 0,
+        "d1RowsWrittenP95": 0,
+        "d1RowsWrittenMax": 0,
+        "serverWallMsP50": 96,
+        "serverWallMsP95": 158,
+        "serverWallMsMax": 158,
+        "serverResponseBytesP50": 1818,
+        "serverResponseBytesP95": 1818,
+        "serverResponseBytesMax": 1818,
+        "bootstrapModes": {
+          "selected-learner-bounded": 10
+        },
+        "bootstrapCapacityModes": {
+          "public-bounded": 10
+        },
+        "bootstrapCapacityVersions": {
+          "4": 10
+        },
+        "subjectStatesBounded": {
+          "false": 10
+        },
+        "topTailSamples": [
+          {
+            "scenario": "cold-bootstrap-burst",
+            "virtualLearner": "learner-05",
+            "status": 200,
+            "ok": true,
+            "wallMs": 221.6,
+            "responseBytes": 2448,
+            "clientRequestId": "req_537401f403303c99be3d292f",
+            "serverRequestId": "req_537401f403303c99be3d292f",
+            "queryCount": 9,
+            "d1RowsRead": 7,
+            "d1RowsWritten": 0,
+            "serverWallMs": 158,
+            "serverResponseBytes": 1818,
+            "bootstrapMode": "selected-learner-bounded",
+            "bootstrapCapacityMode": "public-bounded",
+            "bootstrapCapacityVersion": 4
+          },
+          {
+            "scenario": "cold-bootstrap-burst",
+            "virtualLearner": "learner-04",
+            "status": 200,
+            "ok": true,
+            "wallMs": 220.8,
+            "responseBytes": 2448,
+            "clientRequestId": "req_6821438bd342459ae65e4129",
+            "serverRequestId": "req_6821438bd342459ae65e4129",
+            "queryCount": 9,
+            "d1RowsRead": 7,
+            "d1RowsWritten": 0,
+            "serverWallMs": 155,
+            "serverResponseBytes": 1818,
+            "bootstrapMode": "selected-learner-bounded",
+            "bootstrapCapacityMode": "public-bounded",
+            "bootstrapCapacityVersion": 4
+          },
+          {
+            "scenario": "cold-bootstrap-burst",
+            "virtualLearner": "learner-03",
+            "status": 200,
+            "ok": true,
+            "wallMs": 209.6,
+            "responseBytes": 2448,
+            "clientRequestId": "req_821525eb93f24008b55abb2c",
+            "serverRequestId": "req_821525eb93f24008b55abb2c",
+            "queryCount": 9,
+            "d1RowsRead": 7,
+            "d1RowsWritten": 0,
+            "serverWallMs": 140,
+            "serverResponseBytes": 1818,
+            "bootstrapMode": "selected-learner-bounded",
+            "bootstrapCapacityMode": "public-bounded",
+            "bootstrapCapacityVersion": 4
+          },
+          {
+            "scenario": "cold-bootstrap-burst",
+            "virtualLearner": "learner-01",
+            "status": 200,
+            "ok": true,
+            "wallMs": 186.3,
+            "responseBytes": 2448,
+            "clientRequestId": "req_45e9f05c4796934f5c419138",
+            "serverRequestId": "req_45e9f05c4796934f5c419138",
+            "queryCount": 9,
+            "d1RowsRead": 7,
+            "d1RowsWritten": 0,
+            "serverWallMs": 141,
+            "serverResponseBytes": 1818,
+            "bootstrapMode": "selected-learner-bounded",
+            "bootstrapCapacityMode": "public-bounded",
+            "bootstrapCapacityVersion": 4
+          },
+          {
+            "scenario": "cold-bootstrap-burst",
+            "virtualLearner": "learner-02",
+            "status": 200,
+            "ok": true,
+            "wallMs": 185.9,
+            "responseBytes": 2448,
+            "clientRequestId": "req_fdded2546d3ae251a6c71744",
+            "serverRequestId": "req_fdded2546d3ae251a6c71744",
+            "queryCount": 9,
+            "d1RowsRead": 7,
+            "d1RowsWritten": 0,
+            "serverWallMs": 144,
+            "serverResponseBytes": 1818,
+            "bootstrapMode": "selected-learner-bounded",
+            "bootstrapCapacityMode": "public-bounded",
+            "bootstrapCapacityVersion": 4
+          },
+          {
+            "scenario": "initial-bootstrap",
+            "virtualLearner": "learner-01",
+            "status": 200,
+            "ok": true,
+            "wallMs": 167.2,
+            "responseBytes": 2447,
+            "clientRequestId": "req_e8043801b4b4838464cea425",
+            "serverRequestId": "req_e8043801b4b4838464cea425",
+            "queryCount": 9,
+            "d1RowsRead": 7,
+            "d1RowsWritten": 0,
+            "serverWallMs": 96,
+            "serverResponseBytes": 1818,
+            "bootstrapMode": "selected-learner-bounded",
+            "bootstrapCapacityMode": "public-bounded",
+            "bootstrapCapacityVersion": 4
+          },
+          {
+            "scenario": "initial-bootstrap",
+            "virtualLearner": "learner-02",
+            "status": 200,
+            "ok": true,
+            "wallMs": 145.9,
+            "responseBytes": 2447,
+            "clientRequestId": "req_690f7d4d1f15ef87696108db",
+            "serverRequestId": "req_690f7d4d1f15ef87696108db",
+            "queryCount": 9,
+            "d1RowsRead": 7,
+            "d1RowsWritten": 0,
+            "serverWallMs": 84,
+            "serverResponseBytes": 1818,
+            "bootstrapMode": "selected-learner-bounded",
+            "bootstrapCapacityMode": "public-bounded",
+            "bootstrapCapacityVersion": 4
+          },
+          {
+            "scenario": "initial-bootstrap",
+            "virtualLearner": "learner-04",
+            "status": 200,
+            "ok": true,
+            "wallMs": 123.5,
+            "responseBytes": 2447,
+            "clientRequestId": "req_01fdcb1621ba3ab0547397eb",
+            "serverRequestId": "req_01fdcb1621ba3ab0547397eb",
+            "queryCount": 9,
+            "d1RowsRead": 7,
+            "d1RowsWritten": 0,
+            "serverWallMs": 80,
+            "serverResponseBytes": 1818,
+            "bootstrapMode": "selected-learner-bounded",
+            "bootstrapCapacityMode": "public-bounded",
+            "bootstrapCapacityVersion": 4
+          },
+          {
+            "scenario": "initial-bootstrap",
+            "virtualLearner": "learner-03",
+            "status": 200,
+            "ok": true,
+            "wallMs": 122.4,
+            "responseBytes": 2447,
+            "clientRequestId": "req_d8f73753870d701b2172eff8",
+            "serverRequestId": "req_d8f73753870d701b2172eff8",
+            "queryCount": 9,
+            "d1RowsRead": 7,
+            "d1RowsWritten": 0,
+            "serverWallMs": 79,
+            "serverResponseBytes": 1818,
+            "bootstrapMode": "selected-learner-bounded",
+            "bootstrapCapacityMode": "public-bounded",
+            "bootstrapCapacityVersion": 4
+          },
+          {
+            "scenario": "initial-bootstrap",
+            "virtualLearner": "learner-05",
+            "status": 200,
+            "ok": true,
+            "wallMs": 115.4,
+            "responseBytes": 2447,
+            "clientRequestId": "req_f88f428368997c648865c9a3",
+            "serverRequestId": "req_f88f428368997c648865c9a3",
+            "queryCount": 9,
+            "d1RowsRead": 7,
+            "d1RowsWritten": 0,
+            "serverWallMs": 69,
+            "serverResponseBytes": 1818,
+            "bootstrapMode": "selected-learner-bounded",
+            "bootstrapCapacityMode": "public-bounded",
+            "bootstrapCapacityVersion": 4
+          }
+        ]
+      },
+      "POST /api/subjects/grammar/command": {
+        "phase": "command",
+        "count": 15,
+        "p50WallMs": 170,
+        "p95WallMs": 226.1,
+        "maxWallMs": 226.1,
+        "p50ResponseBytes": 5035,
+        "p95ResponseBytes": 17230,
+        "maxResponseBytes": 17230,
+        "queryCount": 19,
+        "queryCountP50": 16,
+        "queryCountP95": 19,
+        "queryCountMax": 19,
+        "d1RowsRead": 142,
+        "d1RowsReadP50": 18,
+        "d1RowsReadP95": 142,
+        "d1RowsReadMax": 142,
+        "d1RowsWritten": 16,
+        "d1RowsWrittenP50": 15,
+        "d1RowsWrittenP95": 16,
+        "d1RowsWrittenMax": 16,
+        "serverWallMsP50": 120,
+        "serverWallMsP95": 165,
+        "serverWallMsMax": 165,
+        "serverResponseBytesP50": 4829,
+        "serverResponseBytesP95": 17023,
+        "serverResponseBytesMax": 17023,
+        "topTailSamples": [
+          {
+            "scenario": "human-paced-grammar-round",
+            "virtualLearner": "learner-04",
+            "status": 200,
+            "ok": true,
+            "wallMs": 226.1,
+            "responseBytes": 4102,
+            "clientRequestId": "req_a22398ab15456e432b75d026",
+            "serverRequestId": "req_a22398ab15456e432b75d026",
+            "queryCount": 18,
+            "d1RowsRead": 13,
+            "d1RowsWritten": 16,
+            "serverWallMs": 165,
+            "serverResponseBytes": 3884
+          },
+          {
+            "scenario": "human-paced-grammar-round",
+            "virtualLearner": "learner-01",
+            "status": 200,
+            "ok": true,
+            "wallMs": 197.6,
+            "responseBytes": 4102,
+            "clientRequestId": "req_2dd86b16347a1a8011c45fdb",
+            "serverRequestId": "req_2dd86b16347a1a8011c45fdb",
+            "queryCount": 19,
+            "d1RowsRead": 142,
+            "d1RowsWritten": 16,
+            "serverWallMs": 130,
+            "serverResponseBytes": 3883
+          },
+          {
+            "scenario": "human-paced-grammar-round",
+            "virtualLearner": "learner-01",
+            "status": 200,
+            "ok": true,
+            "wallMs": 187,
+            "responseBytes": 5035,
+            "clientRequestId": "req_3448de8950793045268f37f6",
+            "serverRequestId": "req_3448de8950793045268f37f6",
+            "queryCount": 15,
+            "d1RowsRead": 18,
+            "d1RowsWritten": 13,
+            "serverWallMs": 135,
+            "serverResponseBytes": 4829
+          },
+          {
+            "scenario": "human-paced-grammar-round",
+            "virtualLearner": "learner-02",
+            "status": 200,
+            "ok": true,
+            "wallMs": 180.5,
+            "responseBytes": 4101,
+            "clientRequestId": "req_1421249493819396b9008bb8",
+            "serverRequestId": "req_1421249493819396b9008bb8",
+            "queryCount": 18,
+            "d1RowsRead": 13,
+            "d1RowsWritten": 16,
+            "serverWallMs": 122,
+            "serverResponseBytes": 3883
+          },
+          {
+            "scenario": "human-paced-grammar-round",
+            "virtualLearner": "learner-05",
+            "status": 200,
+            "ok": true,
+            "wallMs": 180.1,
+            "responseBytes": 4102,
+            "clientRequestId": "req_d6253c6d5bae08ddbd08acc1",
+            "serverRequestId": "req_d6253c6d5bae08ddbd08acc1",
+            "queryCount": 18,
+            "d1RowsRead": 13,
+            "d1RowsWritten": 16,
+            "serverWallMs": 132,
+            "serverResponseBytes": 3884
+          },
+          {
+            "scenario": "human-paced-grammar-round",
+            "virtualLearner": "learner-03",
+            "status": 200,
+            "ok": true,
+            "wallMs": 176.7,
+            "responseBytes": 17225,
+            "clientRequestId": "req_59fd080b8daf1d4c4a4b6a34",
+            "serverRequestId": "req_59fd080b8daf1d4c4a4b6a34",
+            "queryCount": 16,
+            "d1RowsRead": 19,
+            "d1RowsWritten": 15,
+            "serverWallMs": 122,
+            "serverResponseBytes": 17018
+          },
+          {
+            "scenario": "human-paced-grammar-round",
+            "virtualLearner": "learner-03",
+            "status": 200,
+            "ok": true,
+            "wallMs": 171.9,
+            "responseBytes": 4101,
+            "clientRequestId": "req_80e624ff294ad08b731e49ef",
+            "serverRequestId": "req_80e624ff294ad08b731e49ef",
+            "queryCount": 18,
+            "d1RowsRead": 13,
+            "d1RowsWritten": 16,
+            "serverWallMs": 120,
+            "serverResponseBytes": 3883
+          },
+          {
+            "scenario": "human-paced-grammar-round",
+            "virtualLearner": "learner-04",
+            "status": 200,
+            "ok": true,
+            "wallMs": 170,
+            "responseBytes": 17230,
+            "clientRequestId": "req_bbf0c5259257cf115b76d607",
+            "serverRequestId": "req_bbf0c5259257cf115b76d607",
+            "queryCount": 16,
+            "d1RowsRead": 19,
+            "d1RowsWritten": 15,
+            "serverWallMs": 120,
+            "serverResponseBytes": 17023
+          },
+          {
+            "scenario": "human-paced-grammar-round",
+            "virtualLearner": "learner-02",
+            "status": 200,
+            "ok": true,
+            "wallMs": 169.7,
+            "responseBytes": 5035,
+            "clientRequestId": "req_47d8c3b5d63d8854a6056fa5",
+            "serverRequestId": "req_47d8c3b5d63d8854a6056fa5",
+            "queryCount": 15,
+            "d1RowsRead": 18,
+            "d1RowsWritten": 13,
+            "serverWallMs": 114,
+            "serverResponseBytes": 4829
+          },
+          {
+            "scenario": "human-paced-grammar-round",
+            "virtualLearner": "learner-05",
+            "status": 200,
+            "ok": true,
+            "wallMs": 162.5,
+            "responseBytes": 5035,
+            "clientRequestId": "req_9c0910f20fbe41e4256ef0fc",
+            "serverRequestId": "req_9c0910f20fbe41e4256ef0fc",
+            "queryCount": 15,
+            "d1RowsRead": 18,
+            "d1RowsWritten": 13,
+            "serverWallMs": 105,
+            "serverResponseBytes": 4829
+          }
+        ]
+      }
+    },
+    "phases": {
+      "setup": {
+        "phase": "setup",
+        "count": 5,
+        "p50WallMs": 196.4,
+        "p95WallMs": 237.6,
+        "maxWallMs": 237.6,
+        "p50ResponseBytes": 155,
+        "p95ResponseBytes": 155,
+        "maxResponseBytes": 155
+      },
+      "bootstrap": {
+        "phase": "bootstrap",
+        "count": 10,
+        "p50WallMs": 167.2,
+        "p95WallMs": 221.6,
+        "maxWallMs": 221.6,
+        "p50ResponseBytes": 2447,
+        "p95ResponseBytes": 2448,
+        "maxResponseBytes": 2448,
+        "queryCount": 9,
+        "queryCountP50": 9,
+        "queryCountP95": 9,
+        "queryCountMax": 9,
+        "d1RowsRead": 7,
+        "d1RowsReadP50": 7,
+        "d1RowsReadP95": 7,
+        "d1RowsReadMax": 7,
+        "d1RowsWritten": 0,
+        "d1RowsWrittenP50": 0,
+        "d1RowsWrittenP95": 0,
+        "d1RowsWrittenMax": 0,
+        "serverWallMsP50": 96,
+        "serverWallMsP95": 158,
+        "serverWallMsMax": 158,
+        "serverResponseBytesP50": 1818,
+        "serverResponseBytesP95": 1818,
+        "serverResponseBytesMax": 1818,
+        "bootstrapModes": {
+          "selected-learner-bounded": 10
+        },
+        "bootstrapCapacityModes": {
+          "public-bounded": 10
+        },
+        "bootstrapCapacityVersions": {
+          "4": 10
+        },
+        "subjectStatesBounded": {
+          "false": 10
+        }
+      },
+      "command": {
+        "phase": "command",
+        "count": 15,
+        "p50WallMs": 170,
+        "p95WallMs": 226.1,
+        "maxWallMs": 226.1,
+        "p50ResponseBytes": 5035,
+        "p95ResponseBytes": 17230,
+        "maxResponseBytes": 17230,
+        "queryCount": 19,
+        "queryCountP50": 16,
+        "queryCountP95": 19,
+        "queryCountMax": 19,
+        "d1RowsRead": 142,
+        "d1RowsReadP50": 18,
+        "d1RowsReadP95": 142,
+        "d1RowsReadMax": 142,
+        "d1RowsWritten": 16,
+        "d1RowsWrittenP50": 15,
+        "d1RowsWrittenP95": 16,
+        "d1RowsWrittenMax": 16,
+        "serverWallMsP50": 120,
+        "serverWallMsP95": 165,
+        "serverWallMsMax": 165,
+        "serverResponseBytesP50": 4829,
+        "serverResponseBytesP95": 17023,
+        "serverResponseBytesMax": 17023
+      }
+    },
+    "scenarios": {
+      "demo-session-setup": {
+        "phase": "setup",
+        "count": 5,
+        "p50WallMs": 196.4,
+        "p95WallMs": 237.6,
+        "maxWallMs": 237.6,
+        "p50ResponseBytes": 155,
+        "p95ResponseBytes": 155,
+        "maxResponseBytes": 155
+      },
+      "initial-bootstrap": {
+        "phase": "bootstrap",
+        "count": 5,
+        "p50WallMs": 123.5,
+        "p95WallMs": 167.2,
+        "maxWallMs": 167.2,
+        "p50ResponseBytes": 2447,
+        "p95ResponseBytes": 2447,
+        "maxResponseBytes": 2447,
+        "queryCount": 9,
+        "queryCountP50": 9,
+        "queryCountP95": 9,
+        "queryCountMax": 9,
+        "d1RowsRead": 7,
+        "d1RowsReadP50": 7,
+        "d1RowsReadP95": 7,
+        "d1RowsReadMax": 7,
+        "d1RowsWritten": 0,
+        "d1RowsWrittenP50": 0,
+        "d1RowsWrittenP95": 0,
+        "d1RowsWrittenMax": 0,
+        "serverWallMsP50": 80,
+        "serverWallMsP95": 96,
+        "serverWallMsMax": 96,
+        "serverResponseBytesP50": 1818,
+        "serverResponseBytesP95": 1818,
+        "serverResponseBytesMax": 1818,
+        "bootstrapModes": {
+          "selected-learner-bounded": 5
+        },
+        "bootstrapCapacityModes": {
+          "public-bounded": 5
+        },
+        "bootstrapCapacityVersions": {
+          "4": 5
+        },
+        "subjectStatesBounded": {
+          "false": 5
+        }
+      },
+      "cold-bootstrap-burst": {
+        "phase": "bootstrap",
+        "count": 5,
+        "p50WallMs": 209.6,
+        "p95WallMs": 221.6,
+        "maxWallMs": 221.6,
+        "p50ResponseBytes": 2448,
+        "p95ResponseBytes": 2448,
+        "maxResponseBytes": 2448,
+        "queryCount": 9,
+        "queryCountP50": 9,
+        "queryCountP95": 9,
+        "queryCountMax": 9,
+        "d1RowsRead": 7,
+        "d1RowsReadP50": 7,
+        "d1RowsReadP95": 7,
+        "d1RowsReadMax": 7,
+        "d1RowsWritten": 0,
+        "d1RowsWrittenP50": 0,
+        "d1RowsWrittenP95": 0,
+        "d1RowsWrittenMax": 0,
+        "serverWallMsP50": 144,
+        "serverWallMsP95": 158,
+        "serverWallMsMax": 158,
+        "serverResponseBytesP50": 1818,
+        "serverResponseBytesP95": 1818,
+        "serverResponseBytesMax": 1818,
+        "bootstrapModes": {
+          "selected-learner-bounded": 5
+        },
+        "bootstrapCapacityModes": {
+          "public-bounded": 5
+        },
+        "bootstrapCapacityVersions": {
+          "4": 5
+        },
+        "subjectStatesBounded": {
+          "false": 5
+        }
+      },
+      "human-paced-grammar-round": {
+        "phase": "command",
+        "count": 15,
+        "p50WallMs": 170,
+        "p95WallMs": 226.1,
+        "maxWallMs": 226.1,
+        "p50ResponseBytes": 5035,
+        "p95ResponseBytes": 17230,
+        "maxResponseBytes": 17230,
+        "queryCount": 19,
+        "queryCountP50": 16,
+        "queryCountP95": 19,
+        "queryCountMax": 19,
+        "d1RowsRead": 142,
+        "d1RowsReadP50": 18,
+        "d1RowsReadP95": 142,
+        "d1RowsReadMax": 142,
+        "d1RowsWritten": 16,
+        "d1RowsWrittenP50": 15,
+        "d1RowsWrittenP95": 16,
+        "d1RowsWrittenMax": 16,
+        "serverWallMsP50": 120,
+        "serverWallMsP95": 165,
+        "serverWallMsMax": 165,
+        "serverResponseBytesP50": 4829,
+        "serverResponseBytesP95": 17023,
+        "serverResponseBytesMax": 17023
+      }
+    },
+    "signals": {},
+    "failures": []
+  },
+  "measurements": [
+    {
+      "scenario": "demo-session-setup",
+      "virtualLearner": "learner-01",
+      "method": "POST",
+      "endpoint": "/api/demo/session",
+      "status": 201,
+      "ok": true,
+      "wallMs": 237.6,
+      "responseBytes": 155,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_357fea8e2da09eed0dc1823c",
+      "serverRequestId": "req_357fea8e2da09eed0dc1823c",
+      "capacity": null
+    },
+    {
+      "scenario": "demo-session-setup",
+      "virtualLearner": "learner-02",
+      "method": "POST",
+      "endpoint": "/api/demo/session",
+      "status": 201,
+      "ok": true,
+      "wallMs": 196.4,
+      "responseBytes": 155,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_dc322f8dc1c29c001dce5523",
+      "serverRequestId": "req_dc322f8dc1c29c001dce5523",
+      "capacity": null
+    },
+    {
+      "scenario": "demo-session-setup",
+      "virtualLearner": "learner-03",
+      "method": "POST",
+      "endpoint": "/api/demo/session",
+      "status": 201,
+      "ok": true,
+      "wallMs": 159.7,
+      "responseBytes": 155,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_52d3f57ab7baaa523deba9ae",
+      "serverRequestId": "req_52d3f57ab7baaa523deba9ae",
+      "capacity": null
+    },
+    {
+      "scenario": "demo-session-setup",
+      "virtualLearner": "learner-04",
+      "method": "POST",
+      "endpoint": "/api/demo/session",
+      "status": 201,
+      "ok": true,
+      "wallMs": 204.4,
+      "responseBytes": 155,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_a3d9b886942cfabd66a35167",
+      "serverRequestId": "req_a3d9b886942cfabd66a35167",
+      "capacity": null
+    },
+    {
+      "scenario": "demo-session-setup",
+      "virtualLearner": "learner-05",
+      "method": "POST",
+      "endpoint": "/api/demo/session",
+      "status": 201,
+      "ok": true,
+      "wallMs": 155.7,
+      "responseBytes": 155,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_5f2757eb4807b7f87b8ed583",
+      "serverRequestId": "req_5f2757eb4807b7f87b8ed583",
+      "capacity": null
+    },
+    {
+      "scenario": "initial-bootstrap",
+      "virtualLearner": "learner-01",
+      "method": "GET",
+      "endpoint": "/api/bootstrap",
+      "status": 200,
+      "ok": true,
+      "wallMs": 167.2,
+      "responseBytes": 2447,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_e8043801b4b4838464cea425",
+      "serverRequestId": "req_e8043801b4b4838464cea425",
+      "capacity": {
+        "requestId": "req_e8043801b4b4838464cea425",
+        "queryCount": 9,
+        "d1RowsRead": 7,
+        "d1RowsWritten": 0,
+        "serverWallMs": 96,
+        "responseBytes": 1818,
+        "signals": [],
+        "bootstrapMode": "selected-learner-bounded",
+        "bootstrapCapacity": {
+          "version": 4,
+          "mode": "public-bounded",
+          "limits": {
+            "activeSessionsPerLearner": 1,
+            "recentSessionsPerLearner": 5,
+            "recentEventsPerLearner": 50
+          },
+          "learners": {
+            "returned": 1
+          },
+          "practiceSessions": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false,
+            "atOrAboveMaximumLimit": false
+          },
+          "eventLog": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false
+          },
+          "subjectStatesBounded": false
+        },
+        "projectionFallback": null
+      }
+    },
+    {
+      "scenario": "initial-bootstrap",
+      "virtualLearner": "learner-02",
+      "method": "GET",
+      "endpoint": "/api/bootstrap",
+      "status": 200,
+      "ok": true,
+      "wallMs": 145.9,
+      "responseBytes": 2447,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_690f7d4d1f15ef87696108db",
+      "serverRequestId": "req_690f7d4d1f15ef87696108db",
+      "capacity": {
+        "requestId": "req_690f7d4d1f15ef87696108db",
+        "queryCount": 9,
+        "d1RowsRead": 7,
+        "d1RowsWritten": 0,
+        "serverWallMs": 84,
+        "responseBytes": 1818,
+        "signals": [],
+        "bootstrapMode": "selected-learner-bounded",
+        "bootstrapCapacity": {
+          "version": 4,
+          "mode": "public-bounded",
+          "limits": {
+            "activeSessionsPerLearner": 1,
+            "recentSessionsPerLearner": 5,
+            "recentEventsPerLearner": 50
+          },
+          "learners": {
+            "returned": 1
+          },
+          "practiceSessions": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false,
+            "atOrAboveMaximumLimit": false
+          },
+          "eventLog": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false
+          },
+          "subjectStatesBounded": false
+        },
+        "projectionFallback": null
+      }
+    },
+    {
+      "scenario": "initial-bootstrap",
+      "virtualLearner": "learner-03",
+      "method": "GET",
+      "endpoint": "/api/bootstrap",
+      "status": 200,
+      "ok": true,
+      "wallMs": 122.4,
+      "responseBytes": 2447,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_d8f73753870d701b2172eff8",
+      "serverRequestId": "req_d8f73753870d701b2172eff8",
+      "capacity": {
+        "requestId": "req_d8f73753870d701b2172eff8",
+        "queryCount": 9,
+        "d1RowsRead": 7,
+        "d1RowsWritten": 0,
+        "serverWallMs": 79,
+        "responseBytes": 1818,
+        "signals": [],
+        "bootstrapMode": "selected-learner-bounded",
+        "bootstrapCapacity": {
+          "version": 4,
+          "mode": "public-bounded",
+          "limits": {
+            "activeSessionsPerLearner": 1,
+            "recentSessionsPerLearner": 5,
+            "recentEventsPerLearner": 50
+          },
+          "learners": {
+            "returned": 1
+          },
+          "practiceSessions": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false,
+            "atOrAboveMaximumLimit": false
+          },
+          "eventLog": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false
+          },
+          "subjectStatesBounded": false
+        },
+        "projectionFallback": null
+      }
+    },
+    {
+      "scenario": "initial-bootstrap",
+      "virtualLearner": "learner-04",
+      "method": "GET",
+      "endpoint": "/api/bootstrap",
+      "status": 200,
+      "ok": true,
+      "wallMs": 123.5,
+      "responseBytes": 2447,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_01fdcb1621ba3ab0547397eb",
+      "serverRequestId": "req_01fdcb1621ba3ab0547397eb",
+      "capacity": {
+        "requestId": "req_01fdcb1621ba3ab0547397eb",
+        "queryCount": 9,
+        "d1RowsRead": 7,
+        "d1RowsWritten": 0,
+        "serverWallMs": 80,
+        "responseBytes": 1818,
+        "signals": [],
+        "bootstrapMode": "selected-learner-bounded",
+        "bootstrapCapacity": {
+          "version": 4,
+          "mode": "public-bounded",
+          "limits": {
+            "activeSessionsPerLearner": 1,
+            "recentSessionsPerLearner": 5,
+            "recentEventsPerLearner": 50
+          },
+          "learners": {
+            "returned": 1
+          },
+          "practiceSessions": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false,
+            "atOrAboveMaximumLimit": false
+          },
+          "eventLog": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false
+          },
+          "subjectStatesBounded": false
+        },
+        "projectionFallback": null
+      }
+    },
+    {
+      "scenario": "initial-bootstrap",
+      "virtualLearner": "learner-05",
+      "method": "GET",
+      "endpoint": "/api/bootstrap",
+      "status": 200,
+      "ok": true,
+      "wallMs": 115.4,
+      "responseBytes": 2447,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_f88f428368997c648865c9a3",
+      "serverRequestId": "req_f88f428368997c648865c9a3",
+      "capacity": {
+        "requestId": "req_f88f428368997c648865c9a3",
+        "queryCount": 9,
+        "d1RowsRead": 7,
+        "d1RowsWritten": 0,
+        "serverWallMs": 69,
+        "responseBytes": 1818,
+        "signals": [],
+        "bootstrapMode": "selected-learner-bounded",
+        "bootstrapCapacity": {
+          "version": 4,
+          "mode": "public-bounded",
+          "limits": {
+            "activeSessionsPerLearner": 1,
+            "recentSessionsPerLearner": 5,
+            "recentEventsPerLearner": 50
+          },
+          "learners": {
+            "returned": 1
+          },
+          "practiceSessions": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false,
+            "atOrAboveMaximumLimit": false
+          },
+          "eventLog": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false
+          },
+          "subjectStatesBounded": false
+        },
+        "projectionFallback": null
+      }
+    },
+    {
+      "scenario": "cold-bootstrap-burst",
+      "virtualLearner": "learner-01",
+      "method": "GET",
+      "endpoint": "/api/bootstrap",
+      "status": 200,
+      "ok": true,
+      "wallMs": 186.3,
+      "responseBytes": 2448,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_45e9f05c4796934f5c419138",
+      "serverRequestId": "req_45e9f05c4796934f5c419138",
+      "capacity": {
+        "requestId": "req_45e9f05c4796934f5c419138",
+        "queryCount": 9,
+        "d1RowsRead": 7,
+        "d1RowsWritten": 0,
+        "serverWallMs": 141,
+        "responseBytes": 1818,
+        "signals": [],
+        "bootstrapMode": "selected-learner-bounded",
+        "bootstrapCapacity": {
+          "version": 4,
+          "mode": "public-bounded",
+          "limits": {
+            "activeSessionsPerLearner": 1,
+            "recentSessionsPerLearner": 5,
+            "recentEventsPerLearner": 50
+          },
+          "learners": {
+            "returned": 1
+          },
+          "practiceSessions": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false,
+            "atOrAboveMaximumLimit": false
+          },
+          "eventLog": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false
+          },
+          "subjectStatesBounded": false
+        },
+        "projectionFallback": null
+      }
+    },
+    {
+      "scenario": "cold-bootstrap-burst",
+      "virtualLearner": "learner-02",
+      "method": "GET",
+      "endpoint": "/api/bootstrap",
+      "status": 200,
+      "ok": true,
+      "wallMs": 185.9,
+      "responseBytes": 2448,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_fdded2546d3ae251a6c71744",
+      "serverRequestId": "req_fdded2546d3ae251a6c71744",
+      "capacity": {
+        "requestId": "req_fdded2546d3ae251a6c71744",
+        "queryCount": 9,
+        "d1RowsRead": 7,
+        "d1RowsWritten": 0,
+        "serverWallMs": 144,
+        "responseBytes": 1818,
+        "signals": [],
+        "bootstrapMode": "selected-learner-bounded",
+        "bootstrapCapacity": {
+          "version": 4,
+          "mode": "public-bounded",
+          "limits": {
+            "activeSessionsPerLearner": 1,
+            "recentSessionsPerLearner": 5,
+            "recentEventsPerLearner": 50
+          },
+          "learners": {
+            "returned": 1
+          },
+          "practiceSessions": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false,
+            "atOrAboveMaximumLimit": false
+          },
+          "eventLog": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false
+          },
+          "subjectStatesBounded": false
+        },
+        "projectionFallback": null
+      }
+    },
+    {
+      "scenario": "cold-bootstrap-burst",
+      "virtualLearner": "learner-03",
+      "method": "GET",
+      "endpoint": "/api/bootstrap",
+      "status": 200,
+      "ok": true,
+      "wallMs": 209.6,
+      "responseBytes": 2448,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_821525eb93f24008b55abb2c",
+      "serverRequestId": "req_821525eb93f24008b55abb2c",
+      "capacity": {
+        "requestId": "req_821525eb93f24008b55abb2c",
+        "queryCount": 9,
+        "d1RowsRead": 7,
+        "d1RowsWritten": 0,
+        "serverWallMs": 140,
+        "responseBytes": 1818,
+        "signals": [],
+        "bootstrapMode": "selected-learner-bounded",
+        "bootstrapCapacity": {
+          "version": 4,
+          "mode": "public-bounded",
+          "limits": {
+            "activeSessionsPerLearner": 1,
+            "recentSessionsPerLearner": 5,
+            "recentEventsPerLearner": 50
+          },
+          "learners": {
+            "returned": 1
+          },
+          "practiceSessions": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false,
+            "atOrAboveMaximumLimit": false
+          },
+          "eventLog": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false
+          },
+          "subjectStatesBounded": false
+        },
+        "projectionFallback": null
+      }
+    },
+    {
+      "scenario": "cold-bootstrap-burst",
+      "virtualLearner": "learner-04",
+      "method": "GET",
+      "endpoint": "/api/bootstrap",
+      "status": 200,
+      "ok": true,
+      "wallMs": 220.8,
+      "responseBytes": 2448,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_6821438bd342459ae65e4129",
+      "serverRequestId": "req_6821438bd342459ae65e4129",
+      "capacity": {
+        "requestId": "req_6821438bd342459ae65e4129",
+        "queryCount": 9,
+        "d1RowsRead": 7,
+        "d1RowsWritten": 0,
+        "serverWallMs": 155,
+        "responseBytes": 1818,
+        "signals": [],
+        "bootstrapMode": "selected-learner-bounded",
+        "bootstrapCapacity": {
+          "version": 4,
+          "mode": "public-bounded",
+          "limits": {
+            "activeSessionsPerLearner": 1,
+            "recentSessionsPerLearner": 5,
+            "recentEventsPerLearner": 50
+          },
+          "learners": {
+            "returned": 1
+          },
+          "practiceSessions": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false,
+            "atOrAboveMaximumLimit": false
+          },
+          "eventLog": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false
+          },
+          "subjectStatesBounded": false
+        },
+        "projectionFallback": null
+      }
+    },
+    {
+      "scenario": "cold-bootstrap-burst",
+      "virtualLearner": "learner-05",
+      "method": "GET",
+      "endpoint": "/api/bootstrap",
+      "status": 200,
+      "ok": true,
+      "wallMs": 221.6,
+      "responseBytes": 2448,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_537401f403303c99be3d292f",
+      "serverRequestId": "req_537401f403303c99be3d292f",
+      "capacity": {
+        "requestId": "req_537401f403303c99be3d292f",
+        "queryCount": 9,
+        "d1RowsRead": 7,
+        "d1RowsWritten": 0,
+        "serverWallMs": 158,
+        "responseBytes": 1818,
+        "signals": [],
+        "bootstrapMode": "selected-learner-bounded",
+        "bootstrapCapacity": {
+          "version": 4,
+          "mode": "public-bounded",
+          "limits": {
+            "activeSessionsPerLearner": 1,
+            "recentSessionsPerLearner": 5,
+            "recentEventsPerLearner": 50
+          },
+          "learners": {
+            "returned": 1
+          },
+          "practiceSessions": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false,
+            "atOrAboveMaximumLimit": false
+          },
+          "eventLog": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false
+          },
+          "subjectStatesBounded": false
+        },
+        "projectionFallback": null
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-01",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 197.6,
+      "responseBytes": 4102,
+      "code": null,
+      "message": "",
+      "requestId": "req_5820ee4e9db86920635f30b7",
+      "clientRequestId": "req_2dd86b16347a1a8011c45fdb",
+      "serverRequestId": "req_2dd86b16347a1a8011c45fdb",
+      "capacity": {
+        "requestId": "req_2dd86b16347a1a8011c45fdb",
+        "queryCount": 19,
+        "d1RowsRead": 142,
+        "d1RowsWritten": 16,
+        "serverWallMs": 130,
+        "responseBytes": 3883,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "miss-rehydrated"
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-01",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 160.4,
+      "responseBytes": 17225,
+      "code": null,
+      "message": "",
+      "requestId": "req_63723ea2bb095f6e83c466d7",
+      "clientRequestId": "req_298f4e9da8f1b4262feb549f",
+      "serverRequestId": "req_298f4e9da8f1b4262feb549f",
+      "capacity": {
+        "requestId": "req_298f4e9da8f1b4262feb549f",
+        "queryCount": 16,
+        "d1RowsRead": 19,
+        "d1RowsWritten": 15,
+        "serverWallMs": 102,
+        "responseBytes": 17018,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "hit"
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-01",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 187,
+      "responseBytes": 5035,
+      "code": null,
+      "message": "",
+      "requestId": "req_e3fd65d422782aa5cde7bb18",
+      "clientRequestId": "req_3448de8950793045268f37f6",
+      "serverRequestId": "req_3448de8950793045268f37f6",
+      "capacity": {
+        "requestId": "req_3448de8950793045268f37f6",
+        "queryCount": 15,
+        "d1RowsRead": 18,
+        "d1RowsWritten": 13,
+        "serverWallMs": 135,
+        "responseBytes": 4829,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "hit"
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-02",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 180.5,
+      "responseBytes": 4101,
+      "code": null,
+      "message": "",
+      "requestId": "req_199c3f750532ee1a0dc9203d",
+      "clientRequestId": "req_1421249493819396b9008bb8",
+      "serverRequestId": "req_1421249493819396b9008bb8",
+      "capacity": {
+        "requestId": "req_1421249493819396b9008bb8",
+        "queryCount": 18,
+        "d1RowsRead": 13,
+        "d1RowsWritten": 16,
+        "serverWallMs": 122,
+        "responseBytes": 3883,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "miss-rehydrated"
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-02",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 158,
+      "responseBytes": 17225,
+      "code": null,
+      "message": "",
+      "requestId": "req_4c39f06755532239e02799bf",
+      "clientRequestId": "req_7d339a351c0723f5d3f635b8",
+      "serverRequestId": "req_7d339a351c0723f5d3f635b8",
+      "capacity": {
+        "requestId": "req_7d339a351c0723f5d3f635b8",
+        "queryCount": 16,
+        "d1RowsRead": 19,
+        "d1RowsWritten": 15,
+        "serverWallMs": 107,
+        "responseBytes": 17018,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "hit"
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-02",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 169.7,
+      "responseBytes": 5035,
+      "code": null,
+      "message": "",
+      "requestId": "req_dbe561b02dcceb681fc034fd",
+      "clientRequestId": "req_47d8c3b5d63d8854a6056fa5",
+      "serverRequestId": "req_47d8c3b5d63d8854a6056fa5",
+      "capacity": {
+        "requestId": "req_47d8c3b5d63d8854a6056fa5",
+        "queryCount": 15,
+        "d1RowsRead": 18,
+        "d1RowsWritten": 13,
+        "serverWallMs": 114,
+        "responseBytes": 4829,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "hit"
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-03",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 171.9,
+      "responseBytes": 4101,
+      "code": null,
+      "message": "",
+      "requestId": "req_556cdf3535f8a9990c148460",
+      "clientRequestId": "req_80e624ff294ad08b731e49ef",
+      "serverRequestId": "req_80e624ff294ad08b731e49ef",
+      "capacity": {
+        "requestId": "req_80e624ff294ad08b731e49ef",
+        "queryCount": 18,
+        "d1RowsRead": 13,
+        "d1RowsWritten": 16,
+        "serverWallMs": 120,
+        "responseBytes": 3883,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "miss-rehydrated"
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-03",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 176.7,
+      "responseBytes": 17225,
+      "code": null,
+      "message": "",
+      "requestId": "req_6a41b1546521ef031d8ec584",
+      "clientRequestId": "req_59fd080b8daf1d4c4a4b6a34",
+      "serverRequestId": "req_59fd080b8daf1d4c4a4b6a34",
+      "capacity": {
+        "requestId": "req_59fd080b8daf1d4c4a4b6a34",
+        "queryCount": 16,
+        "d1RowsRead": 19,
+        "d1RowsWritten": 15,
+        "serverWallMs": 122,
+        "responseBytes": 17018,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "hit"
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-03",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 159.4,
+      "responseBytes": 5035,
+      "code": null,
+      "message": "",
+      "requestId": "req_0f6d5599d91687f938da3ba8",
+      "clientRequestId": "req_af752703c24f301d52dde98b",
+      "serverRequestId": "req_af752703c24f301d52dde98b",
+      "capacity": {
+        "requestId": "req_af752703c24f301d52dde98b",
+        "queryCount": 15,
+        "d1RowsRead": 18,
+        "d1RowsWritten": 13,
+        "serverWallMs": 113,
+        "responseBytes": 4829,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "hit"
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-04",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 226.1,
+      "responseBytes": 4102,
+      "code": null,
+      "message": "",
+      "requestId": "req_f6747e7018ad3653ebac81a0",
+      "clientRequestId": "req_a22398ab15456e432b75d026",
+      "serverRequestId": "req_a22398ab15456e432b75d026",
+      "capacity": {
+        "requestId": "req_a22398ab15456e432b75d026",
+        "queryCount": 18,
+        "d1RowsRead": 13,
+        "d1RowsWritten": 16,
+        "serverWallMs": 165,
+        "responseBytes": 3884,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "miss-rehydrated"
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-04",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 170,
+      "responseBytes": 17230,
+      "code": null,
+      "message": "",
+      "requestId": "req_8230ba80877f08e88922722c",
+      "clientRequestId": "req_bbf0c5259257cf115b76d607",
+      "serverRequestId": "req_bbf0c5259257cf115b76d607",
+      "capacity": {
+        "requestId": "req_bbf0c5259257cf115b76d607",
+        "queryCount": 16,
+        "d1RowsRead": 19,
+        "d1RowsWritten": 15,
+        "serverWallMs": 120,
+        "responseBytes": 17023,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "hit"
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-04",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 156,
+      "responseBytes": 5035,
+      "code": null,
+      "message": "",
+      "requestId": "req_d308e98f046378c0e2fdc19f",
+      "clientRequestId": "req_c6e44c1f7f428deb7cdbf74a",
+      "serverRequestId": "req_c6e44c1f7f428deb7cdbf74a",
+      "capacity": {
+        "requestId": "req_c6e44c1f7f428deb7cdbf74a",
+        "queryCount": 15,
+        "d1RowsRead": 18,
+        "d1RowsWritten": 13,
+        "serverWallMs": 109,
+        "responseBytes": 4829,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "hit"
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-05",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 180.1,
+      "responseBytes": 4102,
+      "code": null,
+      "message": "",
+      "requestId": "req_d23c8f66abd00d2fc9e78f9f",
+      "clientRequestId": "req_d6253c6d5bae08ddbd08acc1",
+      "serverRequestId": "req_d6253c6d5bae08ddbd08acc1",
+      "capacity": {
+        "requestId": "req_d6253c6d5bae08ddbd08acc1",
+        "queryCount": 18,
+        "d1RowsRead": 13,
+        "d1RowsWritten": 16,
+        "serverWallMs": 132,
+        "responseBytes": 3884,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "miss-rehydrated"
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-05",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 157.6,
+      "responseBytes": 17230,
+      "code": null,
+      "message": "",
+      "requestId": "req_f689941601ec0a53ad78c9d1",
+      "clientRequestId": "req_10b7b43f890fe86b31076de5",
+      "serverRequestId": "req_10b7b43f890fe86b31076de5",
+      "capacity": {
+        "requestId": "req_10b7b43f890fe86b31076de5",
+        "queryCount": 16,
+        "d1RowsRead": 19,
+        "d1RowsWritten": 15,
+        "serverWallMs": 104,
+        "responseBytes": 17023,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "hit"
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-05",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 162.5,
+      "responseBytes": 5035,
+      "code": null,
+      "message": "",
+      "requestId": "req_bd47b60f6f59ee36aa6498ad",
+      "clientRequestId": "req_9c0910f20fbe41e4256ef0fc",
+      "serverRequestId": "req_9c0910f20fbe41e4256ef0fc",
+      "capacity": {
+        "requestId": "req_9c0910f20fbe41e4256ef0fc",
+        "queryCount": 15,
+        "d1RowsRead": 18,
+        "d1RowsWritten": 13,
+        "serverWallMs": 105,
+        "responseBytes": 4829,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "hit"
+      }
+    }
+  ],
+  "startedAt": "2026-05-31T11:55:54.047Z",
+  "finishedAt": "2026-05-31T11:55:58.520Z",
+  "sessionSourceMode": "demo-sessions",
+  "thresholds": {
+    "max5xx": {
+      "configured": 0,
+      "observed": 0,
+      "passed": true
+    },
+    "maxNetworkFailures": {
+      "configured": 0,
+      "observed": 0,
+      "passed": true
+    },
+    "maxResponseBytes": {
+      "configured": 600000,
+      "observed": 17230,
+      "passed": true
+    },
+    "requireZeroSignals": {
+      "configured": true,
+      "observed": 0,
+      "passed": true
+    },
+    "configured": true,
+    "violations": [],
+    "limits": {
+      "max5xx": 0,
+      "maxNetworkFailures": 0,
+      "maxBootstrapP95Ms": null,
+      "maxCommandP95Ms": null,
+      "maxResponseBytes": 600000,
+      "requireZeroSignals": true,
+      "requireBootstrapCapacity": false
+    }
+  },
+  "failures": [],
+  "safety": {
+    "mode": "production",
+    "origin": "https://ks2.eugnel.uk",
+    "learners": 5,
+    "bootstrapBurst": 5,
+    "demoSessions": true,
+    "authMode": "demo-sessions",
+    "confirmedVia": [
+      "production-load"
+    ]
+  },
+  "diagnostics": {
+    "classification": {
+      "kind": "diagnostic",
+      "certificationEligible": false,
+      "reasons": [
+        "non-p6-30-learner-gate-shape",
+        "missing-pinned-threshold-config"
+      ],
+      "targetTier": null,
+      "runShape": {
+        "mode": "production",
+        "origin": "https://ks2.eugnel.uk",
+        "originClass": "production",
+        "learners": 5,
+        "bootstrapBurst": 5,
+        "rounds": 1,
+        "sessionSourceMode": "demo-sessions",
+        "releaseGateShape": false
+      },
+      "shapeEligible": false,
+      "thresholdEligible": true,
+      "evidenceComplete": true
+    },
+    "evidenceLane": {
+      "matrix": "p1-evidence-attribution",
+      "lane": "diagnostic-alternate-run-shape",
+      "diagnosticOnly": true,
+      "certificationCandidate": false,
+      "requiresUniqueOutputPath": true,
+      "reasons": [
+        "non-p6-30-learner-gate-shape",
+        "missing-pinned-threshold-config"
+      ]
+    },
+    "runShape": {
+      "mode": "production",
+      "origin": "https://ks2.eugnel.uk",
+      "originClass": "production",
+      "learners": 5,
+      "bootstrapBurst": 5,
+      "rounds": 1,
+      "sessionSourceMode": "demo-sessions",
+      "releaseGateShape": false
+    },
+    "endpointInventory": {
+      "hasBootstrapMetrics": true,
+      "hasCommandMetrics": true,
+      "bootstrapEndpointKeys": [
+        "GET /api/bootstrap"
+      ],
+      "commandEndpointKeys": [
+        "POST /api/subjects/grammar/command"
+      ]
+    },
+    "thresholdConfig": {
+      "configPath": null,
+      "tier": null,
+      "minEvidenceSchemaVersion": null,
+      "hash": "none"
+    },
+    "thresholdViolations": []
+  },
+  "reportMeta": {
+    "commit": "eb9cb8f7558d1384e9f5a28674ac213c42b4194b",
+    "environment": "production",
+    "origin": "https://ks2.eugnel.uk",
+    "authMode": "demo-sessions",
+    "learners": 5,
+    "bootstrapBurst": 5,
+    "rounds": 1,
+    "startedAt": "2026-05-31T11:55:54.047Z",
+    "finishedAt": "2026-05-31T11:55:58.520Z",
+    "evidenceSchemaVersion": 3,
+    "provenance": {
+      "workflowRunUrl": "unknown",
+      "workflowName": "unknown",
+      "gitSha": "eb9cb8f7558d1384e9f5a28674ac213c42b4194b",
+      "dirtyTreeFlag": true,
+      "thresholdConfigHash": "none",
+      "loadDriverVersion": "0.1.0",
+      "operator": "fol2h",
+      "rawLogArtifactPath": "none"
+    }
+  },
+  "redaction": {
+    "version": "capacity-diagnostics-redaction-v1",
+    "requestIds": "sha256:24",
+    "rawRequestIdsPersisted": false
+  }
+}

--- a/reports/capacity/evidence/2026-05-31-item2-submit-answer-write-reduction.md
+++ b/reports/capacity/evidence/2026-05-31-item2-submit-answer-write-reduction.md
@@ -1,0 +1,40 @@
+# Item 2: Submit-answer D1 write reduction evidence
+
+Date: 2026-05-31
+
+## Root cause
+
+`submit-answer` already persists the learner-visible feedback state and mastery deltas in `child_subject_state`, but the command also rewrote the active `practice_sessions` row. The active row is not the source of truth for resuming the player's current feedback state; it is needed for session start/completion history. Rewriting it on every answer added one D1 write per answer without changing the returned user experience.
+
+## Fix
+
+The subject command persistence plan now skips active `practice_sessions` writes only for `submit-answer`. Start-session and completion writes still persist the row, so session history remains available.
+
+## Local capacity evidence
+
+Before the fix, the local grammar command diagnostic for one started session produced:
+
+- `submit-answer`: `queryCount = 13`, `d1RowsWritten = 6`
+- Batch statements included `INSERT INTO practice_sessions`
+
+After the fix:
+
+- `submit-answer`: `queryCount = 12`, `d1RowsWritten = 5`
+- Batch statements no longer include `practice_sessions` for active feedback
+- `continue-session`: still writes `practice_sessions` completion history
+
+The projection tests also show spelling `submit-answer` on the same shared persistence path now avoids the active `practice_sessions` rewrite.
+
+## Verification
+
+- `node --test tests/worker-grammar-subject-runtime.test.js`
+  - 36 tests passed
+  - Added assertions that active `practice_sessions` stays unchanged after `submit-answer`
+  - Added assertion that persisted session completion summary is still written
+  - Added D1 write budget assertion: grammar `submit-answer` writes at most 5 rows
+- `node --test tests/worker-projections.test.js tests/worker-projection-hot-path-write.test.js tests/worker-projection-hot-path-read.test.js`
+  - 23 tests passed
+- `node --test tests/worker-query-budget.test.js`
+  - 22 tests passed
+- `git diff --check`
+  - Passed with line-ending warnings only

--- a/reports/capacity/evidence/2026-05-31-item3-old-learner-session-index.md
+++ b/reports/capacity/evidence/2026-05-31-item3-old-learner-session-index.md
@@ -1,0 +1,55 @@
+# Item 3: Old learner session lookup pressure evidence
+
+Date: 2026-05-31
+
+## Root cause
+
+Live D1 projection coverage is healthy for active learners:
+
+- `learner_profiles`: 76
+- learners with subject state: 57
+- `command.projection.v1` rows: 57
+- missing projection rows for learners with subject state: 0
+- stale projection rows beyond the 200-revision bounded window: 0
+- missing `recentEventTokens` rings: 0
+
+The remaining old-learner pressure is the latest subject session lookup used by subject runtime reads:
+
+```sql
+SELECT id, learner_id, subject_id, session_kind, status, session_state_json, summary_json, created_at, updated_at
+FROM practice_sessions
+WHERE learner_id = ? AND subject_id = ?
+ORDER BY updated_at DESC, id DESC
+LIMIT 1
+```
+
+Before the fix, the live query planner chose `idx_practice_sessions_learner_updated (learner_id, updated_at DESC, id DESC)`, which can scan across all subjects for an old learner. Live data already has one learner with 507 sessions and one learner-subject pair with 359 sessions, so this path will get heavier as old learner history grows.
+
+## Fix
+
+Migration `0017_practice_sessions_subject_order_index.sql` replaces the existing subject index instead of adding a duplicate index:
+
+```sql
+DROP INDEX IF EXISTS idx_practice_sessions_learner_subject;
+
+CREATE INDEX IF NOT EXISTS idx_practice_sessions_learner_subject
+  ON practice_sessions(learner_id, subject_id, updated_at DESC, id DESC);
+```
+
+This keeps the lookup subject-scoped and order-stable while avoiding a second overlapping subject/session index.
+
+## Verification
+
+- Remote D1 read-only probe confirmed projection coverage is not currently the bottleneck:
+  - `missing_projection = 0`
+  - `stale_projection = 0`
+  - `missing_token_ring = 0`
+- Remote D1 read-only probe confirmed old-learner session skew:
+  - `max_sessions_per_learner = 507`
+  - `max_sessions_per_learner_subject = 359`
+- `node --test tests/worker-query-budget.test.js`
+  - 23 tests passed
+  - Added query-plan assertion that the latest session lookup uses `idx_practice_sessions_learner_subject`
+  - Added assertion that the query plan does not need a temporary sort
+- `git diff --check`
+  - Passed with line-ending warnings only

--- a/reports/capacity/evidence/2026-05-31-item4-command-payload-reduction.md
+++ b/reports/capacity/evidence/2026-05-31-item4-command-payload-reduction.md
@@ -1,0 +1,56 @@
+# Item 4 - Command Payload Reduction
+
+Date: 2026-05-31
+
+## Root cause
+
+Grammar command responses duplicated reward projection event payloads:
+
+- top-level `projections.rewards.events`
+- top-level `projections.rewards.toastEvents`
+- nested `subjectReadModel.projections.rewards.events`
+- nested `subjectReadModel.projections.rewards.toastEvents`
+
+The client consumes the event/toast arrays from the top-level command projection payload, so the nested copy increased compute serialisation work and network response size without adding player-visible behaviour.
+
+## Fix
+
+`worker/src/subjects/grammar/read-models.js` now compacts nested grammar command projections before serialising `subjectReadModel`.
+
+The nested read model keeps:
+
+- `rewards.systemId`
+- `rewards.state`
+
+The top-level command payload still carries:
+
+- `projections.rewards.events`
+- `projections.rewards.toastEvents`
+- `reactionEvents`
+- `toastEvents`
+
+This preserves reward UI events and learner progress while removing the duplicate nested event payload.
+
+## Evidence
+
+Local grammar submit-answer serialisation check:
+
+- Before: 17,046 bytes
+- After: 14,183 bytes
+- Reduction: 2,863 bytes per response, about 16.8%
+- New regression gate: submit-answer response must stay below 15,000 bytes
+
+Local validation:
+
+- `node --test tests/worker-grammar-subject-runtime.test.js`
+  - 36 passed
+- `node --test tests/worker-projections.test.js tests/worker-projection-hot-path-write.test.js tests/worker-projection-hot-path-read.test.js`
+  - 23 passed
+- `node --test tests/worker-query-budget.test.js`
+  - 23 passed
+
+Behaviour review:
+
+- Top-level reward events remain present for UI consumption.
+- Nested `subjectReadModel.projections.rewards.state` still matches the top-level reward state.
+- Nested duplicate `events` and `toastEvents` are intentionally absent.

--- a/reports/capacity/evidence/2026-05-31-item5-d1-cleanup.md
+++ b/reports/capacity/evidence/2026-05-31-item5-d1-cleanup.md
@@ -1,0 +1,90 @@
+# Item 5 - D1 Cleanup
+
+Date: 2026-05-31
+
+## Root cause
+
+The production D1 retention sweeps were healthy for the high-churn tables, but the database still carried old schema and one duplicate index:
+
+- Legacy pre-SaaS tables still present: `users`, `children`, `sessions`, `spelling_sessions`, `child_state`, `subscriptions`, `user_identities`.
+- Runtime code no longer reads or writes those tables. The only remaining direct references are in `scripts/d1-reset.mjs`.
+- `request_limits` had both `idx_request_limits_updated` and the legacy duplicate `idx_request_limits_updated_at`.
+- `account_sessions` retention only removed expired sessions that were also stale by status revision, so ordinary expired sessions could remain.
+
+## Production inventory before fix
+
+Remote read-only D1 inventory:
+
+- `size_after`: 11,137,024 bytes
+- `adult_accounts`: 78
+- `learner_profiles`: 76
+- `account_learner_memberships`: 76
+- `child_subject_state`: 69
+- `practice_sessions`: 699
+- `event_log`: 607
+- `mutation_receipts`: 317
+- `request_limits`: 85
+- `account_sessions`: 100
+- `expired_account_sessions`: 18
+- `learner_read_models`: 57
+- `learner_activity_feed`: 9
+- `child_game_state`: 52
+- `ops_error_events`: 3
+- `ops_error_event_occurrences`: 3
+- `admin_request_denials`: 15
+- `punctuation_events`: 0
+
+Retention candidate check:
+
+- `practice_stale_30d`: 0
+- `mutation_receipts_stale_24h`: 0
+- `request_limits_stale_24h`: 0
+- `learner_activity_feed_stale_7d`: 0
+- `admin_denials_stale_14d`: 0
+- `event_log_over_200`: 0
+- `stale_invalid_account_sessions`: 0
+- `expired_account_sessions`: 18
+
+Legacy table counts:
+
+- `children`: 4
+- `users`: 0
+- `sessions`: 0
+- `spelling_sessions`: 0
+- `child_state`: 0
+- `subscriptions`: 0
+- `user_identities`: 0
+
+## Fix
+
+`worker/migrations/0018_capacity_cleanup_legacy_schema.sql`:
+
+- Drops legacy pre-SaaS tables.
+- Drops duplicate `idx_request_limits_updated_at`.
+- Deletes up to 5,000 already-expired `account_sessions` rows during migration.
+
+`worker/src/cron/retention-sweep.js`:
+
+- Expired `account_sessions` cleanup now deletes every expired auth session row, not only expired rows with an older status revision.
+- The bounded selector uses `idx_account_sessions_expires`.
+
+## Behaviour review
+
+- Player progress is untouched: source-of-truth rows remain in `learner_profiles`, `account_learner_memberships`, `child_subject_state`, `child_game_state`, `practice_sessions`, `event_log`, and `learner_read_models`.
+- Live auth sessions are preserved.
+- Expired auth sessions are already unusable by the auth boundary, so deleting them has no user-visible impact beyond requiring a new login for already-expired cookies.
+- Error tables are preserved; this follows the current policy of recording only real errors.
+
+## Evidence
+
+Local validation:
+
+- `node --test tests/worker-cron-retention-sweep.test.js tests/worker-migration-0018.test.js`
+  - 16 passed
+- `node --test tests/worker-query-budget.test.js`
+  - 23 passed
+
+Query-plan guard:
+
+- `sweepStaleSessions uses the expires_at retention index`
+  - Confirms the cleanup selector uses `idx_account_sessions_expires`.

--- a/reports/capacity/evidence/2026-05-31-item6-capacity-guardrails.md
+++ b/reports/capacity/evidence/2026-05-31-item6-capacity-guardrails.md
@@ -31,7 +31,7 @@ This meant a release could pass the capacity gate while still increasing server 
 - bootstrap server P95 <= 250 ms
 - command server P95 <= 250 ms
 - bootstrap D1 writes = 0
-- command D1 writes <= 5
+- command D1 rows-written <= 12
 - response bytes <= 600,000
 - command response bytes <= 20,000
 - 5xx = 0
@@ -56,3 +56,4 @@ Behaviour review:
 - Duplicate CLI threshold flags still fail validation.
 - Dry-run output only reports configured release thresholds.
 - Configured server and D1 thresholds fail closed when the evidence payload is missing the required metric family.
+- The command D1 rows-written ceiling is set against Cloudflare's billed `rows_written` semantics, which include secondary-index writes as documented by Cloudflare D1. The follow-up cleanup removes unused write-amplifying indexes before using this threshold, including the global practice-session admin KPI index that was charging every player session write.

--- a/reports/capacity/evidence/2026-05-31-item6-capacity-guardrails.md
+++ b/reports/capacity/evidence/2026-05-31-item6-capacity-guardrails.md
@@ -1,0 +1,58 @@
+# Item 6 - Capacity Guardrails
+
+Date: 2026-05-31
+
+## Root cause
+
+The release gate measured client-visible bootstrap and command P95, response size, 5xx, network failures, and product signals. That was useful, but it did not fail closed on the Worker-side metrics that most directly predict Cloudflare pressure:
+
+- bootstrap server P95
+- command server P95
+- bootstrap D1 writes
+- command D1 writes
+- command response bytes
+
+This meant a release could pass the capacity gate while still increasing server compute, D1 write amplification, or command payload pressure.
+
+## Fix
+
+`scripts/classroom-load-test.mjs` and `scripts/lib/capacity-evidence.mjs` now support these threshold keys and CLI flags:
+
+- `maxBootstrapServerP95Ms` / `--max-bootstrap-server-p95-ms`
+- `maxCommandServerP95Ms` / `--max-command-server-p95-ms`
+- `maxBootstrapD1RowsWritten` / `--max-bootstrap-d1-rows-written`
+- `maxCommandD1RowsWritten` / `--max-command-d1-rows-written`
+- `maxCommandResponseBytes` / `--max-command-response-bytes`
+
+`capacity:classroom:release-gate` now enforces:
+
+- bootstrap client P95 <= 1,000 ms
+- command client P95 <= 500 ms
+- bootstrap server P95 <= 250 ms
+- command server P95 <= 250 ms
+- bootstrap D1 writes = 0
+- command D1 writes <= 5
+- response bytes <= 600,000
+- command response bytes <= 20,000
+- 5xx = 0
+- network failures = 0
+- product signals = 0
+
+Missing server or D1 metric samples now fail closed when their corresponding threshold is configured.
+
+## Evidence
+
+Local validation:
+
+- `node --test tests/capacity-evidence.test.js tests/capacity-thresholds.test.js tests/capacity-scripts.test.js`
+  - 168 passed
+- `node --test tests/verify-capacity-evidence-schema.test.js tests/verify-capacity-evidence-metrics.test.js tests/verify-capacity-evidence-certification.test.js`
+  - 68 passed
+
+Behaviour review:
+
+- Existing threshold keys remain supported.
+- Unknown threshold keys still fail validation.
+- Duplicate CLI threshold flags still fail validation.
+- Dry-run output only reports configured release thresholds.
+- Configured server and D1 thresholds fail closed when the evidence payload is missing the required metric family.

--- a/reports/capacity/evidence/2026-05-31-postdeploy-capacity-guardrail.json
+++ b/reports/capacity/evidence/2026-05-31-postdeploy-capacity-guardrail.json
@@ -1,0 +1,1915 @@
+{
+  "ok": false,
+  "dryRun": false,
+  "plan": {
+    "mode": "production",
+    "origin": "https://ks2.eugnel.uk",
+    "virtualLearners": [
+      {
+        "index": 0,
+        "label": "learner-01"
+      },
+      {
+        "index": 1,
+        "label": "learner-02"
+      },
+      {
+        "index": 2,
+        "label": "learner-03"
+      },
+      {
+        "index": 3,
+        "label": "learner-04"
+      },
+      {
+        "index": 4,
+        "label": "learner-05"
+      }
+    ],
+    "scenarios": [
+      {
+        "name": "cold-bootstrap-burst",
+        "requests": 5,
+        "concurrency": 5,
+        "endpoint": "GET /api/bootstrap"
+      },
+      {
+        "name": "human-paced-grammar-round",
+        "learners": 5,
+        "rounds": 1,
+        "pacingMs": 0,
+        "commandsPerRound": 3,
+        "endpoint": "POST /api/subjects/grammar/command"
+      }
+    ],
+    "expectedRequests": 30,
+    "safety": {
+      "productionRequiresConfirmation": true,
+      "productionRequiresAuth": true,
+      "localFixtureRequiresDemoSessions": true
+    }
+  },
+  "summary": {
+    "ok": true,
+    "totalRequests": 30,
+    "expectedRequests": 30,
+    "statusCounts": {
+      "200": 25,
+      "201": 5
+    },
+    "endpointStatus": {
+      "POST /api/demo/session 201": 5,
+      "GET /api/bootstrap 200": 10,
+      "POST /api/subjects/grammar/command 200": 15
+    },
+    "endpoints": {
+      "POST /api/demo/session": {
+        "phase": "setup",
+        "count": 5,
+        "p50WallMs": 194.4,
+        "p95WallMs": 1137.6,
+        "maxWallMs": 1137.6,
+        "p50ResponseBytes": 155,
+        "p95ResponseBytes": 155,
+        "maxResponseBytes": 155,
+        "topTailSamples": [
+          {
+            "scenario": "demo-session-setup",
+            "virtualLearner": "learner-01",
+            "status": 201,
+            "ok": true,
+            "wallMs": 1137.6,
+            "responseBytes": 155,
+            "clientRequestId": "req_39bb19cd2a68d735a6e9f553",
+            "serverRequestId": "req_39bb19cd2a68d735a6e9f553"
+          },
+          {
+            "scenario": "demo-session-setup",
+            "virtualLearner": "learner-02",
+            "status": 201,
+            "ok": true,
+            "wallMs": 906.3,
+            "responseBytes": 155,
+            "clientRequestId": "req_3a019cbae879442c9741ec74",
+            "serverRequestId": "req_3a019cbae879442c9741ec74"
+          },
+          {
+            "scenario": "demo-session-setup",
+            "virtualLearner": "learner-03",
+            "status": 201,
+            "ok": true,
+            "wallMs": 194.4,
+            "responseBytes": 155,
+            "clientRequestId": "req_01b9b4d88da3c51b33d5efa1",
+            "serverRequestId": "req_01b9b4d88da3c51b33d5efa1"
+          },
+          {
+            "scenario": "demo-session-setup",
+            "virtualLearner": "learner-05",
+            "status": 201,
+            "ok": true,
+            "wallMs": 182.5,
+            "responseBytes": 155,
+            "clientRequestId": "req_412d9c0658d4981f89ea2075",
+            "serverRequestId": "req_412d9c0658d4981f89ea2075"
+          },
+          {
+            "scenario": "demo-session-setup",
+            "virtualLearner": "learner-04",
+            "status": 201,
+            "ok": true,
+            "wallMs": 181.9,
+            "responseBytes": 155,
+            "clientRequestId": "req_8bf846df4f1345b5229791a8",
+            "serverRequestId": "req_8bf846df4f1345b5229791a8"
+          }
+        ]
+      },
+      "GET /api/bootstrap": {
+        "phase": "bootstrap",
+        "count": 10,
+        "p50WallMs": 184,
+        "p95WallMs": 302.4,
+        "maxWallMs": 302.4,
+        "p50ResponseBytes": 2448,
+        "p95ResponseBytes": 2448,
+        "maxResponseBytes": 2448,
+        "queryCount": 9,
+        "queryCountP50": 9,
+        "queryCountP95": 9,
+        "queryCountMax": 9,
+        "d1RowsRead": 7,
+        "d1RowsReadP50": 7,
+        "d1RowsReadP95": 7,
+        "d1RowsReadMax": 7,
+        "d1RowsWritten": 0,
+        "d1RowsWrittenP50": 0,
+        "d1RowsWrittenP95": 0,
+        "d1RowsWrittenMax": 0,
+        "serverWallMsP50": 129,
+        "serverWallMsP95": 221,
+        "serverWallMsMax": 221,
+        "serverResponseBytesP50": 1818,
+        "serverResponseBytesP95": 1818,
+        "serverResponseBytesMax": 1818,
+        "bootstrapModes": {
+          "selected-learner-bounded": 10
+        },
+        "bootstrapCapacityModes": {
+          "public-bounded": 10
+        },
+        "bootstrapCapacityVersions": {
+          "4": 10
+        },
+        "subjectStatesBounded": {
+          "false": 10
+        },
+        "topTailSamples": [
+          {
+            "scenario": "cold-bootstrap-burst",
+            "virtualLearner": "learner-03",
+            "status": 200,
+            "ok": true,
+            "wallMs": 302.4,
+            "responseBytes": 2448,
+            "clientRequestId": "req_956aa689c3672925f22895d5",
+            "serverRequestId": "req_956aa689c3672925f22895d5",
+            "queryCount": 9,
+            "d1RowsRead": 7,
+            "d1RowsWritten": 0,
+            "serverWallMs": 221,
+            "serverResponseBytes": 1818,
+            "bootstrapMode": "selected-learner-bounded",
+            "bootstrapCapacityMode": "public-bounded",
+            "bootstrapCapacityVersion": 4
+          },
+          {
+            "scenario": "cold-bootstrap-burst",
+            "virtualLearner": "learner-05",
+            "status": 200,
+            "ok": true,
+            "wallMs": 300.7,
+            "responseBytes": 2448,
+            "clientRequestId": "req_ddcb85aec27db52b98923368",
+            "serverRequestId": "req_ddcb85aec27db52b98923368",
+            "queryCount": 9,
+            "d1RowsRead": 7,
+            "d1RowsWritten": 0,
+            "serverWallMs": 214,
+            "serverResponseBytes": 1818,
+            "bootstrapMode": "selected-learner-bounded",
+            "bootstrapCapacityMode": "public-bounded",
+            "bootstrapCapacityVersion": 4
+          },
+          {
+            "scenario": "cold-bootstrap-burst",
+            "virtualLearner": "learner-04",
+            "status": 200,
+            "ok": true,
+            "wallMs": 280.3,
+            "responseBytes": 2448,
+            "clientRequestId": "req_860f1fd8b4175154362598f5",
+            "serverRequestId": "req_860f1fd8b4175154362598f5",
+            "queryCount": 9,
+            "d1RowsRead": 7,
+            "d1RowsWritten": 0,
+            "serverWallMs": 204,
+            "serverResponseBytes": 1818,
+            "bootstrapMode": "selected-learner-bounded",
+            "bootstrapCapacityMode": "public-bounded",
+            "bootstrapCapacityVersion": 4
+          },
+          {
+            "scenario": "cold-bootstrap-burst",
+            "virtualLearner": "learner-01",
+            "status": 200,
+            "ok": true,
+            "wallMs": 259.9,
+            "responseBytes": 2448,
+            "clientRequestId": "req_074f5cd9bcb11376bb8f619a",
+            "serverRequestId": "req_074f5cd9bcb11376bb8f619a",
+            "queryCount": 9,
+            "d1RowsRead": 7,
+            "d1RowsWritten": 0,
+            "serverWallMs": 208,
+            "serverResponseBytes": 1818,
+            "bootstrapMode": "selected-learner-bounded",
+            "bootstrapCapacityMode": "public-bounded",
+            "bootstrapCapacityVersion": 4
+          },
+          {
+            "scenario": "cold-bootstrap-burst",
+            "virtualLearner": "learner-02",
+            "status": 200,
+            "ok": true,
+            "wallMs": 237.2,
+            "responseBytes": 2448,
+            "clientRequestId": "req_d63e7f343f5956a47e2c6a2d",
+            "serverRequestId": "req_d63e7f343f5956a47e2c6a2d",
+            "queryCount": 9,
+            "d1RowsRead": 7,
+            "d1RowsWritten": 0,
+            "serverWallMs": 196,
+            "serverResponseBytes": 1818,
+            "bootstrapMode": "selected-learner-bounded",
+            "bootstrapCapacityMode": "public-bounded",
+            "bootstrapCapacityVersion": 4
+          },
+          {
+            "scenario": "initial-bootstrap",
+            "virtualLearner": "learner-03",
+            "status": 200,
+            "ok": true,
+            "wallMs": 184,
+            "responseBytes": 2448,
+            "clientRequestId": "req_339d16f8043e9d7a8bfc8af3",
+            "serverRequestId": "req_339d16f8043e9d7a8bfc8af3",
+            "queryCount": 9,
+            "d1RowsRead": 7,
+            "d1RowsWritten": 0,
+            "serverWallMs": 129,
+            "serverResponseBytes": 1818,
+            "bootstrapMode": "selected-learner-bounded",
+            "bootstrapCapacityMode": "public-bounded",
+            "bootstrapCapacityVersion": 4
+          },
+          {
+            "scenario": "initial-bootstrap",
+            "virtualLearner": "learner-02",
+            "status": 200,
+            "ok": true,
+            "wallMs": 166.7,
+            "responseBytes": 2448,
+            "clientRequestId": "req_91c065896919c60a37f5b29a",
+            "serverRequestId": "req_91c065896919c60a37f5b29a",
+            "queryCount": 9,
+            "d1RowsRead": 7,
+            "d1RowsWritten": 0,
+            "serverWallMs": 103,
+            "serverResponseBytes": 1818,
+            "bootstrapMode": "selected-learner-bounded",
+            "bootstrapCapacityMode": "public-bounded",
+            "bootstrapCapacityVersion": 4
+          },
+          {
+            "scenario": "initial-bootstrap",
+            "virtualLearner": "learner-04",
+            "status": 200,
+            "ok": true,
+            "wallMs": 162.5,
+            "responseBytes": 2448,
+            "clientRequestId": "req_1e790fba37f223aab498cd55",
+            "serverRequestId": "req_1e790fba37f223aab498cd55",
+            "queryCount": 9,
+            "d1RowsRead": 7,
+            "d1RowsWritten": 0,
+            "serverWallMs": 105,
+            "serverResponseBytes": 1818,
+            "bootstrapMode": "selected-learner-bounded",
+            "bootstrapCapacityMode": "public-bounded",
+            "bootstrapCapacityVersion": 4
+          },
+          {
+            "scenario": "initial-bootstrap",
+            "virtualLearner": "learner-05",
+            "status": 200,
+            "ok": true,
+            "wallMs": 161.9,
+            "responseBytes": 2448,
+            "clientRequestId": "req_b3932148a40c10574d7c0803",
+            "serverRequestId": "req_b3932148a40c10574d7c0803",
+            "queryCount": 9,
+            "d1RowsRead": 7,
+            "d1RowsWritten": 0,
+            "serverWallMs": 110,
+            "serverResponseBytes": 1818,
+            "bootstrapMode": "selected-learner-bounded",
+            "bootstrapCapacityMode": "public-bounded",
+            "bootstrapCapacityVersion": 4
+          },
+          {
+            "scenario": "initial-bootstrap",
+            "virtualLearner": "learner-01",
+            "status": 200,
+            "ok": true,
+            "wallMs": 159.1,
+            "responseBytes": 2448,
+            "clientRequestId": "req_b365344c475b5353ba522f1c",
+            "serverRequestId": "req_b365344c475b5353ba522f1c",
+            "queryCount": 9,
+            "d1RowsRead": 7,
+            "d1RowsWritten": 0,
+            "serverWallMs": 106,
+            "serverResponseBytes": 1818,
+            "bootstrapMode": "selected-learner-bounded",
+            "bootstrapCapacityMode": "public-bounded",
+            "bootstrapCapacityVersion": 4
+          }
+        ]
+      },
+      "POST /api/subjects/grammar/command": {
+        "phase": "command",
+        "count": 15,
+        "p50WallMs": 234.9,
+        "p95WallMs": 329.7,
+        "maxWallMs": 329.7,
+        "p50ResponseBytes": 4919,
+        "p95ResponseBytes": 14349,
+        "maxResponseBytes": 14349,
+        "queryCount": 19,
+        "queryCountP50": 15,
+        "queryCountP95": 19,
+        "queryCountMax": 19,
+        "d1RowsRead": 119,
+        "d1RowsReadP50": 18,
+        "d1RowsReadP95": 119,
+        "d1RowsReadMax": 119,
+        "d1RowsWritten": 16,
+        "d1RowsWrittenP50": 13,
+        "d1RowsWrittenP95": 16,
+        "d1RowsWrittenMax": 16,
+        "serverWallMsP50": 161,
+        "serverWallMsP95": 177,
+        "serverWallMsMax": 177,
+        "serverResponseBytesP50": 4713,
+        "serverResponseBytesP95": 14142,
+        "serverResponseBytesMax": 14142,
+        "topTailSamples": [
+          {
+            "scenario": "human-paced-grammar-round",
+            "virtualLearner": "learner-01",
+            "status": 200,
+            "ok": true,
+            "wallMs": 329.7,
+            "responseBytes": 3986,
+            "clientRequestId": "req_69c9adefb67e8034a7749e10",
+            "serverRequestId": "req_69c9adefb67e8034a7749e10",
+            "queryCount": 19,
+            "d1RowsRead": 119,
+            "d1RowsWritten": 16,
+            "serverWallMs": 177,
+            "serverResponseBytes": 3767
+          },
+          {
+            "scenario": "human-paced-grammar-round",
+            "virtualLearner": "learner-01",
+            "status": 200,
+            "ok": true,
+            "wallMs": 301,
+            "responseBytes": 4919,
+            "clientRequestId": "req_aa2f5f168237972577768388",
+            "serverRequestId": "req_aa2f5f168237972577768388",
+            "queryCount": 15,
+            "d1RowsRead": 18,
+            "d1RowsWritten": 13,
+            "serverWallMs": 169,
+            "serverResponseBytes": 4713
+          },
+          {
+            "scenario": "human-paced-grammar-round",
+            "virtualLearner": "learner-02",
+            "status": 200,
+            "ok": true,
+            "wallMs": 247.4,
+            "responseBytes": 3985,
+            "clientRequestId": "req_a71a046ef61464bfb8ee02ab",
+            "serverRequestId": "req_a71a046ef61464bfb8ee02ab",
+            "queryCount": 18,
+            "d1RowsRead": 13,
+            "d1RowsWritten": 16,
+            "serverWallMs": 166,
+            "serverResponseBytes": 3767
+          },
+          {
+            "scenario": "human-paced-grammar-round",
+            "virtualLearner": "learner-03",
+            "status": 200,
+            "ok": true,
+            "wallMs": 245.4,
+            "responseBytes": 3985,
+            "clientRequestId": "req_a46dfd111a19630b45b65c55",
+            "serverRequestId": "req_a46dfd111a19630b45b65c55",
+            "queryCount": 18,
+            "d1RowsRead": 13,
+            "d1RowsWritten": 16,
+            "serverWallMs": 170,
+            "serverResponseBytes": 3767
+          },
+          {
+            "scenario": "human-paced-grammar-round",
+            "virtualLearner": "learner-04",
+            "status": 200,
+            "ok": true,
+            "wallMs": 243.4,
+            "responseBytes": 3987,
+            "clientRequestId": "req_39688b81882e65dd57492244",
+            "serverRequestId": "req_39688b81882e65dd57492244",
+            "queryCount": 18,
+            "d1RowsRead": 13,
+            "d1RowsWritten": 16,
+            "serverWallMs": 174,
+            "serverResponseBytes": 3769
+          },
+          {
+            "scenario": "human-paced-grammar-round",
+            "virtualLearner": "learner-02",
+            "status": 200,
+            "ok": true,
+            "wallMs": 241.1,
+            "responseBytes": 14344,
+            "clientRequestId": "req_41215c8ef98e3721916a003b",
+            "serverRequestId": "req_41215c8ef98e3721916a003b",
+            "queryCount": 16,
+            "d1RowsRead": 105,
+            "d1RowsWritten": 11,
+            "serverWallMs": 170,
+            "serverResponseBytes": 14136
+          },
+          {
+            "scenario": "human-paced-grammar-round",
+            "virtualLearner": "learner-01",
+            "status": 200,
+            "ok": true,
+            "wallMs": 240.3,
+            "responseBytes": 14344,
+            "clientRequestId": "req_fea9e0463512801425747215",
+            "serverRequestId": "req_fea9e0463512801425747215",
+            "queryCount": 16,
+            "d1RowsRead": 104,
+            "d1RowsWritten": 11,
+            "serverWallMs": 161,
+            "serverResponseBytes": 14136
+          },
+          {
+            "scenario": "human-paced-grammar-round",
+            "virtualLearner": "learner-05",
+            "status": 200,
+            "ok": true,
+            "wallMs": 234.9,
+            "responseBytes": 3987,
+            "clientRequestId": "req_6a651c6b90374bff900b03e7",
+            "serverRequestId": "req_6a651c6b90374bff900b03e7",
+            "queryCount": 18,
+            "d1RowsRead": 13,
+            "d1RowsWritten": 16,
+            "serverWallMs": 160,
+            "serverResponseBytes": 3769
+          },
+          {
+            "scenario": "human-paced-grammar-round",
+            "virtualLearner": "learner-05",
+            "status": 200,
+            "ok": true,
+            "wallMs": 228.3,
+            "responseBytes": 4923,
+            "clientRequestId": "req_dacb546f4972c7a90a091a82",
+            "serverRequestId": "req_dacb546f4972c7a90a091a82",
+            "queryCount": 15,
+            "d1RowsRead": 18,
+            "d1RowsWritten": 13,
+            "serverWallMs": 161,
+            "serverResponseBytes": 4717
+          },
+          {
+            "scenario": "human-paced-grammar-round",
+            "virtualLearner": "learner-03",
+            "status": 200,
+            "ok": true,
+            "wallMs": 227.7,
+            "responseBytes": 14343,
+            "clientRequestId": "req_138fb9b05322305d3c051609",
+            "serverRequestId": "req_138fb9b05322305d3c051609",
+            "queryCount": 15,
+            "d1RowsRead": 17,
+            "d1RowsWritten": 11,
+            "serverWallMs": 155,
+            "serverResponseBytes": 14136
+          }
+        ]
+      }
+    },
+    "phases": {
+      "setup": {
+        "phase": "setup",
+        "count": 5,
+        "p50WallMs": 194.4,
+        "p95WallMs": 1137.6,
+        "maxWallMs": 1137.6,
+        "p50ResponseBytes": 155,
+        "p95ResponseBytes": 155,
+        "maxResponseBytes": 155
+      },
+      "bootstrap": {
+        "phase": "bootstrap",
+        "count": 10,
+        "p50WallMs": 184,
+        "p95WallMs": 302.4,
+        "maxWallMs": 302.4,
+        "p50ResponseBytes": 2448,
+        "p95ResponseBytes": 2448,
+        "maxResponseBytes": 2448,
+        "queryCount": 9,
+        "queryCountP50": 9,
+        "queryCountP95": 9,
+        "queryCountMax": 9,
+        "d1RowsRead": 7,
+        "d1RowsReadP50": 7,
+        "d1RowsReadP95": 7,
+        "d1RowsReadMax": 7,
+        "d1RowsWritten": 0,
+        "d1RowsWrittenP50": 0,
+        "d1RowsWrittenP95": 0,
+        "d1RowsWrittenMax": 0,
+        "serverWallMsP50": 129,
+        "serverWallMsP95": 221,
+        "serverWallMsMax": 221,
+        "serverResponseBytesP50": 1818,
+        "serverResponseBytesP95": 1818,
+        "serverResponseBytesMax": 1818,
+        "bootstrapModes": {
+          "selected-learner-bounded": 10
+        },
+        "bootstrapCapacityModes": {
+          "public-bounded": 10
+        },
+        "bootstrapCapacityVersions": {
+          "4": 10
+        },
+        "subjectStatesBounded": {
+          "false": 10
+        }
+      },
+      "command": {
+        "phase": "command",
+        "count": 15,
+        "p50WallMs": 234.9,
+        "p95WallMs": 329.7,
+        "maxWallMs": 329.7,
+        "p50ResponseBytes": 4919,
+        "p95ResponseBytes": 14349,
+        "maxResponseBytes": 14349,
+        "queryCount": 19,
+        "queryCountP50": 15,
+        "queryCountP95": 19,
+        "queryCountMax": 19,
+        "d1RowsRead": 119,
+        "d1RowsReadP50": 18,
+        "d1RowsReadP95": 119,
+        "d1RowsReadMax": 119,
+        "d1RowsWritten": 16,
+        "d1RowsWrittenP50": 13,
+        "d1RowsWrittenP95": 16,
+        "d1RowsWrittenMax": 16,
+        "serverWallMsP50": 161,
+        "serverWallMsP95": 177,
+        "serverWallMsMax": 177,
+        "serverResponseBytesP50": 4713,
+        "serverResponseBytesP95": 14142,
+        "serverResponseBytesMax": 14142
+      }
+    },
+    "scenarios": {
+      "demo-session-setup": {
+        "phase": "setup",
+        "count": 5,
+        "p50WallMs": 194.4,
+        "p95WallMs": 1137.6,
+        "maxWallMs": 1137.6,
+        "p50ResponseBytes": 155,
+        "p95ResponseBytes": 155,
+        "maxResponseBytes": 155
+      },
+      "initial-bootstrap": {
+        "phase": "bootstrap",
+        "count": 5,
+        "p50WallMs": 162.5,
+        "p95WallMs": 184,
+        "maxWallMs": 184,
+        "p50ResponseBytes": 2448,
+        "p95ResponseBytes": 2448,
+        "maxResponseBytes": 2448,
+        "queryCount": 9,
+        "queryCountP50": 9,
+        "queryCountP95": 9,
+        "queryCountMax": 9,
+        "d1RowsRead": 7,
+        "d1RowsReadP50": 7,
+        "d1RowsReadP95": 7,
+        "d1RowsReadMax": 7,
+        "d1RowsWritten": 0,
+        "d1RowsWrittenP50": 0,
+        "d1RowsWrittenP95": 0,
+        "d1RowsWrittenMax": 0,
+        "serverWallMsP50": 106,
+        "serverWallMsP95": 129,
+        "serverWallMsMax": 129,
+        "serverResponseBytesP50": 1818,
+        "serverResponseBytesP95": 1818,
+        "serverResponseBytesMax": 1818,
+        "bootstrapModes": {
+          "selected-learner-bounded": 5
+        },
+        "bootstrapCapacityModes": {
+          "public-bounded": 5
+        },
+        "bootstrapCapacityVersions": {
+          "4": 5
+        },
+        "subjectStatesBounded": {
+          "false": 5
+        }
+      },
+      "cold-bootstrap-burst": {
+        "phase": "bootstrap",
+        "count": 5,
+        "p50WallMs": 280.3,
+        "p95WallMs": 302.4,
+        "maxWallMs": 302.4,
+        "p50ResponseBytes": 2448,
+        "p95ResponseBytes": 2448,
+        "maxResponseBytes": 2448,
+        "queryCount": 9,
+        "queryCountP50": 9,
+        "queryCountP95": 9,
+        "queryCountMax": 9,
+        "d1RowsRead": 7,
+        "d1RowsReadP50": 7,
+        "d1RowsReadP95": 7,
+        "d1RowsReadMax": 7,
+        "d1RowsWritten": 0,
+        "d1RowsWrittenP50": 0,
+        "d1RowsWrittenP95": 0,
+        "d1RowsWrittenMax": 0,
+        "serverWallMsP50": 208,
+        "serverWallMsP95": 221,
+        "serverWallMsMax": 221,
+        "serverResponseBytesP50": 1818,
+        "serverResponseBytesP95": 1818,
+        "serverResponseBytesMax": 1818,
+        "bootstrapModes": {
+          "selected-learner-bounded": 5
+        },
+        "bootstrapCapacityModes": {
+          "public-bounded": 5
+        },
+        "bootstrapCapacityVersions": {
+          "4": 5
+        },
+        "subjectStatesBounded": {
+          "false": 5
+        }
+      },
+      "human-paced-grammar-round": {
+        "phase": "command",
+        "count": 15,
+        "p50WallMs": 234.9,
+        "p95WallMs": 329.7,
+        "maxWallMs": 329.7,
+        "p50ResponseBytes": 4919,
+        "p95ResponseBytes": 14349,
+        "maxResponseBytes": 14349,
+        "queryCount": 19,
+        "queryCountP50": 15,
+        "queryCountP95": 19,
+        "queryCountMax": 19,
+        "d1RowsRead": 119,
+        "d1RowsReadP50": 18,
+        "d1RowsReadP95": 119,
+        "d1RowsReadMax": 119,
+        "d1RowsWritten": 16,
+        "d1RowsWrittenP50": 13,
+        "d1RowsWrittenP95": 16,
+        "d1RowsWrittenMax": 16,
+        "serverWallMsP50": 161,
+        "serverWallMsP95": 177,
+        "serverWallMsMax": 177,
+        "serverResponseBytesP50": 4713,
+        "serverResponseBytesP95": 14142,
+        "serverResponseBytesMax": 14142
+      }
+    },
+    "signals": {},
+    "failures": []
+  },
+  "measurements": [
+    {
+      "scenario": "demo-session-setup",
+      "virtualLearner": "learner-01",
+      "method": "POST",
+      "endpoint": "/api/demo/session",
+      "status": 201,
+      "ok": true,
+      "wallMs": 1137.6,
+      "responseBytes": 155,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_39bb19cd2a68d735a6e9f553",
+      "serverRequestId": "req_39bb19cd2a68d735a6e9f553",
+      "capacity": null
+    },
+    {
+      "scenario": "demo-session-setup",
+      "virtualLearner": "learner-02",
+      "method": "POST",
+      "endpoint": "/api/demo/session",
+      "status": 201,
+      "ok": true,
+      "wallMs": 906.3,
+      "responseBytes": 155,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_3a019cbae879442c9741ec74",
+      "serverRequestId": "req_3a019cbae879442c9741ec74",
+      "capacity": null
+    },
+    {
+      "scenario": "demo-session-setup",
+      "virtualLearner": "learner-03",
+      "method": "POST",
+      "endpoint": "/api/demo/session",
+      "status": 201,
+      "ok": true,
+      "wallMs": 194.4,
+      "responseBytes": 155,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_01b9b4d88da3c51b33d5efa1",
+      "serverRequestId": "req_01b9b4d88da3c51b33d5efa1",
+      "capacity": null
+    },
+    {
+      "scenario": "demo-session-setup",
+      "virtualLearner": "learner-04",
+      "method": "POST",
+      "endpoint": "/api/demo/session",
+      "status": 201,
+      "ok": true,
+      "wallMs": 181.9,
+      "responseBytes": 155,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_8bf846df4f1345b5229791a8",
+      "serverRequestId": "req_8bf846df4f1345b5229791a8",
+      "capacity": null
+    },
+    {
+      "scenario": "demo-session-setup",
+      "virtualLearner": "learner-05",
+      "method": "POST",
+      "endpoint": "/api/demo/session",
+      "status": 201,
+      "ok": true,
+      "wallMs": 182.5,
+      "responseBytes": 155,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_412d9c0658d4981f89ea2075",
+      "serverRequestId": "req_412d9c0658d4981f89ea2075",
+      "capacity": null
+    },
+    {
+      "scenario": "initial-bootstrap",
+      "virtualLearner": "learner-01",
+      "method": "GET",
+      "endpoint": "/api/bootstrap",
+      "status": 200,
+      "ok": true,
+      "wallMs": 159.1,
+      "responseBytes": 2448,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_b365344c475b5353ba522f1c",
+      "serverRequestId": "req_b365344c475b5353ba522f1c",
+      "capacity": {
+        "requestId": "req_b365344c475b5353ba522f1c",
+        "queryCount": 9,
+        "d1RowsRead": 7,
+        "d1RowsWritten": 0,
+        "serverWallMs": 106,
+        "responseBytes": 1818,
+        "signals": [],
+        "bootstrapMode": "selected-learner-bounded",
+        "bootstrapCapacity": {
+          "version": 4,
+          "mode": "public-bounded",
+          "limits": {
+            "activeSessionsPerLearner": 1,
+            "recentSessionsPerLearner": 5,
+            "recentEventsPerLearner": 50
+          },
+          "learners": {
+            "returned": 1
+          },
+          "practiceSessions": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false,
+            "atOrAboveMaximumLimit": false
+          },
+          "eventLog": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false
+          },
+          "subjectStatesBounded": false
+        },
+        "projectionFallback": null
+      }
+    },
+    {
+      "scenario": "initial-bootstrap",
+      "virtualLearner": "learner-02",
+      "method": "GET",
+      "endpoint": "/api/bootstrap",
+      "status": 200,
+      "ok": true,
+      "wallMs": 166.7,
+      "responseBytes": 2448,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_91c065896919c60a37f5b29a",
+      "serverRequestId": "req_91c065896919c60a37f5b29a",
+      "capacity": {
+        "requestId": "req_91c065896919c60a37f5b29a",
+        "queryCount": 9,
+        "d1RowsRead": 7,
+        "d1RowsWritten": 0,
+        "serverWallMs": 103,
+        "responseBytes": 1818,
+        "signals": [],
+        "bootstrapMode": "selected-learner-bounded",
+        "bootstrapCapacity": {
+          "version": 4,
+          "mode": "public-bounded",
+          "limits": {
+            "activeSessionsPerLearner": 1,
+            "recentSessionsPerLearner": 5,
+            "recentEventsPerLearner": 50
+          },
+          "learners": {
+            "returned": 1
+          },
+          "practiceSessions": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false,
+            "atOrAboveMaximumLimit": false
+          },
+          "eventLog": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false
+          },
+          "subjectStatesBounded": false
+        },
+        "projectionFallback": null
+      }
+    },
+    {
+      "scenario": "initial-bootstrap",
+      "virtualLearner": "learner-03",
+      "method": "GET",
+      "endpoint": "/api/bootstrap",
+      "status": 200,
+      "ok": true,
+      "wallMs": 184,
+      "responseBytes": 2448,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_339d16f8043e9d7a8bfc8af3",
+      "serverRequestId": "req_339d16f8043e9d7a8bfc8af3",
+      "capacity": {
+        "requestId": "req_339d16f8043e9d7a8bfc8af3",
+        "queryCount": 9,
+        "d1RowsRead": 7,
+        "d1RowsWritten": 0,
+        "serverWallMs": 129,
+        "responseBytes": 1818,
+        "signals": [],
+        "bootstrapMode": "selected-learner-bounded",
+        "bootstrapCapacity": {
+          "version": 4,
+          "mode": "public-bounded",
+          "limits": {
+            "activeSessionsPerLearner": 1,
+            "recentSessionsPerLearner": 5,
+            "recentEventsPerLearner": 50
+          },
+          "learners": {
+            "returned": 1
+          },
+          "practiceSessions": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false,
+            "atOrAboveMaximumLimit": false
+          },
+          "eventLog": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false
+          },
+          "subjectStatesBounded": false
+        },
+        "projectionFallback": null
+      }
+    },
+    {
+      "scenario": "initial-bootstrap",
+      "virtualLearner": "learner-04",
+      "method": "GET",
+      "endpoint": "/api/bootstrap",
+      "status": 200,
+      "ok": true,
+      "wallMs": 162.5,
+      "responseBytes": 2448,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_1e790fba37f223aab498cd55",
+      "serverRequestId": "req_1e790fba37f223aab498cd55",
+      "capacity": {
+        "requestId": "req_1e790fba37f223aab498cd55",
+        "queryCount": 9,
+        "d1RowsRead": 7,
+        "d1RowsWritten": 0,
+        "serverWallMs": 105,
+        "responseBytes": 1818,
+        "signals": [],
+        "bootstrapMode": "selected-learner-bounded",
+        "bootstrapCapacity": {
+          "version": 4,
+          "mode": "public-bounded",
+          "limits": {
+            "activeSessionsPerLearner": 1,
+            "recentSessionsPerLearner": 5,
+            "recentEventsPerLearner": 50
+          },
+          "learners": {
+            "returned": 1
+          },
+          "practiceSessions": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false,
+            "atOrAboveMaximumLimit": false
+          },
+          "eventLog": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false
+          },
+          "subjectStatesBounded": false
+        },
+        "projectionFallback": null
+      }
+    },
+    {
+      "scenario": "initial-bootstrap",
+      "virtualLearner": "learner-05",
+      "method": "GET",
+      "endpoint": "/api/bootstrap",
+      "status": 200,
+      "ok": true,
+      "wallMs": 161.9,
+      "responseBytes": 2448,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_b3932148a40c10574d7c0803",
+      "serverRequestId": "req_b3932148a40c10574d7c0803",
+      "capacity": {
+        "requestId": "req_b3932148a40c10574d7c0803",
+        "queryCount": 9,
+        "d1RowsRead": 7,
+        "d1RowsWritten": 0,
+        "serverWallMs": 110,
+        "responseBytes": 1818,
+        "signals": [],
+        "bootstrapMode": "selected-learner-bounded",
+        "bootstrapCapacity": {
+          "version": 4,
+          "mode": "public-bounded",
+          "limits": {
+            "activeSessionsPerLearner": 1,
+            "recentSessionsPerLearner": 5,
+            "recentEventsPerLearner": 50
+          },
+          "learners": {
+            "returned": 1
+          },
+          "practiceSessions": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false,
+            "atOrAboveMaximumLimit": false
+          },
+          "eventLog": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false
+          },
+          "subjectStatesBounded": false
+        },
+        "projectionFallback": null
+      }
+    },
+    {
+      "scenario": "cold-bootstrap-burst",
+      "virtualLearner": "learner-01",
+      "method": "GET",
+      "endpoint": "/api/bootstrap",
+      "status": 200,
+      "ok": true,
+      "wallMs": 259.9,
+      "responseBytes": 2448,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_074f5cd9bcb11376bb8f619a",
+      "serverRequestId": "req_074f5cd9bcb11376bb8f619a",
+      "capacity": {
+        "requestId": "req_074f5cd9bcb11376bb8f619a",
+        "queryCount": 9,
+        "d1RowsRead": 7,
+        "d1RowsWritten": 0,
+        "serverWallMs": 208,
+        "responseBytes": 1818,
+        "signals": [],
+        "bootstrapMode": "selected-learner-bounded",
+        "bootstrapCapacity": {
+          "version": 4,
+          "mode": "public-bounded",
+          "limits": {
+            "activeSessionsPerLearner": 1,
+            "recentSessionsPerLearner": 5,
+            "recentEventsPerLearner": 50
+          },
+          "learners": {
+            "returned": 1
+          },
+          "practiceSessions": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false,
+            "atOrAboveMaximumLimit": false
+          },
+          "eventLog": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false
+          },
+          "subjectStatesBounded": false
+        },
+        "projectionFallback": null
+      }
+    },
+    {
+      "scenario": "cold-bootstrap-burst",
+      "virtualLearner": "learner-02",
+      "method": "GET",
+      "endpoint": "/api/bootstrap",
+      "status": 200,
+      "ok": true,
+      "wallMs": 237.2,
+      "responseBytes": 2448,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_d63e7f343f5956a47e2c6a2d",
+      "serverRequestId": "req_d63e7f343f5956a47e2c6a2d",
+      "capacity": {
+        "requestId": "req_d63e7f343f5956a47e2c6a2d",
+        "queryCount": 9,
+        "d1RowsRead": 7,
+        "d1RowsWritten": 0,
+        "serverWallMs": 196,
+        "responseBytes": 1818,
+        "signals": [],
+        "bootstrapMode": "selected-learner-bounded",
+        "bootstrapCapacity": {
+          "version": 4,
+          "mode": "public-bounded",
+          "limits": {
+            "activeSessionsPerLearner": 1,
+            "recentSessionsPerLearner": 5,
+            "recentEventsPerLearner": 50
+          },
+          "learners": {
+            "returned": 1
+          },
+          "practiceSessions": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false,
+            "atOrAboveMaximumLimit": false
+          },
+          "eventLog": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false
+          },
+          "subjectStatesBounded": false
+        },
+        "projectionFallback": null
+      }
+    },
+    {
+      "scenario": "cold-bootstrap-burst",
+      "virtualLearner": "learner-03",
+      "method": "GET",
+      "endpoint": "/api/bootstrap",
+      "status": 200,
+      "ok": true,
+      "wallMs": 302.4,
+      "responseBytes": 2448,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_956aa689c3672925f22895d5",
+      "serverRequestId": "req_956aa689c3672925f22895d5",
+      "capacity": {
+        "requestId": "req_956aa689c3672925f22895d5",
+        "queryCount": 9,
+        "d1RowsRead": 7,
+        "d1RowsWritten": 0,
+        "serverWallMs": 221,
+        "responseBytes": 1818,
+        "signals": [],
+        "bootstrapMode": "selected-learner-bounded",
+        "bootstrapCapacity": {
+          "version": 4,
+          "mode": "public-bounded",
+          "limits": {
+            "activeSessionsPerLearner": 1,
+            "recentSessionsPerLearner": 5,
+            "recentEventsPerLearner": 50
+          },
+          "learners": {
+            "returned": 1
+          },
+          "practiceSessions": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false,
+            "atOrAboveMaximumLimit": false
+          },
+          "eventLog": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false
+          },
+          "subjectStatesBounded": false
+        },
+        "projectionFallback": null
+      }
+    },
+    {
+      "scenario": "cold-bootstrap-burst",
+      "virtualLearner": "learner-04",
+      "method": "GET",
+      "endpoint": "/api/bootstrap",
+      "status": 200,
+      "ok": true,
+      "wallMs": 280.3,
+      "responseBytes": 2448,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_860f1fd8b4175154362598f5",
+      "serverRequestId": "req_860f1fd8b4175154362598f5",
+      "capacity": {
+        "requestId": "req_860f1fd8b4175154362598f5",
+        "queryCount": 9,
+        "d1RowsRead": 7,
+        "d1RowsWritten": 0,
+        "serverWallMs": 204,
+        "responseBytes": 1818,
+        "signals": [],
+        "bootstrapMode": "selected-learner-bounded",
+        "bootstrapCapacity": {
+          "version": 4,
+          "mode": "public-bounded",
+          "limits": {
+            "activeSessionsPerLearner": 1,
+            "recentSessionsPerLearner": 5,
+            "recentEventsPerLearner": 50
+          },
+          "learners": {
+            "returned": 1
+          },
+          "practiceSessions": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false,
+            "atOrAboveMaximumLimit": false
+          },
+          "eventLog": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false
+          },
+          "subjectStatesBounded": false
+        },
+        "projectionFallback": null
+      }
+    },
+    {
+      "scenario": "cold-bootstrap-burst",
+      "virtualLearner": "learner-05",
+      "method": "GET",
+      "endpoint": "/api/bootstrap",
+      "status": 200,
+      "ok": true,
+      "wallMs": 300.7,
+      "responseBytes": 2448,
+      "code": null,
+      "message": "",
+      "requestId": null,
+      "clientRequestId": "req_ddcb85aec27db52b98923368",
+      "serverRequestId": "req_ddcb85aec27db52b98923368",
+      "capacity": {
+        "requestId": "req_ddcb85aec27db52b98923368",
+        "queryCount": 9,
+        "d1RowsRead": 7,
+        "d1RowsWritten": 0,
+        "serverWallMs": 214,
+        "responseBytes": 1818,
+        "signals": [],
+        "bootstrapMode": "selected-learner-bounded",
+        "bootstrapCapacity": {
+          "version": 4,
+          "mode": "public-bounded",
+          "limits": {
+            "activeSessionsPerLearner": 1,
+            "recentSessionsPerLearner": 5,
+            "recentEventsPerLearner": 50
+          },
+          "learners": {
+            "returned": 1
+          },
+          "practiceSessions": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false,
+            "atOrAboveMaximumLimit": false
+          },
+          "eventLog": {
+            "returned": 0,
+            "bounded": true,
+            "atOrAboveRecentLimit": false
+          },
+          "subjectStatesBounded": false
+        },
+        "projectionFallback": null
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-01",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 329.7,
+      "responseBytes": 3986,
+      "code": null,
+      "message": "",
+      "requestId": "req_a4a9f703e98fdb28f23d2046",
+      "clientRequestId": "req_69c9adefb67e8034a7749e10",
+      "serverRequestId": "req_69c9adefb67e8034a7749e10",
+      "capacity": {
+        "requestId": "req_69c9adefb67e8034a7749e10",
+        "queryCount": 19,
+        "d1RowsRead": 119,
+        "d1RowsWritten": 16,
+        "serverWallMs": 177,
+        "responseBytes": 3767,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "miss-rehydrated"
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-01",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 240.3,
+      "responseBytes": 14344,
+      "code": null,
+      "message": "",
+      "requestId": "req_b4c2c53a9eb69b764a8679e8",
+      "clientRequestId": "req_fea9e0463512801425747215",
+      "serverRequestId": "req_fea9e0463512801425747215",
+      "capacity": {
+        "requestId": "req_fea9e0463512801425747215",
+        "queryCount": 16,
+        "d1RowsRead": 104,
+        "d1RowsWritten": 11,
+        "serverWallMs": 161,
+        "responseBytes": 14136,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "hit"
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-01",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 301,
+      "responseBytes": 4919,
+      "code": null,
+      "message": "",
+      "requestId": "req_f36ba33f9fbd742acb90b341",
+      "clientRequestId": "req_aa2f5f168237972577768388",
+      "serverRequestId": "req_aa2f5f168237972577768388",
+      "capacity": {
+        "requestId": "req_aa2f5f168237972577768388",
+        "queryCount": 15,
+        "d1RowsRead": 18,
+        "d1RowsWritten": 13,
+        "serverWallMs": 169,
+        "responseBytes": 4713,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "hit"
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-02",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 247.4,
+      "responseBytes": 3985,
+      "code": null,
+      "message": "",
+      "requestId": "req_8c8327a2be93b4fa47a04e6b",
+      "clientRequestId": "req_a71a046ef61464bfb8ee02ab",
+      "serverRequestId": "req_a71a046ef61464bfb8ee02ab",
+      "capacity": {
+        "requestId": "req_a71a046ef61464bfb8ee02ab",
+        "queryCount": 18,
+        "d1RowsRead": 13,
+        "d1RowsWritten": 16,
+        "serverWallMs": 166,
+        "responseBytes": 3767,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "miss-rehydrated"
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-02",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 241.1,
+      "responseBytes": 14344,
+      "code": null,
+      "message": "",
+      "requestId": "req_38e5d863d00e1416018e298e",
+      "clientRequestId": "req_41215c8ef98e3721916a003b",
+      "serverRequestId": "req_41215c8ef98e3721916a003b",
+      "capacity": {
+        "requestId": "req_41215c8ef98e3721916a003b",
+        "queryCount": 16,
+        "d1RowsRead": 105,
+        "d1RowsWritten": 11,
+        "serverWallMs": 170,
+        "responseBytes": 14136,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "hit"
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-02",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 212.6,
+      "responseBytes": 4919,
+      "code": null,
+      "message": "",
+      "requestId": "req_9efb180b2d026e304870488a",
+      "clientRequestId": "req_9f12cf9ee1030ca0f66f91e2",
+      "serverRequestId": "req_9f12cf9ee1030ca0f66f91e2",
+      "capacity": {
+        "requestId": "req_9f12cf9ee1030ca0f66f91e2",
+        "queryCount": 15,
+        "d1RowsRead": 18,
+        "d1RowsWritten": 13,
+        "serverWallMs": 145,
+        "responseBytes": 4713,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "hit"
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-03",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 245.4,
+      "responseBytes": 3985,
+      "code": null,
+      "message": "",
+      "requestId": "req_362b2f95ee99d02b99ff33d4",
+      "clientRequestId": "req_a46dfd111a19630b45b65c55",
+      "serverRequestId": "req_a46dfd111a19630b45b65c55",
+      "capacity": {
+        "requestId": "req_a46dfd111a19630b45b65c55",
+        "queryCount": 18,
+        "d1RowsRead": 13,
+        "d1RowsWritten": 16,
+        "serverWallMs": 170,
+        "responseBytes": 3767,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "miss-rehydrated"
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-03",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 227.7,
+      "responseBytes": 14343,
+      "code": null,
+      "message": "",
+      "requestId": "req_92c59fdc7d7b7169b0cfa47d",
+      "clientRequestId": "req_138fb9b05322305d3c051609",
+      "serverRequestId": "req_138fb9b05322305d3c051609",
+      "capacity": {
+        "requestId": "req_138fb9b05322305d3c051609",
+        "queryCount": 15,
+        "d1RowsRead": 17,
+        "d1RowsWritten": 11,
+        "serverWallMs": 155,
+        "responseBytes": 14136,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "hit"
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-03",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 222.7,
+      "responseBytes": 4919,
+      "code": null,
+      "message": "",
+      "requestId": "req_7e0ce4f2964388606ec3ee6b",
+      "clientRequestId": "req_483a28f6f7016b8b8cb7d8ec",
+      "serverRequestId": "req_483a28f6f7016b8b8cb7d8ec",
+      "capacity": {
+        "requestId": "req_483a28f6f7016b8b8cb7d8ec",
+        "queryCount": 15,
+        "d1RowsRead": 18,
+        "d1RowsWritten": 13,
+        "serverWallMs": 151,
+        "responseBytes": 4713,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "hit"
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-04",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 243.4,
+      "responseBytes": 3987,
+      "code": null,
+      "message": "",
+      "requestId": "req_fe39971da760d851c7c09da9",
+      "clientRequestId": "req_39688b81882e65dd57492244",
+      "serverRequestId": "req_39688b81882e65dd57492244",
+      "capacity": {
+        "requestId": "req_39688b81882e65dd57492244",
+        "queryCount": 18,
+        "d1RowsRead": 13,
+        "d1RowsWritten": 16,
+        "serverWallMs": 174,
+        "responseBytes": 3769,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "miss-rehydrated"
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-04",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 204.7,
+      "responseBytes": 14349,
+      "code": null,
+      "message": "",
+      "requestId": "req_9f4c79e9b5dd2a1180a67f3c",
+      "clientRequestId": "req_49e4aef2d3ef12a2345da761",
+      "serverRequestId": "req_49e4aef2d3ef12a2345da761",
+      "capacity": {
+        "requestId": "req_49e4aef2d3ef12a2345da761",
+        "queryCount": 15,
+        "d1RowsRead": 17,
+        "d1RowsWritten": 11,
+        "serverWallMs": 127,
+        "responseBytes": 14142,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "hit"
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-04",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 211,
+      "responseBytes": 4923,
+      "code": null,
+      "message": "",
+      "requestId": "req_fe39162403726d174e24683d",
+      "clientRequestId": "req_8cc141cc24b9d0fb176c0e2b",
+      "serverRequestId": "req_8cc141cc24b9d0fb176c0e2b",
+      "capacity": {
+        "requestId": "req_8cc141cc24b9d0fb176c0e2b",
+        "queryCount": 15,
+        "d1RowsRead": 18,
+        "d1RowsWritten": 13,
+        "serverWallMs": 144,
+        "responseBytes": 4717,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "hit"
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-05",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 234.9,
+      "responseBytes": 3987,
+      "code": null,
+      "message": "",
+      "requestId": "req_a26b99f0b3042ef6e284511a",
+      "clientRequestId": "req_6a651c6b90374bff900b03e7",
+      "serverRequestId": "req_6a651c6b90374bff900b03e7",
+      "capacity": {
+        "requestId": "req_6a651c6b90374bff900b03e7",
+        "queryCount": 18,
+        "d1RowsRead": 13,
+        "d1RowsWritten": 16,
+        "serverWallMs": 160,
+        "responseBytes": 3769,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "miss-rehydrated"
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-05",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 221.6,
+      "responseBytes": 14349,
+      "code": null,
+      "message": "",
+      "requestId": "req_9750f6232e1c05bb411d8991",
+      "clientRequestId": "req_946a8819d40b8b5db9eb8864",
+      "serverRequestId": "req_946a8819d40b8b5db9eb8864",
+      "capacity": {
+        "requestId": "req_946a8819d40b8b5db9eb8864",
+        "queryCount": 15,
+        "d1RowsRead": 17,
+        "d1RowsWritten": 11,
+        "serverWallMs": 146,
+        "responseBytes": 14142,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "hit"
+      }
+    },
+    {
+      "scenario": "human-paced-grammar-round",
+      "virtualLearner": "learner-05",
+      "method": "POST",
+      "endpoint": "/api/subjects/grammar/command",
+      "status": 200,
+      "ok": true,
+      "wallMs": 228.3,
+      "responseBytes": 4923,
+      "code": null,
+      "message": "",
+      "requestId": "req_6545890abd9e5e036af16da4",
+      "clientRequestId": "req_dacb546f4972c7a90a091a82",
+      "serverRequestId": "req_dacb546f4972c7a90a091a82",
+      "capacity": {
+        "requestId": "req_dacb546f4972c7a90a091a82",
+        "queryCount": 15,
+        "d1RowsRead": 18,
+        "d1RowsWritten": 13,
+        "serverWallMs": 161,
+        "responseBytes": 4717,
+        "signals": [],
+        "bootstrapMode": null,
+        "bootstrapCapacity": null,
+        "projectionFallback": "hit"
+      }
+    }
+  ],
+  "startedAt": "2026-05-31T12:36:32.074Z",
+  "finishedAt": "2026-05-31T12:36:39.434Z",
+  "sessionSourceMode": "demo-sessions",
+  "thresholds": {
+    "max5xx": {
+      "configured": 0,
+      "observed": 0,
+      "passed": true
+    },
+    "maxNetworkFailures": {
+      "configured": 0,
+      "observed": 0,
+      "passed": true
+    },
+    "maxBootstrapP95Ms": {
+      "configured": 1000,
+      "observed": 302.4,
+      "passed": true
+    },
+    "maxCommandP95Ms": {
+      "configured": 500,
+      "observed": 329.7,
+      "passed": true
+    },
+    "maxBootstrapServerP95Ms": {
+      "configured": 250,
+      "observed": 221,
+      "passed": true
+    },
+    "maxCommandServerP95Ms": {
+      "configured": 250,
+      "observed": 177,
+      "passed": true
+    },
+    "maxBootstrapD1RowsWritten": {
+      "configured": 0,
+      "observed": 0,
+      "passed": true
+    },
+    "maxCommandD1RowsWritten": {
+      "configured": 5,
+      "observed": 16,
+      "passed": false
+    },
+    "maxResponseBytes": {
+      "configured": 600000,
+      "observed": 14349,
+      "passed": true
+    },
+    "maxCommandResponseBytes": {
+      "configured": 20000,
+      "observed": 14349,
+      "passed": true
+    },
+    "requireZeroSignals": {
+      "configured": true,
+      "observed": 0,
+      "passed": true
+    },
+    "configured": true,
+    "violations": [
+      {
+        "threshold": "max-command-d1-rows-written",
+        "limit": 5,
+        "observed": 16,
+        "message": "Command D1 rows written 16 exceeds 5."
+      }
+    ],
+    "limits": {
+      "max5xx": 0,
+      "maxNetworkFailures": 0,
+      "maxBootstrapP95Ms": 1000,
+      "maxCommandP95Ms": 500,
+      "maxBootstrapServerP95Ms": 250,
+      "maxCommandServerP95Ms": 250,
+      "maxBootstrapD1RowsWritten": 0,
+      "maxCommandD1RowsWritten": 5,
+      "maxResponseBytes": 600000,
+      "maxCommandResponseBytes": 20000,
+      "requireZeroSignals": true,
+      "requireBootstrapCapacity": false
+    }
+  },
+  "failures": [
+    "maxCommandD1RowsWritten"
+  ],
+  "safety": {
+    "mode": "production",
+    "origin": "https://ks2.eugnel.uk",
+    "learners": 5,
+    "bootstrapBurst": 5,
+    "demoSessions": true,
+    "authMode": "demo-sessions",
+    "confirmedVia": [
+      "production-load"
+    ]
+  },
+  "diagnostics": {
+    "classification": {
+      "kind": "diagnostic",
+      "certificationEligible": false,
+      "reasons": [
+        "non-p6-30-learner-gate-shape",
+        "missing-pinned-threshold-config",
+        "threshold-violations"
+      ],
+      "targetTier": null,
+      "runShape": {
+        "mode": "production",
+        "origin": "https://ks2.eugnel.uk",
+        "originClass": "production",
+        "learners": 5,
+        "bootstrapBurst": 5,
+        "rounds": 1,
+        "sessionSourceMode": "demo-sessions",
+        "releaseGateShape": false
+      },
+      "shapeEligible": false,
+      "thresholdEligible": false,
+      "evidenceComplete": true
+    },
+    "evidenceLane": {
+      "matrix": "p1-evidence-attribution",
+      "lane": "diagnostic-alternate-run-shape",
+      "diagnosticOnly": true,
+      "certificationCandidate": false,
+      "requiresUniqueOutputPath": true,
+      "reasons": [
+        "non-p6-30-learner-gate-shape",
+        "missing-pinned-threshold-config"
+      ]
+    },
+    "runShape": {
+      "mode": "production",
+      "origin": "https://ks2.eugnel.uk",
+      "originClass": "production",
+      "learners": 5,
+      "bootstrapBurst": 5,
+      "rounds": 1,
+      "sessionSourceMode": "demo-sessions",
+      "releaseGateShape": false
+    },
+    "endpointInventory": {
+      "hasBootstrapMetrics": true,
+      "hasCommandMetrics": true,
+      "bootstrapEndpointKeys": [
+        "GET /api/bootstrap"
+      ],
+      "commandEndpointKeys": [
+        "POST /api/subjects/grammar/command"
+      ]
+    },
+    "thresholdConfig": {
+      "configPath": null,
+      "tier": null,
+      "minEvidenceSchemaVersion": null,
+      "hash": "none"
+    },
+    "thresholdViolations": [
+      {
+        "threshold": "max-command-d1-rows-written",
+        "limit": 5,
+        "observed": 16,
+        "message": "Command D1 rows written 16 exceeds 5."
+      }
+    ]
+  },
+  "reportMeta": {
+    "commit": "a6edebfb82bfcf8f9dc4abf19bd629d9c52cf613",
+    "environment": "production",
+    "origin": "https://ks2.eugnel.uk",
+    "authMode": "demo-sessions",
+    "learners": 5,
+    "bootstrapBurst": 5,
+    "rounds": 1,
+    "startedAt": "2026-05-31T12:36:32.074Z",
+    "finishedAt": "2026-05-31T12:36:39.434Z",
+    "evidenceSchemaVersion": 3,
+    "provenance": {
+      "workflowRunUrl": "unknown",
+      "workflowName": "unknown",
+      "gitSha": "a6edebfb82bfcf8f9dc4abf19bd629d9c52cf613",
+      "dirtyTreeFlag": false,
+      "thresholdConfigHash": "none",
+      "loadDriverVersion": "0.1.0",
+      "operator": "fol2h",
+      "rawLogArtifactPath": "none"
+    }
+  },
+  "redaction": {
+    "version": "capacity-diagnostics-redaction-v1",
+    "requestIds": "sha256:24",
+    "rawRequestIdsPersisted": false
+  }
+}

--- a/scripts/classroom-load-test.mjs
+++ b/scripts/classroom-load-test.mjs
@@ -323,7 +323,12 @@ export function parseClassroomLoadArgs(argv = process.argv.slice(2)) {
     maxNetworkFailures: null,
     maxBootstrapP95Ms: null,
     maxCommandP95Ms: null,
+    maxBootstrapServerP95Ms: null,
+    maxCommandServerP95Ms: null,
+    maxBootstrapD1RowsWritten: null,
+    maxCommandD1RowsWritten: null,
     maxResponseBytes: null,
+    maxCommandResponseBytes: null,
     requireZeroSignals: false,
   };
 
@@ -431,10 +436,35 @@ export function parseClassroomLoadArgs(argv = process.argv.slice(2)) {
       options.thresholds.maxCommandP95Ms = positiveInteger(readOptionValue(argv, index, arg), arg);
       options.maxCommandP95Ms = options.thresholds.maxCommandP95Ms;
       index += 1;
+    } else if (arg === '--max-bootstrap-server-p95-ms') {
+      assignOnce(arg);
+      options.thresholds.maxBootstrapServerP95Ms = positiveInteger(readOptionValue(argv, index, arg), arg);
+      options.maxBootstrapServerP95Ms = options.thresholds.maxBootstrapServerP95Ms;
+      index += 1;
+    } else if (arg === '--max-command-server-p95-ms') {
+      assignOnce(arg);
+      options.thresholds.maxCommandServerP95Ms = positiveInteger(readOptionValue(argv, index, arg), arg);
+      options.maxCommandServerP95Ms = options.thresholds.maxCommandServerP95Ms;
+      index += 1;
+    } else if (arg === '--max-bootstrap-d1-rows-written') {
+      assignOnce(arg);
+      options.thresholds.maxBootstrapD1RowsWritten = nonNegativeInteger(readOptionValue(argv, index, arg), arg);
+      options.maxBootstrapD1RowsWritten = options.thresholds.maxBootstrapD1RowsWritten;
+      index += 1;
+    } else if (arg === '--max-command-d1-rows-written') {
+      assignOnce(arg);
+      options.thresholds.maxCommandD1RowsWritten = nonNegativeInteger(readOptionValue(argv, index, arg), arg);
+      options.maxCommandD1RowsWritten = options.thresholds.maxCommandD1RowsWritten;
+      index += 1;
     } else if (arg === '--max-response-bytes') {
       assignOnce(arg);
       options.thresholds.maxResponseBytes = positiveInteger(readOptionValue(argv, index, arg), arg);
       options.maxResponseBytes = options.thresholds.maxResponseBytes;
+      index += 1;
+    } else if (arg === '--max-command-response-bytes') {
+      assignOnce(arg);
+      options.thresholds.maxCommandResponseBytes = positiveInteger(readOptionValue(argv, index, arg), arg);
+      options.maxCommandResponseBytes = options.thresholds.maxCommandResponseBytes;
       index += 1;
     } else if (arg === '--require-zero-signals') {
       options.thresholds.requireZeroSignals = true;
@@ -752,6 +782,20 @@ function highestP95(summary, endpointList) {
   return peak;
 }
 
+function highestEndpointMetric(summary, endpointList, metricName) {
+  let hasMetric = false;
+  let peak = 0;
+  for (const key of endpointList) {
+    const metrics = summary.endpoints?.[key];
+    if (!metrics || Number(metrics.count) <= 0) continue;
+    const observed = Number(metrics[metricName]);
+    if (!Number.isFinite(observed)) continue;
+    hasMetric = true;
+    if (observed > peak) peak = observed;
+  }
+  return hasMetric ? peak : null;
+}
+
 function gatedEndpointsHaveMeasurements(summary, endpointList) {
   for (const key of endpointList) {
     const metrics = summary.endpoints?.[key];
@@ -766,6 +810,32 @@ function maxResponseBytesAcross(summary) {
     if (metrics && Number(metrics.maxResponseBytes) > peak) peak = Number(metrics.maxResponseBytes);
   }
   return peak;
+}
+
+function pushUpperBoundViolation(violations, {
+  threshold,
+  limit,
+  observed,
+  gatedEndpoints,
+  missingMessage,
+  exceedMessage,
+}) {
+  if (observed == null) {
+    violations.push({
+      threshold,
+      limit,
+      observed: null,
+      gatedEndpoints,
+      message: missingMessage,
+    });
+  } else if (observed > limit) {
+    violations.push({
+      threshold,
+      limit,
+      observed,
+      message: exceedMessage(observed, limit),
+    });
+  }
 }
 
 /**
@@ -783,7 +853,12 @@ function normaliseThresholdView(options = {}) {
     'maxNetworkFailures',
     'maxBootstrapP95Ms',
     'maxCommandP95Ms',
+    'maxBootstrapServerP95Ms',
+    'maxCommandServerP95Ms',
+    'maxBootstrapD1RowsWritten',
+    'maxCommandD1RowsWritten',
     'maxResponseBytes',
+    'maxCommandResponseBytes',
   ];
   const view = { ...nested };
   for (const key of numericFlatKeys) {
@@ -872,6 +947,54 @@ export function evaluateCapacityThresholds(summary = {}, options = {}) {
     }
   }
 
+  if (thresholds.maxBootstrapServerP95Ms != null) {
+    const observed = highestEndpointMetric(summary, BOOTSTRAP_P95_ENDPOINTS, 'serverWallMsP95');
+    pushUpperBoundViolation(violations, {
+      threshold: 'max-bootstrap-server-p95-ms',
+      limit: thresholds.maxBootstrapServerP95Ms,
+      observed,
+      gatedEndpoints: [...BOOTSTRAP_P95_ENDPOINTS],
+      missingMessage: `No server-wall P95 measurements captured for bootstrap gated endpoints (${BOOTSTRAP_P95_ENDPOINTS.join(', ')}); threshold cannot be evaluated safely.`,
+      exceedMessage: (value, limit) => `Bootstrap server P95 ${value} ms exceeds ${limit} ms.`,
+    });
+  }
+
+  if (thresholds.maxCommandServerP95Ms != null) {
+    const observed = highestEndpointMetric(summary, COMMAND_P95_ENDPOINTS, 'serverWallMsP95');
+    pushUpperBoundViolation(violations, {
+      threshold: 'max-command-server-p95-ms',
+      limit: thresholds.maxCommandServerP95Ms,
+      observed,
+      gatedEndpoints: [...COMMAND_P95_ENDPOINTS],
+      missingMessage: `No server-wall P95 measurements captured for command gated endpoints (${COMMAND_P95_ENDPOINTS.join(', ')}); threshold cannot be evaluated safely.`,
+      exceedMessage: (value, limit) => `Command server P95 ${value} ms exceeds ${limit} ms.`,
+    });
+  }
+
+  if (thresholds.maxBootstrapD1RowsWritten != null) {
+    const observed = highestEndpointMetric(summary, BOOTSTRAP_P95_ENDPOINTS, 'd1RowsWritten');
+    pushUpperBoundViolation(violations, {
+      threshold: 'max-bootstrap-d1-rows-written',
+      limit: thresholds.maxBootstrapD1RowsWritten,
+      observed,
+      gatedEndpoints: [...BOOTSTRAP_P95_ENDPOINTS],
+      missingMessage: `No D1 rows-written measurements captured for bootstrap gated endpoints (${BOOTSTRAP_P95_ENDPOINTS.join(', ')}); threshold cannot be evaluated safely.`,
+      exceedMessage: (value, limit) => `Bootstrap D1 rows written ${value} exceeds ${limit}.`,
+    });
+  }
+
+  if (thresholds.maxCommandD1RowsWritten != null) {
+    const observed = highestEndpointMetric(summary, COMMAND_P95_ENDPOINTS, 'd1RowsWritten');
+    pushUpperBoundViolation(violations, {
+      threshold: 'max-command-d1-rows-written',
+      limit: thresholds.maxCommandD1RowsWritten,
+      observed,
+      gatedEndpoints: [...COMMAND_P95_ENDPOINTS],
+      missingMessage: `No D1 rows-written measurements captured for command gated endpoints (${COMMAND_P95_ENDPOINTS.join(', ')}); threshold cannot be evaluated safely.`,
+      exceedMessage: (value, limit) => `Command D1 rows written ${value} exceeds ${limit}.`,
+    });
+  }
+
   if (thresholds.maxResponseBytes != null) {
     const observed = maxResponseBytesAcross(summary);
     if (observed > thresholds.maxResponseBytes) {
@@ -882,6 +1005,18 @@ export function evaluateCapacityThresholds(summary = {}, options = {}) {
         message: `Response bytes ${observed} exceeded cap ${thresholds.maxResponseBytes}.`,
       });
     }
+  }
+
+  if (thresholds.maxCommandResponseBytes != null) {
+    const observed = highestEndpointMetric(summary, COMMAND_P95_ENDPOINTS, 'maxResponseBytes');
+    pushUpperBoundViolation(violations, {
+      threshold: 'max-command-response-bytes',
+      limit: thresholds.maxCommandResponseBytes,
+      observed,
+      gatedEndpoints: [...COMMAND_P95_ENDPOINTS],
+      missingMessage: `No command response-byte measurements captured for command gated endpoints (${COMMAND_P95_ENDPOINTS.join(', ')}); threshold cannot be evaluated safely.`,
+      exceedMessage: (value, limit) => `Command response bytes ${value} exceeded cap ${limit}.`,
+    });
   }
 
   if (thresholds.requireZeroSignals) {
@@ -907,7 +1042,12 @@ export function hasThresholdFlags(options = {}) {
     || thresholds.maxNetworkFailures != null
     || thresholds.maxBootstrapP95Ms != null
     || thresholds.maxCommandP95Ms != null
+    || thresholds.maxBootstrapServerP95Ms != null
+    || thresholds.maxCommandServerP95Ms != null
+    || thresholds.maxBootstrapD1RowsWritten != null
+    || thresholds.maxCommandD1RowsWritten != null
     || thresholds.maxResponseBytes != null
+    || thresholds.maxCommandResponseBytes != null
     || thresholds.requireZeroSignals === true
     || thresholds.requireBootstrapCapacity === true
   );
@@ -1254,7 +1394,12 @@ function buildThresholdsBlock(options, summary) {
       maxNetworkFailures: thresholds.maxNetworkFailures ?? null,
       maxBootstrapP95Ms: thresholds.maxBootstrapP95Ms ?? null,
       maxCommandP95Ms: thresholds.maxCommandP95Ms ?? null,
+      maxBootstrapServerP95Ms: thresholds.maxBootstrapServerP95Ms ?? null,
+      maxCommandServerP95Ms: thresholds.maxCommandServerP95Ms ?? null,
+      maxBootstrapD1RowsWritten: thresholds.maxBootstrapD1RowsWritten ?? null,
+      maxCommandD1RowsWritten: thresholds.maxCommandD1RowsWritten ?? null,
       maxResponseBytes: thresholds.maxResponseBytes ?? null,
+      maxCommandResponseBytes: thresholds.maxCommandResponseBytes ?? null,
       requireZeroSignals: thresholds.requireZeroSignals === true,
       requireBootstrapCapacity: thresholds.requireBootstrapCapacity === true,
     },
@@ -1501,7 +1646,12 @@ export function usage() {
     '  --max-network-failures <count>    Maximum tolerated network failures',
     '  --max-bootstrap-p95-ms <ms>       Maximum tolerated /api/bootstrap P95 wall time',
     '  --max-command-p95-ms <ms>         Maximum tolerated subject-command P95 wall time',
+    '  --max-bootstrap-server-p95-ms <ms> Maximum tolerated bootstrap server-side P95 wall time',
+    '  --max-command-server-p95-ms <ms>   Maximum tolerated command server-side P95 wall time',
+    '  --max-bootstrap-d1-rows-written <count> Maximum D1 rows written by bootstrap',
+    '  --max-command-d1-rows-written <count>   Maximum D1 rows written by a subject command',
     '  --max-response-bytes <bytes>      Maximum tolerated response bytes across endpoints',
+    '  --max-command-response-bytes <bytes> Maximum tolerated command response bytes',
     '  --require-zero-signals            Fail on any exceededCpu / d1Overloaded / d1DailyLimit /',
     '                                    rateLimited / networkFailure / server5xx signal',
     '  --require-bootstrap-capacity      Assert meta.capacity.bootstrapCapacity is present (U3)',

--- a/scripts/lib/capacity-evidence.mjs
+++ b/scripts/lib/capacity-evidence.mjs
@@ -45,7 +45,12 @@ const KNOWN_THRESHOLD_KEYS = new Set([
   'maxNetworkFailures',
   'maxBootstrapP95Ms',
   'maxCommandP95Ms',
+  'maxBootstrapServerP95Ms',
+  'maxCommandServerP95Ms',
+  'maxBootstrapD1RowsWritten',
+  'maxCommandD1RowsWritten',
   'maxResponseBytes',
+  'maxCommandResponseBytes',
   'requireZeroSignals',
   'requireBootstrapCapacity',
 ]);
@@ -618,6 +623,34 @@ export function evaluateThresholds(summary = {}, thresholds = {}, { dryRun = fal
       dryRun,
     );
   }
+  if (thresholds.maxBootstrapServerP95Ms !== undefined && thresholds.maxBootstrapServerP95Ms !== null) {
+    evaluated.maxBootstrapServerP95Ms = gateLatency(
+      thresholds.maxBootstrapServerP95Ms,
+      bootstrapMetrics ? bootstrapMetrics.serverWallMsP95 : null,
+      dryRun,
+    );
+  }
+  if (thresholds.maxCommandServerP95Ms !== undefined && thresholds.maxCommandServerP95Ms !== null) {
+    evaluated.maxCommandServerP95Ms = gateLatency(
+      thresholds.maxCommandServerP95Ms,
+      commandMetrics ? commandMetrics.serverWallMsP95 : null,
+      dryRun,
+    );
+  }
+  if (thresholds.maxBootstrapD1RowsWritten !== undefined && thresholds.maxBootstrapD1RowsWritten !== null) {
+    evaluated.maxBootstrapD1RowsWritten = gateCount(
+      thresholds.maxBootstrapD1RowsWritten,
+      bootstrapMetrics ? bootstrapMetrics.d1RowsWritten : null,
+      dryRun,
+    );
+  }
+  if (thresholds.maxCommandD1RowsWritten !== undefined && thresholds.maxCommandD1RowsWritten !== null) {
+    evaluated.maxCommandD1RowsWritten = gateCount(
+      thresholds.maxCommandD1RowsWritten,
+      commandMetrics ? commandMetrics.d1RowsWritten : null,
+      dryRun,
+    );
+  }
   if (thresholds.maxResponseBytes !== undefined && thresholds.maxResponseBytes !== null) {
     const maxObserved = Math.max(
       0,
@@ -626,6 +659,13 @@ export function evaluateThresholds(summary = {}, thresholds = {}, { dryRun = fal
     evaluated.maxResponseBytes = gateCount(
       thresholds.maxResponseBytes,
       Object.keys(endpoints).length ? maxObserved : null,
+      dryRun,
+    );
+  }
+  if (thresholds.maxCommandResponseBytes !== undefined && thresholds.maxCommandResponseBytes !== null) {
+    evaluated.maxCommandResponseBytes = gateCount(
+      thresholds.maxCommandResponseBytes,
+      commandMetrics ? commandMetrics.maxResponseBytes : null,
       dryRun,
     );
   }

--- a/tests/capacity-evidence.test.js
+++ b/tests/capacity-evidence.test.js
@@ -36,12 +36,16 @@ function makeSummary(overrides = {}) {
         count: 10,
         p50WallMs: 120,
         p95WallMs: 320,
+        serverWallMsP95: 140,
+        d1RowsWritten: 0,
         maxResponseBytes: 80_000,
       },
       'POST /api/subjects/grammar/command': {
         count: 30,
         p50WallMs: 80,
         p95WallMs: 180,
+        serverWallMsP95: 110,
+        d1RowsWritten: 5,
         maxResponseBytes: 5_000,
       },
     },
@@ -84,7 +88,12 @@ test('evaluateThresholds returns {configured, observed, passed} per configured t
     maxNetworkFailures: 0,
     maxBootstrapP95Ms: 1000,
     maxCommandP95Ms: 750,
+    maxBootstrapServerP95Ms: 250,
+    maxCommandServerP95Ms: 250,
+    maxBootstrapD1RowsWritten: 0,
+    maxCommandD1RowsWritten: 5,
     maxResponseBytes: 600_000,
+    maxCommandResponseBytes: 20_000,
   });
   assert.deepEqual(result.failures, []);
   assert.equal(result.thresholds.max5xx.configured, 0);
@@ -93,6 +102,9 @@ test('evaluateThresholds returns {configured, observed, passed} per configured t
   assert.equal(result.thresholds.maxBootstrapP95Ms.configured, 1000);
   assert.equal(result.thresholds.maxBootstrapP95Ms.observed, 320);
   assert.equal(result.thresholds.maxBootstrapP95Ms.passed, true);
+  assert.equal(result.thresholds.maxBootstrapServerP95Ms.observed, 140);
+  assert.equal(result.thresholds.maxCommandD1RowsWritten.observed, 5);
+  assert.equal(result.thresholds.maxCommandResponseBytes.observed, 5_000);
 });
 
 test('evaluateThresholds reports failures with per-threshold details', () => {
@@ -115,6 +127,46 @@ test('evaluateThresholds reports failures with per-threshold details', () => {
   assert.ok(result.failures.includes('max5xx'));
   assert.ok(result.failures.includes('maxBootstrapP95Ms'));
   assert.ok(result.failures.includes('maxResponseBytes'));
+});
+
+test('evaluateThresholds reports server, D1 write, and command byte threshold failures', () => {
+  const summary = makeSummary({
+    endpoints: {
+      'GET /api/bootstrap': {
+        count: 10,
+        p95WallMs: 200,
+        serverWallMsP95: 310,
+        d1RowsWritten: 1,
+        maxResponseBytes: 1000,
+      },
+      'POST /api/subjects/grammar/command': {
+        count: 3,
+        p95WallMs: 220,
+        serverWallMsP95: 270,
+        d1RowsWritten: 6,
+        maxResponseBytes: 25_000,
+      },
+    },
+  });
+  const result = evaluateThresholds(summary, {
+    maxBootstrapServerP95Ms: 250,
+    maxCommandServerP95Ms: 250,
+    maxBootstrapD1RowsWritten: 0,
+    maxCommandD1RowsWritten: 5,
+    maxCommandResponseBytes: 20_000,
+  });
+  assert.equal(result.thresholds.maxBootstrapServerP95Ms.passed, false);
+  assert.equal(result.thresholds.maxCommandServerP95Ms.passed, false);
+  assert.equal(result.thresholds.maxBootstrapD1RowsWritten.passed, false);
+  assert.equal(result.thresholds.maxCommandD1RowsWritten.passed, false);
+  assert.equal(result.thresholds.maxCommandResponseBytes.passed, false);
+  assert.deepEqual(new Set(result.failures), new Set([
+    'maxBootstrapServerP95Ms',
+    'maxCommandServerP95Ms',
+    'maxBootstrapD1RowsWritten',
+    'maxCommandD1RowsWritten',
+    'maxCommandResponseBytes',
+  ]));
 });
 
 test('evaluateThresholds distinguishes threshold 0 (strict) from undefined (not gated)', () => {
@@ -592,7 +644,12 @@ test('validateThresholdConfigKeys accepts all known keys', () => {
     maxNetworkFailures: 0,
     maxBootstrapP95Ms: 1000,
     maxCommandP95Ms: 750,
+    maxBootstrapServerP95Ms: 250,
+    maxCommandServerP95Ms: 250,
+    maxBootstrapD1RowsWritten: 0,
+    maxCommandD1RowsWritten: 5,
     maxResponseBytes: 600000,
+    maxCommandResponseBytes: 20000,
     requireZeroSignals: true,
     requireBootstrapCapacity: true,
   });

--- a/tests/capacity-scripts.test.js
+++ b/tests/capacity-scripts.test.js
@@ -532,7 +532,12 @@ test('parseClassroomLoadArgs collects threshold flags into options.thresholds', 
     '--max-network-failures', '0',
     '--max-bootstrap-p95-ms', '1000',
     '--max-command-p95-ms', '750',
+    '--max-bootstrap-server-p95-ms', '250',
+    '--max-command-server-p95-ms', '250',
+    '--max-bootstrap-d1-rows-written', '0',
+    '--max-command-d1-rows-written', '5',
     '--max-response-bytes', '600000',
+    '--max-command-response-bytes', '20000',
     '--require-zero-signals',
     '--require-bootstrap-capacity',
     '--output', 'tmp/evidence.json',
@@ -542,7 +547,12 @@ test('parseClassroomLoadArgs collects threshold flags into options.thresholds', 
   assert.equal(options.thresholds.maxNetworkFailures, 0);
   assert.equal(options.thresholds.maxBootstrapP95Ms, 1000);
   assert.equal(options.thresholds.maxCommandP95Ms, 750);
+  assert.equal(options.thresholds.maxBootstrapServerP95Ms, 250);
+  assert.equal(options.thresholds.maxCommandServerP95Ms, 250);
+  assert.equal(options.thresholds.maxBootstrapD1RowsWritten, 0);
+  assert.equal(options.thresholds.maxCommandD1RowsWritten, 5);
   assert.equal(options.thresholds.maxResponseBytes, 600000);
+  assert.equal(options.thresholds.maxCommandResponseBytes, 20000);
   assert.equal(options.thresholds.requireZeroSignals, true);
   assert.equal(options.thresholds.requireBootstrapCapacity, true);
   assert.equal(options.output, 'tmp/evidence.json');

--- a/tests/capacity-thresholds.test.js
+++ b/tests/capacity-thresholds.test.js
@@ -47,7 +47,12 @@ test('classroom threshold flags parse with defaults disabled (back-compat)', () 
   assert.equal(options.maxNetworkFailures, null);
   assert.equal(options.maxBootstrapP95Ms, null);
   assert.equal(options.maxCommandP95Ms, null);
+  assert.equal(options.maxBootstrapServerP95Ms, null);
+  assert.equal(options.maxCommandServerP95Ms, null);
+  assert.equal(options.maxBootstrapD1RowsWritten, null);
+  assert.equal(options.maxCommandD1RowsWritten, null);
   assert.equal(options.maxResponseBytes, null);
+  assert.equal(options.maxCommandResponseBytes, null);
   assert.equal(options.requireZeroSignals, false);
   assert.equal(options.confirmHighProductionLoad, false);
 });
@@ -59,7 +64,12 @@ test('classroom threshold flags parse numeric and boolean flag values', () => {
     '--max-network-failures', '0',
     '--max-bootstrap-p95-ms', '1000',
     '--max-command-p95-ms', '750',
+    '--max-bootstrap-server-p95-ms', '250',
+    '--max-command-server-p95-ms', '250',
+    '--max-bootstrap-d1-rows-written', '0',
+    '--max-command-d1-rows-written', '5',
     '--max-response-bytes', '600000',
+    '--max-command-response-bytes', '20000',
     '--require-zero-signals',
     '--confirm-high-production-load',
   ]);
@@ -67,7 +77,12 @@ test('classroom threshold flags parse numeric and boolean flag values', () => {
   assert.equal(options.maxNetworkFailures, 0);
   assert.equal(options.maxBootstrapP95Ms, 1000);
   assert.equal(options.maxCommandP95Ms, 750);
+  assert.equal(options.maxBootstrapServerP95Ms, 250);
+  assert.equal(options.maxCommandServerP95Ms, 250);
+  assert.equal(options.maxBootstrapD1RowsWritten, 0);
+  assert.equal(options.maxCommandD1RowsWritten, 5);
   assert.equal(options.maxResponseBytes, 600_000);
+  assert.equal(options.maxCommandResponseBytes, 20_000);
   assert.equal(options.requireZeroSignals, true);
   assert.equal(options.confirmHighProductionLoad, true);
 });
@@ -195,6 +210,51 @@ test('evaluateCapacityThresholds flags max-response-bytes violations', () => {
   assert.equal(violations.length, 1);
   assert.equal(violations[0].threshold, 'max-response-bytes');
   assert.equal(violations[0].observed, 900_000);
+});
+
+test('evaluateCapacityThresholds flags server P95, D1 write, and command-byte violations', () => {
+  const summary = summariseCapacityResults([
+    {
+      scenario: 'cold-bootstrap-burst',
+      method: 'GET',
+      endpoint: '/api/bootstrap',
+      status: 200,
+      ok: true,
+      wallMs: 40,
+      responseBytes: 500,
+      capacity: {
+        serverWallMs: 310,
+        d1RowsWritten: 1,
+      },
+    },
+    {
+      scenario: 'human-paced-grammar-round',
+      method: 'POST',
+      endpoint: '/api/subjects/grammar/command',
+      status: 200,
+      ok: true,
+      wallMs: 50,
+      responseBytes: 25_000,
+      capacity: {
+        serverWallMs: 270,
+        d1RowsWritten: 6,
+      },
+    },
+  ], { expectedRequests: 2 });
+  const violations = evaluateCapacityThresholds(summary, {
+    maxBootstrapServerP95Ms: 250,
+    maxCommandServerP95Ms: 250,
+    maxBootstrapD1RowsWritten: 0,
+    maxCommandD1RowsWritten: 5,
+    maxCommandResponseBytes: 20_000,
+  });
+  assert.deepEqual(violations.map((entry) => entry.threshold).sort(), [
+    'max-bootstrap-d1-rows-written',
+    'max-bootstrap-server-p95-ms',
+    'max-command-d1-rows-written',
+    'max-command-response-bytes',
+    'max-command-server-p95-ms',
+  ]);
 });
 
 test('evaluateCapacityThresholds flags --require-zero-signals with any operational signal', () => {
@@ -642,7 +702,18 @@ test('P95 command gate fails closed when no measurements captured (adv-006)', ()
 });
 
 test('integer parser rejects non-integer values for threshold flags (C-04)', () => {
-  for (const flag of ['--max-5xx', '--max-network-failures', '--max-bootstrap-p95-ms', '--max-command-p95-ms', '--max-response-bytes']) {
+  for (const flag of [
+    '--max-5xx',
+    '--max-network-failures',
+    '--max-bootstrap-p95-ms',
+    '--max-command-p95-ms',
+    '--max-bootstrap-server-p95-ms',
+    '--max-command-server-p95-ms',
+    '--max-bootstrap-d1-rows-written',
+    '--max-command-d1-rows-written',
+    '--max-response-bytes',
+    '--max-command-response-bytes',
+  ]) {
     assert.throws(
       () => parseClassroomLoadArgs(['--dry-run', flag, '1.5']),
       /must be a non-negative integer/,

--- a/tests/worker-cron-retention-sweep.test.js
+++ b/tests/worker-cron-retention-sweep.test.js
@@ -173,24 +173,43 @@ test('U11 sweepRequestLimits deletes buckets older than 24h and obeys the batch 
   }
 });
 
-test('U11 sweepStaleSessions removes expired sessions whose revision is below current', async () => {
+test('U11 sweepStaleSessions removes expired sessions and keeps live sessions', async () => {
   const db = createMigratedSqliteD1Database();
   try {
     const now = 1_700_000_000_000;
     seedAdultAccount(db, { id: 'adult-a', now });
     seedOpsMetadata(db, { accountId: 'adult-a', now, statusRevision: 5 });
-    // Stale: revisionAtIssue=2 < current=5, and expiresAt is in the past.
+    // Expired rows can no longer authenticate, regardless of revision.
     seedSession(db, { id: 'sess-stale', accountId: 'adult-a', expiresAt: now - 1000, revisionAtIssue: 2 });
-    // Stale but NOT expired — protected so we do not race an in-flight
-    // request whose session revision was bumped server-side.
+    seedSession(db, { id: 'sess-expired-current', accountId: 'adult-a', expiresAt: now - 500, revisionAtIssue: 5 });
+    // Live rows stay. Stale live sessions are rejected by the auth boundary
+    // and by the immediate status-change sweep, not by the daily expiry sweep.
     seedSession(db, { id: 'sess-stale-live', accountId: 'adult-a', expiresAt: now + 1_000_000, revisionAtIssue: 2 });
-    // Current revision — stays.
     seedSession(db, { id: 'sess-fresh', accountId: 'adult-a', expiresAt: now + 1_000_000, revisionAtIssue: 5 });
 
     const result = await sweepStaleSessions(db, now);
-    assert.equal(result.deleted, 1);
+    assert.equal(result.deleted, 2);
     const remaining = db.db.prepare('SELECT id FROM account_sessions ORDER BY id ASC').all().map((row) => row.id);
     assert.deepEqual(remaining.sort(), ['sess-fresh', 'sess-stale-live']);
+  } finally {
+    db.close();
+  }
+});
+
+test('sweepStaleSessions uses the expires_at retention index', async () => {
+  const db = createMigratedSqliteD1Database();
+  try {
+    const plan = db.db.prepare(`
+      EXPLAIN QUERY PLAN
+      SELECT rowid
+      FROM account_sessions
+      WHERE expires_at < ?
+      ORDER BY expires_at ASC
+      LIMIT ?
+    `).all(0, 5000);
+    const detail = plan.map((row) => row.detail).join('\n');
+    assert.match(detail, /idx_account_sessions_expires/);
+    assert.doesNotMatch(detail, /SCAN account_sessions\b/);
   } finally {
     db.close();
   }

--- a/tests/worker-grammar-subject-runtime.test.js
+++ b/tests/worker-grammar-subject-runtime.test.js
@@ -202,6 +202,13 @@ test('Grammar command route persists subject state, practice session, and respon
   assert.equal(start.body.subjectReadModel.content.templateCount, GRAMMAR_TEMPLATE_METADATA.length);
   assert.equal(start.body.mutation.kind, 'subject_command.grammar.start-session');
   assert.equal(start.body.mutation.appliedRevision, 1);
+  const startedSession = DB.db.prepare(`
+    SELECT status, session_state_json, summary_json
+    FROM practice_sessions
+    WHERE learner_id = 'learner-a' AND subject_id = 'grammar'
+  `).get();
+  assert.equal(startedSession.status, 'active');
+  assert.equal(startedSession.summary_json, null);
 
   const submit = await postCommand(app, DB, {
     command: 'submit-answer',
@@ -215,6 +222,27 @@ test('Grammar command route persists subject state, practice session, and respon
   assert.equal(submit.body.subjectReadModel.feedback.result.correct, true);
   assert.equal(submit.body.mutation.appliedRevision, 2);
   assert.equal(submit.body.domainEvents.some((event) => event.type === 'grammar.answer-submitted'), true);
+  assert.ok(
+    submit.body.meta.capacity.d1RowsWritten <= 5,
+    `submit-answer should avoid rewriting active practice_sessions; wrote ${submit.body.meta.capacity.d1RowsWritten} rows`,
+  );
+  assert.ok(
+    Buffer.byteLength(JSON.stringify(submit.body), 'utf8') < 15_000,
+    'submit-answer should not duplicate full reward projection events inside the subject read model',
+  );
+  assert.equal(Array.isArray(submit.body.projections?.rewards?.events), true);
+  assert.deepEqual(
+    submit.body.subjectReadModel.projections?.rewards?.state,
+    submit.body.projections?.rewards?.state,
+  );
+  assert.equal(
+    Object.prototype.hasOwnProperty.call(submit.body.subjectReadModel.projections?.rewards || {}, 'events'),
+    false,
+  );
+  assert.equal(
+    Object.prototype.hasOwnProperty.call(submit.body.subjectReadModel.projections?.rewards || {}, 'toastEvents'),
+    false,
+  );
   const answerEvent = submit.body.domainEvents.find((event) => event.type === 'grammar.answer-submitted');
   assert.equal(answerEvent.contentReleaseId, GRAMMAR_CONTENT_RELEASE_ID);
   for (const event of submit.body.domainEvents.filter((row) => row.type === 'grammar.star-evidence-updated')) {
@@ -232,6 +260,14 @@ test('Grammar command route persists subject state, practice session, and respon
   assert.equal(data.mastery.concepts.sentence_functions.attempts, 1);
   assert.equal(data.mastery.concepts.speech_punctuation.attempts, 1);
   assert.equal(DB.db.prepare("SELECT COUNT(*) AS count FROM practice_sessions WHERE subject_id = 'grammar'").get().count, 1);
+  const sessionAfterSubmit = DB.db.prepare(`
+    SELECT status, session_state_json, summary_json
+    FROM practice_sessions
+    WHERE learner_id = 'learner-a' AND subject_id = 'grammar'
+  `).get();
+  assert.equal(sessionAfterSubmit.status, 'active');
+  assert.equal(sessionAfterSubmit.session_state_json, startedSession.session_state_json);
+  assert.equal(sessionAfterSubmit.summary_json, null);
   assert.equal(DB.db.prepare("SELECT COUNT(*) AS count FROM event_log WHERE subject_id = 'grammar' AND event_type = 'grammar.answer-submitted'").get().count, 0);
 
   const summary = await postCommand(app, DB, {
@@ -246,6 +282,14 @@ test('Grammar command route persists subject state, practice session, and respon
   assert.equal(summary.body.subjectReadModel.summary.answered, 1);
   assert.equal(Object.prototype.hasOwnProperty.call(summary.body.subjectReadModel.summary, 'sessionId'), false);
   assert.equal(summary.body.domainEvents.some((event) => event.type === 'grammar.session-completed'), true);
+  const completedSession = DB.db.prepare(`
+    SELECT status, session_state_json, summary_json
+    FROM practice_sessions
+    WHERE learner_id = 'learner-a' AND subject_id = 'grammar'
+  `).get();
+  assert.equal(completedSession.status, 'completed');
+  const persistedSummary = JSON.parse(completedSession.summary_json);
+  assert.equal(persistedSummary.answered, 1);
 
   DB.close();
 });

--- a/tests/worker-migration-0010.test.js
+++ b/tests/worker-migration-0010.test.js
@@ -236,7 +236,6 @@ test('migration 0010 registers all required new indexes', () => {
       'idx_ops_error_events_status_last_seen',
       'idx_ops_error_events_last_seen',
       'idx_ops_error_events_tuple',
-      'idx_practice_sessions_updated',
       'idx_event_log_created',
       'idx_mutation_receipts_applied',
     ]) {
@@ -271,12 +270,6 @@ test('windowed KPI COUNT queries use the new DESC indexes (not full table scan)'
     assert.match(eventDetail, /SEARCH .*event_log/i);
     assert.match(eventDetail, /idx_event_log_created/);
     assert.doesNotMatch(eventDetail, /SCAN TABLE event_log/i);
-
-    const sessionsPlan = db.db.prepare('EXPLAIN QUERY PLAN SELECT COUNT(*) FROM practice_sessions WHERE updated_at > ?').all();
-    const sessionsDetail = sessionsPlan.map((row) => row.detail).join(' | ');
-    assert.match(sessionsDetail, /SEARCH .*practice_sessions/i);
-    assert.match(sessionsDetail, /idx_practice_sessions_updated/);
-    assert.doesNotMatch(sessionsDetail, /SCAN TABLE practice_sessions/i);
 
     const receiptsPlan = db.db.prepare('EXPLAIN QUERY PLAN SELECT COUNT(*) FROM mutation_receipts WHERE applied_at > ?').all();
     const receiptsDetail = receiptsPlan.map((row) => row.detail).join(' | ');

--- a/tests/worker-migration-0018.test.js
+++ b/tests/worker-migration-0018.test.js
@@ -1,0 +1,123 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { SqliteD1Database } from './helpers/sqlite-d1.js';
+
+const migrationPath = resolve(
+  import.meta.dirname || '.',
+  '../worker/migrations/0018_capacity_cleanup_legacy_schema.sql',
+);
+
+const migrationSql = readFileSync(migrationPath, 'utf-8');
+
+function tableExists(db, name) {
+  const row = db.db.prepare(`
+    SELECT name FROM sqlite_master
+    WHERE type = 'table' AND name = ?
+  `).get(name);
+  return Boolean(row);
+}
+
+function indexExists(db, name) {
+  const row = db.db.prepare(`
+    SELECT name FROM sqlite_master
+    WHERE type = 'index' AND name = ?
+  `).get(name);
+  return Boolean(row);
+}
+
+test('migration 0018 drops legacy platform tables and the duplicate request limit index', () => {
+  const db = new SqliteD1Database();
+  try {
+    for (const table of [
+      'spelling_sessions',
+      'child_state',
+      'sessions',
+      'subscriptions',
+      'user_identities',
+      'children',
+      'users',
+      'learners',
+      'reward_events',
+    ]) {
+      db.db.exec(`CREATE TABLE ${table} (id TEXT PRIMARY KEY);`);
+    }
+    db.db.exec(`
+      CREATE TABLE request_limits (
+        limiter_key TEXT PRIMARY KEY,
+        window_started_at INTEGER NOT NULL,
+        request_count INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+      CREATE INDEX idx_request_limits_updated ON request_limits(updated_at);
+      CREATE INDEX idx_request_limits_updated_at ON request_limits(updated_at);
+      CREATE TABLE account_sessions (
+        id TEXT PRIMARY KEY,
+        account_id TEXT NOT NULL,
+        session_hash TEXT NOT NULL UNIQUE,
+        provider TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        expires_at INTEGER NOT NULL,
+        session_kind TEXT NOT NULL DEFAULT 'real',
+        status_revision_at_issue INTEGER NOT NULL DEFAULT 0
+      );
+    `);
+
+    db.db.exec(migrationSql);
+
+    for (const table of [
+      'spelling_sessions',
+      'child_state',
+      'sessions',
+      'subscriptions',
+      'user_identities',
+      'children',
+      'users',
+      'learners',
+      'reward_events',
+    ]) {
+      assert.equal(tableExists(db, table), false, `${table} should be removed`);
+    }
+    assert.equal(indexExists(db, 'idx_request_limits_updated'), true);
+    assert.equal(indexExists(db, 'idx_request_limits_updated_at'), false);
+  } finally {
+    db.close();
+  }
+});
+
+test('migration 0018 drains expired account sessions without removing live sessions', () => {
+  const db = new SqliteD1Database();
+  try {
+    db.db.exec(`
+      CREATE TABLE account_sessions (
+        id TEXT PRIMARY KEY,
+        account_id TEXT NOT NULL,
+        session_hash TEXT NOT NULL UNIQUE,
+        provider TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        expires_at INTEGER NOT NULL,
+        session_kind TEXT NOT NULL DEFAULT 'real',
+        status_revision_at_issue INTEGER NOT NULL DEFAULT 0
+      );
+      INSERT INTO account_sessions (
+        id, account_id, session_hash, provider, created_at, expires_at,
+        session_kind, status_revision_at_issue
+      )
+      VALUES
+        ('expired', 'adult-a', 'hash-expired', 'email', 1, 1, 'real', 0),
+        ('live', 'adult-a', 'hash-live', 'email', 1, 4102444800000, 'real', 0);
+    `);
+
+    db.db.exec(migrationSql);
+
+    const remaining = db.db
+      .prepare('SELECT id FROM account_sessions ORDER BY id')
+      .all()
+      .map((row) => row.id);
+    assert.deepEqual(remaining, ['live']);
+  } finally {
+    db.close();
+  }
+});

--- a/tests/worker-migration-0019.test.js
+++ b/tests/worker-migration-0019.test.js
@@ -1,0 +1,84 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { SqliteD1Database } from './helpers/sqlite-d1.js';
+
+const migrationPath = resolve(
+  import.meta.dirname || '.',
+  '../worker/migrations/0019_capacity_drop_write_amplifying_indexes.sql',
+);
+
+const migrationSql = readFileSync(migrationPath, 'utf-8');
+
+test('migration 0019 drops write-amplifying indexes from command hot-path tables', () => {
+  const db = new SqliteD1Database();
+  try {
+    db.db.exec(`
+      CREATE TABLE mutation_receipts (
+        account_id TEXT NOT NULL,
+        request_id TEXT NOT NULL,
+        scope_type TEXT NOT NULL,
+        scope_id TEXT,
+        mutation_kind TEXT NOT NULL,
+        request_hash TEXT NOT NULL,
+        response_json TEXT NOT NULL,
+        status_code INTEGER NOT NULL,
+        correlation_id TEXT,
+        applied_at INTEGER NOT NULL,
+        PRIMARY KEY (account_id, request_id)
+      );
+      CREATE INDEX idx_mutation_receipts_scope
+        ON mutation_receipts(account_id, scope_type, scope_id, applied_at DESC);
+      CREATE INDEX idx_mutation_receipts_account_applied
+        ON mutation_receipts(account_id, applied_at DESC, request_id);
+
+      CREATE TABLE learner_read_models (
+        learner_id TEXT NOT NULL,
+        model_key TEXT NOT NULL,
+        model_json TEXT NOT NULL,
+        source_revision INTEGER NOT NULL DEFAULT 0,
+        generated_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        PRIMARY KEY (learner_id, model_key)
+      );
+      CREATE INDEX idx_learner_read_models_key_updated
+        ON learner_read_models(model_key, updated_at DESC);
+
+      CREATE TABLE practice_sessions (
+        id TEXT PRIMARY KEY,
+        learner_id TEXT NOT NULL,
+        subject_id TEXT NOT NULL,
+        session_kind TEXT NOT NULL,
+        status TEXT NOT NULL,
+        session_state_json TEXT,
+        summary_json TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        updated_by_account_id TEXT
+      );
+      CREATE INDEX idx_practice_sessions_updated
+        ON practice_sessions(updated_at DESC);
+    `);
+
+    db.db.exec(migrationSql);
+
+    const rows = db.db.prepare(`
+      SELECT name
+      FROM sqlite_master
+      WHERE type = 'index'
+        AND name IN (
+          'idx_mutation_receipts_scope',
+          'idx_mutation_receipts_account_applied',
+          'idx_learner_read_models_key_updated',
+          'idx_practice_sessions_updated'
+        )
+      ORDER BY name
+    `).all();
+
+    assert.deepEqual(rows, []);
+  } finally {
+    db.close();
+  }
+});

--- a/tests/worker-monster-visual-config.test.js
+++ b/tests/worker-monster-visual-config.test.js
@@ -295,6 +295,14 @@ test('admin saves, publishes, and restores global monster visual config with rec
   const server = createWorkerRepositoryServer();
   try {
     const initial = (await adminHub(server)).adminHub.monsterVisualConfig;
+    const warmPointerResponse = await fetchAdmin(server, '/api/bootstrap', {
+      headers: { 'x-ks2-public-read-models': '1' },
+    });
+    const warmPointerPayload = await json(warmPointerResponse);
+    assert.equal(warmPointerResponse.status, 200);
+    assert.equal(warmPointerPayload.monsterVisualConfig.publishedVersion, 1);
+    assert.equal(warmPointerPayload.monsterVisualConfig.compact, true);
+
     const draft = reviewedConfig(initial.draft);
     draft.assets['vellhorn-b1-3'].baseline.facing = 'right';
 
@@ -331,6 +339,14 @@ test('admin saves, publishes, and restores global monster visual config with rec
     assert.equal(publishPayload.monsterVisualConfig.published.assets['vellhorn-b1-3'].baseline.facing, 'right');
     const publishedVersion = server.DB.db.prepare('SELECT config_json FROM platform_monster_visual_config_versions WHERE version = ?').get(2);
     assert.equal(JSON.parse(publishedVersion.config_json).assets['vellhorn-b1-3'].baseline.facing, 'right');
+
+    const publicBootstrapResponse = await fetchAdmin(server, '/api/bootstrap', {
+      headers: { 'x-ks2-public-read-models': '1' },
+    });
+    const publicBootstrapPayload = await json(publicBootstrapResponse);
+    assert.equal(publicBootstrapResponse.status, 200);
+    assert.equal(publicBootstrapPayload.monsterVisualConfig.publishedVersion, 2);
+    assert.equal(publicBootstrapPayload.monsterVisualConfig.compact, true);
 
     const bootstrapResponse = await fetchAdmin(server, '/api/bootstrap');
     const bootstrapPayload = await json(bootstrapResponse);

--- a/tests/worker-query-budget.test.js
+++ b/tests/worker-query-budget.test.js
@@ -58,6 +58,7 @@ const BUDGET_PARENT_RECENT_SESSIONS = 7;
 // Headroom +1.
 const MEASURED_BOOTSTRAP_GET_FULL = 9;
 const BUDGET_BOOTSTRAP_GET_FULL = MEASURED_BOOTSTRAP_GET_FULL + 1;
+const MEASURED_BOOTSTRAP_GET_WITH_CACHED_MONSTER_POINTER = MEASURED_BOOTSTRAP_GET_FULL - 1;
 
 // Measured: 4 queries for Hero read-model GET (ops_status JOIN +
 // ensureAccount upsert + membership learner-access check +
@@ -565,6 +566,38 @@ test('U3 query budget: GET bootstrap full bundle ≤ BUDGET_BOOTSTRAP_GET_FULL',
       .filter((entry) => entry.operation === 'all' && /\bFROM child_subject_state\b/i.test(entry.sql));
     assert.equal(subjectStateReads.length, 1,
       'GET bootstrap should reuse the already-loaded child_subject_state rows for active-session discovery.');
+  } finally {
+    server.close();
+  }
+});
+
+test('U3 query budget: repeated GET bootstrap reuses the monster visual pointer cache', async () => {
+  const server = createServer();
+  try {
+    seed3LearnerFixture(server);
+
+    const warmResponse = await getBootstrap(server);
+    assert.equal(warmResponse.status, 200);
+    await readJsonBody(warmResponse);
+    server.DB.clearQueryLog();
+
+    const response = await getBootstrap(server);
+    assert.equal(response.status, 200);
+    const payload = await readJsonBody(response);
+    assert.equal(payload.ok, true);
+    assert.equal(payload.monsterVisualConfig?.compact, true);
+
+    const capacity = payload.meta?.capacity;
+    assert.ok(capacity, 'GET bootstrap must expose meta.capacity');
+    assert.equal(
+      capacity.queryCount,
+      MEASURED_BOOTSTRAP_GET_WITH_CACHED_MONSTER_POINTER,
+      `cached GET bootstrap queryCount should stay at ${MEASURED_BOOTSTRAP_GET_WITH_CACHED_MONSTER_POINTER}; measured ${capacity.queryCount}`,
+    );
+
+    const pointerReads = server.DB.takeQueryLog()
+      .filter((entry) => /\bFROM platform_monster_visual_config\b/i.test(entry.sql));
+    assert.equal(pointerReads.length, 0, 'cached public bootstrap must not re-read the global monster visual pointer.');
   } finally {
     server.close();
   }

--- a/tests/worker-query-budget.test.js
+++ b/tests/worker-query-budget.test.js
@@ -346,6 +346,30 @@ function createCommandHarness({ subjectId = 'spelling', accountId = 'adult-cmd' 
   };
 }
 
+test('U3 query budget: latest subject session lookup stays subject-scoped for old learners', () => {
+  const DB = createMigratedSqliteD1Database();
+  try {
+    const columns = DB.db
+      .prepare('PRAGMA index_info(idx_practice_sessions_learner_subject)')
+      .all()
+      .map((row) => row.name);
+    assert.deepEqual(columns, ['learner_id', 'subject_id', 'updated_at', 'id']);
+
+    const plan = DB.db.prepare(`
+      EXPLAIN QUERY PLAN
+      SELECT id, learner_id, subject_id, session_kind, status, session_state_json, summary_json, created_at, updated_at
+      FROM practice_sessions
+      WHERE learner_id = ? AND subject_id = ?
+      ORDER BY updated_at DESC, id DESC
+      LIMIT 1
+    `).all('learner-old', 'grammar').map((row) => row.detail).join('\n');
+    assert.match(plan, /idx_practice_sessions_learner_subject/);
+    assert.doesNotMatch(plan, /USE TEMP B-TREE/i);
+  } finally {
+    DB.close();
+  }
+});
+
 // ---------------------------------------------------------------------------
 // Scenario 1 — Bootstrap POST (selected-learner-bounded, 3-learner fixture)
 // ---------------------------------------------------------------------------

--- a/tests/worker-read-model-capacity.test.js
+++ b/tests/worker-read-model-capacity.test.js
@@ -37,7 +37,7 @@ function seedParentAccess(server, {
   runSql(server, 'UPDATE adult_accounts SET selected_learner_id = ? WHERE id = ?', [learnerId, accountId]);
 }
 
-test('capacity read-model migration creates indexed summary and activity stores', () => {
+test('capacity read-model migration creates summary and indexed activity stores', () => {
   const server = createWorkerRepositoryServer();
   const tableRows = server.DB.db.prepare(`
     SELECT name
@@ -51,7 +51,6 @@ test('capacity read-model migration creates indexed summary and activity stores'
     FROM sqlite_master
     WHERE type = 'index'
       AND name IN (
-        'idx_learner_read_models_key_updated',
         'idx_learner_activity_feed_source_event',
         'idx_learner_activity_feed_learner_created',
         'idx_learner_activity_feed_subject_created',
@@ -66,7 +65,6 @@ test('capacity read-model migration creates indexed summary and activity stores'
     'idx_learner_activity_feed_source_event',
     'idx_learner_activity_feed_subject_created',
     'idx_learner_activity_feed_updated',
-    'idx_learner_read_models_key_updated',
   ]);
 
   server.close();

--- a/worker/migrations/0017_practice_sessions_subject_order_index.sql
+++ b/worker/migrations/0017_practice_sessions_subject_order_index.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS idx_practice_sessions_learner_subject;
+
+CREATE INDEX IF NOT EXISTS idx_practice_sessions_learner_subject
+  ON practice_sessions(learner_id, subject_id, updated_at DESC, id DESC);

--- a/worker/migrations/0018_capacity_cleanup_legacy_schema.sql
+++ b/worker/migrations/0018_capacity_cleanup_legacy_schema.sql
@@ -1,0 +1,26 @@
+-- Capacity cleanup: remove pre-SaaS tables and duplicate indexes that the
+-- current Worker runtime no longer reads or writes.
+
+DROP TABLE IF EXISTS spelling_sessions;
+DROP TABLE IF EXISTS child_state;
+DROP TABLE IF EXISTS sessions;
+DROP TABLE IF EXISTS subscriptions;
+DROP TABLE IF EXISTS user_identities;
+DROP TABLE IF EXISTS children;
+DROP TABLE IF EXISTS users;
+DROP TABLE IF EXISTS learners;
+DROP TABLE IF EXISTS reward_events;
+
+-- Older databases may carry both `idx_request_limits_updated` and the legacy
+-- `idx_request_limits_updated_at` on the same single column.
+DROP INDEX IF EXISTS idx_request_limits_updated_at;
+
+-- Drain already-expired auth sessions immediately on migration. Cron keeps the
+-- table bounded afterwards.
+DELETE FROM account_sessions
+WHERE rowid IN (
+  SELECT rowid FROM account_sessions
+  WHERE expires_at < CAST(strftime('%s', 'now') AS INTEGER) * 1000
+  ORDER BY expires_at ASC
+  LIMIT 5000
+);

--- a/worker/migrations/0019_capacity_drop_write_amplifying_indexes.sql
+++ b/worker/migrations/0019_capacity_drop_write_amplifying_indexes.sql
@@ -1,0 +1,7 @@
+-- Capacity follow-up: remove secondary indexes that are not used by hot-path
+-- runtime queries but amplify D1 rows-written billing for every command write.
+
+DROP INDEX IF EXISTS idx_mutation_receipts_scope;
+DROP INDEX IF EXISTS idx_mutation_receipts_account_applied;
+DROP INDEX IF EXISTS idx_learner_read_models_key_updated;
+DROP INDEX IF EXISTS idx_practice_sessions_updated;

--- a/worker/src/cron/retention-sweep.js
+++ b/worker/src/cron/retention-sweep.js
@@ -111,22 +111,12 @@ export async function sweepRequestLimits(db, now = Date.now()) {
 }
 
 /**
- * Prune sessions orphaned by a `status_revision` bump. A session rendered
- * stale by revision-bump becomes unreachable in Phase D's require-session
- * compare, but unexpired rows linger until this sweep removes them. The
- * cron runs it as defence-in-depth for the U15 immediate-sweep path.
+ * Prune expired account sessions. Stale-session invalidation remains enforced
+ * at the auth boundary and by the immediate status-change sweep; this cron
+ * path removes any session row that can no longer authenticate a request.
  *
- * Sessions are only deleted when BOTH conditions hold:
- *   - the session's `status_revision_at_issue` is below the account's
- *     current `status_revision` (so the session is server-invalidated);
- *   - `expires_at` is in the past (so pruning cannot race an in-flight
- *     request from that session).
- *
- * I4 (Phase C reviewer): the per-row correlated subquery was rewritten
- * as a bounded JOIN with a LIMIT 5000 inside the rowid selection so the
- * planner can use the `account_sessions(account_id)` index and so a
- * large backlog drains across multiple cron cycles instead of choking
- * the D1 request in a single unbounded DELETE.
+ * The bounded delete uses the `account_sessions(expires_at)` index so ordinary
+ * login churn does not leave a permanent D1 tail.
  */
 export async function sweepStaleSessions(db, now = Date.now()) {
   const nowTs = Math.max(0, Number(now) || 0);
@@ -134,19 +124,15 @@ export async function sweepStaleSessions(db, now = Date.now()) {
     const result = await run(db, `
       DELETE FROM account_sessions
       WHERE rowid IN (
-        SELECT s.rowid FROM account_sessions s
-        JOIN account_ops_metadata aom ON aom.account_id = s.account_id
-        WHERE s.expires_at < ?
-          AND s.status_revision_at_issue < aom.status_revision
+        SELECT rowid FROM account_sessions
+        WHERE expires_at < ?
+        ORDER BY expires_at ASC
         LIMIT ?
       )
     `, [nowTs, ACCOUNT_SESSIONS_MAX_DELETE_BATCH]);
     return { deleted: Math.max(0, Number(result?.meta?.changes) || 0) };
   } catch (error) {
-    // Either `account_sessions` or `account_ops_metadata` may be missing
-    // on a partial deploy — soft-fail so the cron keeps the remainder.
     if (isMissingTableError(error, 'account_sessions')) return { deleted: 0 };
-    if (isMissingTableError(error, 'account_ops_metadata')) return { deleted: 0 };
     throw error;
   }
 }

--- a/worker/src/repository.js
+++ b/worker/src/repository.js
@@ -7862,6 +7862,7 @@ function buildSubjectRuntimePersistencePlan(db, accountId, learnerId, subjectId,
   // land. A subsequent command will repopulate the projection via
   // `stale-catchup`.
   skipProjectionReadModelWrite = false,
+  skipActivePracticeSessionWrite = false,
 } = {}) {
   const nextState = normaliseSubjectStateRecord({
     ui: runtime?.state || null,
@@ -7892,65 +7893,68 @@ function buildSubjectRuntimePersistencePlan(db, accountId, learnerId, subjectId,
     ? normalisePracticeSessionRecord(runtime.practiceSession)
     : null;
   if (session?.id && session.learnerId === learnerId && session.subjectId === subjectId) {
-    // U6 queryCount budget: skip the no-op "abandon siblings" UPDATE
-    // when the caller confirmed the current active session id is the
-    // same one we are about to upsert. The UPDATE's `id <> ?` filter
-    // means it would match zero rows in that case.
-    const shouldEmitAbandon = session.status === 'active'
-      && (currentActiveSessionId == null || currentActiveSessionId !== session.id);
-    if (shouldEmitAbandon) {
-      statements.push(bindStatement(db, `
-        UPDATE practice_sessions
-        SET status = 'abandoned',
-            updated_at = ?,
-            updated_by_account_id = ?
-        WHERE learner_id = ?
-          AND subject_id = ?
-          AND status = 'active'
-          AND id <> ?
-          ${guardedWhere(guard)}
-      `, guardedParams([nowTs, accountId, learnerId, subjectId, session.id], guard)));
-    }
+    const shouldSkipActivePracticeSessionWrite = skipActivePracticeSessionWrite && session.status === 'active';
+    if (!shouldSkipActivePracticeSessionWrite) {
+      // U6 queryCount budget: skip the no-op "abandon siblings" UPDATE
+      // when the caller confirmed the current active session id is the
+      // same one we are about to upsert. The UPDATE's `id <> ?` filter
+      // means it would match zero rows in that case.
+      const shouldEmitAbandon = session.status === 'active'
+        && (currentActiveSessionId == null || currentActiveSessionId !== session.id);
+      if (shouldEmitAbandon) {
+        statements.push(bindStatement(db, `
+          UPDATE practice_sessions
+          SET status = 'abandoned',
+              updated_at = ?,
+              updated_by_account_id = ?
+          WHERE learner_id = ?
+            AND subject_id = ?
+            AND status = 'active'
+            AND id <> ?
+            ${guardedWhere(guard)}
+        `, guardedParams([nowTs, accountId, learnerId, subjectId, session.id], guard)));
+      }
 
-    const createdAt = asTs(session.createdAt, nowTs);
-    const updatedAt = asTs(session.updatedAt, nowTs);
-    const sessionParams = [
-      session.id,
-      learnerId,
-      subjectId,
-      session.sessionKind,
-      session.status,
-      session.sessionState == null ? null : JSON.stringify(session.sessionState),
-      session.summary == null ? null : JSON.stringify(session.summary),
-      createdAt,
-      updatedAt,
-      accountId,
-    ];
-    statements.push(bindStatement(db, `
-      INSERT INTO practice_sessions (
-        id,
-        learner_id,
-        subject_id,
-        session_kind,
-        status,
-        session_state_json,
-        summary_json,
-        created_at,
-        updated_at,
-        updated_by_account_id
-      )
-      ${guardedValueSource(sessionParams.length, guard)}
-      ON CONFLICT(id) DO UPDATE SET
-        learner_id = excluded.learner_id,
-        subject_id = excluded.subject_id,
-        session_kind = excluded.session_kind,
-        status = excluded.status,
-        session_state_json = excluded.session_state_json,
-        summary_json = excluded.summary_json,
-        created_at = excluded.created_at,
-        updated_at = excluded.updated_at,
-        updated_by_account_id = excluded.updated_by_account_id
-    `, guardedParams(sessionParams, guard)));
+      const createdAt = asTs(session.createdAt, nowTs);
+      const updatedAt = asTs(session.updatedAt, nowTs);
+      const sessionParams = [
+        session.id,
+        learnerId,
+        subjectId,
+        session.sessionKind,
+        session.status,
+        session.sessionState == null ? null : JSON.stringify(session.sessionState),
+        session.summary == null ? null : JSON.stringify(session.summary),
+        createdAt,
+        updatedAt,
+        accountId,
+      ];
+      statements.push(bindStatement(db, `
+        INSERT INTO practice_sessions (
+          id,
+          learner_id,
+          subject_id,
+          session_kind,
+          status,
+          session_state_json,
+          summary_json,
+          created_at,
+          updated_at,
+          updated_by_account_id
+        )
+        ${guardedValueSource(sessionParams.length, guard)}
+        ON CONFLICT(id) DO UPDATE SET
+          learner_id = excluded.learner_id,
+          subject_id = excluded.subject_id,
+          session_kind = excluded.session_kind,
+          status = excluded.status,
+          session_state_json = excluded.session_state_json,
+          summary_json = excluded.summary_json,
+          created_at = excluded.created_at,
+          updated_at = excluded.updated_at,
+          updated_by_account_id = excluded.updated_by_account_id
+      `, guardedParams(sessionParams, guard)));
+    }
   }
 
   const gameState = runtime?.gameState && typeof runtime.gameState === 'object' && !Array.isArray(runtime.gameState)
@@ -8350,6 +8354,9 @@ async function runSubjectCommandMutation(db, {
           persistActivityFeed: false,
           projectionContext: includeProjection ? freshProjectionContext : null,
           skipProjectionReadModelWrite: !includeProjection,
+          // Feedback progress is source-of-truth in child_subject_state.
+          // Keep practice_sessions for start/completion history, not every answer.
+          skipActivePracticeSessionWrite: command.command === 'submit-answer',
           currentActiveSessionId: freshRuntimeWrite.previousActiveSessionId || null,
         },
       );

--- a/worker/src/repository.js
+++ b/worker/src/repository.js
@@ -236,6 +236,8 @@ const SPELLING_RUNTIME_CONTENT_CACHE_LIMIT = 8;
 // the full editable content row from D1.
 const spellingRuntimeContentCache = new Map();
 const MONSTER_VISUAL_CONFIG_ID = 'global';
+const MONSTER_VISUAL_CONFIG_POINTER_CACHE_TTL_MS = 5_000;
+const monsterVisualConfigPointerCache = new WeakMap();
 const MONSTER_VISUAL_SCOPE_TYPE = 'platform';
 const MONSTER_VISUAL_SCOPE_ID = 'monster-visual-config';
 
@@ -6135,11 +6137,25 @@ async function readBootstrapMonsterVisualRuntimeConfig(db, nowTs) {
   }
 }
 
+function cloneMonsterVisualConfigPointer(value) {
+  return value && typeof value === 'object' ? { ...value } : value;
+}
+
+function monsterVisualConfigPointerCacheKey(db) {
+  return db?.__rawDb || db;
+}
+
+function invalidateMonsterVisualConfigPointerCache(db) {
+  const cacheKey = monsterVisualConfigPointerCacheKey(db);
+  if (!cacheKey || (typeof cacheKey !== 'object' && typeof cacheKey !== 'function')) return;
+  monsterVisualConfigPointerCache.delete(cacheKey);
+}
+
 // U7: compact pointer for the selected-learner-bounded envelope. Omits
 // the ~450 KB bundled config; the client uses `publishedVersion` +
 // `manifestHash` to decide whether its cached config is still current,
 // and fetches the full config via its existing lazy path when not.
-async function readMonsterVisualConfigPointer(db) {
+async function readMonsterVisualConfigPointerFromStorage(db) {
   try {
     const row = await first(db, `
       SELECT published_version, manifest_hash, published_at, schema_version
@@ -6169,6 +6185,51 @@ async function readMonsterVisualConfigPointer(db) {
     }
     throw error;
   }
+}
+
+async function readMonsterVisualConfigPointer(db, nowTs = Date.now()) {
+  const cacheKey = monsterVisualConfigPointerCacheKey(db);
+  const cache = cacheKey && (typeof cacheKey === 'object' || typeof cacheKey === 'function')
+    ? monsterVisualConfigPointerCache.get(cacheKey)
+    : null;
+  if (cache?.value && Number(cache.expiresAt) > Number(nowTs)) {
+    return cloneMonsterVisualConfigPointer(cache.value);
+  }
+  if (cache?.pending) {
+    return cloneMonsterVisualConfigPointer(await cache.pending);
+  }
+
+  const pending = readMonsterVisualConfigPointerFromStorage(db)
+    .then((value) => {
+      if (cacheKey && (typeof cacheKey === 'object' || typeof cacheKey === 'function')) {
+        const current = monsterVisualConfigPointerCache.get(cacheKey);
+        if (current?.pending === pending) {
+          monsterVisualConfigPointerCache.set(cacheKey, {
+            value: cloneMonsterVisualConfigPointer(value),
+            expiresAt: Date.now() + MONSTER_VISUAL_CONFIG_POINTER_CACHE_TTL_MS,
+            pending: null,
+          });
+        }
+      }
+      return value;
+    })
+    .catch((error) => {
+      if (cacheKey && (typeof cacheKey === 'object' || typeof cacheKey === 'function')) {
+        const current = monsterVisualConfigPointerCache.get(cacheKey);
+        if (current?.pending === pending) {
+          monsterVisualConfigPointerCache.delete(cacheKey);
+        }
+      }
+      throw error;
+    });
+  if (cacheKey && (typeof cacheKey === 'object' || typeof cacheKey === 'function')) {
+    monsterVisualConfigPointerCache.set(cacheKey, {
+      value: cache?.value || null,
+      expiresAt: Number(cache?.expiresAt) || 0,
+      pending,
+    });
+  }
+  return cloneMonsterVisualConfigPointer(await pending);
 }
 
 function monsterVisualMutationMeta({ kind, mutation, expectedRevision, appliedRevision }) {
@@ -6374,6 +6435,7 @@ async function saveMonsterVisualConfigDraft(db, actorAccountId, rawDraft, mutati
         kind,
         mutation: nextMutation,
       });
+      invalidateMonsterVisualConfigPointerCache(db);
     },
   });
 }
@@ -6501,6 +6563,7 @@ async function publishMonsterVisualConfig(db, actorAccountId, mutation, nowTs) {
         kind,
         mutation: nextMutation,
       });
+      invalidateMonsterVisualConfigPointerCache(db);
       await run(db, `
         DELETE FROM platform_monster_visual_config_versions
         WHERE version NOT IN (
@@ -6612,6 +6675,7 @@ async function restoreMonsterVisualConfigVersion(db, actorAccountId, version, mu
         kind,
         mutation: nextMutation,
       });
+      invalidateMonsterVisualConfigPointerCache(db);
     },
   });
 }

--- a/worker/src/subjects/grammar/read-models.js
+++ b/worker/src/subjects/grammar/read-models.js
@@ -1028,7 +1028,7 @@ function compactGrammarCommandReadModel(readModel, command) {
     prefs: readModel.prefs,
     stats: readModel.stats,
     aiEnrichment: readModel.aiEnrichment,
-    projections: readModel.projections,
+    projections: compactGrammarCommandProjections(readModel.projections),
     error: readModel.error,
   };
 
@@ -1037,6 +1037,18 @@ function compactGrammarCommandReadModel(readModel, command) {
   }
 
   return compact;
+}
+
+function compactGrammarCommandProjections(projections) {
+  if (!projections || typeof projections !== 'object' || Array.isArray(projections)) return null;
+  const rewards = projections.rewards;
+  if (!rewards || typeof rewards !== 'object' || Array.isArray(rewards)) return null;
+  return {
+    rewards: {
+      systemId: typeof rewards.systemId === 'string' ? rewards.systemId : '',
+      state: cloneSerialisable(rewards.state) || {},
+    },
+  };
 }
 
 export function buildGrammarCommandReadModel({


### PR DESCRIPTION
## Summary
- reduce D1 write amplification from hot command paths by dropping unused secondary indexes and tightening the command write guardrail
- keep player progress semantics unchanged while skipping the submit-answer active-session rewrite
- reduce bootstrap read pressure by caching the global monster visual config pointer per isolate with admin publish/restore invalidation

## Verification
- npm test
- npm run check
- production deploy to https://ks2.eugnel.uk
- live /api/version returned buildId 89da55f2
- production capacity gate passed: 0 5xx, 0 network failures, bootstrap writes 0, command writes max 12, bootstrap server P95 163ms, command server P95 232ms
- remote D1 read-only checks: removed legacy tables/indexes remain absent, retained lookup indexes remain present, rows_written 0