### PR TITLE
perf(tts): harden production cache timing probes

### DIFF
--- a/docs/plans/2026-06-07-001-perf-production-performance-attribution-plan.md
+++ b/docs/plans/2026-06-07-001-perf-production-performance-attribution-plan.md
@@ -1,0 +1,210 @@
+---
+title: "perf: Production Performance Attribution and TTS Page-Load Optimisation"
+type: perf
+status: active
+date: 2026-06-07
+---
+
+# perf: Production Performance Attribution and TTS Page-Load Optimisation
+
+## Summary
+
+Build a measured production performance attribution slice for KS2 Mastery before attempting broader Cloudflare, D1, R2, or browser refactors. The first implementation should expose enough request, cache, route, and browser timing evidence to decide whether the next optimisation belongs in Worker CPU, D1, R2, Static Assets routing, or client audio playback.
+
+---
+
+## Problem Frame
+
+The TTS primary R2 cache migration made the intended cache path work and reduced R2 lookup count, but production TTS cache hits still show client header waits around the two-second range. Online Cloudflare research points to several plausible optimisation levers - Static Assets routing, Worker placement, D1 read replication sessions, Workers Cache API, and R2 custom-domain CDN cache - but they have different costs and failure modes. The next change must therefore improve attribution first, then make only low-risk changes that the new evidence can verify.
+
+---
+
+## Requirements
+
+**Evidence and Measurement**
+
+- R1. Add a repeatable production performance probe that measures browser-observable page, bundle, bootstrap, command, and TTS cache-hit timings without depending on manual DevTools reading.
+- R2. Preserve the ability to run the probe against a real logged-in production session via an operator-supplied cookie, because demo-only smoke has previously misrepresented the real learner path.
+- R3. Capture TTS response headers, `Server-Timing`, `x-ks2-request-id`, cache state, cache source, content type, bytes, header time, body time, and total wall time.
+- R4. Capture page-load-sensitive static asset headers for the shipped app bundle path, including `Cache-Control`, `cf-cache-status` when present, content type, and response timing.
+- R5. Produce bounded JSON and markdown summaries that report p50, p95, maximum, sample count, and notable warnings, without persisting cookies, request bodies, learner names, prompt tokens, or raw audio bodies.
+
+**TTS Attribution**
+
+- R6. Add narrowly scoped TTS phase timings for cache lookup requests so a cache hit can be split into prompt resolution, rate-limit protection, R2 lookup, response construction, and residual Worker overhead.
+- R7. Preserve existing TTS cache correctness: primary hits, legacy fallback lazy migration, word-only key invariants, provider fallback, demo guards, and rate limiting must remain unchanged.
+- R8. Keep any new timing headers non-sensitive and bounded; do not expose prompt text, slug, learner id, account id, SQL details, or provider keys.
+
+**Page Load Attribution**
+
+- R9. Detect whether production bundles are served through the intended immutable Static Assets path or through `/src/bundles/*` Worker-first routing.
+- R10. Do not move bundle output paths, change `run_worker_first`, enable Smart Placement, or add R2 public custom domains in this first slice unless the measurement script first proves the existing route is the bottleneck and tests lock the new routing contract.
+
+**Operational Safety**
+
+- R11. Keep Cloudflare operations on existing package scripts and `scripts/wrangler-oauth.mjs`; do not introduce raw Wrangler deploy or D1 commands.
+- R12. Add focused tests for the probe, timing parsing, TTS timing headers, and audit expectations, then run the existing package-level checks before deployment.
+
+---
+
+## Scope Boundaries
+
+- No D1 Sessions/read-replica adoption in this PR. That requires a separate plan once query duration and consistency needs are measured.
+- No Smart Placement change in this PR. Placement can trade Worker-to-D1 latency against user-to-Worker latency and must be evaluated after static asset routing is separated from Worker execution.
+- No R2 public bucket or custom-domain audio serving in this PR. TTS audio is authenticated and learner-scoped at the request boundary, even when cache objects are cross-account reusable.
+- No Workers Cache API layer for authenticated TTS in this PR. Cloudflare documents the Workers Cache API as local to the data centre, so it is not a first choice until phase timing proves repeated R2 latency is dominant.
+- No broad `repository.js` refactor. Any refactor must be a small extraction needed for timing, not a structural cleanup.
+- No relaxation of SEO, CSP, production audit, TTS smoke, or capacity gates.
+
+---
+
+## Key Technical Decisions
+
+- KTD1. Measurement first, optimisation second: the known symptom is a two-second TTS header wait, but the known R2 primary lookup is already far smaller. The first slice therefore instruments phases before changing architecture.
+- KTD2. Use `Server-Timing` for bounded TTS phase attribution: it is a standard response header that browser tooling and scripts can parse without adding JSON payload weight or child-visible UI fields.
+- KTD3. Keep `x-ks2-request-id` as the join key: the client TTS telemetry already logs it, Worker capacity logs already carry request IDs, and production probes can report it without storing sensitive inputs.
+- KTD4. Treat bundle routing as a page-load hypothesis, not an assumed fix: Cloudflare Static Assets are designed to serve assets directly, while `run_worker_first` intentionally invokes Worker code for matched paths. The repo currently emits bundles under `/src/bundles/*`, so the probe must verify whether that route adds cost before a path migration is attempted.
+- KTD5. Keep D1 and R2 platform features as follow-up candidates: D1 Sessions, Smart Placement, R2 custom domains, and Workers Cache API are plausible, but each changes operational semantics. They should follow evidence, not lead it.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TB
+  Probe["production performance probe"] --> Page["page and bundle timing"]
+  Probe --> Api["bootstrap / command timing"]
+  Probe --> Tts["TTS cache-hit timing"]
+  Tts --> Headers["cache headers + Server-Timing"]
+  Headers --> Summary["bounded JSON + markdown summary"]
+  Page --> Summary
+  Api --> Summary
+  Summary --> Decision["next optimisation decision"]
+  Decision --> A["bundle static-asset route"]
+  Decision --> B["TTS prompt/rate-limit/D1 reduction"]
+  Decision --> C["browser audio prefetch"]
+  Decision --> D["D1 Sessions / Smart Placement follow-up"]
+```
+
+The probe should be useful before and after each optimisation. It should report what was measured, what was not measured, and which bottleneck class is currently most likely.
+
+---
+
+## Implementation Units
+
+### U1. Production performance probe harness
+
+- **Goal:** Add a script that repeatedly probes production page, bundle, bootstrap, command, and TTS paths and writes bounded evidence.
+- **Requirements:** R1, R2, R3, R4, R5, R11
+- **Files:**
+  - Create: `scripts/production-performance-probe.mjs`
+  - Create: `tests/production-performance-probe.test.js`
+  - Modify: `package.json`
+  - Create: `reports/performance/.gitignore`
+- **Patterns to follow:** `scripts/spelling-audio-production-smoke.mjs`, `scripts/probe-production-bootstrap.mjs`, `scripts/lib/production-smoke.mjs`, `scripts/classroom-load-test.mjs`.
+- **Approach:** Support `--origin`, `--iterations`, `--cookie-env`, `--json-output`, `--markdown-output`, and `--timeout-ms`. Use a stub server in tests. Redact cookies and prompt tokens from all outputs. When no operator cookie is present, the script should still measure public page and bundle paths and clearly mark authenticated probes as skipped.
+- **Test scenarios:**
+  - Happy path: a stub origin with page, bundle, bootstrap, command, and TTS responses produces p50/p95 summaries.
+  - Edge case: missing cookie skips authenticated probes but still reports public page and bundle timing.
+  - Error path: non-2xx TTS or bootstrap responses produce bounded warnings without storing response bodies.
+  - Redaction: cookie, prompt token, learner id, and request body material are absent from JSON and markdown outputs.
+- **Verification:** `node --test tests/production-performance-probe.test.js` passes and the script can run against `https://ks2.eugnel.uk` for public-only probes.
+
+### U2. TTS cache-hit phase timing
+
+- **Goal:** Add `Server-Timing` details to `/api/tts` cache lookup responses so the probe can split cache-hit latency by server phase.
+- **Requirements:** R3, R6, R7, R8, R12
+- **Files:**
+  - Modify: `worker/src/tts.js`
+  - Modify: `worker/src/app.js`
+  - Modify: `tests/worker-tts.test.js`
+- **Patterns to follow:** `worker/src/tts.js` TTS R2 lookup telemetry, `worker/src/logger.js` bounded capacity fields, existing `x-ks2-tts-*` response headers.
+- **Approach:** Record monotonic durations around prompt resolution, lookup protection, R2 lookup, audio-budget protection, and response construction. Emit only rounded millisecond values in `Server-Timing`; keep existing cache headers unchanged. Keep timing collection best-effort and non-throwing.
+- **Test scenarios:**
+  - Happy path: cache lookup hit includes `Server-Timing` entries and existing TTS cache headers.
+  - Edge case: cache miss and cache unavailable responses include safe timing where available and keep existing 204 semantics.
+  - Error path: timing collection failures do not fail audio responses.
+  - Security: `Server-Timing` contains no learner id, account id, slug, prompt token, SQL, provider key, or transcript.
+- **Verification:** Focused worker TTS tests pass and production audit remains green.
+
+### U3. TTS probe integration and before/after report
+
+- **Goal:** Teach the performance probe to parse TTS `Server-Timing` and classify likely TTS bottlenecks.
+- **Requirements:** R1, R3, R5, R6
+- **Files:**
+  - Modify: `scripts/production-performance-probe.mjs`
+  - Modify: `tests/production-performance-probe.test.js`
+  - Modify: `docs/operations/capacity.md`
+- **Patterns to follow:** `docs/operations/capacity-cpu-d1-evidence.md`, `reports/capacity/evidence/*-tail-correlation.json`, `scripts/join-capacity-worker-logs.mjs` if present.
+- **Approach:** Parse `Server-Timing` into named phase fields and classify samples as `r2-dominated`, `prompt-validation-dominated`, `rate-limit-dominated`, `client-network-or-platform-overhead`, or `mixed`. Keep classifications diagnostic-only.
+- **Test scenarios:**
+  - Happy path: synthetic timing headers classify a known R2-dominated sample correctly.
+  - Edge case: missing `Server-Timing` results in `unclassified-insufficient-timing`.
+  - Error path: malformed timing header is ignored with a bounded warning.
+- **Verification:** Generated report shows p50/p95 TTS header/body/wall and phase timing fields for measured samples.
+
+### U4. Static asset route audit for page load
+
+- **Goal:** Add checks that make bundle route/cache behaviour visible before any bundle path migration.
+- **Requirements:** R4, R9, R10, R12
+- **Files:**
+  - Modify: `scripts/production-bundle-audit.mjs`
+  - Modify: `tests/bundle-audit.test.js`
+  - Modify: `scripts/production-performance-probe.mjs`
+- **Patterns to follow:** existing cache-split checks in `scripts/production-bundle-audit.mjs`, `_headers`, `wrangler.jsonc`.
+- **Approach:** Record whether the shipped HTML references `/src/bundles/*` or `/assets/bundles/*`, then verify the referenced bundle has immutable caching and the expected content type. Report Worker-first risk as a warning unless a later unit deliberately migrates paths.
+- **Test scenarios:**
+  - Happy path: immutable bundle cache headers pass.
+  - Edge case: `/src/bundles/*` reference emits a warning but does not fail unless cache headers are unsafe.
+  - Error path: bundle served as HTML or `no-store` fails production audit.
+- **Verification:** Bundle audit remains green against production and the performance probe reports bundle route/cache status.
+
+### U5. Operator documentation and decision record
+
+- **Goal:** Document how to run the new probe and how to interpret the first measurements.
+- **Requirements:** R5, R10, R11
+- **Files:**
+  - Modify: `docs/operations/capacity.md`
+  - Create: `docs/operations/performance-probes.md`
+- **Patterns to follow:** `docs/operations/capacity-cpu-d1-evidence.md`, `docs/spelling-word-audio.md`.
+- **Approach:** Document command examples, cookie handling, redaction guarantees, report locations, and the decision rule for follow-up work. Keep platform-feature candidates explicitly gated on measured evidence.
+- **Test scenarios:** Documentation examples reference package scripts and repo-relative output paths.
+- **Verification:** Docs do not include secrets, absolute local paths, or claims unsupported by measurements.
+
+---
+
+## Acceptance Examples
+
+- AE1. Given no operator cookie is configured, when `npm run perf:production -- --iterations 2` runs, then it records public page and bundle timing, marks authenticated routes skipped, and exits successfully unless public checks fail.
+- AE2. Given a valid operator cookie is configured, when the probe measures TTS cache hits, then the report includes cache source, request id, header/body/wall timing, and parsed `Server-Timing` phases.
+- AE3. Given a TTS cache hit spends most of its server time in prompt validation or rate-limit protection, when the report is generated, then it classifies the sample away from R2 so the next optimisation does not target R2 again.
+- AE4. Given production HTML references a bundle route that is served as HTML or `no-store`, when `npm run audit:production` runs, then the audit fails before deployment is considered healthy.
+
+---
+
+## Risks and Dependencies
+
+- The real logged-in path needs an operator-supplied cookie. The probe must make missing credentials explicit rather than silently falling back to demo-only evidence.
+- `Server-Timing` is visible to browsers. Values must stay numeric and generic.
+- Cloudflare headers such as `cf-cache-status` may be absent depending on response lane. The probe must treat absence as evidence to report, not as a parser failure.
+- Probe outputs can become noisy if they store raw response bodies. The report must store summaries only.
+- If `run_worker_first` is part of source-path lockdown, any future bundle migration must preserve direct source denial tests.
+
+---
+
+## Sources and Research
+
+- `worker/src/tts.js` contains TTS cache lookup, lazy legacy-to-primary migration, and cache headers.
+- `src/subjects/spelling/tts.js` logs client cache-hit timing with `x-ks2-request-id`.
+- `scripts/spelling-audio-production-smoke.mjs` is the existing production TTS cache contract probe.
+- `scripts/production-bundle-audit.mjs` and `tests/bundle-audit.test.js` own production bundle and SEO audit gates.
+- `wrangler.jsonc` currently routes `/src/*` through `run_worker_first` and binds Static Assets from `dist/public`.
+- `_headers` currently gives immutable caching to `/assets/bundles/*`, while the shipped app bundle path needs measurement before migration.
+- `docs/solutions/learning-spelling-audio-cache-contract.md` documents the TTS R2 key contract and smoke expectations.
+- `docs/operations/capacity-cpu-d1-evidence.md` documents diagnostic-only attribution and request-id joins.
+- Cloudflare Workers Cache API docs: https://developers.cloudflare.com/workers/runtime-apis/cache/
+- Cloudflare R2 public bucket and custom-domain docs: https://developers.cloudflare.com/r2/data-access/public-buckets/
+- Cloudflare D1 read replication and Sessions docs: https://developers.cloudflare.com/d1/best-practices/read-replication/
+- Cloudflare Static Assets headers docs: https://developers.cloudflare.com/workers/static-assets/headers/
+- MDN `HTMLMediaElement.play()` docs: https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/play
+- MDN `PerformanceResourceTiming` docs: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming

--- a/docs/plans/2026-06-07-002-perf-tts-cache-followup-plan.md
+++ b/docs/plans/2026-06-07-002-perf-tts-cache-followup-plan.md
@@ -1,0 +1,165 @@
+---
+title: "perf: TTS Cache Follow-Up Optimisation"
+type: perf
+status: active
+date: 2026-06-07
+---
+
+# perf: TTS Cache Follow-Up Optimisation
+
+## Summary
+
+Finish the TTS cache optimisation slice by making every intended cached audio path measurable, primary-backed, and regression-guarded. The work should close the remaining word-only cache miss, formalise the sentence-cache and browser play-start probes, and then lightly refactor the TTS timing/limiter helpers without changing response semantics.
+
+---
+
+## Problem Frame
+
+The sentence-shaped TTS cache path now serves primary R2 hits in production with direct `/api/tts` header p50 around 400 ms, down from the earlier two-second range. The remaining gap is not the sentence cache path; it is that word-only Word Bank probes still return `204 miss`, cross-account word smoke remains red, and browser-side play-start measurement is not yet part of the repeatable production probe. Without those guards, future TTS changes could regress the user-visible replay path while direct API timing still looks healthy.
+
+---
+
+## Requirements
+
+**Cache Correctness**
+
+- R1. Word-only Word Bank TTS requests must be able to return `200 hit/primary` when a warmable word audio object exists or can be warmed through the existing authenticated path.
+- R2. Cross-account word audio reuse must keep the existing content-key invariant: reusable word audio keys must not include account id or learner id.
+- R3. Sentence-shaped cached dictation audio must keep returning `200 hit/primary`; this work must not reintroduce legacy fallback dependency.
+
+**Measurement**
+
+- R4. `npm run perf:production` must measure sentence cache-hit audio alongside word-only lookup timing, not rely on one-off `/tmp` scripts.
+- R5. The production probe must optionally measure browser-side audio start latency with bounded `playStartMs` evidence when a browser runtime is available.
+- R6. Probe output must redact cookies, learner ids, account ids, prompt tokens, raw audio bodies, and transcript text.
+
+**Refactor Safety**
+
+- R7. TTS timing and limiter code may be extracted only if existing headers, rate-limit buckets, status codes, warmup rules, and cache semantics remain unchanged.
+- R8. `Server-Timing` must stay numeric and non-sensitive; it must not expose slug, prompt token, learner id, account id, provider key, SQL, or transcript material.
+
+**Verification and Operations**
+
+- R9. Existing package scripts remain the deployment path: `npm test`, `npm run check`, and `npm run deploy`.
+- R10. Existing production bundle and spelling-audio smoke gates must either pass or report only a clearly documented remaining operational prefill limitation.
+
+---
+
+## Scope Boundaries
+
+- No public R2 bucket, R2 custom-domain audio serving, or unauthenticated audio URL migration.
+- No D1 Sessions, Smart Placement, Workers Cache API, or bundle route migration in this slice.
+- No broad spelling subject runtime rewrite.
+- No weakening of prompt-token validation, cross-account isolation, demo limits, or TTS rate-limit behaviour.
+- No claims about lower Worker CPU unless backed by a direct CPU metric; request timing and `Server-Timing` are latency evidence, not CPU proof.
+
+---
+
+## Key Technical Decisions
+
+- KTD1. Fix word-only cache first: the latest production evidence shows sentence cache hits are primary and fast enough for the current slice, while word-only probes still miss and keep the smoke red.
+- KTD2. Keep authenticated warming server-side: word audio can be cross-account reusable at the R2 object key, but request validation must remain learner/account scoped before any lookup or warmup.
+- KTD3. Productise the measurement before deeper refactor: sentence hit and browser play-start measurements should become repeatable probe features before further optimisation decisions.
+- KTD4. Treat `cacheLookupOnly` and `cacheOnly` distinctly: lookup-only remains a read/diagnostic path, while warmup or playback paths may store missing word audio when already authorised.
+- KTD5. Refactor only after behaviour is locked: timing and limiter helper extraction follows tests for word-only hits, sentence hits, and safe headers.
+
+---
+
+## Implementation Units
+
+### U1. Word-only cache warm and hit path
+
+- **Goal:** Make Word Bank word-only audio reach `200 hit/primary` for warmed words and keep cross-account reuse safe.
+- **Requirements:** R1, R2, R3, R7, R8
+- **Files:**
+  - Modify: `worker/src/tts.js`
+  - Modify: `tests/worker-tts.test.js`
+  - Modify: `scripts/spelling-audio-production-smoke.mjs`
+- **Patterns to follow:** `worker/src/tts.js` word metadata key generation, `tests/worker-tts.test.js` word-bank TTS tests, `scripts/spelling-audio-production-smoke.mjs` cross-account probe.
+- **Approach:** Inspect the existing word-only cache miss path before changing it. Preserve lookup-only `204` semantics when the object is genuinely absent, but ensure authorised warm/playback requests store and then serve primary word audio. If the smoke expects a prefilled object, make the warmup step explicit rather than treating absence as a cache contract failure.
+- **Test scenarios:**
+  - Happy path: a warmed word-only request returns `200 hit/primary` with the expected model and voice headers.
+  - Cross-account path: two learners requesting the same word share the same word content key while prompt tokens remain learner scoped.
+  - Edge path: `cacheLookupOnly` for an unwarmed word still returns a bounded miss without provider fetch.
+  - Security path: `Server-Timing`, logs, and probe summaries do not expose learner id, account id, slug, prompt token, transcript, or provider keys.
+- **Verification:** `node --test tests/worker-tts.test.js` passes and `npm run smoke:production:spelling-audio -- --word-sample accident,knowledge --sentence-sample accident,knowledge --json` no longer fails for the word-only prefill reason after deployment.
+
+### U2. Production probe sentence and word-cache coverage
+
+- **Goal:** Move the one-off sentence cache-hit timing script into `scripts/production-performance-probe.mjs`.
+- **Requirements:** R3, R4, R6, R9
+- **Files:**
+  - Modify: `scripts/production-performance-probe.mjs`
+  - Modify: `tests/production-performance-probe.test.js`
+  - Modify: `package.json`
+- **Patterns to follow:** existing `measureTts`, `parseServerTiming`, `classifyTtsTimingSample`, and `computeWordBankPromptToken` usage in `scripts/production-performance-probe.mjs`.
+- **Approach:** Add explicit probe modes for word-only lookup and sentence cache-hit audio. Report per-mode status, cache source, bytes, header/body/total timing, and parsed phases. Keep the default sample count low and redacted.
+- **Test scenarios:**
+  - Happy path: stubbed word lookup miss and sentence hit produce separate summaries.
+  - Edge path: missing sentence cache produces a bounded failure that identifies the cache mode.
+  - Redaction path: output excludes cookies, prompt tokens, learner/account identifiers, and transcript text.
+  - CLI path: duplicate or incompatible timing flags fail fast rather than silently overriding.
+- **Verification:** `node --test tests/production-performance-probe.test.js` passes and `npm run perf:production -- --samples 2 --warmup 1 --word-sample accident,knowledge --voices Iapetus` reports both TTS modes.
+
+### U3. Browser-side TTS play-start measurement
+
+- **Goal:** Add a repeatable browser-side measurement for the real client TTS replay path.
+- **Requirements:** R4, R5, R6, R9
+- **Files:**
+  - Modify: `src/subjects/spelling/tts.js`
+  - Modify: `tests/spelling-tts.test.js`
+  - Modify: `scripts/production-performance-probe.mjs`
+  - Modify: `tests/production-performance-probe.test.js`
+- **Patterns to follow:** `[ks2-tts-cache-latency]` logging in `src/subjects/spelling/tts.js`, existing `playStartMs` tests in `tests/spelling-tts.test.js`, and the repo's Playwright script usage.
+- **Approach:** Keep client telemetry as the source of truth for play-start. Add a probe option that runs the client TTS path in a controlled browser context when available, captures console telemetry or a structured test hook, and records `headerMs`, `blobMs`, `playStartMs`, `bytes`, cache state, and request id.
+- **Test scenarios:**
+  - Happy path: a mocked cached audio response records `playStartMs` and byte size.
+  - Edge path: cache miss records no `playStartMs` and does not trigger provider fallback after cancellation.
+  - Browser-unavailable path: the production probe marks browser timing skipped without failing non-browser runs.
+  - Redaction path: browser timing output excludes prompt token, learner/account identifiers, and transcript text.
+- **Verification:** `node --test tests/spelling-tts.test.js tests/production-performance-probe.test.js` passes and the production probe can mark browser play-start as measured or explicitly skipped.
+
+### U4. TTS timing and limiter helper refactor
+
+- **Goal:** Reduce local complexity in `worker/src/tts.js` after the cache and measurement paths are covered by tests.
+- **Requirements:** R7, R8, R9
+- **Files:**
+  - Modify: `worker/src/tts.js`
+  - Modify: `tests/worker-tts.test.js`
+- **Patterns to follow:** current `createTtsTiming`, `timeTtsPhase`, `withTtsServerTiming`, `protectTts`, `protectTtsLookup`, and `allowTtsWarmup` behaviour.
+- **Approach:** Extract small helpers for limiter-pair execution and timing-header construction only where doing so removes duplication. Do not introduce a new module unless the file becomes harder to read without one. Preserve all thrown error codes and bucket names.
+- **Test scenarios:**
+  - Behavioural path: existing lookup, warmup, playback, demo, and provider tests continue to pass.
+  - Error path: account and IP limiter failures still map to the existing TTS error codes.
+  - Header path: `Server-Timing` remains bounded, numeric, and non-sensitive.
+- **Verification:** focused TTS tests pass before full gates are run.
+
+---
+
+## Acceptance Examples
+
+- AE1. Given a warmed Word Bank word audio object, when a learner requests `wordOnly: true` for that word, then `/api/tts` returns `200`, `x-ks2-tts-cache: hit`, and `x-ks2-tts-cache-source: primary`.
+- AE2. Given two learners request the same warmed Word Bank word, when their prompt tokens differ, then both can hit the same primary R2 word object without sharing learner-scoped prompt material.
+- AE3. Given the production probe runs with TTS enabled, when it finishes, then it reports separate word-only lookup and sentence cache-hit timing summaries.
+- AE4. Given browser timing is unavailable in the environment, when the production probe runs, then it records browser play-start as skipped and still completes API timing.
+- AE5. Given the TTS helper refactor is applied, when focused worker tests run, then cache status codes, rate-limit error codes, and safe `Server-Timing` output remain unchanged.
+
+---
+
+## Risks and Dependencies
+
+- Warming word-only audio may call the Gemini provider when cache is absent. The implementation must respect existing warmup limits and avoid doing provider work for lookup-only diagnostics.
+- Browser play-start timing depends on browser audio APIs and autoplay constraints. The probe must degrade to an explicit skipped state when a reliable browser context is unavailable.
+- Production smoke may require an explicit warmup step before requiring word hits. The smoke should distinguish "not warmed" from "cache contract broken".
+- Existing local tests are large and can generate report/build side effects. Generated files should be cleaned or ignored without reverting unrelated user work.
+
+---
+
+## Sources and Research
+
+- `docs/plans/2026-06-07-001-perf-production-performance-attribution-plan.md` established the first measurement and `Server-Timing` slice.
+- `worker/src/tts.js` owns TTS prompt validation, limiter checks, R2 lookup, warmup, provider fetch, cache headers, and timing headers.
+- `src/subjects/spelling/tts.js` owns client cache lookup, audio blob loading, playback, and `[ks2-tts-cache-latency]` telemetry.
+- `scripts/production-performance-probe.mjs` now measures production assets, bootstrap, and word-only TTS lookup timing.
+- `scripts/spelling-audio-production-smoke.mjs` owns the production word/sentence/cross-account TTS smoke contract.
+- `tests/worker-tts.test.js`, `tests/spelling-tts.test.js`, and `tests/production-performance-probe.test.js` are the primary focused regression targets.

--- a/docs/plans/2026-06-08-001-perf-tts-playback-page-load-hardening-plan.md
+++ b/docs/plans/2026-06-08-001-perf-tts-playback-page-load-hardening-plan.md
@@ -1,0 +1,202 @@
+---
+title: "perf: TTS Playback, Page-Load, and UX Hardening"
+type: perf
+status: active
+date: 2026-06-08
+---
+
+# perf: TTS Playback, Page-Load, and UX Hardening
+
+## Summary
+
+Optimise the real Spelling play path after the TTS cache follow-up branch has been deployed to production. The work must align the code path with the production branch, make the actual browser playback path primary-backed instead of indefinitely reading legacy R2 objects, keep production probes redacted, reduce eager hero-image preload pressure, and add bounded client-side request timeouts so learners do not get stuck in long pending states.
+
+## Problem Frame
+
+Production currently reports build hash `93b7b95c`, which exists on `codex/tts-cache-r2-opt` rather than `main`. A future deploy from `main` would risk rolling back the TTS cache probe and redaction fixes unless this branch remains the source of truth for the follow-up work and PR reconciliation.
+
+Direct `/api/tts` probes now show primary cache hits for selected sentence samples, but the real in-app replay path still shows `x-ks2-tts-cache-source: legacy` with browser play-start around 414-625 ms. The likely cause is semantic overlap: the browser cache-hit fast path sends `cacheLookupOnly: true`, while the Worker disables legacy-to-primary migration for lookup-only requests. That is correct for diagnostics, but wrong for playback if it means real learners keep reading legacy cache forever.
+
+The live play path also eagerly probes multiple 1280 WebP hero backgrounds and core fetch clients have retries but no explicit browser-side timeout. Both are meaningful user-experience risks: they add avoidable page-load work and can leave gameplay controls pending for too long when the network hangs.
+
+## Requirements
+
+### Release Alignment
+
+- R1. Continue implementation from `codex/tts-cache-r2-opt`, the branch whose HEAD matches the currently deployed production hash.
+- R2. Preserve and extend the existing production probe, smoke, bundle audit, and redaction fixes from that branch.
+- R3. Do not deploy or commit from the dirty `main` checkout.
+
+### TTS Playback Cache
+
+- R4. Real browser playback cache-hit requests must be allowed to migrate a legacy R2 hit into the primary R2 key after the request has passed normal audio authorisation and limiter checks.
+- R5. Diagnostic lookup-only requests must remain read-only and must not call providers or write R2.
+- R6. Existing TTS cache headers, status codes, prompt-token validation, cross-account content-key invariants, demo limits, and safe `Server-Timing` output must remain unchanged except for the expected cache source moving to primary after migration.
+- R7. Browser play-start telemetry must keep measuring actual `audio.play()` fulfilment, not just response receipt.
+
+### Probe Redaction
+
+- R8. Production TTS/performance probes must not persist cookies, prompt tokens, account ids, learner ids, R2 object keys, raw prompt text, or raw audio bodies.
+- R9. Tests must fail if a probe output reintroduces sensitive fields.
+
+### Page-Load Optimisation
+
+- R10. Spelling hero image preloading must eagerly load only the active/likely-next background needed for a smooth transition.
+- R11. Speculative hero backgrounds must be deferred until idle time or otherwise bounded so entering Spelling setup does not immediately fan out across many 1280 WebP images.
+- R12. Existing contrast/luminance behaviour must remain safe when speculative preload is delayed.
+
+### Gameplay UX Hardening
+
+- R13. Subject command, read-model, and repository fetch paths must have bounded client-side timeouts with `AbortController` when available.
+- R14. Timeout errors must surface through existing network-error/degraded-flow handling rather than introducing unhandled rejections.
+- R15. Existing retry, stale-write refresh, replay-refresh, submit-lock, and circuit-breaker behaviours must continue to work.
+
+### Maintainability
+
+- R16. Refactor only where it directly supports the optimisation or hardening above.
+- R17. Avoid a broad `worker/src/repository.js` or `worker/src/app.js` rewrite in this slice; use the existing query-budget and smoke tests as the guard for later structural refactors.
+
+## Scope Boundaries
+
+- No R2 public bucket, custom-domain audio URL, unauthenticated audio serving, or Workers Cache API layer in this slice.
+- No Smart Placement, D1 Sessions, or Worker placement change without a separate canary plan and before/after measurement.
+- No destructive production D1 cleanup or schema migration.
+- No broad subject runtime rewrite.
+- No weakening of prompt tokens, auth checks, demo guards, CSP, production audit, or Cloudflare OAuth-safe package scripts.
+
+## Key Technical Decisions
+
+- KTD1. Build on the production-equivalent feature branch first. Reconciliation into `main` is handled by PR update/merge, not by editing the dirty `main` worktree.
+- KTD2. Split diagnostic lookup from playback lookup. `cacheLookupOnly` remains diagnostic/read-only; playback cache requests get an explicit migration-eligible mode or equivalent server-side distinction.
+- KTD3. Migrate only after authorisation and limiter checks. A legacy hit can be copied to primary only on an authenticated playback path that is already allowed to serve audio.
+- KTD4. Optimise hero preload by reducing eagerness, not by removing the visual system. The active background remains reliable; broad speculative loads move behind idle scheduling.
+- KTD5. Add timeouts at shared client fetch boundaries so subject-specific code benefits without duplicating timeout logic.
+- KTD6. Treat maintainability as guardrails in this slice. The next broad refactor should follow after the hot path is measured primary-backed and stable.
+
+## Implementation Units
+
+### U1. Branch and release alignment guard
+
+- **Goal:** Ensure the work continues from the production-equivalent TTS branch and cannot be confused with the dirty `main` checkout.
+- **Requirements:** R1, R2, R3
+- **Files:**
+  - Modify: `docs/plans/2026-06-08-001-perf-tts-playback-page-load-hardening-plan.md`
+  - Modify or create only if needed: `docs/residual-review-findings/*`
+- **Patterns to follow:** Existing `docs/plans/2026-06-07-002-perf-tts-cache-followup-plan.md` and PR branch workflow.
+- **Test scenarios:**
+  - Verify `/api/version` production hash still maps to the current feature branch before implementation.
+  - Verify the working tree is clean before code edits.
+- **Verification:** `git status --short --branch` shows work on `codex/tts-cache-r2-opt` or a branch derived from it; no edits are made in the dirty `main` worktree.
+
+### U2. TTS playback migration semantics
+
+- **Goal:** Let real playback cache hits migrate legacy audio to the primary R2 key while preserving read-only diagnostics.
+- **Requirements:** R4, R5, R6, R7
+- **Files:**
+  - Modify: `src/subjects/spelling/tts.js`
+  - Modify: `worker/src/tts.js`
+  - Modify: `tests/spelling-tts.test.js`
+  - Modify: `tests/worker-tts.test.js`
+  - Modify if needed: `scripts/production-performance-probe.mjs`
+- **Patterns to follow:** `speakWithCachedBufferedAudio` in `src/subjects/spelling/tts.js`, `readBufferedGeminiAudio` and legacy migration tests in `worker/src/tts.js` / `tests/worker-tts.test.js`.
+- **Approach:** Introduce a distinct playback cache flag, or equivalent Worker-side option, that keeps provider calls disabled but allows legacy-to-primary copy after full audio request protection. Keep `cacheLookupOnly` read-only for diagnostics. Browser playback should send the migration-eligible mode; production probes that intentionally test read-only lookup should keep using diagnostic lookup.
+- **Test scenarios:**
+  - Happy path: playback cache request finds legacy audio, returns `200 hit legacy` on that response, writes the primary copy, and a later playback request hits `primary`.
+  - Diagnostic path: `cacheLookupOnly` legacy hit returns the legacy audio without writing a primary copy.
+  - Error path: failed migration write still serves the legacy hit and logs only redacted metadata.
+  - Client path: cached playback telemetry still records `playStartMs` after `audio.play()` resolves.
+- **Verification:** `node --test tests/worker-tts.test.js tests/spelling-tts.test.js` passes; production browser probe after deploy shows the replay path moving to `source=primary` after migration.
+
+### U3. Probe redaction regression lock
+
+- **Goal:** Prevent production probe outputs from leaking sensitive TTS/session material.
+- **Requirements:** R8, R9
+- **Files:**
+  - Modify: `scripts/spelling-audio-production-smoke.mjs`
+  - Modify: `scripts/production-performance-probe.mjs`
+  - Modify: `tests/spelling-audio-production-smoke.test.js`
+  - Modify: `tests/production-performance-probe.test.js`
+- **Patterns to follow:** Existing redaction helpers and forbidden-key assertions in production smoke tests.
+- **Approach:** Extend tests to cover playback-migration fields and any new cache mode. Keep output useful for operators while replacing sensitive ids/tokens/object keys with coarse labels.
+- **Test scenarios:**
+  - Probe JSON omits prompt tokens, account ids, learner ids, cookies, expected R2 keys, transcript text, and raw audio bodies.
+  - Probe warnings for migration failures include cache state and phase but no object key or prompt data.
+  - CLI JSON mode remains parseable when a probe fails.
+- **Verification:** Focused probe tests pass and any generated `/tmp` evidence inspected during development contains only redacted identifiers.
+
+### U4. Spelling hero preload reduction
+
+- **Goal:** Reduce image/network pressure when learners enter Spelling setup and start rounds.
+- **Requirements:** R10, R11, R12
+- **Files:**
+  - Modify: `src/subjects/spelling/components/spelling-view-model.js`
+  - Modify: `src/subjects/spelling/components/SpellingPracticeSurface.jsx`
+  - Modify: `src/platform/ui/luminance.js`
+  - Modify or add: relevant Spelling view-model/component tests
+- **Patterns to follow:** `heroBgForPhase`, `heroBgPreloadUrls`, `preloadImages`, and existing hero contrast tests.
+- **Approach:** Return or split eager and idle preload URLs. Load the active background immediately, maybe one likely next tone/mode, and defer broad mode/tone speculation through `requestIdleCallback` with a timeout fallback. Keep luminance caching intact.
+- **Test scenarios:**
+  - Fresh Spelling setup eager preload count is bounded and includes the active hero URL.
+  - Post-Mega scenes still include the active branch background.
+  - Idle preload schedules speculative URLs without blocking initial render.
+  - No crash when `requestIdleCallback` is unavailable.
+- **Verification:** Focused UI/view-model tests pass; browser smoke shows fewer initial image requests on setup.
+
+### U5. Client fetch timeout hardening
+
+- **Goal:** Bound gameplay network waits without breaking existing retry/degraded-state behaviour.
+- **Requirements:** R13, R14, R15
+- **Files:**
+  - Modify: `src/platform/runtime/subject-command-client.js`
+  - Modify: `src/platform/runtime/read-model-client.js`
+  - Modify: `src/platform/core/repositories/api.js`
+  - Modify or add: tests covering subject command client, read-model client, and repository network errors
+- **Patterns to follow:** `SubjectCommandClientError`, `RepositoryHttpError`, bootstrap circuit-breaker tests, and existing retry/backoff tests.
+- **Approach:** Add a small shared timeout wrapper or local helper that uses `AbortController` when available and preserves caller-supplied `signal`. Convert abort/timeouts into the existing network error paths. Keep default timeout conservative and configurable by constructor options where those clients already accept options.
+- **Test scenarios:**
+  - Subject command timeout becomes `subject_command_network_error` and participates in retry policy.
+  - Read-model timeout throws the same shaped error as a network failure.
+  - Repository timeout becomes `RepositoryHttpError` with status `0`.
+  - Existing caller-provided abort signals still cancel requests.
+- **Verification:** Focused runtime/repository tests pass; no unhandled rejections in browser smoke.
+
+### U6. Focused refactor and measurement guardrails
+
+- **Goal:** Capture enough guardrails for future CPU/page-load/TTS refactors without widening this PR into a repository rewrite.
+- **Requirements:** R16, R17
+- **Files:**
+  - Modify if needed: `tests/worker-query-budget.test.js`
+  - Modify if needed: `tests/bundle-audit.test.js`
+  - Modify if needed: `docs/operations/performance-probes.md`
+- **Patterns to follow:** Existing query-budget tests, production bundle audit, and performance probe docs.
+- **Approach:** Add only narrow assertions needed by U2-U5: cache source expectations, preload budget, timeout error shape, and bundle/resource headroom. Record broad repository/app file splitting as a follow-up rather than mixing it into this optimisation.
+- **Test scenarios:**
+  - Query-budget tests continue to pass after TTS and timeout changes.
+  - Bundle audit remains below the current gzip budget.
+  - Documentation states that broad repository/app refactor is deferred until hot-path metrics are stable.
+- **Verification:** `npm test`, `npm run check`, production audit, and browser smoke all pass before commit/push.
+
+## Acceptance Examples
+
+- AE1. Given the browser replay path serves a legacy cached audio object, when a learner replays the word, then the response plays successfully and a primary copy is written for subsequent requests.
+- AE2. Given a diagnostic lookup-only production probe hits a legacy object, when the probe completes, then it reports the cache source but does not write a primary copy.
+- AE3. Given Spelling setup opens for a demo learner, when the initial render completes, then only a bounded number of hero images are eagerly fetched and the active background remains visible.
+- AE4. Given a subject command fetch hangs, when the client timeout elapses, then the UI leaves the pending state through the existing network/degraded handling instead of waiting indefinitely.
+- AE5. Given production probes run after deployment, when JSON evidence is stored, then it contains timings/cache labels but no cookies, tokens, learner/account ids, object keys, transcript text, or raw audio.
+
+## Verification Plan
+
+- Focused tests: `node --test tests/worker-tts.test.js tests/spelling-tts.test.js tests/spelling-audio-production-smoke.test.js tests/production-performance-probe.test.js`
+- Runtime/client tests for fetch timeout changes.
+- Query and bundle guards: `node --test tests/worker-query-budget.test.js tests/bundle-audit.test.js`
+- Full local gates: `npm test` and `npm run check`.
+- Production-safe audit before deploy/PR update: `npm run audit:production -- --skip-local --retries 1 --retry-delay-ms 1000`.
+- Browser smoke via the pipeline browser test step, covering home -> demo -> Spelling setup -> Smart Review -> Begin -> replay.
+
+## Risks and Dependencies
+
+- A migration-eligible playback flag must not become a provider-generation bypass. It must only copy already-served legacy audio after auth and limiter checks.
+- Delaying hero preloads can cause a background flash if the active URL is not always eager. Tests must pin the active-background rule.
+- Client timeouts can surface previously hidden slow-network conditions. The timeout must be long enough for normal mobile connections and must reuse existing retry/degraded UX.
+- Full `npm test` is large; focused tests should run during each unit and the full suite should run before PR update.
+- Merging the existing PR into `main` remains a repository governance step; this work should make that PR safer to merge rather than bypassing it.

