### PR TITLE
Fix spelling Word Bank facet counts

### DIFF
--- a/docs/plans/2026-06-05-001-refactor-spelling-pool-taxonomy-and-selector-plan.md
+++ b/docs/plans/2026-06-05-001-refactor-spelling-pool-taxonomy-and-selector-plan.md
@@ -1,0 +1,210 @@
+---
+title: Spelling Pool Taxonomy and Measured Selector Refactor
+type: refactor
+status: active
+date: 2026-06-05
+origin: docs/brainstorms/2026-04-22-spelling-extra-expansion-requirements.md
+execution: code
+---
+
+# Spelling Pool Taxonomy and Measured Selector Refactor
+
+## Summary
+
+Refactor Spelling pool/category handling so Setup, Word Bank, Worker analytics, and facet counts all read from one taxonomy. Restore the Pool selector's sliding affordance with measured geometry so long labels and wrapped mobile rows stay aligned.
+
+---
+
+## Problem Frame
+
+The recent Word Bank and Pool hotfixes fixed production counts and sidebar copy, but they exposed a structural issue: pool/category definitions are duplicated across the setup selector, Word Bank chips, side-panel copy, client stats mapping, Worker analytics groups, and Word Bank facets. That duplication makes future pools fragile because each new category can drift in count, label, visibility, or stats key.
+
+The Pool selector has a separate UI issue. The shared `LengthPicker` slider assumes equal-width options, while Spelling pools include variable-width labels such as `Secure vocabulary` and can wrap on mobile. The hotfix made the control usable by turning the Pool selector into chips, but that regressed the sliding segmented-control feel.
+
+---
+
+## Requirements
+
+**Pool taxonomy**
+
+- R1. Define one Spelling pool taxonomy that carries category IDs, labels, ordering, visibility, stats keys, and match rules for `core`, `y3-4`, `y5-6`, `secure-extension`, and `extra`.
+- R2. Generate Setup Pool options, setup side-panel copy, Word Bank category chips, Word Bank summary cards, Worker analytics groups, and Word Bank facets from the taxonomy.
+- R3. Support future basic pools through taxonomy/content metadata without editing JSX chip lists or hand-written facet maps.
+- R4. Preserve the Extra expansion contract: Extra stays independent from Years 3-4, Years 5-6, core statutory completion, SATs Test wording, and Phaeton progress.
+
+**Selector behaviour**
+
+- R5. Restore a sliding selected indicator for the Pool selector that follows the selected option's actual x/y/width/height, including variable-width labels and wrapped mobile layouts.
+- R6. Keep the existing fixed-width `LengthPicker` behaviour for round length and other subject surfaces unless a caller opts into measured slider mode.
+- R7. Provide a stable fallback before measurement completes so the selected Pool is still visibly active during hydration, reduced motion, and test rendering.
+
+**Compatibility and state**
+
+- R8. Keep existing serialised IDs and API query values compatible: `all`, `core`, `y3-4`, `y5-6`, `secure-extension`, and `extra`.
+- R9. Collapse stale or unknown persisted pool filters to the same safe defaults as today instead of rendering orphan chips or sending unsupported Worker queries.
+- R10. Keep Word Bank rows server-filtered and paged; taxonomy-driven facets describe the full authorised matching universe, not only loaded rows.
+
+**Verification**
+
+- R11. Add regression coverage that proves Setup, Word Bank, Worker analytics, and client fallbacks stay in sync for every taxonomy category.
+- R12. Add browser-level verification for desktop and mobile Pool selector alignment, including Secure vocabulary selected and Extra selected.
+
+---
+
+## Key Technical Decisions
+
+- KTD1. Use a shared taxonomy module rather than another view-model map. A pure module under `shared/spelling/` keeps category definitions importable by Worker, client read-models, and React components without making UI code depend on Worker service internals.
+- KTD2. Store match rules as serialisable descriptors, not arbitrary functions. Rules such as `core`, `yearBand: "3-4"`, `coverageTier: "secure-extension"`, and `spellingPool: "extra"` let each runtime evaluate words in its own context while sharing the same category contract.
+- KTD3. Make measured slider mode opt-in on `LengthPicker`. The default `--selected-index` path remains unchanged for round length, Grammar, and Punctuation; Spelling Pool passes a mode/class that enables geometry measurement.
+- KTD4. Treat taxonomy as display and filtering metadata, not content truth. Content still decides whether a word is statutory, secure-extension, or enrichment-extra; taxonomy only names how those words are grouped and surfaced.
+- KTD5. Keep facets authoritative and rows paged. Category and status counts should come from the full server-side query universe, while visible groups remain the current result page.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TB
+  T["Spelling pool taxonomy"] --> S["Setup Pool options and side panel"]
+  T --> W["Word Bank chips and summary cards"]
+  T --> A["Worker analytics wordGroups and pools"]
+  T --> F["Word Bank facet contract"]
+  T --> P["Preference validation and fallback"]
+  L["Measured LengthPicker mode"] --> S
+```
+
+The taxonomy becomes the category contract. The UI should not independently know that Secure vocabulary exists; it should ask the taxonomy which categories are visible for Setup and Word Bank, then render those categories.
+
+---
+
+## Implementation Units
+
+### U1. Shared Spelling Pool Taxonomy
+
+- **Goal:** Introduce the single source of truth for pool/category definitions and safe lookup helpers.
+- **Files:** `shared/spelling/pool-taxonomy.js`, `src/subjects/spelling/components/spelling-view-model.js`, `src/subjects/spelling/service-contract.js`, `tests/spelling-pool-taxonomy.test.js`.
+- **Patterns:** Follow the small pure-module style used by `src/subjects/spelling/content/taxonomy.js`; keep exports serialisable and dependency-light.
+- **Test Scenarios:**
+  - Every taxonomy entry has a stable `id`, `label`, `statsKey`, `order`, visibility flags, and one supported match descriptor.
+  - Lookup helpers return categories in display order and reject duplicate IDs, duplicate stats keys, or unsupported match descriptors.
+  - Existing IDs are preserved for `core`, `y3-4`, `y5-6`, `secure-extension`, and `extra`.
+  - A test-only future category can be passed through helper functions without adding JSX-specific code.
+
+### U2. Worker Analytics and Word Bank Facets From Taxonomy
+
+- **Goal:** Make server-side category groups and facet counts derive from the taxonomy rather than hard-coded arrays.
+- **Files:** `shared/spelling/service.js`, `worker/src/content/spelling-read-models.js`, `tests/server-spelling-engine-parity.test.js`, `tests/spelling-content-api.test.js`.
+- **Patterns:** Preserve the recent facet separation from `docs/plans/spelling-word-bank-facet-counts-hotfix-2026-06-05.md`: rows are the page, facets are the universe.
+- **Test Scenarios:**
+  - `analytics.wordGroups` includes the same visible Word Bank categories as the taxonomy and no extra hand-coded category.
+  - `analytics.pools` exposes stats for each taxonomy category using the taxonomy `statsKey`.
+  - `/api/subjects/spelling/word-bank?year=all` reports category facets for every visible Word Bank category.
+  - `/api/subjects/spelling/word-bank?year=extra` returns Extra rows while sibling category facets stay non-zero where content exists.
+  - Secure vocabulary and Extra still use their existing eligibility rules and counts.
+
+### U3. Client Setup and Word Bank Taxonomy Consumption
+
+- **Goal:** Remove duplicated category lists and setup side-panel copy maps from React surfaces.
+- **Files:** `src/subjects/spelling/components/SpellingSetupScene.jsx`, `src/subjects/spelling/components/SpellingWordBankScene.jsx`, `src/subjects/spelling/components/spelling-view-model.js`, `src/subjects/spelling/client-read-models.js`, `tests/react-spelling-surface.test.js`, `tests/smoke.test.js`.
+- **Patterns:** Keep `renderAction` and `spelling-set-pref` unchanged; use view-model helpers to keep JSX focused on rendering.
+- **Test Scenarios:**
+  - Setup Pool options render from taxonomy order and select `secure-extension` through the existing preference action.
+  - Setup side panel shows category-specific eyebrow, total label, fresh label, and Word Bank footer for Secure vocabulary and Extra.
+  - Word Bank category chips render from taxonomy order and display authoritative facet counts.
+  - The client stats fallback maps taxonomy `statsKey` values without a hand-written `yearFilter` switch.
+  - Legacy responses without the new taxonomy/facet shape still render using conservative fallbacks.
+
+### U4. Measured Slider Mode for Variable-Width Pickers
+
+- **Goal:** Restore the sliding selected indicator for the Pool selector without relying on equal-width options.
+- **Files:** `src/platform/ui/LengthPicker.jsx`, `styles/app.css`, `tests/platform-length-picker.test.js`, `tests/react-spelling-surface.test.js`.
+- **Patterns:** Keep the existing `LengthPicker` DOM rhythm: the `.length-slider` span remains the visual indicator, and option buttons keep their action/data attributes.
+- **Test Scenarios:**
+  - Default `LengthPicker` still emits `--selected-index` and keeps current round-length markup.
+  - Measured mode emits geometry variables or inline styles for selected option x/y/width/height after measurement.
+  - Secure vocabulary selected produces a slider width matching the button width, not the equal-width slot.
+  - Mobile wrapping updates the slider y-position and height when the selected option moves to a second row.
+  - Reduced-motion styling keeps state visible while avoiding animated movement.
+
+### U5. Preference Validation and Remote Action Compatibility
+
+- **Goal:** Ensure taxonomy IDs are accepted, persisted, queried, and safely defaulted through local and remote flows.
+- **Files:** `src/subjects/spelling/optimistic-prefs.js`, `src/subjects/spelling/module.js`, `src/subjects/spelling/remote-actions.js`, `src/subjects/spelling/service-contract.js`, `tests/spelling-remote-actions.test.js`, `tests/spelling-core.test.js`.
+- **Patterns:** Reuse the existing `yearFilter` preference contract and avoid introducing a new preference key.
+- **Test Scenarios:**
+  - Known taxonomy IDs persist through local optimistic prefs and remote sync.
+  - Unknown setup `yearFilter` values collapse to `core`; unknown Word Bank category filters collapse to `all`.
+  - Smart Review starts from the selected taxonomy category when it is practice-eligible.
+  - SATs Test remains core-only and never starts from Extra.
+
+### U6. End-to-End Regression and Production Verification
+
+- **Goal:** Prove the refactor did not regress the production fixes that triggered it.
+- **Files:** `tests/smoke.test.js`, `tests/spelling-remote-actions.test.js`, `tests/spelling-content-api.test.js`, `docs/plans/2026-06-05-001-refactor-spelling-pool-taxonomy-and-selector-plan.md`.
+- **Patterns:** Keep production-sensitive verification aligned with `AGENTS.md`: `npm test`, `npm run check`, `npm run deploy`, then logged-in production browser smoke.
+- **Test Scenarios:**
+  - Word Bank `All` shows Extra as 52 in the current production content set.
+  - Word Bank `Extra` selected keeps sibling category chip counts populated.
+  - Setup Pool selected states survive Core -> Secure vocabulary -> Extra -> Core.
+  - Desktop Pool slider aligns with the selected option.
+  - Mobile Pool slider wraps and aligns without horizontal overflow.
+
+---
+
+## Scope Boundaries
+
+In scope:
+
+- Refactor category definition, display metadata, server facets, and client consumption around one taxonomy.
+- Restore sliding Pool selector behaviour using measured geometry.
+- Preserve current content, learner progress, monster progression, API route names, and preference key names.
+
+Out of scope:
+
+- Adding a new production pool in this change.
+- Changing secure vocabulary or Extra content.
+- Reworking the spelling content CMS, draft/publish workflow, SATs Test model, or monster reward thresholds.
+- Redesigning the whole Spelling setup screen.
+
+---
+
+## System-Wide Impact
+
+- **Client bundle:** The taxonomy module must stay pure and small so importing it into React does not pull Worker service code or full content data.
+- **Worker contract:** Word Bank responses may gain richer taxonomy metadata, but existing query parameters and response fallbacks must stay compatible.
+- **Remote sync:** Persisted learner preferences keep using `yearFilter`; only validation source changes.
+- **Deployment cache:** The existing stylesheet cache-busting path should ensure selector CSS updates reach production browsers.
+
+---
+
+## Risks and Mitigations
+
+- **Risk:** A shared taxonomy module accidentally imports heavy content or service code into the browser bundle. **Mitigation:** Keep taxonomy serialisable and test import boundaries with client bundle audit.
+- **Risk:** Match descriptors become too generic and allow ambiguous future categories. **Mitigation:** Start with a small finite rule set and fail tests on unsupported descriptors.
+- **Risk:** Measured slider geometry is flaky under wrapping, font load, or resize. **Mitigation:** use `ResizeObserver`, font-ready remeasurement where available, and a selected-chip fallback before measurement.
+- **Risk:** Server facets and client fallbacks drift. **Mitigation:** pin each taxonomy category in Worker API tests and React tests, including legacy response fallback.
+- **Risk:** Future pools become visible in practice before their scheduling rules are ready. **Mitigation:** taxonomy entries must carry separate `visibleInWordBank`, `visibleInSetup`, and `practiceEligible` flags.
+
+---
+
+## Acceptance Examples
+
+- AE1. Given a learner opens Spelling setup, when Secure vocabulary is selected, then the Pool slider aligns under `Secure vocabulary` and the side panel uses Secure vocabulary copy and counts.
+- AE2. Given a mobile viewport, when the Pool options wrap, then the slider moves to the selected option's wrapped row without horizontal overflow.
+- AE3. Given the Word Bank is opened with `All`, when category chips render, then Extra shows its full facet count and not the first-page row count.
+- AE4. Given the Word Bank is opened with `Extra`, when category chips render, then Years 3-4, Years 5-6, and Secure vocabulary counts do not collapse to zero.
+- AE5. Given a test-only taxonomy category is registered in a unit test, when Setup or Word Bank option helpers run, then the category appears through helper output without adding JSX-specific chip code.
+- AE6. Given a stale stored category ID, when the app normalises preferences or Word Bank filters, then setup falls back to Core and Word Bank falls back to All.
+
+---
+
+## Sources and Existing Patterns
+
+- `docs/brainstorms/2026-04-22-spelling-extra-expansion-requirements.md` establishes Extra as an independent non-statutory pool.
+- `docs/plans/spelling-word-bank-facet-counts-hotfix-2026-06-05.md` separates authoritative facets from paged display rows.
+- `docs/plans/spelling-secure-vocabulary-pool-selector-hotfix-2026-06-05.md` records the current hotfix and the trade-off that removed the slider from Pool.
+- `src/platform/ui/LengthPicker.jsx` is the shared picker whose default equal-width slider should remain compatible.
+- `src/subjects/spelling/components/spelling-view-model.js` currently hosts `YEAR_FILTER_OPTIONS` and Word Bank filter ID sets.
+- `src/subjects/spelling/components/SpellingWordBankScene.jsx` currently has duplicated category chips and fallback counts.
+- `shared/spelling/service.js` currently builds `analyticsWordGroups` from a hard-coded category array.
+- `worker/src/content/spelling-read-models.js` owns the remote Word Bank read-model and facet response.

--- a/docs/plans/spelling-secure-vocabulary-pool-selector-hotfix-2026-06-05.md
+++ b/docs/plans/spelling-secure-vocabulary-pool-selector-hotfix-2026-06-05.md
@@ -1,0 +1,68 @@
+---
+title: Spelling Secure Vocabulary Pool Selector Hotfix
+status: active
+date: 2026-06-05
+execution: code
+origin: user report, 2026-06-05
+---
+
+# Spelling Secure Vocabulary Pool Selector Hotfix
+
+## Problem Frame
+
+The Spelling setup Pool control exposes Core, Years 3-4, Years 5-6, Secure vocabulary, and Extra. The Secure vocabulary option is long enough to collide with the shared round-length slider styling, so it is visually compressed and behaves as if it cannot be selected.
+
+The behaviour contract is straightforward:
+
+- each Pool option must be an independent radio-style choice
+- choosing Secure vocabulary must save `yearFilter: "secure-extension"`
+- Smart Review must start from the secure vocabulary word subset when that preference is active
+- Core and Extra selection must keep working through the same preference path
+
+## Scope
+
+In scope:
+
+- Make the Pool picker use a chip layout that can fit variable label lengths.
+- Preserve the existing round-length segmented slider behaviour.
+- Keep the existing `spelling-set-pref` command and `yearFilter` preference contract.
+- Add tests for the React setup UI, remote preference sync, and Smart Review secure-vocabulary scoping.
+- Deploy and smoke the production Spelling setup flow.
+
+Out of scope:
+
+- Changing spelling content, seed data, word metadata, or secure vocabulary eligibility.
+- Changing Word Bank filters or facet counts beyond the already implemented Word Bank hotfix.
+- Redesigning the full setup screen.
+
+## Design Decisions
+
+### D1. Split Pool Styling From Round-Length Styling
+
+`LengthPicker` remains the shared control, but the Pool instance now carries a `pool-picker` class. The Pool picker hides the slider track and wraps variable-width options, while round length keeps the existing fixed-width slider presentation.
+
+Rationale: the bug is local to a control variant. A broad setup refactor would increase risk without improving the preference contract.
+
+### D2. Keep the Existing Preference Contract
+
+The Secure vocabulary option continues to save `yearFilter: "secure-extension"` through `spelling-set-pref`, and remote saves still send only the changed preference.
+
+Rationale: this keeps local and remote setup paths aligned and avoids introducing another spelling preference shape.
+
+### D3. Test UI, Sync, and Engine Boundaries
+
+The regression coverage checks:
+
+- the Secure vocabulary Pool button renders with the correct action and selected state
+- remote setup preferences accept and save `secure-extension`
+- Smart Review scoped to `secure-extension` only draws secure vocabulary words
+
+Rationale: the visible failure is UI-facing, but the fix must prove the selection survives through state sync and session creation.
+
+## Verification Contract
+
+- `node --test tests/render.test.js tests/react-spelling-surface.test.js tests/spelling-remote-actions.test.js tests/spelling-core.test.js`
+- `npm test`
+- `npm run check`
+- `npm run deploy`
+- Production UI smoke on `https://ks2.eugnel.uk`: open Spelling setup, choose Secure vocabulary in Pool, confirm it becomes the selected option, then verify Core and Extra remain selectable.

--- a/docs/plans/spelling-secure-vocabulary-pool-selector-hotfix-2026-06-05.md
+++ b/docs/plans/spelling-secure-vocabulary-pool-selector-hotfix-2026-06-05.md
@@ -10,12 +10,14 @@ origin: user report, 2026-06-05
 
 ## Problem Frame
 
-The Spelling setup Pool control exposes Core, Years 3-4, Years 5-6, Secure vocabulary, and Extra. The Secure vocabulary option is long enough to collide with the shared round-length slider styling, so it is visually compressed and behaves as if it cannot be selected.
+The Spelling setup Pool control exposes Core, Years 3-4, Years 5-6, Secure vocabulary, and Extra. The Secure vocabulary option is long enough to collide with the shared round-length slider styling, so it is visually compressed and behaves as if it cannot be selected. The first hotfix made the option clickable, but production still showed two contract breaks: the Pool chip group could visually misalign under the setup panel width, and the setup side panel kept showing core-style stats and copy after Secure vocabulary was selected.
 
 The behaviour contract is straightforward:
 
 - each Pool option must be an independent radio-style choice
 - choosing Secure vocabulary must save `yearFilter: "secure-extension"`
+- the setup side panel must show Secure vocabulary-specific copy and stats when that pool is selected
+- Worker command responses must carry the same secure vocabulary stats bucket as bootstrap/read-model responses
 - Smart Review must start from the secure vocabulary word subset when that preference is active
 - Core and Extra selection must keep working through the same preference path
 
@@ -24,9 +26,13 @@ The behaviour contract is straightforward:
 In scope:
 
 - Make the Pool picker use a chip layout that can fit variable label lengths.
+- Align setup tweak rows so labels and controls do not collide or wrap unpredictably.
+- Make the setup side panel derive its labels and word bank footer copy from the selected pool.
+- Add a stale-response guard so the client read-model can use analytics pool stats when command stats omit a bucket.
+- Add `secureExtension` to Spelling Worker command response stats.
 - Preserve the existing round-length segmented slider behaviour.
 - Keep the existing `spelling-set-pref` command and `yearFilter` preference contract.
-- Add tests for the React setup UI, remote preference sync, and Smart Review secure-vocabulary scoping.
+- Add tests for the React setup UI, client read-model fallback, Worker command stats, remote preference sync, and Smart Review secure-vocabulary scoping.
 - Deploy and smoke the production Spelling setup flow.
 
 Out of scope:
@@ -54,15 +60,30 @@ Rationale: this keeps local and remote setup paths aligned and avoids introducin
 The regression coverage checks:
 
 - the Secure vocabulary Pool button renders with the correct action and selected state
+- the setup side panel renders Secure vocabulary-specific labels and totals when that pool is selected
+- client-side stats selection does not fall back to core if analytics already carries a secure vocabulary pool bucket
+- Worker command stats include `secureExtension`, matching bootstrap/read-model stats
 - remote setup preferences accept and save `secure-extension`
 - Smart Review scoped to `secure-extension` only draws secure vocabulary words
 
 Rationale: the visible failure is UI-facing, but the fix must prove the selection survives through state sync and session creation.
 
+### D4. Treat Pool As A Chip Group, Not A Slider Variant
+
+The Pool control still reuses the shared `LengthPicker` component for accessibility and action payloads, but its layout tokens are reset to a plain wrapping chip group. The setup tweak rows use a label/control grid so the long Secure vocabulary label wraps within the controls column instead of shifting against the Pool label.
+
+Rationale: this keeps the existing component contract while removing the visual dependency that caused the long label to look offset or unselectable.
+
+### D5. Side Panel Copy Follows The Active Pool
+
+The setup side panel now derives its eyebrow, total label, fresh label, and Word Bank footer copy from `statsFilter`. Secure vocabulary selected means the side panel says Secure vocabulary and counts Secure vocabulary words, not generic core spellings.
+
+Rationale: the sidebar is part of the same selection contract as the Pool chips. Showing core labels after selecting Secure vocabulary makes the UI look like the click failed even when prefs saved correctly.
+
 ## Verification Contract
 
-- `node --test tests/render.test.js tests/react-spelling-surface.test.js tests/spelling-remote-actions.test.js tests/spelling-core.test.js`
+- `node --test tests/render.test.js tests/react-spelling-surface.test.js tests/server-spelling-engine-parity.test.js tests/spelling-remote-actions.test.js tests/spelling-core.test.js`
 - `npm test`
 - `npm run check`
 - `npm run deploy`
-- Production UI smoke on `https://ks2.eugnel.uk`: open Spelling setup, choose Secure vocabulary in Pool, confirm it becomes the selected option, then verify Core and Extra remain selectable.
+- Production UI smoke on `https://ks2.eugnel.uk`: open Spelling setup, choose Secure vocabulary in Pool, confirm it becomes the selected option, verify the side panel shows Secure vocabulary stats/copy, then verify Core and Extra remain selectable.