--- a/docs/residual-review-findings/codex-tts-cache-r2-opt.md
+++ b/docs/residual-review-findings/codex-tts-cache-r2-opt.md
@@ -1,0 +1,9 @@
+## Residual Review Findings
+
+- P2 `scripts/production-performance-probe.mjs:644` Measure TTS through real client path — filed as https://github.com/fol2/ks2-mastery/issues/904
+
+Source context:
+
+- Review run: LFG step 3 multi-agent review for `docs/plans/2026-06-07-002-perf-tts-cache-followup-plan.md`.
+- Applied mitigation: `--browser-tts` is now explicitly reported as `browser-direct-audio`, so it no longer claims to exercise the real app TTS port.
+- Residual: a future authenticated UI probe should drive the real spelling replay control and collect `[ks2-tts-cache-latency]` from the app path without adding a public diagnostics hook.

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "deploy:oauth": "npm run deploy",
     "deploy:ci": "npm run deploy",
     "ops:health:production": "node ./scripts/production-health-snapshot.mjs",
+    "perf:production": "node ./scripts/production-performance-probe.mjs",
     "ops:tail": "node ./scripts/wrangler-oauth.mjs tail ks2-mastery --format pretty",
     "ops:tail:json": "node ./scripts/wrangler-oauth.mjs tail ks2-mastery --format json",
     "read-models:backfill": "node ./scripts/backfill-learner-read-models.mjs",

--- a/reports/production-performance-tts-cache-opt-2026-06-08.json
+++ b/reports/production-performance-tts-cache-opt-2026-06-08.json
@@ -1,0 +1,1054 @@
+{
+  "ok": true,
+  "origin": "https://ks2.eugnel.uk",
+  "startedAt": "2026-06-08T17:01:23.471Z",
+  "finishedAt": "2026-06-08T17:01:35.389Z",
+  "config": {
+    "assetSamples": 3,
+    "bootstrapSamples": 2,
+    "ttsSamples": 3,
+    "warmup": 1,
+    "wordSample": [
+      "accident",
+      "knowledge"
+    ],
+    "voices": [
+      "Iapetus"
+    ],
+    "cookieEnv": "KS2_PRODUCTION_COOKIE",
+    "learnerIdProvided": false,
+    "includeAssets": false,
+    "includeBootstrap": true,
+    "includeTts": true,
+    "includeBrowserTts": true
+  },
+  "session": {
+    "ok": true,
+    "status": 201,
+    "source": "demo",
+    "learnerIdPresent": true,
+    "accountIdPresent": true,
+    "serverRequestId": "ks2_req_7a7cfd66-9020-435a-be74-ee33da8e03ce"
+  },
+  "assets": null,
+  "bootstrap": {
+    "samples": [
+      {
+        "ok": true,
+        "label": "GET /api/bootstrap",
+        "url": "https://ks2.eugnel.uk/api/bootstrap",
+        "method": "GET",
+        "clientRequestId": "ks2_req_f44fe384-efef-4457-aea9-48829f3d5daf",
+        "serverRequestId": "ks2_req_f44fe384-efef-4457-aea9-48829f3d5daf",
+        "status": 200,
+        "startedAt": "2026-06-08T17:01:25.805Z",
+        "finishedAt": "2026-06-08T17:01:26.024Z",
+        "headerMs": 218,
+        "bodyMs": 1,
+        "totalMs": 218,
+        "bytes": 2448,
+        "headers": {
+          "cacheControl": "no-store",
+          "cfCacheStatus": "",
+          "contentType": "application/json; charset=utf-8",
+          "contentLength": "",
+          "serverTiming": "",
+          "xRequestId": "ks2_req_f44fe384-efef-4457-aea9-48829f3d5daf",
+          "xTtsCache": "",
+          "xTtsCacheSource": ""
+        },
+        "capacity": {
+          "requestId": "ks2_req_f44fe384-efef-4457-aea9-48829f3d5daf",
+          "queryCount": 9,
+          "d1DurationMs": null,
+          "d1RowsRead": 7,
+          "d1RowsWritten": 0,
+          "serverWallMs": 105,
+          "responseBytes": 1818
+        }
+      },
+      {
+        "ok": true,
+        "label": "GET /api/bootstrap",
+        "url": "https://ks2.eugnel.uk/api/bootstrap",
+        "method": "GET",
+        "clientRequestId": "ks2_req_09f3ffc9-73e2-4f55-9f9d-71ed90e5b36b",
+        "serverRequestId": "ks2_req_09f3ffc9-73e2-4f55-9f9d-71ed90e5b36b",
+        "status": 200,
+        "startedAt": "2026-06-08T17:01:26.025Z",
+        "finishedAt": "2026-06-08T17:01:26.206Z",
+        "headerMs": 180,
+        "bodyMs": 1,
+        "totalMs": 181,
+        "bytes": 2447,
+        "headers": {
+          "cacheControl": "no-store",
+          "cfCacheStatus": "",
+          "contentType": "application/json; charset=utf-8",
+          "contentLength": "",
+          "serverTiming": "",
+          "xRequestId": "ks2_req_09f3ffc9-73e2-4f55-9f9d-71ed90e5b36b",
+          "xTtsCache": "",
+          "xTtsCacheSource": ""
+        },
+        "capacity": {
+          "requestId": "ks2_req_09f3ffc9-73e2-4f55-9f9d-71ed90e5b36b",
+          "queryCount": 8,
+          "d1DurationMs": null,
+          "d1RowsRead": 6,
+          "d1RowsWritten": 0,
+          "serverWallMs": 89,
+          "responseBytes": 1818
+        }
+      }
+    ],
+    "summary": [
+      {
+        "key": "GET /api/bootstrap",
+        "count": 2,
+        "statuses": {
+          "200": 2
+        },
+        "headerMs": {
+          "count": 2,
+          "min": 180,
+          "p50": 180,
+          "p95": 218,
+          "max": 218,
+          "mean": 199
+        },
+        "bodyMs": {
+          "count": 2,
+          "min": 1,
+          "p50": 1,
+          "p95": 1,
+          "max": 1,
+          "mean": 1
+        },
+        "totalMs": {
+          "count": 2,
+          "min": 181,
+          "p50": 181,
+          "p95": 218,
+          "max": 218,
+          "mean": 200
+        },
+        "bytes": {
+          "count": 2,
+          "min": 2447,
+          "p50": 2447,
+          "p95": 2448,
+          "max": 2448,
+          "mean": 2448
+        }
+      }
+    ],
+    "capacity": {
+      "queryCount": {
+        "count": 2,
+        "min": 8,
+        "p50": 8,
+        "p95": 9,
+        "max": 9,
+        "mean": 9
+      },
+      "d1DurationMs": {
+        "count": 0,
+        "min": null,
+        "p50": null,
+        "p95": null,
+        "max": null,
+        "mean": null
+      },
+      "d1RowsRead": {
+        "count": 2,
+        "min": 6,
+        "p50": 6,
+        "p95": 7,
+        "max": 7,
+        "mean": 7
+      },
+      "d1RowsWritten": {
+        "count": 2,
+        "min": 0,
+        "p50": 0,
+        "p95": 0,
+        "max": 0,
+        "mean": 0
+      },
+      "serverWallMs": {
+        "count": 2,
+        "min": 89,
+        "p50": 89,
+        "p95": 105,
+        "max": 105,
+        "mean": 97
+      },
+      "responseBytes": {
+        "count": 2,
+        "min": 1818,
+        "p50": 1818,
+        "p95": 1818,
+        "max": 1818,
+        "mean": 1818
+      }
+    },
+    "selectedLearnerIdPresent": true
+  },
+  "tts": {
+    "samples": [
+      {
+        "ok": true,
+        "label": "POST /api/tts word-lookup accident/Iapetus",
+        "url": "https://ks2.eugnel.uk/api/tts",
+        "method": "POST",
+        "clientRequestId": "ks2_req_301b0c99-9101-4b69-b245-85add858d28e",
+        "serverRequestId": "ks2_req_301b0c99-9101-4b69-b245-85add858d28e",
+        "status": 200,
+        "startedAt": "2026-06-08T17:01:28.285Z",
+        "finishedAt": "2026-06-08T17:01:28.753Z",
+        "headerMs": 466,
+        "bodyMs": 2,
+        "totalMs": 468,
+        "bytes": 61484,
+        "mode": "word-lookup",
+        "slug": "accident",
+        "voice": "Iapetus",
+        "cache": "hit",
+        "source": "primary",
+        "contentType": "audio/wav",
+        "serverTimingPhases": {
+          "body": 0,
+          "prompt": 28,
+          "lookup_limit": 79,
+          "r2": 91,
+          "cache_lookup": 91,
+          "audio_limit": 96,
+          "response": 0,
+          "total": 294
+        },
+        "classification": "rate-limit-dominated"
+      },
+      {
+        "ok": true,
+        "label": "POST /api/tts sentence-cache accident/Iapetus",
+        "url": "https://ks2.eugnel.uk/api/tts",
+        "method": "POST",
+        "clientRequestId": "ks2_req_fb4c0b34-c270-4856-be12-1e96141c3d01",
+        "serverRequestId": "ks2_req_fb4c0b34-c270-4856-be12-1e96141c3d01",
+        "status": 200,
+        "startedAt": "2026-06-08T17:01:28.754Z",
+        "finishedAt": "2026-06-08T17:01:29.215Z",
+        "headerMs": 459,
+        "bodyMs": 2,
+        "totalMs": 461,
+        "bytes": 53661,
+        "mode": "sentence-cache",
+        "slug": "accident",
+        "voice": "Iapetus",
+        "cache": "hit",
+        "source": "primary",
+        "contentType": "audio/mpeg",
+        "serverTimingPhases": {
+          "body": 0,
+          "prompt": 30,
+          "lookup_limit": 79,
+          "r2": 57,
+          "cache_lookup": 57,
+          "audio_limit": 113,
+          "response": 0,
+          "total": 279
+        },
+        "classification": "rate-limit-dominated"
+      },
+      {
+        "ok": true,
+        "label": "POST /api/tts word-lookup knowledge/Iapetus",
+        "url": "https://ks2.eugnel.uk/api/tts",
+        "method": "POST",
+        "clientRequestId": "ks2_req_e4716df5-9b5b-473c-8938-1e51c9502c57",
+        "serverRequestId": "ks2_req_e4716df5-9b5b-473c-8938-1e51c9502c57",
+        "status": 200,
+        "startedAt": "2026-06-08T17:01:29.216Z",
+        "finishedAt": "2026-06-08T17:01:29.731Z",
+        "headerMs": 506,
+        "bodyMs": 9,
+        "totalMs": 515,
+        "bytes": 63404,
+        "mode": "word-lookup",
+        "slug": "knowledge",
+        "voice": "Iapetus",
+        "cache": "hit",
+        "source": "primary",
+        "contentType": "audio/wav",
+        "serverTimingPhases": {
+          "body": 0,
+          "prompt": 28,
+          "lookup_limit": 87,
+          "r2": 109,
+          "cache_lookup": 109,
+          "audio_limit": 103,
+          "response": 0,
+          "total": 327
+        },
+        "classification": "rate-limit-dominated"
+      },
+      {
+        "ok": true,
+        "label": "POST /api/tts sentence-cache knowledge/Iapetus",
+        "url": "https://ks2.eugnel.uk/api/tts",
+        "method": "POST",
+        "clientRequestId": "ks2_req_b15ae352-515c-473b-9e02-af4bd2ce59da",
+        "serverRequestId": "ks2_req_b15ae352-515c-473b-9e02-af4bd2ce59da",
+        "status": 200,
+        "startedAt": "2026-06-08T17:01:29.731Z",
+        "finishedAt": "2026-06-08T17:01:30.251Z",
+        "headerMs": 515,
+        "bodyMs": 5,
+        "totalMs": 520,
+        "bytes": 63021,
+        "mode": "sentence-cache",
+        "slug": "knowledge",
+        "voice": "Iapetus",
+        "cache": "hit",
+        "source": "primary",
+        "contentType": "audio/mpeg",
+        "serverTimingPhases": {
+          "body": 0,
+          "prompt": 36,
+          "lookup_limit": 81,
+          "r2": 48,
+          "cache_lookup": 48,
+          "audio_limit": 107,
+          "response": 0,
+          "total": 272
+        },
+        "classification": "rate-limit-dominated"
+      },
+      {
+        "ok": true,
+        "label": "POST /api/tts word-lookup accident/Iapetus",
+        "url": "https://ks2.eugnel.uk/api/tts",
+        "method": "POST",
+        "clientRequestId": "ks2_req_5ba3b0c2-23e1-4401-883b-684a8fea9f5e",
+        "serverRequestId": "ks2_req_5ba3b0c2-23e1-4401-883b-684a8fea9f5e",
+        "status": 200,
+        "startedAt": "2026-06-08T17:01:30.252Z",
+        "finishedAt": "2026-06-08T17:01:30.732Z",
+        "headerMs": 480,
+        "bodyMs": 0,
+        "totalMs": 481,
+        "bytes": 61484,
+        "mode": "word-lookup",
+        "slug": "accident",
+        "voice": "Iapetus",
+        "cache": "hit",
+        "source": "primary",
+        "contentType": "audio/wav",
+        "serverTimingPhases": {
+          "body": 0,
+          "prompt": 29,
+          "lookup_limit": 81,
+          "r2": 99,
+          "cache_lookup": 99,
+          "audio_limit": 100,
+          "response": 0,
+          "total": 309
+        },
+        "classification": "rate-limit-dominated"
+      },
+      {
+        "ok": true,
+        "label": "POST /api/tts sentence-cache accident/Iapetus",
+        "url": "https://ks2.eugnel.uk/api/tts",
+        "method": "POST",
+        "clientRequestId": "ks2_req_9e1e736b-5171-49d0-85ec-57b1f6d0a2b7",
+        "serverRequestId": "ks2_req_9e1e736b-5171-49d0-85ec-57b1f6d0a2b7",
+        "status": 200,
+        "startedAt": "2026-06-08T17:01:30.733Z",
+        "finishedAt": "2026-06-08T17:01:31.231Z",
+        "headerMs": 496,
+        "bodyMs": 2,
+        "totalMs": 498,
+        "bytes": 53661,
+        "mode": "sentence-cache",
+        "slug": "accident",
+        "voice": "Iapetus",
+        "cache": "hit",
+        "source": "primary",
+        "contentType": "audio/mpeg",
+        "serverTimingPhases": {
+          "body": 0,
+          "prompt": 36,
+          "lookup_limit": 82,
+          "r2": 50,
+          "cache_lookup": 50,
+          "audio_limit": 118,
+          "response": 0,
+          "total": 286
+        },
+        "classification": "rate-limit-dominated"
+      },
+      {
+        "ok": true,
+        "label": "POST /api/tts word-lookup knowledge/Iapetus",
+        "url": "https://ks2.eugnel.uk/api/tts",
+        "method": "POST",
+        "clientRequestId": "ks2_req_c80f76bc-ccef-406e-92ab-06404aa3c76e",
+        "serverRequestId": "ks2_req_c80f76bc-ccef-406e-92ab-06404aa3c76e",
+        "status": 200,
+        "startedAt": "2026-06-08T17:01:31.231Z",
+        "finishedAt": "2026-06-08T17:01:31.713Z",
+        "headerMs": 482,
+        "bodyMs": 0,
+        "totalMs": 482,
+        "bytes": 63404,
+        "mode": "word-lookup",
+        "slug": "knowledge",
+        "voice": "Iapetus",
+        "cache": "hit",
+        "source": "primary",
+        "contentType": "audio/wav",
+        "serverTimingPhases": {
+          "body": 0,
+          "prompt": 26,
+          "lookup_limit": 77,
+          "r2": 108,
+          "cache_lookup": 108,
+          "audio_limit": 107,
+          "response": 0,
+          "total": 318
+        },
+        "classification": "rate-limit-dominated"
+      },
+      {
+        "ok": true,
+        "label": "POST /api/tts sentence-cache knowledge/Iapetus",
+        "url": "https://ks2.eugnel.uk/api/tts",
+        "method": "POST",
+        "clientRequestId": "ks2_req_348a293f-7496-4650-8ad3-9a6e529ac66d",
+        "serverRequestId": "ks2_req_348a293f-7496-4650-8ad3-9a6e529ac66d",
+        "status": 200,
+        "startedAt": "2026-06-08T17:01:31.714Z",
+        "finishedAt": "2026-06-08T17:01:32.187Z",
+        "headerMs": 473,
+        "bodyMs": 0,
+        "totalMs": 473,
+        "bytes": 63021,
+        "mode": "sentence-cache",
+        "slug": "knowledge",
+        "voice": "Iapetus",
+        "cache": "hit",
+        "source": "primary",
+        "contentType": "audio/mpeg",
+        "serverTimingPhases": {
+          "body": 0,
+          "prompt": 30,
+          "lookup_limit": 78,
+          "r2": 61,
+          "cache_lookup": 61,
+          "audio_limit": 129,
+          "response": 0,
+          "total": 298
+        },
+        "classification": "rate-limit-dominated"
+      },
+      {
+        "ok": true,
+        "label": "POST /api/tts word-lookup accident/Iapetus",
+        "url": "https://ks2.eugnel.uk/api/tts",
+        "method": "POST",
+        "clientRequestId": "ks2_req_68e5f170-ee26-44fb-9909-3262e0de094d",
+        "serverRequestId": "ks2_req_68e5f170-ee26-44fb-9909-3262e0de094d",
+        "status": 200,
+        "startedAt": "2026-06-08T17:01:32.187Z",
+        "finishedAt": "2026-06-08T17:01:32.685Z",
+        "headerMs": 494,
+        "bodyMs": 5,
+        "totalMs": 499,
+        "bytes": 61484,
+        "mode": "word-lookup",
+        "slug": "accident",
+        "voice": "Iapetus",
+        "cache": "hit",
+        "source": "primary",
+        "contentType": "audio/wav",
+        "serverTimingPhases": {
+          "body": 0,
+          "prompt": 32,
+          "lookup_limit": 85,
+          "r2": 100,
+          "cache_lookup": 100,
+          "audio_limit": 112,
+          "response": 0,
+          "total": 329
+        },
+        "classification": "rate-limit-dominated"
+      },
+      {
+        "ok": true,
+        "label": "POST /api/tts sentence-cache accident/Iapetus",
+        "url": "https://ks2.eugnel.uk/api/tts",
+        "method": "POST",
+        "clientRequestId": "ks2_req_b5d8f295-44cd-41cd-8c55-d77f4739d470",
+        "serverRequestId": "ks2_req_b5d8f295-44cd-41cd-8c55-d77f4739d470",
+        "status": 200,
+        "startedAt": "2026-06-08T17:01:32.686Z",
+        "finishedAt": "2026-06-08T17:01:33.126Z",
+        "headerMs": 438,
+        "bodyMs": 2,
+        "totalMs": 441,
+        "bytes": 53661,
+        "mode": "sentence-cache",
+        "slug": "accident",
+        "voice": "Iapetus",
+        "cache": "hit",
+        "source": "primary",
+        "contentType": "audio/mpeg",
+        "serverTimingPhases": {
+          "body": 0,
+          "prompt": 31,
+          "lookup_limit": 78,
+          "r2": 61,
+          "cache_lookup": 61,
+          "audio_limit": 110,
+          "response": 0,
+          "total": 280
+        },
+        "classification": "rate-limit-dominated"
+      },
+      {
+        "ok": true,
+        "label": "POST /api/tts word-lookup knowledge/Iapetus",
+        "url": "https://ks2.eugnel.uk/api/tts",
+        "method": "POST",
+        "clientRequestId": "ks2_req_2725352e-fa4f-4b8e-b287-7c837c3dea0b",
+        "serverRequestId": "ks2_req_2725352e-fa4f-4b8e-b287-7c837c3dea0b",
+        "status": 200,
+        "startedAt": "2026-06-08T17:01:33.127Z",
+        "finishedAt": "2026-06-08T17:01:33.675Z",
+        "headerMs": 546,
+        "bodyMs": 2,
+        "totalMs": 548,
+        "bytes": 63404,
+        "mode": "word-lookup",
+        "slug": "knowledge",
+        "voice": "Iapetus",
+        "cache": "hit",
+        "source": "primary",
+        "contentType": "audio/wav",
+        "serverTimingPhases": {
+          "body": 0,
+          "prompt": 21,
+          "lookup_limit": 80,
+          "r2": 112,
+          "cache_lookup": 112,
+          "audio_limit": 103,
+          "response": 0,
+          "total": 316
+        },
+        "classification": "rate-limit-dominated"
+      },
+      {
+        "ok": true,
+        "label": "POST /api/tts sentence-cache knowledge/Iapetus",
+        "url": "https://ks2.eugnel.uk/api/tts",
+        "method": "POST",
+        "clientRequestId": "ks2_req_2d122827-2334-4154-8a29-4ba5e1fd3a12",
+        "serverRequestId": "ks2_req_2d122827-2334-4154-8a29-4ba5e1fd3a12",
+        "status": 200,
+        "startedAt": "2026-06-08T17:01:33.675Z",
+        "finishedAt": "2026-06-08T17:01:34.107Z",
+        "headerMs": 431,
+        "bodyMs": 1,
+        "totalMs": 432,
+        "bytes": 63021,
+        "mode": "sentence-cache",
+        "slug": "knowledge",
+        "voice": "Iapetus",
+        "cache": "hit",
+        "source": "primary",
+        "contentType": "audio/mpeg",
+        "serverTimingPhases": {
+          "body": 0,
+          "prompt": 30,
+          "lookup_limit": 82,
+          "r2": 52,
+          "cache_lookup": 52,
+          "audio_limit": 99,
+          "response": 0,
+          "total": 263
+        },
+        "classification": "rate-limit-dominated"
+      }
+    ],
+    "summary": [
+      {
+        "key": "word-lookup/accident/Iapetus/hit/primary",
+        "count": 3,
+        "statuses": {
+          "200": 3
+        },
+        "headerMs": {
+          "count": 3,
+          "min": 466,
+          "p50": 480,
+          "p95": 494,
+          "max": 494,
+          "mean": 480
+        },
+        "bodyMs": {
+          "count": 3,
+          "min": 0,
+          "p50": 2,
+          "p95": 5,
+          "max": 5,
+          "mean": 2
+        },
+        "totalMs": {
+          "count": 3,
+          "min": 468,
+          "p50": 481,
+          "p95": 499,
+          "max": 499,
+          "mean": 483
+        },
+        "bytes": {
+          "count": 3,
+          "min": 61484,
+          "p50": 61484,
+          "p95": 61484,
+          "max": 61484,
+          "mean": 61484
+        }
+      },
+      {
+        "key": "sentence-cache/accident/Iapetus/hit/primary",
+        "count": 3,
+        "statuses": {
+          "200": 3
+        },
+        "headerMs": {
+          "count": 3,
+          "min": 438,
+          "p50": 459,
+          "p95": 496,
+          "max": 496,
+          "mean": 464
+        },
+        "bodyMs": {
+          "count": 3,
+          "min": 2,
+          "p50": 2,
+          "p95": 2,
+          "max": 2,
+          "mean": 2
+        },
+        "totalMs": {
+          "count": 3,
+          "min": 441,
+          "p50": 461,
+          "p95": 498,
+          "max": 498,
+          "mean": 467
+        },
+        "bytes": {
+          "count": 3,
+          "min": 53661,
+          "p50": 53661,
+          "p95": 53661,
+          "max": 53661,
+          "mean": 53661
+        }
+      },
+      {
+        "key": "word-lookup/knowledge/Iapetus/hit/primary",
+        "count": 3,
+        "statuses": {
+          "200": 3
+        },
+        "headerMs": {
+          "count": 3,
+          "min": 482,
+          "p50": 506,
+          "p95": 546,
+          "max": 546,
+          "mean": 511
+        },
+        "bodyMs": {
+          "count": 3,
+          "min": 0,
+          "p50": 2,
+          "p95": 9,
+          "max": 9,
+          "mean": 4
+        },
+        "totalMs": {
+          "count": 3,
+          "min": 482,
+          "p50": 515,
+          "p95": 548,
+          "max": 548,
+          "mean": 515
+        },
+        "bytes": {
+          "count": 3,
+          "min": 63404,
+          "p50": 63404,
+          "p95": 63404,
+          "max": 63404,
+          "mean": 63404
+        }
+      },
+      {
+        "key": "sentence-cache/knowledge/Iapetus/hit/primary",
+        "count": 3,
+        "statuses": {
+          "200": 3
+        },
+        "headerMs": {
+          "count": 3,
+          "min": 431,
+          "p50": 473,
+          "p95": 515,
+          "max": 515,
+          "mean": 473
+        },
+        "bodyMs": {
+          "count": 3,
+          "min": 0,
+          "p50": 1,
+          "p95": 5,
+          "max": 5,
+          "mean": 2
+        },
+        "totalMs": {
+          "count": 3,
+          "min": 432,
+          "p50": 473,
+          "p95": 520,
+          "max": 520,
+          "mean": 475
+        },
+        "bytes": {
+          "count": 3,
+          "min": 63021,
+          "p50": 63021,
+          "p95": 63021,
+          "max": 63021,
+          "mean": 63021
+        }
+      }
+    ],
+    "phaseSummary": {
+      "body": {
+        "count": 12,
+        "min": 0,
+        "p50": 0,
+        "p95": 0,
+        "max": 0,
+        "mean": 0
+      },
+      "prompt": {
+        "count": 12,
+        "min": 21,
+        "p50": 30,
+        "p95": 36,
+        "max": 36,
+        "mean": 30
+      },
+      "lookup_limit": {
+        "count": 12,
+        "min": 77,
+        "p50": 80,
+        "p95": 87,
+        "max": 87,
+        "mean": 81
+      },
+      "r2": {
+        "count": 12,
+        "min": 48,
+        "p50": 61,
+        "p95": 112,
+        "max": 112,
+        "mean": 79
+      },
+      "cache_lookup": {
+        "count": 12,
+        "min": 48,
+        "p50": 61,
+        "p95": 112,
+        "max": 112,
+        "mean": 79
+      },
+      "audio_limit": {
+        "count": 12,
+        "min": 96,
+        "p50": 107,
+        "p95": 129,
+        "max": 129,
+        "mean": 108
+      },
+      "response": {
+        "count": 12,
+        "min": 0,
+        "p50": 0,
+        "p95": 0,
+        "max": 0,
+        "mean": 0
+      },
+      "total": {
+        "count": 12,
+        "min": 263,
+        "p50": 294,
+        "p95": 329,
+        "max": 329,
+        "mean": 298
+      }
+    },
+    "modeSummary": {
+      "word-lookup": [
+        {
+          "key": "accident/Iapetus/hit/primary",
+          "count": 3,
+          "statuses": {
+            "200": 3
+          },
+          "headerMs": {
+            "count": 3,
+            "min": 466,
+            "p50": 480,
+            "p95": 494,
+            "max": 494,
+            "mean": 480
+          },
+          "bodyMs": {
+            "count": 3,
+            "min": 0,
+            "p50": 2,
+            "p95": 5,
+            "max": 5,
+            "mean": 2
+          },
+          "totalMs": {
+            "count": 3,
+            "min": 468,
+            "p50": 481,
+            "p95": 499,
+            "max": 499,
+            "mean": 483
+          },
+          "bytes": {
+            "count": 3,
+            "min": 61484,
+            "p50": 61484,
+            "p95": 61484,
+            "max": 61484,
+            "mean": 61484
+          }
+        },
+        {
+          "key": "knowledge/Iapetus/hit/primary",
+          "count": 3,
+          "statuses": {
+            "200": 3
+          },
+          "headerMs": {
+            "count": 3,
+            "min": 482,
+            "p50": 506,
+            "p95": 546,
+            "max": 546,
+            "mean": 511
+          },
+          "bodyMs": {
+            "count": 3,
+            "min": 0,
+            "p50": 2,
+            "p95": 9,
+            "max": 9,
+            "mean": 4
+          },
+          "totalMs": {
+            "count": 3,
+            "min": 482,
+            "p50": 515,
+            "p95": 548,
+            "max": 548,
+            "mean": 515
+          },
+          "bytes": {
+            "count": 3,
+            "min": 63404,
+            "p50": 63404,
+            "p95": 63404,
+            "max": 63404,
+            "mean": 63404
+          }
+        }
+      ],
+      "sentence-cache": [
+        {
+          "key": "accident/Iapetus/hit/primary",
+          "count": 3,
+          "statuses": {
+            "200": 3
+          },
+          "headerMs": {
+            "count": 3,
+            "min": 438,
+            "p50": 459,
+            "p95": 496,
+            "max": 496,
+            "mean": 464
+          },
+          "bodyMs": {
+            "count": 3,
+            "min": 2,
+            "p50": 2,
+            "p95": 2,
+            "max": 2,
+            "mean": 2
+          },
+          "totalMs": {
+            "count": 3,
+            "min": 441,
+            "p50": 461,
+            "p95": 498,
+            "max": 498,
+            "mean": 467
+          },
+          "bytes": {
+            "count": 3,
+            "min": 53661,
+            "p50": 53661,
+            "p95": 53661,
+            "max": 53661,
+            "mean": 53661
+          }
+        },
+        {
+          "key": "knowledge/Iapetus/hit/primary",
+          "count": 3,
+          "statuses": {
+            "200": 3
+          },
+          "headerMs": {
+            "count": 3,
+            "min": 431,
+            "p50": 473,
+            "p95": 515,
+            "max": 515,
+            "mean": 473
+          },
+          "bodyMs": {
+            "count": 3,
+            "min": 0,
+            "p50": 1,
+            "p95": 5,
+            "max": 5,
+            "mean": 2
+          },
+          "totalMs": {
+            "count": 3,
+            "min": 432,
+            "p50": 473,
+            "p95": 520,
+            "max": 520,
+            "mean": 475
+          },
+          "bytes": {
+            "count": 3,
+            "min": 63021,
+            "p50": 63021,
+            "p95": 63021,
+            "max": 63021,
+            "mean": 63021
+          }
+        }
+      ]
+    },
+    "classifications": {
+      "rate-limit-dominated": 12
+    },
+    "failures": []
+  },
+  "browserTts": {
+    "ok": true,
+    "scope": "browser-direct-audio",
+    "skipped": false,
+    "skipReason": "",
+    "notes": [
+      "Direct headless-browser fetch of /api/tts plus Audio playback; not the in-app createPlatformTts path."
+    ],
+    "samples": [
+      {
+        "mode": "browser-direct-audio-play-start",
+        "slug": "accident",
+        "voice": "Iapetus",
+        "status": 200,
+        "cache": "hit",
+        "source": "primary",
+        "contentType": "audio/mpeg",
+        "requestId": "ks2_req_ba4ebe4a-ed05-4eb8-b384-ddf0d4540a88",
+        "headerMs": 390,
+        "blobMs": 5,
+        "playStartMs": 603,
+        "totalMs": 603,
+        "bytes": 53661,
+        "skipped": false,
+        "skipReason": ""
+      }
+    ],
+    "summary": [
+      {
+        "key": "accident/Iapetus/hit/primary",
+        "count": 1,
+        "statuses": {
+          "200": 1
+        },
+        "headerMs": {
+          "count": 1,
+          "min": 390,
+          "p50": 390,
+          "p95": 390,
+          "max": 390,
+          "mean": 390
+        },
+        "bodyMs": {
+          "count": 0,
+          "min": null,
+          "p50": null,
+          "p95": null,
+          "max": null,
+          "mean": null
+        },
+        "totalMs": {
+          "count": 1,
+          "min": 603,
+          "p50": 603,
+          "p95": 603,
+          "max": 603,
+          "mean": 603
+        },
+        "bytes": {
+          "count": 1,
+          "min": 53661,
+          "p50": 53661,
+          "p95": 53661,
+          "max": 53661,
+          "mean": 53661
+        }
+      }
+    ],
+    "playStartMs": {
+      "count": 1,
+      "min": 603,
+      "p50": 603,
+      "p95": 603,
+      "max": 603,
+      "mean": 603
+    }
+  },
+  "failures": []
+}

--- a/scripts/production-bundle-audit.mjs
+++ b/scripts/production-bundle-audit.mjs
@@ -169,6 +169,23 @@ function extractJsonLdBlocks(html, failures) {
   return blocks;
 }
 
+function staticSeoAuditHtml(html) {
+  return String(html || '').replace(
+    /<script\b(?=[^>]*\bsrc=["']https:\/\/static\.cloudflareinsights\.com\/beacon\.min\.js\/[^"']*["'])(?=[^>]*\bdata-cf-beacon=)[^>]*>\s*<\/script>/gi,
+    '',
+  );
+}
+
+function assertStaticSeoPageHasNoScripts(path, html, failures) {
+  const auditHtml = staticSeoAuditHtml(html);
+  for (const forbiddenToken of ['application/ld+json', '<script']) {
+    if (auditHtml.includes(forbiddenToken)) {
+      failures.push(`Production SEO page ${path} must remain static and script-free; found token: ${forbiddenToken}`);
+    }
+  }
+  assertNoForbiddenText(`Production SEO page ${path}`, auditHtml, failures);
+}
+
 function assertSeoRootHtml(index, failures) {
   if (!/text\/html/i.test(index.contentType)) {
     failures.push(`Production SEO root expected text/html, got: ${index.contentType || 'absent'}`);
@@ -253,12 +270,7 @@ function assertSeoPracticePageHtml(page, response, failures) {
       failures.push(`Production SEO page ${path} is missing required token: ${token}`);
     }
   }
-  for (const forbiddenToken of ['application/ld+json', '<script']) {
-    if (response.text.includes(forbiddenToken)) {
-      failures.push(`Production SEO page ${path} must remain static and script-free; found token: ${forbiddenToken}`);
-    }
-  }
-  assertNoForbiddenText(`Production SEO page ${path}`, response.text, failures);
+  assertStaticSeoPageHasNoScripts(path, response.text, failures);
 }
 
 async function assertSeoPracticePages(base, failures) {
@@ -307,17 +319,12 @@ function assertSeoIdentityPageHtml(page, response, failures) {
       failures.push(`Production SEO page ${path} is missing required token: ${token}`);
     }
   }
-  for (const forbiddenToken of ['application/ld+json', '<script']) {
-    if (response.text.includes(forbiddenToken)) {
-      failures.push(`Production SEO page ${path} must remain static and script-free; found token: ${forbiddenToken}`);
-    }
-  }
   for (const overclaim of ['guaranteed', 'full curriculum', 'AI tutor', 'exam results']) {
     if (response.text.toLowerCase().includes(overclaim.toLowerCase())) {
       failures.push(`Production SEO page ${path} must not overclaim with token: ${overclaim}`);
     }
   }
-  assertNoForbiddenText(`Production SEO page ${path}`, response.text, failures);
+  assertStaticSeoPageHasNoScripts(path, response.text, failures);
 }
 
 async function assertSeoIdentityPages(base, failures) {
@@ -362,11 +369,6 @@ function assertSeoIntentPageHtml(page, response, failures) {
       failures.push(`Production SEO page ${path} is missing required token: ${token}`);
     }
   }
-  for (const forbiddenToken of ['application/ld+json', '<script']) {
-    if (response.text.includes(forbiddenToken)) {
-      failures.push(`Production SEO page ${path} must remain static and script-free; found token: ${forbiddenToken}`);
-    }
-  }
   for (const overclaim of ['guaranteed', 'full curriculum', 'AI tutor', 'exam results']) {
     if (response.text.toLowerCase().includes(overclaim.toLowerCase())) {
       failures.push(`Production SEO page ${path} must not overclaim with token: ${overclaim}`);
@@ -403,7 +405,7 @@ function assertSeoIntentPageHtml(page, response, failures) {
       }
     }
   }
-  assertNoForbiddenText(`Production SEO page ${path}`, response.text, failures);
+  assertStaticSeoPageHasNoScripts(path, response.text, failures);
 }
 
 async function assertSeoIntentPages(base, failures) {

--- a/scripts/production-performance-probe.mjs
+++ b/scripts/production-performance-probe.mjs
@@ -665,7 +665,7 @@ async function runPlaywrightBrowserTts(origin, cookie, learnerId, options) {
     learnerId,
     promptToken,
     bufferedGeminiVoice: voice,
-    cacheLookupOnly: true,
+    cachePlaybackOnly: true,
   };
   let browser;
   try {

--- a/scripts/production-performance-probe.mjs
+++ b/scripts/production-performance-probe.mjs
@@ -1,0 +1,988 @@
+#!/usr/bin/env node
+
+import { randomUUID } from 'node:crypto';
+import { Buffer } from 'node:buffer';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import {
+  DEFAULT_PRODUCTION_ORIGIN,
+  configuredTimeoutMs,
+} from './lib/production-smoke.mjs';
+import {
+  computeWordBankPromptToken,
+  lookupSeedWord,
+} from './spelling-audio-production-smoke.mjs';
+import {
+  BUFFERED_GEMINI_VOICE_OPTIONS,
+} from '../shared/spelling-audio.js';
+
+const DEFAULT_ASSET_SAMPLES = 3;
+const DEFAULT_BOOTSTRAP_SAMPLES = 5;
+const DEFAULT_TTS_SAMPLES = 5;
+const DEFAULT_WARMUP = 1;
+const DEFAULT_WORD_SAMPLE = ['accident', 'knowledge'];
+const DEFAULT_VOICES = [BUFFERED_GEMINI_VOICE_OPTIONS[0]?.id || 'Iapetus'];
+const DEFAULT_COOKIE_ENV = 'KS2_PRODUCTION_COOKIE';
+const TTS_MODE_WORD_LOOKUP = 'word-lookup';
+const TTS_MODE_SENTENCE_CACHE = 'sentence-cache';
+
+function readOptionValue(argv, index, optionName) {
+  const value = argv[index + 1];
+  if (value == null || value.startsWith('--')) throw new Error(`${optionName} requires a value.`);
+  return value;
+}
+
+function splitCsv(raw) {
+  return String(raw || '')
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function nonNegativeInteger(raw, optionName) {
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 0) throw new Error(`${optionName} must be a non-negative integer.`);
+  return parsed;
+}
+
+function positiveInteger(raw, optionName) {
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0) throw new Error(`${optionName} must be a positive integer.`);
+  return parsed;
+}
+
+function normaliseOrigin(value) {
+  const raw = value || DEFAULT_PRODUCTION_ORIGIN;
+  const url = new URL(/^https?:\/\//i.test(raw) ? raw : `https://${raw}`);
+  return url.origin;
+}
+
+export function parseArgs(argv = process.argv.slice(2)) {
+  const options = {
+    origin: DEFAULT_PRODUCTION_ORIGIN,
+    assetSamples: DEFAULT_ASSET_SAMPLES,
+    bootstrapSamples: DEFAULT_BOOTSTRAP_SAMPLES,
+    ttsSamples: DEFAULT_TTS_SAMPLES,
+    warmup: DEFAULT_WARMUP,
+    wordSample: DEFAULT_WORD_SAMPLE.slice(),
+    voices: DEFAULT_VOICES.slice(),
+    assetPaths: [],
+    cookieEnv: DEFAULT_COOKIE_ENV,
+    learnerId: '',
+    includeAssets: true,
+    includeBootstrap: true,
+    includeTts: true,
+    includeBrowserTts: false,
+    timeoutMs: 0,
+    output: '',
+    help: false,
+  };
+
+  const assigned = new Set();
+  const assignOnce = (flag) => {
+    if (assigned.has(flag)) {
+      throw new Error(`${flag} specified more than once; refusing to let later value silently override the earlier one.`);
+    }
+    assigned.add(flag);
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--help' || arg === '-h') {
+      options.help = true;
+    } else if (arg === '--origin' || arg === '--url') {
+      assignOnce('--origin');
+      options.origin = readOptionValue(argv, index, arg);
+      index += 1;
+    } else if (arg === '--samples') {
+      assignOnce(arg);
+      const samples = nonNegativeInteger(readOptionValue(argv, index, arg), arg);
+      options.assetSamples = samples;
+      options.bootstrapSamples = samples;
+      options.ttsSamples = samples;
+      index += 1;
+    } else if (arg === '--asset-samples') {
+      assignOnce(arg);
+      options.assetSamples = nonNegativeInteger(readOptionValue(argv, index, arg), arg);
+      index += 1;
+    } else if (arg === '--bootstrap-samples') {
+      assignOnce(arg);
+      options.bootstrapSamples = nonNegativeInteger(readOptionValue(argv, index, arg), arg);
+      index += 1;
+    } else if (arg === '--tts-samples') {
+      assignOnce(arg);
+      options.ttsSamples = nonNegativeInteger(readOptionValue(argv, index, arg), arg);
+      index += 1;
+    } else if (arg === '--warmup') {
+      assignOnce(arg);
+      options.warmup = nonNegativeInteger(readOptionValue(argv, index, arg), arg);
+      index += 1;
+    } else if (arg === '--word-sample') {
+      assignOnce(arg);
+      const sample = splitCsv(readOptionValue(argv, index, arg));
+      if (!sample.length) throw new Error('--word-sample requires at least one slug.');
+      options.wordSample = sample;
+      index += 1;
+    } else if (arg === '--voices') {
+      assignOnce(arg);
+      const voices = splitCsv(readOptionValue(argv, index, arg));
+      if (!voices.length) throw new Error('--voices requires at least one voice id.');
+      options.voices = voices;
+      index += 1;
+    } else if (arg === '--asset-path') {
+      options.assetPaths.push(readOptionValue(argv, index, arg));
+      index += 1;
+    } else if (arg === '--cookie-env') {
+      assignOnce(arg);
+      options.cookieEnv = readOptionValue(argv, index, arg);
+      index += 1;
+    } else if (arg === '--learner-id') {
+      assignOnce(arg);
+      options.learnerId = readOptionValue(argv, index, arg);
+      index += 1;
+    } else if (arg === '--timeout-ms') {
+      assignOnce(arg);
+      options.timeoutMs = positiveInteger(readOptionValue(argv, index, arg), arg);
+      index += 1;
+    } else if (arg === '--output') {
+      assignOnce(arg);
+      options.output = readOptionValue(argv, index, arg);
+      index += 1;
+    } else if (arg === '--no-assets') {
+      options.includeAssets = false;
+    } else if (arg === '--no-bootstrap') {
+      options.includeBootstrap = false;
+    } else if (arg === '--no-tts') {
+      options.includeTts = false;
+    } else if (arg === '--browser-tts') {
+      options.includeBrowserTts = true;
+    } else {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  options.origin = normaliseOrigin(options.origin);
+  return options;
+}
+
+function requestId() {
+  return `ks2_req_${randomUUID()}`;
+}
+
+function timeoutSignal(timeoutMs) {
+  if (typeof AbortSignal !== 'undefined' && typeof AbortSignal.timeout === 'function') {
+    return AbortSignal.timeout(timeoutMs);
+  }
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  timer.unref?.();
+  return controller.signal;
+}
+
+function headerValue(response, name) {
+  return response?.headers?.get?.(name) || '';
+}
+
+function selectedHeaders(response) {
+  return {
+    cacheControl: headerValue(response, 'cache-control'),
+    cfCacheStatus: headerValue(response, 'cf-cache-status'),
+    contentType: headerValue(response, 'content-type'),
+    contentLength: headerValue(response, 'content-length'),
+    serverTiming: headerValue(response, 'server-timing'),
+    xRequestId: headerValue(response, 'x-ks2-request-id'),
+    xTtsCache: headerValue(response, 'x-ks2-tts-cache'),
+    xTtsCacheSource: headerValue(response, 'x-ks2-tts-cache-source'),
+  };
+}
+
+async function timedFetch(url, init = {}, {
+  label = '',
+  timeoutMs = configuredTimeoutMs(),
+  readBody = true,
+} = {}) {
+  const headers = new Headers(init.headers || {});
+  if (!headers.has('x-ks2-request-id')) headers.set('x-ks2-request-id', requestId());
+  const clientRequestId = headers.get('x-ks2-request-id');
+  const startedAt = new Date().toISOString();
+  const start = performance.now();
+  let response;
+  try {
+    response = await fetch(url, {
+      ...init,
+      headers,
+      signal: init.signal || timeoutSignal(timeoutMs),
+    });
+  } catch (error) {
+    return {
+      ok: false,
+      label,
+      url: String(url),
+      method: init.method || 'GET',
+      clientRequestId,
+      serverRequestId: '',
+      status: 0,
+      startedAt,
+      finishedAt: new Date().toISOString(),
+      headerMs: Math.round(performance.now() - start),
+      bodyMs: 0,
+      totalMs: Math.round(performance.now() - start),
+      bytes: 0,
+      error: error?.message || String(error),
+      headers: {},
+    };
+  }
+  const responseAt = performance.now();
+  let bytes = 0;
+  let body = Buffer.alloc(0);
+  if (readBody) {
+    const arrayBuffer = await response.arrayBuffer().catch(() => new ArrayBuffer(0));
+    body = Buffer.from(arrayBuffer);
+    bytes = body.byteLength;
+  }
+  const finished = performance.now();
+  return {
+    ok: response.ok,
+    label,
+    url: String(url),
+    method: init.method || 'GET',
+    clientRequestId,
+    serverRequestId: headerValue(response, 'x-ks2-request-id'),
+    status: response.status,
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    headerMs: Math.round(responseAt - start),
+    bodyMs: Math.round(finished - responseAt),
+    totalMs: Math.round(finished - start),
+    bytes,
+    headers: selectedHeaders(response),
+    body,
+  };
+}
+
+function responseText(sample) {
+  return sample?.body ? sample.body.toString('utf8') : '';
+}
+
+function parseJsonBody(sample) {
+  const text = responseText(sample);
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function getSetCookies(responseHeaders) {
+  if (typeof responseHeaders?.getSetCookie === 'function') return responseHeaders.getSetCookie();
+  return String(responseHeaders?.get?.('set-cookie') || '')
+    .split(/,\s*(?=ks2_)/)
+    .filter(Boolean);
+}
+
+function sessionCookieFromHeaders(headers) {
+  return getSetCookies(headers)
+    .map((cookie) => String(cookie || '').split(';')[0])
+    .find((cookie) => cookie.startsWith('ks2_session=')) || '';
+}
+
+function extractScriptSources(html) {
+  return Array.from(String(html || '').matchAll(/<script\b[^>]*\bsrc=["']([^"']+)["'][^>]*>/gi), (match) => match[1]);
+}
+
+function normaliseAssetPath(path, origin) {
+  const value = String(path || '').trim();
+  if (!value) return '/';
+  const url = new URL(value, origin);
+  if (url.origin !== new URL(origin).origin) return null;
+  return `${url.pathname}${url.search}`;
+}
+
+function unique(values) {
+  return Array.from(new Set(values));
+}
+
+function percentile(values, p) {
+  const finite = values.map(Number).filter(Number.isFinite).sort((a, b) => a - b);
+  if (!finite.length) return null;
+  const index = Math.min(finite.length - 1, Math.max(0, Math.ceil((p / 100) * finite.length) - 1));
+  return finite[index];
+}
+
+export function summariseMetric(samples, field) {
+  const values = samples
+    .map((sample) => Number(sample?.[field]))
+    .filter(Number.isFinite);
+  if (!values.length) {
+    return { count: 0, min: null, p50: null, p95: null, max: null, mean: null };
+  }
+  const sum = values.reduce((total, value) => total + value, 0);
+  return {
+    count: values.length,
+    min: Math.min(...values),
+    p50: percentile(values, 50),
+    p95: percentile(values, 95),
+    max: Math.max(...values),
+    mean: Math.round(sum / values.length),
+  };
+}
+
+function groupBy(samples, keyFn) {
+  const groups = new Map();
+  for (const sample of samples) {
+    const key = keyFn(sample);
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(sample);
+  }
+  return groups;
+}
+
+function summariseSamples(samples, keyFn) {
+  return Array.from(groupBy(samples, keyFn).entries()).map(([key, group]) => ({
+    key,
+    count: group.length,
+    statuses: Object.fromEntries(Array.from(groupBy(group, (sample) => String(sample.status || 0)).entries()).map(([status, rows]) => [status, rows.length])),
+    headerMs: summariseMetric(group, 'headerMs'),
+    bodyMs: summariseMetric(group, 'bodyMs'),
+    totalMs: summariseMetric(group, 'totalMs'),
+    bytes: summariseMetric(group, 'bytes'),
+  }));
+}
+
+function bootstrapCapacitySummary(samples) {
+  const rows = samples
+    .map((sample) => sample.capacity)
+    .filter(Boolean);
+  return {
+    queryCount: summariseMetric(rows, 'queryCount'),
+    d1DurationMs: summariseMetric(rows, 'd1DurationMs'),
+    d1RowsRead: summariseMetric(rows, 'd1RowsRead'),
+    d1RowsWritten: summariseMetric(rows, 'd1RowsWritten'),
+    serverWallMs: summariseMetric(rows, 'serverWallMs'),
+    responseBytes: summariseMetric(rows, 'responseBytes'),
+  };
+}
+
+function capacityFromPayload(payload) {
+  const raw = payload?.meta?.capacity || null;
+  if (!raw || typeof raw !== 'object') return null;
+  return {
+    requestId: raw.requestId || null,
+    queryCount: Number(raw.queryCount),
+    d1DurationMs: Number(raw.d1DurationMs),
+    d1RowsRead: Number(raw.d1RowsRead),
+    d1RowsWritten: Number(raw.d1RowsWritten),
+    serverWallMs: Number(raw.wallMs),
+    responseBytes: Number(raw.responseBytes),
+  };
+}
+
+function selectedLearnerIdFromPayload(payload) {
+  return payload?.learners?.selectedId
+    || payload?.learnerId
+    || payload?.session?.learnerId
+    || '';
+}
+
+export function parseServerTiming(value) {
+  const phases = {};
+  for (const entry of String(value || '').split(',')) {
+    const parts = entry.trim().split(';').map((part) => part.trim()).filter(Boolean);
+    const name = parts.shift();
+    if (!name || !name.startsWith('ks2_tts_')) continue;
+    const durPart = parts.find((part) => /^dur=/i.test(part));
+    if (!durPart) continue;
+    const duration = Number(durPart.slice(durPart.indexOf('=') + 1).replace(/^"|"$/g, ''));
+    if (!Number.isFinite(duration) || duration < 0) continue;
+    phases[name.slice('ks2_tts_'.length)] = Math.round(duration);
+  }
+  return phases;
+}
+
+function ttsPhaseSummary(samples) {
+  const phaseNames = unique(samples.flatMap((sample) => Object.keys(sample.serverTimingPhases || {})));
+  return Object.fromEntries(phaseNames.map((phase) => [
+    phase,
+    summariseMetric(samples.map((sample) => sample.serverTimingPhases || {}), phase),
+  ]));
+}
+
+async function ttsPromptToken({ learnerId, slug, seed }) {
+  return await computeWordBankPromptToken({
+    learnerId,
+    slug,
+    word: seed.word,
+    sentence: seed.sentence,
+  });
+}
+
+async function ttsRequestBody({ mode, learnerId, slug, seed, voice }) {
+  const promptToken = await ttsPromptToken({ learnerId, slug, seed });
+  const base = {
+    slug,
+    learnerId,
+    promptToken,
+    bufferedGeminiVoice: voice,
+    cacheLookupOnly: true,
+  };
+  if (mode === TTS_MODE_WORD_LOOKUP) {
+    return {
+      ...base,
+      wordOnly: true,
+      scope: 'word-bank',
+    };
+  }
+  return base;
+}
+
+export function classifyTtsTimingSample(sample) {
+  const phases = sample?.serverTimingPhases || {};
+  const total = Number(phases.total);
+  if (!Number.isFinite(total) || total <= 0) return 'unclassified-insufficient-timing';
+
+  const headerMs = Number(sample?.headerMs);
+  const residualMs = Number.isFinite(headerMs) ? Math.max(0, headerMs - total) : 0;
+  if (residualMs > Math.max(250, total * 1.5)) return 'client-network-or-platform-overhead';
+
+  const candidates = [
+    ['r2-dominated', Number(phases.r2)],
+    ['prompt-validation-dominated', Number(phases.prompt) + Number(phases.body || 0)],
+    ['rate-limit-dominated', Number(phases.lookup_limit) + Number(phases.audio_limit || 0)],
+  ].map(([name, value]) => [name, Number.isFinite(value) ? value : 0]);
+  const [name, value] = candidates.sort((a, b) => b[1] - a[1])[0] || ['mixed', 0];
+  if (value >= Math.max(25, total * 0.5)) return name;
+  return 'mixed';
+}
+
+async function measureAssets(origin, options) {
+  const timeoutMs = options.timeoutMs || configuredTimeoutMs();
+  const discovery = await timedFetch(new URL('/', origin), {
+    headers: { accept: 'text/html,*/*' },
+  }, { label: 'GET / discovery', timeoutMs });
+  const discoveredScripts = extractScriptSources(responseText(discovery))
+    .map((path) => normaliseAssetPath(path, origin))
+    .filter(Boolean);
+  const paths = options.assetPaths.length
+    ? options.assetPaths.map((path) => normaliseAssetPath(path, origin)).filter(Boolean)
+    : unique(['/', ...discoveredScripts]);
+  const samples = [];
+  for (const path of paths) {
+    const url = new URL(path, origin);
+    for (let index = 0; index < options.warmup + options.assetSamples; index += 1) {
+      const sample = await timedFetch(url, {
+        headers: {
+          accept: path.endsWith('.js') ? 'application/javascript,*/*' : 'text/html,application/javascript,*/*',
+        },
+      }, { label: `GET ${path}`, timeoutMs });
+      if (index >= options.warmup) {
+        const { body, ...serialisable } = sample;
+        samples.push({
+          ...serialisable,
+          path,
+          cacheControl: sample.headers.cacheControl,
+          cfCacheStatus: sample.headers.cfCacheStatus,
+          contentType: sample.headers.contentType,
+        });
+      }
+    }
+  }
+  return {
+    discovery: {
+      status: discovery.status,
+      headerMs: discovery.headerMs,
+      totalMs: discovery.totalMs,
+      bytes: discovery.bytes,
+      discoveredScripts,
+    },
+    samples,
+    summary: summariseSamples(samples, (sample) => sample.path),
+    notes: discoveredScripts.some((path) => path.startsWith('/src/bundles/'))
+      ? ['Root HTML references /src/bundles/*.js; compare Worker-first routing and immutable static asset coverage before page-load refactors.']
+      : [],
+  };
+}
+
+async function measureBootstrap(origin, cookie, options) {
+  const timeoutMs = options.timeoutMs || configuredTimeoutMs();
+  const samples = [];
+  let selectedLearnerId = '';
+  for (let index = 0; index < options.warmup + options.bootstrapSamples; index += 1) {
+    const sample = await timedFetch(new URL('/api/bootstrap', origin), {
+      headers: {
+        accept: 'application/json',
+        cookie,
+      },
+    }, { label: 'GET /api/bootstrap', timeoutMs });
+    if (index >= options.warmup) {
+      const payload = parseJsonBody(sample);
+      if (!selectedLearnerId) selectedLearnerId = selectedLearnerIdFromPayload(payload);
+      const { body, ...serialisable } = sample;
+      samples.push({
+        ...serialisable,
+        capacity: capacityFromPayload(payload),
+      });
+    }
+  }
+  return {
+    samples,
+    summary: summariseSamples(samples, () => 'GET /api/bootstrap'),
+    capacity: bootstrapCapacitySummary(samples),
+    selectedLearnerId,
+  };
+}
+
+async function measureTts(origin, cookie, learnerId, options) {
+  const timeoutMs = options.timeoutMs || configuredTimeoutMs();
+  const samples = [];
+  const failures = [];
+  for (let index = 0; index < options.warmup + options.ttsSamples; index += 1) {
+    for (const slug of options.wordSample) {
+      const seed = lookupSeedWord(slug);
+      if (!seed?.word) {
+        failures.push(`Word sample ${slug} is not present in the spelling seed snapshot.`);
+        continue;
+      }
+      for (const voice of options.voices) {
+        for (const mode of [TTS_MODE_WORD_LOOKUP, TTS_MODE_SENTENCE_CACHE]) {
+          const sample = await timedFetch(new URL('/api/tts', origin), {
+            method: 'POST',
+            headers: {
+              accept: 'audio/*,application/json;q=0.8',
+              'content-type': 'application/json',
+              cookie,
+              origin,
+            },
+            body: JSON.stringify(await ttsRequestBody({ mode, learnerId, slug, seed, voice })),
+          }, { label: `POST /api/tts ${mode} ${slug}/${voice}`, timeoutMs });
+          if (index >= options.warmup) {
+            const { body, ...serialisable } = sample;
+            const serverTimingPhases = parseServerTiming(sample.headers.serverTiming);
+            samples.push({
+              ...serialisable,
+              mode,
+              slug,
+              voice,
+              cache: sample.headers.xTtsCache || '',
+              source: sample.headers.xTtsCacheSource || '',
+              contentType: sample.headers.contentType,
+              serverTiming: sample.headers.serverTiming || '',
+              serverTimingPhases,
+              classification: classifyTtsTimingSample({ ...sample, serverTimingPhases }),
+            });
+          }
+        }
+      }
+    }
+  }
+  return {
+    samples,
+    summary: summariseSamples(samples, (sample) => `${sample.mode}/${sample.slug}/${sample.voice}/${sample.cache || 'no-cache'}/${sample.source || 'no-source'}`),
+    phaseSummary: ttsPhaseSummary(samples),
+    modeSummary: Object.fromEntries(Array.from(groupBy(samples, (sample) => sample.mode || 'unknown').entries()).map(([key, rows]) => [key, summariseSamples(rows, (sample) => `${sample.slug}/${sample.voice}/${sample.cache || 'no-cache'}/${sample.source || 'no-source'}`)])),
+    classifications: Object.fromEntries(Array.from(groupBy(samples, (sample) => sample.classification || 'unknown').entries()).map(([key, rows]) => [key, rows.length])),
+    failures,
+  };
+}
+
+function sanitiseBrowserTtsSample(sample = {}) {
+  return {
+    mode: 'browser-play-start',
+    slug: String(sample.slug || ''),
+    voice: String(sample.voice || ''),
+    status: Number(sample.status) || 0,
+    cache: String(sample.cache || ''),
+    source: String(sample.source || ''),
+    contentType: String(sample.contentType || ''),
+    requestId: String(sample.requestId || ''),
+    headerMs: Number.isFinite(Number(sample.headerMs)) ? Math.max(0, Math.round(Number(sample.headerMs))) : null,
+    blobMs: Number.isFinite(Number(sample.blobMs)) ? Math.max(0, Math.round(Number(sample.blobMs))) : null,
+    playStartMs: Number.isFinite(Number(sample.playStartMs)) ? Math.max(0, Math.round(Number(sample.playStartMs))) : null,
+    totalMs: Number.isFinite(Number(sample.totalMs)) ? Math.max(0, Math.round(Number(sample.totalMs))) : null,
+    bytes: Number.isFinite(Number(sample.bytes)) ? Math.max(0, Math.round(Number(sample.bytes))) : null,
+    skipped: Boolean(sample.skipped),
+    skipReason: sample.skipReason ? String(sample.skipReason).slice(0, 200) : '',
+  };
+}
+
+function sanitiseBrowserTtsReport(report = {}) {
+  const samples = Array.isArray(report.samples)
+    ? report.samples.map(sanitiseBrowserTtsSample)
+    : [];
+  const measuredSamples = samples.filter((sample) => !sample.skipped);
+  return {
+    ok: report.ok !== false,
+    skipped: Boolean(report.skipped),
+    skipReason: report.skipReason ? String(report.skipReason).slice(0, 200) : '',
+    samples,
+    summary: summariseSamples(measuredSamples, (sample) => `${sample.slug}/${sample.voice}/${sample.cache || 'no-cache'}/${sample.source || 'no-source'}`),
+    playStartMs: summariseMetric(measuredSamples, 'playStartMs'),
+  };
+}
+
+function firstCookiePair(cookie = '') {
+  const pairs = String(cookie || '')
+    .split(';')
+    .map((part) => part.trim())
+    .filter(Boolean);
+  const pair = pairs.find((part) => part.startsWith('ks2_session=')) || pairs[0] || '';
+  const separator = pair.indexOf('=');
+  if (separator <= 0) return null;
+  return {
+    name: pair.slice(0, separator),
+    value: pair.slice(separator + 1),
+  };
+}
+
+async function runPlaywrightBrowserTts(origin, cookie, learnerId, options) {
+  const seed = lookupSeedWord(options.wordSample[0]);
+  const voice = options.voices[0];
+  if (!seed?.word || !voice) {
+    return { skipped: true, skipReason: 'missing word sample or voice', samples: [] };
+  }
+  const cookiePair = firstCookiePair(cookie);
+  if (!cookiePair) return { skipped: true, skipReason: 'missing session cookie', samples: [] };
+  let chromium;
+  try {
+    ({ chromium } = await import('playwright'));
+  } catch (error) {
+    return { skipped: true, skipReason: `playwright import failed: ${error?.message || error}`, samples: [] };
+  }
+  const promptToken = await ttsPromptToken({ learnerId, slug: seed.slug, seed });
+  const requestBody = {
+    slug: seed.slug,
+    learnerId,
+    promptToken,
+    bufferedGeminiVoice: voice,
+    cacheLookupOnly: true,
+  };
+  let browser;
+  try {
+    browser = await chromium.launch({ headless: true });
+    const context = await browser.newContext();
+    await context.addCookies([{
+      name: cookiePair.name,
+      value: cookiePair.value,
+      url: origin,
+      path: '/',
+    }]);
+    const page = await context.newPage();
+    await page.goto(origin, { waitUntil: 'domcontentloaded', timeout: options.timeoutMs || configuredTimeoutMs() });
+    const sample = await page.evaluate(async ({ body }) => {
+      const startedAt = performance.now();
+      const response = await fetch('/api/tts', {
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+          accept: 'audio/*,application/json;q=0.8',
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify(body),
+      });
+      const responseAt = performance.now();
+      if (!response.ok) {
+        return {
+          status: response.status,
+          cache: response.headers.get('x-ks2-tts-cache') || '',
+          source: response.headers.get('x-ks2-tts-cache-source') || '',
+          contentType: response.headers.get('content-type') || '',
+          requestId: response.headers.get('x-ks2-request-id') || '',
+          headerMs: responseAt - startedAt,
+          totalMs: performance.now() - startedAt,
+          skipped: true,
+          skipReason: `HTTP ${response.status}`,
+        };
+      }
+      const blob = await response.blob();
+      const blobAt = performance.now();
+      let playStartAt = null;
+      let skipReason = '';
+      try {
+        const objectUrl = URL.createObjectURL(blob);
+        const audio = new Audio(objectUrl);
+        audio.preload = 'auto';
+        const playing = new Promise((resolve) => {
+          const done = (value) => resolve(value);
+          audio.addEventListener('playing', () => done(performance.now()), { once: true });
+          audio.addEventListener('error', () => done(null), { once: true });
+          setTimeout(() => done(null), 3000);
+        });
+        await audio.play().catch((error) => {
+          skipReason = error?.message || String(error);
+        });
+        playStartAt = await playing;
+        URL.revokeObjectURL(objectUrl);
+      } catch (error) {
+        skipReason = error?.message || String(error);
+      }
+      return {
+        status: response.status,
+        cache: response.headers.get('x-ks2-tts-cache') || '',
+        source: response.headers.get('x-ks2-tts-cache-source') || '',
+        contentType: response.headers.get('content-type') || '',
+        requestId: response.headers.get('x-ks2-request-id') || '',
+        headerMs: responseAt - startedAt,
+        blobMs: blobAt - responseAt,
+        playStartMs: playStartAt == null ? null : playStartAt - startedAt,
+        totalMs: performance.now() - startedAt,
+        bytes: blob.size,
+        skipped: playStartAt == null,
+        skipReason: playStartAt == null ? (skipReason || 'audio did not reach playing state') : '',
+      };
+    }, { body: requestBody });
+    return {
+      ok: !sample.skipped,
+      skipped: Boolean(sample.skipped),
+      skipReason: sample.skipReason || '',
+      samples: [{ ...sample, slug: seed.slug, voice }],
+    };
+  } catch (error) {
+    return { skipped: true, skipReason: `browser timing failed: ${error?.message || error}`, samples: [] };
+  } finally {
+    await browser?.close?.().catch(() => {});
+  }
+}
+
+async function measureBrowserTts(origin, cookie, learnerId, options) {
+  if (typeof options.browserTtsRunner === 'function') {
+    return sanitiseBrowserTtsReport(await options.browserTtsRunner({ origin, cookie, learnerId, options }));
+  }
+  if (!options.includeBrowserTts) return null;
+  return sanitiseBrowserTtsReport(await runPlaywrightBrowserTts(origin, cookie, learnerId, options));
+}
+
+async function createProbeDemoSession(origin, options) {
+  const timeoutMs = options.timeoutMs || configuredTimeoutMs();
+  const url = new URL('/api/demo/session', origin);
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      accept: 'application/json',
+      'content-type': 'application/json',
+      origin,
+      'x-ks2-request-id': requestId(),
+    },
+    body: '{}',
+    signal: timeoutSignal(timeoutMs),
+  });
+  const cookie = sessionCookieFromHeaders(response.headers);
+  const text = await response.text().catch(() => '');
+  const payload = text ? JSON.parse(text) : {};
+  return {
+    ok: response.ok && Boolean(cookie),
+    status: response.status,
+    cookie,
+    payload,
+    learnerId: payload?.session?.learnerId || '',
+    accountId: payload?.session?.accountId || '',
+    serverRequestId: headerValue(response, 'x-ks2-request-id'),
+  };
+}
+
+function operatorSessionFromEnv(options) {
+  const envName = String(options.cookieEnv || '').trim();
+  const cookie = envName ? process.env[envName] : '';
+  if (!cookie) return null;
+  return {
+    ok: true,
+    status: 0,
+    source: 'operator-cookie',
+    cookie,
+    learnerId: options.learnerId || '',
+    accountId: '',
+    serverRequestId: '',
+  };
+}
+
+function withoutSensitiveSession(report) {
+  const redacted = { ...report };
+  if (report?.session) {
+    redacted.session = {
+      ok: report.session.ok,
+      status: report.session.status,
+      source: report.session.source || 'demo',
+      learnerIdPresent: Boolean(report.session.learnerId),
+      accountIdPresent: Boolean(report.session.accountId),
+      serverRequestId: report.session.serverRequestId,
+    };
+  }
+  if (report?.bootstrap) {
+    const { selectedLearnerId, ...bootstrap } = report.bootstrap;
+    redacted.bootstrap = {
+      ...bootstrap,
+      selectedLearnerIdPresent: Boolean(selectedLearnerId),
+    };
+  }
+  return redacted;
+}
+
+function sessionForReport(session) {
+  if (!session) return null;
+  return {
+    ok: session.ok,
+    status: session.status,
+    source: session.source || 'demo',
+    cookie: session.cookie,
+    learnerId: session.learnerId,
+    accountId: session.accountId,
+    serverRequestId: session.serverRequestId,
+  };
+}
+
+export async function runPerformanceProbe(rawOptions = {}) {
+  const options = {
+    ...parseArgs([]),
+    ...rawOptions,
+  };
+  options.origin = normaliseOrigin(options.origin);
+  const startedAt = new Date().toISOString();
+  const report = {
+    ok: true,
+    origin: options.origin,
+    startedAt,
+    finishedAt: '',
+    config: {
+      assetSamples: options.assetSamples,
+      bootstrapSamples: options.bootstrapSamples,
+      ttsSamples: options.ttsSamples,
+      warmup: options.warmup,
+      wordSample: options.wordSample,
+      voices: options.voices,
+      cookieEnv: options.cookieEnv,
+      learnerIdProvided: Boolean(options.learnerId),
+      includeAssets: options.includeAssets,
+      includeBootstrap: options.includeBootstrap,
+      includeTts: options.includeTts,
+      includeBrowserTts: options.includeBrowserTts,
+    },
+    session: null,
+    assets: null,
+    bootstrap: null,
+    tts: null,
+    browserTts: null,
+    failures: [],
+  };
+
+  if (options.includeAssets && options.assetSamples > 0) {
+    report.assets = await measureAssets(options.origin, options);
+    for (const sample of report.assets.samples) {
+      if (sample.status < 200 || sample.status >= 400) {
+        report.failures.push(`Asset ${sample.path} returned HTTP ${sample.status}.`);
+      }
+    }
+  }
+
+  if (
+    (options.includeBootstrap && options.bootstrapSamples > 0)
+    || (options.includeTts && options.ttsSamples > 0)
+    || options.includeBrowserTts
+    || typeof options.browserTtsRunner === 'function'
+  ) {
+    report.session = sessionForReport(operatorSessionFromEnv(options) || await createProbeDemoSession(options.origin, options));
+    if (!report.session.ok) {
+      report.failures.push(`Demo session setup failed with HTTP ${report.session.status}.`);
+    }
+  }
+
+  if (report.session?.ok && options.includeBootstrap && options.bootstrapSamples > 0) {
+    report.bootstrap = await measureBootstrap(options.origin, report.session.cookie, options);
+    if (!report.session.learnerId && report.bootstrap.selectedLearnerId) {
+      report.session.learnerId = report.bootstrap.selectedLearnerId;
+    }
+    for (const sample of report.bootstrap.samples) {
+      if (sample.status < 200 || sample.status >= 400) {
+        report.failures.push(`Bootstrap sample returned HTTP ${sample.status}.`);
+      }
+    }
+  }
+
+  if (report.session?.ok && options.includeTts && options.ttsSamples > 0) {
+    if (!report.session.learnerId) {
+      report.failures.push('TTS samples skipped because no learner id was available; provide --learner-id or enable /api/bootstrap sampling.');
+    } else {
+      report.tts = await measureTts(options.origin, report.session.cookie, report.session.learnerId, options);
+      report.failures.push(...report.tts.failures);
+      for (const sample of report.tts.samples) {
+        if (sample.mode === TTS_MODE_SENTENCE_CACHE && sample.status !== 200) {
+          report.failures.push(`TTS sentence cache ${sample.slug}/${sample.voice} returned HTTP ${sample.status}.`);
+        } else if (sample.mode === TTS_MODE_WORD_LOOKUP && sample.status !== 200 && sample.status !== 204) {
+          report.failures.push(`TTS word lookup ${sample.slug}/${sample.voice} returned HTTP ${sample.status}.`);
+        }
+      }
+    }
+  }
+
+  if (report.session?.ok && (options.includeBrowserTts || typeof options.browserTtsRunner === 'function')) {
+    if (!report.session.learnerId) {
+      report.failures.push('Browser TTS sample skipped because no learner id was available; provide --learner-id or enable /api/bootstrap sampling.');
+    } else {
+      report.browserTts = await measureBrowserTts(options.origin, report.session.cookie, report.session.learnerId, options);
+      if (report.browserTts && !report.browserTts.skipped && report.browserTts.ok === false) {
+        report.failures.push('Browser TTS play-start measurement failed.');
+      }
+    }
+  }
+
+  report.ok = report.failures.length === 0;
+  report.finishedAt = new Date().toISOString();
+  return withoutSensitiveSession(report);
+}
+
+export function usage() {
+  return [
+    'Usage: node ./scripts/production-performance-probe.mjs [options]',
+    '',
+    'Measures production page asset, bootstrap, word-only TTS lookup, and sentence cached-audio timing.',
+    'The probe creates one demo session when bootstrap, TTS, or browser TTS samples are enabled.',
+    '',
+    'Options:',
+    '  --origin, --url <url>       Origin to probe (default https://ks2.eugnel.uk).',
+    '  --samples <n>               Set asset/bootstrap/TTS samples together.',
+    '  --asset-samples <n>         Asset samples per discovered path (default 3).',
+    '  --bootstrap-samples <n>     /api/bootstrap samples (default 5).',
+    '  --tts-samples <n>           TTS samples per mode × word × voice (default 5).',
+    '  --warmup <n>                Warm-up requests per route before recording (default 1).',
+    '  --word-sample <csv>         TTS word slugs (default accident,knowledge).',
+    '  --voices <csv>              Buffered Gemini voices (default first configured voice).',
+    '  --asset-path <path>         Override asset paths; repeatable.',
+    `  --cookie-env <name>         Use a real session cookie from this env var when set (default ${DEFAULT_COOKIE_ENV}).`,
+    '  --learner-id <id>           Learner id for real-cookie TTS probes when bootstrap is skipped.',
+    '  --timeout-ms <ms>           Per-request timeout.',
+    '  --output <path>             Persist JSON report.',
+    '  --no-assets                 Skip public page/bundle timing.',
+    '  --no-bootstrap              Skip /api/bootstrap timing.',
+    '  --no-tts                    Skip /api/tts timing.',
+    '  --browser-tts               Best-effort browser-side cached audio play-start timing.',
+    '  --help, -h                  Show this banner.',
+  ].join('\n');
+}
+
+export async function runCli(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  if (options.help) {
+    console.log(usage());
+    return 0;
+  }
+  const report = await runPerformanceProbe(options);
+  const json = JSON.stringify(report, null, 2);
+  if (options.output) {
+    mkdirSync(dirname(options.output), { recursive: true });
+    writeFileSync(options.output, `${json}\n`);
+  }
+  console.log(json);
+  return report.ok ? 0 : 1;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runCli().then((code) => {
+    process.exitCode = code;
+  }).catch((error) => {
+    console.error(JSON.stringify({
+      ok: false,
+      error: error?.message || String(error),
+    }, null, 2));
+    process.exitCode = 2;
+  });
+}

--- a/scripts/production-performance-probe.mjs
+++ b/scripts/production-performance-probe.mjs
@@ -675,7 +675,6 @@ async function runPlaywrightBrowserTts(origin, cookie, learnerId, options) {
       name: cookiePair.name,
       value: cookiePair.value,
       url: origin,
-      path: '/',
     }]);
     const page = await context.newPage();
     await page.goto(origin, { waitUntil: 'domcontentloaded', timeout: options.timeoutMs || configuredTimeoutMs() });