--- a/docs/plans/spelling-word-bank-facet-counts-hotfix-2026-06-05.md
+++ b/docs/plans/spelling-word-bank-facet-counts-hotfix-2026-06-05.md
@@ -1,0 +1,151 @@
+---
+title: Spelling Word Bank Facet Count Hotfix
+status: active
+date: 2026-06-05
+execution: code
+origin: user report, 2026-06-05
+---
+
+# Spelling Word Bank Facet Count Hotfix
+
+## Problem Frame
+
+The Spelling Word Bank currently mixes two different concepts:
+
+- the paged rows that are loaded for display, capped at 250 rows per server request
+- the facet counts shown in the category, status, and Guardian filter chips
+
+The previous Extra-pool fix made the selected Extra tab load all 52 Extra rows from the server, but it left the UI deriving chip counts from the currently loaded `wordGroups`. That means:
+
+- when `All` is selected, the first 250 rows only include 37 Extra words, so the Extra chip incorrectly shows 37 instead of the published 52
+- when `Extra` is selected, the server correctly returns only Extra rows, but the UI then recomputes category counts from that Extra-only slice, so Years 3-4, Years 5-6, and Secure vocabulary collapse to 0
+
+The correct contract is that Word Bank facets must describe the full authorised matching word universe, while rows describe only the current display page or selected facet result.
+
+## Scope
+
+In scope:
+
+- Preserve the server-side page and filter loading introduced for the Extra pool.
+- Add or expose authoritative facet counts from the Worker Word Bank read model.
+- Refactor the React Word Bank scene so filter chip counts and the lede use authoritative facet totals instead of loaded rows.
+- Keep row rendering, detail modal lookup, drill submission, and TTS behaviour unchanged.
+- Add regression coverage for both reported states: `All` showing Extra as 52, and `Extra` selected without zeroing sibling category chips.
+- Deploy the corrected production Worker and verify the live Word Bank API/UI contract.
+
+Out of scope:
+
+- Changing spelling content, seed data, or generated word content.
+- Changing Guardian eligibility or post-Mega scheduling semantics.
+- Changing the Word Bank detail modal, audio prompt token contract, or spelling drill command contract.
+
+## Requirements Trace
+
+- User report: `All` currently shows Extra as 37, despite the database/source containing 52 Extra words.
+- User report: selecting `Extra` changes Extra to 52 but changes other category counts to 0, which is not how the filter should behave.
+- Production-sensitive constraint: do not regress English Spelling parity or remote sync paths.
+- Existing server contract: `/api/subjects/spelling/word-bank` already supports `year`, `status`, `q`, `page`, and `pageSize`; it must remain the single remote entry point for this view.
+
+## Design Decisions
+
+### D1. Separate Facets From Rows
+
+`wordGroups` remain the current page/result rows. They must no longer be treated as the full Word Bank universe for chip counts when remote paging is active.
+
+Facet counts should come from the Worker response, with enough shape to represent:
+
+- global category totals for `all`, `y3-4`, `y5-6`, `secure-extension`, and `extra`
+- status totals for the currently selected category/search scope
+- Guardian totals for the currently selected category/search scope when Guardian filters are visible
+
+Rationale: category chips should not collapse when one category is selected, while status chips should still explain the current category/search scope the learner is filtering inside.
+
+### D2. Keep Display Rows Server-Filtered
+
+The client should keep asking the Worker for the selected `year`, supported `status`, search query, and page. This avoids trying to load more than the Worker page cap just to compute local counts.
+
+Rationale: loading all rows into the browser to repair counts would reintroduce the page-size coupling and would become fragile as the word bank grows.
+
+### D3. Make Fallbacks Explicit and Conservative
+
+If a legacy or stale Worker response lacks the new facet shape, the scene may fall back to the old loaded-row counts for compatibility. Tests for the new Worker path must assert that the authoritative shape is present and used.
+
+Rationale: avoids blank or broken UI during partial cache transitions, while the production target still proves the new contract.
+
+## Implementation Units
+
+### U1. Worker Facet Contract
+
+Files:
+
+- `worker/src/content/spelling-read-models.js`
+- `tests/spelling-content-api.test.js`
+
+Approach:
+
+- Build facet rows from the full published Word Bank rows, not from `pageRows`.
+- Preserve `wordBank.totalRows`, `filteredRows`, `returnedRows`, and `hasNextPage`.
+- Add a dedicated facet object that exposes category counts across the full query/status scope and status counts across the selected category/query scope.
+- Keep existing `analytics.pools` for backwards compatibility.
+
+Test scenarios:
+
+- `year=all&pageSize=250` returns `returnedRows=250`, `filteredRows` greater than 250 when content has more rows, and facet category `extra=52`.
+- `year=extra&pageSize=250` returns 52 display rows, while facet category counts still report the non-Extra category totals.
+- Status facet counts for `year=extra` add up to 52 and match the visible Extra rows.
+
+### U2. Client Facet Consumption
+
+Files:
+
+- `src/subjects/spelling/components/SpellingWordBankScene.jsx`
+- `tests/spelling-remote-actions.test.js`
+- `tests/spelling-view-model.test.js` if helper extraction is useful
+
+Approach:
+
+- Read authoritative facet counts from `analytics.wordBank.facets` or an equivalent Worker field.
+- Use category facets for `YearChips`.
+- Use current-scope status facets for `FilterChips` and `GuardianFilterChips`.
+- Use `wordBank.totalRows`/facet totals for the lede and empty-state decision, not `allWords.length` when authoritative metadata is present.
+- Keep `visibleGroups` derived from loaded rows so the rendered list remains page/result based.
+
+Test scenarios:
+
+- Remote action loading `All` with a 250-row page leaves the Extra chip at 52, not 37.
+- Remote action selecting `Extra` leaves Years 3-4 and Years 5-6 counts at their global totals, not 0.
+- Extra selected lede says 52 Extra words selected out of the full Word Bank total, not 52 of 52.
+- Existing legacy response fallback still renders without crashing.
+
+### U3. Verification and Deployment
+
+Files:
+
+- `docs/plans/spelling-word-bank-facet-counts-hotfix-2026-06-05.md`
+- production evidence generated only if needed by the verification scripts
+
+Approach:
+
+- Run targeted Word Bank tests first.
+- Run `npm test`.
+- Run `npm run check`.
+- Deploy with `npm run deploy`.
+- Smoke the live production Word Bank API with same-origin demo session headers and verify:
+  - deployed `/api/version` build hash matches the local commit
+  - `All` metadata reports Extra facet count 52 while the first page may return 250 rows
+  - `Extra` metadata reports 52 display rows and non-zero sibling category facets
+
+## Risks
+
+- The UI currently recomputes Guardian aggregates from loaded rows for orphan sanitisation. If the Worker facet contract includes Guardian counts, it must use the same eligibility rules or the client should keep Guardian count fallback local until server parity is proven.
+- Legacy cache windows may briefly return the old response shape. Client fallbacks must keep the page functional but tests must pin the new production path.
+- Existing generated report files may be dirtied by test/deploy scripts. Only intentional source, test, and plan changes should be staged.
+
+## Acceptance Criteria
+
+- `All` Word Bank category chips show Extra as 52 on production.
+- Selecting `Extra` shows Extra as 52 and keeps sibling category counts at their full published totals instead of 0.
+- Display rows stay correct: Extra selected shows the 52 Extra rows without requiring a client-side full Word Bank fetch.
+- Targeted Word Bank tests pass.
+- Full `npm test` and `npm run check` pass.
+- Production deploy succeeds and live smoke proves the corrected facet contract.

--- a/scripts/assert-build-public.mjs
+++ b/scripts/assert-build-public.mjs
@@ -286,6 +286,7 @@ assertCacheSplitRules(publishedHeadersContent);
 
 const indexHtml = await readFile(path.join(publicDir, 'index.html'), 'utf8');
 const appBundle = await readFile(path.join(publicDir, 'src/bundles/app.bundle.js'), 'utf8');
+const appStylesheet = await readFile(path.join(publicDir, 'styles/app.css'), 'utf8');
 const llmsTxt = await readFile(path.join(publicDir, 'llms.txt'), 'utf8');
 const robotsTxt = await readFile(path.join(publicDir, 'robots.txt'), 'utf8');
 const sitemapXml = await readFile(path.join(publicDir, 'sitemap.xml'), 'utf8');
@@ -316,6 +317,14 @@ if (!appBundleVersionMatch) {
 const expectedAppBundleVersion = createHash('sha256').update(appBundle).digest('hex').slice(0, 12);
 if (appBundleVersionMatch[1] !== expectedAppBundleVersion) {
   throw new Error('Public index.html app.bundle.js version query does not match the bundle content hash.');
+}
+const appStylesheetVersionMatch = indexHtml.match(/\.\/styles\/app\.css\?v=([a-f0-9]{12})/);
+if (!appStylesheetVersionMatch) {
+  throw new Error('Public index.html must load styles/app.css with a content-hash query string.');
+}
+const expectedAppStylesheetVersion = createHash('sha256').update(appStylesheet).digest('hex').slice(0, 12);
+if (appStylesheetVersionMatch[1] !== expectedAppStylesheetVersion) {
+  throw new Error('Public index.html styles/app.css version query does not match the stylesheet content hash.');
 }
 if (indexHtml.includes('home.bundle.js') || indexHtml.includes('src/main.js')) {
   throw new Error('Public index.html must not load legacy home islands or the raw source entry.');

--- a/scripts/build-public.mjs
+++ b/scripts/build-public.mjs
@@ -27,6 +27,7 @@ const lockDir = path.join(distDir, 'public-build.lock');
 const generatedCspHashPath = path.join(rootDir, 'worker', 'src', 'generated-csp-hash.js');
 const publicHeadersPath = path.join(outputDir, '_headers');
 const appBundleScriptSrc = './src/bundles/app.bundle.js';
+const appStylesheetHref = './styles/app.css';
 
 function shortContentHash(buffer) {
   return createHash('sha256').update(buffer).digest('hex').slice(0, 12);
@@ -146,21 +147,29 @@ try {
     { force: true },
   );
 
-  // `app.bundle.js` has a stable filename because index.html is the only
-  // entry point. Stamp the public HTML with the bundle content hash so a
-  // no-store HTML refresh never reuses a browser-cached stale entry bundle
-  // that points at retired lazy chunks.
+  // `app.bundle.js` and `styles/app.css` have stable filenames because
+  // index.html is the only app entry point. Stamp the public HTML with
+  // content hashes so a no-store HTML refresh never reuses browser-cached
+  // stale app assets.
   const appBundlePath = path.join(tmpDir, 'src', 'bundles', 'app.bundle.js');
   const appBundleBytes = await readFile(appBundlePath);
   const appBundleVersion = shortContentHash(appBundleBytes);
+  const appStylesheetPath = path.join(tmpDir, 'styles', 'app.css');
+  const appStylesheetBytes = await readFile(appStylesheetPath);
+  const appStylesheetVersion = shortContentHash(appStylesheetBytes);
   const tmpIndexPath = path.join(tmpDir, 'index.html');
   const tmpIndexHtml = await readFile(tmpIndexPath, 'utf8');
   if (!tmpIndexHtml.includes(appBundleScriptSrc)) {
     throw new Error(`index.html must reference ${appBundleScriptSrc} before build-public can version it.`);
   }
+  if (!tmpIndexHtml.includes(appStylesheetHref)) {
+    throw new Error(`index.html must reference ${appStylesheetHref} before build-public can version it.`);
+  }
   await writeFile(
     tmpIndexPath,
-    tmpIndexHtml.replaceAll(appBundleScriptSrc, `${appBundleScriptSrc}?v=${appBundleVersion}`),
+    tmpIndexHtml
+      .replaceAll(appBundleScriptSrc, `${appBundleScriptSrc}?v=${appBundleVersion}`)
+      .replaceAll(appStylesheetHref, `${appStylesheetHref}?v=${appStylesheetVersion}`),
     'utf8',
   );
 

--- a/shared/spelling/pool-taxonomy.js
+++ b/shared/spelling/pool-taxonomy.js
@@ -1,0 +1,322 @@
+const STATUTORY_CORE = 'statutory-core';
+const SECURE_EXTENSION = 'secure-extension';
+const ENRICHMENT_EXTRA = 'enrichment-extra';
+
+const SUPPORTED_MATCH_KEYS = new Set(['coverageTier', 'year', 'all']);
+
+function clonePanel(panel) {
+  return panel && typeof panel === 'object' && !Array.isArray(panel)
+    ? Object.freeze({ ...panel })
+    : null;
+}
+
+function freezeCategory(raw) {
+  return Object.freeze({
+    ...raw,
+    match: Object.freeze({ ...(raw.match || {}) }),
+    setupPanel: clonePanel(raw.setupPanel),
+    wordBankSummary: clonePanel(raw.wordBankSummary),
+    analyticsAliases: Object.freeze(Array.isArray(raw.analyticsAliases) ? [...raw.analyticsAliases] : []),
+  });
+}
+
+const RAW_SPELLING_POOL_CATEGORIES = [
+  {
+    id: 'all',
+    label: 'All',
+    shortLabel: 'All',
+    statsKey: 'all',
+    match: { all: true },
+    visibleInSetup: false,
+    visibleInWordBankFilter: true,
+    visibleInWordBankSummary: false,
+    visibleInAnalyticsPool: false,
+    visibleInAnalyticsWordGroups: false,
+    practiceEligible: false,
+    order: 0,
+  },
+  {
+    id: 'core',
+    label: 'Core',
+    shortLabel: 'Core',
+    statsKey: 'core',
+    analyticsAliases: ['all'],
+    match: { coverageTier: STATUTORY_CORE },
+    visibleInSetup: true,
+    visibleInWordBankFilter: false,
+    visibleInWordBankSummary: true,
+    visibleInAnalyticsPool: true,
+    visibleInAnalyticsWordGroups: false,
+    practiceEligible: true,
+    order: 10,
+    setupPanel: {
+      eyebrow: 'Where you stand',
+      totalLabel: 'Total spellings',
+      secureLabel: 'Secure',
+      dueLabel: 'Due today',
+      troubleLabel: 'Weak spots',
+      freshLabel: 'Unseen',
+      bankSubTemplate: 'Every word {learner} is learning, with progress and difficulty.',
+    },
+    wordBankSummary: {
+      eyebrow: 'Core spellings',
+      title: 'Core statutory progress',
+      statLabel: 'Words in official statutory pool',
+    },
+  },
+  {
+    id: 'y3-4',
+    label: 'Years 3-4',
+    shortLabel: 'Y3-4',
+    statsKey: 'y34',
+    match: { coverageTier: STATUTORY_CORE, year: '3-4' },
+    visibleInSetup: true,
+    visibleInWordBankFilter: true,
+    visibleInWordBankSummary: true,
+    visibleInAnalyticsPool: true,
+    visibleInAnalyticsWordGroups: true,
+    practiceEligible: true,
+    spellingPool: 'core',
+    year: '3-4',
+    order: 20,
+    setupPanel: {
+      eyebrow: 'Years 3-4 pool',
+      totalLabel: 'Years 3-4 words',
+      secureLabel: 'Secure',
+      dueLabel: 'Due today',
+      troubleLabel: 'Weak spots',
+      freshLabel: 'Unseen',
+      bankSubTemplate: 'Years 3-4 words for {learner}, with progress and difficulty.',
+      nextFocus: 'Years 3-4 pool selected.',
+    },
+    wordBankSummary: {
+      eyebrow: 'Years 3-4',
+      title: 'Lower KS2 spelling pool',
+      statLabel: 'Words in pool',
+    },
+  },
+  {
+    id: 'y5-6',
+    label: 'Years 5-6',
+    shortLabel: 'Y5-6',
+    statsKey: 'y56',
+    match: { coverageTier: STATUTORY_CORE, year: '5-6' },
+    visibleInSetup: true,
+    visibleInWordBankFilter: true,
+    visibleInWordBankSummary: true,
+    visibleInAnalyticsPool: true,
+    visibleInAnalyticsWordGroups: true,
+    practiceEligible: true,
+    spellingPool: 'core',
+    year: '5-6',
+    order: 30,
+    setupPanel: {
+      eyebrow: 'Years 5-6 pool',
+      totalLabel: 'Years 5-6 words',
+      secureLabel: 'Secure',
+      dueLabel: 'Due today',
+      troubleLabel: 'Weak spots',
+      freshLabel: 'Unseen',
+      bankSubTemplate: 'Years 5-6 words for {learner}, with progress and difficulty.',
+      nextFocus: 'Years 5-6 pool selected.',
+    },
+    wordBankSummary: {
+      eyebrow: 'Years 5-6',
+      title: 'Upper KS2 spelling pool',
+      statLabel: 'Words in pool',
+    },
+  },
+  {
+    id: SECURE_EXTENSION,
+    label: 'Secure vocabulary',
+    shortLabel: 'Secure vocabulary',
+    statsKey: 'secureExtension',
+    match: { coverageTier: SECURE_EXTENSION },
+    visibleInSetup: true,
+    visibleInWordBankFilter: true,
+    visibleInWordBankSummary: true,
+    visibleInAnalyticsPool: true,
+    visibleInAnalyticsWordGroups: true,
+    practiceEligible: true,
+    spellingPool: 'core',
+    year: SECURE_EXTENSION,
+    order: 40,
+    setupPanel: {
+      eyebrow: 'Secure vocabulary',
+      totalLabel: 'Secure vocabulary words',
+      secureLabel: 'Already secure',
+      dueLabel: 'Due today',
+      troubleLabel: 'Weak spots',
+      freshLabel: 'Not tried yet',
+      bankSubTemplate: 'Secure vocabulary words for {learner}, with progress and difficulty.',
+      nextFocus: 'Secure vocabulary pool selected.',
+    },
+    wordBankSummary: {
+      eyebrow: 'Secure vocabulary',
+      title: 'Approved secure-extension progress',
+      statLabel: 'Words in secure vocabulary',
+    },
+  },
+  {
+    id: 'extra',
+    label: 'Extra',
+    shortLabel: 'Extra',
+    statsKey: 'extra',
+    match: { coverageTier: ENRICHMENT_EXTRA },
+    visibleInSetup: true,
+    visibleInWordBankFilter: true,
+    visibleInWordBankSummary: true,
+    visibleInAnalyticsPool: true,
+    visibleInAnalyticsWordGroups: true,
+    practiceEligible: true,
+    spellingPool: 'extra',
+    year: 'extra',
+    order: 50,
+    setupPanel: {
+      eyebrow: 'Extra pool',
+      totalLabel: 'Extra words',
+      secureLabel: 'Secure',
+      dueLabel: 'Due today',
+      troubleLabel: 'Weak spots',
+      freshLabel: 'Unseen',
+      bankSubTemplate: 'Extra words for {learner}, with progress and difficulty.',
+      nextFocus: 'Extra pool selected.',
+    },
+    wordBankSummary: {
+      eyebrow: 'Extra',
+      title: 'Expansion spelling pool',
+      statLabel: 'Words in enrichment pool',
+    },
+  },
+];
+
+export const SPELLING_POOL_CATEGORIES = Object.freeze(RAW_SPELLING_POOL_CATEGORIES
+  .map(freezeCategory)
+  .sort((a, b) => a.order - b.order));
+
+function categoryMap(categories = SPELLING_POOL_CATEGORIES) {
+  return new Map((Array.isArray(categories) ? categories : []).map((category) => [category.id, category]));
+}
+
+export function validateSpellingPoolCategories(categories = SPELLING_POOL_CATEGORIES) {
+  const ids = new Set();
+  const statsKeys = new Set();
+  for (const category of Array.isArray(categories) ? categories : []) {
+    if (!category || typeof category !== 'object' || Array.isArray(category)) {
+      throw new Error('Spelling pool category must be an object.');
+    }
+    if (!category.id || typeof category.id !== 'string') {
+      throw new Error('Spelling pool category is missing a string id.');
+    }
+    if (ids.has(category.id)) {
+      throw new Error(`Duplicate Spelling pool category id: ${category.id}`);
+    }
+    ids.add(category.id);
+    if (!category.statsKey || typeof category.statsKey !== 'string') {
+      throw new Error(`Spelling pool category ${category.id} is missing a statsKey.`);
+    }
+    if (statsKeys.has(category.statsKey)) {
+      throw new Error(`Duplicate Spelling pool statsKey: ${category.statsKey}`);
+    }
+    statsKeys.add(category.statsKey);
+    const match = category.match && typeof category.match === 'object' && !Array.isArray(category.match)
+      ? category.match
+      : null;
+    if (!match) {
+      throw new Error(`Spelling pool category ${category.id} is missing a match descriptor.`);
+    }
+    for (const key of Object.keys(match)) {
+      if (!SUPPORTED_MATCH_KEYS.has(key)) {
+        throw new Error(`Unsupported Spelling pool match key "${key}" on ${category.id}.`);
+      }
+    }
+  }
+  return true;
+}
+
+validateSpellingPoolCategories();
+
+export const SPELLING_SETUP_POOL_CATEGORIES = Object.freeze(SPELLING_POOL_CATEGORIES
+  .filter((category) => category.visibleInSetup));
+export const SPELLING_WORD_BANK_FILTER_CATEGORIES = Object.freeze(SPELLING_POOL_CATEGORIES
+  .filter((category) => category.visibleInWordBankFilter));
+export const SPELLING_WORD_BANK_SUMMARY_CATEGORIES = Object.freeze(SPELLING_POOL_CATEGORIES
+  .filter((category) => category.visibleInWordBankSummary));
+export const SPELLING_ANALYTICS_POOL_CATEGORIES = Object.freeze(SPELLING_POOL_CATEGORIES
+  .filter((category) => category.visibleInAnalyticsPool));
+export const SPELLING_ANALYTICS_WORD_GROUP_CATEGORIES = Object.freeze(SPELLING_POOL_CATEGORIES
+  .filter((category) => category.visibleInAnalyticsWordGroups));
+
+export const SPELLING_SETUP_POOL_IDS = Object.freeze(SPELLING_SETUP_POOL_CATEGORIES.map((category) => category.id));
+export const SPELLING_WORD_BANK_FILTER_IDS = Object.freeze(SPELLING_WORD_BANK_FILTER_CATEGORIES.map((category) => category.id));
+
+export function spellingPoolCategoryById(id, categories = SPELLING_POOL_CATEGORIES) {
+  return categoryMap(categories).get(String(id || '')) || null;
+}
+
+export function normaliseSpellingPoolCategoryId(value, fallback = 'core', categories = SPELLING_POOL_CATEGORIES) {
+  const candidate = String(value || '').trim();
+  return spellingPoolCategoryById(candidate, categories)?.id
+    || spellingPoolCategoryById(fallback, categories)?.id
+    || 'core';
+}
+
+export function normaliseSpellingSetupPoolId(value, fallback = 'core') {
+  const candidate = String(value || '').trim();
+  if (SPELLING_SETUP_POOL_IDS.includes(candidate)) return candidate;
+  return SPELLING_SETUP_POOL_IDS.includes(fallback) ? fallback : 'core';
+}
+
+export function normaliseSpellingWordBankFilterId(value, fallback = 'all') {
+  const candidate = String(value || '').trim();
+  if (SPELLING_WORD_BANK_FILTER_IDS.includes(candidate)) return candidate;
+  return SPELLING_WORD_BANK_FILTER_IDS.includes(fallback) ? fallback : 'all';
+}
+
+export function spellingSetupPoolOptions() {
+  return SPELLING_SETUP_POOL_CATEGORIES.map((category) => ({
+    value: category.id,
+    label: category.shortLabel || category.label,
+  }));
+}
+
+export function spellingWordBankFilterOptions() {
+  return SPELLING_WORD_BANK_FILTER_CATEGORIES.map((category) => ({
+    id: category.id,
+    label: category.label,
+  }));
+}
+
+export function spellingPoolStatsKey(id, fallback = 'core') {
+  const category = spellingPoolCategoryById(id) || spellingPoolCategoryById(fallback);
+  return category?.statsKey || 'core';
+}
+
+function normaliseCoverageTierFromWord(word, helpers = {}) {
+  if (typeof helpers.coverageTierForWord === 'function') {
+    const resolved = helpers.coverageTierForWord(word);
+    if (typeof resolved === 'string' && resolved) return resolved;
+  }
+  const raw = typeof word?.coverageTier === 'string' ? word.coverageTier.trim().toLowerCase() : '';
+  if (raw === STATUTORY_CORE || raw === SECURE_EXTENSION || raw === ENRICHMENT_EXTRA) return raw;
+  if (word?.spellingPool === 'extra' || word?.year === 'extra') return ENRICHMENT_EXTRA;
+  return STATUTORY_CORE;
+}
+
+export function spellingPoolCategoryMatchesWord(categoryOrId, word, helpers = {}) {
+  const category = typeof categoryOrId === 'string'
+    ? spellingPoolCategoryById(categoryOrId)
+    : categoryOrId;
+  if (!category || !word) return false;
+  const match = category.match || {};
+  if (match.all === true) return true;
+  const tier = normaliseCoverageTierFromWord(word, helpers);
+  if (match.coverageTier && tier !== match.coverageTier) return false;
+  if (match.year && word.year !== match.year) return false;
+  return true;
+}
+
+export function spellingPoolCategoryForWord(word, categories = SPELLING_ANALYTICS_WORD_GROUP_CATEGORIES, helpers = {}) {
+  return (Array.isArray(categories) ? categories : [])
+    .find((category) => spellingPoolCategoryMatchesWord(category, word, helpers)) || null;
+}

--- a/shared/spelling/service.js
+++ b/shared/spelling/service.js
@@ -1,5 +1,10 @@
 import { createLegacySpellingEngine } from './legacy-engine.js';
 import {
+  SPELLING_ANALYTICS_POOL_CATEGORIES,
+  SPELLING_ANALYTICS_WORD_GROUP_CATEGORIES,
+  spellingPoolCategoryMatchesWord,
+} from './pool-taxonomy.js';
+import {
   SPELLING_MASTERY_MILESTONES,
   createSpellingBossCompletedEvent,
   createSpellingGuardianMissionCompletedEvent,
@@ -1402,23 +1407,13 @@ export function createSpellingService({ repository, storage, tts, now, random, c
   }
 
   function analyticsWordGroups(learnerId, progressStore = null) {
-    const groups = [
-      { key: 'y3-4', title: 'Years 3-4', spellingPool: 'core', year: '3-4' },
-      { key: 'y5-6', title: 'Years 5-6', spellingPool: 'core', year: '5-6' },
-      { key: 'secure-extension', title: 'Secure vocabulary', spellingPool: 'core', year: 'secure-extension' },
-      { key: 'extra', title: 'Extra', spellingPool: 'extra', year: 'extra' },
-    ];
-    return groups.map((group) => ({
-      key: group.key,
-      title: group.title,
-      spellingPool: group.spellingPool,
-      year: group.year,
+    return SPELLING_ANALYTICS_WORD_GROUP_CATEGORIES.map((group) => ({
+      key: group.id,
+      title: group.label,
+      spellingPool: group.spellingPool || 'core',
+      year: group.year || group.id,
       words: runtimeWords
-        .filter((word) => {
-          if (group.key === 'secure-extension') return isSecureExtensionWord(word);
-          if (group.key === 'extra') return isEnrichmentExtraWord(word);
-          return isStatutoryCoreWord(word) && word.year === group.year;
-        })
+        .filter((word) => spellingPoolCategoryMatchesWord(group, word, { coverageTierForWord }))
         .map((word) => analyticsWordRow(learnerId, word, progressStore)),
     }));
   }
@@ -1888,17 +1883,16 @@ export function createSpellingService({ repository, storage, tts, now, random, c
 
   function getAnalyticsSnapshot(learnerId) {
     const progressStore = progressSnapshot(learnerId);
+    const pools = {};
+    for (const category of SPELLING_ANALYTICS_POOL_CATEGORIES) {
+      const stats = getStats(learnerId, category.id, progressStore);
+      for (const alias of category.analyticsAliases) pools[alias] = stats;
+      pools[category.statsKey] = stats;
+    }
     return {
       version: SPELLING_SERVICE_STATE_VERSION,
       generatedAt: clock(),
-      pools: {
-        all: getStats(learnerId, 'core', progressStore),
-        core: getStats(learnerId, 'core', progressStore),
-        y34: getStats(learnerId, 'y3-4', progressStore),
-        y56: getStats(learnerId, 'y5-6', progressStore),
-        secureExtension: getStats(learnerId, 'secure-extension', progressStore),
-        extra: getStats(learnerId, 'extra', progressStore),
-      },
+      pools,
       wordGroups: analyticsWordGroups(learnerId, progressStore),
     };
   }

--- a/src/platform/core/store.js
+++ b/src/platform/core/store.js
@@ -12,6 +12,9 @@ import {
   normaliseMonsterCelebrations,
 } from '../game/monster-celebrations.js';
 import { normaliseRewardToastEvents } from '../rewards/reward-toast-events.js';
+import {
+  SPELLING_WORD_BANK_FILTER_IDS as SPELLING_WORD_BANK_CATEGORY_FILTER_IDS,
+} from '../../../shared/spelling/pool-taxonomy.js';
 
 const DEFAULT_ROUTE = {
   screen: 'dashboard',
@@ -191,12 +194,7 @@ const VALID_SPELLING_WORD_BANK_FILTERS = new Set([
   'renewedRecently',
   'neverRenewed',
 ]);
-const VALID_SPELLING_WORD_BANK_YEAR_FILTERS = new Set([
-  'all',
-  'y3-4',
-  'y5-6',
-  'extra',
-]);
+const VALID_SPELLING_WORD_BANK_YEAR_FILTERS = new Set(SPELLING_WORD_BANK_CATEGORY_FILTER_IDS);
 
 const VALID_WORD_DETAIL_MODES = new Set(['explain', 'drill']);
 const VALID_WORD_DRILL_RESULTS = new Set(['correct', 'incorrect']);

--- a/src/platform/ui/LengthPicker.jsx
+++ b/src/platform/ui/LengthPicker.jsx
@@ -1,3 +1,5 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
 /* Platform slide-button length picker.
  *
  * Canonicalisation of Grammar's `RoundLengthPicker` and Spelling's
@@ -49,7 +51,38 @@ export function LengthPicker({
   actionName,
   prefKey,
   includeDataValue = false,
+  sliderMode = 'indexed',
 }) {
+  const model = normalisePickerModel(options, selectedValue);
+  if (sliderMode === 'measured') {
+    return (
+      <MeasuredLengthPicker
+        {...model}
+        onChange={onChange}
+        disabled={disabled}
+        ariaLabel={ariaLabel}
+        unit={unit}
+        className={className}
+        actionName={actionName}
+        prefKey={prefKey}
+        includeDataValue={includeDataValue}
+      />
+    );
+  }
+  return renderLengthPicker({
+    ...model,
+    onChange,
+    disabled,
+    ariaLabel,
+    unit,
+    className,
+    actionName,
+    prefKey,
+    includeDataValue,
+  });
+}
+
+function normalisePickerModel(options, selectedValue) {
   const optionList = Array.isArray(options) ? options : [];
   const normalised = optionList.map((entry) => {
     if (entry && typeof entry === 'object' && 'value' in entry) {
@@ -69,18 +102,147 @@ export function LengthPicker({
   // in this edge case; changing to -1 would break every such assertion
   // and shift the slider visually. Do NOT change to -1.
   const selectedIndex = selectedIndexRaw >= 0 ? selectedIndexRaw : 0;
+  return { normalised, compareValue, selectedIndex };
+}
 
+function MeasuredLengthPicker({
+  normalised,
+  compareValue,
+  selectedIndex,
+  onChange,
+  disabled = false,
+  ariaLabel,
+  unit,
+  className,
+  actionName,
+  prefKey,
+  includeDataValue = false,
+}) {
+  const pickerRef = useRef(null);
+  const optionRefs = useRef(new Map());
+  const [measuredSliderBox, setMeasuredSliderBox] = useState(null);
+  const optionSignature = normalised
+    .map((entry) => `${entry.value}\u0002${entry.label}`)
+    .join('\u0001');
+
+  const setOptionRef = useCallback((value, node) => {
+    if (node) {
+      optionRefs.current.set(value, node);
+    } else {
+      optionRefs.current.delete(value);
+    }
+  }, []);
+
+  const measureSlider = useCallback(() => {
+    const picker = pickerRef.current;
+    const selectedOption = optionRefs.current.get(compareValue);
+    if (!picker || !selectedOption) {
+      setMeasuredSliderBox(null);
+      return;
+    }
+    const pickerRect = picker.getBoundingClientRect();
+    const optionRect = selectedOption.getBoundingClientRect();
+    const next = {
+      x: Math.round((optionRect.left - pickerRect.left) * 100) / 100,
+      y: Math.round((optionRect.top - pickerRect.top) * 100) / 100,
+      width: Math.round(optionRect.width * 100) / 100,
+      height: Math.round(optionRect.height * 100) / 100,
+    };
+    setMeasuredSliderBox((current) => (
+      current
+        && current.x === next.x
+        && current.y === next.y
+        && current.width === next.width
+        && current.height === next.height
+        ? current
+        : next
+    ));
+  }, [compareValue]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const run = () => {
+      if (!cancelled) measureSlider();
+    };
+    run();
+    const frame = globalThis.requestAnimationFrame ? globalThis.requestAnimationFrame(run) : 0;
+    const picker = pickerRef.current;
+    const selectedOption = optionRefs.current.get(compareValue);
+    const observer = typeof ResizeObserver === 'function' ? new ResizeObserver(run) : null;
+    if (observer && picker) observer.observe(picker);
+    if (observer && selectedOption) observer.observe(selectedOption);
+    globalThis.addEventListener?.('resize', run);
+    if (globalThis.document?.fonts?.ready) {
+      globalThis.document.fonts.ready.then(run).catch(() => {});
+    }
+    return () => {
+      cancelled = true;
+      if (frame && globalThis.cancelAnimationFrame) globalThis.cancelAnimationFrame(frame);
+      observer?.disconnect();
+      globalThis.removeEventListener?.('resize', run);
+    };
+  }, [compareValue, measureSlider, optionSignature]);
+
+  return renderLengthPicker({
+    normalised,
+    compareValue,
+    selectedIndex,
+    onChange,
+    disabled,
+    ariaLabel,
+    unit,
+    className,
+    actionName,
+    prefKey,
+    includeDataValue,
+    measuredSliderBox,
+    pickerRef,
+    setOptionRef,
+    sliderMode: 'measured',
+  });
+}
+
+function renderLengthPicker({
+  normalised,
+  compareValue,
+  selectedIndex,
+  onChange,
+  disabled = false,
+  ariaLabel,
+  unit,
+  className,
+  actionName,
+  prefKey,
+  includeDataValue = false,
+  measuredSliderBox = null,
+  pickerRef = null,
+  setOptionRef = null,
+  sliderMode = 'indexed',
+}) {
+  const measuredSlider = sliderMode === 'measured';
   const pickerClassName = className ? `length-picker ${className}` : 'length-picker';
+  const pickerStyle = {
+    '--option-count': String(normalised.length),
+    '--selected-index': String(selectedIndex),
+  };
+  if (measuredSlider && measuredSliderBox) {
+    pickerStyle['--measured-slider-x'] = `${measuredSliderBox.x}px`;
+    pickerStyle['--measured-slider-y'] = `${measuredSliderBox.y}px`;
+    pickerStyle['--measured-slider-width'] = `${measuredSliderBox.width}px`;
+    pickerStyle['--measured-slider-height'] = `${measuredSliderBox.height}px`;
+  }
 
   const picker = (
     <div
+      ref={pickerRef || undefined}
       className={pickerClassName}
       role="radiogroup"
       aria-label={ariaLabel}
-      style={{
-        '--option-count': String(normalised.length),
-        '--selected-index': String(selectedIndex),
-      }}
+      style={pickerStyle}
+      {...(measuredSlider ? {
+        'data-slider-mode': 'measured',
+        ...(measuredSliderBox ? { 'data-slider-ready': 'true' } : {}),
+      } : {})}
     >
       <span className="length-slider" aria-hidden="true" />
       {normalised.map((entry) => {
@@ -103,6 +265,7 @@ export function LengthPicker({
         buttonProps.value = entry.value;
         buttonProps.disabled = disabled;
         buttonProps.onClick = (event) => onChange(entry.value, event);
+        if (measuredSlider && setOptionRef) buttonProps.ref = (node) => setOptionRef(entry.value, node);
         return (
           <button key={entry.value} {...buttonProps}>
             <span>{entry.label}</span>

--- a/src/subjects/spelling/client-read-models.js
+++ b/src/subjects/spelling/client-read-models.js
@@ -58,8 +58,12 @@ function emptyAnalytics() {
   };
 }
 
-function statsForFilter(stats, yearFilter) {
+function statsForFilter(stats, analytics, yearFilter) {
   const safeStats = stats && typeof stats === 'object' && !Array.isArray(stats) ? stats : {};
+  const safeAnalytics = analytics && typeof analytics === 'object' && !Array.isArray(analytics) ? analytics : {};
+  const analyticsPools = safeAnalytics.pools && typeof safeAnalytics.pools === 'object' && !Array.isArray(safeAnalytics.pools)
+    ? safeAnalytics.pools
+    : {};
   const key = yearFilter === 'y3-4'
     ? 'y34'
     : yearFilter === 'y5-6'
@@ -69,7 +73,7 @@ function statsForFilter(stats, yearFilter) {
         : yearFilter === 'extra'
           ? 'extra'
           : 'core';
-  return normaliseStats(safeStats[key] || safeStats.core || safeStats.all || {});
+  return normaliseStats(safeStats[key] || analyticsPools[key] || safeStats.core || safeStats.all || {});
 }
 
 function asReadModel(rawValue, learnerId) {
@@ -167,7 +171,8 @@ export function createSpellingReadModelService({
       return readModel(learnerId).prefs;
     },
     getStats(learnerId, yearFilter = 'core') {
-      return statsForFilter(readModel(learnerId).stats, yearFilter);
+      const model = readModel(learnerId);
+      return statsForFilter(model.stats, model.analytics, yearFilter);
     },
     getAnalyticsSnapshot(learnerId) {
       return cloneSerialisable(readModel(learnerId).analytics || emptyAnalytics());

--- a/src/subjects/spelling/client-read-models.js
+++ b/src/subjects/spelling/client-read-models.js
@@ -6,6 +6,7 @@ import {
   normaliseMode,
   normaliseRoundLength,
   normaliseStats,
+  spellingPoolStatsKey,
   normaliseYearFilter,
 } from './service-contract.js';
 import {
@@ -64,15 +65,7 @@ function statsForFilter(stats, analytics, yearFilter) {
   const analyticsPools = safeAnalytics.pools && typeof safeAnalytics.pools === 'object' && !Array.isArray(safeAnalytics.pools)
     ? safeAnalytics.pools
     : {};
-  const key = yearFilter === 'y3-4'
-    ? 'y34'
-    : yearFilter === 'y5-6'
-      ? 'y56'
-      : yearFilter === 'secure-extension'
-        ? 'secureExtension'
-        : yearFilter === 'extra'
-          ? 'extra'
-          : 'core';
+  const key = spellingPoolStatsKey(yearFilter, 'core');
   return normaliseStats(safeStats[key] || analyticsPools[key] || safeStats.core || safeStats.all || {});
 }
 

--- a/src/subjects/spelling/components/SpellingSetupScene.jsx
+++ b/src/subjects/spelling/components/SpellingSetupScene.jsx
@@ -25,6 +25,7 @@ import {
   monsterImageVisual,
   normalisePostMegaBranch,
   renderAction,
+  setupPoolPanelCopyForFilter,
 } from './spelling-view-model.js';
 
 // Setup scene picks the post-Mega vista (`f` region) directly when it
@@ -43,67 +44,6 @@ function postMegaBranchFromRepositories(repositories, learnerId) {
   } catch (_error) {
     return normalisePostMegaBranch();
   }
-}
-
-const SETUP_POOL_PANEL_COPY = Object.freeze({
-  core: {
-    eyebrow: 'Where you stand',
-    totalLabel: 'Total spellings',
-    secureLabel: 'Secure',
-    dueLabel: 'Due today',
-    troubleLabel: 'Weak spots',
-    freshLabel: 'Unseen',
-    bankSub: (name) => `Every word ${name} is learning, with progress and difficulty.`,
-  },
-  'y3-4': {
-    eyebrow: 'Years 3-4 pool',
-    totalLabel: 'Years 3-4 words',
-    secureLabel: 'Secure',
-    dueLabel: 'Due today',
-    troubleLabel: 'Weak spots',
-    freshLabel: 'Unseen',
-    bankSub: (name) => `Years 3-4 words for ${name}, with progress and difficulty.`,
-    nextFocus: 'Years 3-4 pool selected.',
-  },
-  'y5-6': {
-    eyebrow: 'Years 5-6 pool',
-    totalLabel: 'Years 5-6 words',
-    secureLabel: 'Secure',
-    dueLabel: 'Due today',
-    troubleLabel: 'Weak spots',
-    freshLabel: 'Unseen',
-    bankSub: (name) => `Years 5-6 words for ${name}, with progress and difficulty.`,
-    nextFocus: 'Years 5-6 pool selected.',
-  },
-  'secure-extension': {
-    eyebrow: 'Secure vocabulary',
-    totalLabel: 'Secure vocabulary words',
-    secureLabel: 'Already secure',
-    dueLabel: 'Due today',
-    troubleLabel: 'Weak spots',
-    freshLabel: 'Not tried yet',
-    bankSub: (name) => `Secure vocabulary words for ${name}, with progress and difficulty.`,
-    nextFocus: 'Secure vocabulary pool selected.',
-  },
-  extra: {
-    eyebrow: 'Extra pool',
-    totalLabel: 'Extra words',
-    secureLabel: 'Secure',
-    dueLabel: 'Due today',
-    troubleLabel: 'Weak spots',
-    freshLabel: 'Unseen',
-    bankSub: (name) => `Extra words for ${name}, with progress and difficulty.`,
-    nextFocus: 'Extra pool selected.',
-  },
-});
-
-function setupPoolPanelCopy(statsFilter, learnerName) {
-  const safeName = String(learnerName || 'this learner');
-  const copy = SETUP_POOL_PANEL_COPY[statsFilter] || SETUP_POOL_PANEL_COPY.core;
-  return {
-    ...copy,
-    bankSubText: copy.bankSub(safeName),
-  };
 }
 
 function ModeCard({ mode, selected, disabled = false, description, badge, actions, textTone = 'dark' }) {
@@ -369,7 +309,7 @@ export function SpellingSetupScene({
 }) {
   const statsFilter = prefs.mode === 'test' ? 'core' : prefs.yearFilter;
   const stats = service.getStats(learner.id, statsFilter);
-  const panelCopy = setupPoolPanelCopy(statsFilter, learner.name);
+  const panelCopy = setupPoolPanelCopyForFilter(statsFilter, learner.name);
   // Post-Mega gating for the hero backdrop. When the learner has a sticky
   // graduation record (or is currently fully Mega), swap the legacy
   // mode-driven region for the post-Mega `f` vista bound to Phaeton's
@@ -674,6 +614,7 @@ function LegacySetupContent({
               disabled={hideTweaks || preferenceControlsDisabled}
               ariaLabel="Spelling pool"
               className="pool-picker"
+              sliderMode="measured"
               actionName="spelling-set-pref"
               prefKey="yearFilter"
               includeDataValue

--- a/src/subjects/spelling/components/SpellingSetupScene.jsx
+++ b/src/subjects/spelling/components/SpellingSetupScene.jsx
@@ -608,8 +608,10 @@ function LegacySetupContent({
             onChange={(value, event) => renderAction(actions, event, 'spelling-set-pref', { pref: 'yearFilter', value })}
             disabled={hideTweaks || preferenceControlsDisabled}
             ariaLabel="Spelling pool"
+            className="pool-picker"
             actionName="spelling-set-pref"
             prefKey="yearFilter"
+            includeDataValue
           />
         </div>
         <div className="tweak-row">

--- a/src/subjects/spelling/components/SpellingSetupScene.jsx
+++ b/src/subjects/spelling/components/SpellingSetupScene.jsx
@@ -45,6 +45,67 @@ function postMegaBranchFromRepositories(repositories, learnerId) {
   }
 }
 
+const SETUP_POOL_PANEL_COPY = Object.freeze({
+  core: {
+    eyebrow: 'Where you stand',
+    totalLabel: 'Total spellings',
+    secureLabel: 'Secure',
+    dueLabel: 'Due today',
+    troubleLabel: 'Weak spots',
+    freshLabel: 'Unseen',
+    bankSub: (name) => `Every word ${name} is learning, with progress and difficulty.`,
+  },
+  'y3-4': {
+    eyebrow: 'Years 3-4 pool',
+    totalLabel: 'Years 3-4 words',
+    secureLabel: 'Secure',
+    dueLabel: 'Due today',
+    troubleLabel: 'Weak spots',
+    freshLabel: 'Unseen',
+    bankSub: (name) => `Years 3-4 words for ${name}, with progress and difficulty.`,
+    nextFocus: 'Years 3-4 pool selected.',
+  },
+  'y5-6': {
+    eyebrow: 'Years 5-6 pool',
+    totalLabel: 'Years 5-6 words',
+    secureLabel: 'Secure',
+    dueLabel: 'Due today',
+    troubleLabel: 'Weak spots',
+    freshLabel: 'Unseen',
+    bankSub: (name) => `Years 5-6 words for ${name}, with progress and difficulty.`,
+    nextFocus: 'Years 5-6 pool selected.',
+  },
+  'secure-extension': {
+    eyebrow: 'Secure vocabulary',
+    totalLabel: 'Secure vocabulary words',
+    secureLabel: 'Already secure',
+    dueLabel: 'Due today',
+    troubleLabel: 'Weak spots',
+    freshLabel: 'Not tried yet',
+    bankSub: (name) => `Secure vocabulary words for ${name}, with progress and difficulty.`,
+    nextFocus: 'Secure vocabulary pool selected.',
+  },
+  extra: {
+    eyebrow: 'Extra pool',
+    totalLabel: 'Extra words',
+    secureLabel: 'Secure',
+    dueLabel: 'Due today',
+    troubleLabel: 'Weak spots',
+    freshLabel: 'Unseen',
+    bankSub: (name) => `Extra words for ${name}, with progress and difficulty.`,
+    nextFocus: 'Extra pool selected.',
+  },
+});
+
+function setupPoolPanelCopy(statsFilter, learnerName) {
+  const safeName = String(learnerName || 'this learner');
+  const copy = SETUP_POOL_PANEL_COPY[statsFilter] || SETUP_POOL_PANEL_COPY.core;
+  return {
+    ...copy,
+    bankSubText: copy.bankSub(safeName),
+  };
+}
+
 function ModeCard({ mode, selected, disabled = false, description, badge, actions, textTone = 'dark' }) {
   const desc = description != null ? description : mode.desc;
   const classes = ['mode-card'];
@@ -308,6 +369,7 @@ export function SpellingSetupScene({
 }) {
   const statsFilter = prefs.mode === 'test' ? 'core' : prefs.yearFilter;
   const stats = service.getStats(learner.id, statsFilter);
+  const panelCopy = setupPoolPanelCopy(statsFilter, learner.name);
   // Post-Mega gating for the hero backdrop. When the learner has a sticky
   // graduation record (or is currently fully Mega), swap the legacy
   // mode-driven region for the post-Mega `f` vista bound to Phaeton's
@@ -490,7 +552,7 @@ export function SpellingSetupScene({
             visible
             head={(
               <>
-                <p className="eyebrow">Where you stand</p>
+                <p className="eyebrow">{panelCopy.eyebrow}</p>
                 <button
                   type="button"
                   className="ss-codex-link"
@@ -504,15 +566,15 @@ export function SpellingSetupScene({
             )}
             monsterVisuals={panelMonsterVisuals}
             stats={[
-              { label: 'Total spellings', value: String(stats.total ?? 0) },
-              { label: 'Secure', value: String(stats.secure ?? 0) },
-              { label: 'Due today', value: String(stats.due ?? 0), tone: 'warn' },
-              { label: 'Weak spots', value: String(stats.trouble ?? 0) },
-              { label: 'Unseen', value: String(stats.fresh ?? 0) },
+              { label: panelCopy.totalLabel, value: String(stats.total ?? 0) },
+              { label: panelCopy.secureLabel, value: String(stats.secure ?? 0) },
+              { label: panelCopy.dueLabel, value: String(stats.due ?? 0), tone: 'warn' },
+              { label: panelCopy.troubleLabel, value: String(stats.trouble ?? 0) },
+              { label: panelCopy.freshLabel, value: String(stats.fresh ?? 0) },
               { label: 'Accuracy', value: stats.accuracy == null ? '—' : `${stats.accuracy}%` },
             ]}
             meadowEmpty="Catch your first monster to populate this meadow."
-            nextFocus={stats.trouble > 0 ? 'Trouble words need attention' : ''}
+            nextFocus={stats.trouble > 0 ? 'Trouble words need attention' : (panelCopy.nextFocus || '')}
           />
         )}
         footer={(
@@ -524,7 +586,7 @@ export function SpellingSetupScene({
           >
             <span className="ss-bank-link-body">
               <span className="ss-bank-link-head">Browse the word bank</span>
-              <span className="ss-bank-link-sub">Every word {learner.name} is learning, with progress and difficulty.</span>
+              <span className="ss-bank-link-sub">{panelCopy.bankSubText}</span>
             </span>
             <span className="ss-bank-link-arrow" aria-hidden="true">→</span>
           </button>
@@ -589,38 +651,44 @@ function LegacySetupContent({
       <div className="setup-control-stack">
         <div className={tweakClass} {...tweakAria}>
           <span className="tool-label">Round length</span>
-          <LengthPicker
-            options={ROUND_LENGTH_OPTIONS}
-            selectedValue={String(prefs.roundLength || '10')}
-            onChange={(value, event) => renderAction(actions, event, 'spelling-set-pref', { pref: 'roundLength', value })}
-            disabled={hideTweaks || preferenceControlsDisabled}
-            ariaLabel="Round length"
-            unit="words"
-            actionName="spelling-set-pref"
-            prefKey="roundLength"
-          />
+          <div className="tweak-controls">
+            <LengthPicker
+              options={ROUND_LENGTH_OPTIONS}
+              selectedValue={String(prefs.roundLength || '10')}
+              onChange={(value, event) => renderAction(actions, event, 'spelling-set-pref', { pref: 'roundLength', value })}
+              disabled={hideTweaks || preferenceControlsDisabled}
+              ariaLabel="Round length"
+              unit="words"
+              actionName="spelling-set-pref"
+              prefKey="roundLength"
+            />
+          </div>
         </div>
         <div className={tweakClass} {...tweakAria}>
           <span className="tool-label">Pool</span>
-          <LengthPicker
-            options={YEAR_FILTER_OPTIONS}
-            selectedValue={prefs.yearFilter || 'core'}
-            onChange={(value, event) => renderAction(actions, event, 'spelling-set-pref', { pref: 'yearFilter', value })}
-            disabled={hideTweaks || preferenceControlsDisabled}
-            ariaLabel="Spelling pool"
-            className="pool-picker"
-            actionName="spelling-set-pref"
-            prefKey="yearFilter"
-            includeDataValue
-          />
+          <div className="tweak-controls tweak-controls--pool">
+            <LengthPicker
+              options={YEAR_FILTER_OPTIONS}
+              selectedValue={prefs.yearFilter || 'core'}
+              onChange={(value, event) => renderAction(actions, event, 'spelling-set-pref', { pref: 'yearFilter', value })}
+              disabled={hideTweaks || preferenceControlsDisabled}
+              ariaLabel="Spelling pool"
+              className="pool-picker"
+              actionName="spelling-set-pref"
+              prefKey="yearFilter"
+              includeDataValue
+            />
+          </div>
         </div>
         <div className="tweak-row">
           <span className="tool-label">Options</span>
-          <ToggleChip pref="showCloze" checked={Boolean(prefs.showCloze)} label="Show sentence" actions={actions} disabled={preferenceControlsDisabled} />
-          <ToggleChip pref="autoSpeak" checked={Boolean(prefs.autoSpeak)} label="Auto-play audio" actions={actions} disabled={preferenceControlsDisabled} />
-          {showExtraFamilyOption ? (
-            <ToggleChip pref="extraWordFamilies" checked={Boolean(prefs.extraWordFamilies)} label="Word-family variants" actions={actions} disabled={preferenceControlsDisabled} />
-          ) : <span className="toggle-chip option-placeholder" aria-hidden="true" />}
+          <div className="tweak-controls">
+            <ToggleChip pref="showCloze" checked={Boolean(prefs.showCloze)} label="Show sentence" actions={actions} disabled={preferenceControlsDisabled} />
+            <ToggleChip pref="autoSpeak" checked={Boolean(prefs.autoSpeak)} label="Auto-play audio" actions={actions} disabled={preferenceControlsDisabled} />
+            {showExtraFamilyOption ? (
+              <ToggleChip pref="extraWordFamilies" checked={Boolean(prefs.extraWordFamilies)} label="Word-family variants" actions={actions} disabled={preferenceControlsDisabled} />
+            ) : <span className="toggle-chip option-placeholder" aria-hidden="true" />}
+          </div>
         </div>
       </div>
       <div className="setup-begin-row">

--- a/src/subjects/spelling/components/SpellingWordBankScene.jsx
+++ b/src/subjects/spelling/components/SpellingWordBankScene.jsx
@@ -15,10 +15,10 @@ import {
   WORD_BANK_GUARDIAN_FILTER_HINTS,
   WORD_BANK_GUARDIAN_FILTER_IDS,
   WORD_BANK_GUARDIAN_FILTER_ID_SET,
+  WORD_BANK_SUMMARY_CATEGORIES,
+  WORD_BANK_YEAR_FILTER_OPTIONS,
   WORD_BANK_YEAR_FILTER_IDS,
-  countWordBankExtra,
-  countWordBankSecureExtension,
-  countWordBankYear,
+  countWordBankCategory,
   dueLabel,
   findWordBankEntry,
   heroBgForLearner,
@@ -116,16 +116,9 @@ function GuardianFilterChips({ counts, activeFilter, actions }) {
 }
 
 function YearChips({ counts, activeYearFilter, actions }) {
-  const chips = [
-    { id: 'all', label: 'All' },
-    { id: 'y3-4', label: 'Years 3-4' },
-    { id: 'y5-6', label: 'Years 5-6' },
-    { id: 'secure-extension', label: 'Secure vocabulary' },
-    { id: 'extra', label: 'Extra' },
-  ];
   return (
     <div className="wb-chips wb-year-chips" role="group" aria-label="Filter word bank by category">
-      {chips.map((chip) => {
+      {WORD_BANK_YEAR_FILTER_OPTIONS.map((chip) => {
         const active = chip.id === activeYearFilter;
         return (
           <button
@@ -230,13 +223,14 @@ function statusCountsFromFacet(source, fallbackStats = {}) {
 function wordBankCategoryCounts({ facets, allWords, fallbackTotal }) {
   const categories = facets && typeof facets.categories === 'object' ? facets.categories : null;
   const allFallback = Number(fallbackTotal) || allWords.length;
-  return {
-    all: countFromFacet(categories, 'all', allFallback),
-    'y3-4': countFromFacet(categories, 'y3-4', countWordBankYear(allWords, '3-4')),
-    'y5-6': countFromFacet(categories, 'y5-6', countWordBankYear(allWords, '5-6')),
-    'secure-extension': countFromFacet(categories, 'secure-extension', countWordBankSecureExtension(allWords)),
-    extra: countFromFacet(categories, 'extra', countWordBankExtra(allWords)),
-  };
+  return Object.fromEntries(WORD_BANK_YEAR_FILTER_OPTIONS.map((option) => [
+    option.id,
+    countFromFacet(
+      categories,
+      option.id,
+      option.id === 'all' ? allFallback : countWordBankCategory(allWords, option.id),
+    ),
+  ]));
 }
 
 function categoryStatusFacet(facets, categoryId) {
@@ -487,47 +481,24 @@ function WordBankAggregates({ analytics, postMastery = null }) {
     ? { guardianMap, todayDay, progressMap: orphanProgressMap, wordBySlug: orphanWordBySlug }
     : undefined;
   const cardOptions = showGuardianCards ? { showGuardian: true } : undefined;
-  const coreFallback = wordBankAggregateStats(allWords.filter((word) => wordBankYearFilterMatches('core', word)), statsOptions);
-  const y34Fallback = wordBankAggregateStats(allWords.filter((word) => wordBankYearFilterMatches('y3-4', word)), statsOptions);
-  const y56Fallback = wordBankAggregateStats(allWords.filter((word) => wordBankYearFilterMatches('y5-6', word)), statsOptions);
-  const secureExtensionFallback = wordBankAggregateStats(allWords.filter((word) => wordBankYearFilterMatches('secure-extension', word)), statsOptions);
-  const extraFallback = wordBankAggregateStats(allWords.filter((word) => wordBankYearFilterMatches('extra', word)));
-  const core = statusCountsFromFacet(categoryStatusFacet(facets, 'core'), coreFallback);
-  const y34 = statusCountsFromFacet(categoryStatusFacet(facets, 'y3-4'), y34Fallback);
-  const y56 = statusCountsFromFacet(categoryStatusFacet(facets, 'y5-6'), y56Fallback);
-  const secureExtension = statusCountsFromFacet(categoryStatusFacet(facets, 'secure-extension'), secureExtensionFallback);
-  const extra = statusCountsFromFacet(categoryStatusFacet(facets, 'extra'), extraFallback);
-  const cards = [
-    {
-      eyebrow: 'Core spellings',
-      title: 'Core statutory progress',
-      stats: wordBankAggregateCards(core, 'Words in official statutory pool', cardOptions),
-    },
-    {
-      eyebrow: 'Years 3-4',
-      title: 'Lower KS2 spelling pool',
-      stats: wordBankAggregateCards(y34, 'Words in pool', cardOptions),
-    },
-    {
-      eyebrow: 'Years 5-6',
-      title: 'Upper KS2 spelling pool',
-      stats: wordBankAggregateCards(y56, 'Words in pool', cardOptions),
-    },
-    {
-      eyebrow: 'Secure vocabulary',
-      title: 'Approved secure-extension progress',
-      stats: wordBankAggregateCards(secureExtension, 'Words in secure vocabulary', cardOptions),
-    },
-    {
-      eyebrow: 'Extra',
-      // Extra pool is never Guardian-eligible (Guardian Mega is core-only),
-      // so we always use the legacy card shape here regardless of
-      // showGuardianCards. This keeps the Extra card's visual rhythm
-      // identical across the post-Mega transition.
-      title: 'Expansion spelling pool',
-      stats: wordBankAggregateCards(extra, 'Words in enrichment pool'),
-    },
-  ];
+  const cards = WORD_BANK_SUMMARY_CATEGORIES.map((category) => {
+    const includeGuardian = category.id !== 'extra';
+    const summary = category.wordBankSummary || {};
+    const fallback = wordBankAggregateStats(
+      allWords.filter((word) => wordBankYearFilterMatches(category.id, word)),
+      includeGuardian ? statsOptions : undefined,
+    );
+    const counts = statusCountsFromFacet(categoryStatusFacet(facets, category.id), fallback);
+    return {
+      eyebrow: summary.eyebrow || category.label,
+      title: summary.title || `${category.label} progress`,
+      stats: wordBankAggregateCards(
+        counts,
+        summary.statLabel || 'Words in pool',
+        includeGuardian ? cardOptions : undefined,
+      ),
+    };
+  });
   return (
     <div className="wb-aggregates">
       {cards.map((card) => (

--- a/src/subjects/spelling/components/SpellingWordBankScene.jsx
+++ b/src/subjects/spelling/components/SpellingWordBankScene.jsx
@@ -18,7 +18,6 @@ import {
   WORD_BANK_YEAR_FILTER_IDS,
   countWordBankExtra,
   countWordBankSecureExtension,
-  countWordBankStatus,
   countWordBankYear,
   dueLabel,
   findWordBankEntry,
@@ -195,6 +194,57 @@ function WordGroup({ group, words, query, actions, runtimeReadOnly = false }) {
   );
 }
 
+function countFromFacet(source, key, fallback = 0) {
+  const value = source && typeof source === 'object' ? source[key] : undefined;
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric >= 0 ? Math.floor(numeric) : fallback;
+}
+
+function countFromMeta(source, key, fallback = 0) {
+  const value = source && typeof source === 'object' ? source[key] : undefined;
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric >= 0 ? Math.floor(numeric) : fallback;
+}
+
+function statusCountsFromFacet(source, fallbackStats = {}) {
+  const trouble = countFromFacet(source, 'trouble', Number(fallbackStats.trouble) || 0);
+  const all = countFromFacet(source, 'all', Number(fallbackStats.total) || 0);
+  return {
+    all,
+    total: all,
+    due: countFromFacet(source, 'due', Number(fallbackStats.due) || 0),
+    weak: countFromFacet(source, 'weak', trouble),
+    trouble,
+    learning: countFromFacet(source, 'learning', Number(fallbackStats.learning) || 0),
+    secure: countFromFacet(source, 'secure', Number(fallbackStats.secure) || 0),
+    unseen: countFromFacet(source, 'unseen', Number(fallbackStats.unseen) || 0),
+    ...(Object.prototype.hasOwnProperty.call(fallbackStats, 'guardianDue') || source ? {
+      guardianDue: countFromFacet(source, 'guardianDue', Number(fallbackStats.guardianDue) || 0),
+      wobbling: countFromFacet(source, 'wobbling', Number(fallbackStats.wobbling) || 0),
+      renewedRecently: countFromFacet(source, 'renewedRecently', Number(fallbackStats.renewedRecently) || 0),
+      neverRenewed: countFromFacet(source, 'neverRenewed', Number(fallbackStats.neverRenewed) || 0),
+    } : {}),
+  };
+}
+
+function wordBankCategoryCounts({ facets, allWords, fallbackTotal }) {
+  const categories = facets && typeof facets.categories === 'object' ? facets.categories : null;
+  const allFallback = Number(fallbackTotal) || allWords.length;
+  return {
+    all: countFromFacet(categories, 'all', allFallback),
+    'y3-4': countFromFacet(categories, 'y3-4', countWordBankYear(allWords, '3-4')),
+    'y5-6': countFromFacet(categories, 'y5-6', countWordBankYear(allWords, '5-6')),
+    'secure-extension': countFromFacet(categories, 'secure-extension', countWordBankSecureExtension(allWords)),
+    extra: countFromFacet(categories, 'extra', countWordBankExtra(allWords)),
+  };
+}
+
+function categoryStatusFacet(facets, categoryId) {
+  const categoryStatus = facets && typeof facets.categoryStatus === 'object' ? facets.categoryStatus : null;
+  if (!categoryStatus) return null;
+  return categoryStatus[categoryId] || null;
+}
+
 function WordBankCard({ learner, analytics, appState, actions, postMastery = null, runtimeReadOnly = false }) {
   const persistedSearchQuery = appState?.transientUi?.spellingAnalyticsWordSearch || '';
   const [draftSearch, setDraftSearch] = React.useState(persistedSearchQuery);
@@ -228,12 +278,13 @@ function WordBankCard({ learner, analytics, appState, actions, postMastery = nul
   const activeYearFilter = WORD_BANK_YEAR_FILTER_IDS.has(yearFilter) ? yearFilter : 'all';
   const groups = Array.isArray(analytics.wordGroups) ? analytics.wordGroups : [];
   const wordBankMeta = analytics.wordBank || {};
+  const facets = wordBankMeta.facets && typeof wordBankMeta.facets === 'object' ? wordBankMeta.facets : null;
   const allWords = groups.flatMap((group) => Array.isArray(group.words) ? group.words : []);
   // SH2-U5: when the learner has zero tracked words we short-circuit to
   // the shared empty-state card. No filters, no toolbar, no group head —
   // the progress is genuinely empty so the canonical "what happened /
   // progress safe / action" copy is the whole panel.
-  const totalTrackedWords = allWords.length;
+  const totalTrackedWords = Math.max(0, Number(wordBankMeta.totalRows) || allWords.length);
   const categoryWords = allWords.filter((word) => wordBankYearFilterMatches(activeYearFilter, word));
   // U2 orphan-sanitiser context: wordBankFilterMatchesStatus uses these when
   // checking `guardianDue` / `wobbling` so a row whose slug no longer
@@ -287,32 +338,12 @@ function WordBankCard({ learner, analytics, appState, actions, postMastery = nul
         wordBySlug: orphanWordBySlug,
       })
     : null;
-  const counts = {
-    all: categoryWords.length,
-    due: legacyStats.due,
-    weak: legacyStats.trouble,
-    learning: legacyStats.learning,
-    secure: legacyStats.secure,
-    unseen: legacyStats.unseen,
-    // Guardian counts only materialise when the chips are surfaced. Keeping
-    // them off the object entirely when allWordsMega === false means the
-    // legacy `counts` literal is byte-identical to what shipped before U6.
-    ...(guardianStats ? {
-      guardianDue: guardianStats.guardianDue,
-      wobbling: guardianStats.wobbling,
-      renewedRecently: guardianStats.renewedRecently,
-      neverRenewed: guardianStats.neverRenewed,
-    } : {}),
-  };
-  const yearCounts = {
-    all: allWords.length,
-    'y3-4': countWordBankYear(allWords, '3-4'),
-    'y5-6': countWordBankYear(allWords, '5-6'),
-    'secure-extension': countWordBankSecureExtension(allWords),
-    extra: countWordBankExtra(allWords),
-  };
-  const totalWords = allWords.length;
-  const categoryTotal = categoryWords.length;
+  const counts = statusCountsFromFacet(facets?.status, guardianStats || legacyStats);
+  const yearCounts = wordBankCategoryCounts({ facets, allWords, fallbackTotal: wordBankMeta.totalRows });
+  const totalWords = facets?.categories ? yearCounts.all : (yearCounts.all || totalTrackedWords);
+  const categoryTotal = activeYearFilter === 'all'
+    ? totalWords
+    : countFromFacet(yearCounts, activeYearFilter, categoryWords.length);
   const categoryLabel = wordBankYearFilterLabel(activeYearFilter);
   const ledeBase = activeYearFilter === 'all'
     ? `${totalWords} word${totalWords === 1 ? '' : 's'} tracked — ${counts.secure} secure, ${counts.due} due today, ${counts.weak} weak spots.`
@@ -320,8 +351,8 @@ function WordBankCard({ learner, analytics, appState, actions, postMastery = nul
   const ledeSearch = query
     ? ` Showing ${visibleWords.length} match${visibleWords.length === 1 ? '' : 'es'} for "${searchQuery}".`
     : '';
-  const loadedRows = Number(wordBankMeta.returnedRows) || totalWords;
-  const filteredRows = Number(wordBankMeta.filteredRows) || categoryTotal || totalWords;
+  const loadedRows = countFromMeta(wordBankMeta, 'returnedRows', totalWords);
+  const filteredRows = countFromMeta(wordBankMeta, 'filteredRows', categoryTotal || totalWords);
   const footText = wordBankMeta.hasNextPage
     ? `Showing ${visibleWords.length} visible spellings from ${loadedRows} loaded rows.`
     : activeYearFilter === 'all'
@@ -422,6 +453,8 @@ function WordBankCard({ learner, analytics, appState, actions, postMastery = nul
 
 function WordBankAggregates({ analytics, postMastery = null }) {
   const groups = Array.isArray(analytics.wordGroups) ? analytics.wordGroups : [];
+  const wordBankMeta = analytics.wordBank || {};
+  const facets = wordBankMeta.facets && typeof wordBankMeta.facets === 'object' ? wordBankMeta.facets : null;
   const allWords = groups.flatMap((group) => Array.isArray(group.words) ? group.words : []);
   const showGuardianCards = Boolean(postMastery?.allWordsMega);
   const guardianMap = postMastery?.guardianMap && typeof postMastery.guardianMap === 'object'
@@ -454,11 +487,16 @@ function WordBankAggregates({ analytics, postMastery = null }) {
     ? { guardianMap, todayDay, progressMap: orphanProgressMap, wordBySlug: orphanWordBySlug }
     : undefined;
   const cardOptions = showGuardianCards ? { showGuardian: true } : undefined;
-  const core = wordBankAggregateStats(allWords.filter((word) => wordBankYearFilterMatches('core', word)), statsOptions);
-  const y34 = wordBankAggregateStats(allWords.filter((word) => wordBankYearFilterMatches('y3-4', word)), statsOptions);
-  const y56 = wordBankAggregateStats(allWords.filter((word) => wordBankYearFilterMatches('y5-6', word)), statsOptions);
-  const secureExtension = wordBankAggregateStats(allWords.filter((word) => wordBankYearFilterMatches('secure-extension', word)), statsOptions);
-  const extra = wordBankAggregateStats(allWords.filter((word) => wordBankYearFilterMatches('extra', word)), statsOptions);
+  const coreFallback = wordBankAggregateStats(allWords.filter((word) => wordBankYearFilterMatches('core', word)), statsOptions);
+  const y34Fallback = wordBankAggregateStats(allWords.filter((word) => wordBankYearFilterMatches('y3-4', word)), statsOptions);
+  const y56Fallback = wordBankAggregateStats(allWords.filter((word) => wordBankYearFilterMatches('y5-6', word)), statsOptions);
+  const secureExtensionFallback = wordBankAggregateStats(allWords.filter((word) => wordBankYearFilterMatches('secure-extension', word)), statsOptions);
+  const extraFallback = wordBankAggregateStats(allWords.filter((word) => wordBankYearFilterMatches('extra', word)));
+  const core = statusCountsFromFacet(categoryStatusFacet(facets, 'core'), coreFallback);
+  const y34 = statusCountsFromFacet(categoryStatusFacet(facets, 'y3-4'), y34Fallback);
+  const y56 = statusCountsFromFacet(categoryStatusFacet(facets, 'y5-6'), y56Fallback);
+  const secureExtension = statusCountsFromFacet(categoryStatusFacet(facets, 'secure-extension'), secureExtensionFallback);
+  const extra = statusCountsFromFacet(categoryStatusFacet(facets, 'extra'), extraFallback);
   const cards = [
     {
       eyebrow: 'Core spellings',

--- a/src/subjects/spelling/components/spelling-view-model.js
+++ b/src/subjects/spelling/components/spelling-view-model.js
@@ -1029,7 +1029,17 @@ export function buildSpellingContext({ appState, service, repositories, subject 
     pendingCommand: appState.transientUi?.spellingPendingCommand || '',
   };
   const needsAnalytics = ui.phase === 'dashboard' || ui.phase === 'word-bank';
-  const analytics = needsAnalytics ? service.getAnalyticsSnapshot(learner.id) : null;
+  const loadedWordBankAnalytics = appState.subjectUi?.spelling?.analytics;
+  const hasLoadedWordBankAnalytics = loadedWordBankAnalytics
+    && typeof loadedWordBankAnalytics === 'object'
+    && Array.isArray(loadedWordBankAnalytics.wordGroups)
+    && loadedWordBankAnalytics.wordBank
+    && typeof loadedWordBankAnalytics.wordBank === 'object';
+  const analytics = needsAnalytics
+    ? (ui.phase === 'word-bank' && hasLoadedWordBankAnalytics
+        ? loadedWordBankAnalytics
+        : service.getAnalyticsSnapshot(learner.id))
+    : null;
   // Post-mastery aggregates are needed on the dashboard (mode selection,
   // Alt+4 gate), the summary scene (to render "Next check" in Guardian
   // mode), and the Word Bank (to gate the four Guardian filter chips and

--- a/src/subjects/spelling/components/spelling-view-model.js
+++ b/src/subjects/spelling/components/spelling-view-model.js
@@ -9,11 +9,19 @@ import {
 } from '../../../platform/ui/hero-bg.js';
 import {
   coverageTierLabel,
+  coverageTierForWord,
   createLockedPostMasteryState,
   isEnrichmentExtraWord,
   isGuardianEligibleSlug,
   isSecureExtensionWord,
   isStatutoryCoreWord,
+  normaliseSpellingWordBankFilterId,
+  spellingPoolCategoryById,
+  spellingPoolCategoryForWord,
+  spellingPoolCategoryMatchesWord,
+  SPELLING_WORD_BANK_SUMMARY_CATEGORIES,
+  spellingSetupPoolOptions,
+  spellingWordBankFilterOptions,
 } from '../service-contract.js';
 
 export const SPELLING_ACCENT = '#3E6FA8';
@@ -108,13 +116,7 @@ export const POST_MEGA_MODE_CARDS = Object.freeze([
   },
 ]);
 export const ROUND_LENGTH_OPTIONS = Object.freeze(['10', '20', '40']);
-export const YEAR_FILTER_OPTIONS = Object.freeze([
-  { value: 'core', label: 'Core' },
-  { value: 'y3-4', label: 'Y3-4' },
-  { value: 'y5-6', label: 'Y5-6' },
-  { value: 'secure-extension', label: 'Secure vocabulary' },
-  { value: 'extra', label: 'Extra' },
-]);
+export const YEAR_FILTER_OPTIONS = Object.freeze(spellingSetupPoolOptions());
 export const WORD_BANK_FILTER_IDS = new Set([
   'all',
   'due',
@@ -140,7 +142,9 @@ export const WORD_BANK_GUARDIAN_FILTER_IDS = Object.freeze([
   'neverRenewed',
 ]);
 export const WORD_BANK_GUARDIAN_FILTER_ID_SET = new Set(WORD_BANK_GUARDIAN_FILTER_IDS);
-export const WORD_BANK_YEAR_FILTER_IDS = new Set(['all', 'y3-4', 'y5-6', 'secure-extension', 'extra']);
+export const WORD_BANK_YEAR_FILTER_OPTIONS = Object.freeze(spellingWordBankFilterOptions());
+export const WORD_BANK_YEAR_FILTER_IDS = new Set(WORD_BANK_YEAR_FILTER_OPTIONS.map((option) => option.id));
+export const WORD_BANK_SUMMARY_CATEGORIES = SPELLING_WORD_BANK_SUMMARY_CATEGORIES;
 
 /* U5: Word Bank Guardian chip copy polish (R10).
  *
@@ -533,21 +537,31 @@ export function wordBankFilterMatchesStatus(filter, status, options = {}) {
 }
 
 export function wordBankYearFilterMatches(filter, word) {
-  if (filter === 'all') return true;
-  if (filter === 'core') return isStatutoryCoreWord(word);
-  if (filter === 'y3-4') return isStatutoryCoreWord(word) && word.year === '3-4';
-  if (filter === 'y5-6') return isStatutoryCoreWord(word) && word.year === '5-6';
-  if (filter === 'secure-extension') return isSecureExtensionWord(word);
-  if (filter === 'extra') return isEnrichmentExtraWord(word);
-  return true;
+  const category = spellingPoolCategoryById(filter)
+    || spellingPoolCategoryById(normaliseSpellingWordBankFilterId(filter, 'all'));
+  return spellingPoolCategoryMatchesWord(category, word, { coverageTierForWord });
 }
 
 export function wordBankYearFilterLabel(filter) {
-  if (filter === 'y3-4') return 'Years 3-4';
-  if (filter === 'y5-6') return 'Years 5-6';
-  if (filter === 'secure-extension') return 'Secure vocabulary';
-  if (filter === 'extra') return 'Extra';
-  return 'All';
+  const category = spellingPoolCategoryById(normaliseSpellingWordBankFilterId(filter, 'all'));
+  return category?.label || 'All';
+}
+
+export function setupPoolPanelCopyForFilter(filter, learnerName) {
+  const category = spellingPoolCategoryById(filter) || spellingPoolCategoryById('core');
+  const panel = category?.setupPanel || spellingPoolCategoryById('core')?.setupPanel || {};
+  const safeName = String(learnerName || 'this learner');
+  return {
+    eyebrow: panel.eyebrow || category?.label || 'Where you stand',
+    totalLabel: panel.totalLabel || 'Total spellings',
+    secureLabel: panel.secureLabel || 'Secure',
+    dueLabel: panel.dueLabel || 'Due today',
+    troubleLabel: panel.troubleLabel || 'Weak spots',
+    freshLabel: panel.freshLabel || 'Unseen',
+    nextFocus: panel.nextFocus,
+    bankSubText: String(panel.bankSubTemplate || 'Every word {learner} is learning, with progress and difficulty.')
+      .replaceAll('{learner}', safeName),
+  };
 }
 
 export function wordStatusLabel(status) {
@@ -568,8 +582,8 @@ export function wordBankPillClass(status) {
 }
 
 export function spellingPoolLabel(word) {
-  if (isSecureExtensionWord(word)) return 'Secure vocabulary';
-  if (isEnrichmentExtraWord(word)) return 'Extra';
+  const category = spellingPoolCategoryForWord(word, undefined, { coverageTierForWord });
+  if (category) return category.label;
   return word?.yearLabel || 'Core';
 }
 
@@ -906,16 +920,25 @@ export function countWordBankStatus(words, status) {
   return words.reduce((count, word) => count + (word.status === status ? 1 : 0), 0);
 }
 
+export function countWordBankCategory(words, categoryId) {
+  const safeCategoryId = normaliseSpellingWordBankFilterId(categoryId, 'all');
+  return words.reduce(
+    (count, word) => count + (spellingPoolCategoryMatchesWord(safeCategoryId, word, { coverageTierForWord }) ? 1 : 0),
+    0,
+  );
+}
+
 export function countWordBankYear(words, year) {
-  return words.reduce((count, word) => count + (isStatutoryCoreWord(word) && word.year === year ? 1 : 0), 0);
+  const categoryId = year === '5-6' ? 'y5-6' : 'y3-4';
+  return countWordBankCategory(words, categoryId);
 }
 
 export function countWordBankExtra(words) {
-  return words.reduce((count, word) => count + (isEnrichmentExtraWord(word) ? 1 : 0), 0);
+  return countWordBankCategory(words, 'extra');
 }
 
 export function countWordBankSecureExtension(words) {
-  return words.reduce((count, word) => count + (isSecureExtensionWord(word) ? 1 : 0), 0);
+  return countWordBankCategory(words, 'secure-extension');
 }
 
 /**

--- a/src/subjects/spelling/remote-actions.js
+++ b/src/subjects/spelling/remote-actions.js
@@ -19,6 +19,7 @@ import { isMegaSafeMode, isPostMasteryMode } from './service-contract.js';
 const READ_ONLY_MESSAGE = 'Practice is read-only while sync is degraded. Retry sync before continuing.';
 const SETUP_PREF_SAVE_DEBOUNCE_MS = 120;
 const SPELLING_COMPENSATION_EVENT_LIMIT = 25;
+const SERVER_WORD_BANK_STATUS_FILTER_IDS = new Set(['all', 'due', 'weak', 'learning', 'secure', 'unseen']);
 
 const SPELLING_COMMAND_ACTIONS = new Set([
   'spelling-set-mode',
@@ -213,6 +214,18 @@ export function createRemoteSpellingActionHandler({
 
   function wordBankAnalyticsFromState(state = appState()) {
     return state.subjectUi?.spelling?.analytics || null;
+  }
+
+  function wordBankFiltersFromState(state = appState(), overrides = {}) {
+    const transient = state.transientUi || {};
+    const query = String(overrides.query ?? transient.spellingAnalyticsWordSearch ?? '').slice(0, 80);
+    const rawYear = String(overrides.year ?? transient.spellingAnalyticsYearFilter ?? 'all');
+    const rawStatus = String(overrides.status ?? transient.spellingAnalyticsStatusFilter ?? 'all');
+    return {
+      query,
+      year: WORD_BANK_YEAR_FILTER_IDS.has(rawYear) ? rawYear : 'all',
+      status: SERVER_WORD_BANK_STATUS_FILTER_IDS.has(rawStatus) ? rawStatus : 'all',
+    };
   }
 
   function currentSpellingRewardEventIds(learnerId) {
@@ -430,12 +443,16 @@ export function createRemoteSpellingActionHandler({
     }
   }
 
-  async function loadWordBank({ detailSlug = '', page = 1, append = false } = {}) {
+  async function loadWordBank({ detailSlug = '', page = 1, append = false, filters: filterOverrides = {} } = {}) {
     const state = appState();
     const learnerId = state.learners?.selectedId;
     if (!learnerId) return null;
+    const filters = wordBankFiltersFromState(state, filterOverrides);
     const params = new URLSearchParams({
       learnerId,
+      q: filters.query,
+      status: filters.status,
+      year: filters.year,
       page: String(page),
       pageSize: '250',
     });
@@ -774,12 +791,19 @@ export function createRemoteSpellingActionHandler({
     }
 
     if (action === 'spelling-analytics-search') {
+      const nextValue = String(data.value || '').slice(0, 80);
       store.patch((current) => ({
         transientUi: {
           ...current.transientUi,
-          spellingAnalyticsWordSearch: String(data.value || '').slice(0, 80),
+          spellingAnalyticsWordSearch: nextValue,
         },
       }));
+      if (!isReadOnly()) {
+        loadWordBank({ page: 1, filters: { query: nextValue } }).catch((error) => {
+          globalThis.console?.warn?.('Word bank search failed.', error);
+          setRuntimeError(commandErrorMessage(error, 'The word bank could not be searched.'));
+        });
+      }
       return true;
     }
 
@@ -791,6 +815,12 @@ export function createRemoteSpellingActionHandler({
           spellingAnalyticsYearFilter: WORD_BANK_YEAR_FILTER_IDS.has(raw) ? raw : 'all',
         },
       }));
+      if (!isReadOnly()) {
+        loadWordBank({ page: 1, filters: { year: raw } }).catch((error) => {
+          globalThis.console?.warn?.('Word bank category filter failed.', error);
+          setRuntimeError(commandErrorMessage(error, 'The word bank category could not be loaded.'));
+        });
+      }
       return true;
     }
 
@@ -802,6 +832,12 @@ export function createRemoteSpellingActionHandler({
           spellingAnalyticsStatusFilter: WORD_BANK_FILTER_IDS.has(raw) ? raw : 'all',
         },
       }));
+      if (!isReadOnly() && SERVER_WORD_BANK_STATUS_FILTER_IDS.has(raw)) {
+        loadWordBank({ page: 1, filters: { status: raw } }).catch((error) => {
+          globalThis.console?.warn?.('Word bank status filter failed.', error);
+          setRuntimeError(commandErrorMessage(error, 'The word bank status could not be loaded.'));
+        });
+      }
       return true;
     }
 

--- a/src/subjects/spelling/remote-actions.js
+++ b/src/subjects/spelling/remote-actions.js
@@ -82,6 +82,10 @@ const SPELLING_WORD_BANK_ACTIONS = new Set([
   'spelling-word-bank-drill-replay-slow',
   'spelling-word-bank-load-more',
 ]);
+// The chips show full category totals, so the first page must include the
+// current complete word bank. The Worker still paginates if content outgrows
+// this safety cap.
+const WORD_BANK_PAGE_SIZE = 5000;
 
 function commandErrorMessage(error, fallback) {
   return error?.payload?.message || error?.message || fallback;
@@ -454,7 +458,7 @@ export function createRemoteSpellingActionHandler({
       status: filters.status,
       year: filters.year,
       page: String(page),
-      pageSize: '250',
+      pageSize: String(WORD_BANK_PAGE_SIZE),
     });
     if (detailSlug) params.set('detailSlug', detailSlug);
     const payload = await readModels.readJson(`/api/subjects/spelling/word-bank?${params.toString()}`);

--- a/src/subjects/spelling/service-contract.js
+++ b/src/subjects/spelling/service-contract.js
@@ -2,6 +2,10 @@ import {
   SPELLING_COVERAGE_TIER as SPELLING_COVERAGE_TIER_VALUE,
   coverageTierForWord as coverageTierForWordValue,
 } from './content/taxonomy.js';
+import {
+  SPELLING_SETUP_POOL_IDS as SPELLING_SETUP_POOL_IDS_VALUE,
+  normaliseSpellingSetupPoolId as normaliseSpellingSetupPoolIdValue,
+} from '../../../shared/spelling/pool-taxonomy.js';
 
 /**
  * P2 versioning convention (H7 synthesis, documented at U10): content-model
@@ -52,6 +56,27 @@ export {
   isStatutoryCoreWord,
   normaliseCoverageTier,
 } from './content/taxonomy.js';
+
+export {
+  SPELLING_ANALYTICS_POOL_CATEGORIES,
+  SPELLING_ANALYTICS_WORD_GROUP_CATEGORIES,
+  SPELLING_POOL_CATEGORIES,
+  SPELLING_SETUP_POOL_CATEGORIES,
+  SPELLING_SETUP_POOL_IDS,
+  SPELLING_WORD_BANK_FILTER_CATEGORIES,
+  SPELLING_WORD_BANK_FILTER_IDS,
+  SPELLING_WORD_BANK_SUMMARY_CATEGORIES,
+  normaliseSpellingPoolCategoryId,
+  normaliseSpellingSetupPoolId,
+  normaliseSpellingWordBankFilterId,
+  spellingPoolCategoryById,
+  spellingPoolCategoryForWord,
+  spellingPoolCategoryMatchesWord,
+  spellingPoolStatsKey,
+  spellingSetupPoolOptions,
+  spellingWordBankFilterOptions,
+  validateSpellingPoolCategories,
+} from '../../../shared/spelling/pool-taxonomy.js';
 
 /**
  * P2 U12: re-export of the achievement-framework canonical identifiers so
@@ -290,7 +315,7 @@ export function isMegaSafeMode(mode, options = {}) {
 export function isSingleAttemptMegaSafeMode(mode) {
   return isPostMasteryMode(mode);
 }
-export const SPELLING_YEAR_FILTERS = Object.freeze(['core', 'y3-4', 'y5-6', 'secure-extension', 'extra']);
+export const SPELLING_YEAR_FILTERS = Object.freeze([...SPELLING_SETUP_POOL_IDS_VALUE]);
 export const LEGACY_SPELLING_YEAR_FILTER_ALIASES = Object.freeze({
   all: 'core',
 });
@@ -329,10 +354,11 @@ export function normaliseMode(value, fallback = 'smart') {
 export function normaliseYearFilter(value, fallback = 'core') {
   const candidate = typeof value === 'string' ? value : '';
   const aliased = LEGACY_SPELLING_YEAR_FILTER_ALIASES[candidate] || candidate;
-  const normalisedFallback = SPELLING_YEAR_FILTERS.includes(fallback)
-    ? fallback
-    : LEGACY_SPELLING_YEAR_FILTER_ALIASES[fallback] || 'core';
-  return SPELLING_YEAR_FILTERS.includes(aliased) ? aliased : normalisedFallback;
+  const normalisedFallback = normaliseSpellingSetupPoolIdValue(
+    LEGACY_SPELLING_YEAR_FILTER_ALIASES[fallback] || fallback,
+    'core',
+  );
+  return normaliseSpellingSetupPoolIdValue(aliased, normalisedFallback);
 }
 
 export function normaliseRoundLength(value, mode = 'smart') {

--- a/styles/app.css
+++ b/styles/app.css
@@ -6044,7 +6044,10 @@ button.chip,
     0 1px 2px rgba(0,0,0,0.14),
     inset 0 1px 0 color-mix(in oklab, white 28%, transparent);
   transform: translateX(calc(var(--selected-index) * 100%));
-  transition: transform 260ms var(--ease-out);
+  transition:
+    transform 260ms var(--ease-out),
+    width 260ms var(--ease-out),
+    height 260ms var(--ease-out);
   z-index: 0;
   pointer-events: none;
 }
@@ -6071,19 +6074,23 @@ button.chip,
 }
 .length-picker.pool-picker {
   max-width: 100%;
-  padding: 0;
-  border: 0;
-  border-radius: 0;
-  background: transparent;
-  box-shadow: none;
+  padding: var(--picker-pad);
   flex-wrap: wrap;
   align-items: center;
-  gap: 8px;
-  backdrop-filter: none;
-  -webkit-backdrop-filter: none;
+  gap: 2px 4px;
 }
-.length-picker.pool-picker .length-slider {
-  display: none;
+.length-picker[data-slider-mode="measured"] .length-slider {
+  top: 0;
+  bottom: auto;
+  left: 0;
+  width: var(--measured-slider-width, var(--slider-width));
+  height: var(--measured-slider-height, calc(100% - (var(--picker-pad) * 2)));
+  transform:
+    translateX(var(--measured-slider-x, var(--picker-pad)))
+    translateY(var(--measured-slider-y, var(--picker-pad)));
+}
+.length-picker[data-slider-mode="measured"]:not([data-slider-ready="true"]) .length-slider {
+  opacity: 0;
 }
 .length-picker.pool-picker .length-option {
   display: inline-flex;
@@ -6092,28 +6099,28 @@ button.chip,
   min-width: max-content;
   height: 34px;
   white-space: nowrap;
-  border: 1px solid var(--toggle-chip-border, color-mix(in oklab, white 26%, transparent));
-  background: var(--toggle-chip-surface, color-mix(in oklab, black 20%, transparent));
-  box-shadow: inset 0 1px 0 color-mix(in oklab, white 16%, transparent);
-  transition: border-color var(--dur) var(--ease-out),
-              background var(--dur) var(--ease-out),
-              color var(--dur) var(--ease-out),
-              transform var(--dur) var(--ease-out),
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+  transition: color var(--dur) var(--ease-out),
               text-shadow var(--dur) var(--ease-out);
 }
 .length-picker.pool-picker .length-option:hover {
-  transform: translateY(-1px);
-  border-color: var(--toggle-chip-hover-border, color-mix(in oklab, var(--brand) 38%, white 20%));
+  color: var(--length-option-hover);
 }
-.length-picker.pool-picker .length-option.selected {
+.length-picker.pool-picker[data-slider-mode="measured"]:not([data-slider-ready="true"]) .length-option.selected {
   background:
     linear-gradient(180deg,
       color-mix(in oklab, var(--brand) 92%, white) 0%,
       var(--brand) 100%);
-  border-color: color-mix(in oklab, var(--brand) 82%, white 20%);
   box-shadow:
     0 1px 2px rgba(0,0,0,0.14),
     inset 0 1px 0 color-mix(in oklab, white 28%, transparent);
+}
+@media (prefers-reduced-motion: reduce) {
+  .length-picker[data-slider-mode="measured"] .length-slider {
+    transition: none;
+  }
 }
 .length-unit {
   color: var(--setup-label-ink);

--- a/styles/app.css
+++ b/styles/app.css
@@ -6051,6 +6051,30 @@ button.chip,
   color: #fff;
   text-shadow: 0 1px 2px rgba(0,0,0,0.18);
 }
+.length-picker.pool-picker {
+  max-width: 100%;
+  flex-wrap: wrap;
+  align-items: stretch;
+}
+.length-picker.pool-picker .length-slider {
+  display: none;
+}
+.length-picker.pool-picker .length-option {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: max-content;
+  white-space: nowrap;
+}
+.length-picker.pool-picker .length-option.selected {
+  background:
+    linear-gradient(180deg,
+      color-mix(in oklab, var(--brand) 92%, white) 0%,
+      var(--brand) 100%);
+  box-shadow:
+    0 1px 2px rgba(0,0,0,0.14),
+    inset 0 1px 0 color-mix(in oklab, white 28%, transparent);
+}
 .length-unit {
   color: var(--setup-label-ink);
   font-weight: 600;

--- a/styles/app.css
+++ b/styles/app.css
@@ -5897,9 +5897,10 @@ button.chip,
   margin-top: 20px;
 }
 .tweak-row {
-  display: flex;
-  gap: 10px;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: 102px minmax(0, 1fr);
+  column-gap: 14px;
+  row-gap: 8px;
   align-items: center;
   padding: 18px 0 2px;
   border-top: 1px dashed var(--line);
@@ -5930,15 +5931,31 @@ button.chip,
 }
 .tool-label {
   display: inline-block;
-  min-width: 102px;
+  min-width: 0;
   font-size: 0.78rem;
   font-weight: 700;
   letter-spacing: 0.04em;
   text-transform: uppercase;
   color: var(--setup-label-ink);
   text-shadow: 0 1px 12px var(--setup-label-shadow);
-  margin-right: 4px;
+  margin-right: 0;
   transition: color var(--dur) var(--ease-out), text-shadow var(--dur) var(--ease-out);
+}
+.tweak-controls {
+  min-width: 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+}
+.tweak-controls--pool {
+  gap: 8px;
+}
+@media (max-width: 560px) {
+  .tweak-row {
+    grid-template-columns: 1fr;
+    column-gap: 0;
+  }
 }
 
 .toggle-chip {
@@ -5992,6 +6009,7 @@ button.chip,
   display: inline-flex;
   align-items: center;
   gap: 10px;
+  min-width: 0;
 }
 .length-picker {
   --option-count: 3;
@@ -6053,8 +6071,16 @@ button.chip,
 }
 .length-picker.pool-picker {
   max-width: 100%;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
   flex-wrap: wrap;
-  align-items: stretch;
+  align-items: center;
+  gap: 8px;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
 }
 .length-picker.pool-picker .length-slider {
   display: none;
@@ -6064,13 +6090,27 @@ button.chip,
   align-items: center;
   justify-content: center;
   min-width: max-content;
+  height: 34px;
   white-space: nowrap;
+  border: 1px solid var(--toggle-chip-border, color-mix(in oklab, white 26%, transparent));
+  background: var(--toggle-chip-surface, color-mix(in oklab, black 20%, transparent));
+  box-shadow: inset 0 1px 0 color-mix(in oklab, white 16%, transparent);
+  transition: border-color var(--dur) var(--ease-out),
+              background var(--dur) var(--ease-out),
+              color var(--dur) var(--ease-out),
+              transform var(--dur) var(--ease-out),
+              text-shadow var(--dur) var(--ease-out);
+}
+.length-picker.pool-picker .length-option:hover {
+  transform: translateY(-1px);
+  border-color: var(--toggle-chip-hover-border, color-mix(in oklab, var(--brand) 38%, white 20%));
 }
 .length-picker.pool-picker .length-option.selected {
   background:
     linear-gradient(180deg,
       color-mix(in oklab, var(--brand) 92%, white) 0%,
       var(--brand) 100%);
+  border-color: color-mix(in oklab, var(--brand) 82%, white 20%);
   box-shadow:
     0 1px 2px rgba(0,0,0,0.14),
     inset 0 1px 0 color-mix(in oklab, white 28%, transparent);

--- a/tests/build-public.test.js
+++ b/tests/build-public.test.js
@@ -50,10 +50,16 @@ test('public build emits the React app bundle entrypoint', () => {
   ]));
   const cspHashArtefact = readFileSync('dist/public/.csp-theme-hash', 'utf8');
   const appBundle = readFileSync('dist/public/src/bundles/app.bundle.js', 'utf8');
+  const appStylesheet = readFileSync('dist/public/styles/app.css', 'utf8');
   const expectedAppBundleVersion = createHash('sha256').update(appBundle).digest('hex').slice(0, 12);
+  const expectedAppStylesheetVersion = createHash('sha256').update(appStylesheet).digest('hex').slice(0, 12);
   assert.match(
     indexHtml,
     new RegExp(`type="module" src="\\.\\/src\\/bundles\\/app\\.bundle\\.js\\?v=${expectedAppBundleVersion}"`),
+  );
+  assert.match(
+    indexHtml,
+    new RegExp(`rel="stylesheet" href="\\.\\/styles\\/app\\.css\\?v=${expectedAppStylesheetVersion}"`),
   );
   assert.doesNotMatch(indexHtml, /home\.bundle\.js/);
   assert.doesNotMatch(indexHtml, /src\/main\.js/);

--- a/tests/helpers/react-render.js
+++ b/tests/helpers/react-render.js
@@ -901,6 +901,7 @@ export function renderSpellingSurfaceFixture({
   phase = 'setup',
   pendingCommand = '',
   wordBankAnalytics = null,
+  prefs = null,
   // postMega: {} → force allWordsMega via seeded progress + optional guardian
   // records. Omit to render the legacy setup dashboard.
   postMega = null,
@@ -918,6 +919,10 @@ export function renderSpellingSurfaceFixture({
     const controller = createLocalAppController();
     const selectedPhase = ${JSON.stringify(phase)};
     const learnerId = controller.store.getState().learners.selectedId;
+    const prefs = ${JSON.stringify(prefs)};
+    if (prefs && typeof prefs === 'object') {
+      controller.services.spelling.savePrefs(learnerId, prefs);
+    }
     const postMega = ${JSON.stringify(postMega)};
     if (postMega) {
       // Seed all core words as stage-4 secure, then optionally drop a guardian

--- a/tests/helpers/react-render.js
+++ b/tests/helpers/react-render.js
@@ -996,6 +996,34 @@ export function renderSpellingSurfaceFixture({
   `);
 }
 
+export function renderSpellingWordBankSceneFixture({
+  analytics,
+  transientUi = {},
+  postMastery = null,
+} = {}) {
+  return renderFixture(`
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { SpellingWordBankScene } from ${JSON.stringify(absoluteSpecifier('src/subjects/spelling/components/SpellingWordBankScene.jsx'))};
+
+    const analytics = ${JSON.stringify(analytics || { wordGroups: [], wordBank: {} })};
+    const transientUi = ${JSON.stringify(transientUi || {})};
+    const postMastery = ${JSON.stringify(postMastery)};
+    const actions = { dispatch() {} };
+    const html = renderToStaticMarkup(
+      <SpellingWordBankScene
+        appState={{ transientUi }}
+        learner={{ id: 'learner-a', name: 'Nelson' }}
+        analytics={analytics}
+        accent="#3E6FA8"
+        actions={actions}
+        postMastery={postMastery}
+      />
+    );
+    console.log(html);
+  `);
+}
+
 /**
  * Render the Spelling summary scene after a Guardian Mission round ends.
  *

--- a/tests/helpers/react-render.js
+++ b/tests/helpers/react-render.js
@@ -900,6 +900,7 @@ export function renderSubjectRouteFixture({ subject = 'placeholder' } = {}) {
 export function renderSpellingSurfaceFixture({
   phase = 'setup',
   pendingCommand = '',
+  wordBankAnalytics = null,
   // postMega: {} → force allWordsMega via seeded progress + optional guardian
   // records. Omit to render the legacy setup dashboard.
   postMega = null,
@@ -970,6 +971,10 @@ export function renderSpellingSurfaceFixture({
     }
     if (selectedPhase === 'word-bank' || selectedPhase === 'modal') {
       controller.dispatch('spelling-open-word-bank');
+    }
+    const wordBankAnalytics = ${JSON.stringify(wordBankAnalytics)};
+    if (wordBankAnalytics) {
+      controller.store.updateSubjectUi('spelling', { analytics: wordBankAnalytics });
     }
     if (selectedPhase === 'modal') {
       controller.dispatch('spelling-word-detail-open', { slug: 'possess', value: 'drill' });

--- a/tests/platform-length-picker.test.js
+++ b/tests/platform-length-picker.test.js
@@ -141,6 +141,39 @@ test('LengthPicker: without `unit` renders the bare .length-picker (Spelling yea
   assert.match(html, /<button[^>]*value="core"[^>]*><span>Core<\/span>/);
 });
 
+test('LengthPicker: measured slider mode is opt-in and keeps selected fallback markup', async () => {
+  const html = await runFixture(`
+    ${renderHeader(componentSpec)}
+    const tree = React.createElement(LengthPicker, {
+      options: [
+        { value: 'core', label: 'Core' },
+        { value: 'secure-extension', label: 'Secure vocabulary' },
+        { value: 'extra', label: 'Extra' },
+      ],
+      selectedValue: 'secure-extension',
+      onChange: () => {},
+      ariaLabel: 'Spelling pool',
+      className: 'pool-picker',
+      sliderMode: 'measured',
+      actionName: 'spelling-set-pref',
+      prefKey: 'yearFilter',
+      includeDataValue: true,
+    });
+    console.log(renderToStaticMarkup(tree));
+  `);
+  assert.match(
+    html,
+    /^<div class="length-picker pool-picker" role="radiogroup" aria-label="Spelling pool" style="--option-count:3;--selected-index:1" data-slider-mode="measured">/,
+  );
+  assert.doesNotMatch(html, /data-slider-ready/);
+  const securePoolButtonMatch = html.match(
+    /<button\b(?=[^>]*data-value="secure-extension")(?=[^>]*value="secure-extension")[^>]*>[\s\S]*?<span>Secure vocabulary<\/span><\/button>/,
+  );
+  assert.ok(securePoolButtonMatch, 'expected secure vocabulary option');
+  assert.match(securePoolButtonMatch[0], /class="length-option selected"/);
+  assert.match(securePoolButtonMatch[0], /aria-checked="true"/);
+});
+
 // ---------------------------------------------------------------
 // Edge case: zero-length options array.
 // ---------------------------------------------------------------

--- a/tests/react-spelling-surface.test.js
+++ b/tests/react-spelling-surface.test.js
@@ -33,6 +33,16 @@ test('React spelling setup scene can select the secure vocabulary pool', async (
   assert.ok(securePoolButtonMatch, 'expected a secure vocabulary pool button with the yearFilter payload');
   assert.match(securePoolButtonMatch[0], /class="length-option selected"/);
   assert.match(securePoolButtonMatch[0], /aria-checked="true"/);
+  assert.match(html, /<p class="eyebrow">Secure vocabulary<\/p>/);
+  assert.match(
+    html,
+    /<div class="ss-stat-label">Secure vocabulary words<\/div><div class="ss-stat-value">1215<\/div>/,
+  );
+  assert.match(
+    html,
+    /<div class="ss-stat-label">Not tried yet<\/div><div class="ss-stat-value">1215<\/div>/,
+  );
+  assert.match(html, /Secure vocabulary words for Learner 1, with progress and difficulty\./);
 });
 
 test('React spelling setup scene disables start while a remote start is pending', async () => {
@@ -137,6 +147,41 @@ test('client spelling read model preserves word-family variant preference', () =
   });
 
   assert.equal(service.getPrefs('learner-a').extraWordFamilies, true);
+});
+
+test('client spelling read model uses analytics pool stats before falling back to core', () => {
+  const service = createSpellingReadModelService({
+    getState: () => ({
+      learners: { selectedId: 'learner-a' },
+      subjectUi: {
+        spelling: {
+          subjectId: 'spelling',
+          learnerId: 'learner-a',
+          version: 3,
+          prefs: {
+            mode: 'smart',
+            yearFilter: 'secure-extension',
+            roundLength: '20',
+            showCloze: true,
+            autoSpeak: true,
+          },
+          stats: {
+            core: { total: 213, secure: 0, due: 0, trouble: 0, fresh: 213 },
+          },
+          analytics: {
+            pools: {
+              secureExtension: { total: 1215, secure: 35, due: 0, trouble: 0, fresh: 1180 },
+            },
+          },
+        },
+      },
+    }),
+  });
+
+  const secureStats = service.getStats('learner-a', 'secure-extension');
+  assert.equal(secureStats.total, 1215);
+  assert.equal(secureStats.secure, 35);
+  assert.equal(secureStats.fresh, 1180);
 });
 
 // ----- U1: remote-sync fallback getPostMasteryState stub ---------------------

--- a/tests/react-spelling-surface.test.js
+++ b/tests/react-spelling-surface.test.js
@@ -17,6 +17,24 @@ test('React spelling setup scene renders primary practice controls', async () =>
   assert.match(html, /data-action="spelling-start"/);
 });
 
+test('React spelling setup scene can select the secure vocabulary pool', async () => {
+  const html = await renderSpellingSurfaceFixture({
+    phase: 'setup',
+    prefs: { yearFilter: 'secure-extension' },
+  });
+
+  assert.match(
+    html,
+    /<div class="length-picker pool-picker" role="radiogroup" aria-label="Spelling pool"/,
+  );
+  const securePoolButtonMatch = html.match(
+    /<button\b(?=[^>]*data-action="spelling-set-pref")(?=[^>]*data-pref="yearFilter")(?=[^>]*data-value="secure-extension")(?=[^>]*value="secure-extension")[^>]*>[\s\S]*?<span>Secure vocabulary<\/span><\/button>/,
+  );
+  assert.ok(securePoolButtonMatch, 'expected a secure vocabulary pool button with the yearFilter payload');
+  assert.match(securePoolButtonMatch[0], /class="length-option selected"/);
+  assert.match(securePoolButtonMatch[0], /aria-checked="true"/);
+});
+
 test('React spelling setup scene disables start while a remote start is pending', async () => {
   const html = await renderSpellingSurfaceFixture({
     phase: 'setup',

--- a/tests/react-spelling-surface.test.js
+++ b/tests/react-spelling-surface.test.js
@@ -518,6 +518,18 @@ test('React spelling Word Bank keeps sibling category counts when Extra is selec
   assert.match(html, /Showing 52 of 52 Extra spellings/);
 });
 
+test('React spelling Word Bank surface uses server-loaded analytics', async () => {
+  const html = await renderSpellingSurfaceFixture({
+    phase: 'word-bank',
+    wordBankAnalytics: wordBankFacetAnalytics({ year: 'all' }),
+  });
+
+  assert.doesNotMatch(html, /No words yet/);
+  assert.match(html, /data-value="extra"[\s\S]*?<span class="wb-chip-count"[^>]*>52<\/span>/);
+  assert.match(html, /Showing 38 visible spellings from 250 loaded rows/);
+  assert.match(html, /265 authorised matches available/);
+});
+
 test('React spelling Word Bank renders the 4 Guardian chips only when allWordsMega is true', async () => {
   const today = Math.floor(Date.now() / (24 * 60 * 60 * 1000));
   const html = await renderSpellingSurfaceFixture({

--- a/tests/react-spelling-surface.test.js
+++ b/tests/react-spelling-surface.test.js
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict';
 import {
   renderSpellingClozeFixture,
   renderSpellingGuardianSummaryFixture,
+  renderSpellingWordBankSceneFixture,
   renderSpellingSurfaceFixture,
 } from './helpers/react-render.js';
 import { createSpellingReadModelService } from '../src/subjects/spelling/client-read-models.js';
@@ -419,6 +420,102 @@ test('React spelling Word Bank renders the legacy 6-chip row identically when al
   // Legacy chips must still be present.
   assert.match(html, /data-action="spelling-analytics-status-filter"[^>]*data-value="all"/);
   assert.match(html, /data-action="spelling-analytics-status-filter"[^>]*data-value="secure"/);
+});
+
+function wordBankFacetAnalytics({ year = 'all' } = {}) {
+  const extraRows = Array.from({ length: year === 'extra' ? 52 : 37 }, (_, index) => ({
+    slug: `extra-${index}`,
+    word: `extra-${index}`,
+    status: index < 35 ? 'secure' : index < 41 ? 'learning' : 'new',
+    year: 'extra',
+    yearLabel: 'Extra',
+    spellingPool: 'extra',
+    progress: { stage: index < 35 ? 4 : 0, attempts: index < 41 ? 1 : 0, correct: index < 35 ? 1 : 0, wrong: 0 },
+  }));
+  const y34Rows = year === 'all'
+    ? [{
+        slug: 'accident',
+        word: 'accident',
+        status: 'secure',
+        year: '3-4',
+        yearLabel: 'Years 3-4',
+        spellingPool: 'core',
+        progress: { stage: 4, attempts: 1, correct: 1, wrong: 0 },
+      }]
+    : [];
+  return {
+    wordGroups: [
+      { key: 'y3-4', title: 'Years 3-4', words: y34Rows },
+      { key: 'extra', title: 'Extra', words: extraRows },
+    ],
+    wordBank: {
+      page: 1,
+      pageSize: 250,
+      totalRows: 265,
+      filteredRows: year === 'extra' ? 52 : 265,
+      returnedRows: year === 'extra' ? 52 : 250,
+      hasNextPage: year !== 'extra',
+      facets: {
+        version: 1,
+        categories: {
+          all: 265,
+          core: 213,
+          'y3-4': 109,
+          'y5-6': 104,
+          'secure-extension': 0,
+          extra: 52,
+        },
+        status: {
+          all: year === 'extra' ? 52 : 265,
+          total: year === 'extra' ? 52 : 265,
+          secure: year === 'extra' ? 35 : 207,
+          due: year === 'extra' ? 0 : 40,
+          trouble: 0,
+          weak: 0,
+          learning: year === 'extra' ? 6 : 6,
+          unseen: year === 'extra' ? 11 : 12,
+          guardianDue: 0,
+          wobbling: 0,
+          renewedRecently: 0,
+          neverRenewed: 0,
+        },
+        categoryStatus: {
+          core: { all: 213, total: 213, secure: 172, due: 40, trouble: 0, weak: 0, learning: 1, unseen: 0 },
+          'y3-4': { all: 109, total: 109, secure: 80, due: 28, trouble: 0, weak: 0, learning: 1, unseen: 0 },
+          'y5-6': { all: 104, total: 104, secure: 92, due: 12, trouble: 0, weak: 0, learning: 0, unseen: 0 },
+          'secure-extension': { all: 0, total: 0, secure: 0, due: 0, trouble: 0, weak: 0, learning: 0, unseen: 0 },
+          extra: { all: 52, total: 52, secure: 35, due: 0, trouble: 0, weak: 0, learning: 6, unseen: 11 },
+        },
+      },
+    },
+  };
+}
+
+test('React spelling Word Bank uses server facets when All page rows are truncated', async () => {
+  const html = await renderSpellingWordBankSceneFixture({
+    analytics: wordBankFacetAnalytics({ year: 'all' }),
+  });
+
+  assert.match(html, /data-value="extra"[\s\S]*?<span class="wb-chip-count"[^>]*>52<\/span>/);
+  assert.match(html, /data-value="all"[\s\S]*?<span class="wb-chip-count"[^>]*>265<\/span>/);
+  assert.match(html, /Showing 38 visible spellings from 250 loaded rows/);
+  assert.match(html, /265 authorised matches available/);
+  assert.match(html, /Expansion spelling pool[\s\S]*?Total[\s\S]*?52/);
+});
+
+test('React spelling Word Bank keeps sibling category counts when Extra is selected', async () => {
+  const html = await renderSpellingWordBankSceneFixture({
+    analytics: wordBankFacetAnalytics({ year: 'extra' }),
+    transientUi: { spellingAnalyticsYearFilter: 'extra' },
+  });
+
+  assert.match(html, /Extra selected[\s\S]*?52 of 265 words/);
+  assert.match(html, /data-value="y3-4"[\s\S]*?<span class="wb-chip-count"[^>]*>109<\/span>/);
+  assert.match(html, /data-value="y5-6"[\s\S]*?<span class="wb-chip-count"[^>]*>104<\/span>/);
+  assert.match(html, /data-value="extra"[\s\S]*?<span class="wb-chip-count"[^>]*>52<\/span>/);
+  assert.match(html, /data-value="secure"[\s\S]*?<span class="wb-chip-count"[^>]*>35<\/span>/);
+  assert.match(html, /data-value="unseen"[\s\S]*?<span class="wb-chip-count"[^>]*>11<\/span>/);
+  assert.match(html, /Showing 52 of 52 Extra spellings/);
 });
 
 test('React spelling Word Bank renders the 4 Guardian chips only when allWordsMega is true', async () => {

--- a/tests/react-spelling-surface.test.js
+++ b/tests/react-spelling-surface.test.js
@@ -487,7 +487,42 @@ test('React spelling Word Bank renders the legacy 6-chip row identically when al
 });
 
 function wordBankFacetAnalytics({ year = 'all' } = {}) {
-  const extraRows = Array.from({ length: year === 'extra' ? 52 : 37 }, (_, index) => ({
+  const y34Rows = year === 'all'
+    ? Array.from({ length: 109 }, (_, index) => ({
+        slug: `y34-${index}`,
+        word: index === 0 ? 'accident' : `y34-${index}`,
+        status: 'new',
+        year: '3-4',
+        yearLabel: 'Years 3-4',
+        spellingPool: 'core',
+        progress: { stage: 0, attempts: 0, correct: 0, wrong: 0 },
+      }))
+    : [];
+  const y56Rows = year === 'all'
+    ? Array.from({ length: 104 }, (_, index) => ({
+        slug: `y56-${index}`,
+        word: `y56-${index}`,
+        status: 'new',
+        year: '5-6',
+        yearLabel: 'Years 5-6',
+        spellingPool: 'core',
+        progress: { stage: 0, attempts: 0, correct: 0, wrong: 0 },
+      }))
+    : [];
+  const secureRows = year === 'all' || year === 'secure-extension'
+    ? Array.from({ length: 1215 }, (_, index) => ({
+        slug: `secure-${index}`,
+        word: `secure-word-${index}`,
+        status: 'new',
+        year: 'secure-extension',
+        yearLabel: 'Secure vocabulary',
+        spellingPool: 'core',
+        coverageTier: 'secure-extension',
+        progress: { stage: 0, attempts: 0, correct: 0, wrong: 0 },
+      }))
+    : [];
+  const extraRows = year === 'all' || year === 'extra'
+    ? Array.from({ length: 52 }, (_, index) => ({
     slug: `extra-${index}`,
     word: `extra-${index}`,
     status: index < 35 ? 'secure' : index < 41 ? 'learning' : 'new',
@@ -495,59 +530,57 @@ function wordBankFacetAnalytics({ year = 'all' } = {}) {
     yearLabel: 'Extra',
     spellingPool: 'extra',
     progress: { stage: index < 35 ? 4 : 0, attempts: index < 41 ? 1 : 0, correct: index < 35 ? 1 : 0, wrong: 0 },
-  }));
-  const y34Rows = year === 'all'
-    ? [{
-        slug: 'accident',
-        word: 'accident',
-        status: 'secure',
-        year: '3-4',
-        yearLabel: 'Years 3-4',
-        spellingPool: 'core',
-        progress: { stage: 4, attempts: 1, correct: 1, wrong: 0 },
-      }]
+  }))
     : [];
+  const returnedRows = y34Rows.length + y56Rows.length + secureRows.length + extraRows.length;
+  const filteredRows = year === 'extra' ? 52 : year === 'secure-extension' ? 1215 : 1480;
+  const statusTotal = filteredRows;
+  const statusSecure = year === 'extra' ? 35 : 0;
+  const statusLearning = year === 'extra' ? 6 : 0;
+  const statusUnseen = year === 'extra' ? 11 : statusTotal;
   return {
     wordGroups: [
       { key: 'y3-4', title: 'Years 3-4', words: y34Rows },
+      { key: 'y5-6', title: 'Years 5-6', words: y56Rows },
+      { key: 'secure-extension', title: 'Secure vocabulary', words: secureRows },
       { key: 'extra', title: 'Extra', words: extraRows },
     ],
     wordBank: {
       page: 1,
-      pageSize: 250,
-      totalRows: 265,
-      filteredRows: year === 'extra' ? 52 : 265,
-      returnedRows: year === 'extra' ? 52 : 250,
-      hasNextPage: year !== 'extra',
+      pageSize: 5000,
+      totalRows: 1480,
+      filteredRows,
+      returnedRows,
+      hasNextPage: false,
       facets: {
         version: 1,
         categories: {
-          all: 265,
+          all: 1480,
           core: 213,
           'y3-4': 109,
           'y5-6': 104,
-          'secure-extension': 0,
+          'secure-extension': 1215,
           extra: 52,
         },
         status: {
-          all: year === 'extra' ? 52 : 265,
-          total: year === 'extra' ? 52 : 265,
-          secure: year === 'extra' ? 35 : 207,
-          due: year === 'extra' ? 0 : 40,
+          all: statusTotal,
+          total: statusTotal,
+          secure: statusSecure,
+          due: 0,
           trouble: 0,
           weak: 0,
-          learning: year === 'extra' ? 6 : 6,
-          unseen: year === 'extra' ? 11 : 12,
+          learning: statusLearning,
+          unseen: statusUnseen,
           guardianDue: 0,
           wobbling: 0,
           renewedRecently: 0,
           neverRenewed: 0,
         },
         categoryStatus: {
-          core: { all: 213, total: 213, secure: 172, due: 40, trouble: 0, weak: 0, learning: 1, unseen: 0 },
-          'y3-4': { all: 109, total: 109, secure: 80, due: 28, trouble: 0, weak: 0, learning: 1, unseen: 0 },
-          'y5-6': { all: 104, total: 104, secure: 92, due: 12, trouble: 0, weak: 0, learning: 0, unseen: 0 },
-          'secure-extension': { all: 0, total: 0, secure: 0, due: 0, trouble: 0, weak: 0, learning: 0, unseen: 0 },
+          core: { all: 213, total: 213, secure: 0, due: 0, trouble: 0, weak: 0, learning: 0, unseen: 213 },
+          'y3-4': { all: 109, total: 109, secure: 0, due: 0, trouble: 0, weak: 0, learning: 0, unseen: 109 },
+          'y5-6': { all: 104, total: 104, secure: 0, due: 0, trouble: 0, weak: 0, learning: 0, unseen: 104 },
+          'secure-extension': { all: 1215, total: 1215, secure: 0, due: 0, trouble: 0, weak: 0, learning: 0, unseen: 1215 },
           extra: { all: 52, total: 52, secure: 35, due: 0, trouble: 0, weak: 0, learning: 6, unseen: 11 },
         },
       },
@@ -555,15 +588,17 @@ function wordBankFacetAnalytics({ year = 'all' } = {}) {
   };
 }
 
-test('React spelling Word Bank uses server facets when All page rows are truncated', async () => {
+test('React spelling Word Bank renders complete All rows when category totals are complete', async () => {
   const html = await renderSpellingWordBankSceneFixture({
     analytics: wordBankFacetAnalytics({ year: 'all' }),
   });
 
   assert.match(html, /data-value="extra"[\s\S]*?<span class="wb-chip-count"[^>]*>52<\/span>/);
-  assert.match(html, /data-value="all"[\s\S]*?<span class="wb-chip-count"[^>]*>265<\/span>/);
-  assert.match(html, /Showing 38 visible spellings from 250 loaded rows/);
-  assert.match(html, /265 authorised matches available/);
+  assert.match(html, /data-value="secure-extension"[\s\S]*?<span class="wb-chip-count"[^>]*>1215<\/span>/);
+  assert.match(html, /data-value="all"[\s\S]*?<span class="wb-chip-count"[^>]*>1480<\/span>/);
+  assert.match(html, /Secure vocabulary[\s\S]*?secure-word-0/);
+  assert.match(html, /Extra[\s\S]*?extra-51/);
+  assert.match(html, /Showing 1480 of 1480 tracked spellings/);
   assert.match(html, /Expansion spelling pool[\s\S]*?Total[\s\S]*?52/);
 });
 
@@ -573,7 +608,7 @@ test('React spelling Word Bank keeps sibling category counts when Extra is selec
     transientUi: { spellingAnalyticsYearFilter: 'extra' },
   });
 
-  assert.match(html, /Extra selected[\s\S]*?52 of 265 words/);
+  assert.match(html, /Extra selected[\s\S]*?52 of 1480 words/);
   assert.match(html, /data-value="y3-4"[\s\S]*?<span class="wb-chip-count"[^>]*>109<\/span>/);
   assert.match(html, /data-value="y5-6"[\s\S]*?<span class="wb-chip-count"[^>]*>104<\/span>/);
   assert.match(html, /data-value="extra"[\s\S]*?<span class="wb-chip-count"[^>]*>52<\/span>/);
@@ -590,8 +625,10 @@ test('React spelling Word Bank surface uses server-loaded analytics', async () =
 
   assert.doesNotMatch(html, /No words yet/);
   assert.match(html, /data-value="extra"[\s\S]*?<span class="wb-chip-count"[^>]*>52<\/span>/);
-  assert.match(html, /Showing 38 visible spellings from 250 loaded rows/);
-  assert.match(html, /265 authorised matches available/);
+  assert.match(html, /data-value="secure-extension"[\s\S]*?<span class="wb-chip-count"[^>]*>1215<\/span>/);
+  assert.match(html, /Secure vocabulary[\s\S]*?secure-word-0/);
+  assert.match(html, /Extra[\s\S]*?extra-51/);
+  assert.match(html, /Showing 1480 of 1480 tracked spellings/);
 });
 
 test('React spelling Word Bank renders the 4 Guardian chips only when allWordsMega is true', async () => {

--- a/tests/react-spelling-surface.test.js
+++ b/tests/react-spelling-surface.test.js
@@ -27,6 +27,7 @@ test('React spelling setup scene can select the secure vocabulary pool', async (
     html,
     /<div class="length-picker pool-picker" role="radiogroup" aria-label="Spelling pool"/,
   );
+  assert.match(html, /data-slider-mode="measured"/);
   const securePoolButtonMatch = html.match(
     /<button\b(?=[^>]*data-action="spelling-set-pref")(?=[^>]*data-pref="yearFilter")(?=[^>]*data-value="secure-extension")(?=[^>]*value="secure-extension")[^>]*>[\s\S]*?<span>Secure vocabulary<\/span><\/button>/,
   );

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -27,9 +27,11 @@ test('spelling setup renders pool choices without the legacy All label', () => {
   const html = harness.render();
 
   assert.match(html, /aria-label="Spelling pool"/);
-  assert.match(html, /data-pref="yearFilter" value="core"/);
-  assert.match(html, /data-pref="yearFilter" value="extra"/);
+  assert.match(html, /<button\b(?=[^>]*data-pref="yearFilter")(?=[^>]*data-value="core")(?=[^>]*value="core")[^>]*>/);
+  assert.match(html, /<button\b(?=[^>]*data-pref="yearFilter")(?=[^>]*data-value="secure-extension")(?=[^>]*value="secure-extension")[^>]*>/);
+  assert.match(html, /<button\b(?=[^>]*data-pref="yearFilter")(?=[^>]*data-value="extra")(?=[^>]*value="extra")[^>]*>/);
   assert.match(html, />Core<\/span>/);
+  assert.match(html, />Secure vocabulary<\/span>/);
   assert.match(html, />Extra<\/span>/);
   assert.doesNotMatch(html, />All<\/span>/);
   assert.doesNotMatch(html, /Year group/);

--- a/tests/server-spelling-engine-parity.test.js
+++ b/tests/server-spelling-engine-parity.test.js
@@ -238,6 +238,30 @@ test('server spelling engine preserves deterministic selection and retry progres
   assert.deepEqual(serverSubmitted.data.progress, {});
 });
 
+test('server spelling command stats include secure vocabulary pool', () => {
+  const server = createServerSpellingEngine({
+    now: () => Date.UTC(2026, 0, 1),
+    random: makeSeededRandom(7),
+    contentSnapshot: contentSnapshot(),
+  });
+
+  const result = server.apply({
+    learnerId: 'learner-a',
+    subjectRecord: { ui: null, data: {} },
+    latestSession: null,
+    command: 'save-prefs',
+    payload: {
+      prefs: { yearFilter: 'secure-extension' },
+    },
+  });
+
+  assert.equal(result.prefs.yearFilter, 'secure-extension');
+  assert.equal(result.stats.core.total, 213);
+  assert.equal(result.stats.secureExtension.total, 1215);
+  assert.equal(result.stats.secureExtension.fresh, 1215);
+  assert.notEqual(result.stats.secureExtension.total, result.stats.core.total);
+});
+
 test('worker spelling command route starts, submits, continues, and completes server-side', async () => {
   const server = createWorkerRepositoryServer();
   seedAccountLearner(server.DB);

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -194,7 +194,8 @@ test('spelling word bank opens from setup and exposes searchable progress with e
   html = harness.render();
   assert.match(html, /value="extra"[^>]*>\s*<span>Extra<\/span>/);
   assert.match(html, /data-pref="extraWordFamilies"[\s\S]*Word-family variants/);
-  assert.match(html, new RegExp(`ss-stat-label">Total spellings</div>\\s*<div class="ss-stat-value"[^>]*>${EXTRA_SPELLING_WORDS}</div>`));
+  assert.match(html, /<p class="eyebrow">Extra pool<\/p>/);
+  assert.match(html, new RegExp(`ss-stat-label">Extra words</div>\\s*<div class="ss-stat-value"[^>]*>${EXTRA_SPELLING_WORDS}</div>`));
   assert.match(html, /value="trouble"[^>]*disabled[^>]*>[\s\S]*Trouble Drill/);
 
   /* The Codex Journal redesign folds the old Analytics tab into a standalone

--- a/tests/spelling-content-api.test.js
+++ b/tests/spelling-content-api.test.js
@@ -330,15 +330,38 @@ test('worker spelling word bank route returns the complete Extra pool when categ
   try {
     seedAccountLearner(server.DB);
 
+    const allResponse = await server.fetch('https://repo.test/api/subjects/spelling/word-bank?learnerId=learner-a&pageSize=250');
+    const allPayload = await allResponse.json();
+    const allRows = allPayload.wordBank.analytics.wordGroups.flatMap((group) => group.words);
+
+    assert.equal(allResponse.status, 200);
+    assert.equal(allPayload.wordBank.analytics.wordBank.returnedRows, 250);
+    assert.equal(allPayload.wordBank.analytics.wordBank.hasNextPage, true);
+    assert.equal(allRows.filter((word) => word.spellingPool === 'extra').length, 37);
+    assert.equal(allPayload.wordBank.analytics.wordBank.facets.categories.extra, 52);
+    assert.equal(allPayload.wordBank.analytics.wordBank.facets.categoryStatus.extra.total, 52);
+    assert.ok(allPayload.wordBank.analytics.wordBank.facets.categories['y3-4'] > 0);
+    assert.ok(allPayload.wordBank.analytics.wordBank.facets.categories['y5-6'] > 0);
+
     const response = await server.fetch('https://repo.test/api/subjects/spelling/word-bank?learnerId=learner-a&pageSize=250&year=extra');
     const payload = await response.json();
     const rows = payload.wordBank.analytics.wordGroups.flatMap((group) => group.words);
+    const facets = payload.wordBank.analytics.wordBank.facets;
 
     assert.equal(response.status, 200);
     assert.equal(payload.wordBank.analytics.pools.extra.total, 52);
     assert.equal(payload.wordBank.analytics.wordBank.filteredRows, 52);
     assert.equal(payload.wordBank.analytics.wordBank.returnedRows, 52);
     assert.equal(payload.wordBank.analytics.wordBank.hasNextPage, false);
+    assert.equal(facets.categories.extra, 52);
+    assert.ok(facets.categories['y3-4'] > 0);
+    assert.ok(facets.categories['y5-6'] > 0);
+    assert.equal(facets.status.total, 52);
+    assert.equal(
+      facets.status.secure + facets.status.due + facets.status.trouble + facets.status.learning + facets.status.unseen,
+      52,
+    );
+    assert.equal(facets.categoryStatus.extra.total, 52);
     assert.equal(rows.length, 52);
     assert.equal(rows.every((word) => word.spellingPool === 'extra'), true);
   } finally {

--- a/tests/spelling-content-api.test.js
+++ b/tests/spelling-content-api.test.js
@@ -325,25 +325,29 @@ test('worker spelling word bank route returns paginated public rows and detail a
   }
 });
 
-test('worker spelling word bank route returns the complete Extra pool when category-filtered', async () => {
+test('worker spelling word bank route returns complete category rows with the expanded page size', async () => {
   const server = createWorkerRepositoryServer();
   try {
     seedAccountLearner(server.DB);
 
-    const allResponse = await server.fetch('https://repo.test/api/subjects/spelling/word-bank?learnerId=learner-a&pageSize=250');
+    const allResponse = await server.fetch('https://repo.test/api/subjects/spelling/word-bank?learnerId=learner-a&pageSize=5000');
     const allPayload = await allResponse.json();
     const allRows = allPayload.wordBank.analytics.wordGroups.flatMap((group) => group.words);
 
     assert.equal(allResponse.status, 200);
-    assert.equal(allPayload.wordBank.analytics.wordBank.returnedRows, 250);
-    assert.equal(allPayload.wordBank.analytics.wordBank.hasNextPage, true);
-    assert.equal(allRows.filter((word) => word.spellingPool === 'extra').length, 37);
+    assert.equal(allPayload.wordBank.analytics.wordBank.returnedRows, 1480);
+    assert.equal(allPayload.wordBank.analytics.wordBank.hasNextPage, false);
+    assert.equal(allRows.length, 1480);
+    assert.equal(allRows.filter((word) => word.spellingPool === 'extra').length, 52);
+    assert.equal(allRows.filter((word) => word.coverageTier === 'secure-extension').length, 1215);
     assert.equal(allPayload.wordBank.analytics.wordBank.facets.categories.extra, 52);
+    assert.equal(allPayload.wordBank.analytics.wordBank.facets.categories['secure-extension'], 1215);
     assert.equal(allPayload.wordBank.analytics.wordBank.facets.categoryStatus.extra.total, 52);
+    assert.equal(allPayload.wordBank.analytics.wordBank.facets.categoryStatus['secure-extension'].total, 1215);
     assert.ok(allPayload.wordBank.analytics.wordBank.facets.categories['y3-4'] > 0);
     assert.ok(allPayload.wordBank.analytics.wordBank.facets.categories['y5-6'] > 0);
 
-    const response = await server.fetch('https://repo.test/api/subjects/spelling/word-bank?learnerId=learner-a&pageSize=250&year=extra');
+    const response = await server.fetch('https://repo.test/api/subjects/spelling/word-bank?learnerId=learner-a&pageSize=5000&year=extra');
     const payload = await response.json();
     const rows = payload.wordBank.analytics.wordGroups.flatMap((group) => group.words);
     const facets = payload.wordBank.analytics.wordBank.facets;

--- a/tests/spelling-content-api.test.js
+++ b/tests/spelling-content-api.test.js
@@ -325,6 +325,27 @@ test('worker spelling word bank route returns paginated public rows and detail a
   }
 });
 
+test('worker spelling word bank route returns the complete Extra pool when category-filtered', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    seedAccountLearner(server.DB);
+
+    const response = await server.fetch('https://repo.test/api/subjects/spelling/word-bank?learnerId=learner-a&pageSize=250&year=extra');
+    const payload = await response.json();
+    const rows = payload.wordBank.analytics.wordGroups.flatMap((group) => group.words);
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.wordBank.analytics.pools.extra.total, 52);
+    assert.equal(payload.wordBank.analytics.wordBank.filteredRows, 52);
+    assert.equal(payload.wordBank.analytics.wordBank.returnedRows, 52);
+    assert.equal(payload.wordBank.analytics.wordBank.hasNextPage, false);
+    assert.equal(rows.length, 52);
+    assert.equal(rows.every((word) => word.spellingPool === 'extra'), true);
+  } finally {
+    server.close();
+  }
+});
+
 test('worker spelling word bank route controls empty, high-page, and invalid-detail cases', async () => {
   const server = createWorkerRepositoryServer();
   try {

--- a/tests/spelling-core.test.js
+++ b/tests/spelling-core.test.js
@@ -8,7 +8,7 @@ import { createSpellingPersistence } from '../src/subjects/spelling/repository.j
 import { SPELLING_EVENT_TYPES } from '../src/subjects/spelling/events.js';
 import { SPELLING_SERVICE_STATE_VERSION } from '../src/subjects/spelling/service-contract.js';
 import { WORDS, WORD_BY_SLUG } from '../src/subjects/spelling/data/word-data.js';
-import { isStatutoryCoreWord } from '../src/subjects/spelling/content/taxonomy.js';
+import { isSecureExtensionWord, isStatutoryCoreWord } from '../src/subjects/spelling/content/taxonomy.js';
 import { rewardEventsFromSpellingEvents } from '../src/subjects/spelling/event-hooks.js';
 import { monsterSummaryFromSpellingAnalytics } from '../src/platform/game/monster-system.js';
 import { getOverallSpellingStats, spellingModule } from '../src/subjects/spelling/module.js';
@@ -153,6 +153,22 @@ test('Smart Review can be scoped to the Extra spelling pool', () => {
   assert.equal(words.length, 6);
   assert.ok(words.every((word) => word.spellingPool === 'extra'));
   assert.ok(words.every((word) => word.year === 'extra'));
+});
+
+test('Smart Review can be scoped to the secure vocabulary pool', () => {
+  const { service } = makeService({ random: makeSeededRandom(7) });
+  const transition = service.startSession('learner-a', {
+    mode: 'smart',
+    yearFilter: 'secure-extension',
+    length: 6,
+  });
+
+  assert.equal(transition.ok, true);
+  const words = sessionWords(transition.state.session);
+  assert.equal(words.length, 6);
+  assert.ok(words.every((word) => word.spellingPool === 'core'));
+  assert.ok(words.every((word) => word.coverageTier === 'secure-extension'));
+  assert.ok(words.every((word) => isSecureExtensionWord(word)));
 });
 
 test('Smart Review reuses one progress snapshot when starting from dense learner history', () => {

--- a/tests/spelling-pool-taxonomy.test.js
+++ b/tests/spelling-pool-taxonomy.test.js
@@ -1,0 +1,125 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  SPELLING_ANALYTICS_POOL_CATEGORIES,
+  SPELLING_ANALYTICS_WORD_GROUP_CATEGORIES,
+  SPELLING_POOL_CATEGORIES,
+  SPELLING_SETUP_POOL_IDS,
+  SPELLING_WORD_BANK_FILTER_IDS,
+  normaliseSpellingPoolCategoryId,
+  normaliseSpellingSetupPoolId,
+  normaliseSpellingWordBankFilterId,
+  spellingPoolCategoryById,
+  spellingPoolCategoryMatchesWord,
+  spellingPoolStatsKey,
+  spellingSetupPoolOptions,
+  spellingWordBankFilterOptions,
+  validateSpellingPoolCategories,
+} from '../shared/spelling/pool-taxonomy.js';
+
+test('Spelling pool taxonomy pins current category ids, order, and visibility', () => {
+  assert.deepEqual(
+    SPELLING_POOL_CATEGORIES.map((category) => category.id),
+    ['all', 'core', 'y3-4', 'y5-6', 'secure-extension', 'extra'],
+  );
+  assert.deepEqual(SPELLING_SETUP_POOL_IDS, ['core', 'y3-4', 'y5-6', 'secure-extension', 'extra']);
+  assert.deepEqual(SPELLING_WORD_BANK_FILTER_IDS, ['all', 'y3-4', 'y5-6', 'secure-extension', 'extra']);
+  assert.deepEqual(
+    SPELLING_ANALYTICS_POOL_CATEGORIES.map((category) => category.statsKey),
+    ['core', 'y34', 'y56', 'secureExtension', 'extra'],
+  );
+  assert.deepEqual(
+    SPELLING_ANALYTICS_WORD_GROUP_CATEGORIES.map((category) => category.id),
+    ['y3-4', 'y5-6', 'secure-extension', 'extra'],
+  );
+});
+
+test('Spelling pool taxonomy drives setup and Word Bank options', () => {
+  assert.deepEqual(spellingSetupPoolOptions(), [
+    { value: 'core', label: 'Core' },
+    { value: 'y3-4', label: 'Y3-4' },
+    { value: 'y5-6', label: 'Y5-6' },
+    { value: 'secure-extension', label: 'Secure vocabulary' },
+    { value: 'extra', label: 'Extra' },
+  ]);
+  assert.deepEqual(spellingWordBankFilterOptions(), [
+    { id: 'all', label: 'All' },
+    { id: 'y3-4', label: 'Years 3-4' },
+    { id: 'y5-6', label: 'Years 5-6' },
+    { id: 'secure-extension', label: 'Secure vocabulary' },
+    { id: 'extra', label: 'Extra' },
+  ]);
+});
+
+test('Spelling pool taxonomy maps filter ids to stats keys and safe defaults', () => {
+  assert.equal(spellingPoolStatsKey('y3-4'), 'y34');
+  assert.equal(spellingPoolStatsKey('y5-6'), 'y56');
+  assert.equal(spellingPoolStatsKey('secure-extension'), 'secureExtension');
+  assert.equal(spellingPoolStatsKey('extra'), 'extra');
+  assert.equal(spellingPoolStatsKey('unknown'), 'core');
+  assert.equal(normaliseSpellingSetupPoolId('secure-extension'), 'secure-extension');
+  assert.equal(normaliseSpellingSetupPoolId('all'), 'core');
+  assert.equal(normaliseSpellingWordBankFilterId('all'), 'all');
+  assert.equal(normaliseSpellingWordBankFilterId('core'), 'all');
+  assert.equal(normaliseSpellingWordBankFilterId('unknown'), 'all');
+});
+
+test('Spelling pool taxonomy match descriptors classify current word rows', () => {
+  const statutoryY34 = { slug: 'early', year: '3-4', coverageTier: 'statutory-core', spellingPool: 'core' };
+  const statutoryY56 = { slug: 'relevant', year: '5-6', coverageTier: 'statutory-core', spellingPool: 'core' };
+  const secure = { slug: 'analyse', year: 'secure-extension', coverageTier: 'secure-extension', spellingPool: 'core' };
+  const extra = { slug: 'divide', year: 'extra', coverageTier: 'enrichment-extra', spellingPool: 'extra' };
+
+  assert.equal(spellingPoolCategoryMatchesWord('all', extra), true);
+  assert.equal(spellingPoolCategoryMatchesWord('core', statutoryY34), true);
+  assert.equal(spellingPoolCategoryMatchesWord('core', extra), false);
+  assert.equal(spellingPoolCategoryMatchesWord('y3-4', statutoryY34), true);
+  assert.equal(spellingPoolCategoryMatchesWord('y3-4', statutoryY56), false);
+  assert.equal(spellingPoolCategoryMatchesWord('secure-extension', secure), true);
+  assert.equal(spellingPoolCategoryMatchesWord('secure-extension', statutoryY34), false);
+  assert.equal(spellingPoolCategoryMatchesWord('extra', extra), true);
+});
+
+test('Spelling pool taxonomy validates duplicate and unsupported category definitions', () => {
+  assert.equal(validateSpellingPoolCategories(), true);
+  assert.throws(
+    () => validateSpellingPoolCategories([
+      ...SPELLING_POOL_CATEGORIES,
+      { ...spellingPoolCategoryById('extra') },
+    ]),
+    /Duplicate Spelling pool category id: extra/,
+  );
+  assert.throws(
+    () => validateSpellingPoolCategories([
+      ...SPELLING_POOL_CATEGORIES,
+      {
+        id: 'future',
+        label: 'Future',
+        statsKey: 'future',
+        order: 90,
+        match: { unsupported: true },
+      },
+    ]),
+    /Unsupported Spelling pool match key/,
+  );
+});
+
+test('Spelling pool taxonomy helpers can accept a future category outside JSX code', () => {
+  const future = {
+    id: 'future-science',
+    label: 'Future science',
+    statsKey: 'futureScience',
+    order: 90,
+    match: { coverageTier: 'enrichment-extra', year: 'future-science' },
+  };
+  const custom = [...SPELLING_POOL_CATEGORIES, future];
+
+  assert.equal(validateSpellingPoolCategories(custom), true);
+  assert.equal(normaliseSpellingPoolCategoryId('future-science', 'core', custom), 'future-science');
+  assert.equal(spellingPoolCategoryMatchesWord(future, {
+    slug: 'gravity',
+    year: 'future-science',
+    coverageTier: 'enrichment-extra',
+  }), true);
+});

--- a/tests/spelling-remote-actions.test.js
+++ b/tests/spelling-remote-actions.test.js
@@ -1232,7 +1232,7 @@ test('remote spelling word bank category filter reloads the server-filtered rows
   assert.equal(request.searchParams.get('learnerId'), 'learner-a');
   assert.equal(request.searchParams.get('year'), 'extra');
   assert.equal(request.searchParams.get('page'), '1');
-  assert.equal(request.searchParams.get('pageSize'), '250');
+  assert.equal(request.searchParams.get('pageSize'), '5000');
   assert.equal(getState().transientUi.spellingAnalyticsYearFilter, 'extra');
   assert.equal(getState().subjectUi.spelling.analytics.wordGroups[0].words.length, 52);
   assert.equal(getState().subjectUi.spelling.analytics.wordBank.filteredRows, 52);
@@ -1267,12 +1267,12 @@ test('remote spelling word bank category filter preserves secure vocabulary UI s
           wordBank: {
             analytics: {
               wordGroups: [
-                { key: 'secure-extension', title: 'Secure vocabulary', words: Array.from({ length: 250 }, (_, index) => ({ slug: `secure-${index}` })) },
+                { key: 'secure-extension', title: 'Secure vocabulary', words: Array.from({ length: 1215 }, (_, index) => ({ slug: `secure-${index}` })) },
               ],
               wordBank: {
                 page: 1,
-                hasNextPage: true,
-                returnedRows: 250,
+                hasNextPage: false,
+                returnedRows: 1215,
                 filteredRows: 1215,
                 totalRows: 1480,
                 facets: {

--- a/tests/spelling-remote-actions.test.js
+++ b/tests/spelling-remote-actions.test.js
@@ -1098,6 +1098,53 @@ test('remote spelling word bank open loads analytics and detail into the store',
   assert.equal(getState().transientUi.spellingWordDetail.slug, 'early');
 });
 
+test('remote spelling word bank category filter reloads the server-filtered rows', async () => {
+  const { getState, store } = createStoreHarness({
+    subjectUi: {
+      spelling: {
+        phase: 'word-bank',
+        analytics: {
+          wordGroups: [{ key: 'extra', words: Array.from({ length: 37 }, (_, index) => ({ slug: `extra-${index}` })) }],
+          wordBank: { page: 1, hasNextPage: true, returnedRows: 250 },
+        },
+        error: '',
+      },
+    },
+  });
+  const urls = [];
+  const handler = createRemoteSpellingActionHandler({
+    store,
+    services: { spelling: {} },
+    tts: createTtsHarness(),
+    subjectCommands: { send: async () => ({}) },
+    readModels: {
+      async readJson(url) {
+        urls.push(url);
+        return {
+          wordBank: {
+            analytics: {
+              wordGroups: [{ key: 'extra', words: Array.from({ length: 52 }, (_, index) => ({ slug: `extra-${index}` })) }],
+              wordBank: { page: 1, hasNextPage: false, returnedRows: 52, filteredRows: 52 },
+            },
+          },
+        };
+      },
+    },
+  });
+
+  assert.equal(handler.handle('spelling-analytics-year-filter', { value: 'extra' }), true);
+
+  await flushPromises();
+  const request = new URL(`https://repo.test${urls[0]}`);
+  assert.equal(request.searchParams.get('learnerId'), 'learner-a');
+  assert.equal(request.searchParams.get('year'), 'extra');
+  assert.equal(request.searchParams.get('page'), '1');
+  assert.equal(request.searchParams.get('pageSize'), '250');
+  assert.equal(getState().transientUi.spellingAnalyticsYearFilter, 'extra');
+  assert.equal(getState().subjectUi.spelling.analytics.wordGroups[0].words.length, 52);
+  assert.equal(getState().subjectUi.spelling.analytics.wordBank.filteredRows, 52);
+});
+
 test('remote spelling word-bank drill submit is blocked while read-only', () => {
   const { store } = createStoreHarness({
     transientUi: {

--- a/tests/spelling-remote-actions.test.js
+++ b/tests/spelling-remote-actions.test.js
@@ -280,6 +280,57 @@ test('remote spelling setup preference changes are coalesced before saving', asy
   });
 });
 
+test('remote spelling preferences accept secure vocabulary as a setup pool', async () => {
+  const { getState, store } = createStoreHarness({
+    subjectUi: {
+      spelling: {
+        phase: 'dashboard',
+        prefs: {
+          mode: 'smart',
+          roundLength: '20',
+          yearFilter: 'core',
+          autoSpeak: true,
+          showCloze: true,
+        },
+        analytics: null,
+        error: '',
+      },
+    },
+  });
+  const sent = [];
+  const handler = createRemoteSpellingActionHandler({
+    store,
+    services: {
+      spelling: {
+        getPrefs() {
+          return getState().subjectUi.spelling.prefs;
+        },
+      },
+    },
+    tts: createTtsHarness(),
+    readModels: { readJson: async () => ({}) },
+    subjectCommands: {
+      send(request) {
+        sent.push(request);
+        return Promise.resolve({ subjectReadModel: { phase: 'dashboard' } });
+      },
+    },
+    preferenceSaveDebounceMs: 0,
+  });
+
+  assert.equal(handler.handle('spelling-set-pref', { pref: 'yearFilter', value: 'secure-extension' }), true);
+  assert.equal(getState().subjectUi.spelling.prefs.yearFilter, 'secure-extension');
+
+  await flushTimers();
+  await flushPromises();
+
+  assert.equal(sent.length, 1);
+  assert.equal(sent[0].command, 'save-prefs');
+  assert.deepEqual(sent[0].payload, {
+    prefs: { yearFilter: 'secure-extension' },
+  });
+});
+
 test('remote spelling start flushes pending setup preferences first', async () => {
   const { getState, store } = createStoreHarness({
     subjectUi: {

--- a/tests/spelling-remote-actions.test.js
+++ b/tests/spelling-remote-actions.test.js
@@ -1124,7 +1124,49 @@ test('remote spelling word bank category filter reloads the server-filtered rows
           wordBank: {
             analytics: {
               wordGroups: [{ key: 'extra', words: Array.from({ length: 52 }, (_, index) => ({ slug: `extra-${index}` })) }],
-              wordBank: { page: 1, hasNextPage: false, returnedRows: 52, filteredRows: 52 },
+              wordBank: {
+                page: 1,
+                hasNextPage: false,
+                returnedRows: 52,
+                filteredRows: 52,
+                totalRows: 265,
+                facets: {
+                  categories: {
+                    all: 265,
+                    core: 213,
+                    'y3-4': 109,
+                    'y5-6': 104,
+                    'secure-extension': 0,
+                    extra: 52,
+                  },
+                  status: {
+                    all: 52,
+                    total: 52,
+                    secure: 35,
+                    due: 0,
+                    trouble: 0,
+                    weak: 0,
+                    learning: 6,
+                    unseen: 11,
+                    guardianDue: 0,
+                    wobbling: 0,
+                    renewedRecently: 0,
+                    neverRenewed: 0,
+                  },
+                  categoryStatus: {
+                    extra: {
+                      all: 52,
+                      total: 52,
+                      secure: 35,
+                      due: 0,
+                      trouble: 0,
+                      weak: 0,
+                      learning: 6,
+                      unseen: 11,
+                    },
+                  },
+                },
+              },
             },
           },
         };
@@ -1143,6 +1185,9 @@ test('remote spelling word bank category filter reloads the server-filtered rows
   assert.equal(getState().transientUi.spellingAnalyticsYearFilter, 'extra');
   assert.equal(getState().subjectUi.spelling.analytics.wordGroups[0].words.length, 52);
   assert.equal(getState().subjectUi.spelling.analytics.wordBank.filteredRows, 52);
+  assert.equal(getState().subjectUi.spelling.analytics.wordBank.facets.categories.extra, 52);
+  assert.equal(getState().subjectUi.spelling.analytics.wordBank.facets.categories['y3-4'], 109);
+  assert.equal(getState().subjectUi.spelling.analytics.wordBank.facets.status.total, 52);
 });
 
 test('remote spelling word-bank drill submit is blocked while read-only', () => {

--- a/tests/spelling-remote-actions.test.js
+++ b/tests/spelling-remote-actions.test.js
@@ -1241,6 +1241,76 @@ test('remote spelling word bank category filter reloads the server-filtered rows
   assert.equal(getState().subjectUi.spelling.analytics.wordBank.facets.status.total, 52);
 });
 
+test('remote spelling word bank category filter preserves secure vocabulary UI state', async () => {
+  const { getState, store } = createStoreHarness({
+    subjectUi: {
+      spelling: {
+        phase: 'word-bank',
+        analytics: {
+          wordGroups: [],
+          wordBank: { page: 1, hasNextPage: true, returnedRows: 250 },
+        },
+        error: '',
+      },
+    },
+  });
+  const urls = [];
+  const handler = createRemoteSpellingActionHandler({
+    store,
+    services: { spelling: {} },
+    tts: createTtsHarness(),
+    subjectCommands: { send: async () => ({}) },
+    readModels: {
+      async readJson(url) {
+        urls.push(url);
+        return {
+          wordBank: {
+            analytics: {
+              wordGroups: [
+                { key: 'secure-extension', title: 'Secure vocabulary', words: Array.from({ length: 250 }, (_, index) => ({ slug: `secure-${index}` })) },
+              ],
+              wordBank: {
+                page: 1,
+                hasNextPage: true,
+                returnedRows: 250,
+                filteredRows: 1215,
+                totalRows: 1480,
+                facets: {
+                  categories: {
+                    all: 1480,
+                    'y3-4': 109,
+                    'y5-6': 104,
+                    'secure-extension': 1215,
+                    extra: 52,
+                  },
+                  status: {
+                    all: 1215,
+                    total: 1215,
+                    secure: 0,
+                    due: 0,
+                    trouble: 0,
+                    weak: 0,
+                    learning: 0,
+                    unseen: 1215,
+                  },
+                },
+              },
+            },
+          },
+        };
+      },
+    },
+  });
+
+  assert.equal(handler.handle('spelling-analytics-year-filter', { value: 'secure-extension' }), true);
+
+  await flushPromises();
+  const request = new URL(`https://repo.test${urls[0]}`);
+  assert.equal(request.searchParams.get('year'), 'secure-extension');
+  assert.equal(getState().transientUi.spellingAnalyticsYearFilter, 'secure-extension');
+  assert.equal(getState().subjectUi.spelling.analytics.wordBank.facets.status.total, 1215);
+});
+
 test('remote spelling word-bank drill submit is blocked while read-only', () => {
   const { store } = createStoreHarness({
     transientUi: {

--- a/tests/store.test.js
+++ b/tests/store.test.js
@@ -196,6 +196,21 @@ test('shared store preserves transient word-bank detail payloads for remote moda
   assert.equal(detail.audio.word.promptToken, 'word-token');
 });
 
+test('shared store preserves secure vocabulary as a word-bank category filter', () => {
+  const storage = installMemoryStorage();
+  const repositories = createLocalPlatformRepositories({ storage });
+  const store = createStore(SUBJECTS, { repositories });
+
+  store.patch((current) => ({
+    transientUi: {
+      ...current.transientUi,
+      spellingAnalyticsYearFilter: 'secure-extension',
+    },
+  }));
+
+  assert.equal(store.getState().transientUi.spellingAnalyticsYearFilter, 'secure-extension');
+});
+
 test('serialisable spelling state survives store persistence for resume', () => {
   const storage = installMemoryStorage();
   const repositories = createLocalPlatformRepositories({ storage });

--- a/worker/src/content/spelling-read-models.js
+++ b/worker/src/content/spelling-read-models.js
@@ -1,13 +1,18 @@
 import { cloneSerialisable } from '../../../src/platform/core/repositories/helpers.js';
+import {
+  SPELLING_ANALYTICS_POOL_CATEGORIES,
+  SPELLING_ANALYTICS_WORD_GROUP_CATEGORIES,
+  SPELLING_POOL_CATEGORIES,
+  SPELLING_WORD_BANK_FILTER_IDS,
+  normaliseSpellingWordBankFilterId,
+  spellingPoolCategoryMatchesWord,
+} from '../../../shared/spelling/pool-taxonomy.js';
 import { normaliseServerSpellingData } from '../subjects/spelling/engine.js';
 import { buildSpellingWordBankAudioCue } from '../subjects/spelling/audio.js';
 import { BadRequestError, NotFoundError } from '../errors.js';
 import {
   coverageTierForWord,
   coverageTierLabel,
-  isEnrichmentExtraWord,
-  isSecureExtensionWord,
-  isStatutoryCoreWord,
 } from '../../../src/subjects/spelling/content/taxonomy.js';
 import { isGuardianEligibleSlug } from '../../../src/subjects/spelling/service-contract.js';
 
@@ -16,7 +21,7 @@ const STAGE_INTERVALS = [0, 1, 3, 7, 14, 30, 60];
 const SECURE_STAGE = 4;
 const GUARDIAN_RENEWED_RECENTLY_WINDOW_DAYS = 7;
 const STATUS_FILTERS = new Set(['all', 'due', 'weak', 'learning', 'secure', 'unseen']);
-const YEAR_FILTERS = new Set(['all', 'y3-4', 'y5-6', 'secure-extension', 'extra']);
+const YEAR_FILTERS = new Set(SPELLING_WORD_BANK_FILTER_IDS);
 const MAX_PAGE_SIZE = 250;
 
 function cleanText(value) {
@@ -80,10 +85,7 @@ function statusForProgress(progress, now) {
 }
 
 function yearMatches(filter, row) {
-  if (filter === 'all') return true;
-  if (filter === 'secure-extension') return isSecureExtensionWord(row);
-  if (filter === 'extra') return isEnrichmentExtraWord(row);
-  return isStatutoryCoreWord(row) && row.year === filter.replace(/^y/, '');
+  return spellingPoolCategoryMatchesWord(normaliseSpellingWordBankFilterId(filter, 'all'), row, { coverageTierForWord });
 }
 
 function statusMatches(filter, row) {
@@ -95,19 +97,13 @@ function statusMatches(filter, row) {
 
 function categoryFacetCounts(rows) {
   const safeRows = Array.isArray(rows) ? rows : [];
-  const y34 = safeRows.filter((row) => isStatutoryCoreWord(row) && row.year === '3-4').length;
-  const y56 = safeRows.filter((row) => isStatutoryCoreWord(row) && row.year === '5-6').length;
-  const secureExtension = safeRows.filter((row) => isSecureExtensionWord(row)).length;
-  const extra = safeRows.filter((row) => isEnrichmentExtraWord(row)).length;
-  return {
-    all: safeRows.length,
-    core: y34 + y56,
-    'y3-4': y34,
-    'y5-6': y56,
-    'secure-extension': secureExtension,
-    secureExtension,
-    extra,
-  };
+  const counts = {};
+  for (const category of SPELLING_POOL_CATEGORIES) {
+    const count = safeRows.filter((row) => spellingPoolCategoryMatchesWord(category, row, { coverageTierForWord })).length;
+    counts[category.id] = count;
+    if (category.statsKey && category.statsKey !== category.id) counts[category.statsKey] = count;
+  }
+  return counts;
 }
 
 function statusFacetCounts(rows, {
@@ -163,14 +159,13 @@ function statusFacetCounts(rows, {
 
 function categoryStatusFacets(rows, context = {}) {
   const safeRows = Array.isArray(rows) ? rows : [];
-  return {
-    all: statusFacetCounts(safeRows, context),
-    core: statusFacetCounts(safeRows.filter((row) => isStatutoryCoreWord(row)), context),
-    'y3-4': statusFacetCounts(safeRows.filter((row) => isStatutoryCoreWord(row) && row.year === '3-4'), context),
-    'y5-6': statusFacetCounts(safeRows.filter((row) => isStatutoryCoreWord(row) && row.year === '5-6'), context),
-    'secure-extension': statusFacetCounts(safeRows.filter((row) => isSecureExtensionWord(row)), context),
-    extra: statusFacetCounts(safeRows.filter((row) => isEnrichmentExtraWord(row)), context),
-  };
+  return Object.fromEntries(SPELLING_POOL_CATEGORIES.map((category) => [
+    category.id,
+    statusFacetCounts(
+      safeRows.filter((row) => spellingPoolCategoryMatchesWord(category, row, { coverageTierForWord })),
+      context,
+    ),
+  ]));
 }
 
 function buildWordBankFacets({
@@ -269,35 +264,23 @@ function withAccuracy(stats) {
 }
 
 function poolsFor(words, progressMap, now) {
-  const coreWords = words.filter((word) => isStatutoryCoreWord(word));
-  const y34Words = coreWords.filter((word) => word.year === '3-4');
-  const y56Words = coreWords.filter((word) => word.year === '5-6');
-  const secureExtensionWords = words.filter((word) => isSecureExtensionWord(word));
-  const extraWords = words.filter((word) => isEnrichmentExtraWord(word));
-  return {
-    all: withAccuracy(statsForWords(coreWords, progressMap, now)),
-    core: withAccuracy(statsForWords(coreWords, progressMap, now)),
-    y34: withAccuracy(statsForWords(y34Words, progressMap, now)),
-    y56: withAccuracy(statsForWords(y56Words, progressMap, now)),
-    secureExtension: withAccuracy(statsForWords(secureExtensionWords, progressMap, now)),
-    extra: withAccuracy(statsForWords(extraWords, progressMap, now)),
-  };
+  const pools = {};
+  for (const category of SPELLING_ANALYTICS_POOL_CATEGORIES) {
+    const categoryWords = words.filter((word) => spellingPoolCategoryMatchesWord(category, word, { coverageTierForWord }));
+    const stats = withAccuracy(statsForWords(categoryWords, progressMap, now));
+    for (const alias of category.analyticsAliases) pools[alias] = stats;
+    pools[category.statsKey] = stats;
+  }
+  return pools;
 }
 
 function groupRows(rows) {
-  const groups = [
-    { key: 'y3-4', title: 'Years 3-4', spellingPool: 'core', year: '3-4' },
-    { key: 'y5-6', title: 'Years 5-6', spellingPool: 'core', year: '5-6' },
-    { key: 'secure-extension', title: 'Secure vocabulary', spellingPool: 'core', year: 'secure-extension' },
-    { key: 'extra', title: 'Extra', spellingPool: 'extra', year: 'extra' },
-  ];
-  return groups.map((group) => ({
-    ...group,
-    words: rows.filter((row) => {
-      if (group.key === 'secure-extension') return isSecureExtensionWord(row);
-      if (group.key === 'extra') return isEnrichmentExtraWord(row);
-      return isStatutoryCoreWord(row) && row.year === group.year;
-    }),
+  return SPELLING_ANALYTICS_WORD_GROUP_CATEGORIES.map((group) => ({
+    key: group.id,
+    title: group.label,
+    spellingPool: group.spellingPool || 'core',
+    year: group.year || group.id,
+    words: rows.filter((row) => spellingPoolCategoryMatchesWord(group, row, { coverageTierForWord })),
   }));
 }
 

--- a/worker/src/content/spelling-read-models.js
+++ b/worker/src/content/spelling-read-models.js
@@ -9,10 +9,12 @@ import {
   isSecureExtensionWord,
   isStatutoryCoreWord,
 } from '../../../src/subjects/spelling/content/taxonomy.js';
+import { isGuardianEligibleSlug } from '../../../src/subjects/spelling/service-contract.js';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const STAGE_INTERVALS = [0, 1, 3, 7, 14, 30, 60];
 const SECURE_STAGE = 4;
+const GUARDIAN_RENEWED_RECENTLY_WINDOW_DAYS = 7;
 const STATUS_FILTERS = new Set(['all', 'due', 'weak', 'learning', 'secure', 'unseen']);
 const YEAR_FILTERS = new Set(['all', 'y3-4', 'y5-6', 'secure-extension', 'extra']);
 const MAX_PAGE_SIZE = 250;
@@ -89,6 +91,112 @@ function statusMatches(filter, row) {
   if (filter === 'weak') return row.status === 'trouble';
   if (filter === 'unseen') return row.status === 'new';
   return row.status === filter;
+}
+
+function categoryFacetCounts(rows) {
+  const safeRows = Array.isArray(rows) ? rows : [];
+  const y34 = safeRows.filter((row) => isStatutoryCoreWord(row) && row.year === '3-4').length;
+  const y56 = safeRows.filter((row) => isStatutoryCoreWord(row) && row.year === '5-6').length;
+  const secureExtension = safeRows.filter((row) => isSecureExtensionWord(row)).length;
+  const extra = safeRows.filter((row) => isEnrichmentExtraWord(row)).length;
+  return {
+    all: safeRows.length,
+    core: y34 + y56,
+    'y3-4': y34,
+    'y5-6': y56,
+    'secure-extension': secureExtension,
+    secureExtension,
+    extra,
+  };
+}
+
+function statusFacetCounts(rows, {
+  guardianMap = {},
+  progressMap = {},
+  wordBySlug = {},
+  today = 0,
+} = {}) {
+  const stats = {
+    all: 0,
+    total: 0,
+    secure: 0,
+    due: 0,
+    trouble: 0,
+    weak: 0,
+    learning: 0,
+    unseen: 0,
+    guardianDue: 0,
+    wobbling: 0,
+    renewedRecently: 0,
+    neverRenewed: 0,
+  };
+  for (const row of Array.isArray(rows) ? rows : []) {
+    stats.all += 1;
+    stats.total += 1;
+    if (row.status === 'secure') stats.secure += 1;
+    else if (row.status === 'due') stats.due += 1;
+    else if (row.status === 'trouble') {
+      stats.trouble += 1;
+      stats.weak += 1;
+    } else if (row.status === 'learning') stats.learning += 1;
+    else if (row.status === 'new') stats.unseen += 1;
+
+    const eligible = isGuardianEligibleSlug(row.slug, progressMap, wordBySlug);
+    const guardian = row.slug && guardianMap[row.slug] && typeof guardianMap[row.slug] === 'object'
+      ? guardianMap[row.slug]
+      : null;
+    if (!eligible) continue;
+    if (!guardian) {
+      if (row.status === 'secure') stats.neverRenewed += 1;
+      continue;
+    }
+    const nextDue = Number.isFinite(Number(guardian.nextDueDay)) ? Math.floor(Number(guardian.nextDueDay)) : Infinity;
+    if (row.status === 'secure' && nextDue <= today) stats.guardianDue += 1;
+    if (row.status === 'secure' && guardian.wobbling === true) stats.wobbling += 1;
+    const lastReviewed = Number(guardian.lastReviewedDay);
+    if (Number.isFinite(lastReviewed) && today - Math.floor(lastReviewed) <= GUARDIAN_RENEWED_RECENTLY_WINDOW_DAYS) {
+      stats.renewedRecently += 1;
+    }
+  }
+  return stats;
+}
+
+function categoryStatusFacets(rows, context = {}) {
+  const safeRows = Array.isArray(rows) ? rows : [];
+  return {
+    all: statusFacetCounts(safeRows, context),
+    core: statusFacetCounts(safeRows.filter((row) => isStatutoryCoreWord(row)), context),
+    'y3-4': statusFacetCounts(safeRows.filter((row) => isStatutoryCoreWord(row) && row.year === '3-4'), context),
+    'y5-6': statusFacetCounts(safeRows.filter((row) => isStatutoryCoreWord(row) && row.year === '5-6'), context),
+    'secure-extension': statusFacetCounts(safeRows.filter((row) => isSecureExtensionWord(row)), context),
+    extra: statusFacetCounts(safeRows.filter((row) => isEnrichmentExtraWord(row)), context),
+  };
+}
+
+function buildWordBankFacets({
+  rows,
+  filters,
+  contentSnapshot,
+  progressMap,
+  guardianMap,
+  now,
+} = {}) {
+  const queryRows = (Array.isArray(rows) ? rows : [])
+    .filter((row) => searchMatches(filters.query, contentSnapshot?.wordBySlug?.[row.slug] || row));
+  const categoryRows = queryRows.filter((row) => statusMatches(filters.status, row));
+  const statusRows = queryRows.filter((row) => yearMatches(filters.year, row));
+  const context = {
+    guardianMap,
+    progressMap,
+    wordBySlug: contentSnapshot?.wordBySlug || {},
+    today: todayDay(now),
+  };
+  return {
+    version: 1,
+    categories: categoryFacetCounts(categoryRows),
+    status: statusFacetCounts(statusRows, context),
+    categoryStatus: categoryStatusFacets(categoryRows, context),
+  };
 }
 
 function searchMatches(query, word) {
@@ -228,7 +336,9 @@ export async function buildSpellingWordBankReadModel({
 } = {}) {
   const filters = normaliseWordBankFilters(rawFilters);
   const words = Array.isArray(contentSnapshot?.words) ? contentSnapshot.words : [];
-  const progressMap = normaliseServerSpellingData(data).progress;
+  const spellingData = normaliseServerSpellingData(data, now);
+  const progressMap = spellingData.progress;
+  const guardianMap = spellingData.guardian;
   const rows = words.map((word) => publicWordRow(word, progressFor(progressMap, word.slug, now), now));
   const filtered = rows
     .filter((row) => yearMatches(filters.year, row))
@@ -276,6 +386,14 @@ export async function buildSpellingWordBankReadModel({
         filteredRows: filtered.length,
         returnedRows: pageRows.length,
         hasNextPage: start + pageRows.length < filtered.length,
+        facets: buildWordBankFacets({
+          rows,
+          filters,
+          contentSnapshot,
+          progressMap,
+          guardianMap,
+          now,
+        }),
       },
     },
     detail,

--- a/worker/src/content/spelling-read-models.js
+++ b/worker/src/content/spelling-read-models.js
@@ -22,7 +22,7 @@ const SECURE_STAGE = 4;
 const GUARDIAN_RENEWED_RECENTLY_WINDOW_DAYS = 7;
 const STATUS_FILTERS = new Set(['all', 'due', 'weak', 'learning', 'secure', 'unseen']);
 const YEAR_FILTERS = new Set(SPELLING_WORD_BANK_FILTER_IDS);
-const MAX_PAGE_SIZE = 250;
+const MAX_PAGE_SIZE = 5000;
 
 function cleanText(value) {
   return String(value || '').replace(/\s+/g, ' ').trim();

--- a/worker/src/subjects/spelling/engine.js
+++ b/worker/src/subjects/spelling/engine.js
@@ -544,6 +544,7 @@ export function createServerSpellingEngine({
           core: service.getStats(learnerId, 'core'),
           y34: service.getStats(learnerId, 'y3-4'),
           y56: service.getStats(learnerId, 'y5-6'),
+          secureExtension: service.getStats(learnerId, 'secure-extension'),
           extra: service.getStats(learnerId, 'extra'),
         },
         analytics: service.getAnalyticsSnapshot(learnerId),


### PR DESCRIPTION
## Summary
- refactor the spelling Word Bank read model so facet counts come from the full authorised filtered universe, not the current page rows
- render Word Bank category/status chips from server facets while keeping the visible word groups scoped to the loaded rows
- make the spelling surface use server-loaded Word Bank analytics instead of falling back to the local service snapshot during the Word Bank phase

## Verification
- node --test tests/spelling-content-api.test.js tests/spelling-remote-actions.test.js tests/react-spelling-surface.test.js
- npm test
- npm run check
- npm run deploy
- production API smoke on https://ks2.eugnel.uk: build a9681f8d, All Extra group 37 with Extra facet 52, Extra selected 52 with Years 3-4 109 and Years 5-6 104
- production browser smoke on https://ks2.eugnel.uk demo Word Bank: no No words yet state, All shows Extra 52, Extra selected keeps sibling filter counts