--- a/scripts/production-performance-probe.mjs
+++ b/scripts/production-performance-probe.mjs
@@ -163,6 +163,12 @@ export function parseArgs(argv = process.argv.slice(2)) {
     }
   }
 
+  const perRouteSampleFlags = ['--asset-samples', '--bootstrap-samples', '--tts-samples']
+    .filter((flag) => assigned.has(flag));
+  if (assigned.has('--samples') && perRouteSampleFlags.length) {
+    throw new Error(`--samples cannot be combined with ${perRouteSampleFlags.join(', ')}; choose one sample-shape style.`);
+  }
+
   options.origin = normaliseOrigin(options.origin);
   return options;
 }
@@ -558,17 +564,16 @@ async function measureTts(origin, cookie, learnerId, options) {
             body: JSON.stringify(await ttsRequestBody({ mode, learnerId, slug, seed, voice })),
           }, { label: `POST /api/tts ${mode} ${slug}/${voice}`, timeoutMs });
           if (index >= options.warmup) {
-            const { body, ...serialisable } = sample;
-            const serverTimingPhases = parseServerTiming(sample.headers.serverTiming);
+            const { body, headers, ...serialisable } = sample;
+            const serverTimingPhases = parseServerTiming(headers.serverTiming);
             samples.push({
               ...serialisable,
               mode,
               slug,
               voice,
-              cache: sample.headers.xTtsCache || '',
-              source: sample.headers.xTtsCacheSource || '',
-              contentType: sample.headers.contentType,
-              serverTiming: sample.headers.serverTiming || '',
+              cache: headers.xTtsCache || '',
+              source: headers.xTtsCacheSource || '',
+              contentType: headers.contentType,
               serverTimingPhases,
               classification: classifyTtsTimingSample({ ...sample, serverTimingPhases }),
             });
@@ -589,7 +594,7 @@ async function measureTts(origin, cookie, learnerId, options) {
 
 function sanitiseBrowserTtsSample(sample = {}) {
   return {
-    mode: 'browser-play-start',
+    mode: 'browser-direct-audio-play-start',
     slug: String(sample.slug || ''),
     voice: String(sample.voice || ''),
     status: Number(sample.status) || 0,
@@ -614,8 +619,12 @@ function sanitiseBrowserTtsReport(report = {}) {
   const measuredSamples = samples.filter((sample) => !sample.skipped);
   return {
     ok: report.ok !== false,
+    scope: report.scope || 'browser-direct-audio',
     skipped: Boolean(report.skipped),
     skipReason: report.skipReason ? String(report.skipReason).slice(0, 200) : '',
+    notes: Array.isArray(report.notes)
+      ? report.notes.map((note) => String(note).slice(0, 240))
+      : ['Direct headless-browser fetch of /api/tts plus Audio playback; app TTS-port telemetry is covered by unit tests.'],
     samples,
     summary: summariseSamples(measuredSamples, (sample) => `${sample.slug}/${sample.voice}/${sample.cache || 'no-cache'}/${sample.source || 'no-source'}`),
     playStartMs: summariseMetric(measuredSamples, 'playStartMs'),
@@ -734,8 +743,10 @@ async function runPlaywrightBrowserTts(origin, cookie, learnerId, options) {
     }, { body: requestBody });
     return {
       ok: !sample.skipped,
+      scope: 'browser-direct-audio',
       skipped: Boolean(sample.skipped),
       skipReason: sample.skipReason || '',
+      notes: ['Direct headless-browser fetch of /api/tts plus Audio playback; not the in-app createPlatformTts path.'],
       samples: [{ ...sample, slug: seed.slug, voice }],
     };
   } catch (error) {
@@ -785,6 +796,7 @@ function operatorSessionFromEnv(options) {
   const envName = String(options.cookieEnv || '').trim();
   const cookie = envName ? process.env[envName] : '';
   if (!cookie) return null;
+  if (normaliseOrigin(options.origin) !== normaliseOrigin(DEFAULT_PRODUCTION_ORIGIN)) return null;
   return {
     ok: true,
     status: 0,
@@ -907,6 +919,8 @@ export async function runPerformanceProbe(rawOptions = {}) {
       for (const sample of report.tts.samples) {
         if (sample.mode === TTS_MODE_SENTENCE_CACHE && sample.status !== 200) {
           report.failures.push(`TTS sentence cache ${sample.slug}/${sample.voice} returned HTTP ${sample.status}.`);
+        } else if (sample.mode === TTS_MODE_SENTENCE_CACHE && (sample.cache !== 'hit' || sample.source !== 'primary')) {
+          report.failures.push(`TTS sentence cache ${sample.slug}/${sample.voice} returned cache=${sample.cache || 'missing'} source=${sample.source || 'missing'}; expected hit/primary.`);
         } else if (sample.mode === TTS_MODE_WORD_LOOKUP && sample.status !== 200 && sample.status !== 204) {
           report.failures.push(`TTS word lookup ${sample.slug}/${sample.voice} returned HTTP ${sample.status}.`);
         }
@@ -920,7 +934,7 @@ export async function runPerformanceProbe(rawOptions = {}) {
     } else {
       report.browserTts = await measureBrowserTts(options.origin, report.session.cookie, report.session.learnerId, options);
       if (report.browserTts && !report.browserTts.skipped && report.browserTts.ok === false) {
-        report.failures.push('Browser TTS play-start measurement failed.');
+        report.failures.push('Browser direct-audio TTS play-start measurement failed.');
       }
     }
   }
@@ -954,7 +968,7 @@ export function usage() {
     '  --no-assets                 Skip public page/bundle timing.',
     '  --no-bootstrap              Skip /api/bootstrap timing.',
     '  --no-tts                    Skip /api/tts timing.',
-    '  --browser-tts               Best-effort browser-side cached audio play-start timing.',
+    '  --browser-tts               Best-effort direct-browser /api/tts audio play-start timing.',
     '  --help, -h                  Show this banner.',
   ].join('\n');
 }

--- a/scripts/spelling-audio-production-smoke.mjs
+++ b/scripts/spelling-audio-production-smoke.mjs
@@ -479,8 +479,8 @@ async function runWordProbe({
         kind: 'word',
         slug,
         voice,
-        promptToken,
-        expectedR2Key: expectedKey,
+        tokenPresent: Boolean(promptToken),
+        r2KeyPresent: Boolean(expectedKey),
         cache: state.cache,
         source: state.source,
         model: state.model,
@@ -503,8 +503,8 @@ async function runWordProbe({
     kind: 'word',
     slug,
     voice,
-    promptToken,
-    expectedR2Key: expectedKey,
+    tokenPresent: Boolean(promptToken),
+    r2KeyPresent: Boolean(expectedKey),
     cache,
     source,
     model,
@@ -613,7 +613,7 @@ async function runSentenceProbe({
   const probe = {
     kind: 'sentence',
     slug,
-    promptToken,
+    tokenPresent: Boolean(promptToken),
     cache,
     source,
     status: response.status,
@@ -719,13 +719,13 @@ async function runCrossAccountProbe({
   // Per-learner token salt: tokens MUST differ.
   if (tokenA === tokenB) {
     throw validationError(
-      `Cross-account probe: prompt tokens collapsed (per-learner salt regression). tokenA === tokenB`,
+      'Cross-account probe: prompt tokens collapsed (per-learner salt regression).',
     );
   }
   // Cross-account R2 reuse: keys MUST match.
   if (expectedKeyA !== expectedKeyB) {
     throw validationError(
-      `Cross-account probe: expected R2 keys diverged for the same word (accountId leaked into wordOnly metadata). keyA=${expectedKeyA} keyB=${expectedKeyB}`,
+      'Cross-account probe: expected R2 keys diverged for the same word (accountId leaked into wordOnly metadata).',
     );
   }
 
@@ -856,15 +856,16 @@ async function runCrossAccountProbe({
 
   return {
     kind: 'cross-account',
-    learnerA: bootstrapA.learnerId,
-    learnerB: bootstrapB.learnerId,
+    learnerAPresent: Boolean(bootstrapA.learnerId),
+    learnerBPresent: Boolean(bootstrapB.learnerId),
+    learnersDistinct: bootstrapA.learnerId !== bootstrapB.learnerId,
     fixtureWord,
     distinctWord,
     voice,
-    tokenA,
-    tokenB,
-    expectedR2Key: expectedKeyA,
-    expectedR2KeyDistinct: expectedKeyDistinct,
+    tokensDistinct: tokenA !== tokenB,
+    r2KeyPresent: Boolean(expectedKeyA),
+    distinctR2KeyPresent: Boolean(expectedKeyDistinct),
+    r2KeysMatch: expectedKeyA === expectedKeyB,
     bytesAlength: bytesA.length,
     bytesBLength: bytesB.length,
     bytesDistinctLength: bytesDistinct.length,
@@ -879,6 +880,13 @@ async function runCrossAccountProbe({
 // rather than short-circuiting the entire run. Operator gets the full
 // matrix of pass/fail in one report instead of "first failure only" —
 // makes triage faster when several probes regress at once.
+function redactSmokeDiagnostic(value) {
+  return String(value || '')
+    .replace(/ks2_session=[^;\s"']+/g, 'ks2_session=[redacted]')
+    .replace(/\b[a-f0-9]{64}\b/gi, '[sha256]')
+    .replace(/spelling-audio\/v1\/[^\s"'`]+/g, 'spelling-audio/v1/[redacted]');
+}
+
 async function safeRunProbe(kindLabel, runner) {
   try {
     return await runner();
@@ -888,14 +896,15 @@ async function safeRunProbe(kindLabel, runner) {
       : error?.kind === 'usage'
         ? 'usage'
         : 'validation';
+    const message = redactSmokeDiagnostic(error?.message || String(error));
     return {
       kind: kindLabel,
       ok: false,
       error: {
         kind,
-        message: error?.message || String(error),
+        message,
       },
-      notes: [`error[${kind}]: ${error?.message || String(error)}`],
+      notes: [`error[${kind}]: ${message}`],
     };
   }
 }
@@ -979,8 +988,8 @@ export async function runSpellingAudioSmoke(options = {}) {
     startedAt,
     finishedAt,
     origin,
-    accountId: demo.session?.accountId || null,
-    learnerId: bootstrap.learnerId,
+    accountPresent: Boolean(demo.session?.accountId),
+    learnerPresent: Boolean(bootstrap.learnerId),
     probes,
   };
 }
@@ -988,7 +997,7 @@ export async function runSpellingAudioSmoke(options = {}) {
 function renderHumanReadableReport(report) {
   const lines = [];
   lines.push(`spelling-audio-production-smoke @ ${report.origin}`);
-  lines.push(`  account: ${report.accountId || '(none)'}  learner: ${report.learnerId}`);
+  lines.push(`  accountPresent=${Boolean(report.accountPresent)}  learnerPresent=${Boolean(report.learnerPresent)}`);
   lines.push(`  ${report.startedAt} → ${report.finishedAt}`);
   for (const probe of report.probes) {
     if (probe.kind === 'word') {
@@ -996,7 +1005,7 @@ function renderHumanReadableReport(report) {
     } else if (probe.kind === 'sentence') {
       lines.push(`  [sentence] ${probe.slug} cache=${probe.cache || '-'} source=${probe.source || '-'}`);
     } else if (probe.kind === 'cross-account') {
-      lines.push(`  [cross-account] ${probe.fixtureWord} (${probe.voice}) tokensDistinct=true sameR2Key=true bytesIdentical=true distinctWord=${probe.distinctWord}`);
+      lines.push(`  [cross-account] ${probe.fixtureWord} (${probe.voice}) tokensDistinct=${Boolean(probe.tokensDistinct)} sameR2Key=${Boolean(probe.r2KeysMatch)} bytesIdentical=true distinctWord=${probe.distinctWord}`);
     }
     for (const note of probe.notes || []) {
       lines.push(`      - ${note}`);

--- a/scripts/spelling-audio-production-smoke.mjs
+++ b/scripts/spelling-audio-production-smoke.mjs
@@ -7,8 +7,10 @@
 // Three distinct probes:
 //   1. Word-only primary probe — for each --word-sample × 2 voices, build
 //      a word-bank prompt token via the canonical `sha256` from
-//      `worker/src/auth.js` and POST `/api/tts` with `cacheLookupOnly: true`.
-//      Expect HTTP 200 + `x-ks2-tts-cache: hit` + `x-ks2-tts-cache-source: primary`.
+//      `worker/src/auth.js`, POST `/api/tts` with `cacheLookupOnly: true`,
+//      and explicitly warm via `cacheOnly: true` when the first lookup
+//      reports a cold miss. Expect the final lookup to return HTTP 200 +
+//      `x-ks2-tts-cache: hit` + `x-ks2-tts-cache-source: primary`.
 //   2. Sentence legacy probe — POSTs the session-style payload for known
 //      seeded sentence cards and asserts the legacy R2 fallback fires
 //      (PR 252). Without `--require-legacy-hit` a `primary` source is
@@ -361,6 +363,40 @@ function looksLikeServerError(status) {
   return Number(status) >= 500;
 }
 
+function wordProbeBody({ slug, learnerId, promptToken, voice }) {
+  return {
+    wordOnly: true,
+    scope: 'word-bank',
+    slug,
+    learnerId,
+    promptToken,
+    bufferedGeminiVoice: voice,
+  };
+}
+
+function wordCacheState(response) {
+  return {
+    status: response?.status || 0,
+    cache: readResponseHeader(response, 'x-ks2-tts-cache'),
+    source: readResponseHeader(response, 'x-ks2-tts-cache-source'),
+    model: readResponseHeader(response, 'x-ks2-tts-model'),
+    voice: readResponseHeader(response, 'x-ks2-tts-voice'),
+  };
+}
+
+async function warmWordAudio({ origin, cookie, timeoutMs, body }) {
+  return await postTtsRequest({
+    origin,
+    cookie,
+    timeoutMs,
+    body: {
+      ...body,
+      provider: 'gemini',
+      cacheOnly: true,
+    },
+  });
+}
+
 // --- Probe: word-only primary -------------------------------------------
 
 async function runWordProbe({
@@ -389,17 +425,14 @@ async function runWordProbe({
   const promptToken = await computeWordBankPromptToken({ learnerId, slug, word, sentence });
   const expectedKey = await expectedWordR2Key({ slug, word, voice });
 
-  const response = await postTtsRequest({
+  const baseBody = wordProbeBody({ slug, learnerId, promptToken, voice });
+  const notes = [];
+  let response = await postTtsRequest({
     origin,
     cookie,
     timeoutMs,
     body: {
-      wordOnly: true,
-      scope: 'word-bank',
-      slug,
-      learnerId,
-      promptToken,
-      bufferedGeminiVoice: voice,
+      ...baseBody,
       cacheLookupOnly: true,
     },
   });
@@ -408,15 +441,63 @@ async function runWordProbe({
     const excerpt = await bodyExcerpt(response);
     throw transportError(`/api/tts word probe ${slug}/${voice} returned HTTP ${response.status}: ${excerpt}`);
   }
+
+  let state = wordCacheState(response);
+  if (response.status === 204 && state.cache === 'miss') {
+    notes.push('INFO: initial word lookup missed; warming Gemini word cache before final lookup');
+    const warmupResponse = await warmWordAudio({
+      origin,
+      cookie,
+      timeoutMs,
+      body: baseBody,
+    });
+    if (looksLikeServerError(warmupResponse.status)) {
+      const excerpt = await bodyExcerpt(warmupResponse);
+      throw transportError(`/api/tts word warmup ${slug}/${voice} returned HTTP ${warmupResponse.status}: ${excerpt}`);
+    }
+    const warmupState = wordCacheState(warmupResponse);
+    notes.push(`INFO: word warmup cache=${warmupState.cache || '(missing)'}`);
+    response = await postTtsRequest({
+      origin,
+      cookie,
+      timeoutMs,
+      body: {
+        ...baseBody,
+        cacheLookupOnly: true,
+      },
+    });
+    if (looksLikeServerError(response.status)) {
+      const excerpt = await bodyExcerpt(response);
+      throw transportError(`/api/tts word probe ${slug}/${voice} returned HTTP ${response.status}: ${excerpt}`);
+    }
+    state = wordCacheState(response);
+  }
+
   if (response.status !== 200) {
+    if (!requireWordHit) {
+      return {
+        kind: 'word',
+        slug,
+        voice,
+        promptToken,
+        expectedR2Key: expectedKey,
+        cache: state.cache,
+        source: state.source,
+        model: state.model,
+        voiceHeader: state.voice,
+        status: response.status,
+        notes: [
+          ...notes,
+          `WARN: HTTP ${response.status} cache=${state.cache || '(missing)'} (word cache is not warm)`,
+        ],
+        ok: true,
+      };
+    }
     const excerpt = await bodyExcerpt(response);
     throw validationError(`/api/tts word probe ${slug}/${voice} returned HTTP ${response.status}: ${excerpt}`);
   }
 
-  const cache = readResponseHeader(response, 'x-ks2-tts-cache');
-  const source = readResponseHeader(response, 'x-ks2-tts-cache-source');
-  const model = readResponseHeader(response, 'x-ks2-tts-model');
-  const responseVoice = readResponseHeader(response, 'x-ks2-tts-voice');
+  const { cache, source, model, voice: responseVoice } = state;
 
   const probe = {
     kind: 'word',
@@ -429,7 +510,7 @@ async function runWordProbe({
     model,
     voiceHeader: responseVoice,
     status: response.status,
-    notes: [],
+    notes,
     ok: true,
   };
 
@@ -439,7 +520,7 @@ async function runWordProbe({
       probe.notes.push(`cache=${cache || '(missing)'} (expected hit)`);
       throw validationError(`Word probe ${slug}/${voice} cache=${cache || '(missing)'} but --require-word-hit is set.`);
     }
-    probe.notes.push(`WARN: cache=${cache || '(missing)'} (pre-fill baseline; suppress with --require-word-hit once U4 lands)`);
+    probe.notes.push(`WARN: cache=${cache || '(missing)'} (word cache is not warm)`);
     return probe;
   }
 
@@ -653,27 +734,60 @@ async function runCrossAccountProbe({
     cookie: sessionA.cookie,
     timeoutMs,
     body: {
-      wordOnly: true,
-      scope: 'word-bank',
-      slug: fixtureWord,
-      learnerId: bootstrapA.learnerId,
-      promptToken: tokenA,
-      bufferedGeminiVoice: voice,
-      // Fetch real bytes — `cacheLookupOnly` returns 204; we want 200 +
-      // body bytes so the byte-identity assertion has something to compare.
+      ...wordProbeBody({
+        slug: fixtureWord,
+        learnerId: bootstrapA.learnerId,
+        promptToken: tokenA,
+        voice,
+      }),
+      cacheLookupOnly: true,
     },
   });
+  if (responseA.status === 204 && readResponseHeader(responseA, 'x-ks2-tts-cache') === 'miss') {
+    const warmupResponse = await warmWordAudio({
+      origin,
+      cookie: sessionA.cookie,
+      timeoutMs,
+      body: wordProbeBody({
+        slug: fixtureWord,
+        learnerId: bootstrapA.learnerId,
+        promptToken: tokenA,
+        voice,
+      }),
+    });
+    if (looksLikeServerError(warmupResponse.status)) {
+      const excerpt = await bodyExcerpt(warmupResponse);
+      throw transportError(`Cross-account probe warmup returned HTTP ${warmupResponse.status}: ${excerpt}`);
+    }
+  }
+  const warmedResponseA = responseA.status === 204 && readResponseHeader(responseA, 'x-ks2-tts-cache') === 'miss'
+    ? await postTtsRequest({
+      origin,
+      cookie: sessionA.cookie,
+      timeoutMs,
+      body: {
+        ...wordProbeBody({
+          slug: fixtureWord,
+          learnerId: bootstrapA.learnerId,
+          promptToken: tokenA,
+          voice,
+        }),
+        cacheLookupOnly: true,
+      },
+    })
+    : responseA;
   const responseB = await postTtsRequest({
     origin,
     cookie: sessionB.cookie,
     timeoutMs,
     body: {
-      wordOnly: true,
-      scope: 'word-bank',
-      slug: fixtureWord,
-      learnerId: bootstrapB.learnerId,
-      promptToken: tokenB,
-      bufferedGeminiVoice: voice,
+      ...wordProbeBody({
+        slug: fixtureWord,
+        learnerId: bootstrapB.learnerId,
+        promptToken: tokenB,
+        voice,
+      }),
+      cacheLookupOnly: true,
     },
   });
   const responseDistinct = await postTtsRequest({
@@ -681,22 +795,23 @@ async function runCrossAccountProbe({
     cookie: sessionA.cookie,
     timeoutMs,
     body: {
-      wordOnly: true,
-      scope: 'word-bank',
-      slug: distinctWord,
-      learnerId: bootstrapA.learnerId,
-      promptToken: await computeWordBankPromptToken({
-        learnerId: bootstrapA.learnerId,
+      ...wordProbeBody({
         slug: distinctWord,
-        word: distinctWordText,
-        sentence: distinctSentence,
+        learnerId: bootstrapA.learnerId,
+        promptToken: await computeWordBankPromptToken({
+          learnerId: bootstrapA.learnerId,
+          slug: distinctWord,
+          word: distinctWordText,
+          sentence: distinctSentence,
+        }),
+        voice,
       }),
-      bufferedGeminiVoice: voice,
+      provider: 'gemini',
     },
   });
 
   for (const [label, response] of [
-    ['A', responseA],
+    ['A', warmedResponseA],
     ['B', responseB],
     ['distinct', responseDistinct],
   ]) {
@@ -709,7 +824,7 @@ async function runCrossAccountProbe({
       throw validationError(`Cross-account probe ${label} returned HTTP ${response.status}: ${excerpt}`);
     }
   }
-  for (const [label, response] of [['A', responseA], ['B', responseB]]) {
+  for (const [label, response] of [['A', warmedResponseA], ['B', responseB]]) {
     const cache = readResponseHeader(response, 'x-ks2-tts-cache');
     if (cache !== 'hit') {
       throw validationError(
@@ -724,7 +839,7 @@ async function runCrossAccountProbe({
     }
   }
 
-  const bytesA = await readResponseBytes(responseA);
+  const bytesA = await readResponseBytes(warmedResponseA);
   const bytesB = await readResponseBytes(responseB);
   const bytesDistinct = await readResponseBytes(responseDistinct);
 

--- a/src/platform/core/fetch-timeout.js
+++ b/src/platform/core/fetch-timeout.js
@@ -1,0 +1,113 @@
+export const CLIENT_FETCH_TIMEOUT_CODE = 'client_fetch_timeout';
+export const DEFAULT_CLIENT_FETCH_TIMEOUT_MS = 15_000;
+
+export class ClientFetchTimeoutError extends Error {
+  constructor({ timeoutMs = DEFAULT_CLIENT_FETCH_TIMEOUT_MS, message = 'Request took too long to respond.' } = {}) {
+    super(message);
+    this.name = 'AbortError';
+    this.code = CLIENT_FETCH_TIMEOUT_CODE;
+    this.timeoutMs = timeoutMs;
+    this.timedOut = true;
+  }
+}
+
+export function isClientFetchTimeout(error) {
+  return error?.code === CLIENT_FETCH_TIMEOUT_CODE || error?.timedOut === true;
+}
+
+export function normaliseClientFetchTimeoutMs(value, fallback = DEFAULT_CLIENT_FETCH_TIMEOUT_MS) {
+  const source = value == null ? fallback : value;
+  const timeoutMs = Number(source);
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) return 0;
+  return Math.floor(timeoutMs);
+}
+
+export async function fetchWithClientTimeout(fetchFn, input, init = {}, options = {}) {
+  const timeoutMs = normaliseClientFetchTimeoutMs(options.timeoutMs, DEFAULT_CLIENT_FETCH_TIMEOUT_MS);
+  const requestInit = init && typeof init === 'object' ? init : {};
+  const callerSignal = requestInit.signal;
+  if (callerSignal?.aborted) throw abortErrorFromReason(callerSignal.reason);
+  if (!timeoutMs && !callerSignal) return fetchFn(input, requestInit);
+
+  const controller = typeof AbortController === 'function' ? new AbortController() : null;
+  const finalInit = controller ? { ...requestInit, signal: controller.signal } : requestInit;
+  const racers = [];
+  let timeoutHandle = null;
+  let abortListener = null;
+  let timeoutError = null;
+  let timeoutFired = false;
+
+  let fetchPromise;
+  try {
+    fetchPromise = Promise.resolve(fetchFn(input, finalInit)).catch((error) => {
+      if (timeoutFired && isAbortError(error)) {
+        throw timeoutError || new ClientFetchTimeoutError({
+          timeoutMs,
+          message: options.timeoutMessage || 'Request took too long to respond.',
+        });
+      }
+      throw error;
+    });
+  } catch (error) {
+    fetchPromise = Promise.reject(error);
+  }
+  fetchPromise.catch(() => {});
+  racers.push(fetchPromise);
+
+  if (timeoutMs) {
+    racers.push(new Promise((_, reject) => {
+      timeoutHandle = setTimeout(() => {
+        timeoutFired = true;
+        timeoutError = new ClientFetchTimeoutError({
+          timeoutMs,
+          message: options.timeoutMessage || 'Request took too long to respond.',
+        });
+        abortController(controller, timeoutError);
+        reject(timeoutError);
+      }, timeoutMs);
+    }));
+  }
+
+  if (callerSignal) {
+    racers.push(new Promise((_, reject) => {
+      abortListener = () => {
+        abortController(controller, callerSignal.reason);
+        reject(abortErrorFromReason(callerSignal.reason));
+      };
+      callerSignal.addEventListener('abort', abortListener, { once: true });
+    }));
+  }
+
+  try {
+    return await Promise.race(racers);
+  } finally {
+    if (timeoutHandle != null) clearTimeout(timeoutHandle);
+    if (callerSignal && abortListener) callerSignal.removeEventListener('abort', abortListener);
+  }
+}
+
+function abortController(controller, reason) {
+  if (!controller) return;
+  try {
+    controller.abort(reason);
+  } catch {
+    try {
+      controller.abort();
+    } catch {
+      // Older runtimes can be inconsistent here; the timeout race still
+      // rejects even when the underlying request cannot be signalled.
+    }
+  }
+}
+
+function isAbortError(error) {
+  return error?.name === 'AbortError';
+}
+
+function abortErrorFromReason(reason) {
+  if (reason instanceof Error) return reason;
+  const error = new Error('Request was cancelled.');
+  error.name = 'AbortError';
+  if (reason !== undefined) error.reason = reason;
+  return error;
+}

--- a/src/platform/core/repositories/api.js
+++ b/src/platform/core/repositories/api.js
@@ -40,8 +40,13 @@ import {
   createCircuitBreaker,
   isResetableBreakerName,
 } from '../circuit-breaker.js';
+import {
+  fetchWithClientTimeout,
+  isClientFetchTimeout,
+} from '../fetch-timeout.js';
 
 const MUTATION_POLICY_VERSION = 1;
+const DEFAULT_REPOSITORY_FETCH_TIMEOUT_MS = 30_000;
 const OPERATION_STATUS_PENDING = 'pending';
 const OPERATION_STATUS_BLOCKED_STALE = 'blocked-stale';
 const SUBJECT_STATE_MERGE_STRATEGIES = new Set(['merge', 'ui', 'data', 'replace']);
@@ -299,13 +304,17 @@ async function fetchJson(fetchFn, url, init, authSession) {
 
   let response;
   try {
-    response = await fetchFn(url, decoratedInit);
+    response = await fetchWithClientTimeout(fetchFn, url, decoratedInit, {
+      timeoutMs: DEFAULT_REPOSITORY_FETCH_TIMEOUT_MS,
+      timeoutMessage: 'Repository request took too long to respond.',
+    });
   } catch (error) {
+    const timedOut = isClientFetchTimeout(error);
     const wrapped = new RepositoryHttpError({
       url,
       method,
       status: 0,
-      payload: null,
+      payload: timedOut ? { code: 'repository_request_timeout' } : null,
       text: error?.message || String(error),
     });
     wrapped.cause = error;

--- a/src/platform/hubs/admin-marketing-api.js
+++ b/src/platform/hubs/admin-marketing-api.js
@@ -12,6 +12,12 @@ import {
   applyRepositoryAuthSession,
   createNoopRepositoryAuthSession,
 } from '../core/repositories/auth-session.js';
+import {
+  fetchWithClientTimeout,
+  isClientFetchTimeout,
+} from '../core/fetch-timeout.js';
+
+const DEFAULT_ADMIN_MARKETING_TIMEOUT_MS = 15_000;
 
 // ---------------------------------------------------------------------------
 // Helpers (mirrored from api.js)
@@ -31,9 +37,25 @@ async function parseResponse(response) {
   return response.text().catch(() => '');
 }
 
-async function fetchJson(fetchFn, url, init, authSession) {
+async function fetchJson(fetchFn, url, init, authSession, timeoutMs = DEFAULT_ADMIN_MARKETING_TIMEOUT_MS) {
   const requestInit = await applyRepositoryAuthSession(authSession, init);
-  const response = await fetchFn(url, requestInit);
+  let response;
+  try {
+    response = await fetchWithClientTimeout(fetchFn, url, requestInit, {
+      timeoutMs,
+      timeoutMessage: 'Marketing API request took too long to respond.',
+    });
+  } catch (error) {
+    const timedOut = isClientFetchTimeout(error);
+    const wrapped = new Error(error?.message || (timedOut
+      ? 'Marketing API request took too long to respond.'
+      : 'Marketing API request could not reach the server.'));
+    wrapped.status = 0;
+    wrapped.code = timedOut ? 'marketing_api_timeout' : 'marketing_api_network_error';
+    wrapped.payload = { code: wrapped.code };
+    wrapped.cause = error;
+    throw wrapped;
+  }
   const payload = await parseResponse(response);
   if (!response.ok) {
     const message = payload?.message || `Marketing API request failed (${response.status}).`;
@@ -108,6 +130,7 @@ export function createAdminMarketingApi({
   baseUrl = '',
   fetch: fetchImpl = globalThis.fetch?.bind(globalThis),
   authSession = createNoopRepositoryAuthSession(),
+  timeoutMs = DEFAULT_ADMIN_MARKETING_TIMEOUT_MS,
 } = {}) {
   if (typeof fetchImpl !== 'function') {
     throw new TypeError('Admin Marketing API requires a fetch implementation.');
@@ -121,7 +144,7 @@ export function createAdminMarketingApi({
     /** List all marketing messages (admin sees all; ops sees published + scheduled). */
     async fetchMarketingMessages() {
       const url = buildUrl('/api/admin/marketing/messages');
-      return fetchJson(fetchImpl, url, { method: 'GET' }, authSession);
+      return fetchJson(fetchImpl, url, { method: 'GET' }, authSession, timeoutMs);
     },
 
     /** Create a new marketing message (admin only, returns status=draft). */
@@ -131,13 +154,13 @@ export function createAdminMarketingApi({
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify(data),
-      }, authSession);
+      }, authSession, timeoutMs);
     },
 
     /** Fetch a single marketing message by ID. */
     async fetchMarketingMessage(id) {
       const url = buildUrl(`/api/admin/marketing/messages/${encodeURIComponent(id)}`);
-      return fetchJson(fetchImpl, url, { method: 'GET' }, authSession);
+      return fetchJson(fetchImpl, url, { method: 'GET' }, authSession, timeoutMs);
     },
 
     /**
@@ -150,7 +173,7 @@ export function createAdminMarketingApi({
         method: 'PUT',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify(data),
-      }, authSession);
+      }, authSession, timeoutMs);
     },
 
     /**
@@ -164,7 +187,7 @@ export function createAdminMarketingApi({
         method: 'PUT',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify(data),
-      }, authSession);
+      }, authSession, timeoutMs);
     },
   };
 }

--- a/src/platform/runtime/read-model-client.js
+++ b/src/platform/runtime/read-model-client.js
@@ -1,3 +1,10 @@
+import {
+  fetchWithClientTimeout,
+  isClientFetchTimeout,
+} from '../core/fetch-timeout.js';
+
+const DEFAULT_READ_MODEL_TIMEOUT_MS = 15_000;
+
 function joinUrl(baseUrl, path) {
   const base = String(baseUrl || '').replace(/\/$/, '');
   const suffix = String(path || '').startsWith('/') ? path : `/${path}`;
@@ -7,16 +14,33 @@ function joinUrl(baseUrl, path) {
 export function createReadModelClient({
   baseUrl = '',
   fetch: fetchFn = (input, init) => globalThis.fetch(input, init),
+  timeoutMs = DEFAULT_READ_MODEL_TIMEOUT_MS,
 } = {}) {
   if (typeof fetchFn !== 'function') {
     throw new TypeError('Read-model client requires a fetch implementation.');
   }
 
   async function readJson(path) {
-    const response = await fetchFn(joinUrl(baseUrl, path), {
-      method: 'GET',
-      headers: { accept: 'application/json' },
-    });
+    let response;
+    try {
+      response = await fetchWithClientTimeout(fetchFn, joinUrl(baseUrl, path), {
+        method: 'GET',
+        headers: { accept: 'application/json' },
+      }, {
+        timeoutMs,
+        timeoutMessage: 'Read model request took too long to respond.',
+      });
+    } catch (error) {
+      const timedOut = isClientFetchTimeout(error);
+      const wrapped = new Error(error?.message || (timedOut
+        ? 'Read model request took too long to respond.'
+        : 'Read model request could not reach the server.'));
+      wrapped.status = 0;
+      wrapped.code = timedOut ? 'read_model_timeout' : 'read_model_network_error';
+      wrapped.payload = { code: wrapped.code };
+      wrapped.cause = error;
+      throw wrapped;
+    }
     const payload = await response.json().catch(() => ({}));
     if (!response.ok || payload?.ok === false) {
       const error = new Error(payload?.message || `Read model request failed (${response.status}).`);

--- a/src/platform/runtime/subject-command-client.js
+++ b/src/platform/runtime/subject-command-client.js
@@ -1,7 +1,12 @@
 import { uid } from '../core/utils.js';
+import {
+  fetchWithClientTimeout,
+  isClientFetchTimeout,
+} from '../core/fetch-timeout.js';
 
 const DEFAULT_RETRY_JITTER_MAX_MS = 125;
 const DEFAULT_RETRY_MAX_DELAY_MS = 2_000;
+const DEFAULT_SUBJECT_COMMAND_TIMEOUT_MS = 15_000;
 
 function joinUrl(baseUrl, path) {
   const base = String(baseUrl || '').replace(/\/$/, '');
@@ -126,6 +131,7 @@ export function createSubjectCommandClient({
   retryMaxDelayMs = DEFAULT_RETRY_MAX_DELAY_MS,
   random = Math.random,
   sleep: sleepFn = sleep,
+  timeoutMs = DEFAULT_SUBJECT_COMMAND_TIMEOUT_MS,
 } = {}) {
   if (typeof fetchFn !== 'function') {
     throw new TypeError('Subject command client requires a fetch implementation.');
@@ -158,7 +164,7 @@ export function createSubjectCommandClient({
     // alongside this function — the audit here is U3-only.
     let response;
     try {
-      response = await fetchFn(joinUrl(baseUrl, `/api/subjects/${encodeURIComponent(cleanSubjectId)}/command`), {
+      response = await fetchWithClientTimeout(fetchFn, joinUrl(baseUrl, `/api/subjects/${encodeURIComponent(cleanSubjectId)}/command`), {
         method: 'POST',
         headers: {
           accept: 'application/json',
@@ -167,12 +173,21 @@ export function createSubjectCommandClient({
           'x-ks2-correlation-id': requestId,
         },
         body,
+      }, {
+        timeoutMs,
+        timeoutMessage: 'Subject command took too long to respond.',
       });
     } catch (error) {
+      const timedOut = isClientFetchTimeout(error);
       throw new SubjectCommandClientError({
         status: 0,
-        payload: { code: 'subject_command_network_error' },
-        message: error?.message || 'Subject command could not reach the server.',
+        payload: {
+          code: 'subject_command_network_error',
+          timedOut: timedOut ? true : undefined,
+        },
+        message: error?.message || (timedOut
+          ? 'Subject command took too long to respond.'
+          : 'Subject command could not reach the server.'),
       });
     }
 

--- a/src/platform/ui/luminance.js
+++ b/src/platform/ui/luminance.js
@@ -64,11 +64,20 @@ export function probeRelLuminance(url) {
   return pending;
 }
 
-export function preloadImages(urls) {
-  if (!Array.isArray(urls)) return;
-  urls.forEach((url) => {
-    if (url) void loadProbeImage(url);
-  });
+export function preloadImages(urls, options = {}) {
+  if (!Array.isArray(urls)) return undefined;
+  const pendingUrls = Array.from(new Set(urls.filter(Boolean)));
+  if (!pendingUrls.length) return undefined;
+
+  const run = () => {
+    pendingUrls.forEach((url) => {
+      void loadProbeImage(url);
+    });
+  };
+
+  if (options?.mode === 'idle') return scheduleIdle(run);
+  run();
+  return undefined;
 }
 
 export async function probeHeroTextTones(url, container, probes) {
@@ -147,6 +156,25 @@ function loadProbeImage(url) {
   });
   imageCache.set(url, pending);
   return pending;
+}
+
+function scheduleIdle(callback) {
+  if (typeof window !== 'undefined' && typeof window.requestIdleCallback === 'function') {
+    const handle = window.requestIdleCallback(callback, { timeout: 1500 });
+    return () => {
+      if (typeof window.cancelIdleCallback === 'function') {
+        window.cancelIdleCallback(handle);
+      }
+    };
+  }
+
+  if (typeof window !== 'undefined' && typeof window.setTimeout === 'function') {
+    const handle = window.setTimeout(callback, 250);
+    return () => window.clearTimeout(handle);
+  }
+
+  callback();
+  return undefined;
 }
 
 function fallbackToneResults(container, probes) {

--- a/src/subjects/spelling/components/SpellingPracticeSurface.jsx
+++ b/src/subjects/spelling/components/SpellingPracticeSurface.jsx
@@ -5,6 +5,7 @@ import { SpellingSummaryScene } from './SpellingSummaryScene.jsx';
 import { SpellingWordBankScene } from './SpellingWordBankScene.jsx';
 import { PatternQuestScene } from './PatternQuestScene.jsx';
 import { preloadImages } from '../../../platform/ui/luminance.js';
+import { POST_MASTERY_HYDRATION_WINDOW_MS } from '../client-read-models.js';
 import {
   buildSpellingContext,
   heroBgForLearner,
@@ -105,6 +106,7 @@ export function SpellingPracticeSurface(props) {
   const [setupHeroTone, setSetupHeroTone] = React.useState(() => (
     selectSpellingSetupTone(learnerId, readPreviousSetupTone(learnerId))
   ));
+  const [, refreshHydrationFallback] = React.useReducer((value) => value + 1, 0);
   const previousLearnerRef = React.useRef(learnerId);
   const previousPhaseRef = React.useRef(spelling.ui.phase);
   React.useEffect(() => {
@@ -122,6 +124,14 @@ export function SpellingPracticeSurface(props) {
   React.useEffect(() => {
     rememberSetupTone(learnerId, setupHeroTone);
   }, [learnerId, setupHeroTone]);
+  React.useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    if (spelling.postMastery?.postMasteryDebug?.source !== 'checking') return undefined;
+    const timeout = window.setTimeout(() => {
+      refreshHydrationFallback();
+    }, POST_MASTERY_HYDRATION_WINDOW_MS + 50);
+    return () => window.clearTimeout(timeout);
+  }, [learnerId, spelling.postMastery?.postMasteryDebug?.source]);
   // Post-Mega gating + branch resolution. The dashboard / sessions follow
   // the learner's Phaeton branch (b1 / b2) so the vista matches the
   // grand-master Codex creature even when the rest of the monster set
@@ -148,7 +158,8 @@ export function SpellingPracticeSurface(props) {
     postMega: isPostMegaScene,
     postMegaBranch,
   });
-  const preloadKey = preloadedHeroUrls.join('|');
+  const idleHeroPreloadUrls = preloadedHeroUrls.filter((url) => url && url !== heroBg);
+  const idlePreloadKey = idleHeroPreloadUrls.join('|');
   const previousHeroBgRef = React.useRef('');
   const previousHeroBg = previousHeroBgRef.current && previousHeroBgRef.current !== heroBg
     ? previousHeroBgRef.current
@@ -157,8 +168,12 @@ export function SpellingPracticeSurface(props) {
     if (heroBg) previousHeroBgRef.current = heroBg;
   }, [heroBg]);
   React.useEffect(() => {
-    preloadImages(preloadedHeroUrls);
-  }, [preloadKey]);
+    preloadImages(heroBg ? [heroBg] : []);
+  }, [heroBg]);
+  React.useEffect(() => {
+    if (!idleHeroPreloadUrls.length) return undefined;
+    return preloadImages(idleHeroPreloadUrls, { mode: 'idle' });
+  }, [idlePreloadKey]);
   React.useEffect(() => {
     if (typeof window === 'undefined') return undefined;
     const frame = window.requestAnimationFrame(() => {

--- a/src/subjects/spelling/tts.js
+++ b/src/subjects/spelling/tts.js
@@ -18,8 +18,8 @@ import {
 //                          reuses the prefetched blob, so `emitLoading` is
 //                          skipped and the status jumps straight to
 //                          playing when audio.play() is invoked. No
-//                          `loading` latency telemetry emits on this path;
-//                          the completed telemetry fires at onended.)
+//                          status-channel latency telemetry emits on this
+//                          path; cache lookup timing logs separately.)
 //     loading -> playing  (audio play after remote fetch)
 //     loading -> failed   (watchdog fires OR fetch rejects / non-ok)
 //     loading -> idle     (abortPending called)
@@ -162,6 +162,7 @@ export function createPlatformTts({
   clearTimeoutFn = (typeof globalThis.clearTimeout === 'function' ? globalThis.clearTimeout.bind(globalThis) : null),
   now = () => Date.now(),
   logger = (typeof globalThis.console?.log === 'function' ? globalThis.console.log.bind(globalThis.console) : null),
+  onCacheLookupTelemetry = null,
 } = {}) {
   let playbackId = 0;
   let currentAbort = null;
@@ -209,6 +210,87 @@ export function createPlatformTts({
     const kind = loadingKind || 'normal';
     try {
       logger(`[ks2-tts-latency] status=${statusTag} wallMs=${wallMs} kind=${kind}`);
+    } catch { /* swallow logger failure */ }
+  }
+
+  function responseHeader(response, name) {
+    try {
+      return response?.headers?.get?.(name) || '';
+    } catch {
+      return '';
+    }
+  }
+
+  function emitCacheLookupLog({
+    statusTag,
+    kind,
+    requestStartedAt,
+    response,
+    responseAt = null,
+    blobAt = null,
+    playStartAt = null,
+    bytes = null,
+  } = {}) {
+    const startedAt = Number(requestStartedAt);
+    if (!Number.isFinite(startedAt)) return;
+    const hasTiming = (value) => value != null && Number.isFinite(Number(value));
+    const finishedAt = hasTiming(playStartAt)
+      ? Number(playStartAt)
+      : hasTiming(blobAt)
+        ? Number(blobAt)
+        : hasTiming(responseAt)
+          ? Number(responseAt)
+          : now();
+    const headerMs = hasTiming(responseAt)
+      ? Math.max(0, Math.round(Number(responseAt) - startedAt))
+      : null;
+    const blobMs = hasTiming(blobAt) && hasTiming(responseAt)
+      ? Math.max(0, Math.round(Number(blobAt) - Number(responseAt)))
+      : null;
+    const playStartMs = hasTiming(playStartAt)
+      ? Math.max(0, Math.round(Number(playStartAt) - startedAt))
+      : null;
+    const wallMs = Math.max(0, Math.round(finishedAt - startedAt));
+    const byteCount = hasTiming(bytes) ? Number(bytes) : null;
+    const telemetry = {
+      status: statusTag || 'unknown',
+      wallMs,
+      kind: kind || 'normal',
+      http: Number(response?.status) || 0,
+      cache: responseHeader(response, 'x-ks2-tts-cache') || 'unknown',
+      source: responseHeader(response, 'x-ks2-tts-cache-source') || 'unknown',
+      provider: responseHeader(response, 'x-ks2-tts-provider') || 'unknown',
+      contentType: responseHeader(response, 'content-type') || 'unknown',
+      requestId: responseHeader(response, 'x-ks2-request-id') || 'unknown',
+      headerMs,
+      blobMs,
+      playStartMs,
+      bytes: byteCount === null ? null : Math.max(0, Math.round(byteCount)),
+    };
+    if (typeof onCacheLookupTelemetry === 'function') {
+      try {
+        onCacheLookupTelemetry({ ...telemetry });
+      } catch { /* swallow observer failure */ }
+    }
+    if (typeof logger !== 'function') return;
+    const fields = [
+      '[ks2-tts-cache-latency]',
+      `status=${telemetry.status}`,
+      `wallMs=${telemetry.wallMs}`,
+      `kind=${telemetry.kind}`,
+      `http=${telemetry.http}`,
+      `cache=${telemetry.cache}`,
+      `source=${telemetry.source}`,
+      `provider=${telemetry.provider}`,
+      `contentType=${telemetry.contentType}`,
+      `requestId=${telemetry.requestId}`,
+    ];
+    if (telemetry.headerMs !== null) fields.push(`headerMs=${telemetry.headerMs}`);
+    if (telemetry.blobMs !== null) fields.push(`blobMs=${telemetry.blobMs}`);
+    if (telemetry.playStartMs !== null) fields.push(`playStartMs=${telemetry.playStartMs}`);
+    if (telemetry.bytes !== null) fields.push(`bytes=${telemetry.bytes}`);
+    try {
+      logger(fields.join(' '));
     } catch { /* swallow logger failure */ }
   }
 
@@ -419,6 +501,8 @@ export function createPlatformTts({
 
     currentAbort = new AbortController();
     const kindId = playbackKind(payload);
+    const cacheLookupTelemetry = !emitLoading && payload?.cacheLookupOnly === true;
+    const requestStartedAt = cacheLookupTelemetry ? now() : null;
     if (emitLoading) {
       emit({ type: 'loading', kind: kindId, provider: providerId });
       loadingKind = kindId;
@@ -435,17 +519,37 @@ export function createPlatformTts({
         signal: currentAbort.signal,
         body: JSON.stringify(requestBody),
       });
+      const responseAt = cacheLookupTelemetry ? now() : null;
       if (response.status === 204) {
+        if (cacheLookupTelemetry) {
+          emitCacheLookupLog({
+            statusTag: 'miss',
+            kind: kindId,
+            requestStartedAt,
+            response,
+            responseAt,
+          });
+        }
         if (emitLoading && token === playbackId && status === 'loading') setStatus('idle', { telemetry: 'completed' });
         if (emitMissEnd && token === playbackId) emit({ type: 'end' });
         return false;
       }
       if (!response.ok) {
+        if (cacheLookupTelemetry) {
+          emitCacheLookupLog({
+            statusTag: 'failed',
+            kind: kindId,
+            requestStartedAt,
+            response,
+            responseAt,
+          });
+        }
         if (emitLoading && token === playbackId && status === 'loading') setStatus('failed', { telemetry: 'failed' });
         if (emitMissEnd && token === playbackId) emit({ type: 'end' });
         return false;
       }
       const blob = await response.blob();
+      const blobAt = cacheLookupTelemetry ? now() : null;
       if (token !== playbackId) return false;
 
       currentObjectUrl = URL.createObjectURL(blob);
@@ -483,8 +587,21 @@ export function createPlatformTts({
         //      was passed, so no `loading` transition occurred. Audio is
         //      playing immediately, so the audio-playing invariant
         //      (`status === 'playing' when audio.play() runs`) must hold.
-        //      No latency telemetry emits on this path because there was
-        //      no `loading` timer to close out.
+        //      Status-channel latency stays tied to `loading`, but cache
+        //      lookup timing still logs separately so production can split
+        //      header, body, and play-start delay.
+        if (cacheLookupTelemetry) {
+          emitCacheLookupLog({
+            statusTag: 'play-start',
+            kind: kindId,
+            requestStartedAt,
+            response,
+            responseAt,
+            blobAt,
+            playStartAt: now(),
+            bytes: blob.size,
+          });
+        }
         if (status === 'loading') setStatus('playing', { telemetry: 'completed' });
         else if (status === 'idle') setStatus('playing');
         emit({ type: 'start', kind: kindId });

--- a/src/subjects/spelling/tts.js
+++ b/src/subjects/spelling/tts.js
@@ -146,6 +146,7 @@ function remotePromptRequest(payload = {}, providerId = DEFAULT_TTS_PROVIDER, bu
   if (payload.wordOnly) body.wordOnly = true;
   if (payload.cacheOnly) body.cacheOnly = true;
   if (payload.cacheLookupOnly) body.cacheLookupOnly = true;
+  if (payload.cachePlaybackOnly) body.cachePlaybackOnly = true;
   if (typeof payload.slug === 'string' && payload.slug) body.slug = payload.slug;
   if (typeof payload.scope === 'string' && payload.scope) body.scope = payload.scope;
   return body;
@@ -478,7 +479,7 @@ export function createPlatformTts({
       return false;
     }
     return await speakWithRemote(
-      { ...payload, cacheLookupOnly: true },
+      { ...payload, cachePlaybackOnly: true },
       'gemini',
       bufferedVoiceId,
       token,
@@ -501,7 +502,7 @@ export function createPlatformTts({
 
     currentAbort = new AbortController();
     const kindId = playbackKind(payload);
-    const cacheLookupTelemetry = !emitLoading && payload?.cacheLookupOnly === true;
+    const cacheLookupTelemetry = !emitLoading && (payload?.cacheLookupOnly === true || payload?.cachePlaybackOnly === true);
     const requestStartedAt = cacheLookupTelemetry ? now() : null;
     if (emitLoading) {
       emit({ type: 'loading', kind: kindId, provider: providerId });

--- a/src/subjects/spelling/tts.js
+++ b/src/subjects/spelling/tts.js
@@ -584,28 +584,44 @@ export function createPlatformTts({
         //      telemetry measured from the `loading` entry.
         //   2. idle -> playing: cache-hit fast path via
         //      `speakWithCachedBufferedAudio` where `emitLoading: false`
-        //      was passed, so no `loading` transition occurred. Audio is
-        //      playing immediately, so the audio-playing invariant
-        //      (`status === 'playing' when audio.play() runs`) must hold.
-        //      Status-channel latency stays tied to `loading`, but cache
-        //      lookup timing still logs separately so production can split
-        //      header, body, and play-start delay.
-        if (cacheLookupTelemetry) {
-          emitCacheLookupLog({
-            statusTag: 'play-start',
-            kind: kindId,
-            requestStartedAt,
-            response,
-            responseAt,
-            blobAt,
-            playStartAt: now(),
-            bytes: blob.size,
-          });
-        }
+        //      was passed, so no `loading` transition occurred. The status
+        //      moves to `playing` before `audio.play()` starts, while cache
+        //      lookup telemetry records the real play() fulfilment time.
         if (status === 'loading') setStatus('playing', { telemetry: 'completed' });
         else if (status === 'idle') setStatus('playing');
         emit({ type: 'start', kind: kindId });
-        currentAudio.play().catch(() => {
+        let playPromise;
+        try {
+          playPromise = currentAudio.play();
+        } catch {
+          playPromise = Promise.reject();
+        }
+        Promise.resolve(playPromise).then(() => {
+          if (cacheLookupTelemetry && token === playbackId) {
+            emitCacheLookupLog({
+              statusTag: 'play-start',
+              kind: kindId,
+              requestStartedAt,
+              response,
+              responseAt,
+              blobAt,
+              playStartAt: now(),
+              bytes: blob.size,
+            });
+          }
+        }).catch(() => {
+          if (token !== playbackId) return;
+          if (cacheLookupTelemetry && token === playbackId) {
+            emitCacheLookupLog({
+              statusTag: 'failed',
+              kind: kindId,
+              requestStartedAt,
+              response,
+              responseAt,
+              blobAt,
+              bytes: blob.size,
+            });
+          }
           if (status === 'playing' || status === 'loading') setStatus('idle');
           emit({ type: 'end' });
           cleanupAudio();

--- a/tests/admin-marketing-section.test.js
+++ b/tests/admin-marketing-section.test.js
@@ -227,6 +227,29 @@ test('createAdminMarketingApi — non-ok response throws with status and code', 
   }
 });
 
+test('createAdminMarketingApi — slow requests reject with a structured timeout error', async () => {
+  let aborted = false;
+  const mockFetch = (url, init = {}) => {
+    init.signal?.addEventListener('abort', () => {
+      aborted = true;
+    });
+    return new Promise(() => {});
+  };
+  const api = createAdminMarketingApi({ fetch: mockFetch, timeoutMs: 1 });
+
+  await assert.rejects(
+    api.fetchMarketingMessages(),
+    (error) => {
+      assert.equal(error.status, 0);
+      assert.equal(error.code, 'marketing_api_timeout');
+      assert.deepEqual(error.payload, { code: 'marketing_api_timeout' });
+      return true;
+    },
+  );
+
+  assert.equal(aborted, true);
+});
+
 // ---------------------------------------------------------------------------
 // 3. VALID_TRANSITIONS map coverage
 // ---------------------------------------------------------------------------

--- a/tests/bundle-audit.test.js
+++ b/tests/bundle-audit.test.js
@@ -860,7 +860,15 @@ function seoAuditRootHtml({ omitCanonical = false } = {}) {
   ].join('');
 }
 
-function seoAuditPracticePageHtml(page, { omitCanonical = false, forbiddenToken = '' } = {}) {
+function cloudflareWebAnalyticsBeacon() {
+  return '<script defer src="https://static.cloudflareinsights.com/beacon.min.js/vcd15cbe7772f49c399c6a5babf22c1241717689176015" data-cf-beacon=\'{"version":"2024.11.0","token":"test"}\' crossorigin="anonymous"></script>';
+}
+
+function seoAuditPracticePageHtml(page, {
+  omitCanonical = false,
+  forbiddenToken = '',
+  edgeScript = '',
+} = {}) {
   const canonicalUrl = canonicalPracticePageUrl(page);
   return [
     '<!doctype html><html lang="en-GB"><head>',
@@ -883,11 +891,12 @@ function seoAuditPracticePageHtml(page, { omitCanonical = false, forbiddenToken 
     '<a href="/about/">About KS2 Mastery</a>',
     '<a href="/">KS2 Mastery home</a>',
     '</main>',
+    edgeScript,
     '</body></html>',
   ].join('');
 }
 
-function seoAuditIdentityPageHtml(page, { forbiddenToken = '' } = {}) {
+function seoAuditIdentityPageHtml(page, { forbiddenToken = '', edgeScript = '' } = {}) {
   const canonicalUrl = canonicalIdentityPageUrl(page);
   return [
     '<!doctype html><html lang="en-GB"><head>',
@@ -912,11 +921,12 @@ function seoAuditIdentityPageHtml(page, { forbiddenToken = '' } = {}) {
     ...INTENT_SEO_PAGES.map((intentPage) => `<a href="/${intentPage.slug}/">${intentPage.heading}</a>`),
     '<a href="/demo">Try demo</a>',
     '</main>',
+    edgeScript,
     '</body></html>',
   ].join('');
 }
 
-function seoAuditIntentPageHtml(page, { forbiddenToken = '' } = {}) {
+function seoAuditIntentPageHtml(page, { forbiddenToken = '', edgeScript = '' } = {}) {
   const canonicalUrl = canonicalIntentPageUrl(page);
   return [
     '<!doctype html><html lang="en-GB"><head>',
@@ -939,6 +949,7 @@ function seoAuditIntentPageHtml(page, { forbiddenToken = '' } = {}) {
     '<a href="/demo">Try demo</a>',
     '<a href="/">KS2 Mastery home</a>',
     '</main>',
+    edgeScript,
     '</body></html>',
   ].join('');
 }
@@ -997,6 +1008,11 @@ function createSeoAuditStubServer(options = {}) {
           forbiddenToken: options.practiceForbiddenTokenSlug === page.slug
             ? 'OPENAI_API_KEY'
             : '',
+          edgeScript: options.cloudflareWebAnalyticsBeacon
+            ? cloudflareWebAnalyticsBeacon()
+            : options.practiceScriptSlug === page.slug
+              ? '<script defer src="https://example.test/not-allowed.js"></script>'
+              : '',
         }));
         return;
       }
@@ -1011,6 +1027,9 @@ function createSeoAuditStubServer(options = {}) {
           forbiddenToken: options.identityForbiddenTokenSlug === page.slug
             ? 'OPENAI_API_KEY'
             : '',
+          edgeScript: options.cloudflareWebAnalyticsBeacon
+            ? cloudflareWebAnalyticsBeacon()
+            : '',
         }));
         return;
       }
@@ -1024,6 +1043,9 @@ function createSeoAuditStubServer(options = {}) {
         write(200, { 'content-type': 'text/html', 'cache-control': 'no-store' }, seoAuditIntentPageHtml(page, {
           forbiddenToken: options.intentForbiddenTokenSlug === page.slug
             ? 'OPENAI_API_KEY'
+            : '',
+          edgeScript: options.cloudflareWebAnalyticsBeacon
+            ? cloudflareWebAnalyticsBeacon()
             : '',
         }));
         return;
@@ -1208,6 +1230,52 @@ test('production bundle audit passes with SEO root, robots, and sitemap resource
     });
     assert.match(stdout, /Production bundle audit passed/);
     assert.match(stdout, /cache-split checks: 15\/15/);
+  } finally {
+    await closeServer(server);
+  }
+});
+
+test('production bundle audit allows Cloudflare Web Analytics beacon on static SEO pages', async () => {
+  const server = createSeoAuditStubServer({ cloudflareWebAnalyticsBeacon: true });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+  try {
+    const { port } = server.address();
+    const { stdout } = await execFileAsync(process.execPath, [
+      './scripts/production-bundle-audit.mjs',
+      '--skip-local',
+      '--url',
+      `http://127.0.0.1:${port}/`,
+    ], {
+      cwd: process.cwd(),
+      timeout: 8000,
+    });
+    assert.match(stdout, /Production bundle audit passed/);
+  } finally {
+    await closeServer(server);
+  }
+});
+
+test('production bundle audit rejects non-Cloudflare script on static SEO pages', async () => {
+  const server = createSeoAuditStubServer({ practiceScriptSlug: 'ks2-spelling-practice' });
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+
+  try {
+    const { port } = server.address();
+    await assert.rejects(async () => {
+      await execFileAsync(process.execPath, [
+        './scripts/production-bundle-audit.mjs',
+        '--skip-local',
+        '--url',
+        `http://127.0.0.1:${port}/`,
+      ], {
+        cwd: process.cwd(),
+        timeout: 8000,
+      });
+    }, (error) => {
+      assert.match(error.stderr, /Production SEO page \/ks2-spelling-practice\/ must remain static and script-free; found token: <script/);
+      return true;
+    });
   } finally {
     await closeServer(server);
   }

--- a/tests/fetch-timeout.test.js
+++ b/tests/fetch-timeout.test.js
@@ -1,0 +1,75 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  CLIENT_FETCH_TIMEOUT_CODE,
+  fetchWithClientTimeout,
+  isClientFetchTimeout,
+} from '../src/platform/core/fetch-timeout.js';
+
+test('fetchWithClientTimeout aborts and rejects slow requests', async () => {
+  let signal = null;
+  const fetch = (url, init = {}) => {
+    signal = init.signal;
+    return new Promise(() => {});
+  };
+
+  await assert.rejects(
+    fetchWithClientTimeout(fetch, '/api/slow', {}, {
+      timeoutMs: 1,
+      timeoutMessage: 'Slow request timed out.',
+    }),
+    (error) => {
+      assert.equal(error.name, 'AbortError');
+      assert.equal(error.code, CLIENT_FETCH_TIMEOUT_CODE);
+      assert.equal(error.message, 'Slow request timed out.');
+      assert.equal(isClientFetchTimeout(error), true);
+      return true;
+    },
+  );
+
+  assert.equal(signal.aborted, true);
+});
+
+test('fetchWithClientTimeout preserves timeout classification when abort rejects first', async () => {
+  const fetch = (url, init = {}) => new Promise((_, reject) => {
+    init.signal?.addEventListener('abort', () => {
+      const error = new Error('The operation was aborted.');
+      error.name = 'AbortError';
+      reject(error);
+    });
+  });
+
+  await assert.rejects(
+    fetchWithClientTimeout(fetch, '/api/slow', {}, {
+      timeoutMs: 1,
+      timeoutMessage: 'Slow request timed out.',
+    }),
+    (error) => {
+      assert.equal(error.name, 'AbortError');
+      assert.equal(error.code, CLIENT_FETCH_TIMEOUT_CODE);
+      assert.equal(error.message, 'Slow request timed out.');
+      assert.equal(isClientFetchTimeout(error), true);
+      return true;
+    },
+  );
+});
+
+test('fetchWithClientTimeout honours caller abort signals', async () => {
+  const controller = new AbortController();
+  let forwardedSignal = null;
+  const fetch = (url, init = {}) => {
+    forwardedSignal = init.signal;
+    return new Promise(() => {});
+  };
+
+  const pending = fetchWithClientTimeout(fetch, '/api/slow', {
+    signal: controller.signal,
+  }, { timeoutMs: 0 });
+
+  const reason = new Error('Manual abort.');
+  controller.abort(reason);
+
+  await assert.rejects(pending, reason);
+  assert.equal(forwardedSignal.aborted, true);
+});

--- a/tests/luminance-preload.test.js
+++ b/tests/luminance-preload.test.js
@@ -1,0 +1,138 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { preloadImages } from '../src/platform/ui/luminance.js';
+
+function withImageProbe(run) {
+  const originalDocument = globalThis.document;
+  const originalImage = globalThis.Image;
+  const requestedUrls = [];
+
+  globalThis.document = {};
+  globalThis.Image = class ProbeImage {
+    set src(value) {
+      requestedUrls.push(value);
+      queueMicrotask(() => this.onload?.());
+    }
+  };
+
+  try {
+    return run(requestedUrls);
+  } finally {
+    if (typeof originalDocument === 'undefined') {
+      delete globalThis.document;
+    } else {
+      globalThis.document = originalDocument;
+    }
+    if (typeof originalImage === 'undefined') {
+      delete globalThis.Image;
+    } else {
+      globalThis.Image = originalImage;
+    }
+  }
+}
+
+test('preloadImages starts eager image loads immediately and de-dupes URLs', () => withImageProbe((requestedUrls) => {
+  preloadImages([
+    '/assets/test/eager-a.webp',
+    '/assets/test/eager-b.webp',
+    '/assets/test/eager-a.webp',
+    '',
+    null,
+  ]);
+
+  assert.deepEqual(requestedUrls, [
+    '/assets/test/eager-a.webp',
+    '/assets/test/eager-b.webp',
+  ]);
+}));
+
+test('preloadImages defers idle image loads until the browser idle callback', () => withImageProbe((requestedUrls) => {
+  const originalWindow = globalThis.window;
+  let idleCallback = null;
+  let idleOptions = null;
+  let cancelledHandle = null;
+
+  globalThis.window = {
+    requestIdleCallback(callback, options) {
+      idleCallback = callback;
+      idleOptions = options;
+      return 42;
+    },
+    cancelIdleCallback(handle) {
+      cancelledHandle = handle;
+    },
+  };
+
+  try {
+    const cancel = preloadImages([
+      '/assets/test/idle-a.webp',
+      '/assets/test/idle-b.webp',
+    ], { mode: 'idle' });
+
+    assert.equal(typeof cancel, 'function');
+    assert.deepEqual(requestedUrls, []);
+    assert.deepEqual(idleOptions, { timeout: 1500 });
+
+    idleCallback();
+
+    assert.deepEqual(requestedUrls, [
+      '/assets/test/idle-a.webp',
+      '/assets/test/idle-b.webp',
+    ]);
+
+    cancel();
+    assert.equal(cancelledHandle, 42);
+  } finally {
+    if (typeof originalWindow === 'undefined') {
+      delete globalThis.window;
+    } else {
+      globalThis.window = originalWindow;
+    }
+  }
+}));
+
+test('preloadImages defers idle image loads with a timer fallback when idle callback is unavailable', () => withImageProbe((requestedUrls) => {
+  const originalWindow = globalThis.window;
+  let timeoutCallback = null;
+  let timeoutDelay = null;
+  let clearedHandle = null;
+
+  globalThis.window = {
+    setTimeout(callback, delay) {
+      timeoutCallback = callback;
+      timeoutDelay = delay;
+      return 77;
+    },
+    clearTimeout(handle) {
+      clearedHandle = handle;
+    },
+  };
+
+  try {
+    const cancel = preloadImages([
+      '/assets/test/timer-idle-a.webp',
+      '/assets/test/timer-idle-b.webp',
+    ], { mode: 'idle' });
+
+    assert.equal(typeof cancel, 'function');
+    assert.equal(timeoutDelay, 250);
+    assert.deepEqual(requestedUrls, []);
+
+    timeoutCallback();
+
+    assert.deepEqual(requestedUrls, [
+      '/assets/test/timer-idle-a.webp',
+      '/assets/test/timer-idle-b.webp',
+    ]);
+
+    cancel();
+    assert.equal(clearedHandle, 77);
+  } finally {
+    if (typeof originalWindow === 'undefined') {
+      delete globalThis.window;
+    } else {
+      globalThis.window = originalWindow;
+    }
+  }
+}));

--- a/tests/persistence.test.js
+++ b/tests/persistence.test.js
@@ -272,6 +272,50 @@ test('remote write failure is surfaced as degraded persistence instead of preten
   assert.equal(server.store.learners.selectedId, null);
 });
 
+test('repository hydrate timeout surfaces as a structured status-0 remote error', async () => {
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalClearTimeout = globalThis.clearTimeout;
+  const storage = installMemoryStorage();
+  let aborted = false;
+
+  globalThis.setTimeout = (callback) => {
+    queueMicrotask(callback);
+    return 1;
+  };
+  globalThis.clearTimeout = () => {};
+
+  try {
+    const fetch = (url, init = {}) => new Promise((_, reject) => {
+      init.signal?.addEventListener('abort', () => {
+        aborted = true;
+        const error = new Error('The operation was aborted.');
+        error.name = 'AbortError';
+        reject(error);
+      });
+    });
+    const repositories = createApiPlatformRepositories({
+      baseUrl: 'https://repo.test',
+      fetch,
+      storage,
+    });
+
+    await assert.rejects(
+      () => repositories.hydrate(),
+      /Repository request took too long to respond/,
+    );
+
+    const snapshot = repositories.persistence.read();
+    assert.equal(aborted, true);
+    assert.equal(snapshot.lastError.code, 'repository_request_timeout');
+    assert.equal(snapshot.lastError.retryable, true);
+    assert.equal(snapshot.lastError.details.status, 0);
+    assert.equal(snapshot.inFlightWriteCount, 0);
+  } finally {
+    globalThis.setTimeout = originalSetTimeout;
+    globalThis.clearTimeout = originalClearTimeout;
+  }
+});
+
 test('retryable remote failures can leave degraded mode and clear pending writes once sync succeeds', async () => {
   const storage = installMemoryStorage();
   const server = createMockRepositoryServer();

--- a/tests/production-performance-probe.test.js
+++ b/tests/production-performance-probe.test.js
@@ -1,0 +1,453 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  classifyTtsTimingSample,
+  parseServerTiming,
+  parseArgs,
+  runPerformanceProbe,
+  summariseMetric,
+} from '../scripts/production-performance-probe.mjs';
+
+function headerFrom(init, name) {
+  const headers = init?.headers;
+  if (typeof headers?.get === 'function') return headers.get(name) || '';
+  return headers?.[name] || headers?.[name.toLowerCase()] || '';
+}
+
+function response(body, init = {}) {
+  const status = Number(init.status) || 200;
+  const headers = Object.fromEntries(Object.entries({
+    'content-type': 'text/plain',
+    ...(init.headers || {}),
+  }).map(([key, value]) => [key.toLowerCase(), value]));
+  const bytes = body instanceof Uint8Array
+    ? body
+    : new TextEncoder().encode(String(body ?? ''));
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: {
+      get(name) {
+        return headers[String(name).toLowerCase()] || null;
+      },
+      getSetCookie() {
+        const value = headers['set-cookie'];
+        if (Array.isArray(value)) return value;
+        return value ? [value] : [];
+      },
+    },
+    async arrayBuffer() {
+      return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+    },
+    async text() {
+      return new TextDecoder().decode(bytes);
+    },
+  };
+}
+
+function jsonResponse(payload, init = {}) {
+  return response(JSON.stringify(payload), {
+    ...init,
+    headers: {
+      'content-type': 'application/json',
+      ...(init.headers || {}),
+    },
+  });
+}
+
+test('parseArgs rejects duplicate sample flags that would hide probe shape', () => {
+  assert.throws(
+    () => parseArgs(['--samples', '1', '--samples', '2']),
+    /--samples specified more than once/,
+  );
+});
+
+test('parseArgs supports low-impact focused probe shape', () => {
+  const options = parseArgs([
+    '--url', 'ks2.eugnel.uk',
+    '--asset-samples', '1',
+    '--bootstrap-samples', '2',
+    '--tts-samples', '3',
+    '--warmup', '0',
+    '--word-sample', 'accident',
+    '--voices', 'Iapetus',
+    '--no-assets',
+    '--browser-tts',
+  ]);
+  assert.equal(options.origin, 'https://ks2.eugnel.uk');
+  assert.equal(options.assetSamples, 1);
+  assert.equal(options.bootstrapSamples, 2);
+  assert.equal(options.ttsSamples, 3);
+  assert.equal(options.warmup, 0);
+  assert.deepEqual(options.wordSample, ['accident']);
+  assert.deepEqual(options.voices, ['Iapetus']);
+  assert.equal(options.includeAssets, false);
+  assert.equal(options.includeBrowserTts, true);
+});
+
+test('summariseMetric reports stable p50 and p95 values', () => {
+  assert.deepEqual(summariseMetric([
+    { totalMs: 10 },
+    { totalMs: 20 },
+    { totalMs: 30 },
+    { totalMs: 40 },
+  ], 'totalMs'), {
+    count: 4,
+    min: 10,
+    p50: 20,
+    p95: 40,
+    max: 40,
+    mean: 25,
+  });
+});
+
+test('parseServerTiming extracts bounded TTS phase timings only', () => {
+  assert.deepEqual(
+    parseServerTiming('cf;dur=3, ks2_tts_prompt;dur=12.4, ks2_tts_r2;dur="7", ks2_tts_total;dur=24, bad;dur=x'),
+    {
+      prompt: 12,
+      r2: 7,
+      total: 24,
+    },
+  );
+});
+
+test('classifyTtsTimingSample separates R2 and platform overhead cases', () => {
+  assert.equal(classifyTtsTimingSample({
+    headerMs: 120,
+    serverTimingPhases: { r2: 80, prompt: 10, lookup_limit: 5, total: 100 },
+  }), 'r2-dominated');
+  assert.equal(classifyTtsTimingSample({
+    headerMs: 1500,
+    serverTimingPhases: { r2: 10, prompt: 20, lookup_limit: 10, total: 100 },
+  }), 'client-network-or-platform-overhead');
+  assert.equal(classifyTtsTimingSample({ headerMs: 120, serverTimingPhases: {} }), 'unclassified-insufficient-timing');
+});
+
+test('runPerformanceProbe captures asset, bootstrap, and TTS timings with request ids', async () => {
+  const previousFetch = globalThis.fetch;
+  const calls = [];
+  globalThis.fetch = async (url, init = {}) => {
+    calls.push({ url: String(url), init });
+    const pathname = new URL(String(url)).pathname;
+    const echoedRequestId = headerFrom(init, 'x-ks2-request-id');
+    if (pathname === '/') {
+      return response('<!doctype html><script type="module" src="/src/bundles/app.bundle.js"></script>', {
+        headers: {
+          'content-type': 'text/html',
+          'cache-control': 'no-store',
+          'x-ks2-request-id': echoedRequestId,
+        },
+      });
+    }
+    if (pathname === '/src/bundles/app.bundle.js') {
+      return response('console.log("ok");', {
+        headers: {
+          'content-type': 'application/javascript',
+          'cache-control': 'public, max-age=31536000, immutable',
+          'cf-cache-status': 'HIT',
+          'x-ks2-request-id': echoedRequestId,
+        },
+      });
+    }
+    if (pathname === '/api/demo/session') {
+      return jsonResponse({
+        ok: true,
+        session: { demo: true, accountId: 'account-a', learnerId: 'learner-a' },
+      }, {
+        status: 201,
+        headers: {
+          'set-cookie': 'ks2_session=demo; Path=/; HttpOnly',
+          'x-ks2-request-id': echoedRequestId,
+        },
+      });
+    }
+    if (pathname === '/api/bootstrap') {
+      return jsonResponse({
+        ok: true,
+        learners: {
+          selectedId: 'learner-a',
+          byId: { 'learner-a': { stateRevision: 0 } },
+        },
+        meta: {
+          capacity: {
+            requestId: echoedRequestId,
+            queryCount: 9,
+            d1DurationMs: 12,
+            d1RowsRead: 3,
+            d1RowsWritten: 0,
+            wallMs: 30,
+            responseBytes: 2048,
+          },
+        },
+      }, {
+        headers: { 'x-ks2-request-id': echoedRequestId },
+      });
+    }
+    if (pathname === '/api/tts') {
+      const body = JSON.parse(init.body || '{}');
+      assert.equal(body.cacheLookupOnly, true);
+      assert.equal(body.slug, 'accident');
+      assert.equal(body.learnerId, 'learner-a');
+      assert.equal(headerFrom(init, 'cookie'), 'ks2_session=demo');
+      if (body.wordOnly === true) {
+        assert.equal(body.scope, 'word-bank');
+        return response('', {
+          status: 204,
+          headers: {
+            'x-ks2-tts-cache': 'miss',
+            'x-ks2-request-id': echoedRequestId,
+            'server-timing': 'ks2_tts_prompt;dur=10, ks2_tts_lookup_limit;dur=8, ks2_tts_r2;dur=5, ks2_tts_total;dur=40',
+          },
+        });
+      }
+      return response(new Uint8Array([1, 2, 3, 4]), {
+        headers: {
+          'content-type': 'audio/mpeg',
+          'x-ks2-tts-cache': 'hit',
+          'x-ks2-tts-cache-source': 'primary',
+          'x-ks2-request-id': echoedRequestId,
+          'server-timing': 'ks2_tts_prompt;dur=10, ks2_tts_lookup_limit;dur=8, ks2_tts_r2;dur=5, ks2_tts_total;dur=40',
+        },
+      });
+    }
+    return jsonResponse({ ok: false, error: 'unexpected' }, { status: 500 });
+  };
+
+  try {
+    const report = await runPerformanceProbe({
+      origin: 'https://example.test',
+      assetSamples: 1,
+      bootstrapSamples: 1,
+      ttsSamples: 1,
+      warmup: 0,
+      wordSample: ['accident'],
+      voices: ['Iapetus'],
+    });
+    assert.equal(report.ok, true);
+    assert.equal(report.assets.samples.length, 2);
+    assert.deepEqual(report.assets.discovery.discoveredScripts, ['/src/bundles/app.bundle.js']);
+    assert.match(report.assets.notes.join('\n'), /\/src\/bundles/);
+    assert.equal(report.bootstrap.samples.length, 1);
+    assert.equal(report.bootstrap.capacity.queryCount.p50, 9);
+    assert.equal(report.tts.samples.length, 2);
+    const wordLookup = report.tts.samples.find((sample) => sample.mode === 'word-lookup');
+    const sentenceCache = report.tts.samples.find((sample) => sample.mode === 'sentence-cache');
+    assert.equal(wordLookup.cache, 'miss');
+    assert.equal(wordLookup.status, 204);
+    assert.equal(sentenceCache.cache, 'hit');
+    assert.equal(sentenceCache.source, 'primary');
+    assert.deepEqual(sentenceCache.serverTimingPhases, {
+      prompt: 10,
+      lookup_limit: 8,
+      r2: 5,
+      total: 40,
+    });
+    assert.equal(report.tts.phaseSummary.r2.p50, 5);
+    assert.equal(report.tts.modeSummary['word-lookup'][0].key, 'accident/Iapetus/miss/no-source');
+    assert.equal(report.tts.modeSummary['sentence-cache'][0].key, 'accident/Iapetus/hit/primary');
+    assert.equal(report.tts.classifications.mixed, 2);
+    assert.match(sentenceCache.clientRequestId, /^ks2_req_/);
+    assert.equal(report.session.learnerIdPresent, true);
+    assert.equal(report.bootstrap.selectedLearnerIdPresent, true);
+    assert.doesNotMatch(JSON.stringify(report), /ks2_session=demo|learner-a|account-a|promptToken/);
+    assert.ok(calls.some((call) => new URL(call.url).pathname === '/api/tts'));
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test('runPerformanceProbe can use an operator cookie from an environment variable', async () => {
+  const previousFetch = globalThis.fetch;
+  const previousCookie = process.env.KS2_PROBE_TEST_COOKIE;
+  const calls = [];
+  process.env.KS2_PROBE_TEST_COOKIE = 'ks2_session=real-session';
+  globalThis.fetch = async (url, init = {}) => {
+    calls.push({ url: String(url), init });
+    const pathname = new URL(String(url)).pathname;
+    const echoedRequestId = headerFrom(init, 'x-ks2-request-id');
+    if (pathname === '/api/bootstrap') {
+      assert.equal(headerFrom(init, 'cookie'), 'ks2_session=real-session');
+      return jsonResponse({
+        ok: true,
+        learners: {
+          selectedId: 'real-learner-id',
+          byId: { 'real-learner-id': { stateRevision: 1 } },
+        },
+        meta: { capacity: { requestId: echoedRequestId, queryCount: 3, d1DurationMs: 4, d1RowsRead: 2, d1RowsWritten: 0, wallMs: 20, responseBytes: 1000 } },
+      }, {
+        headers: { 'x-ks2-request-id': echoedRequestId },
+      });
+    }
+    if (pathname === '/api/tts') {
+      const body = JSON.parse(init.body || '{}');
+      assert.equal(body.learnerId, 'real-learner-id');
+      assert.equal(headerFrom(init, 'cookie'), 'ks2_session=real-session');
+      if (body.wordOnly === true) {
+        return response('', {
+          status: 204,
+          headers: {
+            'x-ks2-tts-cache': 'miss',
+            'server-timing': 'ks2_tts_prompt;dur=9, ks2_tts_lookup_limit;dur=11, ks2_tts_r2;dur=6, ks2_tts_total;dur=35',
+            'x-ks2-request-id': echoedRequestId,
+          },
+        });
+      }
+      return response('', {
+        headers: {
+          'content-type': 'audio/mpeg',
+          'x-ks2-tts-cache': 'hit',
+          'x-ks2-tts-cache-source': 'primary',
+          'server-timing': 'ks2_tts_prompt;dur=9, ks2_tts_lookup_limit;dur=11, ks2_tts_r2;dur=6, ks2_tts_total;dur=35',
+          'x-ks2-request-id': echoedRequestId,
+        },
+      });
+    }
+    return jsonResponse({ ok: false, error: 'unexpected' }, { status: 500 });
+  };
+
+  try {
+    const report = await runPerformanceProbe({
+      origin: 'https://example.test',
+      includeAssets: false,
+      bootstrapSamples: 1,
+      ttsSamples: 1,
+      warmup: 0,
+      wordSample: ['accident'],
+      voices: ['Iapetus'],
+      cookieEnv: 'KS2_PROBE_TEST_COOKIE',
+    });
+
+    assert.equal(report.ok, true);
+    assert.equal(report.session.source, 'operator-cookie');
+    assert.equal(report.session.learnerIdPresent, true);
+    assert.equal(report.tts.samples.find((sample) => sample.mode === 'word-lookup').cache, 'miss');
+    assert.equal(report.tts.samples.find((sample) => sample.mode === 'sentence-cache').cache, 'hit');
+    assert.doesNotMatch(JSON.stringify(report), /real-session|real-learner-id|promptToken/);
+    assert.ok(calls.every((call) => new URL(call.url).pathname !== '/api/demo/session'));
+  } finally {
+    globalThis.fetch = previousFetch;
+    if (previousCookie == null) delete process.env.KS2_PROBE_TEST_COOKIE;
+    else process.env.KS2_PROBE_TEST_COOKIE = previousCookie;
+  }
+});
+
+test('runPerformanceProbe records browser TTS play-start samples from an injected runner', async () => {
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init = {}) => {
+    const pathname = new URL(String(url)).pathname;
+    const echoedRequestId = headerFrom(init, 'x-ks2-request-id');
+    if (pathname === '/api/demo/session') {
+      return jsonResponse({
+        ok: true,
+        session: { demo: true, accountId: 'account-a', learnerId: 'learner-a' },
+      }, {
+        status: 201,
+        headers: {
+          'set-cookie': 'ks2_session=demo; Path=/; HttpOnly',
+          'x-ks2-request-id': echoedRequestId,
+        },
+      });
+    }
+    return jsonResponse({ ok: false, error: 'unexpected' }, { status: 500 });
+  };
+
+  try {
+    const report = await runPerformanceProbe({
+      origin: 'https://example.test',
+      includeAssets: false,
+      includeBootstrap: false,
+      includeTts: false,
+      warmup: 0,
+      wordSample: ['accident'],
+      voices: ['Iapetus'],
+      browserTtsRunner: async ({ origin, cookie, learnerId, options }) => {
+        assert.equal(origin, 'https://example.test');
+        assert.equal(cookie, 'ks2_session=demo');
+        assert.equal(learnerId, 'learner-a');
+        assert.deepEqual(options.wordSample, ['accident']);
+        return {
+          ok: true,
+          skipped: false,
+          samples: [{
+            slug: 'accident',
+            voice: 'Iapetus',
+            status: 200,
+            cache: 'hit',
+            source: 'primary',
+            contentType: 'audio/mpeg',
+            requestId: 'ks2_req_browser',
+            headerMs: 120,
+            blobMs: 20,
+            playStartMs: 175,
+            totalMs: 180,
+            bytes: 12345,
+          }],
+        };
+      },
+    });
+
+    assert.equal(report.ok, true);
+    assert.equal(report.config.includeBrowserTts, false);
+    assert.equal(report.browserTts.ok, true);
+    assert.equal(report.browserTts.skipped, false);
+    assert.equal(report.browserTts.samples.length, 1);
+    assert.equal(report.browserTts.playStartMs.p50, 175);
+    assert.equal(report.browserTts.summary[0].key, 'accident/Iapetus/hit/primary');
+    assert.equal(report.browserTts.samples[0].requestId, 'ks2_req_browser');
+    assert.equal(report.session.learnerIdPresent, true);
+    assert.doesNotMatch(JSON.stringify(report), /ks2_session=demo|learner-a|account-a|promptToken/);
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test('runPerformanceProbe treats browser TTS skips as non-fatal', async () => {
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init = {}) => {
+    const pathname = new URL(String(url)).pathname;
+    const echoedRequestId = headerFrom(init, 'x-ks2-request-id');
+    if (pathname === '/api/demo/session') {
+      return jsonResponse({
+        ok: true,
+        session: { demo: true, accountId: 'account-a', learnerId: 'learner-a' },
+      }, {
+        status: 201,
+        headers: {
+          'set-cookie': 'ks2_session=demo; Path=/; HttpOnly',
+          'x-ks2-request-id': echoedRequestId,
+        },
+      });
+    }
+    return jsonResponse({ ok: false, error: 'unexpected' }, { status: 500 });
+  };
+
+  try {
+    const report = await runPerformanceProbe({
+      origin: 'https://example.test',
+      includeAssets: false,
+      includeBootstrap: false,
+      includeTts: false,
+      includeBrowserTts: true,
+      warmup: 0,
+      wordSample: ['accident'],
+      voices: ['Iapetus'],
+      browserTtsRunner: async () => ({
+        skipped: true,
+        skipReason: 'playwright import failed',
+        samples: [],
+      }),
+    });
+
+    assert.equal(report.ok, true);
+    assert.equal(report.config.includeBrowserTts, true);
+    assert.equal(report.browserTts.ok, true);
+    assert.equal(report.browserTts.skipped, true);
+    assert.equal(report.browserTts.skipReason, 'playwright import failed');
+    assert.deepEqual(report.browserTts.samples, []);
+    assert.equal(report.browserTts.playStartMs.count, 0);
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});

--- a/tests/production-performance-probe.test.js
+++ b/tests/production-performance-probe.test.js
@@ -61,6 +61,14 @@ test('parseArgs rejects duplicate sample flags that would hide probe shape', () 
     () => parseArgs(['--samples', '1', '--samples', '2']),
     /--samples specified more than once/,
   );
+  assert.throws(
+    () => parseArgs(['--samples', '1', '--tts-samples', '2']),
+    /--samples cannot be combined with --tts-samples/,
+  );
+  assert.throws(
+    () => parseArgs(['--asset-samples', '1', '--samples', '2']),
+    /--samples cannot be combined with --asset-samples/,
+  );
 });
 
 test('parseArgs supports low-impact focused probe shape', () => {
@@ -238,6 +246,7 @@ test('runPerformanceProbe captures asset, bootstrap, and TTS timings with reques
     assert.equal(wordLookup.status, 204);
     assert.equal(sentenceCache.cache, 'hit');
     assert.equal(sentenceCache.source, 'primary');
+    assert.equal(sentenceCache.headers, undefined);
     assert.deepEqual(sentenceCache.serverTimingPhases, {
       prompt: 10,
       lookup_limit: 8,
@@ -251,7 +260,7 @@ test('runPerformanceProbe captures asset, bootstrap, and TTS timings with reques
     assert.match(sentenceCache.clientRequestId, /^ks2_req_/);
     assert.equal(report.session.learnerIdPresent, true);
     assert.equal(report.bootstrap.selectedLearnerIdPresent, true);
-    assert.doesNotMatch(JSON.stringify(report), /ks2_session=demo|learner-a|account-a|promptToken/);
+    assert.doesNotMatch(JSON.stringify(report), /ks2_session=demo|learner-a|account-a|promptToken|server-timing|ks2_tts_prompt/);
     assert.ok(calls.some((call) => new URL(call.url).pathname === '/api/tts'));
   } finally {
     globalThis.fetch = previousFetch;
@@ -309,7 +318,7 @@ test('runPerformanceProbe can use an operator cookie from an environment variabl
 
   try {
     const report = await runPerformanceProbe({
-      origin: 'https://example.test',
+      origin: 'https://ks2.eugnel.uk',
       includeAssets: false,
       bootstrapSamples: 1,
       ttsSamples: 1,
@@ -330,6 +339,125 @@ test('runPerformanceProbe can use an operator cookie from an environment variabl
     globalThis.fetch = previousFetch;
     if (previousCookie == null) delete process.env.KS2_PROBE_TEST_COOKIE;
     else process.env.KS2_PROBE_TEST_COOKIE = previousCookie;
+  }
+});
+
+test('runPerformanceProbe does not send an operator cookie to a non-production origin', async () => {
+  const previousFetch = globalThis.fetch;
+  const previousCookie = process.env.KS2_PROBE_TEST_COOKIE;
+  const calls = [];
+  process.env.KS2_PROBE_TEST_COOKIE = 'ks2_session=real-session';
+  globalThis.fetch = async (url, init = {}) => {
+    calls.push({ url: String(url), init });
+    assert.notEqual(headerFrom(init, 'cookie'), 'ks2_session=real-session');
+    const pathname = new URL(String(url)).pathname;
+    const echoedRequestId = headerFrom(init, 'x-ks2-request-id');
+    if (pathname === '/api/demo/session') {
+      return jsonResponse({
+        ok: true,
+        session: { demo: true, accountId: 'demo-account', learnerId: 'demo-learner' },
+      }, {
+        status: 201,
+        headers: {
+          'set-cookie': 'ks2_session=demo; Path=/; HttpOnly',
+          'x-ks2-request-id': echoedRequestId,
+        },
+      });
+    }
+    if (pathname === '/api/bootstrap') {
+      assert.equal(headerFrom(init, 'cookie'), 'ks2_session=demo');
+      return jsonResponse({
+        ok: true,
+        learners: {
+          selectedId: 'demo-learner',
+          byId: { 'demo-learner': { stateRevision: 1 } },
+        },
+        meta: { capacity: { requestId: echoedRequestId, queryCount: 3, d1DurationMs: 4, d1RowsRead: 2, d1RowsWritten: 0, wallMs: 20, responseBytes: 1000 } },
+      }, {
+        headers: { 'x-ks2-request-id': echoedRequestId },
+      });
+    }
+    return jsonResponse({ ok: false, error: 'unexpected' }, { status: 500 });
+  };
+
+  try {
+    const report = await runPerformanceProbe({
+      origin: 'https://example.test',
+      includeAssets: false,
+      includeTts: false,
+      bootstrapSamples: 1,
+      warmup: 0,
+      cookieEnv: 'KS2_PROBE_TEST_COOKIE',
+    });
+
+    assert.equal(report.ok, true);
+    assert.equal(report.session.source, 'demo');
+    assert.ok(calls.some((call) => new URL(call.url).pathname === '/api/demo/session'));
+    assert.doesNotMatch(JSON.stringify(report), /real-session|demo-learner|demo-account/);
+  } finally {
+    globalThis.fetch = previousFetch;
+    if (previousCookie == null) delete process.env.KS2_PROBE_TEST_COOKIE;
+    else process.env.KS2_PROBE_TEST_COOKIE = previousCookie;
+  }
+});
+
+test('runPerformanceProbe fails sentence cache samples that are not primary hits', async () => {
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init = {}) => {
+    const pathname = new URL(String(url)).pathname;
+    const echoedRequestId = headerFrom(init, 'x-ks2-request-id');
+    if (pathname === '/api/demo/session') {
+      return jsonResponse({
+        ok: true,
+        session: { demo: true, accountId: 'account-a', learnerId: 'learner-a' },
+      }, {
+        status: 201,
+        headers: {
+          'set-cookie': 'ks2_session=demo; Path=/; HttpOnly',
+          'x-ks2-request-id': echoedRequestId,
+        },
+      });
+    }
+    if (pathname === '/api/tts') {
+      const body = JSON.parse(init.body || '{}');
+      if (body.wordOnly === true) {
+        return response('', {
+          status: 204,
+          headers: {
+            'x-ks2-tts-cache': 'miss',
+            'x-ks2-request-id': echoedRequestId,
+          },
+        });
+      }
+      return response(new Uint8Array([1, 2, 3, 4]), {
+        headers: {
+          'content-type': 'audio/mpeg',
+          'x-ks2-tts-cache': 'hit',
+          'x-ks2-tts-cache-source': 'legacy',
+          'x-ks2-request-id': echoedRequestId,
+          'server-timing': 'ks2_tts_prompt;dur=10, ks2_tts_total;dur=40',
+        },
+      });
+    }
+    return jsonResponse({ ok: false, error: 'unexpected' }, { status: 500 });
+  };
+
+  try {
+    const report = await runPerformanceProbe({
+      origin: 'https://example.test',
+      includeAssets: false,
+      includeBootstrap: false,
+      ttsSamples: 1,
+      warmup: 0,
+      wordSample: ['accident'],
+      voices: ['Iapetus'],
+    });
+
+    assert.equal(report.ok, false);
+    assert.match(report.failures.join('\n'), /expected hit\/primary/);
+    assert.equal(report.tts.samples.find((sample) => sample.mode === 'sentence-cache').source, 'legacy');
+  } finally {
+    globalThis.fetch = previousFetch;
   }
 });
 
@@ -391,8 +519,10 @@ test('runPerformanceProbe records browser TTS play-start samples from an injecte
     assert.equal(report.ok, true);
     assert.equal(report.config.includeBrowserTts, false);
     assert.equal(report.browserTts.ok, true);
+    assert.equal(report.browserTts.scope, 'browser-direct-audio');
     assert.equal(report.browserTts.skipped, false);
     assert.equal(report.browserTts.samples.length, 1);
+    assert.equal(report.browserTts.samples[0].mode, 'browser-direct-audio-play-start');
     assert.equal(report.browserTts.playStartMs.p50, 175);
     assert.equal(report.browserTts.summary[0].key, 'accident/Iapetus/hit/primary');
     assert.equal(report.browserTts.samples[0].requestId, 'ks2_req_browser');
@@ -443,6 +573,7 @@ test('runPerformanceProbe treats browser TTS skips as non-fatal', async () => {
     assert.equal(report.ok, true);
     assert.equal(report.config.includeBrowserTts, true);
     assert.equal(report.browserTts.ok, true);
+    assert.equal(report.browserTts.scope, 'browser-direct-audio');
     assert.equal(report.browserTts.skipped, true);
     assert.equal(report.browserTts.skipReason, 'playwright import failed');
     assert.deepEqual(report.browserTts.samples, []);

--- a/tests/read-model-client.test.js
+++ b/tests/read-model-client.test.js
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createReadModelClient } from '../src/platform/runtime/read-model-client.js';
+
+test('read model client bounds slow requests with a structured timeout error', async () => {
+  let calls = 0;
+  let aborted = false;
+  const fetch = (input, init = {}) => {
+    calls += 1;
+    init.signal?.addEventListener('abort', () => {
+      aborted = true;
+    });
+    return new Promise(() => {});
+  };
+  const client = createReadModelClient({ fetch, timeoutMs: 1 });
+
+  await assert.rejects(
+    client.readJson('/api/read-models/spelling/demo'),
+    (error) => {
+      assert.equal(error.status, 0);
+      assert.equal(error.code, 'read_model_timeout');
+      assert.deepEqual(error.payload, { code: 'read_model_timeout' });
+      return true;
+    },
+  );
+
+  assert.equal(calls, 1);
+  assert.equal(aborted, true);
+});

--- a/tests/spelling-audio-production-smoke.test.js
+++ b/tests/spelling-audio-production-smoke.test.js
@@ -325,11 +325,13 @@ test('runSpellingAudioSmoke passes an AbortSignal to /api/tts fetch (timeout plu
 // resulting report has `ok: false` with the failed word probe recorded
 // alongside successful sentence + cross-account probes.
 test('runSpellingAudioSmoke continues running probes after the first word probe fails', async () => {
+  let wordLookupCalls = 0;
   const fixture = installDemoBootstrapHandlers({
     ttsHandler: (body) => {
-      // Word probes always miss; sentence + cross-account probes still
-      // hit primary so the test can assert they ran.
-      if (body.wordOnly === true && body.cacheLookupOnly === true) {
+      // The first two word probes miss; sentence + cross-account probes
+      // still hit primary so the test can assert they ran.
+      if (body.wordOnly === true && body.cacheLookupOnly === true && wordLookupCalls < 2) {
+        wordLookupCalls += 1;
         return jsonResponse({ ok: true }, {
           status: 200,
           headers: { 'x-ks2-tts-cache': 'miss' },
@@ -478,6 +480,75 @@ test('runSpellingAudioSmoke reports WARN on word miss without --require-word-hit
   }
 });
 
+test('runSpellingAudioSmoke warms a cold word-only cache before final lookup', async () => {
+  const warmed = new Set();
+  const fixture = installDemoBootstrapHandlers({
+    ttsHandler: (body) => {
+      if (body.wordOnly === true && body.cacheLookupOnly === true) {
+        const key = `${body.slug}:${body.bufferedGeminiVoice || 'Iapetus'}`;
+        if (!warmed.has(key)) {
+          return jsonResponse({ ok: true }, {
+            status: 204,
+            headers: { 'x-ks2-tts-cache': 'miss' },
+          });
+        }
+        return jsonResponse({ ok: true }, {
+          status: 200,
+          headers: {
+            'x-ks2-tts-cache': 'hit',
+            'x-ks2-tts-cache-source': 'primary',
+            'x-ks2-tts-model': SPELLING_AUDIO_MODEL,
+            'x-ks2-tts-voice': body.bufferedGeminiVoice || 'Iapetus',
+          },
+          bytes: new TextEncoder().encode(`audio-${body.slug}`),
+        });
+      }
+      if (body.wordOnly === true && body.cacheOnly === true) {
+        warmed.add(`${body.slug}:${body.bufferedGeminiVoice || 'Iapetus'}`);
+        return jsonResponse({ ok: true }, {
+          status: 204,
+          headers: {
+            'x-ks2-tts-cache': 'stored',
+            'x-ks2-tts-model': SPELLING_AUDIO_MODEL,
+            'x-ks2-tts-voice': body.bufferedGeminiVoice || 'Iapetus',
+          },
+        });
+      }
+      if (body.wordOnly === true) {
+        return jsonResponse({ ok: true }, {
+          status: 200,
+          headers: {
+            'x-ks2-tts-cache': 'stored',
+            'x-ks2-tts-model': SPELLING_AUDIO_MODEL,
+            'x-ks2-tts-voice': body.bufferedGeminiVoice || 'Iapetus',
+          },
+          bytes: new TextEncoder().encode(`audio-${body.slug}`),
+        });
+      }
+      return buildPrimaryHitHandler()(body);
+    },
+  });
+  try {
+    const report = await runSpellingAudioSmoke({
+      origin: 'https://preview.example.test',
+      wordSample: ['actual'],
+      sentenceSample: [],
+      requireWordHit: true,
+    });
+    assert.equal(report.ok, true);
+    const wordProbes = report.probes.filter((probe) => probe.kind === 'word');
+    assert.equal(wordProbes.length, 2);
+    assert.ok(wordProbes.every((probe) => probe.cache === 'hit' && probe.source === 'primary'));
+    assert.ok(wordProbes.every((probe) => probe.notes.some((note) => /initial word lookup missed/i.test(note))));
+    const ttsBodies = fixture.calls
+      .filter((entry) => new URL(entry.url).pathname === '/api/tts')
+      .map((entry) => JSON.parse(entry.init.body || '{}'));
+    assert.ok(ttsBodies.some((body) => body.cacheOnly === true && body.provider === 'gemini'));
+  } finally {
+    fixture.restore();
+  }
+});
+
 test('runSpellingAudioSmoke records validation probe entry when word probe misses with --require-word-hit', async () => {
   // After the partial-failure fix, errors no longer short-circuit the run
   // — they are recorded as `{ ok: false, error: { kind, message } }` so
@@ -584,6 +655,67 @@ test('runSpellingAudioSmoke cross-account probe asserts byte-identical bodies + 
     assert.notEqual(probe.tokenA, probe.tokenB);
     assert.equal(probe.bytesAlength, probe.bytesBLength);
     assert.notEqual(probe.bytesDistinctLength, 0);
+  } finally {
+    fixture.restore();
+  }
+});
+
+test('runSpellingAudioSmoke cross-account probe warms a cold fixture before asserting shared primary hits', async () => {
+  const warmed = new Set();
+  const fixture = installDemoBootstrapHandlers({
+    demoSessions: [
+      { accountId: 'account-a', learnerId: 'learner-a', cookie: 'ks2_session=demoA' },
+      { accountId: 'account-b', learnerId: 'learner-b', cookie: 'ks2_session=demoB' },
+      { accountId: 'account-a', learnerId: 'learner-a', cookie: 'ks2_session=demoA' },
+    ],
+    ttsHandler: (body) => {
+      const key = `${body.slug}:${body.bufferedGeminiVoice || 'Iapetus'}`;
+      if (body.wordOnly === true && body.cacheLookupOnly === true && !warmed.has(key)) {
+        return jsonResponse({ ok: true }, {
+          status: 204,
+          headers: { 'x-ks2-tts-cache': 'miss' },
+        });
+      }
+      if (body.wordOnly === true && body.cacheOnly === true) {
+        warmed.add(key);
+        return jsonResponse({ ok: true }, {
+          status: 204,
+          headers: {
+            'x-ks2-tts-cache': 'stored',
+            'x-ks2-tts-model': SPELLING_AUDIO_MODEL,
+            'x-ks2-tts-voice': body.bufferedGeminiVoice || 'Iapetus',
+          },
+        });
+      }
+      const audioBytes = new TextEncoder().encode(`audio-bytes-for-${body.slug}`);
+      return jsonResponse({ ok: true }, {
+        status: 200,
+        headers: {
+          'x-ks2-tts-cache': warmed.has(key) ? 'hit' : 'stored',
+          'x-ks2-tts-cache-source': warmed.has(key) ? 'primary' : undefined,
+          'x-ks2-tts-model': SPELLING_AUDIO_MODEL,
+          'x-ks2-tts-voice': body.bufferedGeminiVoice || 'Iapetus',
+        },
+        bytes: audioBytes,
+      });
+    },
+  });
+  try {
+    const report = await runSpellingAudioSmoke({
+      origin: 'https://preview.example.test',
+      wordSample: [],
+      sentenceSample: [],
+      requireWordHit: true,
+    });
+    assert.equal(report.ok, true);
+    const probe = report.probes.find((entry) => entry.kind === 'cross-account');
+    assert.ok(probe);
+    assert.equal(probe.bytesAlength, probe.bytesBLength);
+    const ttsBodies = fixture.calls
+      .filter((entry) => new URL(entry.url).pathname === '/api/tts')
+      .map((entry) => JSON.parse(entry.init.body || '{}'));
+    assert.ok(ttsBodies.some((body) => body.cacheOnly === true && body.provider === 'gemini'));
+    assert.ok(ttsBodies.filter((body) => body.cacheLookupOnly === true && body.slug === probe.fixtureWord).length >= 3);
   } finally {
     fixture.restore();
   }

--- a/tests/spelling-audio-production-smoke.test.js
+++ b/tests/spelling-audio-production-smoke.test.js
@@ -434,12 +434,14 @@ test('runSpellingAudioSmoke happy path reports all probes succeeded', async () =
     assert.equal(sentenceProbe.source, 'legacy');
     const crossAccount = report.probes.find((probe) => probe.kind === 'cross-account');
     assert.ok(crossAccount, 'expected a cross-account probe');
-    assert.notEqual(crossAccount.tokenA, crossAccount.tokenB);
-    assert.equal(crossAccount.expectedR2Key, await expectedWordR2Key({
-      slug: crossAccount.fixtureWord,
-      word: crossAccount.fixtureWord,
-      voice: crossAccount.voice,
-    }));
+    assert.equal(crossAccount.learnerAPresent, true);
+    assert.equal(crossAccount.learnerBPresent, true);
+    assert.equal(crossAccount.learnersDistinct, true);
+    assert.equal(crossAccount.tokensDistinct, true);
+    assert.equal(crossAccount.r2KeyPresent, true);
+    assert.equal(crossAccount.r2KeysMatch, true);
+    assert.equal(crossAccount.tokenA, undefined);
+    assert.equal(crossAccount.expectedR2Key, undefined);
   } finally {
     fixture.restore();
   }
@@ -652,7 +654,7 @@ test('runSpellingAudioSmoke cross-account probe asserts byte-identical bodies + 
     });
     const probe = report.probes.find((entry) => entry.kind === 'cross-account');
     assert.ok(probe);
-    assert.notEqual(probe.tokenA, probe.tokenB);
+    assert.equal(probe.tokensDistinct, true);
     assert.equal(probe.bytesAlength, probe.bytesBLength);
     assert.notEqual(probe.bytesDistinctLength, 0);
   } finally {
@@ -895,8 +897,15 @@ test('runCli happy path returns EXIT_OK and emits JSON when --json supplied', as
     const payload = JSON.parse(logged.join('\n'));
     assert.equal(payload.ok, true);
     assert.equal(payload.origin, 'https://preview.example.test');
+    assert.equal(payload.accountPresent, true);
+    assert.equal(payload.learnerPresent, true);
     assert.ok(Array.isArray(payload.probes));
     assert.ok(payload.probes.length > 0);
+    const encoded = JSON.stringify(payload);
+    assert.doesNotMatch(
+      encoded,
+      /learner-a|learner-b|account-a|account-b|ks2_session|demoA|demoB|tokenA|tokenB|promptToken|expectedR2Key|spelling-audio\/v1\//,
+    );
   } finally {
     console.log = previousLog;
     fixture.restore();

--- a/tests/spelling-tts.test.js
+++ b/tests/spelling-tts.test.js
@@ -192,6 +192,206 @@ test('platform TTS plays cached Gemini audio before the selected provider', asyn
   }
 });
 
+test('platform TTS logs cached Gemini lookup timing before playback', async () => {
+  const originalAudio = globalThis.Audio;
+  const originalCreateObjectUrl = URL.createObjectURL;
+  const originalRevokeObjectUrl = URL.revokeObjectURL;
+  const played = [];
+  const logs = [];
+  const telemetryEvents = [];
+  let currentTime = 1000;
+
+  globalThis.Audio = class MockAudio {
+    constructor(src) {
+      this.src = src;
+      this.onended = null;
+      this.onerror = null;
+    }
+
+    play() {
+      played.push(this.src);
+      setTimeout(() => this.onended?.(), 0);
+      return Promise.resolve();
+    }
+
+    pause() {}
+    removeAttribute() {}
+    load() {}
+  };
+  URL.createObjectURL = () => 'blob:cached-gemini-audio';
+  URL.revokeObjectURL = () => {};
+
+  const calls = [];
+  const tts = createPlatformTts({
+    remoteEnabled: true,
+    provider: 'openai',
+    now: () => {
+      currentTime += 25;
+      return currentTime;
+    },
+    logger: (line) => logs.push(line),
+    onCacheLookupTelemetry: (event) => telemetryEvents.push(event),
+    fetchFn: async (url, init = {}) => {
+      calls.push({
+        url,
+        headers: init.headers,
+        body: JSON.parse(init.body),
+      });
+      return new Response(new Blob([new Uint8Array([9, 8, 7, 6])], { type: 'audio/mpeg' }), {
+        status: 200,
+        headers: {
+          'content-type': 'audio/mpeg',
+          'x-ks2-request-id': 'ks2_req_cache_timing',
+          'x-ks2-tts-cache': 'hit',
+          'x-ks2-tts-cache-source': 'primary',
+          'x-ks2-tts-provider': 'gemini',
+        },
+      });
+    },
+  });
+
+  try {
+    const result = await tts.speak({
+      learnerId: 'learner-a',
+      promptToken: 'prompt-token-cached-timing',
+      word: 'early',
+      sentence: 'The birds sang early in the day.',
+    });
+
+    assert.equal(result, true);
+    assert.deepEqual(played, ['blob:cached-gemini-audio']);
+    assert.equal(calls.length, 1);
+    assert.deepEqual(calls[0].body, {
+      learnerId: 'learner-a',
+      promptToken: 'prompt-token-cached-timing',
+      slow: false,
+      provider: 'gemini',
+      bufferedGeminiVoice: 'Iapetus',
+      cacheLookupOnly: true,
+    });
+
+    const cacheLog = logs.find((line) => line.startsWith('[ks2-tts-cache-latency]'));
+    assert.ok(cacheLog, `expected cache lookup telemetry, got ${JSON.stringify(logs)}`);
+    assert.match(cacheLog, /status=play-start/);
+    assert.match(cacheLog, /wallMs=75/);
+    assert.match(cacheLog, /kind=normal/);
+    assert.match(cacheLog, /http=200/);
+    assert.match(cacheLog, /cache=hit/);
+    assert.match(cacheLog, /source=primary/);
+    assert.match(cacheLog, /provider=gemini/);
+    assert.match(cacheLog, /contentType=audio\/mpeg/);
+    assert.match(cacheLog, /requestId=ks2_req_cache_timing/);
+    assert.match(cacheLog, /headerMs=25/);
+    assert.match(cacheLog, /blobMs=25/);
+    assert.match(cacheLog, /playStartMs=75/);
+    assert.match(cacheLog, /bytes=4/);
+    assert.doesNotMatch(cacheLog, /prompt-token|learner-a|early|birds/);
+    assert.deepEqual(telemetryEvents, [{
+      status: 'play-start',
+      wallMs: 75,
+      kind: 'normal',
+      http: 200,
+      cache: 'hit',
+      source: 'primary',
+      provider: 'gemini',
+      contentType: 'audio/mpeg',
+      requestId: 'ks2_req_cache_timing',
+      headerMs: 25,
+      blobMs: 25,
+      playStartMs: 75,
+      bytes: 4,
+    }]);
+  } finally {
+    tts.stop();
+    globalThis.Audio = originalAudio;
+    URL.createObjectURL = originalCreateObjectUrl;
+    URL.revokeObjectURL = originalRevokeObjectUrl;
+  }
+});
+
+test('platform TTS logs cache lookup misses without body timing fields', async () => {
+  const originalAudio = globalThis.Audio;
+  const originalCreateObjectUrl = URL.createObjectURL;
+  const originalRevokeObjectUrl = URL.revokeObjectURL;
+  const logs = [];
+  let currentTime = 2000;
+
+  globalThis.Audio = class MockAudio {
+    constructor(src) {
+      this.src = src;
+      this.onended = null;
+      this.onerror = null;
+    }
+
+    play() {
+      setTimeout(() => this.onended?.(), 0);
+      return Promise.resolve();
+    }
+
+    pause() {}
+    removeAttribute() {}
+    load() {}
+  };
+  URL.createObjectURL = () => 'blob:selected-provider-audio';
+  URL.revokeObjectURL = () => {};
+
+  const calls = [];
+  const tts = createPlatformTts({
+    remoteEnabled: true,
+    provider: 'openai',
+    now: () => {
+      currentTime += 10;
+      return currentTime;
+    },
+    logger: (line) => logs.push(line),
+    fetchFn: async (url, init = {}) => {
+      const body = JSON.parse(init.body);
+      calls.push({ url, body });
+      if (body.cacheLookupOnly || body.cacheOnly) {
+        return new Response(null, {
+          status: 204,
+          headers: {
+            'x-ks2-request-id': 'ks2_req_cache_miss',
+            'x-ks2-tts-cache': body.cacheOnly ? 'stored' : 'miss',
+          },
+        });
+      }
+      return new Response(new Blob([new Uint8Array([1, 2, 3])], { type: 'audio/mpeg' }), {
+        status: 200,
+        headers: { 'content-type': 'audio/mpeg' },
+      });
+    },
+  });
+
+  try {
+    const result = await tts.speak({
+      learnerId: 'learner-a',
+      promptToken: 'prompt-token-cache-miss',
+      word: 'early',
+      sentence: 'The birds sang early in the day.',
+    });
+
+    assert.equal(result, true);
+    assert.ok(calls.some((call) => call.body.cacheLookupOnly), 'preflight cache lookup must run');
+    const missLog = logs.find((line) => line.startsWith('[ks2-tts-cache-latency]'));
+    assert.ok(missLog, `expected cache miss telemetry, got ${JSON.stringify(logs)}`);
+    assert.match(missLog, /status=miss/);
+    assert.match(missLog, /http=204/);
+    assert.match(missLog, /cache=miss/);
+    assert.match(missLog, /requestId=ks2_req_cache_miss/);
+    assert.match(missLog, /headerMs=10/);
+    assert.doesNotMatch(missLog, /blobMs=/);
+    assert.doesNotMatch(missLog, /playStartMs=/);
+    assert.doesNotMatch(missLog, /bytes=/);
+    assert.doesNotMatch(missLog, /prompt-token|learner-a|early|birds/);
+  } finally {
+    tts.stop();
+    globalThis.Audio = originalAudio;
+    URL.createObjectURL = originalCreateObjectUrl;
+    URL.revokeObjectURL = originalRevokeObjectUrl;
+  }
+});
+
 test('platform TTS uses cached Gemini audio for word-bank word replay', async () => {
   const originalAudio = globalThis.Audio;
   const originalCreateObjectUrl = URL.createObjectURL;

--- a/tests/spelling-tts.test.js
+++ b/tests/spelling-tts.test.js
@@ -182,7 +182,7 @@ test('platform TTS plays cached Gemini audio before the selected provider', asyn
       slow: false,
       provider: 'gemini',
       bufferedGeminiVoice: 'Iapetus',
-      cacheLookupOnly: true,
+      cachePlaybackOnly: true,
     });
   } finally {
     tts.stop();
@@ -267,7 +267,7 @@ test('platform TTS logs cached Gemini lookup timing before playback', async () =
       slow: false,
       provider: 'gemini',
       bufferedGeminiVoice: 'Iapetus',
-      cacheLookupOnly: true,
+      cachePlaybackOnly: true,
     });
 
     const cacheLog = logs.find((line) => line.startsWith('[ks2-tts-cache-latency]'));
@@ -518,7 +518,7 @@ test('platform TTS logs cache lookup misses without body timing fields', async (
     fetchFn: async (url, init = {}) => {
       const body = JSON.parse(init.body);
       calls.push({ url, body });
-      if (body.cacheLookupOnly || body.cacheOnly) {
+      if (body.cacheLookupOnly || body.cachePlaybackOnly || body.cacheOnly) {
         return new Response(null, {
           status: 204,
           headers: {
@@ -543,7 +543,7 @@ test('platform TTS logs cache lookup misses without body timing fields', async (
     });
 
     assert.equal(result, true);
-    assert.ok(calls.some((call) => call.body.cacheLookupOnly), 'preflight cache lookup must run');
+    assert.ok(calls.some((call) => call.body.cachePlaybackOnly), 'preflight cache playback lookup must run');
     const missLog = logs.find((line) => line.startsWith('[ks2-tts-cache-latency]'));
     assert.ok(missLog, `expected cache miss telemetry, got ${JSON.stringify(logs)}`);
     assert.match(missLog, /status=miss/);
@@ -628,7 +628,7 @@ test('platform TTS uses cached Gemini audio for word-bank word replay', async ()
       provider: 'gemini',
       bufferedGeminiVoice: 'Iapetus',
       wordOnly: true,
-      cacheLookupOnly: true,
+      cachePlaybackOnly: true,
       slug: 'early',
       scope: 'word-bank',
     });
@@ -656,7 +656,7 @@ test('platform TTS does not warm or fall back after cancelled cache lookup', asy
     fetchFn: async (url, init = {}) => {
       const body = JSON.parse(init.body);
       calls.push({ url, body });
-      if (body.cacheLookupOnly) {
+      if (body.cachePlaybackOnly) {
         lookupStarted();
         await new Promise((resolve) => {
           releaseLookup = resolve;
@@ -693,7 +693,7 @@ test('platform TTS does not warm or fall back after cancelled cache lookup', asy
       slow: false,
       provider: 'gemini',
       bufferedGeminiVoice: 'Iapetus',
-      cacheLookupOnly: true,
+      cachePlaybackOnly: true,
     });
   } finally {
     tts.stop();
@@ -902,7 +902,7 @@ test('platform TTS does not fall back when the selected remote provider fails', 
       slow: false,
       provider: 'gemini',
       bufferedGeminiVoice: 'Iapetus',
-      cacheLookupOnly: true,
+      cachePlaybackOnly: true,
     });
     assert.deepEqual(calls[1].body, {
       learnerId: 'learner-a',

--- a/tests/spelling-tts.test.js
+++ b/tests/spelling-tts.test.js
@@ -309,6 +309,177 @@ test('platform TTS logs cached Gemini lookup timing before playback', async () =
   }
 });
 
+test('platform TTS waits for cached audio play() before logging play-start', async () => {
+  const originalAudio = globalThis.Audio;
+  const originalCreateObjectUrl = URL.createObjectURL;
+  const originalRevokeObjectUrl = URL.revokeObjectURL;
+  const played = [];
+  const logs = [];
+  const telemetryEvents = [];
+  let currentTime = 1000;
+  let releasePlay = null;
+  let playCalled = null;
+  const playCalledPromise = new Promise((resolve) => {
+    playCalled = resolve;
+  });
+
+  globalThis.Audio = class MockAudio {
+    constructor(src) {
+      this.src = src;
+      this.onended = null;
+      this.onerror = null;
+    }
+
+    play() {
+      played.push(this.src);
+      playCalled();
+      return new Promise((resolve) => {
+        releasePlay = () => {
+          resolve();
+          setTimeout(() => this.onended?.(), 0);
+        };
+      });
+    }
+
+    pause() {}
+    removeAttribute() {}
+    load() {}
+  };
+  URL.createObjectURL = () => 'blob:cached-gemini-audio';
+  URL.revokeObjectURL = () => {};
+
+  const tts = createPlatformTts({
+    remoteEnabled: true,
+    provider: 'openai',
+    now: () => {
+      currentTime += 25;
+      return currentTime;
+    },
+    logger: (line) => logs.push(line),
+    onCacheLookupTelemetry: (event) => telemetryEvents.push(event),
+    fetchFn: async () => new Response(new Blob([new Uint8Array([9, 8, 7, 6])], { type: 'audio/mpeg' }), {
+      status: 200,
+      headers: {
+        'content-type': 'audio/mpeg',
+        'x-ks2-request-id': 'ks2_req_cache_timing_delayed',
+        'x-ks2-tts-cache': 'hit',
+        'x-ks2-tts-cache-source': 'primary',
+        'x-ks2-tts-provider': 'gemini',
+      },
+    }),
+  });
+
+  try {
+    const resultPromise = tts.speak({
+      learnerId: 'learner-a',
+      promptToken: 'prompt-token-cached-timing-delayed',
+      word: 'early',
+      sentence: 'The birds sang early in the day.',
+    });
+    await playCalledPromise;
+
+    assert.deepEqual(played, ['blob:cached-gemini-audio']);
+    assert.deepEqual(telemetryEvents, []);
+    assert.equal(logs.some((line) => line.startsWith('[ks2-tts-cache-latency]')), false);
+
+    releasePlay();
+    const result = await resultPromise;
+
+    assert.equal(result, true);
+    assert.equal(telemetryEvents.length, 1);
+    assert.equal(telemetryEvents[0].status, 'play-start');
+    assert.equal(telemetryEvents[0].playStartMs, 75);
+    assert.match(logs.find((line) => line.startsWith('[ks2-tts-cache-latency]')), /status=play-start/);
+  } finally {
+    tts.stop();
+    globalThis.Audio = originalAudio;
+    URL.createObjectURL = originalCreateObjectUrl;
+    URL.revokeObjectURL = originalRevokeObjectUrl;
+  }
+});
+
+test('platform TTS logs cached audio play rejection without play-start timing', async () => {
+  const originalAudio = globalThis.Audio;
+  const originalCreateObjectUrl = URL.createObjectURL;
+  const originalRevokeObjectUrl = URL.revokeObjectURL;
+  const logs = [];
+  const telemetryEvents = [];
+  let currentTime = 1000;
+
+  globalThis.Audio = class MockAudio {
+    constructor(src) {
+      this.src = src;
+      this.onended = null;
+      this.onerror = null;
+    }
+
+    play() {
+      return Promise.reject(new Error('Autoplay blocked.'));
+    }
+
+    pause() {}
+    removeAttribute() {}
+    load() {}
+  };
+  URL.createObjectURL = () => 'blob:cached-gemini-audio';
+  URL.revokeObjectURL = () => {};
+
+  const tts = createPlatformTts({
+    remoteEnabled: true,
+    provider: 'openai',
+    now: () => {
+      currentTime += 25;
+      return currentTime;
+    },
+    logger: (line) => logs.push(line),
+    onCacheLookupTelemetry: (event) => telemetryEvents.push(event),
+    fetchFn: async () => new Response(new Blob([new Uint8Array([9, 8, 7, 6])], { type: 'audio/mpeg' }), {
+      status: 200,
+      headers: {
+        'content-type': 'audio/mpeg',
+        'x-ks2-request-id': 'ks2_req_cache_timing_rejected',
+        'x-ks2-tts-cache': 'hit',
+        'x-ks2-tts-cache-source': 'primary',
+        'x-ks2-tts-provider': 'gemini',
+      },
+    }),
+  });
+
+  try {
+    const result = await tts.speak({
+      learnerId: 'learner-a',
+      promptToken: 'prompt-token-cached-timing-rejected',
+      word: 'early',
+      sentence: 'The birds sang early in the day.',
+    });
+
+    assert.equal(result, false);
+    assert.deepEqual(telemetryEvents, [{
+      status: 'failed',
+      wallMs: 50,
+      kind: 'normal',
+      http: 200,
+      cache: 'hit',
+      source: 'primary',
+      provider: 'gemini',
+      contentType: 'audio/mpeg',
+      requestId: 'ks2_req_cache_timing_rejected',
+      headerMs: 25,
+      blobMs: 25,
+      playStartMs: null,
+      bytes: 4,
+    }]);
+    const cacheLog = logs.find((line) => line.startsWith('[ks2-tts-cache-latency]'));
+    assert.match(cacheLog, /status=failed/);
+    assert.doesNotMatch(cacheLog, /playStartMs=/);
+  } finally {
+    tts.stop();
+    globalThis.Audio = originalAudio;
+    URL.createObjectURL = originalCreateObjectUrl;
+    URL.revokeObjectURL = originalRevokeObjectUrl;
+  }
+});
+
 test('platform TTS logs cache lookup misses without body timing fields', async () => {
   const originalAudio = globalThis.Audio;
   const originalCreateObjectUrl = URL.createObjectURL;

--- a/tests/subject-command-client.test.js
+++ b/tests/subject-command-client.test.js
@@ -333,3 +333,48 @@ test('subject command client jitters bounded retry delays for transient command 
   assert.deepEqual(commandBodies.map((body) => body.expectedLearnerRevision), [12, 12, 12]);
   assert.deepEqual(retryDelays, [120, 220]);
 });
+
+test('subject command client retries bounded command timeouts with the same frozen request', async () => {
+  let aborted = false;
+  const commandBodies = [];
+  const fetch = (input, init = {}) => {
+    const body = JSON.parse(init.body);
+    commandBodies.push(body);
+    if (commandBodies.length > 1) {
+      return Promise.resolve(new Response(JSON.stringify({
+        ok: true,
+        mutation: {
+          appliedRevision: body.expectedLearnerRevision + 1,
+        },
+      }), { status: 200, headers: { 'content-type': 'application/json' } }));
+    }
+    init.signal?.addEventListener('abort', () => {
+      aborted = true;
+    });
+    return new Promise(() => {});
+  };
+  const commands = createSubjectCommandClient({
+    fetch,
+    getLearnerRevision: () => 9,
+    retryAttempts: 1,
+    retryDelayMs: 0,
+    timeoutMs: 1,
+  });
+
+  await commands.send({
+    subjectId: 'spelling',
+    learnerId: 'learner-a',
+    command: 'submit-answer',
+    payload: { typed: 'answer' },
+    requestId: 'cmd-timeout',
+  });
+
+  assert.equal(aborted, true);
+  assert.equal(commandBodies.length, 2);
+  assert.deepEqual(commandBodies.map((body) => body.requestId), ['cmd-timeout', 'cmd-timeout']);
+  assert.deepEqual(commandBodies.map((body) => body.expectedLearnerRevision), [9, 9]);
+  assert.deepEqual(commandBodies.map((body) => body.payload), [
+    { typed: 'answer' },
+    { typed: 'answer' },
+  ]);
+});

--- a/tests/worker-tts.test.js
+++ b/tests/worker-tts.test.js
@@ -683,7 +683,7 @@ test('TTS route serves cached audio for lookup-only requests before selected pro
   }
 });
 
-test('TTS route logs lookup-only R2 timing for primary miss then legacy hit', async () => {
+test('TTS route logs lookup-only R2 timing for primary miss then legacy hit without migrating', async () => {
   const originalFetch = globalThis.fetch;
   const originalConsoleLog = console.log;
   const logs = [];
@@ -764,13 +764,7 @@ test('TTS route logs lookup-only R2 timing for primary miss then legacy hit', as
     assert.equal(bucket.gets.length, 2);
     assert.match(bucket.gets[0], /\/Sulafat\/standard\/[^/]+\/early\/\d+\.mp3$/);
     assert.match(bucket.gets[1], /\/Sulafat\/standard\/early\/\d+\.mp3$/);
-    assert.equal(bucket.puts.length, 1);
-    assert.equal(bucket.puts[0].key, bucket.gets[0]);
-    assert.deepEqual([...bucket.puts[0].bytes], [7, 8, 9]);
-    assert.equal(bucket.puts[0].options.httpMetadata.contentType, 'audio/mpeg');
-    assert.equal(bucket.puts[0].options.customMetadata.source, 'worker-legacy-primary-migration');
-    assert.equal(bucket.puts[0].options.customMetadata.kind, 'sentence');
-    assert.equal(bucket.puts[0].options.customMetadata.speed, 'standard');
+    assert.equal(bucket.puts.length, 0);
     assert.equal(telemetry.length, 1);
     assert.equal(telemetry[0].requestId, requestId);
     assert.equal(telemetry[0].provider, 'gemini');
@@ -791,7 +785,7 @@ test('TTS route logs lookup-only R2 timing for primary miss then legacy hit', as
     ]);
     assert.doesNotMatch(rawLogs, /adult-a|learner-a|promptToken|early|birds|Sulafat/);
 
-    const migratedResponse = await server.fetch('https://repo.test/api/tts', {
+    const secondLookupResponse = await server.fetch('https://repo.test/api/tts', {
       ...ttsRequest({
         learnerId: prompt.learnerId,
         promptToken: prompt.promptToken,
@@ -804,27 +798,29 @@ test('TTS route logs lookup-only R2 timing for primary miss then legacy hit', as
         'x-ks2-request-id': migratedRequestId,
       },
     });
-    const migratedBytes = new Uint8Array(await migratedResponse.arrayBuffer());
-    const migratedTelemetry = ttsR2CacheLookupLogs(logs).find((entry) => entry.requestId === migratedRequestId);
+    const secondLookupBytes = new Uint8Array(await secondLookupResponse.arrayBuffer());
+    const secondLookupTelemetry = ttsR2CacheLookupLogs(logs).find((entry) => entry.requestId === migratedRequestId);
 
-    assert.equal(migratedResponse.status, 200);
-    assert.equal(migratedResponse.headers.get('x-ks2-tts-cache'), 'hit');
-    assert.equal(migratedResponse.headers.get('x-ks2-tts-cache-source'), 'primary');
-    assert.ok(Number.isFinite(serverTimingDurations(migratedResponse).r2));
-    assert.deepEqual([...migratedBytes], [7, 8, 9]);
-    assert.equal(bucket.gets.length, 3);
+    assert.equal(secondLookupResponse.status, 200);
+    assert.equal(secondLookupResponse.headers.get('x-ks2-tts-cache'), 'hit');
+    assert.equal(secondLookupResponse.headers.get('x-ks2-tts-cache-source'), 'legacy');
+    assert.ok(Number.isFinite(serverTimingDurations(secondLookupResponse).r2));
+    assert.deepEqual([...secondLookupBytes], [7, 8, 9]);
+    assert.equal(bucket.gets.length, 4);
     assert.equal(bucket.gets[2], bucket.gets[0]);
-    assert.equal(bucket.puts.length, 1);
-    assert.equal(migratedTelemetry.cache, 'hit');
-    assert.equal(migratedTelemetry.source, 'primary');
-    assert.equal(migratedTelemetry.lookupCount, 1);
-    assert.deepEqual(migratedTelemetry.attempts.map(({ extension, source, hit, failed }) => ({
+    assert.equal(bucket.gets[3], bucket.gets[1]);
+    assert.equal(bucket.puts.length, 0);
+    assert.equal(secondLookupTelemetry.cache, 'hit');
+    assert.equal(secondLookupTelemetry.source, 'legacy');
+    assert.equal(secondLookupTelemetry.lookupCount, 2);
+    assert.deepEqual(secondLookupTelemetry.attempts.map(({ extension, source, hit, failed }) => ({
       extension,
       source,
       hit,
       failed: Boolean(failed),
     })), [
-      { extension: 'mp3', source: 'primary', hit: true, failed: false },
+      { extension: 'mp3', source: 'primary', hit: false, failed: false },
+      { extension: 'mp3', source: 'legacy', hit: true, failed: false },
     ]);
   } finally {
     globalThis.fetch = originalFetch;
@@ -875,7 +871,6 @@ test('TTS route still serves legacy cached audio when primary migration write fa
       promptToken: prompt.promptToken,
       provider: 'openai',
       bufferedGeminiVoice: 'Sulafat',
-      cacheLookupOnly: true,
     }));
     const bytes = new Uint8Array(await response.arrayBuffer());
 
@@ -891,6 +886,62 @@ test('TTS route still serves legacy cached audio when primary migration write fa
   } finally {
     globalThis.fetch = originalFetch;
     console.error = originalConsoleError;
+    server.close();
+  }
+});
+
+test('TTS route blocks lookup-only legacy cached playback before primary migration when playback quota is exhausted', async () => {
+  const originalFetch = globalThis.fetch;
+  let providerCalls = 0;
+  globalThis.fetch = async () => {
+    providerCalls += 1;
+    throw new Error('Provider should not be called for lookup-only cached audio.');
+  };
+  const bucket = {
+    gets: [],
+    puts: [],
+    async get(key) {
+      this.gets.push(key);
+      if (/\/Sulafat\/standard\/early\/\d+\.mp3$/.test(String(key))) {
+        return {
+          body: Uint8Array.from([5, 6, 7]),
+          httpMetadata: { contentType: 'audio/mpeg' },
+          customMetadata: {},
+        };
+      }
+      return null;
+    },
+    async put(key, value, options = {}) {
+      const bytes = new Uint8Array(await new Response(value).arrayBuffer());
+      this.puts.push({ key, bytes, options });
+    },
+  };
+
+  const server = createWorkerRepositoryServer({
+    env: {
+      SPELLING_AUDIO_BUCKET: bucket,
+    },
+  });
+  try {
+    const prompt = await startSpellingPrompt(server);
+    await seedRateLimit(server, 'tts-account', 'adult-a', 120);
+
+    const response = await server.fetch('https://repo.test/api/tts', ttsRequest({
+      learnerId: prompt.learnerId,
+      promptToken: prompt.promptToken,
+      provider: 'openai',
+      bufferedGeminiVoice: 'Sulafat',
+      cacheLookupOnly: true,
+    }));
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.code, 'tts_rate_limited');
+    assert.equal(providerCalls, 0);
+    assert.equal(bucket.gets.length, 2);
+    assert.equal(bucket.puts.length, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
     server.close();
   }
 });

--- a/tests/worker-tts.test.js
+++ b/tests/worker-tts.test.js
@@ -829,6 +829,201 @@ test('TTS route logs lookup-only R2 timing for primary miss then legacy hit with
   }
 });
 
+test('TTS route migrates legacy cached audio on playback-only cache hits', async () => {
+  const originalFetch = globalThis.fetch;
+  let providerCalls = 0;
+  globalThis.fetch = async () => {
+    providerCalls += 1;
+    throw new Error('Provider should not be called for cached playback audio.');
+  };
+  const migratedObjects = new Map();
+  const bucket = {
+    gets: [],
+    puts: [],
+    async get(key) {
+      this.gets.push(key);
+      const stored = migratedObjects.get(key);
+      if (stored) {
+        return {
+          body: stored.bytes,
+          httpMetadata: { contentType: stored.contentType },
+          customMetadata: stored.customMetadata,
+        };
+      }
+      if (/\/Sulafat\/standard\/early\/\d+\.mp3$/.test(String(key))) {
+        return {
+          body: Uint8Array.from([7, 8, 9]),
+          httpMetadata: { contentType: 'audio/mpeg' },
+          customMetadata: {},
+        };
+      }
+      return null;
+    },
+    async put(key, value, options = {}) {
+      const bytes = new Uint8Array(await new Response(value).arrayBuffer());
+      this.puts.push({ key, bytes, options });
+      migratedObjects.set(key, {
+        bytes,
+        contentType: options.httpMetadata?.contentType || 'application/octet-stream',
+        customMetadata: options.customMetadata || {},
+      });
+    },
+  };
+
+  const server = createWorkerRepositoryServer({
+    env: {
+      SPELLING_AUDIO_BUCKET: bucket,
+    },
+  });
+  try {
+    const prompt = await startSpellingPrompt(server);
+    const firstResponse = await server.fetch('https://repo.test/api/tts', ttsRequest({
+      learnerId: prompt.learnerId,
+      promptToken: prompt.promptToken,
+      provider: 'openai',
+      bufferedGeminiVoice: 'Sulafat',
+      cachePlaybackOnly: true,
+    }));
+    const firstBytes = new Uint8Array(await firstResponse.arrayBuffer());
+
+    assert.equal(firstResponse.status, 200);
+    assert.equal(firstResponse.headers.get('x-ks2-tts-cache'), 'hit');
+    assert.equal(firstResponse.headers.get('x-ks2-tts-cache-source'), 'legacy');
+    assert.deepEqual([...firstBytes], [7, 8, 9]);
+    assert.equal(providerCalls, 0);
+    assert.equal(bucket.gets.length, 2);
+    assert.match(bucket.gets[0], /\/Sulafat\/standard\/[^/]+\/early\/\d+\.mp3$/);
+    assert.match(bucket.gets[1], /\/Sulafat\/standard\/early\/\d+\.mp3$/);
+    assert.equal(bucket.puts.length, 1);
+    assert.equal(bucket.puts[0].key, bucket.gets[0]);
+    assert.deepEqual([...bucket.puts[0].bytes], [7, 8, 9]);
+    assert.equal(bucket.puts[0].options.customMetadata.source, 'worker-legacy-primary-migration');
+
+    const firstLimiterCounts = ttsLimiterCounts(server);
+    assert.equal(firstLimiterCounts.get('tts-lookup-account'), 1);
+    assert.equal(firstLimiterCounts.get('tts-lookup-ip'), 1);
+    assert.equal(firstLimiterCounts.get('tts-account'), 1);
+    assert.equal(firstLimiterCounts.get('tts-ip'), 1);
+
+    const secondResponse = await server.fetch('https://repo.test/api/tts', ttsRequest({
+      learnerId: prompt.learnerId,
+      promptToken: prompt.promptToken,
+      provider: 'openai',
+      bufferedGeminiVoice: 'Sulafat',
+      cachePlaybackOnly: true,
+    }));
+    const secondBytes = new Uint8Array(await secondResponse.arrayBuffer());
+
+    assert.equal(secondResponse.status, 200);
+    assert.equal(secondResponse.headers.get('x-ks2-tts-cache'), 'hit');
+    assert.equal(secondResponse.headers.get('x-ks2-tts-cache-source'), 'primary');
+    assert.deepEqual([...secondBytes], [7, 8, 9]);
+    assert.equal(bucket.gets.length, 3);
+    assert.equal(bucket.gets[2], bucket.gets[0]);
+    assert.equal(bucket.puts.length, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+    server.close();
+  }
+});
+
+test('TTS route blocks playback-only legacy migration when playback quota is exhausted', async () => {
+  const originalFetch = globalThis.fetch;
+  let providerCalls = 0;
+  globalThis.fetch = async () => {
+    providerCalls += 1;
+    throw new Error('Provider should not be called for playback-only cached audio.');
+  };
+  const bucket = {
+    gets: [],
+    puts: [],
+    async get(key) {
+      this.gets.push(key);
+      if (/\/Sulafat\/standard\/early\/\d+\.mp3$/.test(String(key))) {
+        return {
+          body: Uint8Array.from([5, 6, 7]),
+          httpMetadata: { contentType: 'audio/mpeg' },
+          customMetadata: {},
+        };
+      }
+      return null;
+    },
+    async put(key, value, options = {}) {
+      const bytes = new Uint8Array(await new Response(value).arrayBuffer());
+      this.puts.push({ key, bytes, options });
+    },
+  };
+
+  const server = createWorkerRepositoryServer({
+    env: {
+      SPELLING_AUDIO_BUCKET: bucket,
+    },
+  });
+  try {
+    const prompt = await startSpellingPrompt(server);
+    await seedRateLimit(server, 'tts-account', 'adult-a', 120);
+
+    const response = await server.fetch('https://repo.test/api/tts', ttsRequest({
+      learnerId: prompt.learnerId,
+      promptToken: prompt.promptToken,
+      provider: 'openai',
+      bufferedGeminiVoice: 'Sulafat',
+      cachePlaybackOnly: true,
+    }));
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.code, 'tts_rate_limited');
+    assert.equal(providerCalls, 0);
+    assert.equal(bucket.gets.length, 2);
+    assert.equal(bucket.puts.length, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+    server.close();
+  }
+});
+
+test('TTS route returns a playback-only cache miss without generating audio or charging playback quota', async () => {
+  const originalFetch = globalThis.fetch;
+  let providerCalls = 0;
+  globalThis.fetch = async () => {
+    providerCalls += 1;
+    return geminiAudioResponse();
+  };
+  const bucket = createMemoryR2Bucket();
+
+  const server = createWorkerRepositoryServer({
+    env: {
+      GEMINI_API_KEY: 'test-gemini-key',
+      SPELLING_AUDIO_BUCKET: bucket,
+    },
+  });
+  try {
+    const prompt = await startSpellingPrompt(server);
+    const response = await server.fetch('https://repo.test/api/tts', ttsRequest({
+      learnerId: prompt.learnerId,
+      promptToken: prompt.promptToken,
+      provider: 'openai',
+      bufferedGeminiVoice: 'Sulafat',
+      cachePlaybackOnly: true,
+    }));
+    const limiterCounts = ttsLimiterCounts(server);
+
+    assert.equal(response.status, 204);
+    assert.equal(response.headers.get('x-ks2-tts-cache'), 'miss');
+    assert.equal(providerCalls, 0);
+    assert.equal(bucket.gets.length, 3);
+    assert.equal(bucket.puts.length, 0);
+    assert.equal(limiterCounts.get('tts-lookup-account'), 1);
+    assert.equal(limiterCounts.get('tts-lookup-ip'), 1);
+    assert.equal(limiterCounts.has('tts-account'), false);
+    assert.equal(limiterCounts.has('tts-ip'), false);
+  } finally {
+    globalThis.fetch = originalFetch;
+    server.close();
+  }
+});
+
 test('TTS route still serves legacy cached audio when primary migration write fails', async () => {
   const originalFetch = globalThis.fetch;
   const originalConsoleError = console.error;

--- a/tests/worker-tts.test.js
+++ b/tests/worker-tts.test.js
@@ -198,6 +198,34 @@ function createMemoryR2Bucket({ hit = null, failGet = false, failPut = false } =
   };
 }
 
+function ttsR2CacheLookupLogs(logs) {
+  const entries = [];
+  for (const args of logs) {
+    const line = Array.isArray(args) ? args[0] : args;
+    try {
+      const parsed = JSON.parse(String(line || ''));
+      if (parsed?.event === 'tts_r2_cache_lookup') entries.push(parsed);
+    } catch {
+      // Ignore unrelated console output.
+    }
+  }
+  return entries;
+}
+
+function serverTimingDurations(response) {
+  const phases = {};
+  const value = response.headers.get('server-timing') || '';
+  for (const entry of value.split(',')) {
+    const parts = entry.trim().split(';').map((part) => part.trim()).filter(Boolean);
+    const name = parts.shift();
+    if (!name?.startsWith('ks2_tts_')) continue;
+    const dur = parts.find((part) => /^dur=/i.test(part));
+    if (!dur) continue;
+    phases[name.slice('ks2_tts_'.length)] = Number(dur.slice(dur.indexOf('=') + 1));
+  }
+  return phases;
+}
+
 test('TTS route requires an authenticated account session', async () => {
   const server = createWorkerRepositoryServer({
     env: { OPENAI_API_KEY: 'test-openai-key' },
@@ -373,8 +401,9 @@ test('TTS route reads legacy batch-generated spelling audio keys', async () => {
         customMetadata: {},
       };
     },
-    async put() {
-      this.puts.push(arguments);
+    async put(key, value, options = {}) {
+      const bytes = new Uint8Array(await new Response(value).arrayBuffer());
+      this.puts.push({ key, bytes, options });
     },
   };
 
@@ -405,7 +434,11 @@ test('TTS route reads legacy batch-generated spelling audio keys', async () => {
     assert.equal(bucket.gets.length, 2);
     assert.match(bucket.gets[0], /\/gemini-custom-tts-preview\/Sulafat\/standard\/[^/]+\/early\/\d+\.mp3$/);
     assert.match(bucket.gets[1], /\/gemini-3\.1-flash-tts-preview\/Sulafat\/standard\/early\/\d+\.mp3$/);
-    assert.equal(bucket.puts.length, 0);
+    assert.equal(bucket.puts.length, 1);
+    assert.equal(bucket.puts[0].key, bucket.gets[0]);
+    assert.deepEqual([...bucket.puts[0].bytes], [7, 8, 9]);
+    assert.equal(bucket.puts[0].options.httpMetadata.contentType, 'audio/mpeg');
+    assert.equal(bucket.puts[0].options.customMetadata.source, 'worker-legacy-primary-migration');
   } finally {
     globalThis.fetch = originalFetch;
     server.close();
@@ -620,6 +653,14 @@ test('TTS route serves cached audio for lookup-only requests before selected pro
     assert.equal(response.headers.get('x-ks2-tts-cache'), 'hit');
     assert.equal(response.headers.get('x-ks2-tts-provider'), 'gemini');
     assert.deepEqual([...bytes], [6, 5, 4]);
+    const timings = serverTimingDurations(response);
+    assert.ok(Number.isFinite(timings.prompt));
+    assert.ok(Number.isFinite(timings.lookup_limit));
+    assert.ok(Number.isFinite(timings.audio_limit));
+    assert.ok(Number.isFinite(timings.r2));
+    assert.ok(Number.isFinite(timings.cache_lookup));
+    assert.ok(Number.isFinite(timings.response));
+    assert.ok(Number.isFinite(timings.total));
     assert.equal(providerCalls, 0);
     assert.equal(bucket.gets.length, 1);
     assert.equal(bucket.puts.length, 0);
@@ -638,6 +679,218 @@ test('TTS route serves cached audio for lookup-only requests before selected pro
     assert.equal(limiterCounts.get('tts-ip'), 1);
   } finally {
     globalThis.fetch = originalFetch;
+    server.close();
+  }
+});
+
+test('TTS route logs lookup-only R2 timing for primary miss then legacy hit', async () => {
+  const originalFetch = globalThis.fetch;
+  const originalConsoleLog = console.log;
+  const logs = [];
+  let providerCalls = 0;
+  globalThis.fetch = async () => {
+    providerCalls += 1;
+    throw new Error('Provider should not be called for lookup-only cached audio.');
+  };
+  console.log = (...args) => {
+    logs.push(args);
+  };
+  const migratedObjects = new Map();
+  const bucket = {
+    gets: [],
+    puts: [],
+    async get(key) {
+      this.gets.push(key);
+      const stored = migratedObjects.get(key);
+      if (stored) {
+        return {
+          body: stored.bytes,
+          httpMetadata: { contentType: stored.contentType },
+          customMetadata: stored.customMetadata,
+        };
+      }
+      if (/\/Sulafat\/standard\/early\/\d+\.mp3$/.test(String(key))) {
+        return {
+          body: Uint8Array.from([7, 8, 9]),
+          httpMetadata: { contentType: 'audio/mpeg' },
+          customMetadata: {},
+        };
+      }
+      return null;
+    },
+    async put(key, value, options = {}) {
+      const bytes = new Uint8Array(await new Response(value).arrayBuffer());
+      this.puts.push({ key, bytes, options });
+      migratedObjects.set(key, {
+        bytes,
+        contentType: options.httpMetadata?.contentType || 'application/octet-stream',
+        customMetadata: options.customMetadata || {},
+      });
+    },
+  };
+  const requestId = 'ks2_req_11111111-1111-4111-8111-111111111111';
+  const migratedRequestId = 'ks2_req_11111111-1111-4111-8111-111111111112';
+
+  const server = createWorkerRepositoryServer({
+    env: {
+      SPELLING_AUDIO_BUCKET: bucket,
+    },
+  });
+  try {
+    const prompt = await startSpellingPrompt(server);
+    const response = await server.fetch('https://repo.test/api/tts', {
+      ...ttsRequest({
+        learnerId: prompt.learnerId,
+        promptToken: prompt.promptToken,
+        provider: 'openai',
+        bufferedGeminiVoice: 'Sulafat',
+        cacheLookupOnly: true,
+      }),
+      headers: {
+        'content-type': 'application/json',
+        'x-ks2-request-id': requestId,
+      },
+    });
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    const telemetry = ttsR2CacheLookupLogs(logs);
+    const rawLogs = logs.flat().join('\n');
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get('x-ks2-tts-cache'), 'hit');
+    assert.equal(response.headers.get('x-ks2-tts-cache-source'), 'legacy');
+    assert.ok(Number.isFinite(serverTimingDurations(response).r2));
+    assert.deepEqual([...bytes], [7, 8, 9]);
+    assert.equal(providerCalls, 0);
+    assert.equal(bucket.gets.length, 2);
+    assert.match(bucket.gets[0], /\/Sulafat\/standard\/[^/]+\/early\/\d+\.mp3$/);
+    assert.match(bucket.gets[1], /\/Sulafat\/standard\/early\/\d+\.mp3$/);
+    assert.equal(bucket.puts.length, 1);
+    assert.equal(bucket.puts[0].key, bucket.gets[0]);
+    assert.deepEqual([...bucket.puts[0].bytes], [7, 8, 9]);
+    assert.equal(bucket.puts[0].options.httpMetadata.contentType, 'audio/mpeg');
+    assert.equal(bucket.puts[0].options.customMetadata.source, 'worker-legacy-primary-migration');
+    assert.equal(bucket.puts[0].options.customMetadata.kind, 'sentence');
+    assert.equal(bucket.puts[0].options.customMetadata.speed, 'standard');
+    assert.equal(telemetry.length, 1);
+    assert.equal(telemetry[0].requestId, requestId);
+    assert.equal(telemetry[0].provider, 'gemini');
+    assert.equal(telemetry[0].cache, 'hit');
+    assert.equal(telemetry[0].source, 'legacy');
+    assert.equal(telemetry[0].kind, 'sentence');
+    assert.equal(telemetry[0].extension, 'mp3');
+    assert.equal(telemetry[0].lookupCount, 2);
+    assert.ok(Number.isFinite(Number(telemetry[0].r2Ms)));
+    assert.deepEqual(telemetry[0].attempts.map(({ extension, source, hit, failed }) => ({
+      extension,
+      source,
+      hit,
+      failed: Boolean(failed),
+    })), [
+      { extension: 'mp3', source: 'primary', hit: false, failed: false },
+      { extension: 'mp3', source: 'legacy', hit: true, failed: false },
+    ]);
+    assert.doesNotMatch(rawLogs, /adult-a|learner-a|promptToken|early|birds|Sulafat/);
+
+    const migratedResponse = await server.fetch('https://repo.test/api/tts', {
+      ...ttsRequest({
+        learnerId: prompt.learnerId,
+        promptToken: prompt.promptToken,
+        provider: 'openai',
+        bufferedGeminiVoice: 'Sulafat',
+        cacheLookupOnly: true,
+      }),
+      headers: {
+        'content-type': 'application/json',
+        'x-ks2-request-id': migratedRequestId,
+      },
+    });
+    const migratedBytes = new Uint8Array(await migratedResponse.arrayBuffer());
+    const migratedTelemetry = ttsR2CacheLookupLogs(logs).find((entry) => entry.requestId === migratedRequestId);
+
+    assert.equal(migratedResponse.status, 200);
+    assert.equal(migratedResponse.headers.get('x-ks2-tts-cache'), 'hit');
+    assert.equal(migratedResponse.headers.get('x-ks2-tts-cache-source'), 'primary');
+    assert.ok(Number.isFinite(serverTimingDurations(migratedResponse).r2));
+    assert.deepEqual([...migratedBytes], [7, 8, 9]);
+    assert.equal(bucket.gets.length, 3);
+    assert.equal(bucket.gets[2], bucket.gets[0]);
+    assert.equal(bucket.puts.length, 1);
+    assert.equal(migratedTelemetry.cache, 'hit');
+    assert.equal(migratedTelemetry.source, 'primary');
+    assert.equal(migratedTelemetry.lookupCount, 1);
+    assert.deepEqual(migratedTelemetry.attempts.map(({ extension, source, hit, failed }) => ({
+      extension,
+      source,
+      hit,
+      failed: Boolean(failed),
+    })), [
+      { extension: 'mp3', source: 'primary', hit: true, failed: false },
+    ]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    console.log = originalConsoleLog;
+    server.close();
+  }
+});
+
+test('TTS route still serves legacy cached audio when primary migration write fails', async () => {
+  const originalFetch = globalThis.fetch;
+  const originalConsoleError = console.error;
+  const errors = [];
+  globalThis.fetch = async () => {
+    throw new Error('Provider should not be called for cached audio.');
+  };
+  console.error = (...args) => {
+    errors.push(args);
+  };
+  const bucket = {
+    gets: [],
+    puts: [],
+    async get(key) {
+      this.gets.push(key);
+      if (/\/Sulafat\/standard\/early\/\d+\.mp3$/.test(String(key))) {
+        return {
+          body: new Response(Uint8Array.from([5, 6, 7])).body,
+          httpMetadata: { contentType: 'audio/mpeg' },
+          customMetadata: {},
+        };
+      }
+      return null;
+    },
+    async put(key) {
+      this.puts.push({ key });
+      throw new Error('R2 put failed.');
+    },
+  };
+
+  const server = createWorkerRepositoryServer({
+    env: {
+      SPELLING_AUDIO_BUCKET: bucket,
+    },
+  });
+  try {
+    const prompt = await startSpellingPrompt(server);
+    const response = await server.fetch('https://repo.test/api/tts', ttsRequest({
+      learnerId: prompt.learnerId,
+      promptToken: prompt.promptToken,
+      provider: 'openai',
+      bufferedGeminiVoice: 'Sulafat',
+      cacheLookupOnly: true,
+    }));
+    const bytes = new Uint8Array(await response.arrayBuffer());
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get('x-ks2-tts-cache'), 'hit');
+    assert.equal(response.headers.get('x-ks2-tts-cache-source'), 'legacy');
+    assert.deepEqual([...bytes], [5, 6, 7]);
+    assert.equal(bucket.gets.length, 2);
+    assert.equal(bucket.puts.length, 1);
+    assert.equal(errors[0][0], '[ks2-tts] R2 legacy primary migration failed');
+    assert.equal(errors[0][1].keyKind, 'sentence');
+    assert.equal(errors[0][1].message, 'R2 put failed.');
+  } finally {
+    globalThis.fetch = originalFetch;
+    console.error = originalConsoleError;
     server.close();
   }
 });
@@ -739,12 +992,18 @@ test('TTS route blocks lookup-only cached playback when playback quota is exhaus
 
 test('TTS route returns a lookup-only cache miss without generating audio', async () => {
   const originalFetch = globalThis.fetch;
+  const originalConsoleLog = console.log;
+  const logs = [];
   let providerCalls = 0;
   globalThis.fetch = async () => {
     providerCalls += 1;
     return geminiAudioResponse();
   };
+  console.log = (...args) => {
+    logs.push(args);
+  };
   const bucket = createMemoryR2Bucket();
+  const requestId = 'ks2_req_22222222-2222-4222-8222-222222222222';
 
   const server = createWorkerRepositoryServer({
     env: {
@@ -754,21 +1013,55 @@ test('TTS route returns a lookup-only cache miss without generating audio', asyn
   });
   try {
     const prompt = await startSpellingPrompt(server);
-    const response = await server.fetch('https://repo.test/api/tts', ttsRequest({
-      learnerId: prompt.learnerId,
-      promptToken: prompt.promptToken,
-      provider: 'openai',
-      bufferedGeminiVoice: 'Sulafat',
-      cacheLookupOnly: true,
-    }));
+    const response = await server.fetch('https://repo.test/api/tts', {
+      ...ttsRequest({
+        learnerId: prompt.learnerId,
+        promptToken: prompt.promptToken,
+        provider: 'openai',
+        bufferedGeminiVoice: 'Sulafat',
+        cacheLookupOnly: true,
+      }),
+      headers: {
+        'content-type': 'application/json',
+        'x-ks2-request-id': requestId,
+      },
+    });
+    const telemetry = ttsR2CacheLookupLogs(logs);
+    const rawLogs = logs.flat().join('\n');
 
     assert.equal(response.status, 204);
     assert.equal(response.headers.get('x-ks2-tts-cache'), 'miss');
+    const timings = serverTimingDurations(response);
+    assert.ok(Number.isFinite(timings.prompt));
+    assert.ok(Number.isFinite(timings.lookup_limit));
+    assert.ok(Number.isFinite(timings.r2));
+    assert.ok(Number.isFinite(timings.cache_lookup));
+    assert.ok(Number.isFinite(timings.total));
+    assert.doesNotMatch(response.headers.get('server-timing') || '', /adult-a|learner-a|promptToken|early|birds|Sulafat/);
     assert.equal(providerCalls, 0);
     assert.equal(bucket.gets.length, 3);
     assert.equal(bucket.puts.length, 0);
+    assert.equal(telemetry.length, 1);
+    assert.equal(telemetry[0].requestId, requestId);
+    assert.equal(telemetry[0].cache, 'miss');
+    assert.equal(telemetry[0].source, 'none');
+    assert.equal(telemetry[0].kind, 'sentence');
+    assert.equal(telemetry[0].extension, 'wav');
+    assert.equal(telemetry[0].lookupCount, 3);
+    assert.deepEqual(telemetry[0].attempts.map(({ extension, source, hit, failed }) => ({
+      extension,
+      source,
+      hit,
+      failed: Boolean(failed),
+    })), [
+      { extension: 'mp3', source: 'primary', hit: false, failed: false },
+      { extension: 'mp3', source: 'legacy', hit: false, failed: false },
+      { extension: 'wav', source: 'primary', hit: false, failed: false },
+    ]);
+    assert.doesNotMatch(rawLogs, /adult-a|learner-a|promptToken|early|birds|Sulafat/);
   } finally {
     globalThis.fetch = originalFetch;
+    console.log = originalConsoleLog;
     server.close();
   }
 });

--- a/worker/src/app.js
+++ b/worker/src/app.js
@@ -2253,6 +2253,7 @@ export function createWorkerApp({
             repository,
             now: now(),
             fetchFn,
+            requestId: validatedRequestId,
           });
         }
 

--- a/worker/src/tts.js
+++ b/worker/src/tts.js
@@ -154,6 +154,10 @@ function normaliseTtsCacheLookupOnly(value) {
   return value === true || cleanText(value).toLowerCase() === 'true';
 }
 
+function normaliseTtsCachePlaybackOnly(value) {
+  return value === true || cleanText(value).toLowerCase() === 'true';
+}
+
 function ttsInstructions(slow = false, wordOnly = false) {
   if (wordOnly) {
     return 'Use natural British English pronunciation for a KS2 vocabulary preview. Read exactly the supplied word once and do not add extra words.';
@@ -617,14 +621,6 @@ async function readBufferedGeminiAudio(env, payload, options = {}) {
         objectKey = fallbackKey;
         if (object) {
           source = 'legacy';
-          if (allowLegacyMigration) {
-            object = await copyLegacyAudioToPrimary(bucket, {
-              legacyObject: object,
-              primaryKey: key,
-              metadata,
-              extension,
-            });
-          }
         }
       }
     } catch (error) {
@@ -648,6 +644,17 @@ async function readBufferedGeminiAudio(env, payload, options = {}) {
         contentType: 'audio/wav',
         cacheUnavailable: true,
       };
+    }
+    if (object && source === 'legacy' && allowLegacyMigration) {
+      if (typeof options.beforeLegacyMigration === 'function') {
+        await options.beforeLegacyMigration();
+      }
+      object = await copyLegacyAudioToPrimary(bucket, {
+        legacyObject: object,
+        primaryKey: key,
+        metadata,
+        extension,
+      });
     }
     if (!object) continue;
     const responseMetadata = source === 'legacy'
@@ -997,7 +1004,9 @@ export async function handleTextToSpeechRequest({
   const bodyMs = monotonicNowMs() - bodyStartedAt;
   const cacheOnly = normaliseTtsCacheOnly(body?.cacheOnly);
   const cacheLookupOnly = normaliseTtsCacheLookupOnly(body?.cacheLookupOnly);
-  timing.enabled = cacheLookupOnly;
+  const cachePlaybackOnly = !cacheLookupOnly && normaliseTtsCachePlaybackOnly(body?.cachePlaybackOnly);
+  const cacheReadOnly = cacheLookupOnly || cachePlaybackOnly;
+  timing.enabled = cacheReadOnly;
   recordTtsTiming(timing, 'body', bodyMs);
   const payload = {
     ...(await timeTtsPhase(timing, 'prompt', () => resolveSpellingAudioRequest({
@@ -1006,10 +1015,11 @@ export async function handleTextToSpeechRequest({
       body,
     }))),
     accountId: session.accountId,
-    provider: cacheOnly || cacheLookupOnly ? 'gemini' : normaliseRemoteTtsProvider(body?.provider),
+    provider: cacheOnly || cacheReadOnly ? 'gemini' : normaliseRemoteTtsProvider(body?.provider),
     bufferedGeminiVoice: normaliseBufferedGeminiVoice(body?.bufferedGeminiVoice || body?.cachedVoice),
     cacheOnly,
     cacheLookupOnly,
+    cachePlaybackOnly,
   };
   const openAi = openAiConfig(env);
   const gemini = geminiConfig(env);
@@ -1040,29 +1050,30 @@ export async function handleTextToSpeechRequest({
     return await recordDemoTtsFallback(env, session, now, withFallbackHeader(withTtsServerTiming(response, timing), fallbackFrom));
   }
 
- async function tryGemini(fallbackFrom = '') {
-    if (cacheLookupOnly) await protectLookupRequest();
+  async function tryGemini(fallbackFrom = '') {
+    if (cacheReadOnly) await protectLookupRequest();
     else if (!cacheOnly) await protectAudioRequest();
     const cacheHit = await timeTtsPhase(timing, 'cache_lookup', () => readBufferedGeminiAudio(env, payload, {
       model: geminiForPayload.model,
-      allowLegacyMigration: !cacheLookupOnly && !cacheOnly,
-      telemetry: cacheLookupOnly ? {
+      allowLegacyMigration: cachePlaybackOnly || (!cacheLookupOnly && !cacheOnly),
+      beforeLegacyMigration: cachePlaybackOnly ? protectAudioRequest : null,
+      telemetry: cacheReadOnly ? {
         enabled: true,
         requestId,
         recordPhase: (name, durationMs) => recordTtsTiming(timing, name, durationMs),
       } : null,
     }));
     if (cacheHit?.object) {
-      if (cacheLookupOnly) await protectAudioRequest();
+      if (cacheReadOnly) await protectAudioRequest();
       const output = timeTtsPhase(timing, 'response', async () => (
         cacheOnly ? cacheOnlyResponse('hit', cacheHit) : cachedGeminiAudioResponse(cacheHit)
       ));
       const response = await output;
       return cacheOnly ? withTtsServerTiming(response, timing) : await finish(response, fallbackFrom);
     }
-    if (cacheLookupOnly && cacheHit?.cacheUnavailable) return withTtsServerTiming(cacheOnlyResponse('unavailable', cacheHit), timing);
-    if (cacheLookupOnly && !cacheHit?.metadata) return withTtsServerTiming(cacheOnlyResponse('uncacheable'), timing);
-    if (cacheLookupOnly) return withTtsServerTiming(cacheOnlyResponse('miss', cacheHit), timing);
+    if (cacheReadOnly && cacheHit?.cacheUnavailable) return withTtsServerTiming(cacheOnlyResponse('unavailable', cacheHit), timing);
+    if (cacheReadOnly && !cacheHit?.metadata) return withTtsServerTiming(cacheOnlyResponse('uncacheable'), timing);
+    if (cacheReadOnly) return withTtsServerTiming(cacheOnlyResponse('miss', cacheHit), timing);
     if (cacheOnly && cacheHit?.cacheUnavailable) return withTtsServerTiming(cacheOnlyResponse('unavailable', cacheHit), timing);
     if (cacheOnly && !cacheHit?.metadata) return withTtsServerTiming(cacheOnlyResponse('uncacheable'), timing);
     if (cacheOnly) {

--- a/worker/src/tts.js
+++ b/worker/src/tts.js
@@ -60,73 +60,74 @@ function positiveInteger(value, fallback, { min = 1, max = 30000 } = {}) {
 // `worker/src/rate-limit.js`. TTS uses the shared helper with an
 // env-first signature, same shape as before (feasibility F-06).
 
-async function protectTts(env, request, session, now) {
+async function consumeTtsRateLimitPair(env, request, session, now, {
+  accountBucket,
+  accountLimit,
+  ipBucket,
+  ipLimit,
+}) {
   const { bucketKey } = rateLimitSubject(request, env);
-  const accountLimit = await consumeRateLimit(env, {
-    bucket: 'tts-account',
-    identifier: session.accountId,
-    limit: TTS_ACCOUNT_LIMIT,
-    windowMs: TTS_WINDOW_MS,
-    now,
-  });
-  const ipLimit = await consumeRateLimit(env, {
-    bucket: 'tts-ip',
-    identifier: bucketKey,
-    limit: TTS_IP_LIMIT,
-    windowMs: TTS_WINDOW_MS,
-    now,
-  });
+  const [accountResult, ipResult] = await Promise.all([
+    consumeRateLimit(env, {
+      bucket: accountBucket,
+      identifier: session.accountId,
+      limit: accountLimit,
+      windowMs: TTS_WINDOW_MS,
+      now,
+    }),
+    consumeRateLimit(env, {
+      bucket: ipBucket,
+      identifier: bucketKey,
+      limit: ipLimit,
+      windowMs: TTS_WINDOW_MS,
+      now,
+    }),
+  ]);
+  return {
+    allowed: accountResult.allowed && ipResult.allowed,
+    retryAfterSeconds: Math.max(accountResult.retryAfterSeconds, ipResult.retryAfterSeconds),
+  };
+}
 
-  if (!accountLimit.allowed || !ipLimit.allowed) {
-    throw new BadRequestError('Too many dictation audio requests. Please wait a few minutes and try again.', {
-      code: 'tts_rate_limited',
-      retryAfterSeconds: Math.max(accountLimit.retryAfterSeconds, ipLimit.retryAfterSeconds),
-    });
-  }
+async function requireTtsRateLimitPair(env, request, session, now, spec) {
+  const result = await consumeTtsRateLimitPair(env, request, session, now, spec);
+  if (result.allowed) return;
+  throw new BadRequestError(spec.message, {
+    code: spec.code,
+    retryAfterSeconds: result.retryAfterSeconds,
+  });
+}
+
+async function protectTts(env, request, session, now) {
+  await requireTtsRateLimitPair(env, request, session, now, {
+    accountBucket: 'tts-account',
+    accountLimit: TTS_ACCOUNT_LIMIT,
+    ipBucket: 'tts-ip',
+    ipLimit: TTS_IP_LIMIT,
+    message: 'Too many dictation audio requests. Please wait a few minutes and try again.',
+    code: 'tts_rate_limited',
+  });
 }
 
 async function protectTtsLookup(env, request, session, now) {
-  const { bucketKey } = rateLimitSubject(request, env);
-  const accountLimit = await consumeRateLimit(env, {
-    bucket: 'tts-lookup-account',
-    identifier: session.accountId,
-    limit: TTS_LOOKUP_ACCOUNT_LIMIT,
-    windowMs: TTS_WINDOW_MS,
-    now,
+  await requireTtsRateLimitPair(env, request, session, now, {
+    accountBucket: 'tts-lookup-account',
+    accountLimit: TTS_LOOKUP_ACCOUNT_LIMIT,
+    ipBucket: 'tts-lookup-ip',
+    ipLimit: TTS_LOOKUP_IP_LIMIT,
+    message: 'Too many dictation audio cache lookups. Please wait a few minutes and try again.',
+    code: 'tts_lookup_rate_limited',
   });
-  const ipLimit = await consumeRateLimit(env, {
-    bucket: 'tts-lookup-ip',
-    identifier: bucketKey,
-    limit: TTS_LOOKUP_IP_LIMIT,
-    windowMs: TTS_WINDOW_MS,
-    now,
-  });
-
-  if (!accountLimit.allowed || !ipLimit.allowed) {
-    throw new BadRequestError('Too many dictation audio cache lookups. Please wait a few minutes and try again.', {
-      code: 'tts_lookup_rate_limited',
-      retryAfterSeconds: Math.max(accountLimit.retryAfterSeconds, ipLimit.retryAfterSeconds),
-    });
-  }
 }
 
 async function allowTtsWarmup(env, request, session, now) {
-  const { bucketKey } = rateLimitSubject(request, env);
-  const accountLimit = await consumeRateLimit(env, {
-    bucket: 'tts-warmup-account',
-    identifier: session.accountId,
-    limit: TTS_WARMUP_ACCOUNT_LIMIT,
-    windowMs: TTS_WINDOW_MS,
-    now,
+  const result = await consumeTtsRateLimitPair(env, request, session, now, {
+    accountBucket: 'tts-warmup-account',
+    accountLimit: TTS_WARMUP_ACCOUNT_LIMIT,
+    ipBucket: 'tts-warmup-ip',
+    ipLimit: TTS_WARMUP_IP_LIMIT,
   });
-  const ipLimit = await consumeRateLimit(env, {
-    bucket: 'tts-warmup-ip',
-    identifier: bucketKey,
-    limit: TTS_WARMUP_IP_LIMIT,
-    windowMs: TTS_WINDOW_MS,
-    now,
-  });
-  return accountLimit.allowed && ipLimit.allowed;
+  return result.allowed;
 }
 
 async function recordDemoTtsFallback(env, session, now, response) {
@@ -383,11 +384,207 @@ function audioCacheErrorFields(error) {
   };
 }
 
+function monotonicNowMs() {
+  try {
+    if (typeof performance !== 'undefined' && typeof performance.now === 'function') return performance.now();
+  } catch {
+    // Fall through to Date.now below.
+  }
+  return Date.now();
+}
+
+function roundedMs(value) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) return 0;
+  return Math.round(parsed);
+}
+
+function createTtsTiming() {
+  return {
+    enabled: false,
+    startedAt: monotonicNowMs(),
+    phases: new Map(),
+  };
+}
+
+function recordTtsTiming(timing, name, durationMs) {
+  if (!timing?.enabled) return;
+  const cleanName = cleanText(name).toLowerCase().replace(/[^a-z0-9_]/g, '');
+  if (!cleanName) return;
+  const duration = roundedMs(durationMs);
+  timing.phases.set(cleanName, roundedMs((timing.phases.get(cleanName) || 0) + duration));
+}
+
+async function timeTtsPhase(timing, name, fn) {
+  if (!timing?.enabled) return await fn();
+  const startedAt = monotonicNowMs();
+  try {
+    return await fn();
+  } finally {
+    recordTtsTiming(timing, name, monotonicNowMs() - startedAt);
+  }
+}
+
+function ttsServerTimingValue(timing) {
+  if (!timing?.enabled) return '';
+  const entries = Array.from(timing.phases.entries())
+    .filter(([name, duration]) => name && Number.isFinite(Number(duration)))
+    .map(([name, duration]) => `ks2_tts_${name};dur=${roundedMs(duration)}`);
+  entries.push(`ks2_tts_total;dur=${roundedMs(monotonicNowMs() - timing.startedAt)}`);
+  return entries.join(', ');
+}
+
+function withTtsServerTiming(response, timing) {
+  const value = ttsServerTimingValue(timing);
+  if (!value) return response;
+  const headers = new Headers(response.headers);
+  const existing = headers.get('Server-Timing');
+  headers.set('Server-Timing', existing ? `${existing}, ${value}` : value);
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+function ttsR2LookupAttempt({ extension, source, object, startedAt, failed = false }) {
+  return {
+    extension,
+    source,
+    hit: Boolean(object),
+    failed: Boolean(failed),
+    durationMs: roundedMs(monotonicNowMs() - startedAt),
+  };
+}
+
+function logTtsR2CacheLookup(telemetry, {
+  cacheState,
+  metadata = null,
+  source = '',
+  extension = '',
+  attempts = [],
+} = {}) {
+  const r2Ms = roundedMs(attempts.reduce((sum, attempt) => sum + Number(attempt.durationMs || 0), 0));
+  try {
+    telemetry?.recordPhase?.('r2', r2Ms);
+  } catch {
+    // Best-effort telemetry must not affect audio playback.
+  }
+  if (!telemetry?.enabled) return;
+  const logEntry = {
+    event: 'tts_r2_cache_lookup',
+    requestId: cleanText(telemetry.requestId) || 'unknown',
+    provider: 'gemini',
+    cache: cacheState || 'unknown',
+    source: source || 'none',
+    kind: metadata?.kind || 'sentence',
+    extension: extension || 'none',
+    lookupCount: attempts.length,
+    r2Ms,
+    attempts: attempts.map((attempt) => ({
+      extension: attempt.extension,
+      source: attempt.source,
+      hit: Boolean(attempt.hit),
+      durationMs: roundedMs(attempt.durationMs),
+      ...(attempt.failed ? { failed: true } : {}),
+    })),
+  };
+  try {
+    console.log(JSON.stringify(logEntry));
+  } catch {
+    // Best-effort telemetry must not affect audio playback.
+  }
+}
+
+async function getBufferedAudioObject(bucket, key, { extension, source, attempts }) {
+  const startedAt = monotonicNowMs();
+  try {
+    const object = await bucket.get(key);
+    attempts.push(ttsR2LookupAttempt({ extension, source, object, startedAt }));
+    return object;
+  } catch (error) {
+    attempts.push(ttsR2LookupAttempt({ extension, source, object: null, startedAt, failed: true }));
+    throw error;
+  }
+}
+
+async function audioObjectBytes(object) {
+  if (typeof object?.arrayBuffer === 'function') return await object.arrayBuffer();
+  return await new Response(object?.body || new Uint8Array()).arrayBuffer();
+}
+
+function migratedAudioObject({ bytes, sourceObject, contentType }) {
+  return {
+    body: bytes,
+    httpMetadata: {
+      ...(sourceObject?.httpMetadata || {}),
+      contentType,
+    },
+    customMetadata: sourceObject?.customMetadata || {},
+  };
+}
+
+async function copyLegacyAudioToPrimary(bucket, {
+  legacyObject,
+  primaryKey,
+  metadata,
+  extension,
+} = {}) {
+  const contentType = objectContentType(legacyObject, extension);
+  let bytes;
+  try {
+    bytes = await audioObjectBytes(legacyObject);
+  } catch (error) {
+    console.error('[ks2-tts] R2 legacy primary migration failed', {
+      extension,
+      keyKind: metadata?.kind || 'sentence',
+      ...audioCacheErrorFields(error),
+    });
+    return legacyObject;
+  }
+  try {
+    await bucket.put(primaryKey, bytes, {
+      httpMetadata: { contentType },
+      customMetadata: {
+        model: metadata.model || SPELLING_AUDIO_MODEL,
+        voice: metadata.voice,
+        contentKey: metadata.contentKey,
+        slug: metadata.slug,
+        source: 'worker-legacy-primary-migration',
+        kind: metadata.kind || 'sentence',
+        ...(metadata.speed ? { speed: metadata.speed } : {}),
+        ...(Number.isInteger(metadata.sentenceIndex) ? { sentenceIndex: String(metadata.sentenceIndex) } : {}),
+      },
+    });
+  } catch (error) {
+    console.error('[ks2-tts] R2 legacy primary migration failed', {
+      extension,
+      keyKind: metadata?.kind || 'sentence',
+      ...audioCacheErrorFields(error),
+    });
+  }
+  return migratedAudioObject({ bytes, sourceObject: legacyObject, contentType });
+}
+
 async function readBufferedGeminiAudio(env, payload, options = {}) {
+  const lookupTelemetry = options.telemetry || null;
+  const lookupAttempts = [];
   const metadata = await bufferedAudioMetadata(payload, options);
-  if (!metadata) return null;
+  if (!metadata) {
+    logTtsR2CacheLookup(lookupTelemetry, {
+      cacheState: 'uncacheable',
+      attempts: lookupAttempts,
+    });
+    return null;
+  }
   const bucket = spellingAudioBucket(env);
   if (!bucket) {
+    logTtsR2CacheLookup(lookupTelemetry, {
+      cacheState: 'unavailable',
+      metadata,
+      extension: 'wav',
+      attempts: lookupAttempts,
+    });
     return {
       object: null,
       metadata,
@@ -405,11 +602,27 @@ async function readBufferedGeminiAudio(env, payload, options = {}) {
     let objectKey = key;
     let source = 'primary';
     try {
-      object = await bucket.get(key);
+      object = await getBufferedAudioObject(bucket, key, {
+        extension,
+        source: 'primary',
+        attempts: lookupAttempts,
+      });
       if (!object && fallbackKey) {
-        object = await bucket.get(fallbackKey);
+        object = await getBufferedAudioObject(bucket, fallbackKey, {
+          extension,
+          source: 'legacy',
+          attempts: lookupAttempts,
+        });
         objectKey = fallbackKey;
-        if (object) source = 'legacy';
+        if (object) {
+          source = 'legacy';
+          object = await copyLegacyAudioToPrimary(bucket, {
+            legacyObject: object,
+            primaryKey: key,
+            metadata,
+            extension,
+          });
+        }
       }
     } catch (error) {
       console.error('[ks2-tts] R2 audio read failed', {
@@ -417,6 +630,12 @@ async function readBufferedGeminiAudio(env, payload, options = {}) {
         keyKind: metadata.kind || 'sentence',
         triedFallback: Boolean(fallbackKey),
         ...audioCacheErrorFields(error),
+      });
+      logTtsR2CacheLookup(lookupTelemetry, {
+        cacheState: 'unavailable',
+        metadata,
+        extension,
+        attempts: lookupAttempts,
       });
       return {
         object: null,
@@ -431,6 +650,13 @@ async function readBufferedGeminiAudio(env, payload, options = {}) {
     const responseMetadata = source === 'legacy'
       ? { ...metadata, model: SPELLING_AUDIO_MODEL }
       : metadata;
+    logTtsR2CacheLookup(lookupTelemetry, {
+      cacheState: 'hit',
+      metadata: responseMetadata,
+      source,
+      extension,
+      attempts: lookupAttempts,
+    });
     return {
       object,
       metadata: responseMetadata,
@@ -440,6 +666,12 @@ async function readBufferedGeminiAudio(env, payload, options = {}) {
       source,
     };
   }
+  logTtsR2CacheLookup(lookupTelemetry, {
+    cacheState: 'miss',
+    metadata,
+    extension: 'wav',
+    attempts: lookupAttempts,
+  });
   return {
     object: null,
     metadata,
@@ -754,16 +986,22 @@ export async function handleTextToSpeechRequest({
   repository,
   now = Date.now(),
   fetchFn = fetch,
+  requestId = '',
 } = {}) {
+  const timing = createTtsTiming();
+  const bodyStartedAt = monotonicNowMs();
   const body = await readJson(request);
+  const bodyMs = monotonicNowMs() - bodyStartedAt;
   const cacheOnly = normaliseTtsCacheOnly(body?.cacheOnly);
   const cacheLookupOnly = normaliseTtsCacheLookupOnly(body?.cacheLookupOnly);
+  timing.enabled = cacheLookupOnly;
+  recordTtsTiming(timing, 'body', bodyMs);
   const payload = {
-    ...(await resolveSpellingAudioRequest({
+    ...(await timeTtsPhase(timing, 'prompt', () => resolveSpellingAudioRequest({
       repository,
       accountId: session.accountId,
       body,
-    })),
+    }))),
     accountId: session.accountId,
     provider: cacheOnly || cacheLookupOnly ? 'gemini' : normaliseRemoteTtsProvider(body?.provider),
     bufferedGeminiVoice: normaliseBufferedGeminiVoice(body?.bufferedGeminiVoice || body?.cachedVoice),
@@ -780,43 +1018,57 @@ export async function handleTextToSpeechRequest({
   let protectedLookup = false;
   async function protectAudioRequest() {
     if (protectedRequest) return;
-    await protectTts(env, request, session, now);
-    await protectDemoTtsFallback({ env, request, session, payload, now });
+    await timeTtsPhase(timing, 'audio_limit', async () => {
+      await protectTts(env, request, session, now);
+      await protectDemoTtsFallback({ env, request, session, payload, now });
+    });
     protectedRequest = true;
   }
   async function protectLookupRequest() {
     if (protectedLookup) return;
-    await protectTtsLookup(env, request, session, now);
-    await protectDemoTtsLookup({ env, request, session, now });
+    await timeTtsPhase(timing, 'lookup_limit', async () => {
+      await protectTtsLookup(env, request, session, now);
+      await protectDemoTtsLookup({ env, request, session, now });
+    });
     protectedLookup = true;
   }
 
   async function finish(response, fallbackFrom = '') {
-    return await recordDemoTtsFallback(env, session, now, withFallbackHeader(response, fallbackFrom));
+    return await recordDemoTtsFallback(env, session, now, withFallbackHeader(withTtsServerTiming(response, timing), fallbackFrom));
   }
 
   async function tryGemini(fallbackFrom = '') {
     if (cacheLookupOnly) await protectLookupRequest();
     else if (!cacheOnly) await protectAudioRequest();
-    const cacheHit = await readBufferedGeminiAudio(env, payload, { model: geminiForPayload.model });
+    const cacheHit = await timeTtsPhase(timing, 'cache_lookup', () => readBufferedGeminiAudio(env, payload, {
+      model: geminiForPayload.model,
+      telemetry: cacheLookupOnly ? {
+        enabled: true,
+        requestId,
+        recordPhase: (name, durationMs) => recordTtsTiming(timing, name, durationMs),
+      } : null,
+    }));
     if (cacheHit?.object) {
       if (cacheLookupOnly) await protectAudioRequest();
-      const output = cacheOnly ? cacheOnlyResponse('hit', cacheHit) : cachedGeminiAudioResponse(cacheHit);
-      return cacheOnly ? output : await finish(output, fallbackFrom);
+      const output = timeTtsPhase(timing, 'response', async () => (
+        cacheOnly ? cacheOnlyResponse('hit', cacheHit) : cachedGeminiAudioResponse(cacheHit)
+      ));
+      const response = await output;
+      return cacheOnly ? withTtsServerTiming(response, timing) : await finish(response, fallbackFrom);
     }
-    if (cacheLookupOnly && cacheHit?.cacheUnavailable) return cacheOnlyResponse('unavailable', cacheHit);
-    if (cacheLookupOnly && !cacheHit?.metadata) return cacheOnlyResponse('uncacheable');
-    if (cacheLookupOnly) return cacheOnlyResponse('miss', cacheHit);
-    if (cacheOnly && cacheHit?.cacheUnavailable) return cacheOnlyResponse('unavailable', cacheHit);
-    if (cacheOnly && !cacheHit?.metadata) return cacheOnlyResponse('uncacheable');
+    if (cacheLookupOnly && cacheHit?.cacheUnavailable) return withTtsServerTiming(cacheOnlyResponse('unavailable', cacheHit), timing);
+    if (cacheLookupOnly && !cacheHit?.metadata) return withTtsServerTiming(cacheOnlyResponse('uncacheable'), timing);
+    if (cacheLookupOnly) return withTtsServerTiming(cacheOnlyResponse('miss', cacheHit), timing);
+    if (cacheOnly && cacheHit?.cacheUnavailable) return withTtsServerTiming(cacheOnlyResponse('unavailable', cacheHit), timing);
+    if (cacheOnly && !cacheHit?.metadata) return withTtsServerTiming(cacheOnlyResponse('uncacheable'), timing);
     if (cacheOnly) {
-      if (!geminiForPayload.apiKey) return cacheOnlyResponse('unavailable');
+      if (!geminiForPayload.apiKey) return withTtsServerTiming(cacheOnlyResponse('unavailable'), timing);
       const warmupAllowed = await allowTtsWarmup(env, request, session, now);
-      if (!warmupAllowed) return cacheOnlyResponse('skipped_rate_limited');
+      if (!warmupAllowed) return withTtsServerTiming(cacheOnlyResponse('skipped_rate_limited'), timing);
       await protectDemoTtsFallback({ env, request, session, payload, now });
     }
     if (!geminiForPayload.apiKey) {
-      if (cacheOnly) return cacheOnlyResponse('unavailable');
+      if (cacheOnly) return withTtsServerTiming(cacheOnlyResponse('unavailable'), timing);
       throw missingProviderConfig('gemini');
     }
     if (!cacheOnly) await protectAudioRequest();
@@ -825,7 +1077,7 @@ export async function handleTextToSpeechRequest({
     const output = cacheOnly
       ? cacheOnlyResponse(stored.cacheState, { metadata: stored.metadata })
       : stored.response;
-    return await finish(output, fallbackFrom);
+    return await finish(withTtsServerTiming(output, timing), fallbackFrom);
   }
 
   async function tryOpenAi(fallbackFrom = '') {

--- a/worker/src/tts.js
+++ b/worker/src/tts.js
@@ -569,6 +569,7 @@ async function copyLegacyAudioToPrimary(bucket, {
 async function readBufferedGeminiAudio(env, payload, options = {}) {
   const lookupTelemetry = options.telemetry || null;
   const lookupAttempts = [];
+  const allowLegacyMigration = options.allowLegacyMigration !== false;
   const metadata = await bufferedAudioMetadata(payload, options);
   if (!metadata) {
     logTtsR2CacheLookup(lookupTelemetry, {
@@ -616,12 +617,14 @@ async function readBufferedGeminiAudio(env, payload, options = {}) {
         objectKey = fallbackKey;
         if (object) {
           source = 'legacy';
-          object = await copyLegacyAudioToPrimary(bucket, {
-            legacyObject: object,
-            primaryKey: key,
-            metadata,
-            extension,
-          });
+          if (allowLegacyMigration) {
+            object = await copyLegacyAudioToPrimary(bucket, {
+              legacyObject: object,
+              primaryKey: key,
+              metadata,
+              extension,
+            });
+          }
         }
       }
     } catch (error) {
@@ -1037,11 +1040,12 @@ export async function handleTextToSpeechRequest({
     return await recordDemoTtsFallback(env, session, now, withFallbackHeader(withTtsServerTiming(response, timing), fallbackFrom));
   }
 
-  async function tryGemini(fallbackFrom = '') {
+ async function tryGemini(fallbackFrom = '') {
     if (cacheLookupOnly) await protectLookupRequest();
     else if (!cacheOnly) await protectAudioRequest();
     const cacheHit = await timeTtsPhase(timing, 'cache_lookup', () => readBufferedGeminiAudio(env, payload, {
       model: geminiForPayload.model,
+      allowLegacyMigration: !cacheLookupOnly && !cacheOnly,
       telemetry: cacheLookupOnly ? {
         enabled: true,
         requestId,


### PR DESCRIPTION
## Summary

Production TTS cache work can now separate word-only lookup, sentence-cache lookup, server timing phases, and browser direct-audio play-start instead of treating the old cached-audio wait as a single black box. The Worker cache path also avoids diagnostic lookup side effects: lookup-only requests no longer migrate legacy R2 objects before the playback quota guard, while normal cached playback still keeps the primary migration repair path.

The production smoke output is now safe to store in CI or /tmp: it keeps the pass/fail invariants but removes learner ids, prompt tokens, session values, and full R2 object keys from report JSON.

## Measurement And Validation

| Check | Result |
| --- | --- |
| Prior production diagnosis | word-only cache around 204 ms; /api/health around 92 ms; cached sentence header wait around 1.6 s, pointing at server-side lookup/fallback rather than browser playback alone |
| Post-deploy TTS probe | ok=true; sentence-cache primary hits only; accident total p50 323 ms / p95 324 ms; knowledge total p50 337 ms / p95 390 ms; no TTS failures |
| Post-deploy browser direct audio | browser-direct-audio ok=true; skipped=false; cache=hit/source=primary; header 410 ms; play-start 595 ms |
| Post-deploy spelling audio smoke | ok=true; word and sentence probes hit primary cache; cross-account token/key isolation probe ok |
| Production UI smoke | Playwright clicked Try demo on https://ks2.eugnel.uk; /api/auth/session 200, /api/bootstrap 200, dashboard rendered Demo Learner/Spelling; no console/page/request/server errors |
| Deployment | npm run deploy passed; Worker Version ID 5fe4aedb-77af-43f8-b9bf-a3a1a672c0ae; production bundle audit passed |
| Focused TTS/probe tests | node --test tests/spelling-tts.test.js tests/production-performance-probe.test.js tests/spelling-audio-production-smoke.test.js tests/worker-tts.test.js passed 99/99 |
| Full test suite | npm test passed 111,682 / 0 failed / 8 skipped |
| Deploy dry run | npm run check passed; main bundle 212,768 bytes gzip during check and 212,788 bytes gzip during deploy, both under the 232,000-byte gate |
| CI | gh pr checks --watch passed for PR #905; Audits, Node Tests, 80 test shards, Wrangler dry-run, GitGuardian, and audits passed; Chromium/mobile golden path was skipped by workflow configuration |

## Notes

--browser-tts is deliberately labelled browser-direct-audio: it fetches /api/tts from headless Playwright and measures Audio playback start. The real in-app createPlatformTts telemetry path is covered by unit tests here, and the follow-up production-safe UI telemetry probe is tracked in fol2/ks2-mastery#904.

Residual review findings are also recorded in docs/residual-review-findings/codex-tts-cache-r2-opt.md.

## Test Plan

- git diff --check
- node --test tests/spelling-tts.test.js tests/production-performance-probe.test.js tests/spelling-audio-production-smoke.test.js tests/worker-tts.test.js
- node --test tests/production-performance-probe.test.js
- npm test
- npm run check
- npm run deploy
- curl https://ks2.eugnel.uk/api/health
- NODE_OPTIONS="--require /tmp/ks2-undici-prod-agent.cjs" npm run perf:production -- --samples 2 --warmup 1 --word-sample accident,knowledge --voices Iapetus --browser-tts
- NODE_OPTIONS="--require /tmp/ks2-undici-prod-agent.cjs" npm run smoke:production:spelling-audio -- --word-sample accident,knowledge --sentence-sample accident,knowledge --json
- Playwright production UI smoke: open https://ks2.eugnel.uk, click Try demo, verify session/bootstrap 200 and dashboard render
- gh pr checks --watch

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
