### PR TITLE
Add content operations foundation for spelling releases

### DIFF
--- a/docs/brainstorms/2026-06-10-content-operations-centre-requirements.md
+++ b/docs/brainstorms/2026-06-10-content-operations-centre-requirements.md
@@ -103,14 +103,14 @@ flowchart TB
   - **Actors:** A1, A6, A7, A9
   - **Steps:** The system computes missing audio by lane, voice, pace, slug, and sentence id, then allows selected generation, batch generation, or approved override through the TTS service.
   - **Outcome:** R2 audio readiness is visible and traceable before approval, with no manual audio upload path.
-  - **Covered by:** R20, R21, R22, R23, R24, R25, R26, R27, R28
+  - **Covered by:** R29, R30, R31, R32, R33, R34, R35, R36, R37, R38, R39, R40
 
 - F4. Configure pools, rewards, monsters, and Hero exposure
   - **Trigger:** A package creates a pool, changes a reward rule, binds a monster, uploads assets, or changes Hero / Codex visibility.
   - **Actors:** A1, A5, A8, A9
   - **Steps:** The admin configures pool metadata, reward tracks, progression mode, thresholds, monster bindings, image assets, and staged visibility in one package.
   - **Outcome:** A learner-visible pool cannot ship without complete reward, asset, and exposure configuration unless the package explicitly approves an exception.
-  - **Covered by:** R29, R30, R31, R32, R33, R34, R35, R36, R37, R38, R39, R40, R41, R42, R43, R44, R45, R46
+  - **Covered by:** R41, R42, R43, R44, R45, R46, R47, R48, R49, R50, R51, R52, R53, R54, R55, R56, R57, R58, R59, R60, R61
 
 - F5. Rebase, resolve conflicts, approve, and publish
   - **Trigger:** An admin submits a package for approval or attempts to publish after the global release has changed.
@@ -131,7 +131,7 @@ flowchart TB
   - **Actors:** A1, A2, A5, A7, A9
   - **Steps:** Whole-release rollback restores a prior global release after approval; package revert creates an inverse package that goes through validation, approval, and publish.
   - **Outcome:** Recovery is available without deleting R2 audio or losing package audit history.
-  - **Covered by:** R47, R48, R49
+  - **Covered by:** R74, R75, R76, R77, R78
 
 ---
 
@@ -177,7 +177,7 @@ flowchart TB
 **Audio Operations**
 
 - R29. Each package must have an `audioRequirementProfile` that defines required voices and paces by audio lane.
-- R30. The default word lane must require male and female natural or normal pace audio.
+- R30. The default word lane must require male and female natural pace audio.
 - R31. The default sentence dictation lane must require male and female normal and slow pace audio.
 - R32. Audio readiness scans must report missing, present, stale, generated, failed, skipped, and override-requested states by lane, voice, pace, slug, sentence id, model, and content key.
 - R33. Admins must be able to generate selected audio, batch generate a package scope, and regenerate existing audio through an explicit override action.

--- a/docs/brainstorms/2026-06-10-content-operations-centre-requirements.md
+++ b/docs/brainstorms/2026-06-10-content-operations-centre-requirements.md
@@ -1,0 +1,340 @@
+---
+date: 2026-06-10
+topic: content-operations-centre
+---
+
+# Content Operations Centre
+
+## Summary
+
+The Content Operations Centre is a global Admin Console workflow for managing English Spelling content, spelling audio generation, spelling pools, reward tracks, monster bindings, monster image assets, and Hero / Codex exposure through one approved release package model.
+
+The work should be delivered as one contract and implementation plan, then split into epics and tickets. Delivery order may be staged, but the data model, approval workflow, validation gates, and rollback strategy must be designed as one connected system so no ticket ships a partial surface with hidden production gaps.
+
+---
+
+## Problem Frame
+
+English Spelling now has a draft, validation, publish, and runtime-snapshot content model, but the Admin Console only exposes thin import, export, publish, reset, and status hooks. Adding or correcting a word still requires engineering work against `content/spelling.seed.json`, regeneration, validation, deployment, and separate audio cache handling.
+
+James needs an operator-facing UI that can manage every learner-facing part of a spelling content release: words, word families, sentence entries, pools, audio readiness, reward tracks, monster bindings, Hero / Codex visibility, and monster image assets. The same workflow must protect production-sensitive paths such as learner state, D1 content storage, R2 audio, generated runtime bundles, Hero rewards, and English Spelling parity.
+
+The existing Monster Visual & Effect Config and Asset & Effect Registry establish a useful admin pattern for draft, publish, restore, review gates, preview, and fallback. The new centre should reuse that discipline but widen it from visual config alone to complete spelling content operations.
+
+---
+
+## Key Decisions
+
+- **Single release package.** Spelling words, word-family variants, sentence entries, pools, reward tracks, monster bindings, Hero / Codex visibility, required audio readiness, and monster image asset references are approved and published together.
+- **Multiple change packages.** Every ticket or epic works inside a `changePackage` with its own base release hash, diff, validation results, audio scan, asset checks, approval record, and publish state.
+- **Optimistic merge with hard conflict blocking.** Unrelated packages can rebase automatically onto the current global release. Same entity and same field conflicts block publish until an admin resolves them.
+- **Approval required for publish.** V1 maps edit, approve, and publish capability to the existing `admin` role, so one admin user can complete the whole workflow. The UI and audit model still separate edit, approval, and publish states so future roles can split these capabilities without changing the workflow.
+- **Global default with account override capability.** V1 manages global product content. The runtime model should reserve account override support for future special programmes or diagnostics, but the primary Admin UI must not make account-specific content the default path.
+- **Audio is generated, not uploaded.** Admin users may scan, generate, batch generate, and override audio through the TTS generation service. They must not upload arbitrary audio files.
+- **Audio requirements are lane-configurable.** Each release package declares an `audioRequirementProfile` by lane. The default profile requires word audio in male and female natural pace, and sentence dictation audio in male and female normal and slow pace.
+- **Pools have reward tracks, not hard-coded one-monster rules.** A pool may have zero or more reward tracks. Learner-facing pools require at least one active reward track unless the package explicitly approves a no-reward exception.
+- **Track-defined progression.** Each reward track defines whether it progresses in parallel or after another track. UI defaults to parallel.
+- **Hero is an exposure layer.** Monster identity, reward track progression, and Hero / Codex exposure are separate concepts. Hero does not introduce a second creature model.
+- **Scheduled and staged visibility.** A package can publish content before making a pool or reward track learner-visible. Visibility can be hidden, visible, scheduled, or gated by rollout flag.
+- **Published deletion becomes retirement.** Draft-only items may be hard deleted. Once published, words, sentence entries, pools, reward tracks, and bindings are retired or tombstoned instead of removed.
+- **Rollback and revert both exist.** Operators can roll back a whole global release for emergencies and create inverse packages to revert individual published packages in normal operations.
+
+```mermaid
+flowchart TB
+  A["Open or create change package"] --> B["Edit package-scoped content, audio, reward, asset, or visibility data"]
+  B --> C["Build merged candidate against current global release"]
+  C --> D{"Validation, audio, asset, reward, and visibility gates pass?"}
+  D -->|no| E["Resolve blockers or conflicts"]
+  E --> C
+  D -->|yes| F["Submit for approval"]
+  F --> G["Approve exact candidate hash"]
+  G --> H["Publish package into immutable global release"]
+  H --> I["Runtime reads published release plus visibility rules"]
+```
+
+---
+
+## Terminology
+
+- **Global release:** The immutable platform-level published spelling operations state used by learner runtime surfaces.
+- **Change package:** A ticket-scoped draft diff against a base global release. It is the unit of edit, validation, approval, publish, revert, and audit.
+- **Merged candidate:** The result of applying a change package to the current global release. Approval binds to this exact candidate hash.
+- **Spelling pool:** A content and practice grouping such as core statutory words, Extra words, or a future themed pool.
+- **Word-family variant:** A variant prompt under a base word. Variants may have their own accepted spellings, explanations, and sentence references, while progress can remain keyed to the base slug where the pool rules require it.
+- **Audio lane:** A generation target such as word audio or sentence dictation audio, each with its own voice and pace requirements.
+- **Reward track:** A rule that converts pool progress into monster catch, evolve, level-up, mega, or related reward states.
+- **Monster:** The creature identity, image assets, visual metadata, branches, and stages shown in learner-facing surfaces.
+- **Hero exposure:** The configuration that makes a reward track or monster appear in Hero Camp, Hero Quest, Codex, or subject setup.
+
+---
+
+## Actors
+
+- A1. James / Admin operator: Creates packages, edits content, runs scans, generates audio, uploads monster images, resolves conflicts, approves, publishes, rolls back, and reverts.
+- A2. Future approver / publisher: A capability holder who may later approve or publish without being the same role as the editor.
+- A3. Operations viewer: Can inspect packages, release history, validation, audio status, and asset previews without mutating production state.
+- A4. Learner: Sees only published and currently visible spelling content, reward tracks, monster assets, and Hero / Codex exposure.
+- A5. Content runtime: Resolves global release, optional account override, visibility state, and bundled fallback into learner-safe runtime snapshots.
+- A6. TTS generation service: Generates approved word and sentence audio variants and stores them in R2 with provenance.
+- A7. R2 audio store: Serves generated spelling audio by content-addressed keys and retains orphaned objects until cleanup.
+- A8. Monster asset registry: Stores, validates, previews, and publishes monster image assets and visual metadata.
+- A9. Package merge engine: Rebases packages, detects conflicts, builds merged candidates, invalidates stale approvals, and records audit events.
+
+---
+
+## Key Flows
+
+- F1. Create a package from a light template
+  - **Trigger:** An admin wants to add words, create a pool, refill audio, update a monster asset, bind rewards, or change Hero visibility.
+  - **Actors:** A1, A9
+  - **Steps:** The admin chooses a light template, the system records the base release id and hash, and the package opens with relevant checklist tabs.
+  - **Outcome:** All future mutations are scoped to a package rather than an untracked shared draft.
+  - **Covered by:** R1, R2, R3, R4, R50, R51
+
+- F2. Edit spelling content in a package
+  - **Trigger:** An admin edits words, word families, sentence entries, accepted spellings, explanations, pools, provenance, or visibility.
+  - **Actors:** A1, A5, A9
+  - **Steps:** The UI shows the current published value beside the package draft value, records structured operations, and validates the package plus merged candidate.
+  - **Outcome:** The admin can manage content through UI without touching generated runtime files.
+  - **Covered by:** R12, R13, R14, R15, R16, R17, R18, R19, R52, R53
+
+- F3. Scan and generate audio
+  - **Trigger:** A package adds or changes words, variants, sentences, audio profile requirements, or requests an override.
+  - **Actors:** A1, A6, A7, A9
+  - **Steps:** The system computes missing audio by lane, voice, pace, slug, and sentence id, then allows selected generation, batch generation, or approved override through the TTS service.
+  - **Outcome:** R2 audio readiness is visible and traceable before approval, with no manual audio upload path.
+  - **Covered by:** R20, R21, R22, R23, R24, R25, R26, R27, R28
+
+- F4. Configure pools, rewards, monsters, and Hero exposure
+  - **Trigger:** A package creates a pool, changes a reward rule, binds a monster, uploads assets, or changes Hero / Codex visibility.
+  - **Actors:** A1, A5, A8, A9
+  - **Steps:** The admin configures pool metadata, reward tracks, progression mode, thresholds, monster bindings, image assets, and staged visibility in one package.
+  - **Outcome:** A learner-visible pool cannot ship without complete reward, asset, and exposure configuration unless the package explicitly approves an exception.
+  - **Covered by:** R29, R30, R31, R32, R33, R34, R35, R36, R37, R38, R39, R40, R41, R42, R43, R44, R45, R46
+
+- F5. Rebase, resolve conflicts, approve, and publish
+  - **Trigger:** An admin submits a package for approval or attempts to publish after the global release has changed.
+  - **Actors:** A1, A2, A9
+  - **Steps:** The system auto-rebases unrelated changes, blocks same-field conflicts, requires manual conflict resolution, rebuilds the merged candidate, invalidates stale approvals, and allows publish only after approval of the exact candidate hash.
+  - **Outcome:** Packages do not overwrite each other by accident, and production receives only reviewed merged releases.
+  - **Covered by:** R5, R6, R7, R8, R9, R10, R11, R54, R55, R56, R57
+
+- F6. Stage visibility and prove production readiness
+  - **Trigger:** A package is published with hidden, scheduled, or rollout-flagged exposure.
+  - **Actors:** A1, A4, A5
+  - **Steps:** Runtime surfaces read the published release and visibility rules, the Admin Console tracks hidden or scheduled assets, and production proof checks the exposed learner surfaces when visibility is enabled.
+  - **Outcome:** Content can be prepared ahead of learner exposure without leaking drafts.
+  - **Covered by:** R44, R45, R46, R58, R59
+
+- F7. Roll back or revert
+  - **Trigger:** A production issue requires reversing a whole release or undoing one package.
+  - **Actors:** A1, A2, A5, A7, A9
+  - **Steps:** Whole-release rollback restores a prior global release after approval; package revert creates an inverse package that goes through validation, approval, and publish.
+  - **Outcome:** Recovery is available without deleting R2 audio or losing package audit history.
+  - **Covered by:** R47, R48, R49
+
+---
+
+## Requirements
+
+**Release and Package Model**
+
+- R1. The Content Operations Centre must live inside the existing role-gated Admin Console rather than a public route.
+- R2. Every production mutation must belong to a `changePackage`; browsing current state may be package-free, but editing may not.
+- R3. A package must record its light template, base global release id, base release hash, creator, created time, and current lifecycle state.
+- R4. Light templates must include new spelling words, edit spelling word or family, new spelling pool, audio refill or regenerate, monster asset update, reward binding update, and Hero / Codex visibility update.
+- R5. Package validation must run against both the package diff and the merged candidate global release.
+- R6. If the global release changes after package creation, the system must auto-rebase unrelated changes.
+- R7. Same entity and same field conflicts must block publish until an admin resolves them in UI; last-write-wins is not allowed.
+- R8. Conflict resolution must invalidate prior approval and require validation, audio scan, asset checks, and approval to run again.
+- R9. Publishing a package must create a new immutable global release version linked to the package id and candidate hash.
+
+**Approval and Audit**
+
+- R10. Approval is required before publish, even when the same V1 admin user edits and approves the package.
+- R11. V1 must expose edit, approval, and publish actions to the existing `admin` role while modelling separate capabilities for future role splits.
+- R12. Package lifecycle states must distinguish draft, ready for approval, approved, published, rejected, blocked, reverted, and superseded states.
+- R13. Approval must record approver account id, approval time, notes, candidate hash, base release id, merged release hash, validation summary, audio fallback decision, and asset readiness summary.
+- R14. Any package mutation after approval must invalidate approval.
+- R15. Publish must only apply the exact approved candidate hash.
+- R16. Audit history must record create, edit, scan, generate, override, rebase, conflict resolution, approval, publish, rollback, and revert events.
+- R17. Safe-copy and export actions must use the existing admin redaction discipline and avoid leaking learner or account personal data.
+
+**Spelling Editorial Management**
+
+- R18. Admin UI must manage spelling word lists, pools, words, word-family variants, sentence entries, accepted spellings, explanations, tags, source notes, and provenance.
+- R19. Each editable word must show its current published state, package draft state, validation state, audio readiness, pool membership, and reward impact.
+- R20. Word-family variants must be first-class editable children of a base word, with their own accepted spellings, learner-facing explanation, sentence references, and audio readiness.
+- R21. The model must keep clear whether progress and rewards are keyed to the base word slug or to variant-specific prompts.
+- R22. Core statutory spelling parity must be preserved unless James explicitly accepts a documented trade-off in the package approval notes.
+- R23. Extra and future non-statutory pools must not inflate statutory Years 3-4, Years 5-6, or core completion metrics.
+- R24. Sentence entries must remain linked by stable ids rather than free text embedded directly in each word row.
+- R25. A word or variant cannot become learner-visible without at least one valid sentence reference, accepted spelling set, explanation, pool assignment, and provenance.
+- R26. Draft-only items may be hard deleted before first publish.
+- R27. Published words, sentences, pools, reward tracks, and bindings must be retired or tombstoned instead of hard deleted.
+- R28. Retired items must not appear in new learner sessions or active pool totals, but must remain available for audit and learner-history references.
+
+**Audio Operations**
+
+- R29. Each package must have an `audioRequirementProfile` that defines required voices and paces by audio lane.
+- R30. The default word lane must require male and female natural or normal pace audio.
+- R31. The default sentence dictation lane must require male and female normal and slow pace audio.
+- R32. Audio readiness scans must report missing, present, stale, generated, failed, skipped, and override-requested states by lane, voice, pace, slug, sentence id, model, and content key.
+- R33. Admins must be able to generate selected audio, batch generate a package scope, and regenerate existing audio through an explicit override action.
+- R34. Audio override must be a high-risk action that invalidates approval and records the reason.
+- R35. Audio assets must be generated through the approved TTS generation service and stored in R2; manual audio upload must not be supported.
+- R36. Generated audio provenance must include source content identity, voice, pace, model, prompt/profile version, generated account id, generated time, and R2 key.
+- R37. The publish gate must default to strict audio readiness.
+- R38. Approval may explicitly allow runtime TTS fallback for a release, with reason, affected matrix summary, approving account id, and timestamp.
+- R39. Packages published with fallback allowed must leave a visible Admin warning until all required audio is generated.
+- R40. Audio scans and generation must cover both word audio and sentence dictation audio.
+
+**Pools, Reward Tracks, and Monster Bindings**
+
+- R41. A spelling pool must be a learner-facing practice grouping with stable id, title, pool type, source notes, active or retired state, and visibility configuration.
+- R42. A pool may have zero or more reward tracks, but learner-facing active pools require at least one active reward track unless the package approval explicitly allows no reward.
+- R43. Each reward track must bind to one monster and define progression mode, threshold template, optional threshold overrides, active state, and display labels.
+- R44. Threshold templates must provide sensible defaults, and per-pool overrides must be allowed.
+- R45. Reward thresholds must validate against active pool word counts and cannot require impossible progress.
+- R46. Track-defined progression must support `parallel` and `sequentialAfter`, with `parallel` as the UI default.
+- R47. Sequential reward tracks must reference an existing prior track and must not create cycles.
+- R48. Cross-pool reward dependencies must be blocked unless explicitly allowed by package approval.
+- R49. Reward track changes must preserve learner history and avoid corrupting existing monster progress.
+
+**Monster Image Assets**
+
+- R50. V1 asset upload must support monster image assets only.
+- R51. Uploaded monster assets must be validated for allowed format, expected dimensions or derivable responsive sizes, monster id, branch, stage, and renderer-preview compatibility.
+- R52. Asset upload must create draft assets in a package; learner runtime must continue using published assets until package publish.
+- R53. Admin UI must preview monster assets in relevant renderer contexts before approval.
+- R54. A learner-visible monster binding must not publish if required image assets are missing or invalid.
+- R55. Existing Monster Visual & Effect Config review and fallback principles must remain compatible with uploaded assets.
+- R56. Asset changes must not alter reward thresholds, learner state, or progression logic unless those changes are explicitly included in the same package.
+
+**Hero and Codex Exposure**
+
+- R57. Hero exposure must be configuration over published reward tracks and monsters, not a separate creature identity model.
+- R58. Hero Camp, Hero Quest, Codex, and subject setup must read published and currently visible exposure rules.
+- R59. Exposure rules must support hidden, visible, scheduled, and rollout-flag states.
+- R60. First learner-visible exposure of a new pool, monster, or reward track must go through the package approval boundary.
+- R61. Hidden or scheduled published content must remain available for audio generation, asset checks, and admin preview.
+
+**Global Content Resolution**
+
+- R62. The primary V1 UI must manage global product content, not account-scoped content.
+- R63. Runtime resolution must reserve the order: explicit account override, global published release, bundled fallback.
+- R64. Account override support must remain outside the main V1 UI unless used for diagnostics or a later special programme workflow.
+- R65. Bundled fallback must stay available so a broken remote release cannot blank spelling or monster runtime surfaces.
+
+**UI and Operator Experience**
+
+- R66. The Content Operations Centre home must prioritise open packages, blocked packages, ready-for-approval packages, approved pending publish packages, and recently published releases.
+- R67. Top-level areas must include Packages, Spelling, Audio, Pools & Rewards, Monsters & Assets, Hero / Codex, Approvals, and Release History.
+- R68. Area pages may browse published state without an active package, but any mutation must ask the admin to choose or create a package.
+- R69. Package detail pages must expose the same domain tabs scoped to that package.
+- R70. Item-level UI must show published value, package draft value, diff state, validation blockers, audio blockers, asset blockers, reward impact, and visibility impact.
+- R71. The conflict resolver must support keeping the package value, keeping the current release value, or editing a merged value.
+- R72. Generated runtime files must remain downstream outputs; operators must not be asked to edit `src/subjects/spelling/data/*` or `worker/src/generated-spelling-content-seed.js`.
+- R73. Large content reads must avoid pulling the full spelling dataset into the public React bundle.
+
+**Release History, Rollback, and Revert**
+
+- R74. Release History must show global release versions, included packages, changed entities, audio fallback decisions, asset changes, approver, publisher, publish time, and production proof status.
+- R75. Whole-release rollback must be available as an approved high-risk action for emergency recovery.
+- R76. Package-level revert must create an inverse change package that follows the same validation, approval, and publish workflow.
+- R77. Rollback and revert must not delete R2 audio objects; audio cleanup belongs to a separate retention process.
+- R78. Production proof must be captured when learner-facing visibility changes, especially for Spelling setup, Word Bank, Hero / Codex, and monster rendering surfaces.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R1, R2, R18, R29, R41, R42, R57.** Given an admin creates a "New spelling pool" package, when they add a pool, words, sentences, audio requirements, reward track, monster binding, and Hero exposure, then the package validates as one release unit rather than separate partial approvals.
+- AE2. **Covers R10, R13, R14, R15.** Given an admin approves a package, when any word, sentence, reward track, asset, or visibility field changes afterwards, then the previous approval becomes invalid and publish is blocked until re-approval.
+- AE3. **Covers R10, R11.** Given V1 only has the `admin` role, when James edits and approves a package with the same account, then the UI allows the workflow but still records distinct edit and approval events.
+- AE4. **Covers R6, R7, R8, R71.** Given package A edits `metamorphosis.explanation` and package B also edits the same field, when package B tries to publish second, then the system blocks publish and opens conflict resolution.
+- AE5. **Covers R6, R9.** Given package A adds `botanist` to one pool and package B adds `arachnid` to another pool, when package B publishes after package A, then the system auto-rebases package B and publishes a new global release without manual conflict resolution.
+- AE6. **Covers R20, R21, R25, R40.** Given an Extra base word has two word-family variants, when a variant lacks a sentence reference or sentence audio readiness, then approval shows the gap at the variant level rather than hiding it under the base word.
+- AE7. **Covers R29, R32, R37, R38, R39.** Given a package adds a new sentence and the required slow female audio is missing, when the admin approves fallback with notes, then publish can proceed and the Admin Console keeps warning until that audio is generated.
+- AE8. **Covers R33, R34, R35, R36.** Given an admin wants to replace poor-quality audio, when they choose override, then the system regenerates through TTS, writes to R2 with new provenance, invalidates approval, and does not offer file upload.
+- AE9. **Covers R42, R43, R45, R46, R47.** Given a pool has two reward tracks, one parallel and one sequential, when thresholds exceed the active pool count or create a sequence cycle, then publish is blocked with specific reward-track errors.
+- AE10. **Covers R50, R51, R52, R53, R54.** Given an admin uploads a new monster stage image, when the image fails validation or cannot preview in required contexts, then the package cannot make that monster binding learner-visible.
+- AE11. **Covers R58, R59, R60, R61.** Given a new pool is published with scheduled visibility for next week, when learners open Spelling today, then they do not see the pool, while Admin can still preview it and generate audio.
+- AE12. **Covers R26, R27, R28.** Given a word has already been published and learners may have progress for it, when an admin removes it from active practice, then the word is retired rather than hard deleted.
+- AE13. **Covers R62, R63, R64, R65.** Given no account override exists, when a learner starts Spelling, then runtime uses the global published release; if remote content is unavailable, it falls back to the bundled release.
+- AE14. **Covers R74, R75, R76, R77.** Given a published package causes a production issue, when the admin chooses recovery, then they can either roll back the whole release or create a package-level revert without deleting audio objects.
+
+---
+
+## Success Criteria
+
+- James can add, edit, retire, and review spelling words, word families, sentence entries, pools, reward tracks, monster bindings, Hero / Codex exposure, and monster images from Admin UI without code edits.
+- Every learner-visible spelling content change is package-scoped, validated as a merged candidate, approved, audited, and published into an immutable global release.
+- Word and sentence audio readiness is visible at the same level as content readiness, with controlled fallback and no arbitrary audio upload.
+- A new pool cannot become learner-visible with missing reward, monster, asset, audio, or visibility configuration unless the package explicitly records the approved exception.
+- Multiple tickets can proceed in parallel without a shared-draft collision or last-write-wins overwrite.
+- English Spelling statutory parity, learner progress, D1 content safety, R2 audio provenance, and runtime fallback behaviour remain protected.
+- Release History gives enough evidence to review, roll back, or revert production changes without reconstructing what happened from git alone.
+
+---
+
+## Scope Boundaries
+
+- Do not build a general CMS for every subject in V1. The full manager is for spelling-centred content operations with reward, audio, monster, and Hero dependencies.
+- Do not support manual audio upload. Audio must be generated through the approved TTS service and stored in R2.
+- Do not make account-scoped content the primary Admin UI path in V1.
+- Do not rewrite the spelling engine, scheduler, marking logic, or statutory word parity rules as part of this centre.
+- Do not let draft package edits leak into learner runtime before publish and visibility activation.
+- Do not hard delete published content or R2 audio objects as part of normal editorial removal.
+- Do not require operators to edit generated runtime modules or seed files manually for normal content operations.
+- Do not make monster image changes alter reward progression unless the package explicitly changes reward-track rules.
+
+---
+
+## Dependencies / Assumptions
+
+- The existing Admin Console remains the correct protected home for this workflow.
+- Existing `admin` role can perform edit, approval, and publish in V1, while capability names are modelled for future role separation.
+- Existing spelling draft, publish, validation, and runtime snapshot helpers remain the behavioural starting point.
+- Existing account-scoped `account_subject_content` storage is not the final global product-content model; planning must define how global releases and optional account overrides coexist.
+- Existing TTS and R2 cache helpers remain the approved audio path, but planning may need to extend key shapes or job metadata to support configurable lane profiles.
+- Existing Monster Visual & Effect Config and Asset & Effect Registry patterns provide the draft, publish, preview, review, restore, and fallback precedent for monster image assets.
+- Existing generated runtime bundle-size constraints still apply; public client bundles must not absorb full content datasets.
+- Production verification remains required when learner-facing visibility changes on `https://ks2.eugnel.uk`.
+
+---
+
+## Sources / Research
+
+- `docs/spelling-content-model.md`
+- `docs/spelling-word-audio.md`
+- `docs/monster-visual-config.md`
+- `docs/brainstorms/2026-04-22-spelling-extra-expansion-requirements.md`
+- `docs/brainstorms/2026-04-24-monster-visual-config-centre-requirements.md`
+- `docs/solutions/learning-spelling-audio-cache-contract.md`
+- `docs/solutions/architecture-patterns/admin-console-p6-evidence-integrity-content-ops-maturity-2026-04-29.md`
+- `src/surfaces/hubs/AdminContentSection.jsx`
+- `src/platform/hubs/admin-asset-registry.js`
+- `src/subjects/spelling/content/model.js`
+- `src/subjects/spelling/content/service.js`
+- `worker/src/app.js`
+- `worker/src/repository.js`
+
+---
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+- None.
+
+### Deferred to Planning
+
+- [Affects R3, R5, R9, R62][Technical] Define the D1 schema and migration path for global releases, change packages, package operations, approvals, and optional account overrides.
+- [Affects R6, R7, R8, R71][Technical] Define the operation format and conflict-detection rules for same entity and same field merges.
+- [Affects R29, R30, R31, R36][Technical] Confirm exact TTS voice identifiers, pace identifiers, model defaults, and cache-key versioning for configurable audio lanes.
+- [Affects R32, R33, R39][Technical] Decide whether batch audio generation runs inside Worker-triggered queues, local operator scripts, or a hybrid service wrapper.
+- [Affects R50, R51, R53, R55][Technical] Define monster image upload constraints, responsive size generation, storage location, validation rules, and preview contexts.
+- [Affects R41, R42, R43, R44, R45][Technical] Define the reward-track schema and how existing Spelling monsters map into the new track model without changing current learner progress.
+- [Affects R58, R59, R60][Technical] Define the storage and runtime resolution model for hidden, scheduled, visible, and rollout-flagged exposure.
+- [Affects R74, R75, R76][Technical] Define rollback and inverse-package generation rules, including how retired content and visibility changes revert.

--- a/docs/plans/2026-06-11-feat-content-operations-centre-plan.md
+++ b/docs/plans/2026-06-11-feat-content-operations-centre-plan.md
@@ -98,7 +98,7 @@ Out of scope:
 
 6. **Audio is generated through TTS only.** The admin centre can scan, queue, generate, regenerate, and override TTS audio. It must not provide audio file upload. R2 keys and provenance should remain content-addressed and must include lane, voice, pace, model, prompt/profile version, and source identity.
 
-7. **Audio requirements are profile-driven.** Do not hard-code four audio outputs for every entity. Store `audioRequirementProfile` by lane. Default word lane is male/female natural or normal pace. Default sentence dictation lane is male/female normal and slow pace.
+7. **Audio requirements are profile-driven.** Do not hard-code four audio outputs for every entity. Store `audioRequirementProfile` by lane. Default word lane is male/female natural pace. Default sentence dictation lane is male/female normal and slow pace.
 
 8. **Reward tracks are separate from monsters.** Pools bind to zero or more reward tracks. Each reward track binds to one monster and defines progression mode, threshold template, optional overrides, active state, and labels. Hero / Codex exposure reads reward tracks and monsters; it does not create a second creature model.
 
@@ -132,7 +132,7 @@ Proposed tables:
 - `content_operation_releases`
   - Immutable global releases.
   - Fields: `release_id`, `subject_id`, `status`, `snapshot_json`, `snapshot_hash`, `base_release_id`, `package_id`, `published_at`, `published_by_account_id`, `rollback_of_release_id`, `proof_json`, `created_at`.
-  - Current published release is the latest `status = 'published'` row per subject, unless a rollback marks another release as active.
+  - V1 active release is the latest `status = 'published'` row per subject with deterministic ordering. Whole-release rollback creates a new published release whose snapshot equals the target release and whose `rollback_of_release_id` points to that target; V1 does not use a mutable active pointer.
 
 - `content_operation_packages`
   - Draft-to-publish package lifecycle.
@@ -258,13 +258,13 @@ Whole-release rollback is an approved high-risk operation that marks a prior rel
 | Epic | Tickets | Outcome |
 | --- | --- | --- |
 | E1. Global Content Operations Foundation | T1-T4 | D1 schema, operation model, repository layer, runtime resolution bridge |
-| E2. Package Workflow and Admin Shell | T5-T8 | Admin package list/detail, lifecycle API, validation, approval, publish, audit |
+| E2. Package Workflow and Admin Shell | T5A-T8 | First global release cutover, admin package list/detail, lifecycle API, validation, approval, publish, audit |
 | E3. Spelling Editorial Manager | T9-T12 | UI and APIs for words, word-family variants, sentence entries, lists, pools, retirements |
 | E4. Audio Operations | T13-T16 | Requirement profiles, audio scan, TTS generation, R2 provenance, fallback warnings |
 | E5. Pools, Reward Tracks, Hero Exposure | T17-T20 | Pool reward-track model, monster bindings, Hero / Codex exposure, learner-history safety |
 | E6. Monster Image Assets | T21-T23 | Monster image upload, validation, preview, package publish integration |
 | E7. Release Safety and Recovery | T24-T27 | release history, visibility proof, rollback, package-level revert |
-| E8. Hardening, Migration, Documentation | T28-T31 | compatibility, capacity, security, production runbooks, live verification |
+| E8. Hardening, Migration, Documentation | T28-T31 | compatibility decommission, capacity, security, production runbooks, live verification |
 
 ## Implementation Units
 
@@ -384,6 +384,37 @@ Whole-release rollback is an approved high-risk operation that marks a prior rel
 
 ### E2. Package Workflow and Admin Shell
 
+#### T5A. Seed first global release and lock active-release semantics
+
+**Goal:** Complete the first global release cutover before learner-visible admin publish is enabled.
+
+**Covers:** R9, R62-R65, R74-R78, AE13, AE14.
+
+**Primary files:**
+
+- `scripts/migrate-spelling-content-to-global-release.mjs`
+- `worker/src/content-operations/routes.js`
+- `worker/src/repository.js`
+- `tests/spelling-content-api.test.js`
+- `tests/worker-subject-runtime.test.js`
+- `tests/content-operations-rollback.test.js`
+
+**Approach:**
+
+- Seed the first global release from the current published spelling content or bundled fallback before E2 publish routes are enabled.
+- Freeze the legacy `/api/content/spelling` publish path or route it through a compatibility package so it cannot bypass approval after cutover.
+- Define V1 active release as the latest published release with deterministic ordering.
+- Implement rollback as a new published release whose snapshot equals the target release and whose `rollback_of_release_id` points to that target.
+- Make normal publish and rollback share the same release writer and runtime resolution invariant.
+- Add parity proof that learner runtime before and after first global release seed is identical.
+
+**Exit criteria:**
+
+- API publish cannot run before the first global release seed/cutover gate is satisfied.
+- Legacy publish cannot bypass package approval after cutover.
+- Rollback can be exercised through the release writer before learner-visible admin publish is enabled.
+- Spelling runtime parity is proven before and after the first global release.
+
 #### T5. Add admin content operations API routes
 
 **Goal:** Expose the package, candidate, validation, approval, publish, and release-history API under `/api/admin/content-operations`.
@@ -402,9 +433,13 @@ Whole-release rollback is an approved high-risk operation that marks a prior rel
 
 - Gate all routes behind the existing admin session and role checks.
 - Keep edit, approve, and publish capability names separate in code while mapping all three to the current `admin` role.
+- Add typed operation request/response schemas, serialiser fixtures, and a client SDK surface for the entity types used by E3-E6.
+- Add route stubs for later pool, reward, monster asset, audio, visibility, rollback, and revert operations so downstream tickets extend a stable contract instead of inventing new shapes.
+- Return a stable blocker envelope with `validation`, `conflicts`, `audio`, `assets`, `rewards`, `visibility`, `exposure`, and `publishReadiness` sections.
 - Return compact summaries for list pages.
 - Require explicit package ids for mutations.
 - Return structured conflict, validation, audio, asset, reward, and exposure blockers.
+- Make publish routes depend on the T5A first-release cutover and active-release invariant.
 
 **Exit criteria:**
 
@@ -654,7 +689,10 @@ Whole-release rollback is an approved high-risk operation that marks a prior rel
 **Approach:**
 
 - Add a service boundary that can generate selected package audio, batch-generate package audio, or regenerate with override.
-- Persist `content_operation_audio_jobs` rows for generation requests and provenance.
+- Treat `content_operation_audio_jobs` as the authoritative admin audio job ledger, not a passive audit mirror.
+- Claim and update jobs by idempotency key so Worker-triggered generation and local operator scripts reconcile to the same rows.
+- Require any script-generated R2 object to reconcile into `content_operation_audio_jobs` before readiness can move to present/generated.
+- Define per-request batch limits, queue concurrency, provider rate-limit handling, retry state, and failed-job visibility before the UI triggers large batches.
 - Continue storing generated audio in R2 through the approved path.
 - Keep local operator script compatibility for large batch runs if Worker-triggered generation is not suitable for every run.
 
@@ -763,10 +801,11 @@ Whole-release rollback is an approved high-risk operation that marks a prior rel
 
 **Approach:**
 
-- Create a compatibility projection from existing spelling progress and monster state into the new reward-track model.
-- Keep current progress keys stable.
-- Add migrations or seed release data that represents current pool/monster behaviour as reward tracks.
-- Avoid writing learner-progress migrations unless tests prove they are needed.
+- First characterise existing spelling monster, Hero, Codex, and learner-history behaviour with focused tests.
+- Add a projection adapter from existing spelling progress and monster state into the new reward-track model while keeping current progress keys stable.
+- Rehearse seed release data that represents current pool/monster behaviour as reward tracks before runtime cutover.
+- Add cutover proof that existing learner monster progress still appears through Hero and Codex after the adapter is enabled.
+- Avoid writing learner-progress migrations unless the characterisation tests prove they are needed.
 
 **Exit criteria:**
 
@@ -870,8 +909,6 @@ Whole-release rollback is an approved high-risk operation that marks a prior rel
 
 - `src/surfaces/hubs/AdminContentOperationsSection.jsx`
 - `src/platform/game/monster-visual-config.js`
-- `src/platform/game/monster-asset-manifest.js`
-- `scripts/generate-monster-assets.mjs`
 - `tests/admin-asset-registry-v1.test.js`
 - `tests/build-public.test.js`
 
@@ -880,7 +917,9 @@ Whole-release rollback is an approved high-risk operation that marks a prior rel
 - Extend the asset registry pattern beyond `monster-visual-config` to package monster image assets.
 - Add preview cards for stage, branch, and target renderer contexts.
 - Store package operations that reference validated asset upload ids.
-- On publish, promote package asset references into the global release snapshot or published asset manifest reference.
+- On publish, promote package asset references into a published asset-reference manifest inside the content release snapshot.
+- Do not write uploaded R2 assets back into the bundled `monster-asset-manifest.js`; that manifest remains a generated fallback and compatibility fixture.
+- Define responsive derivative policy, retention period, rollback availability, and cleanup ownership before learner runtime reads remote assets.
 
 **Exit criteria:**
 
@@ -898,7 +937,7 @@ Whole-release rollback is an approved high-risk operation that marks a prior rel
 
 - `worker/src/repository.js`
 - `src/platform/game/monster-visual-config.js`
-- `src/platform/game/monster-asset-manifest.js`
+- `src/platform/game/monster-asset-manifest.js` for fallback compatibility only.
 - `tests/admin-asset-registry-characterisation.test.js`
 - `tests/hero-contracts.test.js`
 
@@ -907,6 +946,7 @@ Whole-release rollback is an approved high-risk operation that marks a prior rel
 - Resolve monster asset references from published global release first, then bundled/generated fallback.
 - Ensure asset changes do not mutate reward thresholds or progress state unless package operations include those changes.
 - Keep old published assets available while new package assets are draft or while rollback is possible.
+- Keep rollback non-destructive: old R2 asset references must remain available until retention cleanup runs separately.
 
 **Exit criteria:**
 
@@ -944,7 +984,7 @@ Whole-release rollback is an approved high-risk operation that marks a prior rel
 
 **Goal:** Provide emergency recovery by restoring a previous global release.
 
-**Covers:** R47, R75, R77, AE14.
+**Covers:** R75, R77, AE14.
 
 **Primary files:**
 
@@ -957,7 +997,7 @@ Whole-release rollback is an approved high-risk operation that marks a prior rel
 
 - Add approved high-risk rollback action.
 - Record rollback target, reason, approver, publisher, and proof requirement.
-- Mark active release atomically.
+- Publish a rollback release atomically using the same release writer as normal publish.
 - Do not delete R2 audio or draft assets.
 
 **Exit criteria:**
@@ -970,7 +1010,7 @@ Whole-release rollback is an approved high-risk operation that marks a prior rel
 
 **Goal:** Allow ordinary recovery from a specific package without rolling back unrelated later releases.
 
-**Covers:** R48, R76-R77, AE14.
+**Covers:** R76-R77, AE14.
 
 **Primary files:**
 
@@ -995,7 +1035,7 @@ Whole-release rollback is an approved high-risk operation that marks a prior rel
 
 **Goal:** Separate publishing content from making it learner-visible, while still proving learner-facing changes.
 
-**Covers:** R44-R46, R58-R61, R78.
+**Covers:** R58-R61, R78.
 
 **Primary files:**
 
@@ -1019,9 +1059,9 @@ Whole-release rollback is an approved high-risk operation that marks a prior rel
 
 ### E8. Hardening, Migration, Documentation
 
-#### T28. Add compatibility and migration path
+#### T28. Decommission compatibility paths and harden migration
 
-**Goal:** Move current spelling content into the new global release model without breaking existing admin or runtime paths.
+**Goal:** Retire or harden legacy spelling content paths after T5A has seeded the first global release and locked the publish invariant.
 
 **Covers:** R62-R65, R72.
 
@@ -1035,14 +1075,14 @@ Whole-release rollback is an approved high-risk operation that marks a prior rel
 
 **Approach:**
 
-- Seed the first global release from current published spelling content or bundled fallback.
-- Keep existing import/export/publish controls working until fully replaced.
-- Make legacy admin publish either disabled with migration guidance or mapped into a compatibility package.
-- Document the cutover clearly.
+- Verify the T5A first global release seed remains current and idempotent in production.
+- Remove, disable, or explicitly map remaining legacy admin publish controls into compatibility packages.
+- Keep legacy read/export compatibility only where it is still needed for diagnostics or safe rollback.
+- Document the post-cutover state clearly, including which old paths are read-only and which are removed.
 
 **Exit criteria:**
 
-- Production can be migrated to a first global release.
+- Production remains on a seeded global release after legacy compatibility cleanup.
 - Existing learners continue to receive the same content before and after migration.
 - Legacy admin tools cannot silently bypass package approval after cutover.
 
@@ -1117,6 +1157,7 @@ Whole-release rollback is an approved high-risk operation that marks a prior rel
 
 **Approach:**
 
+- From T5A onwards, run a minimal content-operations smoke for any deploy touching admin publish or learner runtime resolution.
 - Add a production smoke script for admin release metadata and public runtime snapshots.
 - Verify Spelling setup, Word Bank, Hero / Codex, and monster rendering surfaces after learner-facing visibility changes.
 - Keep logged-in browser verification for UI flows that need session state.
@@ -1135,15 +1176,20 @@ flowchart LR
   T1["T1 schema"] --> T2["T2 operations"]
   T2 --> T3["T3 repository"]
   T3 --> T4["T4 runtime bridge"]
-  T3 --> T5["T5 API routes"]
+  T4 --> T5A["T5A first release cutover"]
+  T3 --> T5A
+  T5A --> T5["T5 API routes"]
   T5 --> T6["T6 admin shell"]
   T5 --> T7["T7 approval UX"]
+  T5A --> T7
   T2 --> T8["T8 conflict resolver"]
   T6 --> T9["T9 spelling browse"]
   T9 --> T10["T10 word editor"]
   T9 --> T11["T11 sentence editor"]
   T9 --> T12["T12 pool editorial"]
   T2 --> T13["T13 audio scanner"]
+  T9 --> T13
+  T11 --> T13
   T13 --> T14["T14 TTS package service"]
   T14 --> T15["T15 override/fallback"]
   T15 --> T16["T16 audio UI"]
@@ -1151,14 +1197,18 @@ flowchart LR
   T17 --> T18["T18 existing monster mapping"]
   T18 --> T19["T19 pools/rewards UI"]
   T18 --> T20["T20 Hero exposure"]
+  T18 --> T21["T21 asset upload"]
+  T20 --> T21
+  T20 --> T22["T22 asset preview"]
   T5 --> T21["T21 asset upload"]
   T21 --> T22["T22 asset preview"]
   T22 --> T23["T23 asset publish/fallback"]
   T7 --> T24["T24 release history/proof"]
   T24 --> T25["T25 rollback"]
   T24 --> T26["T26 package revert"]
+  T23 --> T25
   T20 --> T27["T27 visibility proof"]
-  T4 --> T28["T28 migration"]
+  T5A --> T28["T28 compatibility cleanup"]
   T28 --> T29["T29 hardening"]
   T29 --> T30["T30 docs"]
   T30 --> T31["T31 production verification"]
@@ -1211,6 +1261,7 @@ Per-ticket targeted tests:
 Release gates:
 
 - Run relevant targeted tests for each ticket.
+- From T5A onwards, run a minimal admin release metadata and learner runtime smoke for any deploy touching content operations publish or runtime resolution.
 - Run `npm test` and `npm run check` before deployment.
 - When working from a fresh worktree, run `node scripts/worktree-setup.mjs` before test/check commands.
 - After deployment, verify `https://ks2.eugnel.uk` with a logged-in admin session when the change affects Admin Console or learner-facing visibility.

--- a/docs/plans/2026-06-11-feat-content-operations-centre-plan.md
+++ b/docs/plans/2026-06-11-feat-content-operations-centre-plan.md
@@ -1,0 +1,1274 @@
+---
+title: "feat: Content Operations Centre"
+type: feat
+date: 2026-06-11
+origin: docs/brainstorms/2026-06-10-content-operations-centre-requirements.md
+---
+
+# feat: Content Operations Centre
+
+## Overview
+
+Build a full Admin Console Content Operations Centre for English Spelling content, audio readiness, spelling pools, reward tracks, monster bindings, monster image assets, and Hero / Codex exposure.
+
+The implementation must be treated as one product and data contract, split into epics and tickets for delivery. The central constraint is that every learner-facing content operation must flow through one package-scoped edit, validation, approval, publish, audit, and recovery model. Delivery order may be staged, but no ticket should create a disconnected surface that cannot later join the same release package.
+
+This plan uses `docs/brainstorms/2026-06-10-content-operations-centre-requirements.md` as the origin contract.
+
+## Problem Frame
+
+Current English Spelling content has a useful model, validation helpers, publish helpers, runtime snapshots, and generated bundle fallbacks. The current Admin Console surface is still thin: import, export, publish, reset, and quality status. Real editorial work still depends on engineering edits to seed data, generated runtime files, deployment, and separate audio cache operations.
+
+The current remote storage model is also not the right foundation for the full manager. `account_subject_content` is account-scoped and stores a whole subject bundle. The new centre needs global product content, optional future account overrides, multiple concurrent change packages, conflict-aware merges, immutable global releases, release history, rollback, and package-level revert. Building the full manager directly on the existing account-scoped whole-bundle API would leave the largest operational gap in the first ticket.
+
+The correct foundation is a platform-level content operations layer that wraps the existing spelling content bundle and runtime fallback. The spelling engine should not be rewritten. The new layer should own packages, operations, releases, approvals, audio readiness, reward configuration, asset references, visibility, and audit.
+
+## Requirements Trace
+
+| Origin requirements | Plan coverage | Implementation area |
+| --- | --- | --- |
+| R1-R9 | Package model, base release hash, validation against merged candidate, optimistic rebase, conflict blocking, immutable global release | E1, E2, E7 |
+| R10-R17 | Approval, capability modelling, lifecycle states, audit events, safe export/redaction | E2, E7, E8 |
+| R18-R28 | Spelling lists, pools, words, word-family variants, sentence entries, parity, visibility, hard delete vs retirement | E3 |
+| R29-R40 | Audio requirement profiles, word and sentence lanes, TTS generation, R2 provenance, strict gate, fallback exception | E4 |
+| R41-R49 | Pool model, reward tracks, monster bindings, threshold templates, progression, learner-history preservation | E5 |
+| R50-R56 | Monster image upload, validation, draft assets, previews, runtime asset readiness | E6 |
+| R57-R61 | Hero exposure as configuration over reward tracks and monsters, hidden/scheduled/flagged visibility | E5, E7 |
+| R62-R65 | Global default, optional account override, bundled fallback, runtime resolution order | E1, E7 |
+| R66-R73 | Content Operations Centre IA, package-first mutations, browse-without-package, conflict resolver, large-read discipline | E2, E3, E4, E5, E6 |
+| R74-R78 | Release history, whole-release rollback, package revert, R2 retention, production proof | E7, E8 |
+| AE1-AE14 | Acceptance examples are used as test scenarios and ticket exit criteria | All epics |
+
+## Scope Boundaries
+
+In scope:
+
+- Global product content management for English Spelling.
+- Package-scoped edits and publish workflow for words, word-family variants, sentence entries, pools, audio requirements, reward tracks, monster bindings, Hero / Codex exposure, and monster image assets.
+- TTS-generated word and sentence audio operations stored in R2.
+- Monster image upload and validation for V1 asset upload.
+- Runtime resolution from optional account override to global release to bundled fallback.
+- Whole-release rollback and package-level revert.
+- Admin proof and audit evidence.
+
+Out of scope:
+
+- A general CMS for all subjects.
+- Manual audio upload.
+- A rewrite of the spelling engine, scheduler, answer marking, or learner progress model.
+- Making account-scoped content the primary V1 operator workflow.
+- Hard deletion of published learner-facing content or R2 audio as part of ordinary editorial removal.
+- Upload support for non-monster asset categories in V1.
+- Changing existing learner progress or reward history without an explicit package operation and validation.
+
+## Context and Research
+
+### Current Repo Surfaces
+
+- `docs/spelling-content-model.md` documents the existing spelling bundle, sentence-entry model, word-family variants for Extra words, draft validation, publish, runtime snapshot, and `account_subject_content`.
+- `src/subjects/spelling/content/model.js` already normalises words, `variants`, `sentenceEntryIds`, pools, releases, and runtime projections. This is the starting point for editorial validation.
+- `src/subjects/spelling/content/service.js` exposes read, write, validate, publish, portable import/export, runtime snapshot, and reset operations over the current bundle.
+- `src/subjects/spelling/content/repository.js` currently stores local content in browser storage or remote content through `/api/content/spelling`.
+- `worker/migrations/0005_spelling_content_model.sql` creates `account_subject_content`, which is account-scoped and unsuitable as the primary global release table.
+- `worker/src/app.js` currently serves `/api/content/spelling` and generic admin asset routes for `monster-visual-config`.
+- `worker/src/repository.js` currently exports, writes, and resolves subject content, reads spelling runtime content, builds admin overview signals, and owns existing Monster Visual Config persistence.
+- `src/surfaces/hubs/AdminContentSection.jsx` currently provides Content overview, spelling status/import controls, quality signals, and the Asset & Effect Registry.
+- `src/platform/hubs/admin-asset-registry.js` provides the asset registry and handler capability pattern currently used by `monster-visual-config`.
+- `docs/spelling-word-audio.md` documents the existing `npm run spelling:audio-cache` path, TTS generation, R2 audio cache, content-addressed keys, word and sentence lanes, and production caution points.
+- `docs/monster-visual-config.md` documents the existing monster visual config review, fallback, preview, and renderer compatibility model.
+
+### Institutional Constraints
+
+- The Worker bundle has been under size pressure before. Public runtime paths must not load full admin datasets or large content blobs into the public client bundle.
+- `account_subject_content` has had large-row runtime constraints. Global release storage should be explicit and compact on read paths, with published snapshots projected into runtime shapes.
+- Monster assets already have generated manifests and renderer contracts. New image upload must integrate with those contracts rather than bypass them.
+- Admin safe-copy and operational redaction rules are production-sensitive; release history and package export must avoid leaking learner or account personal data.
+
+## Key Technical Decisions
+
+1. **Introduce a global content operations layer.** Create new D1 tables for content operations releases, change packages, package operations, approvals, events, audio jobs, and asset uploads. Keep `account_subject_content` for compatibility and future account override support, but do not use it as the primary global product-content store.
+
+2. **Keep the spelling bundle as the canonical snapshot payload.** The current spelling content bundle remains the data shape that validation and runtime projection understand. The new layer stores package operations and global releases around that bundle instead of rewriting the spelling engine.
+
+3. **Use structured operations for package diffs.** Each mutation becomes a normalised operation with `entityType`, `entityId`, `fieldPath`, `action`, `beforeHash`, `afterHash`, payload, actor, and timestamp. Conflict detection is based on same entity plus same field path, with entity-level guards for deletes, retirements, and structural moves.
+
+4. **Approve exact merged candidate hashes.** Approval records the base release id, current release id, package operations hash, merged candidate hash, validation summary, audio readiness summary, asset readiness summary, and any fallback exceptions. Any package mutation or conflict resolution invalidates approval.
+
+5. **Runtime reads only published releases.** Learner-facing routes resolve optional account override, then global published release, then bundled fallback. Draft packages and candidate releases are admin-only.
+
+6. **Audio is generated through TTS only.** The admin centre can scan, queue, generate, regenerate, and override TTS audio. It must not provide audio file upload. R2 keys and provenance should remain content-addressed and must include lane, voice, pace, model, prompt/profile version, and source identity.
+
+7. **Audio requirements are profile-driven.** Do not hard-code four audio outputs for every entity. Store `audioRequirementProfile` by lane. Default word lane is male/female natural or normal pace. Default sentence dictation lane is male/female normal and slow pace.
+
+8. **Reward tracks are separate from monsters.** Pools bind to zero or more reward tracks. Each reward track binds to one monster and defines progression mode, threshold template, optional overrides, active state, and labels. Hero / Codex exposure reads reward tracks and monsters; it does not create a second creature model.
+
+9. **Monster image assets use package draft and asset registry patterns.** Uploaded monster images are draft package assets until publish. They are validated, previewed in renderer contexts, and referenced by package operations. Audio is deliberately excluded from upload assets.
+
+10. **Delivery must be contract-first.** Tickets can ship in sequence, but all schema, API, UI, validation, audit, and runtime contracts must point to the same final model from the first foundation ticket.
+
+## High-Level Technical Design
+
+```mermaid
+flowchart TB
+  A["Admin opens Content Operations Centre"] --> B["Browse published global release"]
+  B --> C["Create or select change package"]
+  C --> D["Apply structured package operations"]
+  D --> E["Build merged candidate against current global release"]
+  E --> F{"Validation, audio, asset, reward, exposure gates pass?"}
+  F -->|No| G["Resolve blockers or conflicts"]
+  G --> E
+  F -->|Yes| H["Approve exact candidate hash"]
+  H --> I["Publish immutable global release"]
+  I --> J["Runtime resolves account override, global release, bundled fallback"]
+  I --> K["Release history, rollback, package revert, production proof"]
+```
+
+### Domain Model
+
+The schema should be introduced in the next available migration number after `worker/migrations/0019_capacity_drop_write_amplifying_indexes.sql`.
+
+Proposed tables:
+
+- `content_operation_releases`
+  - Immutable global releases.
+  - Fields: `release_id`, `subject_id`, `status`, `snapshot_json`, `snapshot_hash`, `base_release_id`, `package_id`, `published_at`, `published_by_account_id`, `rollback_of_release_id`, `proof_json`, `created_at`.
+  - Current published release is the latest `status = 'published'` row per subject, unless a rollback marks another release as active.
+
+- `content_operation_packages`
+  - Draft-to-publish package lifecycle.
+  - Fields: `package_id`, `subject_id`, `template_id`, `title`, `description`, `base_release_id`, `base_release_hash`, `state`, `created_by_account_id`, `updated_by_account_id`, `created_at`, `updated_at`, `approved_at`, `published_at`, `superseded_by_package_id`.
+
+- `content_operation_package_operations`
+  - Structured package diff.
+  - Fields: `operation_id`, `package_id`, `operation_order`, `entity_type`, `entity_id`, `field_path`, `action`, `before_hash`, `after_hash`, `payload_json`, `created_by_account_id`, `created_at`.
+
+- `content_operation_package_candidates`
+  - Cached merged candidate output for validation and approval.
+  - Fields: `candidate_id`, `package_id`, `base_release_id`, `current_release_id`, `operations_hash`, `candidate_hash`, `candidate_snapshot_json`, `validation_json`, `audio_scan_json`, `asset_scan_json`, `reward_scan_json`, `visibility_scan_json`, `conflicts_json`, `created_at`.
+
+- `content_operation_package_approvals`
+  - Approval records.
+  - Fields: `approval_id`, `package_id`, `candidate_id`, `candidate_hash`, `approved_by_account_id`, `approved_at`, `notes`, `audio_fallback_json`, `asset_summary_json`, `validation_summary_json`.
+
+- `content_operation_events`
+  - Audit trail.
+  - Fields: `event_id`, `package_id`, `release_id`, `subject_id`, `event_type`, `actor_account_id`, `event_json`, `created_at`.
+
+- `content_operation_audio_jobs`
+  - TTS generation queue and provenance.
+  - Fields: `job_id`, `package_id`, `candidate_id`, `lane`, `entity_type`, `entity_id`, `voice_id`, `pace_id`, `model_id`, `profile_version`, `content_key`, `status`, `r2_key`, `error_json`, `requested_by_account_id`, `completed_at`, `created_at`.
+
+- `content_operation_asset_uploads`
+  - Monster image draft assets and validation.
+  - Fields: `asset_upload_id`, `package_id`, `monster_id`, `branch_id`, `stage_id`, `asset_kind`, `r2_key`, `content_type`, `byte_size`, `width`, `height`, `validation_json`, `preview_json`, `status`, `created_by_account_id`, `created_at`.
+
+- `content_operation_account_overrides`
+  - Reserved override support.
+  - Fields: `override_id`, `account_id`, `subject_id`, `release_id`, `reason`, `active`, `created_by_account_id`, `created_at`, `ended_at`.
+  - V1 uses this for diagnostics or special programme support only, not the main UI path.
+
+### Operation Entity Types
+
+Use stable entity types so conflict detection and UI diffing are predictable:
+
+- `spelling.word`
+- `spelling.wordVariant`
+- `spelling.sentenceEntry`
+- `spelling.wordList`
+- `spelling.pool`
+- `spelling.audioRequirementProfile`
+- `spelling.rewardTrack`
+- `spelling.monsterBinding`
+- `spelling.monsterAsset`
+- `spelling.heroExposure`
+- `spelling.visibilityRule`
+
+### Runtime Resolution
+
+Runtime read order:
+
+1. Active account override for `subject_id = 'spelling'`, if present.
+2. Latest active global published release for `subject_id = 'spelling'`.
+3. Bundled fallback snapshot generated from the repo.
+
+The runtime service should return the same shape expected by existing spelling routes, word bank routes, Hero read-models, and Codex projections. Draft packages, approvals, audio jobs, and admin scans must remain admin-only.
+
+### API Shape
+
+Introduce new admin routes under `/api/admin/content-operations`:
+
+- `GET /api/admin/content-operations/subjects/spelling/overview`
+- `GET /api/admin/content-operations/subjects/spelling/releases`
+- `GET /api/admin/content-operations/subjects/spelling/releases/:releaseId`
+- `POST /api/admin/content-operations/subjects/spelling/packages`
+- `GET /api/admin/content-operations/packages`
+- `GET /api/admin/content-operations/packages/:packageId`
+- `PATCH /api/admin/content-operations/packages/:packageId`
+- `POST /api/admin/content-operations/packages/:packageId/operations`
+- `DELETE /api/admin/content-operations/packages/:packageId/operations/:operationId`
+- `POST /api/admin/content-operations/packages/:packageId/rebase`
+- `POST /api/admin/content-operations/packages/:packageId/validate`
+- `POST /api/admin/content-operations/packages/:packageId/scan-audio`
+- `POST /api/admin/content-operations/packages/:packageId/generate-audio`
+- `POST /api/admin/content-operations/packages/:packageId/upload-monster-asset`
+- `POST /api/admin/content-operations/packages/:packageId/approve`
+- `POST /api/admin/content-operations/packages/:packageId/publish`
+- `POST /api/admin/content-operations/releases/:releaseId/rollback`
+- `POST /api/admin/content-operations/packages/:packageId/create-revert`
+
+Keep `/api/content/spelling` as a compatibility route during transition. It can eventually read from the global release and write through a restricted compatibility package, but the primary Admin UI should use the new routes.
+
+### Admin UI Information Architecture
+
+Add a Content Operations Centre under the existing Admin Console Content area. Top-level tabs:
+
+- Overview
+- Packages
+- Spelling
+- Audio
+- Pools & Rewards
+- Monsters & Assets
+- Hero / Codex
+- Approvals
+- Release History
+
+Browse pages can show the current published global release without an active package. Any mutation must prompt the admin to choose an existing package or create a new package. Package detail pages reuse the same domain tabs scoped to that package.
+
+### Validation Gates
+
+The merged candidate must pass:
+
+- Existing spelling bundle validation.
+- Word-family and progress-key validation.
+- Pool and statutory parity validation.
+- Audio requirement profile scan.
+- Reward-track threshold and progression validation.
+- Monster binding and asset readiness validation.
+- Hero / Codex exposure and visibility validation.
+- Runtime projection validation.
+- Bundle/capacity guardrails for public surfaces.
+- Approval hash and state validation.
+
+### Recovery Model
+
+Whole-release rollback is an approved high-risk operation that marks a prior release active and records proof. Package revert creates a new inverse package that follows the same validation, approval, and publish workflow. Neither path deletes R2 audio objects.
+
+## Epic and Ticket Breakdown
+
+| Epic | Tickets | Outcome |
+| --- | --- | --- |
+| E1. Global Content Operations Foundation | T1-T4 | D1 schema, operation model, repository layer, runtime resolution bridge |
+| E2. Package Workflow and Admin Shell | T5-T8 | Admin package list/detail, lifecycle API, validation, approval, publish, audit |
+| E3. Spelling Editorial Manager | T9-T12 | UI and APIs for words, word-family variants, sentence entries, lists, pools, retirements |
+| E4. Audio Operations | T13-T16 | Requirement profiles, audio scan, TTS generation, R2 provenance, fallback warnings |
+| E5. Pools, Reward Tracks, Hero Exposure | T17-T20 | Pool reward-track model, monster bindings, Hero / Codex exposure, learner-history safety |
+| E6. Monster Image Assets | T21-T23 | Monster image upload, validation, preview, package publish integration |
+| E7. Release Safety and Recovery | T24-T27 | release history, visibility proof, rollback, package-level revert |
+| E8. Hardening, Migration, Documentation | T28-T31 | compatibility, capacity, security, production runbooks, live verification |
+
+## Implementation Units
+
+### E1. Global Content Operations Foundation
+
+#### T1. Add global content operations D1 schema
+
+**Goal:** Create the persistent foundation for global releases, packages, operations, candidates, approvals, audit events, audio jobs, monster asset uploads, and reserved account overrides.
+
+**Covers:** R1-R5, R9, R16, R62-R65, AE13.
+
+**Primary files:**
+
+- `worker/migrations/0020_content_operations_centre.sql` or next available migration number.
+- `worker/src/repository.js`
+- `tests/content-operations-repository.test.js`
+
+**Approach:**
+
+- Add the tables listed in the domain model section.
+- Add indexes for subject release lookup, package state lookup, package operation ordering, event history, and audio job status.
+- Keep `account_subject_content` intact for compatibility.
+- Store JSON as compact strings; only hydrate large snapshots on admin or runtime paths that need them.
+
+**Exit criteria:**
+
+- Repository tests can create packages, append operations, create candidates, approve, publish releases, read latest published release, and read audit events.
+- Account override rows exist but are not used by the primary UI.
+- Migration is idempotent and follows current D1 migration conventions.
+
+#### T2. Build shared operation and candidate model
+
+**Goal:** Define the JS domain helpers that normalise package operations, apply them to a base snapshot, compute hashes, and detect conflicts.
+
+**Covers:** R5-R8, R14-R15, R71.
+
+**Primary files:**
+
+- `src/subjects/spelling/content/operations-model.js`
+- `src/subjects/spelling/content/package-operations.js`
+- `src/subjects/spelling/content/model.js`
+- `tests/content-operations-merge.test.js`
+- `tests/spelling-content-operations-model.test.js`
+
+**Approach:**
+
+- Define operation entity types and actions.
+- Apply operations to the existing spelling content bundle, not generated runtime files.
+- Compute stable hashes with deterministic serialisation.
+- Detect same entity plus same field conflicts.
+- Treat deletion/retirement/move operations as structural conflicts against any child-field edits.
+- Invalidate candidate and approval hashes when operations change.
+
+**Exit criteria:**
+
+- Unrelated packages auto-rebase cleanly.
+- Same-field edits block publish.
+- Retire/delete conflicts with child edits are blocked.
+- Existing spelling validation still catches malformed entries after operations are applied.
+
+#### T3. Add repository methods for packages, candidates, approvals, releases, and audit
+
+**Goal:** Expose a worker-side persistence API that route handlers can use without leaking SQL or storage details into UI-facing code.
+
+**Covers:** R3-R17, R74.
+
+**Primary files:**
+
+- `worker/src/repository.js`
+- `tests/content-operations-repository.test.js`
+- `tests/admin-production-evidence.test.js`
+
+**Approach:**
+
+- Add methods to create and update packages.
+- Append operations and audit events atomically where possible.
+- Build and persist candidate rows.
+- Approve exact candidates.
+- Publish approved candidates into immutable releases.
+- Read release history summaries without loading full snapshots by default.
+
+**Exit criteria:**
+
+- Package mutation after approval clears approval.
+- Publish fails if candidate hash differs from approval hash.
+- Release history summary includes package, actor, validation, audio, asset, and proof summaries.
+- Admin safe-copy redaction still holds for operational views.
+
+#### T4. Bridge runtime resolution to global release with fallback
+
+**Goal:** Route spelling runtime reads through optional account override, global published release, and bundled fallback while preserving current learner behaviour.
+
+**Covers:** R62-R65, R72-R73, AE13.
+
+**Primary files:**
+
+- `worker/src/repository.js`
+- `worker/src/app.js`
+- `src/subjects/spelling/content/service.js`
+- `tests/worker-subject-runtime.test.js`
+- `tests/spelling-content-api.test.js`
+- `tests/bundle-audit.test.js`
+
+**Approach:**
+
+- Add a global release reader that returns the same runtime snapshot shape currently used by spelling routes.
+- Keep bundled fallback when global release lookup fails or is missing.
+- Preserve compatibility for existing `/api/content/spelling` consumers while the new admin UI moves to content operations routes.
+- Keep public bundle and Worker bundle size under existing guardrails.
+
+**Exit criteria:**
+
+- Existing spelling runtime tests pass unchanged or with intentional fixture updates.
+- Missing D1 release falls back to bundled content.
+- Draft package content cannot leak into learner runtime.
+- Large content data does not move into public React bundles.
+
+### E2. Package Workflow and Admin Shell
+
+#### T5. Add admin content operations API routes
+
+**Goal:** Expose the package, candidate, validation, approval, publish, and release-history API under `/api/admin/content-operations`.
+
+**Covers:** R1-R17, R66-R74.
+
+**Primary files:**
+
+- `worker/src/app.js`
+- `worker/src/content-operations/routes.js`
+- `worker/src/content-operations/serialisers.js`
+- `tests/content-operations-api.test.js`
+- `tests/admin-safe-copy.test.js`
+
+**Approach:**
+
+- Gate all routes behind the existing admin session and role checks.
+- Keep edit, approve, and publish capability names separate in code while mapping all three to the current `admin` role.
+- Return compact summaries for list pages.
+- Require explicit package ids for mutations.
+- Return structured conflict, validation, audio, asset, reward, and exposure blockers.
+
+**Exit criteria:**
+
+- Non-admin sessions cannot access routes.
+- Admin can create a package, add operations, validate, approve, and publish through API tests.
+- Approval and publish are separate route actions even when the same admin account performs both.
+
+#### T6. Build Content Operations Centre shell
+
+**Goal:** Add the operator-facing home, tab structure, package list, and package detail container.
+
+**Covers:** R66-R70.
+
+**Primary files:**
+
+- `src/surfaces/hubs/AdminContentSection.jsx`
+- `src/surfaces/hubs/AdminContentOperationsSection.jsx`
+- `src/platform/hubs/admin-content-operations.js`
+- `src/platform/hubs/api.js`
+- `src/main.js`
+- `styles/app.css`
+- `tests/admin-content-operations-v2.test.js`
+- `tests/admin-content-overview-characterisation.test.js`
+
+**Approach:**
+
+- Add a Content Operations Centre card or tab inside the existing Admin Console Content section.
+- Provide overview lanes for blocked packages, ready-for-approval packages, approved pending publish packages, recent releases, and audio/asset warnings.
+- Build package list and package detail views before deep editors.
+- Allow browsing without a package; prompt for package selection before mutation.
+
+**Exit criteria:**
+
+- The UI can load package summaries and release summaries.
+- Package detail tabs are present even before all editors are feature-complete.
+- Existing Admin Content overview and Asset & Effect Registry still render.
+
+#### T7. Implement validation, approval, publish, and audit UX
+
+**Goal:** Make package lifecycle safe and reviewable from UI.
+
+**Covers:** R10-R17, R54-R56, R74.
+
+**Primary files:**
+
+- `src/surfaces/hubs/AdminContentOperationsSection.jsx`
+- `src/platform/hubs/admin-content-operations.js`
+- `worker/src/content-operations/routes.js`
+- `tests/content-operations-approval.test.js`
+- `tests/admin-content-operations-v2.test.js`
+
+**Approach:**
+
+- Add action buttons for validate, submit for approval, approve, publish, reject, and mark blocked.
+- Show exact candidate hash, base release, current release, validation status, audio summary, asset summary, and visibility impact.
+- Invalidate approval visually and in API when package operations change.
+- Record notes for approval, fallback allowance, and publish proof.
+
+**Exit criteria:**
+
+- Publish is blocked without approval.
+- Approval is blocked when candidate has unresolved validation, conflict, asset, reward, or visibility blockers, unless the relevant fallback exception is explicitly supported.
+- Approval notes and summaries appear in release history.
+
+#### T8. Add conflict resolver
+
+**Goal:** Provide the UI needed to resolve same-field package conflicts without last-write-wins.
+
+**Covers:** R6-R8, R71, AE4, AE5.
+
+**Primary files:**
+
+- `src/surfaces/hubs/AdminContentOperationsSection.jsx`
+- `src/subjects/spelling/content/package-operations.js`
+- `worker/src/content-operations/routes.js`
+- `tests/content-operations-merge.test.js`
+- `tests/admin-content-operations-v2.test.js`
+
+**Approach:**
+
+- Auto-rebase unrelated operations when current release changes.
+- Display conflicts by entity and field path.
+- Support keeping package value, keeping current release value, or editing a merged value.
+- Persist conflict resolution as new package operations and invalidate approval.
+
+**Exit criteria:**
+
+- Conflict resolver produces a new candidate hash.
+- Same-field conflicts cannot publish until resolved.
+- Unrelated concurrent packages still publish without manual work.
+
+### E3. Spelling Editorial Manager
+
+#### T9. Build spelling browse and read models
+
+**Goal:** Provide fast published-state browsing for words, word-family variants, sentence entries, lists, pools, audio readiness, and reward impact.
+
+**Covers:** R18-R24, R66-R70, R73.
+
+**Primary files:**
+
+- `src/subjects/spelling/content/model.js`
+- `src/subjects/spelling/content/editor-read-model.js`
+- `src/platform/hubs/admin-content-operations.js`
+- `worker/src/content-operations/read-models.js`
+- `tests/spelling-content-operations-model.test.js`
+- `tests/admin-content-operations-v2.test.js`
+
+**Approach:**
+
+- Build compact server summaries for list pages.
+- Provide detailed item reads by slug or id.
+- Surface current published state, package draft state, validation state, pool membership, audio readiness, and reward impact.
+- Avoid pulling full datasets into initial UI load.
+
+**Exit criteria:**
+
+- Admin can browse spelling content without opening a package.
+- Item detail can show current and package-draft values when a package is active.
+- Public bundle size remains within guardrails.
+
+#### T10. Implement word and word-family editor operations
+
+**Goal:** Allow admins to add, edit, retire, and validate words and word-family variants from UI.
+
+**Covers:** R18-R23, R25-R28, AE6, AE12.
+
+**Primary files:**
+
+- `src/surfaces/hubs/AdminContentOperationsSection.jsx`
+- `src/subjects/spelling/content/package-operations.js`
+- `src/subjects/spelling/content/model.js`
+- `tests/spelling-content-operations-model.test.js`
+- `tests/admin-content-operations-v2.test.js`
+
+**Approach:**
+
+- Add forms for base word, accepted spellings, explanation, tags, source notes, provenance, pool membership, and visibility.
+- Add first-class child editing for Extra word-family variants.
+- Make progress key explicit: base slug or variant prompt where allowed.
+- Enforce statutory parity warnings for core word changes.
+- Support hard delete for draft-only words and retirement for published words.
+
+**Exit criteria:**
+
+- A word or variant cannot become learner-visible without sentence references, accepted spellings, explanation, pool assignment, and provenance.
+- Core variants remain separate word rows unless a package explicitly documents a parity trade-off.
+- Retired words leave audit/history references intact.
+
+#### T11. Implement sentence-entry and list editor operations
+
+**Goal:** Manage sentence entries, sentence references, and word lists without editing generated files.
+
+**Covers:** R18, R24-R28, R72.
+
+**Primary files:**
+
+- `src/surfaces/hubs/AdminContentOperationsSection.jsx`
+- `src/subjects/spelling/content/package-operations.js`
+- `src/subjects/spelling/content/model.js`
+- `tests/spelling-content-operations-model.test.js`
+- `tests/spelling-content.test.js`
+
+**Approach:**
+
+- Add sentence-entry create/edit/retire flows with stable ids.
+- Link sentences to base words and variants by id.
+- Validate sentence word ownership and missing references.
+- Support list membership operations without embedding sentence text in word rows.
+
+**Exit criteria:**
+
+- Broken sentence references block validation.
+- Sentence retirements are blocked when active visible words still require them.
+- Operators never edit `src/subjects/spelling/data/*` for normal content operations.
+
+#### T12. Implement pool metadata and editorial retirement
+
+**Goal:** Manage pool metadata and active/retired lifecycle in the spelling editorial surface, before reward-track details are added in E5.
+
+**Covers:** R23, R26-R28, R41, R59, R61.
+
+**Primary files:**
+
+- `src/subjects/spelling/content/package-operations.js`
+- `src/subjects/spelling/content/model.js`
+- `src/surfaces/hubs/AdminContentOperationsSection.jsx`
+- `tests/spelling-content-operations-model.test.js`
+
+**Approach:**
+
+- Extend beyond current `core` and `extra` assumptions while preserving current pools.
+- Add pool metadata: title, type, source notes, active/retired state, visibility state.
+- Keep future pool ids stable and validation-friendly.
+- Block active learner-facing pool publish until E5 reward requirements are satisfied, unless explicit no-reward exception is approved.
+
+**Exit criteria:**
+
+- New pools can be created as hidden or staged.
+- Retired pools disappear from new sessions but remain in release history and learner-history references.
+- Extra/future pools do not inflate statutory metrics.
+
+### E4. Audio Operations
+
+#### T13. Add audio requirement profile and readiness scanner
+
+**Goal:** Make audio readiness visible and enforceable for package candidates.
+
+**Covers:** R29-R32, R37, R40, AE7.
+
+**Primary files:**
+
+- `src/subjects/spelling/content/audio-readiness.js`
+- `src/subjects/spelling/content/package-operations.js`
+- `worker/src/content-operations/audio.js`
+- `tests/content-operations-audio-readiness.test.js`
+- `tests/build-spelling-word-audio-plan.test.js`
+
+**Approach:**
+
+- Define profile defaults for word and sentence dictation lanes.
+- Scan package candidate content for required lane, voice, pace, slug, sentence id, model, and content key.
+- Return missing, present, stale, generated, failed, skipped, and override-requested states.
+- Keep the profile configurable per package.
+
+**Exit criteria:**
+
+- Word and sentence audio readiness is reported separately.
+- Variant-level sentence audio gaps are visible at the variant level.
+- Strict publish gate blocks missing required audio by default.
+
+#### T14. Wrap TTS generation as a package service
+
+**Goal:** Reuse the existing TTS/R2 generation path from the Content Operations Centre.
+
+**Covers:** R33-R36, R40, AE8.
+
+**Primary files:**
+
+- `worker/src/tts.js`
+- `worker/src/content-operations/audio.js`
+- `scripts/build-spelling-word-audio-plan.mjs`
+- `scripts/spelling-audio-cache.mjs` or existing audio script entrypoint.
+- `tests/worker-tts.test.js`
+- `tests/build-spelling-word-audio-generate.test.js`
+
+**Approach:**
+
+- Add a service boundary that can generate selected package audio, batch-generate package audio, or regenerate with override.
+- Persist `content_operation_audio_jobs` rows for generation requests and provenance.
+- Continue storing generated audio in R2 through the approved path.
+- Keep local operator script compatibility for large batch runs if Worker-triggered generation is not suitable for every run.
+
+**Exit criteria:**
+
+- Admin-triggered generation uses TTS, not upload.
+- Generated audio provenance includes source identity, lane, voice, pace, model, profile version, generated account id, generated time, and R2 key.
+- Failed generation is visible and retryable.
+
+#### T15. Implement audio override and fallback approval
+
+**Goal:** Support high-risk regenerate and fallback decisions without weakening the default strict gate.
+
+**Covers:** R34, R37-R39.
+
+**Primary files:**
+
+- `worker/src/content-operations/routes.js`
+- `worker/src/content-operations/audio.js`
+- `src/surfaces/hubs/AdminContentOperationsSection.jsx`
+- `tests/content-operations-approval.test.js`
+- `tests/content-operations-audio-readiness.test.js`
+
+**Approach:**
+
+- Treat regenerate existing audio as an explicit override operation with reason.
+- Invalidate package approval after override.
+- Allow approval to explicitly permit runtime TTS fallback with notes and affected matrix summary.
+- Keep visible warnings on packages/releases until all required audio exists.
+
+**Exit criteria:**
+
+- Fallback is never silent.
+- Override cannot publish without re-approval.
+- Release history records fallback and override decisions.
+
+#### T16. Add audio operations UI
+
+**Goal:** Give operators package-level and item-level audio controls.
+
+**Covers:** R29-R40, R66-R70.
+
+**Primary files:**
+
+- `src/surfaces/hubs/AdminContentOperationsSection.jsx`
+- `src/platform/hubs/admin-content-operations.js`
+- `styles/app.css`
+- `tests/admin-content-operations-v2.test.js`
+
+**Approach:**
+
+- Add Audio tab with missing matrix, filters, selected generation, batch generation, regenerate, failures, and warnings.
+- Show audio state on word, variant, sentence, and package detail surfaces.
+- Clearly distinguish strict blockers from approved fallback warnings.
+
+**Exit criteria:**
+
+- James can scan missing word and sentence audio for a package.
+- James can generate selected items or batch generate a package scope.
+- Already-present audio can be regenerated only via explicit override.
+
+### E5. Pools, Reward Tracks, Hero Exposure
+
+#### T17. Add reward-track schema and validators
+
+**Goal:** Model pool rewards without hard-coding one monster per pool.
+
+**Covers:** R41-R49, AE9.
+
+**Primary files:**
+
+- `src/platform/game/reward-track-config.js`
+- `src/subjects/spelling/content/package-operations.js`
+- `src/subjects/spelling/content/model.js`
+- `tests/spelling-reward-tracks.test.js`
+- `tests/hero-contracts.test.js`
+
+**Approach:**
+
+- Add reward track fields: track id, pool id, monster id, progression mode, threshold template, threshold overrides, active state, labels.
+- Default progression mode to `parallel`.
+- Support `sequentialAfter` with cycle detection.
+- Validate thresholds against active pool word counts.
+- Block cross-pool dependencies unless explicitly approved.
+
+**Exit criteria:**
+
+- Pool can bind to multiple reward tracks.
+- Impossible thresholds block publish.
+- Sequential cycles block publish.
+
+#### T18. Map existing spelling monsters into reward tracks safely
+
+**Goal:** Preserve existing learner history while introducing reward tracks.
+
+**Covers:** R43, R48-R49, R57-R58.
+
+**Primary files:**
+
+- `worker/src/repository.js`
+- `src/platform/game/monster-visual-config.js`
+- `src/platform/game/reward-track-config.js`
+- `tests/hero-contracts.test.js`
+- `tests/hero-subject-banner-progress.test.js`
+- `tests/worker-subject-runtime.test.js`
+
+**Approach:**
+
+- Create a compatibility projection from existing spelling progress and monster state into the new reward-track model.
+- Keep current progress keys stable.
+- Add migrations or seed release data that represents current pool/monster behaviour as reward tracks.
+- Avoid writing learner-progress migrations unless tests prove they are needed.
+
+**Exit criteria:**
+
+- Existing learner monster progress still appears.
+- Existing Hero / Codex tests continue to pass or have explicit fixture updates.
+- No reward state is reset by the content operations migration.
+
+#### T19. Build pools and rewards UI
+
+**Goal:** Allow operators to configure pools, reward tracks, monster bindings, thresholds, and progression modes.
+
+**Covers:** R41-R49, R66-R70.
+
+**Primary files:**
+
+- `src/surfaces/hubs/AdminContentOperationsSection.jsx`
+- `src/platform/hubs/admin-content-operations.js`
+- `styles/app.css`
+- `tests/admin-content-operations-v2.test.js`
+- `tests/spelling-reward-tracks.test.js`
+
+**Approach:**
+
+- Add Pools & Rewards tab.
+- Show active pool word counts and threshold validation.
+- Provide threshold template selector and override editor.
+- Provide monster binding selector.
+- Show reward impact and learner-history safety notes before approval.
+
+**Exit criteria:**
+
+- New pool can have multiple reward tracks.
+- Existing pool can add, retire, or reorder tracks through package operations.
+- UI blocks learner-visible pool without required reward configuration unless approved exception exists.
+
+#### T20. Add Hero / Codex exposure model and UI
+
+**Goal:** Configure how reward tracks and monsters appear in Hero Camp, Hero Quest, Codex, and subject setup.
+
+**Covers:** R57-R61, R78, AE11.
+
+**Primary files:**
+
+- `shared/hero/*`
+- `worker/src/hero/*`
+- `src/platform/game/reward-track-config.js`
+- `src/surfaces/hubs/AdminContentOperationsSection.jsx`
+- `tests/hero-contracts.test.js`
+- `tests/hero-subject-banner.test.js`
+- `tests/playwright/hero-task-indicator.playwright.test.mjs`
+
+**Approach:**
+
+- Add exposure config over reward tracks and monsters.
+- Support hidden, visible, scheduled, and rollout-flagged states.
+- Ensure hidden/scheduled content can still be previewed by admin and used for audio/asset readiness.
+- Keep Hero as an exposure layer, not a duplicate creature model.
+
+**Exit criteria:**
+
+- Scheduled content does not show to learners before its visibility date.
+- Admin can preview hidden/scheduled exposure.
+- Hero / Codex runtime reads published and currently visible exposure rules.
+
+### E6. Monster Image Assets
+
+#### T21. Add monster image asset upload storage and validation
+
+**Goal:** Let admins upload monster image assets as package draft assets.
+
+**Covers:** R50-R52, R54-R56, AE10.
+
+**Primary files:**
+
+- `worker/src/content-operations/assets.js`
+- `worker/src/app.js`
+- `src/platform/hubs/admin-asset-registry.js`
+- `tests/monster-asset-upload-validation.test.js`
+- `tests/admin-asset-preview-url-safety.test.js`
+
+**Approach:**
+
+- Add upload route for monster image assets only.
+- Store draft uploads in R2 with package-scoped keys.
+- Validate content type, byte size, dimensions, monster id, branch, stage, and renderer compatibility metadata.
+- Return safe preview URLs or signed preview handles without exposing private object internals.
+
+**Exit criteria:**
+
+- Non-image and oversized uploads are rejected.
+- Uploads cannot target unknown monster ids, branches, or stages.
+- Draft upload does not affect learner runtime until package publish.
+
+#### T22. Add monster asset preview and package references
+
+**Goal:** Preview uploaded assets in relevant renderer contexts and bind them to package operations.
+
+**Covers:** R52-R56.
+
+**Primary files:**
+
+- `src/surfaces/hubs/AdminContentOperationsSection.jsx`
+- `src/platform/game/monster-visual-config.js`
+- `src/platform/game/monster-asset-manifest.js`
+- `scripts/generate-monster-assets.mjs`
+- `tests/admin-asset-registry-v1.test.js`
+- `tests/build-public.test.js`
+
+**Approach:**
+
+- Extend the asset registry pattern beyond `monster-visual-config` to package monster image assets.
+- Add preview cards for stage, branch, and target renderer contexts.
+- Store package operations that reference validated asset upload ids.
+- On publish, promote package asset references into the global release snapshot or published asset manifest reference.
+
+**Exit criteria:**
+
+- Missing required monster images block learner-visible monster binding.
+- Admin preview catches renderer compatibility problems before approval.
+- Existing monster visual config behaviour remains intact.
+
+#### T23. Publish and fallback monster assets
+
+**Goal:** Make published monster asset references safe for runtime while retaining fallback.
+
+**Covers:** R53-R56, R65.
+
+**Primary files:**
+
+- `worker/src/repository.js`
+- `src/platform/game/monster-visual-config.js`
+- `src/platform/game/monster-asset-manifest.js`
+- `tests/admin-asset-registry-characterisation.test.js`
+- `tests/hero-contracts.test.js`
+
+**Approach:**
+
+- Resolve monster asset references from published global release first, then bundled/generated fallback.
+- Ensure asset changes do not mutate reward thresholds or progress state unless package operations include those changes.
+- Keep old published assets available while new package assets are draft or while rollback is possible.
+
+**Exit criteria:**
+
+- Published asset rollback is possible through release rollback.
+- Draft assets never show to learners.
+- Runtime falls back if remote published asset reference is unavailable.
+
+### E7. Release Safety and Recovery
+
+#### T24. Build release history and production proof
+
+**Goal:** Make published changes reviewable and auditable.
+
+**Covers:** R74, R78.
+
+**Primary files:**
+
+- `worker/src/content-operations/routes.js`
+- `src/surfaces/hubs/AdminContentOperationsSection.jsx`
+- `tests/admin-production-evidence.test.js`
+- `tests/content-operations-api.test.js`
+
+**Approach:**
+
+- Show releases, packages, changed entities, approver, publisher, publish time, audio fallback, asset changes, and proof status.
+- Store proof metadata for learner-facing visibility changes.
+- Link proof to Spelling setup, Word Bank, Hero / Codex, and monster rendering surfaces where relevant.
+
+**Exit criteria:**
+
+- Release History can answer what changed, who approved it, who published it, and what proof exists.
+- Visibility changes require proof capture after publish.
+
+#### T25. Implement whole-release rollback
+
+**Goal:** Provide emergency recovery by restoring a previous global release.
+
+**Covers:** R47, R75, R77, AE14.
+
+**Primary files:**
+
+- `worker/src/content-operations/routes.js`
+- `worker/src/repository.js`
+- `src/surfaces/hubs/AdminContentOperationsSection.jsx`
+- `tests/content-operations-rollback.test.js`
+
+**Approach:**
+
+- Add approved high-risk rollback action.
+- Record rollback target, reason, approver, publisher, and proof requirement.
+- Mark active release atomically.
+- Do not delete R2 audio or draft assets.
+
+**Exit criteria:**
+
+- Runtime switches to the rollback release.
+- Release History records rollback lineage.
+- R2 objects remain untouched.
+
+#### T26. Implement package-level revert
+
+**Goal:** Allow ordinary recovery from a specific package without rolling back unrelated later releases.
+
+**Covers:** R48, R76-R77, AE14.
+
+**Primary files:**
+
+- `src/subjects/spelling/content/package-operations.js`
+- `worker/src/content-operations/routes.js`
+- `tests/content-operations-revert.test.js`
+- `tests/content-operations-merge.test.js`
+
+**Approach:**
+
+- Generate inverse operations for a published package against the current release.
+- Treat the inverse as a new package with validation, conflict detection, approval, and publish.
+- Preserve retired content and asset references as auditable history.
+
+**Exit criteria:**
+
+- Package revert does not undo unrelated later releases.
+- Revert can conflict and require manual resolution.
+- Revert does not delete R2 audio objects.
+
+#### T27. Add visibility activation proof workflow
+
+**Goal:** Separate publishing content from making it learner-visible, while still proving learner-facing changes.
+
+**Covers:** R44-R46, R58-R61, R78.
+
+**Primary files:**
+
+- `worker/src/content-operations/routes.js`
+- `src/surfaces/hubs/AdminContentOperationsSection.jsx`
+- `tests/content-operations-api.test.js`
+- `tests/worker-subject-runtime.test.js`
+
+**Approach:**
+
+- Track hidden, visible, scheduled, and rollout-flag states.
+- Add admin warnings for scheduled content with missing proof after activation.
+- Provide proof fields for production checks.
+- Ensure runtime enforces visibility at request time.
+
+**Exit criteria:**
+
+- Scheduled publish can be prepared without learner exposure.
+- Visibility activation is audited.
+- Production proof is visible in Release History.
+
+### E8. Hardening, Migration, Documentation
+
+#### T28. Add compatibility and migration path
+
+**Goal:** Move current spelling content into the new global release model without breaking existing admin or runtime paths.
+
+**Covers:** R62-R65, R72.
+
+**Primary files:**
+
+- `scripts/migrate-spelling-content-to-global-release.mjs`
+- `worker/src/repository.js`
+- `worker/src/app.js`
+- `tests/spelling-content-api.test.js`
+- `tests/worker-subject-runtime.test.js`
+
+**Approach:**
+
+- Seed the first global release from current published spelling content or bundled fallback.
+- Keep existing import/export/publish controls working until fully replaced.
+- Make legacy admin publish either disabled with migration guidance or mapped into a compatibility package.
+- Document the cutover clearly.
+
+**Exit criteria:**
+
+- Production can be migrated to a first global release.
+- Existing learners continue to receive the same content before and after migration.
+- Legacy admin tools cannot silently bypass package approval after cutover.
+
+#### T29. Add capacity, security, and redaction hardening
+
+**Goal:** Protect production-sensitive paths before wider use.
+
+**Covers:** R1, R17, R73, R78.
+
+**Primary files:**
+
+- `tests/bundle-audit.test.js`
+- `tests/admin-safe-copy.test.js`
+- `tests/admin-asset-preview-url-safety.test.js`
+- `tests/content-operations-api.test.js`
+- `worker/src/content-operations/routes.js`
+
+**Approach:**
+
+- Add request body limits for package operations and asset uploads.
+- Enforce admin-only access and capability checks.
+- Ensure release/package exports do not leak learner personal data.
+- Keep list endpoints compact.
+- Add rate or concurrency controls for audio generation and uploads where needed.
+
+**Exit criteria:**
+
+- Non-admin access is blocked.
+- Large package operations fail safely.
+- Public bundles and Worker bundle stay within current guardrails.
+- Safe-copy tests cover package and release history data.
+
+#### T30. Add documentation and runbooks
+
+**Goal:** Make the new operations model understandable and operable.
+
+**Covers:** R16, R29-R40, R74-R78.
+
+**Primary files:**
+
+- `docs/content-operations-centre.md`
+- `docs/spelling-content-model.md`
+- `docs/spelling-word-audio.md`
+- `docs/monster-visual-config.md`
+- `docs/operations/capacity.md`
+- `docs/solutions/architecture-patterns/content-operations-centre.md`
+
+**Approach:**
+
+- Document package lifecycle, approval, publish, conflict resolution, audio generation, fallback, asset upload, visibility, rollback, and revert.
+- Update spelling content docs to explain global release and package model.
+- Update audio docs to cover package-scoped scans and TTS generation.
+- Update monster docs to cover uploaded image assets and fallback.
+
+**Exit criteria:**
+
+- Operators can follow a runbook to add a word, add a pool, generate audio, upload a monster image, approve, publish, and recover.
+- Documentation reflects the final data model and not only UI behaviour.
+
+#### T31. Add production verification scripts and close-out gates
+
+**Goal:** Provide repeatable proof for releases that affect learners.
+
+**Covers:** R78 and all acceptance examples that affect runtime.
+
+**Primary files:**
+
+- `scripts/verify-content-operations-production.mjs`
+- `scripts/verify-spelling-audio-production.mjs`
+- `tests/playwright/content-operations-centre.playwright.test.mjs`
+- `docs/operations/content-operations-production-proof.md`
+
+**Approach:**
+
+- Add a production smoke script for admin release metadata and public runtime snapshots.
+- Verify Spelling setup, Word Bank, Hero / Codex, and monster rendering surfaces after learner-facing visibility changes.
+- Keep logged-in browser verification for UI flows that need session state.
+- Capture evidence paths in the release history proof field.
+
+**Exit criteria:**
+
+- `npm test` and `npm run check` remain the pre-deploy gates.
+- Production proof can be captured and linked after deploy.
+- Release History shows proof status for learner-facing changes.
+
+## Ticket Dependency Graph
+
+```mermaid
+flowchart LR
+  T1["T1 schema"] --> T2["T2 operations"]
+  T2 --> T3["T3 repository"]
+  T3 --> T4["T4 runtime bridge"]
+  T3 --> T5["T5 API routes"]
+  T5 --> T6["T6 admin shell"]
+  T5 --> T7["T7 approval UX"]
+  T2 --> T8["T8 conflict resolver"]
+  T6 --> T9["T9 spelling browse"]
+  T9 --> T10["T10 word editor"]
+  T9 --> T11["T11 sentence editor"]
+  T9 --> T12["T12 pool editorial"]
+  T2 --> T13["T13 audio scanner"]
+  T13 --> T14["T14 TTS package service"]
+  T14 --> T15["T15 override/fallback"]
+  T15 --> T16["T16 audio UI"]
+  T12 --> T17["T17 reward validators"]
+  T17 --> T18["T18 existing monster mapping"]
+  T18 --> T19["T19 pools/rewards UI"]
+  T18 --> T20["T20 Hero exposure"]
+  T5 --> T21["T21 asset upload"]
+  T21 --> T22["T22 asset preview"]
+  T22 --> T23["T23 asset publish/fallback"]
+  T7 --> T24["T24 release history/proof"]
+  T24 --> T25["T25 rollback"]
+  T24 --> T26["T26 package revert"]
+  T20 --> T27["T27 visibility proof"]
+  T4 --> T28["T28 migration"]
+  T28 --> T29["T29 hardening"]
+  T29 --> T30["T30 docs"]
+  T30 --> T31["T31 production verification"]
+```
+
+## System-Wide Impact
+
+- **Admin Console:** Gains a new Content Operations Centre and additional admin-only routes. Existing Admin Content and Asset Registry surfaces must remain usable during migration.
+- **Worker/D1:** Adds global content operations tables and new admin routes. Runtime content reads gain global-release lookup while retaining fallback.
+- **Spelling:** Existing bundle, validation, variants, sentence-entry references, and runtime projection stay central. New operation helpers layer on top.
+- **Audio/R2:** Existing TTS and R2 cache are reused behind package-scoped scan and generation controls. No audio upload path is introduced.
+- **Hero/Codex:** Hero reads exposure configuration over reward tracks and monsters. Existing progress must remain stable.
+- **Monster assets:** Existing generated/fallback assets remain valid. Uploaded images become package draft assets and then published release references.
+- **Testing:** Adds repository, API, merge, UI, audio, reward, asset, rollback, revert, and production proof coverage.
+- **Operations:** Release history becomes the primary evidence record for content changes. Git remains source for code, not the only content-change audit.
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Building UI before global package foundation | Creates a second partial admin surface that cannot safely publish | Deliver E1 before mutation-heavy UI tickets |
+| Large snapshots in public bundles or hot Worker paths | Bundle-size and runtime failures | Keep list endpoints compact, use runtime projection, extend bundle audit tests |
+| Account-scoped storage leaking into global workflow | Confusing operator model and unsafe overrides | Make global release primary, reserve account override table for diagnostics |
+| Conflict model too coarse | Blocks too many parallel packages | Use same entity plus same field path, with structural guards for retire/delete/move |
+| Conflict model too loose | Silent overwrites | Hard block same-field conflicts and invalidate approval after rebase/resolution |
+| Audio generation cost or timeout | Failed batch operations | Support selected generation, package batch jobs, retry status, and local operator script bridge |
+| Runtime TTS fallback becoming normal | Production quality drift | Strict default gate, explicit approval reason, visible warning until audio is complete |
+| Reward-track migration corrupting progress | Learner trust regression | Characterise current Hero/Codex behaviour before mapping, preserve existing keys |
+| Asset uploads bypassing renderer contracts | Broken monsters in learner UI | Validate format/dimensions/context preview before publish |
+| Rollback deleting or orphaning R2 data | Recovery becomes destructive | Rollback/revert never delete audio; cleanup is separate retention work |
+
+## Verification Strategy
+
+Per-ticket targeted tests:
+
+- Repository and D1: `tests/content-operations-repository.test.js`
+- API: `tests/content-operations-api.test.js`
+- Merge/conflict: `tests/content-operations-merge.test.js`
+- Approval: `tests/content-operations-approval.test.js`
+- Editorial model: `tests/spelling-content-operations-model.test.js`
+- Admin UI: `tests/admin-content-operations-v2.test.js`
+- Audio readiness: `tests/content-operations-audio-readiness.test.js`
+- TTS/R2 compatibility: `tests/worker-tts.test.js`, `tests/build-spelling-word-audio-generate.test.js`
+- Rewards/Hero: `tests/spelling-reward-tracks.test.js`, `tests/hero-contracts.test.js`, `tests/hero-subject-banner.test.js`
+- Assets: `tests/monster-asset-upload-validation.test.js`, `tests/admin-asset-registry-v1.test.js`, `tests/admin-asset-preview-url-safety.test.js`
+- Runtime/fallback: `tests/worker-subject-runtime.test.js`, `tests/spelling-content-api.test.js`
+- Recovery: `tests/content-operations-rollback.test.js`, `tests/content-operations-revert.test.js`
+- Capacity/security: `tests/bundle-audit.test.js`, `tests/admin-safe-copy.test.js`
+
+Release gates:
+
+- Run relevant targeted tests for each ticket.
+- Run `npm test` and `npm run check` before deployment.
+- When working from a fresh worktree, run `node scripts/worktree-setup.mjs` before test/check commands.
+- After deployment, verify `https://ks2.eugnel.uk` with a logged-in admin session when the change affects Admin Console or learner-facing visibility.
+- Capture production proof for Spelling setup, Word Bank, Hero / Codex, and monster rendering when a release makes content learner-visible.
+
+## Acceptance Matrix
+
+| Acceptance example | Ticket coverage |
+| --- | --- |
+| AE1. New spelling pool package validates content, audio, reward, monster, and exposure together | T5, T7, T12, T13, T17, T19, T20, T21 |
+| AE2. Post-approval mutation invalidates approval | T3, T7 |
+| AE3. Same V1 admin can edit and approve while audit separates actions | T5, T7 |
+| AE4. Same-field conflict blocks publish | T2, T8 |
+| AE5. Unrelated package auto-rebases | T2, T8 |
+| AE6. Variant-level sentence/audio gaps are visible | T9, T10, T13, T16 |
+| AE7. Missing slow female sentence audio can publish only with approved fallback warning | T13, T15, T24 |
+| AE8. Poor-quality audio replacement regenerates through TTS and R2, not upload | T14, T15 |
+| AE9. Multiple reward tracks validate thresholds and sequence cycles | T17, T19 |
+| AE10. Monster image validation and preview block learner-visible publish when invalid | T21, T22, T23 |
+| AE11. Scheduled visibility hides content from learners but allows admin preview and audio generation | T20, T27 |
+| AE12. Published word removal becomes retirement | T10, T11, T12 |
+| AE13. Runtime resolves account override, global release, bundled fallback | T4, T28 |
+| AE14. Recovery supports whole rollback and package revert without deleting audio | T25, T26 |
+
+## Documentation and Operational Notes
+
+- The first implementation ticket should include a short architecture note in `docs/content-operations-centre.md` so later tickets share terms and table names.
+- Existing spelling docs should be updated when global release resolution becomes active, not left describing `account_subject_content` as the effective production path.
+- Audio docs should clearly state that Admin UI generation uses TTS and R2 only; audio upload is not supported.
+- Monster docs should distinguish existing visual config from uploaded monster image assets.
+- Runbooks should show the common operator flows:
+  - Add a word and its sentences.
+  - Add a word-family variant.
+  - Scan and generate missing word audio.
+  - Scan and generate missing sentence dictation audio.
+  - Create a new pool with multiple reward tracks.
+  - Upload a monster image asset.
+  - Schedule Hero / Codex exposure.
+  - Approve and publish a package.
+  - Roll back a release.
+  - Create a package-level revert.
+
+## Sources and References
+
+- `docs/brainstorms/2026-06-10-content-operations-centre-requirements.md`
+- `docs/spelling-content-model.md`
+- `docs/spelling-word-audio.md`
+- `docs/monster-visual-config.md`
+- `docs/plans/2026-04-22-002-feat-spelling-extra-expansion-plan.md`
+- `docs/plans/2026-04-24-002-feat-monster-visual-config-centre-plan.md`
+- `docs/plans/2026-04-26-001-feat-spelling-word-audio-cache-plan.md`
+- `docs/solutions/learning-spelling-audio-cache-contract.md`
+- `docs/solutions/architecture-patterns/admin-console-p6-evidence-integrity-content-ops-maturity-2026-04-29.md`
+- `src/subjects/spelling/content/model.js`
+- `src/subjects/spelling/content/service.js`
+- `src/subjects/spelling/content/repository.js`
+- `src/surfaces/hubs/AdminContentSection.jsx`
+- `src/platform/hubs/admin-asset-registry.js`
+- `worker/migrations/0005_spelling_content_model.sql`
+- `worker/src/app.js`
+- `worker/src/repository.js`

--- a/src/subjects/spelling/content/operations-model.js
+++ b/src/subjects/spelling/content/operations-model.js
@@ -1,0 +1,315 @@
+import { cloneSerialisable } from '../../../platform/core/repositories/helpers.js';
+import { stableHash } from '../../../platform/core/utils.js';
+import {
+  normaliseSpellingContentBundle,
+  validateSpellingContentBundle,
+} from './model.js';
+
+export const CONTENT_OPERATION_SUBJECT_ID = 'spelling';
+
+export const CONTENT_OPERATION_PACKAGE_STATES = Object.freeze({
+  DRAFT: 'draft',
+  READY_FOR_APPROVAL: 'ready_for_approval',
+  APPROVED: 'approved',
+  PUBLISHED: 'published',
+  REJECTED: 'rejected',
+  BLOCKED: 'blocked',
+  REVERTED: 'reverted',
+  SUPERSEDED: 'superseded',
+});
+
+export const CONTENT_OPERATION_ENTITY_TYPES = Object.freeze([
+  'spelling.word',
+  'spelling.wordVariant',
+  'spelling.sentenceEntry',
+  'spelling.wordList',
+  'spelling.pool',
+  'spelling.audioRequirementProfile',
+  'spelling.rewardTrack',
+  'spelling.monsterBinding',
+  'spelling.monsterAsset',
+  'spelling.heroExposure',
+  'spelling.visibilityRule',
+]);
+
+export const CONTENT_OPERATION_ACTIONS = Object.freeze([
+  'create',
+  'upsert',
+  'replace',
+  'set',
+  'remove',
+  'retire',
+]);
+
+const ENTITY_TYPE_SET = new Set(CONTENT_OPERATION_ENTITY_TYPES);
+const ACTION_SET = new Set(CONTENT_OPERATION_ACTIONS);
+const STRUCTURAL_ACTIONS = new Set(['create', 'upsert', 'replace', 'remove', 'retire']);
+
+const EDITABLE_COLLECTIONS = Object.freeze({
+  'spelling.word': Object.freeze({ collectionPath: ['draft', 'words'], idField: 'slug' }),
+  'spelling.sentenceEntry': Object.freeze({ collectionPath: ['draft', 'sentences'], idField: 'id' }),
+  'spelling.wordList': Object.freeze({ collectionPath: ['draft', 'wordLists'], idField: 'id' }),
+});
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normaliseString(value, fallback = '') {
+  return typeof value === 'string' ? value.trim() || fallback : fallback;
+}
+
+function stableStringify(value) {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map((entry) => stableStringify(entry)).join(',')}]`;
+  const keys = Object.keys(value).sort();
+  return `{${keys.map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`).join(',')}}`;
+}
+
+function hashPayload(value, prefix = 'co') {
+  return `${prefix}-${stableHash(stableStringify(value)).toString(36)}`;
+}
+
+function splitFieldPath(fieldPath) {
+  return normaliseString(fieldPath)
+    .split('.')
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+function getAtPath(root, pathParts) {
+  let cursor = root;
+  for (const part of pathParts) {
+    if (cursor == null) return undefined;
+    const key = Array.isArray(cursor) && /^\d+$/.test(part) ? Number(part) : part;
+    cursor = cursor[key];
+  }
+  return cursor;
+}
+
+function setAtPath(root, pathParts, value) {
+  if (!pathParts.length) return value;
+  let cursor = root;
+  for (let index = 0; index < pathParts.length - 1; index += 1) {
+    const part = pathParts[index];
+    const key = Array.isArray(cursor) && /^\d+$/.test(part) ? Number(part) : part;
+    if (!isPlainObject(cursor[key]) && !Array.isArray(cursor[key])) {
+      cursor[key] = /^\d+$/.test(pathParts[index + 1]) ? [] : {};
+    }
+    cursor = cursor[key];
+  }
+  const last = pathParts[pathParts.length - 1];
+  const key = Array.isArray(cursor) && /^\d+$/.test(last) ? Number(last) : last;
+  cursor[key] = cloneSerialisable(value);
+  return root;
+}
+
+function collectionFor(bundle, entityType) {
+  const descriptor = EDITABLE_COLLECTIONS[entityType];
+  if (!descriptor) return null;
+  let collection = bundle;
+  for (const part of descriptor.collectionPath) {
+    collection = collection?.[part];
+  }
+  return Array.isArray(collection) ? { ...descriptor, collection } : null;
+}
+
+function findEntity(collection, idField, entityId) {
+  const index = collection.findIndex((entry) => normaliseString(entry?.[idField]) === entityId);
+  return { index, entity: index >= 0 ? collection[index] : null };
+}
+
+function applyCollectionOperation(bundle, operation) {
+  const descriptor = collectionFor(bundle, operation.entityType);
+  if (!descriptor) {
+    throw new Error(`Unsupported content operation entity type "${operation.entityType}".`);
+  }
+  const { collection, idField } = descriptor;
+  const { index, entity } = findEntity(collection, idField, operation.entityId);
+
+  if (operation.action === 'create') {
+    if (entity) throw new Error(`Cannot create existing ${operation.entityType} "${operation.entityId}".`);
+    collection.push(cloneSerialisable(operation.payload));
+    return;
+  }
+
+  if (operation.action === 'upsert') {
+    if (entity) {
+      collection[index] = cloneSerialisable(operation.payload);
+    } else {
+      collection.push(cloneSerialisable(operation.payload));
+    }
+    return;
+  }
+
+  if (!entity) {
+    throw new Error(`Cannot ${operation.action} missing ${operation.entityType} "${operation.entityId}".`);
+  }
+
+  if (operation.action === 'replace') {
+    collection[index] = cloneSerialisable(operation.payload);
+    return;
+  }
+
+  if (operation.action === 'remove') {
+    collection.splice(index, 1);
+    return;
+  }
+
+  if (operation.action === 'retire') {
+    collection[index] = {
+      ...cloneSerialisable(entity),
+      active: false,
+      retired: true,
+      retirement: cloneSerialisable(operation.payload) || {},
+    };
+    return;
+  }
+
+  if (operation.action === 'set') {
+    const pathParts = splitFieldPath(operation.fieldPath);
+    if (!pathParts.length) {
+      throw new Error('Set operations require a fieldPath.');
+    }
+    const next = cloneSerialisable(entity);
+    setAtPath(next, pathParts, operation.payload);
+    collection[index] = next;
+  }
+}
+
+function isStructuralOperation(operation) {
+  return STRUCTURAL_ACTIONS.has(operation.action) || !operation.fieldPath || operation.fieldPath === '$';
+}
+
+function conflictCodeFor(left, right) {
+  if (isStructuralOperation(left) || isStructuralOperation(right)) return 'structural_conflict';
+  return 'same_field_conflict';
+}
+
+export function stableContentOperationStringify(value) {
+  return stableStringify(value);
+}
+
+export function contentOperationHash(value, prefix = 'co') {
+  return hashPayload(value, prefix);
+}
+
+export function normaliseContentOperation(rawValue = {}, {
+  actorAccountId = '',
+  now = null,
+  operationId = '',
+} = {}) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  const entityType = normaliseString(raw.entityType || raw.entity_type);
+  const action = normaliseString(raw.action).toLowerCase();
+  const entityId = normaliseString(raw.entityId || raw.entity_id);
+  const fieldPath = normaliseString(raw.fieldPath || raw.field_path);
+  const rawPayload = Object.prototype.hasOwnProperty.call(raw, 'payload') ? raw.payload : raw.payload_json;
+  const payload = cloneSerialisable(rawPayload === undefined ? null : rawPayload);
+
+  if (!ENTITY_TYPE_SET.has(entityType)) {
+    throw new Error(`Unsupported content operation entity type "${entityType}".`);
+  }
+  if (!ACTION_SET.has(action)) {
+    throw new Error(`Unsupported content operation action "${action}".`);
+  }
+  if (!entityId) {
+    throw new Error('Content operations require an entityId.');
+  }
+  if (action === 'set' && !fieldPath) {
+    throw new Error('Set operations require a fieldPath.');
+  }
+
+  const rawCreatedAt = raw.createdAt ?? raw.created_at;
+  const createdAt = Number.isFinite(Number(rawCreatedAt))
+    ? Number(rawCreatedAt)
+    : (typeof now === 'function' ? Number(now()) : 0);
+  const createdByAccountId = normaliseString(
+    raw.createdByAccountId || raw.created_by_account_id,
+    actorAccountId,
+  );
+  const beforeHash = normaliseString(raw.beforeHash || raw.before_hash);
+  const afterHash = normaliseString(raw.afterHash || raw.after_hash, hashPayload(payload, 'after'));
+
+  return {
+    operationId: normaliseString(raw.operationId || raw.operation_id, operationId),
+    entityType,
+    entityId,
+    fieldPath,
+    action,
+    beforeHash,
+    afterHash,
+    payload,
+    createdByAccountId,
+    createdAt,
+  };
+}
+
+export function operationConflictKey(operation) {
+  const normalised = normaliseContentOperation(operation, { now: () => 0 });
+  return `${normalised.entityType}::${normalised.entityId}::${normalised.fieldPath || '$'}`;
+}
+
+export function detectContentOperationConflicts(leftOperations = [], rightOperations = []) {
+  const normaliseForComparison = (operation) => normaliseContentOperation(operation, { now: () => 0 });
+  const left = leftOperations.map(normaliseForComparison);
+  const right = rightOperations.map(normaliseForComparison);
+  const conflicts = [];
+
+  for (const leftOperation of left) {
+    for (const rightOperation of right) {
+      if (
+        leftOperation.entityType !== rightOperation.entityType
+        || leftOperation.entityId !== rightOperation.entityId
+      ) {
+        continue;
+      }
+      const sameField = (leftOperation.fieldPath || '$') === (rightOperation.fieldPath || '$');
+      const structural = isStructuralOperation(leftOperation) || isStructuralOperation(rightOperation);
+      if (!sameField && !structural) continue;
+      if (contentOperationHash(leftOperation) === contentOperationHash(rightOperation)) continue;
+      conflicts.push({
+        code: conflictCodeFor(leftOperation, rightOperation),
+        entityType: leftOperation.entityType,
+        entityId: leftOperation.entityId,
+        fieldPath: sameField ? (leftOperation.fieldPath || rightOperation.fieldPath || '$') : '$',
+        leftOperationId: leftOperation.operationId,
+        rightOperationId: rightOperation.operationId,
+      });
+    }
+  }
+
+  return conflicts;
+}
+
+export function readContentOperationField(bundle, operation) {
+  const normalised = normaliseContentOperation(operation, { now: () => 0 });
+  const descriptor = collectionFor(normaliseSpellingContentBundle(bundle), normalised.entityType);
+  if (!descriptor) return undefined;
+  const { entity } = findEntity(descriptor.collection, descriptor.idField, normalised.entityId);
+  if (!entity) return undefined;
+  return getAtPath(entity, splitFieldPath(normalised.fieldPath));
+}
+
+export function applyContentOperationsToSpellingContent(baseBundle, operations = []) {
+  const candidate = normaliseSpellingContentBundle(baseBundle);
+  const normalisedOperations = operations.map((operation) => normaliseContentOperation(operation, { now: () => 0 }));
+  for (const operation of normalisedOperations) {
+    applyCollectionOperation(candidate, operation);
+  }
+  return normaliseSpellingContentBundle(candidate);
+}
+
+export function buildSpellingContentOperationCandidate(baseBundle, operations = []) {
+  const normalisedOperations = operations.map((operation) => normaliseContentOperation(operation, { now: () => 0 }));
+  const candidate = applyContentOperationsToSpellingContent(baseBundle, normalisedOperations);
+  const validation = validateSpellingContentBundle(candidate);
+  return {
+    baseHash: hashPayload(normaliseSpellingContentBundle(baseBundle), 'base'),
+    operationsHash: hashPayload(normalisedOperations, 'ops'),
+    candidateHash: hashPayload(candidate, 'candidate'),
+    candidate,
+    validation,
+    conflicts: [],
+  };
+}

--- a/src/subjects/spelling/content/operations-model.js
+++ b/src/subjects/spelling/content/operations-model.js
@@ -20,16 +20,8 @@ export const CONTENT_OPERATION_PACKAGE_STATES = Object.freeze({
 
 export const CONTENT_OPERATION_ENTITY_TYPES = Object.freeze([
   'spelling.word',
-  'spelling.wordVariant',
   'spelling.sentenceEntry',
   'spelling.wordList',
-  'spelling.pool',
-  'spelling.audioRequirementProfile',
-  'spelling.rewardTrack',
-  'spelling.monsterBinding',
-  'spelling.monsterAsset',
-  'spelling.heroExposure',
-  'spelling.visibilityRule',
 ]);
 
 export const CONTENT_OPERATION_ACTIONS = Object.freeze([

--- a/tests/content-operations-merge.test.js
+++ b/tests/content-operations-merge.test.js
@@ -1,0 +1,120 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildSpellingContentOperationCandidate,
+  contentOperationHash,
+  detectContentOperationConflicts,
+  normaliseContentOperation,
+  readContentOperationField,
+} from '../src/subjects/spelling/content/operations-model.js';
+import {
+  readSeededSpellingContentBundle,
+} from '../worker/src/generated-spelling-content-seed.js';
+
+test('content operations produce stable hashes and normalised field edits', () => {
+  const operation = normaliseContentOperation({
+    entityType: 'spelling.word',
+    entityId: 'receipt',
+    fieldPath: 'explanation',
+    action: 'set',
+    payload: 'A learner-facing explanation used by the content operation test.',
+  }, {
+    actorAccountId: 'admin-a',
+    now: () => 1_777_000_000_000,
+    operationId: 'op-a',
+  });
+
+  assert.equal(operation.operationId, 'op-a');
+  assert.equal(operation.createdByAccountId, 'admin-a');
+  assert.equal(operation.createdAt, 1_777_000_000_000);
+  assert.equal(operation.afterHash, contentOperationHash(operation.payload, 'after'));
+  assert.equal(contentOperationHash(operation), contentOperationHash({ ...operation }));
+});
+
+test('content operations detect same-field conflicts without blocking unrelated fields', () => {
+  const left = [{
+    operationId: 'left-op',
+    entityType: 'spelling.word',
+    entityId: 'receipt',
+    fieldPath: 'explanation',
+    action: 'set',
+    payload: 'First explanation.',
+  }];
+  const right = [{
+    operationId: 'right-op',
+    entityType: 'spelling.word',
+    entityId: 'receipt',
+    fieldPath: 'explanation',
+    action: 'set',
+    payload: 'Second explanation.',
+  }];
+  const unrelated = [{
+    operationId: 'right-tags',
+    entityType: 'spelling.word',
+    entityId: 'receipt',
+    fieldPath: 'tags',
+    action: 'set',
+    payload: ['test-tag'],
+  }];
+
+  assert.deepEqual(detectContentOperationConflicts(left, unrelated), []);
+
+  const conflicts = detectContentOperationConflicts(left, right);
+  assert.equal(conflicts.length, 1);
+  assert.equal(conflicts[0].code, 'same_field_conflict');
+  assert.equal(conflicts[0].entityType, 'spelling.word');
+  assert.equal(conflicts[0].entityId, 'receipt');
+  assert.equal(conflicts[0].fieldPath, 'explanation');
+});
+
+test('structural operations conflict with child-field edits on the same entity', () => {
+  const structural = [{
+    operationId: 'retire-op',
+    entityType: 'spelling.word',
+    entityId: 'receipt',
+    action: 'retire',
+    payload: { reason: 'No longer active.' },
+  }];
+  const edit = [{
+    operationId: 'edit-op',
+    entityType: 'spelling.word',
+    entityId: 'receipt',
+    fieldPath: 'explanation',
+    action: 'set',
+    payload: 'A new explanation.',
+  }];
+
+  const conflicts = detectContentOperationConflicts(structural, edit);
+  assert.equal(conflicts.length, 1);
+  assert.equal(conflicts[0].code, 'structural_conflict');
+  assert.equal(conflicts[0].fieldPath, '$');
+});
+
+test('spelling package candidate applies word edits against the existing bundle', async () => {
+  const bundle = await readSeededSpellingContentBundle();
+  const word = bundle.draft.words[0];
+  const nextExplanation = `A package-scoped learner-facing explanation for ${word.word}.`;
+  const candidate = buildSpellingContentOperationCandidate(bundle, [{
+    entityType: 'spelling.word',
+    entityId: word.slug,
+    fieldPath: 'explanation',
+    action: 'set',
+    payload: nextExplanation,
+  }]);
+
+  assert.equal(candidate.validation.ok, true);
+  assert.equal(candidate.candidate.draft.words[0].explanation, nextExplanation);
+  assert.equal(
+    readContentOperationField(candidate.candidate, {
+      entityType: 'spelling.word',
+      entityId: word.slug,
+      fieldPath: 'explanation',
+      action: 'set',
+      payload: nextExplanation,
+    }),
+    nextExplanation,
+  );
+  assert.match(candidate.operationsHash, /^ops-/);
+  assert.match(candidate.candidateHash, /^candidate-/);
+});

--- a/tests/content-operations-merge.test.js
+++ b/tests/content-operations-merge.test.js
@@ -32,6 +32,18 @@ test('content operations produce stable hashes and normalised field edits', () =
   assert.equal(contentOperationHash(operation), contentOperationHash({ ...operation }));
 });
 
+test('content operations reject entity contracts that the candidate builder cannot apply yet', () => {
+  assert.throws(
+    () => normaliseContentOperation({
+      entityType: 'spelling.pool',
+      entityId: 'core-y5',
+      action: 'upsert',
+      payload: { id: 'core-y5', title: 'Core Year 5' },
+    }),
+    /Unsupported content operation entity type "spelling\.pool"/,
+  );
+});
+
 test('content operations detect same-field conflicts without blocking unrelated fields', () => {
   const left = [{
     operationId: 'left-op',

--- a/tests/content-operations-repository.test.js
+++ b/tests/content-operations-repository.test.js
@@ -1,0 +1,307 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createWorkerRepository } from '../worker/src/repository.js';
+import { createMigratedSqliteD1Database } from './helpers/sqlite-d1.js';
+import {
+  readSeededSpellingContentBundle,
+} from '../worker/src/generated-spelling-content-seed.js';
+
+test('content operations repository publishes an approved package as a global release', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const repository = createWorkerRepository({
+    env: { DB },
+    now: () => 1_777_000_000_000,
+  });
+
+  try {
+    const seeded = await readSeededSpellingContentBundle();
+    const word = seeded.draft.words[0];
+    const explanation = `A package-approved learner-facing explanation for ${word.word}.`;
+
+    const contentPackage = await repository.createContentOperationPackage({
+      subjectId: 'spelling',
+      templateId: 'edit-spelling-word',
+      title: 'Edit first seeded spelling word',
+      description: 'Repository lifecycle test package.',
+      createdByAccountId: 'admin-a',
+    });
+
+    assert.equal(contentPackage.state, 'draft');
+    assert.equal(contentPackage.baseReleaseId, null);
+    assert.equal(contentPackage.baseReleaseHash, null);
+
+    const operation = await repository.appendContentOperation(contentPackage.packageId, {
+      entityType: 'spelling.word',
+      entityId: word.slug,
+      fieldPath: 'explanation',
+      action: 'set',
+      payload: explanation,
+    }, {
+      actorAccountId: 'admin-a',
+    });
+
+    assert.equal(operation.packageId, contentPackage.packageId);
+    assert.equal(operation.operationOrder, 1);
+    assert.equal(operation.entityId, word.slug);
+
+    const candidate = await repository.buildContentOperationCandidate(contentPackage.packageId, {
+      actorAccountId: 'admin-a',
+    });
+
+    assert.equal(candidate.validation.ok, true);
+    assert.equal(candidate.candidate.draft.words[0].explanation, explanation);
+    assert.match(candidate.candidateHash, /^candidate-/);
+
+    const approval = await repository.approveContentOperationCandidate(
+      contentPackage.packageId,
+      candidate.candidateId,
+      {
+        approvedByAccountId: 'admin-a',
+        notes: 'Approved in repository lifecycle test.',
+      },
+    );
+
+    assert.equal(approval.candidateHash, candidate.candidateHash);
+    assert.equal(approval.approvedByAccountId, 'admin-a');
+
+    const release = await repository.publishContentOperationPackage(contentPackage.packageId, {
+      publishedByAccountId: 'admin-a',
+      proof: { source: 'node-test' },
+    });
+
+    assert.equal(release.status, 'published');
+    assert.equal(release.packageId, contentPackage.packageId);
+    assert.equal(release.snapshot.draft.words[0].explanation, explanation);
+
+    const latest = await repository.readLatestContentOperationRelease('spelling', {
+      includeSnapshot: true,
+    });
+    assert.equal(latest.releaseId, release.releaseId);
+    assert.equal(latest.snapshot.draft.words[0].explanation, explanation);
+
+    const packages = await repository.listContentOperationPackages({ subjectId: 'spelling' });
+    assert.equal(packages.length, 1);
+    assert.equal(packages[0].state, 'published');
+
+    const events = await repository.listContentOperationEvents({
+      packageId: contentPackage.packageId,
+    });
+    assert.deepEqual(
+      events.map((event) => event.eventType).sort(),
+      [
+        'candidate.built',
+        'operation.appended',
+        'package.approved',
+        'package.created',
+        'package.published',
+      ].sort(),
+    );
+  } finally {
+    DB.close();
+  }
+});
+
+test('content operations repository invalidates approval after package mutation', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const repository = createWorkerRepository({
+    env: { DB },
+    now: () => 1_777_000_000_000,
+  });
+
+  try {
+    const seeded = await readSeededSpellingContentBundle();
+    const word = seeded.draft.words[0];
+    const contentPackage = await repository.createContentOperationPackage({
+      templateId: 'edit-spelling-word',
+      title: 'Approval invalidation package',
+      createdByAccountId: 'admin-a',
+    });
+
+    await repository.appendContentOperation(contentPackage.packageId, {
+      entityType: 'spelling.word',
+      entityId: word.slug,
+      fieldPath: 'explanation',
+      action: 'set',
+      payload: `First learner-facing explanation for ${word.word}.`,
+    }, {
+      actorAccountId: 'admin-a',
+    });
+    const candidate = await repository.buildContentOperationCandidate(contentPackage.packageId, {
+      actorAccountId: 'admin-a',
+    });
+    await repository.approveContentOperationCandidate(contentPackage.packageId, candidate.candidateId, {
+      approvedByAccountId: 'admin-a',
+    });
+
+    await repository.appendContentOperation(contentPackage.packageId, {
+      entityType: 'spelling.word',
+      entityId: word.slug,
+      fieldPath: 'sourceNote',
+      action: 'set',
+      payload: 'Changed after approval.',
+    }, {
+      actorAccountId: 'admin-a',
+    });
+
+    const updated = await repository.readContentOperationPackage(contentPackage.packageId, {
+      includeOperations: false,
+    });
+    assert.equal(updated.state, 'draft');
+    assert.equal(updated.approvedAt, null);
+
+    await assert.rejects(
+      () => repository.publishContentOperationPackage(contentPackage.packageId, {
+        publishedByAccountId: 'admin-a',
+      }),
+      /approved before publish/,
+    );
+  } finally {
+    DB.close();
+  }
+});
+
+test('content operations repository blocks stale package approval after release drift', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const repository = createWorkerRepository({
+    env: { DB },
+    now: () => 1_777_000_000_000,
+  });
+
+  try {
+    const seeded = await readSeededSpellingContentBundle();
+    const firstWord = seeded.draft.words[0];
+    const secondWord = seeded.draft.words[1];
+
+    const stalePackage = await repository.createContentOperationPackage({
+      templateId: 'edit-spelling-word',
+      title: 'Package that starts before a newer release',
+      createdByAccountId: 'admin-a',
+    });
+    await repository.appendContentOperation(stalePackage.packageId, {
+      entityType: 'spelling.word',
+      entityId: firstWord.slug,
+      fieldPath: 'explanation',
+      action: 'set',
+      payload: `Stale package explanation for ${firstWord.word}.`,
+    }, {
+      actorAccountId: 'admin-a',
+    });
+
+    const newerPackage = await repository.createContentOperationPackage({
+      templateId: 'edit-spelling-word',
+      title: 'Newer package',
+      createdByAccountId: 'admin-b',
+    });
+    await repository.appendContentOperation(newerPackage.packageId, {
+      entityType: 'spelling.word',
+      entityId: secondWord.slug,
+      fieldPath: 'sourceNote',
+      action: 'set',
+      payload: `Newer package note for ${secondWord.word}.`,
+    }, {
+      actorAccountId: 'admin-b',
+    });
+    const newerCandidate = await repository.buildContentOperationCandidate(newerPackage.packageId, {
+      actorAccountId: 'admin-b',
+    });
+    await repository.approveContentOperationCandidate(newerPackage.packageId, newerCandidate.candidateId, {
+      approvedByAccountId: 'admin-b',
+    });
+    const newerRelease = await repository.publishContentOperationPackage(newerPackage.packageId, {
+      publishedByAccountId: 'admin-b',
+    });
+
+    const staleCandidate = await repository.buildContentOperationCandidate(stalePackage.packageId, {
+      actorAccountId: 'admin-a',
+    });
+
+    assert.equal(staleCandidate.currentReleaseId, newerRelease.releaseId);
+    assert.equal(staleCandidate.conflicts.length, 1);
+    assert.equal(staleCandidate.conflicts[0].code, 'base_release_changed');
+    assert.equal(staleCandidate.conflicts[0].packageBaseReleaseId, null);
+    assert.equal(staleCandidate.conflicts[0].currentReleaseId, newerRelease.releaseId);
+
+    await assert.rejects(
+      () => repository.approveContentOperationCandidate(stalePackage.packageId, staleCandidate.candidateId, {
+        approvedByAccountId: 'admin-a',
+      }),
+      /unresolved conflicts/,
+    );
+  } finally {
+    DB.close();
+  }
+});
+
+test('content operations repository blocks publish when approval becomes stale', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const repository = createWorkerRepository({
+    env: { DB },
+    now: () => 1_777_000_000_000,
+  });
+
+  try {
+    const seeded = await readSeededSpellingContentBundle();
+    const firstWord = seeded.draft.words[0];
+    const secondWord = seeded.draft.words[1];
+
+    const approvedPackage = await repository.createContentOperationPackage({
+      templateId: 'edit-spelling-word',
+      title: 'Approved before another release',
+      createdByAccountId: 'admin-a',
+    });
+    await repository.appendContentOperation(approvedPackage.packageId, {
+      entityType: 'spelling.word',
+      entityId: firstWord.slug,
+      fieldPath: 'explanation',
+      action: 'set',
+      payload: `Approved package explanation for ${firstWord.word}.`,
+    }, {
+      actorAccountId: 'admin-a',
+    });
+    const approvedCandidate = await repository.buildContentOperationCandidate(approvedPackage.packageId, {
+      actorAccountId: 'admin-a',
+    });
+    await repository.approveContentOperationCandidate(approvedPackage.packageId, approvedCandidate.candidateId, {
+      approvedByAccountId: 'admin-a',
+    });
+
+    const newerPackage = await repository.createContentOperationPackage({
+      templateId: 'edit-spelling-word',
+      title: 'Release that lands first',
+      createdByAccountId: 'admin-b',
+    });
+    await repository.appendContentOperation(newerPackage.packageId, {
+      entityType: 'spelling.word',
+      entityId: secondWord.slug,
+      fieldPath: 'sourceNote',
+      action: 'set',
+      payload: `First published release note for ${secondWord.word}.`,
+    }, {
+      actorAccountId: 'admin-b',
+    });
+    const newerCandidate = await repository.buildContentOperationCandidate(newerPackage.packageId, {
+      actorAccountId: 'admin-b',
+    });
+    await repository.approveContentOperationCandidate(newerPackage.packageId, newerCandidate.candidateId, {
+      approvedByAccountId: 'admin-b',
+    });
+    const newerRelease = await repository.publishContentOperationPackage(newerPackage.packageId, {
+      publishedByAccountId: 'admin-b',
+    });
+
+    await assert.rejects(
+      () => repository.publishContentOperationPackage(approvedPackage.packageId, {
+        publishedByAccountId: 'admin-a',
+      }),
+      (error) => {
+        assert.equal(error.extra?.code, 'content_operation_release_drift');
+        assert.equal(error.extra?.candidateCurrentReleaseId, null);
+        assert.equal(error.extra?.currentReleaseId, newerRelease.releaseId);
+        return true;
+      },
+    );
+  } finally {
+    DB.close();
+  }
+});

--- a/tests/content-operations-repository.test.js
+++ b/tests/content-operations-repository.test.js
@@ -7,6 +7,38 @@ import {
   readSeededSpellingContentBundle,
 } from '../worker/src/generated-spelling-content-seed.js';
 
+async function publishWordEdit(repository, word, {
+  actorAccountId = 'admin-a',
+  title = 'Repository helper package',
+  fieldPath = 'explanation',
+  payload = `Published learner-facing explanation for ${word?.word || 'word'}.`,
+} = {}) {
+  const contentPackage = await repository.createContentOperationPackage({
+    templateId: 'edit-spelling-word',
+    title,
+    createdByAccountId: actorAccountId,
+  });
+  await repository.appendContentOperation(contentPackage.packageId, {
+    entityType: 'spelling.word',
+    entityId: word.slug,
+    fieldPath,
+    action: 'set',
+    payload,
+  }, {
+    actorAccountId,
+  });
+  const candidate = await repository.buildContentOperationCandidate(contentPackage.packageId, {
+    actorAccountId,
+  });
+  await repository.approveContentOperationCandidate(contentPackage.packageId, candidate.candidateId, {
+    approvedByAccountId: actorAccountId,
+  });
+  const release = await repository.publishContentOperationPackage(contentPackage.packageId, {
+    publishedByAccountId: actorAccountId,
+  });
+  return { contentPackage, candidate, release };
+}
+
 test('content operations repository publishes an approved package as a global release', async () => {
   const DB = createMigratedSqliteD1Database();
   const repository = createWorkerRepository({
@@ -79,6 +111,12 @@ test('content operations repository publishes an approved package as a global re
     });
     assert.equal(latest.releaseId, release.releaseId);
     assert.equal(latest.snapshot.draft.words[0].explanation, explanation);
+
+    const detail = await repository.readContentOperationRelease('spelling', release.releaseId, {
+      includeSnapshot: true,
+    });
+    assert.equal(detail.releaseId, release.releaseId);
+    assert.equal(detail.snapshot.draft.words[0].explanation, explanation);
 
     const packages = await repository.listContentOperationPackages({ subjectId: 'spelling' });
     assert.equal(packages.length, 1);
@@ -156,6 +194,198 @@ test('content operations repository invalidates approval after package mutation'
       }),
       /approved before publish/,
     );
+  } finally {
+    DB.close();
+  }
+});
+
+test('content operations repository blocks approving a candidate after package operations change', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const repository = createWorkerRepository({
+    env: { DB },
+    now: () => 1_777_000_000_000,
+  });
+
+  try {
+    const seeded = await readSeededSpellingContentBundle();
+    const word = seeded.draft.words[0];
+    const contentPackage = await repository.createContentOperationPackage({
+      templateId: 'edit-spelling-word',
+      title: 'Stale candidate operations package',
+      createdByAccountId: 'admin-a',
+    });
+
+    await repository.appendContentOperation(contentPackage.packageId, {
+      entityType: 'spelling.word',
+      entityId: word.slug,
+      fieldPath: 'explanation',
+      action: 'set',
+      payload: `Candidate explanation for ${word.word}.`,
+    }, {
+      actorAccountId: 'admin-a',
+    });
+    const staleCandidate = await repository.buildContentOperationCandidate(contentPackage.packageId, {
+      actorAccountId: 'admin-a',
+    });
+
+    await repository.appendContentOperation(contentPackage.packageId, {
+      entityType: 'spelling.word',
+      entityId: word.slug,
+      fieldPath: 'sourceNote',
+      action: 'set',
+      payload: 'Operation added after candidate build.',
+    }, {
+      actorAccountId: 'admin-a',
+    });
+
+    await assert.rejects(
+      () => repository.approveContentOperationCandidate(contentPackage.packageId, staleCandidate.candidateId, {
+        approvedByAccountId: 'admin-a',
+      }),
+      (error) => {
+        assert.equal(error.extra?.code, 'content_operation_candidate_operations_stale');
+        assert.equal(error.extra?.candidateId, staleCandidate.candidateId);
+        return true;
+      },
+    );
+
+    const updated = await repository.readContentOperationPackage(contentPackage.packageId, {
+      includeOperations: false,
+    });
+    assert.equal(updated.state, 'draft');
+    assert.equal(updated.approvedAt, null);
+  } finally {
+    DB.close();
+  }
+});
+
+test('content operations repository blocks approving a candidate after release drift', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const repository = createWorkerRepository({
+    env: { DB },
+    now: () => 1_777_000_000_000,
+  });
+
+  try {
+    const seeded = await readSeededSpellingContentBundle();
+    const firstWord = seeded.draft.words[0];
+    const secondWord = seeded.draft.words[1];
+
+    const stalePackage = await repository.createContentOperationPackage({
+      templateId: 'edit-spelling-word',
+      title: 'Candidate built before release drift',
+      createdByAccountId: 'admin-a',
+    });
+    await repository.appendContentOperation(stalePackage.packageId, {
+      entityType: 'spelling.word',
+      entityId: firstWord.slug,
+      fieldPath: 'explanation',
+      action: 'set',
+      payload: `Stale candidate explanation for ${firstWord.word}.`,
+    }, {
+      actorAccountId: 'admin-a',
+    });
+    const staleCandidate = await repository.buildContentOperationCandidate(stalePackage.packageId, {
+      actorAccountId: 'admin-a',
+    });
+
+    const newerPackage = await repository.createContentOperationPackage({
+      templateId: 'edit-spelling-word',
+      title: 'Release that creates drift before approval',
+      createdByAccountId: 'admin-b',
+    });
+    await repository.appendContentOperation(newerPackage.packageId, {
+      entityType: 'spelling.word',
+      entityId: secondWord.slug,
+      fieldPath: 'sourceNote',
+      action: 'set',
+      payload: `Drift package note for ${secondWord.word}.`,
+    }, {
+      actorAccountId: 'admin-b',
+    });
+    const newerCandidate = await repository.buildContentOperationCandidate(newerPackage.packageId, {
+      actorAccountId: 'admin-b',
+    });
+    await repository.approveContentOperationCandidate(newerPackage.packageId, newerCandidate.candidateId, {
+      approvedByAccountId: 'admin-b',
+    });
+    const newerRelease = await repository.publishContentOperationPackage(newerPackage.packageId, {
+      publishedByAccountId: 'admin-b',
+    });
+
+    await assert.rejects(
+      () => repository.approveContentOperationCandidate(stalePackage.packageId, staleCandidate.candidateId, {
+        approvedByAccountId: 'admin-a',
+      }),
+      (error) => {
+        assert.equal(error.extra?.code, 'content_operation_candidate_release_drift');
+        assert.equal(error.extra?.candidateCurrentReleaseId, null);
+        assert.equal(error.extra?.currentReleaseId, newerRelease.releaseId);
+        return true;
+      },
+    );
+  } finally {
+    DB.close();
+  }
+});
+
+test('content operations repository keeps published packages immutable', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const repository = createWorkerRepository({
+    env: { DB },
+    now: () => 1_777_000_000_000,
+  });
+
+  try {
+    const seeded = await readSeededSpellingContentBundle();
+    const word = seeded.draft.words[0];
+    const contentPackage = await repository.createContentOperationPackage({
+      templateId: 'edit-spelling-word',
+      title: 'Published package immutability package',
+      createdByAccountId: 'admin-a',
+    });
+    await repository.appendContentOperation(contentPackage.packageId, {
+      entityType: 'spelling.word',
+      entityId: word.slug,
+      fieldPath: 'explanation',
+      action: 'set',
+      payload: `Published package explanation for ${word.word}.`,
+    }, {
+      actorAccountId: 'admin-a',
+    });
+    const candidate = await repository.buildContentOperationCandidate(contentPackage.packageId, {
+      actorAccountId: 'admin-a',
+    });
+    await repository.approveContentOperationCandidate(contentPackage.packageId, candidate.candidateId, {
+      approvedByAccountId: 'admin-a',
+    });
+    await repository.publishContentOperationPackage(contentPackage.packageId, {
+      publishedByAccountId: 'admin-a',
+    });
+
+    await assert.rejects(
+      () => repository.buildContentOperationCandidate(contentPackage.packageId, {
+        actorAccountId: 'admin-a',
+      }),
+      (error) => {
+        assert.equal(error.extra?.code, 'content_operation_package_published');
+        return true;
+      },
+    );
+    await assert.rejects(
+      () => repository.approveContentOperationCandidate(contentPackage.packageId, candidate.candidateId, {
+        approvedByAccountId: 'admin-a',
+      }),
+      (error) => {
+        assert.equal(error.extra?.code, 'content_operation_package_published');
+        return true;
+      },
+    );
+
+    const updated = await repository.readContentOperationPackage(contentPackage.packageId, {
+      includeOperations: false,
+    });
+    assert.equal(updated.state, 'published');
   } finally {
     DB.close();
   }
@@ -300,6 +530,106 @@ test('content operations repository blocks publish when approval becomes stale',
         assert.equal(error.extra?.currentReleaseId, newerRelease.releaseId);
         return true;
       },
+    );
+  } finally {
+    DB.close();
+  }
+});
+
+test('content operations repository keeps publish idempotent for the same package', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const repository = createWorkerRepository({
+    env: { DB },
+    now: () => 1_777_000_000_000,
+  });
+
+  try {
+    const seeded = await readSeededSpellingContentBundle();
+    const word = seeded.draft.words[0];
+    const { contentPackage, release } = await publishWordEdit(repository, word, {
+      title: 'Duplicate publish guard package',
+      payload: `Duplicate publish guard explanation for ${word.word}.`,
+    });
+
+    await assert.rejects(
+      () => repository.publishContentOperationPackage(contentPackage.packageId, {
+        publishedByAccountId: 'admin-a',
+      }),
+      (error) => {
+        assert.equal(error.extra?.code, 'content_operation_package_published');
+        return true;
+      },
+    );
+
+    DB.db.prepare(`
+      UPDATE content_operation_packages
+      SET state = 'approved'
+      WHERE package_id = ?
+    `).run(contentPackage.packageId);
+    DB.db.prepare(`
+      UPDATE content_operation_package_candidates
+      SET current_release_id = ?
+      WHERE package_id = ?
+    `).run(release.releaseId, contentPackage.packageId);
+
+    await assert.rejects(
+      () => repository.publishContentOperationPackage(contentPackage.packageId, {
+        publishedByAccountId: 'admin-a',
+      }),
+      (error) => {
+        assert.equal(error.extra?.code, 'content_operation_package_published');
+        return true;
+      },
+    );
+
+    const releaseRows = DB.db.prepare(`
+      SELECT release_id
+      FROM content_operation_releases
+      WHERE package_id = ?
+    `).all(contentPackage.packageId);
+    assert.equal(releaseRows.length, 1);
+  } finally {
+    DB.close();
+  }
+});
+
+test('content operations repository orders latest releases deterministically on timestamp ties', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const repository = createWorkerRepository({
+    env: { DB },
+    now: () => 1_777_000_000_000,
+  });
+
+  try {
+    const seeded = await readSeededSpellingContentBundle();
+    const firstWord = seeded.draft.words[0];
+    const secondWord = seeded.draft.words[1];
+
+    const first = await publishWordEdit(repository, firstWord, {
+      title: 'First same-timestamp package',
+      payload: `First same-timestamp explanation for ${firstWord.word}.`,
+    });
+    const second = await publishWordEdit(repository, secondWord, {
+      actorAccountId: 'admin-b',
+      title: 'Second same-timestamp package',
+      payload: `Second same-timestamp explanation for ${secondWord.word}.`,
+    });
+
+    assert.equal(first.release.publishedAt, second.release.publishedAt);
+
+    const latest = await repository.readLatestContentOperationRelease('spelling', {
+      includeSnapshot: true,
+    });
+    assert.equal(latest.releaseId, second.release.releaseId);
+    assert.equal(latest.snapshot.draft.words[1].explanation, `Second same-timestamp explanation for ${secondWord.word}.`);
+
+    const releases = await repository.listContentOperationReleases({
+      subjectId: 'spelling',
+      limit: 2,
+    });
+    assert.deepEqual(
+      releases.map((release) => release.releaseId),
+      [second.release.releaseId, first.release.releaseId],
     );
   } finally {
     DB.close();

--- a/tests/worker-bootstrap-v2.test.js
+++ b/tests/worker-bootstrap-v2.test.js
@@ -24,7 +24,14 @@ import {
   BOOTSTRAP_V2_ENVELOPE_SHAPE,
   computeBootstrapRevisionHash,
   computeWritableLearnerStatesDigest,
+  createWorkerRepository,
 } from '../worker/src/repository.js';
+import {
+  readSeededSpellingContentBundle,
+} from '../worker/src/generated-spelling-content-seed.js';
+import {
+  isStatutoryCoreWord,
+} from '../src/subjects/spelling/content/taxonomy.js';
 import { createWorkerRepositoryServer } from './helpers/worker-server.js';
 
 const BASE_URL = 'https://repo.test';
@@ -154,6 +161,38 @@ function guardAgainstBootstrapSpellingContentRead(server) {
     }
     return originalPrepare(sql);
   };
+}
+
+async function publishSpellingWordEdit(repository, word, {
+  actorAccountId = 'admin-a',
+  title = 'Bootstrap content package',
+  fieldPath = 'explanation',
+  action = 'set',
+  payload = `Bootstrap content explanation for ${word?.word || 'word'}.`,
+} = {}) {
+  const contentPackage = await repository.createContentOperationPackage({
+    templateId: 'edit-spelling-word',
+    title,
+    createdByAccountId: actorAccountId,
+  });
+  await repository.appendContentOperation(contentPackage.packageId, {
+    entityType: 'spelling.word',
+    entityId: word.slug,
+    fieldPath,
+    action,
+    payload,
+  }, {
+    actorAccountId,
+  });
+  const candidate = await repository.buildContentOperationCandidate(contentPackage.packageId, {
+    actorAccountId,
+  });
+  await repository.approveContentOperationCandidate(contentPackage.packageId, candidate.candidateId, {
+    approvedByAccountId: actorAccountId,
+  });
+  return repository.publishContentOperationPackage(contentPackage.packageId, {
+    publishedByAccountId: actorAccountId,
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -1079,6 +1118,40 @@ test('public bootstrap does not touch account spelling content rows', async () =
     assert.equal(payload.ok, true);
     assert.equal(payload.subjectStates?.['learner-a::spelling']?.ui?.subjectId, 'spelling');
     assert.deepEqual(payload.subjectStates?.['learner-a::spelling']?.data, {});
+  } finally {
+    server.close();
+  }
+});
+
+test('public bootstrap uses the published global content operations release without account content rows', async () => {
+  const server = createServer();
+  try {
+    const repository = createWorkerRepository({ env: server.env, now: () => NOW });
+    const seeded = await readSeededSpellingContentBundle();
+    const word = seeded.draft.words.find((entry) => entry.spellingPool !== 'extra') || seeded.draft.words[0];
+    await publishSpellingWordEdit(repository, word, {
+      title: 'Bootstrap public read-model content release',
+      fieldPath: '',
+      action: 'retire',
+      payload: { reason: 'Bootstrap visibility regression test.' },
+    });
+    insertLearner(server, 'adult-u7', { id: 'learner-a', name: 'Alpha', sortIndex: 0, selected: true });
+    insertSubjectStateFor(server, 'adult-u7', 'learner-a', 'spelling');
+    insertLargeSpellingContentRow(server, 'adult-u7');
+    guardAgainstBootstrapSpellingContentRead(server);
+
+    const runtime = await repository.readSpellingRuntimeContent('adult-u7', 'spelling', {
+      includeAccountContent: false,
+    });
+    const expectedCoreWordCount = runtime.snapshot.words.filter(isStatutoryCoreWord).length;
+    const response = await getBootstrap(server);
+    assert.equal(response.status, 200);
+    const payload = await readJsonBody(response);
+    assert.equal(payload.ok, true);
+
+    const spelling = payload.subjectStates?.['learner-a::spelling'];
+    assert.ok(spelling, 'fresh bootstrap includes spelling subject state');
+    assert.equal(spelling.ui?.stats?.all?.total, expectedCoreWordCount);
   } finally {
     server.close();
   }

--- a/tests/worker-migration-0020.test.js
+++ b/tests/worker-migration-0020.test.js
@@ -1,0 +1,72 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { SqliteD1Database } from './helpers/sqlite-d1.js';
+
+const migrationPath = resolve(
+  import.meta.dirname || '.',
+  '../worker/migrations/0020_content_operations_centre.sql',
+);
+
+const migrationSql = readFileSync(migrationPath, 'utf-8');
+
+function tableNames(db) {
+  return db.db.prepare(`
+    SELECT name
+    FROM sqlite_master
+    WHERE type = 'table' AND name LIKE 'content_operation_%'
+    ORDER BY name
+  `).all().map((row) => row.name);
+}
+
+function indexNames(db) {
+  return db.db.prepare(`
+    SELECT name
+    FROM sqlite_master
+    WHERE type = 'index' AND name LIKE 'idx_content_operation_%'
+    ORDER BY name
+  `).all().map((row) => row.name);
+}
+
+test('migration 0020 creates the Content Operations Centre tables and indexes', () => {
+  const db = new SqliteD1Database();
+  try {
+    db.db.exec(migrationSql);
+    db.db.exec(migrationSql);
+
+    assert.deepEqual(tableNames(db), [
+      'content_operation_account_overrides',
+      'content_operation_asset_uploads',
+      'content_operation_audio_jobs',
+      'content_operation_events',
+      'content_operation_package_approvals',
+      'content_operation_package_candidates',
+      'content_operation_package_operations',
+      'content_operation_packages',
+      'content_operation_releases',
+    ]);
+
+    assert.deepEqual(indexNames(db), [
+      'idx_content_operation_account_overrides_active',
+      'idx_content_operation_asset_uploads_monster',
+      'idx_content_operation_asset_uploads_package',
+      'idx_content_operation_audio_jobs_content_key',
+      'idx_content_operation_audio_jobs_package_status',
+      'idx_content_operation_events_package',
+      'idx_content_operation_events_release',
+      'idx_content_operation_events_subject',
+      'idx_content_operation_package_approvals_package',
+      'idx_content_operation_package_candidates_package',
+      'idx_content_operation_package_operations_entity',
+      'idx_content_operation_package_operations_order',
+      'idx_content_operation_packages_base_release',
+      'idx_content_operation_packages_subject_state',
+      'idx_content_operation_releases_package',
+      'idx_content_operation_releases_subject_status',
+    ]);
+  } finally {
+    db.close();
+  }
+});

--- a/tests/worker-migration-0020.test.js
+++ b/tests/worker-migration-0020.test.js
@@ -64,6 +64,7 @@ test('migration 0020 creates the Content Operations Centre tables and indexes', 
       'idx_content_operation_packages_base_release',
       'idx_content_operation_packages_subject_state',
       'idx_content_operation_releases_package',
+      'idx_content_operation_releases_package_once',
       'idx_content_operation_releases_subject_status',
     ]);
   } finally {

--- a/tests/worker-query-budget.test.js
+++ b/tests/worker-query-budget.test.js
@@ -31,8 +31,10 @@ import { createApiPlatformRepositories } from '../src/platform/core/repositories
 // event_log + spelling content). P7 removed the duplicate account point read.
 // May 2026 hotfix removed the spelling content table read from bootstrap
 // public read-model hydration, so the measured runtime path is now 9.
+// Content Operations Centre restored learner-visible global release checks
+// without returning to account_subject_content, so the measured path is 11.
 // Headroom +1.
-const MEASURED_BOOTSTRAP_MULTI_LEARNER = 9;
+const MEASURED_BOOTSTRAP_MULTI_LEARNER = 11;
 const BUDGET_BOOTSTRAP_MULTI_LEARNER = MEASURED_BOOTSTRAP_MULTI_LEARNER + 1;
 
 // Measured: 5 queries for the notModified probe (ops_status JOIN +
@@ -45,7 +47,10 @@ const BUDGET_BOOTSTRAP_NOT_MODIFIED = 6;
 // ensureAccount + membership + learner+account revision + subject_state +
 // active_session + spelling_content + projection read-model + 5 batch
 // writes). Phase D / U14 added the account_ops_metadata JOIN.
-const BUDGET_COMMAND_HOT_PATH = 13;
+// Content Operations Centre moved spelling runtime reads through the
+// override/global release precedence checks; the command hot path now carries
+// two release lookups while still avoiding account_subject_content.
+const BUDGET_COMMAND_HOT_PATH = 15;
 
 // Measured: 6 queries for parent hub recent-sessions (ops_status JOIN +
 // ensureAccount upsert + account select + membership list + learner
@@ -55,15 +60,18 @@ const BUDGET_PARENT_RECENT_SESSIONS = 7;
 // P7 measured: 10 queries for GET bootstrap full bundle. May 2026 hotfix
 // removed the spelling content table read from public read-model hydration,
 // leaving the route-level account snapshot reuse and 9 measured queries.
+// Content Operations Centre restored learner-visible global release checks
+// without returning to account_subject_content, so the measured path is 11.
 // Headroom +1.
-const MEASURED_BOOTSTRAP_GET_FULL = 9;
+const MEASURED_BOOTSTRAP_GET_FULL = 11;
 const BUDGET_BOOTSTRAP_GET_FULL = MEASURED_BOOTSTRAP_GET_FULL + 1;
 const MEASURED_BOOTSTRAP_GET_WITH_CACHED_MONSTER_POINTER = MEASURED_BOOTSTRAP_GET_FULL - 1;
 
-// Measured: 4 queries for Hero read-model GET (ops_status JOIN +
+// Measured: 6 queries for Hero read-model GET (ops_status JOIN +
 // ensureAccount upsert + membership learner-access check +
-// child_subject_state read). Headroom +1.
-const BUDGET_HERO_READ_MODEL = 5;
+// child_subject_state read + content-operation override/global release
+// checks). Headroom +1.
+const BUDGET_HERO_READ_MODEL = 7;
 
 // Measured: 20 queries for Admin Ops KPI dashboard (ops_status JOIN +
 // ensureAccount upsert + assertAdminHubActor SELECT + 14 COUNT(*)
@@ -82,18 +90,18 @@ const BUDGET_ADMIN_ACCOUNTS_SEARCH = 5;
 const BUDGET_ADMIN_DEBUG_BUNDLE = 11;
 const MIN_ADMIN_DEBUG_BUNDLE_TRACKED_QUERIES = 10;
 
-// Measured: 19 queries for Hero command POST start-task (ops_status JOIN +
+// Measured: 22 queries for Hero command POST start-task (ops_status JOIN +
 // ensureAccount upsert + requireLearnerReadAccess + readHeroSubjectReadModels
 // [1st child_subject_state read for server-side quest recomputation] +
 // requireLearnerReadAccess [2nd, within runSubjectCommand] + learner+account
 // revision CAS + child_subject_state [2nd read for subject dispatch] +
-// active_session scan + spelling_content + projection read-model +
-// child_game_state + event_log + sqlite_master + 6 batch writes).
+// active_session scan + content-operation release checks + projection
+// read-model + child_game_state + event_log + sqlite_master + 6 batch writes).
 // The 2x child_subject_state reads are inherent to the Hero launch
 // architecture: resolveHeroStartTaskCommand recomputes the quest from
 // live subject state, then runSubjectCommand re-reads it for dispatch.
 // Headroom +1.
-const BUDGET_HERO_COMMAND = 20;
+const BUDGET_HERO_COMMAND = 23;
 
 // Measured: 5 queries for Admin Ops error-events (ops_status JOIN +
 // ensureAccount upsert + assertAdminHubActor SELECT + totals GROUP BY

--- a/tests/worker-subject-runtime.test.js
+++ b/tests/worker-subject-runtime.test.js
@@ -16,6 +16,9 @@ import {
   readSeededSpellingContentBundle,
   readSeededSpellingPublishedSnapshot,
 } from '../worker/src/generated-spelling-content-seed.js';
+import {
+  isStatutoryCoreWord,
+} from '../src/subjects/spelling/content/taxonomy.js';
 import { createWorkerRepositoryServer } from './helpers/worker-server.js';
 import { createMigratedSqliteD1Database } from './helpers/sqlite-d1.js';
 
@@ -42,6 +45,38 @@ async function postJson(server, path, body = {}, headers = {}) {
       ...headers,
     },
     body: JSON.stringify(body),
+  });
+}
+
+async function publishSpellingWordEdit(repository, word, {
+  actorAccountId = 'admin-a',
+  title = 'Runtime content package',
+  fieldPath = 'explanation',
+  action = 'set',
+  payload = `Runtime content explanation for ${word?.word || 'word'}.`,
+} = {}) {
+  const contentPackage = await repository.createContentOperationPackage({
+    templateId: 'edit-spelling-word',
+    title,
+    createdByAccountId: actorAccountId,
+  });
+  await repository.appendContentOperation(contentPackage.packageId, {
+    entityType: 'spelling.word',
+    entityId: word.slug,
+    fieldPath,
+    action,
+    payload,
+  }, {
+    actorAccountId,
+  });
+  const candidate = await repository.buildContentOperationCandidate(contentPackage.packageId, {
+    actorAccountId,
+  });
+  await repository.approveContentOperationCandidate(contentPackage.packageId, candidate.candidateId, {
+    approvedByAccountId: actorAccountId,
+  });
+  return repository.publishContentOperationPackage(contentPackage.packageId, {
+    publishedByAccountId: actorAccountId,
   });
 }
 
@@ -219,6 +254,94 @@ test('repository serves spelling runtime from the global content operations rele
     assert.equal(runtime.content.draft.words.length, seeded.draft.words.length);
     assert.equal(runtime.summary.runtimeWordCount, seeded.releases.at(-1).snapshot.words.length);
     assert.equal(accountContentReads.length, 0);
+  } finally {
+    DB.close();
+  }
+});
+
+test('repository runtime keeps account overrides ahead of global releases without reading account content rows', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const repository = createWorkerRepository({ env: { DB }, now: () => 1_777_000_000_000 });
+  try {
+    const seeded = await readSeededSpellingContentBundle();
+    const firstWord = seeded.draft.words[0];
+    const secondWord = seeded.draft.words[1];
+    const overrideExplanation = `Override release explanation for ${firstWord.word}.`;
+    const globalExplanation = `Latest global explanation for ${secondWord.word}.`;
+
+    const overrideRelease = await publishSpellingWordEdit(repository, firstWord, {
+      title: 'Account override source release',
+      payload: overrideExplanation,
+    });
+    await publishSpellingWordEdit(repository, secondWord, {
+      actorAccountId: 'admin-b',
+      title: 'Latest global source release',
+      payload: globalExplanation,
+    });
+    DB.db.prepare(`
+      INSERT INTO content_operation_account_overrides (
+        override_id, account_id, subject_id, release_id, reason, active,
+        created_by_account_id, created_at, ended_at
+      )
+      VALUES ('override-runtime-a', 'adult-a', 'spelling', ?, 'Runtime test override', 1, 'admin-a', ?, NULL)
+    `).run(overrideRelease.releaseId, 1_777_000_000_001);
+
+    DB.clearQueryLog();
+    const overridden = await repository.readSpellingRuntimeContent('adult-a', 'spelling', {
+      includeAccountContent: false,
+    });
+    const latest = await repository.readSpellingRuntimeContent('adult-b', 'spelling', {
+      includeAccountContent: false,
+    });
+    const accountContentReads = accountContentQueries(DB);
+
+    assert.equal(overridden.content.draft.words[0].explanation, overrideExplanation);
+    assert.equal(latest.content.draft.words[1].explanation, globalExplanation);
+    assert.equal(accountContentReads.length, 0);
+  } finally {
+    DB.close();
+  }
+});
+
+test('Hero spelling read-model uses the published global content operations release', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const repository = createWorkerRepository({ env: { DB }, now: () => 1_777_000_000_000 });
+  try {
+    const seeded = await readSeededSpellingContentBundle();
+    const word = seeded.draft.words.find((entry) => entry.spellingPool !== 'extra') || seeded.draft.words[0];
+    await publishSpellingWordEdit(repository, word, {
+      title: 'Hero public read-model content release',
+      fieldPath: '',
+      action: 'retire',
+      payload: { reason: 'Hero read-model visibility regression test.' },
+    });
+    DB.db.prepare(`
+      INSERT INTO adult_accounts (id, email, display_name, platform_role, selected_learner_id, created_at, updated_at, repo_revision)
+      VALUES ('adult-a', 'adult-a@example.test', 'Adult A', 'parent', NULL, ?, ?, 0)
+    `).run(1_777_000_000_000, 1_777_000_000_000);
+    DB.db.prepare(`
+      INSERT INTO learner_profiles (id, name, year_group, avatar_color, goal, daily_minutes, created_at, updated_at, state_revision)
+      VALUES ('learner-hero', 'Hero Learner', 'Y5', '#3E6FA8', 'sats', 15, ?, ?, 0)
+    `).run(1_777_000_000_000, 1_777_000_000_000);
+    DB.db.prepare(`
+      INSERT INTO child_subject_state (learner_id, subject_id, ui_json, data_json, updated_at, updated_by_account_id)
+      VALUES ('learner-hero', 'spelling', ?, ?, ?, 'adult-a')
+    `).run(
+      JSON.stringify({ phase: 'dashboard' }),
+      JSON.stringify({ prefs: { mode: 'smart' } }),
+      1_777_000_000_000,
+    );
+
+    const runtime = await repository.readSpellingRuntimeContent('adult-a', 'spelling', {
+      includeAccountContent: false,
+    });
+    const expectedCoreWordCount = runtime.snapshot.words.filter(isStatutoryCoreWord).length;
+    const heroModels = await repository.readHeroSubjectReadModels('learner-hero', {
+      accountId: 'adult-a',
+      now: 1_777_000_000_000,
+    });
+
+    assert.equal(heroModels.spelling.ui.stats.all.total, expectedCoreWordCount);
   } finally {
     DB.close();
   }

--- a/tests/worker-subject-runtime.test.js
+++ b/tests/worker-subject-runtime.test.js
@@ -178,6 +178,52 @@ test('repository can serve spelling runtime from the bundled snapshot without D1
   }
 });
 
+test('repository serves spelling runtime from the global content operations release', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const repository = createWorkerRepository({ env: { DB }, now: () => 1_777_000_000_000 });
+  try {
+    const seeded = await readSeededSpellingContentBundle();
+    const word = seeded.draft.words[0];
+    const explanation = `A global-release learner-facing explanation for ${word.word}.`;
+    const contentPackage = await repository.createContentOperationPackage({
+      templateId: 'edit-spelling-word',
+      title: 'Runtime global release package',
+      createdByAccountId: 'admin-a',
+    });
+    await repository.appendContentOperation(contentPackage.packageId, {
+      entityType: 'spelling.word',
+      entityId: word.slug,
+      fieldPath: 'explanation',
+      action: 'set',
+      payload: explanation,
+    }, {
+      actorAccountId: 'admin-a',
+    });
+    const candidate = await repository.buildContentOperationCandidate(contentPackage.packageId, {
+      actorAccountId: 'admin-a',
+    });
+    await repository.approveContentOperationCandidate(contentPackage.packageId, candidate.candidateId, {
+      approvedByAccountId: 'admin-a',
+    });
+    await repository.publishContentOperationPackage(contentPackage.packageId, {
+      publishedByAccountId: 'admin-a',
+    });
+
+    DB.clearQueryLog();
+    const runtime = await repository.readSpellingRuntimeContent('adult-a', 'spelling', {
+      includeAccountContent: false,
+    });
+    const accountContentReads = accountContentQueries(DB);
+
+    assert.equal(runtime.content.draft.words[0].explanation, explanation);
+    assert.equal(runtime.content.draft.words.length, seeded.draft.words.length);
+    assert.equal(runtime.summary.runtimeWordCount, seeded.releases.at(-1).snapshot.words.length);
+    assert.equal(accountContentReads.length, 0);
+  } finally {
+    DB.close();
+  }
+});
+
 test('repository reads full spelling runtime content rows when they exceed the public inline budget', async () => {
   const DB = createMigratedSqliteD1Database();
   const repository = createWorkerRepository({ env: { DB }, now: () => 1_776_000_000_000 });

--- a/worker/migrations/0020_content_operations_centre.sql
+++ b/worker/migrations/0020_content_operations_centre.sql
@@ -19,6 +19,10 @@ CREATE INDEX IF NOT EXISTS idx_content_operation_releases_subject_status
 CREATE INDEX IF NOT EXISTS idx_content_operation_releases_package
   ON content_operation_releases(package_id);
 
+CREATE UNIQUE INDEX IF NOT EXISTS idx_content_operation_releases_package_once
+  ON content_operation_releases(package_id)
+  WHERE package_id IS NOT NULL;
+
 CREATE TABLE IF NOT EXISTS content_operation_packages (
   package_id TEXT PRIMARY KEY,
   subject_id TEXT NOT NULL,

--- a/worker/migrations/0020_content_operations_centre.sql
+++ b/worker/migrations/0020_content_operations_centre.sql
@@ -1,0 +1,192 @@
+CREATE TABLE IF NOT EXISTS content_operation_releases (
+  release_id TEXT PRIMARY KEY,
+  subject_id TEXT NOT NULL,
+  status TEXT NOT NULL,
+  snapshot_json TEXT NOT NULL,
+  snapshot_hash TEXT NOT NULL,
+  base_release_id TEXT,
+  package_id TEXT,
+  published_at INTEGER,
+  published_by_account_id TEXT,
+  rollback_of_release_id TEXT,
+  proof_json TEXT,
+  created_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_content_operation_releases_subject_status
+  ON content_operation_releases(subject_id, status, published_at DESC, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_content_operation_releases_package
+  ON content_operation_releases(package_id);
+
+CREATE TABLE IF NOT EXISTS content_operation_packages (
+  package_id TEXT PRIMARY KEY,
+  subject_id TEXT NOT NULL,
+  template_id TEXT NOT NULL,
+  title TEXT NOT NULL,
+  description TEXT NOT NULL DEFAULT '',
+  base_release_id TEXT,
+  base_release_hash TEXT,
+  state TEXT NOT NULL,
+  created_by_account_id TEXT NOT NULL,
+  updated_by_account_id TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  approved_at INTEGER,
+  published_at INTEGER,
+  superseded_by_package_id TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_content_operation_packages_subject_state
+  ON content_operation_packages(subject_id, state, updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_content_operation_packages_base_release
+  ON content_operation_packages(base_release_id);
+
+CREATE TABLE IF NOT EXISTS content_operation_package_operations (
+  operation_id TEXT PRIMARY KEY,
+  package_id TEXT NOT NULL,
+  operation_order INTEGER NOT NULL,
+  entity_type TEXT NOT NULL,
+  entity_id TEXT NOT NULL,
+  field_path TEXT NOT NULL DEFAULT '',
+  action TEXT NOT NULL,
+  before_hash TEXT,
+  after_hash TEXT,
+  payload_json TEXT NOT NULL,
+  created_by_account_id TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  FOREIGN KEY (package_id) REFERENCES content_operation_packages(package_id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_content_operation_package_operations_order
+  ON content_operation_package_operations(package_id, operation_order);
+
+CREATE INDEX IF NOT EXISTS idx_content_operation_package_operations_entity
+  ON content_operation_package_operations(package_id, entity_type, entity_id, field_path);
+
+CREATE TABLE IF NOT EXISTS content_operation_package_candidates (
+  candidate_id TEXT PRIMARY KEY,
+  package_id TEXT NOT NULL,
+  base_release_id TEXT,
+  current_release_id TEXT,
+  operations_hash TEXT NOT NULL,
+  candidate_hash TEXT NOT NULL,
+  candidate_snapshot_json TEXT NOT NULL,
+  validation_json TEXT NOT NULL,
+  audio_scan_json TEXT,
+  asset_scan_json TEXT,
+  reward_scan_json TEXT,
+  visibility_scan_json TEXT,
+  conflicts_json TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  FOREIGN KEY (package_id) REFERENCES content_operation_packages(package_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_content_operation_package_candidates_package
+  ON content_operation_package_candidates(package_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS content_operation_package_approvals (
+  approval_id TEXT PRIMARY KEY,
+  package_id TEXT NOT NULL,
+  candidate_id TEXT NOT NULL,
+  candidate_hash TEXT NOT NULL,
+  approved_by_account_id TEXT NOT NULL,
+  approved_at INTEGER NOT NULL,
+  notes TEXT NOT NULL DEFAULT '',
+  audio_fallback_json TEXT,
+  asset_summary_json TEXT,
+  validation_summary_json TEXT,
+  FOREIGN KEY (package_id) REFERENCES content_operation_packages(package_id),
+  FOREIGN KEY (candidate_id) REFERENCES content_operation_package_candidates(candidate_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_content_operation_package_approvals_package
+  ON content_operation_package_approvals(package_id, approved_at DESC);
+
+CREATE TABLE IF NOT EXISTS content_operation_events (
+  event_id TEXT PRIMARY KEY,
+  package_id TEXT,
+  release_id TEXT,
+  subject_id TEXT NOT NULL,
+  event_type TEXT NOT NULL,
+  actor_account_id TEXT,
+  event_json TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_content_operation_events_package
+  ON content_operation_events(package_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_content_operation_events_release
+  ON content_operation_events(release_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_content_operation_events_subject
+  ON content_operation_events(subject_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS content_operation_audio_jobs (
+  job_id TEXT PRIMARY KEY,
+  package_id TEXT,
+  candidate_id TEXT,
+  lane TEXT NOT NULL,
+  entity_type TEXT NOT NULL,
+  entity_id TEXT NOT NULL,
+  voice_id TEXT NOT NULL,
+  pace_id TEXT NOT NULL,
+  model_id TEXT NOT NULL,
+  profile_version TEXT NOT NULL,
+  content_key TEXT NOT NULL,
+  status TEXT NOT NULL,
+  r2_key TEXT,
+  error_json TEXT,
+  requested_by_account_id TEXT NOT NULL,
+  completed_at INTEGER,
+  created_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_content_operation_audio_jobs_package_status
+  ON content_operation_audio_jobs(package_id, status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_content_operation_audio_jobs_content_key
+  ON content_operation_audio_jobs(content_key, lane, voice_id, pace_id);
+
+CREATE TABLE IF NOT EXISTS content_operation_asset_uploads (
+  asset_upload_id TEXT PRIMARY KEY,
+  package_id TEXT NOT NULL,
+  monster_id TEXT NOT NULL,
+  branch_id TEXT NOT NULL,
+  stage_id TEXT NOT NULL,
+  asset_kind TEXT NOT NULL,
+  r2_key TEXT NOT NULL,
+  content_type TEXT NOT NULL,
+  byte_size INTEGER NOT NULL,
+  width INTEGER,
+  height INTEGER,
+  validation_json TEXT NOT NULL,
+  preview_json TEXT,
+  status TEXT NOT NULL,
+  created_by_account_id TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  FOREIGN KEY (package_id) REFERENCES content_operation_packages(package_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_content_operation_asset_uploads_package
+  ON content_operation_asset_uploads(package_id, status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_content_operation_asset_uploads_monster
+  ON content_operation_asset_uploads(monster_id, branch_id, stage_id);
+
+CREATE TABLE IF NOT EXISTS content_operation_account_overrides (
+  override_id TEXT PRIMARY KEY,
+  account_id TEXT NOT NULL,
+  subject_id TEXT NOT NULL,
+  release_id TEXT NOT NULL,
+  reason TEXT NOT NULL DEFAULT '',
+  active INTEGER NOT NULL DEFAULT 1,
+  created_by_account_id TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  ended_at INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_content_operation_account_overrides_active
+  ON content_operation_account_overrides(account_id, subject_id, active);

--- a/worker/src/content-operations/repository.js
+++ b/worker/src/content-operations/repository.js
@@ -44,6 +44,14 @@ function normaliseString(value, fallback = '') {
   return typeof value === 'string' ? value.trim() || fallback : fallback;
 }
 
+function mutationChangeCount(result) {
+  return Math.max(0, Number(result?.meta?.changes ?? result?.meta?.rows_written) || 0);
+}
+
+function isUniqueConstraintError(error) {
+  return /unique constraint|constraint failed/i.test(String(error?.message || error || ''));
+}
+
 function packageRowToRecord(row) {
   if (!row) return null;
   return {
@@ -189,7 +197,7 @@ async function readLatestReleaseRow(db, subjectId, { includeSnapshot = false } =
       rollback_of_release_id, proof_json, created_at
     FROM content_operation_releases
     WHERE subject_id = ? AND status = 'published'
-    ORDER BY published_at DESC, created_at DESC
+    ORDER BY published_at DESC, created_at DESC, rowid DESC
     LIMIT 1
   `, [subjectId]);
 }
@@ -204,6 +212,7 @@ async function readReleaseRowById(db, subjectId, releaseId, { includeSnapshot = 
       rollback_of_release_id, proof_json, created_at
     FROM content_operation_releases
     WHERE subject_id = ? AND release_id = ? AND status = 'published'
+    ORDER BY published_at DESC, created_at DESC, rowid DESC
     LIMIT 1
   `, [subjectId, releaseId]);
 }
@@ -263,6 +272,22 @@ function releaseDriftConflict(packageRow, currentReleaseRow, baseReleaseRow) {
   }
 
   return null;
+}
+
+function packageOperationsHash(operations = []) {
+  return contentOperationHash(
+    operations.map((operation) => normaliseContentOperation(operation, { now: () => 0 })),
+    'ops',
+  );
+}
+
+function assertPackageIsNotPublished(packageRow, packageId) {
+  if (packageRow.state === CONTENT_OPERATION_PACKAGE_STATES.PUBLISHED) {
+    throw new ConflictError('Published content operation packages cannot be mutated.', {
+      code: 'content_operation_package_published',
+      packageId,
+    });
+  }
 }
 
 export function createContentOperationsRepository({ db, now }) {
@@ -370,12 +395,7 @@ export function createContentOperationsRepository({ db, now }) {
 
     async appendContentOperation(packageId, rawOperation, { actorAccountId } = {}) {
       const packageRow = await requirePackage(db, packageId);
-      if (packageRow.state === CONTENT_OPERATION_PACKAGE_STATES.PUBLISHED) {
-        throw new ConflictError('Published content operation packages cannot be mutated.', {
-          code: 'content_operation_package_published',
-          packageId,
-        });
-      }
+      assertPackageIsNotPublished(packageRow, packageId);
       const actor = normaliseString(actorAccountId);
       if (!actor) throw new BadRequestError('Content operations require an actor account id.');
       const nowTs = Number(nowFactory());
@@ -455,6 +475,7 @@ export function createContentOperationsRepository({ db, now }) {
 
     async buildContentOperationCandidate(packageId, { actorAccountId = null } = {}) {
       const packageRow = await requirePackage(db, packageId);
+      assertPackageIsNotPublished(packageRow, packageId);
       const operations = await listPackageOperations(db, packageId);
       const currentReleaseRow = await readLatestReleaseRow(db, packageRow.subject_id, { includeSnapshot: true });
       const baseReleaseRow = await readReleaseRowById(
@@ -554,8 +575,12 @@ export function createContentOperationsRepository({ db, now }) {
       assetSummary = null,
     } = {}) {
       const packageRow = await requirePackage(db, packageId);
+      assertPackageIsNotPublished(packageRow, packageId);
       const actor = normaliseString(approvedByAccountId);
       if (!actor) throw new BadRequestError('Content operation approval requires an approver account id.');
+      const operations = await listPackageOperations(db, packageId);
+      const currentOperationsHash = packageOperationsHash(operations);
+      const currentReleaseRow = await readLatestReleaseRow(db, packageRow.subject_id);
       const candidateRow = await first(db, `
         SELECT *
         FROM content_operation_package_candidates
@@ -569,6 +594,24 @@ export function createContentOperationsRepository({ db, now }) {
         });
       }
       const candidate = candidateRowToRecord(candidateRow);
+      if (candidate.operationsHash !== currentOperationsHash) {
+        throw new ConflictError('Content operation candidate was built from stale package operations.', {
+          code: 'content_operation_candidate_operations_stale',
+          packageId,
+          candidateId,
+          candidateOperationsHash: candidate.operationsHash,
+          currentOperationsHash,
+        });
+      }
+      if ((candidate.currentReleaseId || null) !== (currentReleaseRow?.release_id || null)) {
+        throw new ConflictError('Content operation candidate was built against a stale release.', {
+          code: 'content_operation_candidate_release_drift',
+          packageId,
+          candidateId,
+          candidateCurrentReleaseId: candidate.currentReleaseId || null,
+          currentReleaseId: currentReleaseRow?.release_id || null,
+        });
+      }
       if (!candidate.validation?.ok) {
         throw new ConflictError('Content operation candidate has validation blockers.', {
           code: 'content_operation_candidate_invalid',
@@ -656,6 +699,12 @@ export function createContentOperationsRepository({ db, now }) {
       const packageRow = await requirePackage(db, packageId);
       const actor = normaliseString(publishedByAccountId);
       if (!actor) throw new BadRequestError('Content operation publish requires a publisher account id.');
+      if (packageRow.state === CONTENT_OPERATION_PACKAGE_STATES.PUBLISHED) {
+        throw new ConflictError('Content operation package was already published.', {
+          code: 'content_operation_package_published',
+          packageId,
+        });
+      }
       if (packageRow.state !== CONTENT_OPERATION_PACKAGE_STATES.APPROVED) {
         throw new ConflictError('Content operation package must be approved before publish.', {
           code: 'content_operation_package_not_approved',
@@ -710,60 +759,107 @@ export function createContentOperationsRepository({ db, now }) {
       const nowTs = Number(nowFactory());
       const snapshotHash = contentOperationHash(candidate.candidate, 'release');
 
-      await batch(db, [
-        bindStatement(db, `
-          INSERT INTO content_operation_releases (
-            release_id, subject_id, status, snapshot_json, snapshot_hash,
-            base_release_id, package_id, published_at, published_by_account_id,
-            rollback_of_release_id, proof_json, created_at
-          )
-          VALUES (?, ?, 'published', ?, ?, ?, ?, ?, ?, NULL, ?, ?)
-        `, [
-          releaseId,
-          packageRow.subject_id,
-          JSON.stringify(candidate.candidate),
-          snapshotHash,
-          candidate.currentReleaseId || packageRow.base_release_id || null,
-          packageId,
-          nowTs,
-          actor,
-          proof == null ? null : JSON.stringify(proof),
-          nowTs,
-        ]),
-        bindStatement(db, `
-          UPDATE content_operation_packages
-          SET state = ?, published_at = ?, updated_by_account_id = ?, updated_at = ?
-          WHERE package_id = ?
-        `, [
-          CONTENT_OPERATION_PACKAGE_STATES.PUBLISHED,
-          nowTs,
-          actor,
-          nowTs,
-          packageId,
-        ]),
-        bindStatement(db, `
-          INSERT INTO content_operation_events (
-            event_id, package_id, release_id, subject_id, event_type,
-            actor_account_id, event_json, created_at
-          )
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-        `, [
-          uid('coevt'),
-          packageId,
-          releaseId,
-          packageRow.subject_id,
-          'package.published',
-          actor,
-          JSON.stringify({
+      let publishResults = [];
+      try {
+        publishResults = await batch(db, [
+          bindStatement(db, `
+            INSERT INTO content_operation_releases (
+              release_id, subject_id, status, snapshot_json, snapshot_hash,
+              base_release_id, package_id, published_at, published_by_account_id,
+              rollback_of_release_id, proof_json, created_at
+            )
+            SELECT ?, ?, 'published', ?, ?, ?, ?, ?, ?, NULL, ?, ?
+            WHERE EXISTS (
+              SELECT 1
+              FROM content_operation_packages
+              WHERE package_id = ? AND state = ?
+            )
+          `, [
             releaseId,
-            candidateId: candidate.candidateId,
-            candidateHash: candidate.candidateHash,
+            packageRow.subject_id,
+            JSON.stringify(candidate.candidate),
             snapshotHash,
-            summary: buildSpellingContentSummary(candidate.candidate),
-          }),
-          nowTs,
-        ]),
-      ]);
+            candidate.currentReleaseId || packageRow.base_release_id || null,
+            packageId,
+            nowTs,
+            actor,
+            proof == null ? null : JSON.stringify(proof),
+            nowTs,
+            packageId,
+            CONTENT_OPERATION_PACKAGE_STATES.APPROVED,
+          ]),
+          bindStatement(db, `
+            UPDATE content_operation_packages
+            SET state = ?, published_at = ?, updated_by_account_id = ?, updated_at = ?
+            WHERE package_id = ?
+              AND state = ?
+              AND EXISTS (
+                SELECT 1
+                FROM content_operation_releases
+                WHERE release_id = ?
+              )
+          `, [
+            CONTENT_OPERATION_PACKAGE_STATES.PUBLISHED,
+            nowTs,
+            actor,
+            nowTs,
+            packageId,
+            CONTENT_OPERATION_PACKAGE_STATES.APPROVED,
+            releaseId,
+          ]),
+          bindStatement(db, `
+            INSERT INTO content_operation_events (
+              event_id, package_id, release_id, subject_id, event_type,
+              actor_account_id, event_json, created_at
+            )
+            SELECT ?, ?, ?, ?, ?, ?, ?, ?
+            WHERE EXISTS (
+              SELECT 1
+              FROM content_operation_releases
+              WHERE release_id = ?
+            )
+          `, [
+            uid('coevt'),
+            packageId,
+            releaseId,
+            packageRow.subject_id,
+            'package.published',
+            actor,
+            JSON.stringify({
+              releaseId,
+              candidateId: candidate.candidateId,
+              candidateHash: candidate.candidateHash,
+              snapshotHash,
+              summary: buildSpellingContentSummary(candidate.candidate),
+            }),
+            nowTs,
+            releaseId,
+          ]),
+        ]);
+      } catch (error) {
+        if (isUniqueConstraintError(error)) {
+          throw new ConflictError('Content operation package was already published.', {
+            code: 'content_operation_package_published',
+            packageId,
+          });
+        }
+        throw error;
+      }
+
+      if (mutationChangeCount(publishResults[0]) < 1 || mutationChangeCount(publishResults[1]) < 1) {
+        const latestPackageRow = await requirePackage(db, packageId);
+        if (latestPackageRow.state === CONTENT_OPERATION_PACKAGE_STATES.PUBLISHED) {
+          throw new ConflictError('Content operation package was already published.', {
+            code: 'content_operation_package_published',
+            packageId,
+          });
+        }
+        throw new ConflictError('Content operation package must be approved before publish.', {
+          code: 'content_operation_package_not_approved',
+          packageId,
+          state: latestPackageRow.state,
+        });
+      }
 
       return {
         releaseId,
@@ -783,6 +879,13 @@ export function createContentOperationsRepository({ db, now }) {
       return releaseRowToRecord(row, { includeSnapshot });
     },
 
+    async readContentOperationRelease(subjectId = CONTENT_OPERATION_SUBJECT_ID, releaseId, { includeSnapshot = false } = {}) {
+      const row = await readReleaseRowById(db, normaliseSubjectId(subjectId), normaliseString(releaseId), {
+        includeSnapshot,
+      });
+      return releaseRowToRecord(row, { includeSnapshot });
+    },
+
     async listContentOperationReleases({ subjectId = CONTENT_OPERATION_SUBJECT_ID, includeSnapshot = false, limit = 20 } = {}) {
       const safeLimit = Math.max(1, Math.min(100, Number(limit) || 20));
       const rows = await all(db, `
@@ -793,7 +896,7 @@ export function createContentOperationsRepository({ db, now }) {
           rollback_of_release_id, proof_json, created_at
         FROM content_operation_releases
         WHERE subject_id = ?
-        ORDER BY published_at DESC, created_at DESC
+        ORDER BY published_at DESC, created_at DESC, rowid DESC
         LIMIT ?
       `, [normaliseSubjectId(subjectId), safeLimit]);
       return rows.map((row) => releaseRowToRecord(row, { includeSnapshot }));

--- a/worker/src/content-operations/repository.js
+++ b/worker/src/content-operations/repository.js
@@ -1,0 +1,839 @@
+import { uid } from '../../../src/platform/core/utils.js';
+import {
+  buildSpellingContentOperationCandidate,
+  CONTENT_OPERATION_PACKAGE_STATES,
+  CONTENT_OPERATION_SUBJECT_ID,
+  contentOperationHash,
+  normaliseContentOperation,
+} from '../../../src/subjects/spelling/content/operations-model.js';
+import {
+  buildSpellingContentSummary,
+  validateSpellingContentBundle,
+} from '../../../src/subjects/spelling/content/model.js';
+import {
+  readSeededSpellingContentBundle,
+} from '../generated-spelling-content-seed.js';
+import {
+  all,
+  batch,
+  bindStatement,
+  first,
+  run,
+} from '../d1.js';
+import {
+  BadRequestError,
+  ConflictError,
+  NotFoundError,
+} from '../errors.js';
+
+function parseJson(value, fallback = null) {
+  if (value == null || value === '') return fallback;
+  if (typeof value !== 'string') return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return fallback;
+  }
+}
+
+function normaliseSubjectId(value) {
+  return typeof value === 'string' && value.trim() ? value.trim() : CONTENT_OPERATION_SUBJECT_ID;
+}
+
+function normaliseString(value, fallback = '') {
+  return typeof value === 'string' ? value.trim() || fallback : fallback;
+}
+
+function packageRowToRecord(row) {
+  if (!row) return null;
+  return {
+    packageId: row.package_id,
+    subjectId: row.subject_id,
+    templateId: row.template_id,
+    title: row.title,
+    description: row.description || '',
+    baseReleaseId: row.base_release_id || null,
+    baseReleaseHash: row.base_release_hash || null,
+    state: row.state,
+    createdByAccountId: row.created_by_account_id,
+    updatedByAccountId: row.updated_by_account_id,
+    createdAt: Number(row.created_at) || 0,
+    updatedAt: Number(row.updated_at) || 0,
+    approvedAt: row.approved_at == null ? null : Number(row.approved_at),
+    publishedAt: row.published_at == null ? null : Number(row.published_at),
+    supersededByPackageId: row.superseded_by_package_id || null,
+  };
+}
+
+function operationRowToRecord(row) {
+  if (!row) return null;
+  return {
+    operationId: row.operation_id,
+    packageId: row.package_id,
+    operationOrder: Number(row.operation_order) || 0,
+    entityType: row.entity_type,
+    entityId: row.entity_id,
+    fieldPath: row.field_path || '',
+    action: row.action,
+    beforeHash: row.before_hash || '',
+    afterHash: row.after_hash || '',
+    payload: parseJson(row.payload_json, null),
+    createdByAccountId: row.created_by_account_id,
+    createdAt: Number(row.created_at) || 0,
+  };
+}
+
+function candidateRowToRecord(row, { includeSnapshot = false } = {}) {
+  if (!row) return null;
+  return {
+    candidateId: row.candidate_id,
+    packageId: row.package_id,
+    baseReleaseId: row.base_release_id || null,
+    currentReleaseId: row.current_release_id || null,
+    operationsHash: row.operations_hash,
+    candidateHash: row.candidate_hash,
+    candidate: includeSnapshot ? parseJson(row.candidate_snapshot_json, null) : null,
+    validation: parseJson(row.validation_json, { ok: false, errors: [], warnings: [] }),
+    audioScan: parseJson(row.audio_scan_json, null),
+    assetScan: parseJson(row.asset_scan_json, null),
+    rewardScan: parseJson(row.reward_scan_json, null),
+    visibilityScan: parseJson(row.visibility_scan_json, null),
+    conflicts: parseJson(row.conflicts_json, []),
+    createdAt: Number(row.created_at) || 0,
+  };
+}
+
+function releaseRowToRecord(row, { includeSnapshot = false } = {}) {
+  if (!row) return null;
+  return {
+    releaseId: row.release_id,
+    subjectId: row.subject_id,
+    status: row.status,
+    snapshotHash: row.snapshot_hash,
+    snapshot: includeSnapshot ? parseJson(row.snapshot_json, null) : null,
+    baseReleaseId: row.base_release_id || null,
+    packageId: row.package_id || null,
+    publishedAt: row.published_at == null ? null : Number(row.published_at),
+    publishedByAccountId: row.published_by_account_id || null,
+    rollbackOfReleaseId: row.rollback_of_release_id || null,
+    proof: parseJson(row.proof_json, null),
+    createdAt: Number(row.created_at) || 0,
+  };
+}
+
+function approvalRowToRecord(row) {
+  if (!row) return null;
+  return {
+    approvalId: row.approval_id,
+    packageId: row.package_id,
+    candidateId: row.candidate_id,
+    candidateHash: row.candidate_hash,
+    approvedByAccountId: row.approved_by_account_id,
+    approvedAt: Number(row.approved_at) || 0,
+    notes: row.notes || '',
+    audioFallback: parseJson(row.audio_fallback_json, null),
+    assetSummary: parseJson(row.asset_summary_json, null),
+    validationSummary: parseJson(row.validation_summary_json, null),
+  };
+}
+
+function eventRowToRecord(row) {
+  if (!row) return null;
+  return {
+    eventId: row.event_id,
+    packageId: row.package_id || null,
+    releaseId: row.release_id || null,
+    subjectId: row.subject_id,
+    eventType: row.event_type,
+    actorAccountId: row.actor_account_id || null,
+    event: parseJson(row.event_json, {}),
+    createdAt: Number(row.created_at) || 0,
+  };
+}
+
+async function insertContentOperationEvent(db, {
+  eventId = uid('coevt'),
+  packageId = null,
+  releaseId = null,
+  subjectId = CONTENT_OPERATION_SUBJECT_ID,
+  eventType,
+  actorAccountId = null,
+  event = {},
+  createdAt,
+}) {
+  await run(db, `
+    INSERT INTO content_operation_events (
+      event_id, package_id, release_id, subject_id, event_type,
+      actor_account_id, event_json, created_at
+    )
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `, [
+    eventId,
+    packageId,
+    releaseId,
+    subjectId,
+    eventType,
+    actorAccountId,
+    JSON.stringify(event || {}),
+    createdAt,
+  ]);
+  return eventId;
+}
+
+async function readLatestReleaseRow(db, subjectId, { includeSnapshot = false } = {}) {
+  return first(db, `
+    SELECT
+      release_id, subject_id, status, snapshot_hash,
+      ${includeSnapshot ? 'snapshot_json' : 'NULL AS snapshot_json'},
+      base_release_id, package_id, published_at, published_by_account_id,
+      rollback_of_release_id, proof_json, created_at
+    FROM content_operation_releases
+    WHERE subject_id = ? AND status = 'published'
+    ORDER BY published_at DESC, created_at DESC
+    LIMIT 1
+  `, [subjectId]);
+}
+
+async function readReleaseRowById(db, subjectId, releaseId, { includeSnapshot = false } = {}) {
+  if (!releaseId) return null;
+  return first(db, `
+    SELECT
+      release_id, subject_id, status, snapshot_hash,
+      ${includeSnapshot ? 'snapshot_json' : 'NULL AS snapshot_json'},
+      base_release_id, package_id, published_at, published_by_account_id,
+      rollback_of_release_id, proof_json, created_at
+    FROM content_operation_releases
+    WHERE subject_id = ? AND release_id = ? AND status = 'published'
+    LIMIT 1
+  `, [subjectId, releaseId]);
+}
+
+async function requirePackage(db, packageId) {
+  const row = await first(db, `
+    SELECT *
+    FROM content_operation_packages
+    WHERE package_id = ?
+  `, [packageId]);
+  if (!row) {
+    throw new NotFoundError('Content operation package was not found.', {
+      code: 'content_operation_package_not_found',
+      packageId,
+    });
+  }
+  return row;
+}
+
+async function listPackageOperations(db, packageId) {
+  const rows = await all(db, `
+    SELECT *
+    FROM content_operation_package_operations
+    WHERE package_id = ?
+    ORDER BY operation_order ASC
+  `, [packageId]);
+  return rows.map(operationRowToRecord);
+}
+
+function releaseDriftConflict(packageRow, currentReleaseRow, baseReleaseRow) {
+  const packageBaseReleaseId = packageRow.base_release_id || null;
+  const currentReleaseId = currentReleaseRow?.release_id || null;
+  const packageBaseReleaseHash = packageRow.base_release_hash || null;
+  const currentReleaseHash = currentReleaseRow?.snapshot_hash || null;
+
+  if (packageBaseReleaseId && !baseReleaseRow) {
+    return {
+      code: 'base_release_missing',
+      packageBaseReleaseId,
+      packageBaseReleaseHash,
+      currentReleaseId,
+      currentReleaseHash,
+    };
+  }
+
+  if (
+    packageBaseReleaseId !== currentReleaseId
+    || packageBaseReleaseHash !== currentReleaseHash
+  ) {
+    return {
+      code: 'base_release_changed',
+      packageBaseReleaseId,
+      packageBaseReleaseHash,
+      currentReleaseId,
+      currentReleaseHash,
+    };
+  }
+
+  return null;
+}
+
+export function createContentOperationsRepository({ db, now }) {
+  const nowFactory = typeof now === 'function' ? now : () => Date.now();
+
+  return {
+    async createContentOperationPackage({
+      subjectId = CONTENT_OPERATION_SUBJECT_ID,
+      templateId = 'general',
+      title = '',
+      description = '',
+      createdByAccountId,
+    } = {}) {
+      const resolvedSubjectId = normaliseSubjectId(subjectId);
+      const actor = normaliseString(createdByAccountId);
+      if (!actor) throw new BadRequestError('Content operation packages require a creator account id.');
+      const nowTs = Number(nowFactory());
+      const latestRelease = await readLatestReleaseRow(db, resolvedSubjectId);
+      const packageId = uid('copkg');
+      const record = {
+        packageId,
+        subjectId: resolvedSubjectId,
+        templateId: normaliseString(templateId, 'general'),
+        title: normaliseString(title, 'Untitled content package'),
+        description: normaliseString(description),
+        baseReleaseId: latestRelease?.release_id || null,
+        baseReleaseHash: latestRelease?.snapshot_hash || null,
+        state: CONTENT_OPERATION_PACKAGE_STATES.DRAFT,
+        createdByAccountId: actor,
+        updatedByAccountId: actor,
+        createdAt: nowTs,
+        updatedAt: nowTs,
+      };
+
+      await batch(db, [
+        bindStatement(db, `
+          INSERT INTO content_operation_packages (
+            package_id, subject_id, template_id, title, description,
+            base_release_id, base_release_hash, state, created_by_account_id,
+            updated_by_account_id, created_at, updated_at
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `, [
+          record.packageId,
+          record.subjectId,
+          record.templateId,
+          record.title,
+          record.description,
+          record.baseReleaseId,
+          record.baseReleaseHash,
+          record.state,
+          record.createdByAccountId,
+          record.updatedByAccountId,
+          record.createdAt,
+          record.updatedAt,
+        ]),
+        bindStatement(db, `
+          INSERT INTO content_operation_events (
+            event_id, package_id, release_id, subject_id, event_type,
+            actor_account_id, event_json, created_at
+          )
+          VALUES (?, ?, NULL, ?, ?, ?, ?, ?)
+        `, [
+          uid('coevt'),
+          record.packageId,
+          record.subjectId,
+          'package.created',
+          actor,
+          JSON.stringify({ templateId: record.templateId, title: record.title }),
+          nowTs,
+        ]),
+      ]);
+
+      return record;
+    },
+
+    async readContentOperationPackage(packageId, { includeOperations = true } = {}) {
+      const row = await requirePackage(db, packageId);
+      const record = packageRowToRecord(row);
+      if (includeOperations) {
+        record.operations = await listPackageOperations(db, packageId);
+      }
+      return record;
+    },
+
+    async listContentOperationPackages({ subjectId = CONTENT_OPERATION_SUBJECT_ID, state = null, limit = 50 } = {}) {
+      const resolvedSubjectId = normaliseSubjectId(subjectId);
+      const safeLimit = Math.max(1, Math.min(100, Number(limit) || 50));
+      const params = [resolvedSubjectId];
+      let where = 'subject_id = ?';
+      if (state) {
+        where += ' AND state = ?';
+        params.push(state);
+      }
+      params.push(safeLimit);
+      const rows = await all(db, `
+        SELECT *
+        FROM content_operation_packages
+        WHERE ${where}
+        ORDER BY updated_at DESC
+        LIMIT ?
+      `, params);
+      return rows.map(packageRowToRecord);
+    },
+
+    async appendContentOperation(packageId, rawOperation, { actorAccountId } = {}) {
+      const packageRow = await requirePackage(db, packageId);
+      if (packageRow.state === CONTENT_OPERATION_PACKAGE_STATES.PUBLISHED) {
+        throw new ConflictError('Published content operation packages cannot be mutated.', {
+          code: 'content_operation_package_published',
+          packageId,
+        });
+      }
+      const actor = normaliseString(actorAccountId);
+      if (!actor) throw new BadRequestError('Content operations require an actor account id.');
+      const nowTs = Number(nowFactory());
+      const nextOrder = Number(await first(db, `
+        SELECT COALESCE(MAX(operation_order), 0) + 1 AS next_order
+        FROM content_operation_package_operations
+        WHERE package_id = ?
+      `, [packageId]).then((row) => row?.next_order || 1));
+      const operationId = uid('coop');
+      const operation = normaliseContentOperation(rawOperation, {
+        actorAccountId: actor,
+        now: () => nowTs,
+        operationId,
+      });
+
+      await batch(db, [
+        bindStatement(db, `
+          INSERT INTO content_operation_package_operations (
+            operation_id, package_id, operation_order, entity_type, entity_id,
+            field_path, action, before_hash, after_hash, payload_json,
+            created_by_account_id, created_at
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `, [
+          operation.operationId,
+          packageId,
+          nextOrder,
+          operation.entityType,
+          operation.entityId,
+          operation.fieldPath,
+          operation.action,
+          operation.beforeHash || null,
+          operation.afterHash || null,
+          JSON.stringify(operation.payload),
+          operation.createdByAccountId,
+          operation.createdAt,
+        ]),
+        bindStatement(db, `
+          DELETE FROM content_operation_package_approvals
+          WHERE package_id = ?
+        `, [packageId]),
+        bindStatement(db, `
+          UPDATE content_operation_packages
+          SET state = ?, approved_at = NULL, updated_by_account_id = ?, updated_at = ?
+          WHERE package_id = ?
+        `, [
+          CONTENT_OPERATION_PACKAGE_STATES.DRAFT,
+          actor,
+          nowTs,
+          packageId,
+        ]),
+        bindStatement(db, `
+          INSERT INTO content_operation_events (
+            event_id, package_id, release_id, subject_id, event_type,
+            actor_account_id, event_json, created_at
+          )
+          VALUES (?, ?, NULL, ?, ?, ?, ?, ?)
+        `, [
+          uid('coevt'),
+          packageId,
+          packageRow.subject_id,
+          'operation.appended',
+          actor,
+          JSON.stringify({
+            operationId: operation.operationId,
+            entityType: operation.entityType,
+            entityId: operation.entityId,
+            fieldPath: operation.fieldPath,
+            action: operation.action,
+          }),
+          nowTs,
+        ]),
+      ]);
+
+      return { ...operation, packageId, operationOrder: nextOrder };
+    },
+
+    async buildContentOperationCandidate(packageId, { actorAccountId = null } = {}) {
+      const packageRow = await requirePackage(db, packageId);
+      const operations = await listPackageOperations(db, packageId);
+      const currentReleaseRow = await readLatestReleaseRow(db, packageRow.subject_id, { includeSnapshot: true });
+      const baseReleaseRow = await readReleaseRowById(
+        db,
+        packageRow.subject_id,
+        packageRow.base_release_id,
+        { includeSnapshot: true },
+      );
+      const baseSnapshot = baseReleaseRow?.snapshot_json
+        ? parseJson(baseReleaseRow.snapshot_json, null)
+        : await readSeededSpellingContentBundle();
+      const candidate = buildSpellingContentOperationCandidate(baseSnapshot, operations);
+      const conflicts = [
+        ...(candidate.conflicts || []),
+        releaseDriftConflict(packageRow, currentReleaseRow, baseReleaseRow),
+      ].filter(Boolean);
+      const candidateId = uid('cocand');
+      const nowTs = Number(nowFactory());
+      const validationSummary = {
+        ok: Boolean(candidate.validation.ok),
+        errorCount: candidate.validation.errors.length,
+        warningCount: candidate.validation.warnings.length,
+        errors: candidate.validation.errors,
+        warnings: candidate.validation.warnings,
+      };
+
+      await batch(db, [
+        bindStatement(db, `
+          INSERT INTO content_operation_package_candidates (
+            candidate_id, package_id, base_release_id, current_release_id,
+            operations_hash, candidate_hash, candidate_snapshot_json,
+            validation_json, audio_scan_json, asset_scan_json, reward_scan_json,
+            visibility_scan_json, conflicts_json, created_at
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, ?, ?)
+        `, [
+          candidateId,
+          packageId,
+          packageRow.base_release_id || null,
+          currentReleaseRow?.release_id || null,
+          candidate.operationsHash,
+          candidate.candidateHash,
+          JSON.stringify(candidate.candidate),
+          JSON.stringify(validationSummary),
+          JSON.stringify(conflicts),
+          nowTs,
+        ]),
+        bindStatement(db, `
+          UPDATE content_operation_packages
+          SET updated_by_account_id = ?, updated_at = ?
+          WHERE package_id = ?
+        `, [
+          normaliseString(actorAccountId, packageRow.updated_by_account_id),
+          nowTs,
+          packageId,
+        ]),
+        bindStatement(db, `
+          INSERT INTO content_operation_events (
+            event_id, package_id, release_id, subject_id, event_type,
+            actor_account_id, event_json, created_at
+          )
+          VALUES (?, ?, NULL, ?, ?, ?, ?, ?)
+        `, [
+          uid('coevt'),
+          packageId,
+          packageRow.subject_id,
+          'candidate.built',
+          normaliseString(actorAccountId) || null,
+          JSON.stringify({
+            candidateId,
+            candidateHash: candidate.candidateHash,
+            operationsHash: candidate.operationsHash,
+            validation: validationSummary,
+          }),
+          nowTs,
+        ]),
+      ]);
+
+      return {
+        candidateId,
+        packageId,
+        baseReleaseId: packageRow.base_release_id || null,
+        currentReleaseId: currentReleaseRow?.release_id || null,
+        operationsHash: candidate.operationsHash,
+        candidateHash: candidate.candidateHash,
+        candidate: candidate.candidate,
+        validation: validationSummary,
+        conflicts,
+        createdAt: nowTs,
+      };
+    },
+
+    async approveContentOperationCandidate(packageId, candidateId, {
+      approvedByAccountId,
+      notes = '',
+      audioFallback = null,
+      assetSummary = null,
+    } = {}) {
+      const packageRow = await requirePackage(db, packageId);
+      const actor = normaliseString(approvedByAccountId);
+      if (!actor) throw new BadRequestError('Content operation approval requires an approver account id.');
+      const candidateRow = await first(db, `
+        SELECT *
+        FROM content_operation_package_candidates
+        WHERE package_id = ? AND candidate_id = ?
+      `, [packageId, candidateId]);
+      if (!candidateRow) {
+        throw new NotFoundError('Content operation candidate was not found.', {
+          code: 'content_operation_candidate_not_found',
+          packageId,
+          candidateId,
+        });
+      }
+      const candidate = candidateRowToRecord(candidateRow);
+      if (!candidate.validation?.ok) {
+        throw new ConflictError('Content operation candidate has validation blockers.', {
+          code: 'content_operation_candidate_invalid',
+          packageId,
+          candidateId,
+          validation: candidate.validation,
+        });
+      }
+      if (Array.isArray(candidate.conflicts) && candidate.conflicts.length) {
+        throw new ConflictError('Content operation candidate has unresolved conflicts.', {
+          code: 'content_operation_candidate_conflicted',
+          packageId,
+          candidateId,
+          conflicts: candidate.conflicts,
+        });
+      }
+
+      const approvalId = uid('coapp');
+      const nowTs = Number(nowFactory());
+      await batch(db, [
+        bindStatement(db, `
+          DELETE FROM content_operation_package_approvals
+          WHERE package_id = ?
+        `, [packageId]),
+        bindStatement(db, `
+          INSERT INTO content_operation_package_approvals (
+            approval_id, package_id, candidate_id, candidate_hash,
+            approved_by_account_id, approved_at, notes, audio_fallback_json,
+            asset_summary_json, validation_summary_json
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `, [
+          approvalId,
+          packageId,
+          candidateId,
+          candidate.candidateHash,
+          actor,
+          nowTs,
+          normaliseString(notes),
+          audioFallback == null ? null : JSON.stringify(audioFallback),
+          assetSummary == null ? null : JSON.stringify(assetSummary),
+          JSON.stringify(candidate.validation),
+        ]),
+        bindStatement(db, `
+          UPDATE content_operation_packages
+          SET state = ?, approved_at = ?, updated_by_account_id = ?, updated_at = ?
+          WHERE package_id = ?
+        `, [
+          CONTENT_OPERATION_PACKAGE_STATES.APPROVED,
+          nowTs,
+          actor,
+          nowTs,
+          packageId,
+        ]),
+        bindStatement(db, `
+          INSERT INTO content_operation_events (
+            event_id, package_id, release_id, subject_id, event_type,
+            actor_account_id, event_json, created_at
+          )
+          VALUES (?, ?, NULL, ?, ?, ?, ?, ?)
+        `, [
+          uid('coevt'),
+          packageId,
+          packageRow.subject_id,
+          'package.approved',
+          actor,
+          JSON.stringify({ approvalId, candidateId, candidateHash: candidate.candidateHash }),
+          nowTs,
+        ]),
+      ]);
+
+      return {
+        approvalId,
+        packageId,
+        candidateId,
+        candidateHash: candidate.candidateHash,
+        approvedByAccountId: actor,
+        approvedAt: nowTs,
+        notes: normaliseString(notes),
+        validationSummary: candidate.validation,
+      };
+    },
+
+    async publishContentOperationPackage(packageId, { publishedByAccountId, proof = null } = {}) {
+      const packageRow = await requirePackage(db, packageId);
+      const actor = normaliseString(publishedByAccountId);
+      if (!actor) throw new BadRequestError('Content operation publish requires a publisher account id.');
+      if (packageRow.state !== CONTENT_OPERATION_PACKAGE_STATES.APPROVED) {
+        throw new ConflictError('Content operation package must be approved before publish.', {
+          code: 'content_operation_package_not_approved',
+          packageId,
+          state: packageRow.state,
+        });
+      }
+      const approvalRow = await first(db, `
+        SELECT *
+        FROM content_operation_package_approvals
+        WHERE package_id = ?
+        ORDER BY approved_at DESC
+        LIMIT 1
+      `, [packageId]);
+      const approval = approvalRowToRecord(approvalRow);
+      if (!approval) {
+        throw new ConflictError('Content operation package has no approval.', {
+          code: 'content_operation_approval_missing',
+          packageId,
+        });
+      }
+      const candidateRow = await first(db, `
+        SELECT *
+        FROM content_operation_package_candidates
+        WHERE package_id = ? AND candidate_id = ?
+      `, [packageId, approval.candidateId]);
+      const candidate = candidateRowToRecord(candidateRow, { includeSnapshot: true });
+      if (!candidate || candidate.candidateHash !== approval.candidateHash) {
+        throw new ConflictError('Content operation approval does not match the candidate hash.', {
+          code: 'content_operation_approval_hash_mismatch',
+          packageId,
+        });
+      }
+      const currentReleaseRow = await readLatestReleaseRow(db, packageRow.subject_id);
+      if ((candidate.currentReleaseId || null) !== (currentReleaseRow?.release_id || null)) {
+        throw new ConflictError('A newer content operation release was published after approval.', {
+          code: 'content_operation_release_drift',
+          packageId,
+          candidateCurrentReleaseId: candidate.currentReleaseId || null,
+          currentReleaseId: currentReleaseRow?.release_id || null,
+        });
+      }
+      const validation = validateSpellingContentBundle(candidate.candidate);
+      if (!validation.ok) {
+        throw new ConflictError('Approved candidate no longer validates.', {
+          code: 'content_operation_candidate_invalid',
+          packageId,
+          validation,
+        });
+      }
+      const releaseId = uid('corel');
+      const nowTs = Number(nowFactory());
+      const snapshotHash = contentOperationHash(candidate.candidate, 'release');
+
+      await batch(db, [
+        bindStatement(db, `
+          INSERT INTO content_operation_releases (
+            release_id, subject_id, status, snapshot_json, snapshot_hash,
+            base_release_id, package_id, published_at, published_by_account_id,
+            rollback_of_release_id, proof_json, created_at
+          )
+          VALUES (?, ?, 'published', ?, ?, ?, ?, ?, ?, NULL, ?, ?)
+        `, [
+          releaseId,
+          packageRow.subject_id,
+          JSON.stringify(candidate.candidate),
+          snapshotHash,
+          candidate.currentReleaseId || packageRow.base_release_id || null,
+          packageId,
+          nowTs,
+          actor,
+          proof == null ? null : JSON.stringify(proof),
+          nowTs,
+        ]),
+        bindStatement(db, `
+          UPDATE content_operation_packages
+          SET state = ?, published_at = ?, updated_by_account_id = ?, updated_at = ?
+          WHERE package_id = ?
+        `, [
+          CONTENT_OPERATION_PACKAGE_STATES.PUBLISHED,
+          nowTs,
+          actor,
+          nowTs,
+          packageId,
+        ]),
+        bindStatement(db, `
+          INSERT INTO content_operation_events (
+            event_id, package_id, release_id, subject_id, event_type,
+            actor_account_id, event_json, created_at
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        `, [
+          uid('coevt'),
+          packageId,
+          releaseId,
+          packageRow.subject_id,
+          'package.published',
+          actor,
+          JSON.stringify({
+            releaseId,
+            candidateId: candidate.candidateId,
+            candidateHash: candidate.candidateHash,
+            snapshotHash,
+            summary: buildSpellingContentSummary(candidate.candidate),
+          }),
+          nowTs,
+        ]),
+      ]);
+
+      return {
+        releaseId,
+        packageId,
+        subjectId: packageRow.subject_id,
+        status: 'published',
+        snapshotHash,
+        snapshot: candidate.candidate,
+        publishedAt: nowTs,
+        publishedByAccountId: actor,
+        proof,
+      };
+    },
+
+    async readLatestContentOperationRelease(subjectId = CONTENT_OPERATION_SUBJECT_ID, { includeSnapshot = false } = {}) {
+      const row = await readLatestReleaseRow(db, normaliseSubjectId(subjectId), { includeSnapshot });
+      return releaseRowToRecord(row, { includeSnapshot });
+    },
+
+    async listContentOperationReleases({ subjectId = CONTENT_OPERATION_SUBJECT_ID, includeSnapshot = false, limit = 20 } = {}) {
+      const safeLimit = Math.max(1, Math.min(100, Number(limit) || 20));
+      const rows = await all(db, `
+        SELECT
+          release_id, subject_id, status, snapshot_hash,
+          ${includeSnapshot ? 'snapshot_json' : 'NULL AS snapshot_json'},
+          base_release_id, package_id, published_at, published_by_account_id,
+          rollback_of_release_id, proof_json, created_at
+        FROM content_operation_releases
+        WHERE subject_id = ?
+        ORDER BY published_at DESC, created_at DESC
+        LIMIT ?
+      `, [normaliseSubjectId(subjectId), safeLimit]);
+      return rows.map((row) => releaseRowToRecord(row, { includeSnapshot }));
+    },
+
+    async listContentOperationEvents({ packageId = null, releaseId = null, subjectId = CONTENT_OPERATION_SUBJECT_ID, limit = 50 } = {}) {
+      const safeLimit = Math.max(1, Math.min(200, Number(limit) || 50));
+      const params = [];
+      const clauses = [];
+      if (packageId) {
+        clauses.push('package_id = ?');
+        params.push(packageId);
+      }
+      if (releaseId) {
+        clauses.push('release_id = ?');
+        params.push(releaseId);
+      }
+      if (!packageId && !releaseId) {
+        clauses.push('subject_id = ?');
+        params.push(normaliseSubjectId(subjectId));
+      }
+      params.push(safeLimit);
+      const rows = await all(db, `
+        SELECT *
+        FROM content_operation_events
+        WHERE ${clauses.join(' AND ')}
+        ORDER BY created_at DESC
+        LIMIT ?
+      `, params);
+      return rows.map(eventRowToRecord);
+    },
+
+    async recordContentOperationEvent(event) {
+      const createdAt = Number(event?.createdAt) || Number(nowFactory());
+      const eventId = await insertContentOperationEvent(db, {
+        ...event,
+        subjectId: normaliseSubjectId(event?.subjectId),
+        createdAt,
+      });
+      return { eventId, createdAt };
+    },
+  };
+}

--- a/worker/src/repository.js
+++ b/worker/src/repository.js
@@ -533,6 +533,18 @@ async function readSeededSpellingRuntimeContentBundle(subjectId = 'spelling') {
     || rememberSpellingRuntimeContent(key, await buildSeededSpellingRuntimeContent(subjectId));
 }
 
+async function readSpellingRuntimeContentReleaseBundle(db, subjectId, releaseRow, cachePrefix = 'release') {
+  if (!releaseRow) return readSeededSpellingRuntimeContentBundle(subjectId);
+  const key = spellingRuntimeContentReleaseKey(releaseRow, subjectId, cachePrefix);
+  const cached = readCachedSpellingRuntimeContent(key);
+  if (cached) return cached;
+  const fullReleaseRow = await readPublishedContentOperationReleaseRow(db, subjectId, {
+    includeSnapshot: true,
+    releaseId: releaseRow.release_id,
+  });
+  return rememberSpellingRuntimeContent(key, await buildSpellingRuntimeContentFromRelease(fullReleaseRow, subjectId));
+}
+
 async function readPublishedContentOperationReleaseRow(db, subjectId = 'spelling', {
   includeSnapshot = false,
   releaseId = null,
@@ -553,7 +565,7 @@ async function readPublishedContentOperationReleaseRow(db, subjectId = 'spelling
         created_at
       FROM content_operation_releases
       WHERE ${releaseFilter}
-      ORDER BY published_at DESC, created_at DESC
+      ORDER BY published_at DESC, created_at DESC, rowid DESC
       LIMIT 1
     `, params);
   } catch (error) {
@@ -601,30 +613,17 @@ async function readSpellingRuntimeContentBundle(db, accountId, subjectId = 'spel
   includeAccountContent = true,
   includeGlobalContent = true,
 } = {}) {
+  if (includeGlobalContent) {
+    const overrideRow = await readActiveContentOperationOverrideReleaseRow(db, accountId, subjectId);
+    if (overrideRow) {
+      return readSpellingRuntimeContentReleaseBundle(db, subjectId, overrideRow, 'override');
+    }
+  }
+
   if (!includeAccountContent) {
     if (!includeGlobalContent) return readSeededSpellingRuntimeContentBundle(subjectId);
     const releaseRow = await readPublishedContentOperationReleaseRow(db, subjectId);
-    if (!releaseRow) return readSeededSpellingRuntimeContentBundle(subjectId);
-    const key = spellingRuntimeContentReleaseKey(releaseRow, subjectId);
-    const cached = readCachedSpellingRuntimeContent(key);
-    if (cached) return cached;
-    const fullReleaseRow = await readPublishedContentOperationReleaseRow(db, subjectId, {
-      includeSnapshot: true,
-      releaseId: releaseRow.release_id,
-    });
-    return rememberSpellingRuntimeContent(key, await buildSpellingRuntimeContentFromRelease(fullReleaseRow, subjectId));
-  }
-
-  const overrideRow = await readActiveContentOperationOverrideReleaseRow(db, accountId, subjectId);
-  if (overrideRow) {
-    const key = spellingRuntimeContentReleaseKey(overrideRow, subjectId, 'override');
-    const cached = readCachedSpellingRuntimeContent(key);
-    if (cached) return cached;
-    const fullOverrideRow = await readPublishedContentOperationReleaseRow(db, subjectId, {
-      includeSnapshot: true,
-      releaseId: overrideRow.release_id,
-    });
-    return rememberSpellingRuntimeContent(key, await buildSpellingRuntimeContentFromRelease(fullOverrideRow, subjectId));
+    return readSpellingRuntimeContentReleaseBundle(db, subjectId, releaseRow);
   }
 
   const accountRow = await first(db, `
@@ -659,14 +658,7 @@ async function readSpellingRuntimeContentBundle(db, accountId, subjectId = 'spel
   if (includeGlobalContent) {
     const releaseRow = await readPublishedContentOperationReleaseRow(db, subjectId);
     if (releaseRow) {
-      const key = spellingRuntimeContentReleaseKey(releaseRow, subjectId);
-      const cached = readCachedSpellingRuntimeContent(key);
-      if (cached) return cached;
-      const fullReleaseRow = await readPublishedContentOperationReleaseRow(db, subjectId, {
-        includeSnapshot: true,
-        releaseId: releaseRow.release_id,
-      });
-      return rememberSpellingRuntimeContent(key, await buildSpellingRuntimeContentFromRelease(fullReleaseRow, subjectId));
+      return readSpellingRuntimeContentReleaseBundle(db, subjectId, releaseRow);
     }
   }
 
@@ -7630,7 +7622,7 @@ async function bootstrapBundle(db, accountId, {
     publicReadModels && subjectRows.some((row) => row.subject_id === 'spelling')
       ? readSpellingRuntimeContentBundle(db, accountId, 'spelling', {
         includeAccountContent: false,
-        includeGlobalContent: false,
+        includeGlobalContent: true,
       })
       : null
   ));
@@ -10184,7 +10176,7 @@ export function createWorkerRepository({ env = {}, now = Date.now, capacity = nu
       const spellingContent = accountId && rows.some((row) => row.subject_id === 'spelling')
         ? await readSpellingRuntimeContentBundle(db, accountId, 'spelling', {
           includeAccountContent: false,
-          includeGlobalContent: false,
+          includeGlobalContent: true,
         })
         : null;
       for (const row of rows) {

--- a/worker/src/repository.js
+++ b/worker/src/repository.js
@@ -160,6 +160,7 @@ import {
   eventToken as eventTokenForDedupe,
 } from './projections/events.js';
 import { buildSpellingAudioCue } from './subjects/spelling/audio.js';
+import { createContentOperationsRepository } from './content-operations/repository.js';
 import { buildGrammarReadModel } from './subjects/grammar/read-models.js';
 import { ARITHMETIC_CONTENT_RELEASE_ID } from '../../shared/arithmetic/content.js';
 import { READING_CONTENT_RELEASE_ID } from '../../shared/reading/metadata.js';
@@ -532,10 +533,142 @@ async function readSeededSpellingRuntimeContentBundle(subjectId = 'spelling') {
     || rememberSpellingRuntimeContent(key, await buildSeededSpellingRuntimeContent(subjectId));
 }
 
+async function readPublishedContentOperationReleaseRow(db, subjectId = 'spelling', {
+  includeSnapshot = false,
+  releaseId = null,
+} = {}) {
+  const releaseFilter = releaseId
+    ? 'subject_id = ? AND status = \'published\' AND release_id = ?'
+    : 'subject_id = ? AND status = \'published\'';
+  const params = releaseId ? [subjectId, releaseId] : [subjectId];
+  try {
+    return await first(db, `
+      SELECT
+        release_id,
+        subject_id,
+        status,
+        snapshot_hash,
+        ${includeSnapshot ? 'snapshot_json' : 'NULL AS snapshot_json'},
+        published_at,
+        created_at
+      FROM content_operation_releases
+      WHERE ${releaseFilter}
+      ORDER BY published_at DESC, created_at DESC
+      LIMIT 1
+    `, params);
+  } catch (error) {
+    if (isMissingTableError(error, 'content_operation_releases')) return null;
+    throw error;
+  }
+}
+
+async function readActiveContentOperationOverrideReleaseRow(db, accountId, subjectId = 'spelling', {
+  includeSnapshot = false,
+} = {}) {
+  try {
+    return await first(db, `
+      SELECT
+        r.release_id,
+        r.subject_id,
+        r.status,
+        r.snapshot_hash,
+        ${includeSnapshot ? 'r.snapshot_json' : 'NULL'} AS snapshot_json,
+        r.published_at,
+        r.created_at
+      FROM content_operation_account_overrides o
+      JOIN content_operation_releases r
+        ON r.release_id = o.release_id
+       AND r.subject_id = o.subject_id
+       AND r.status = 'published'
+      WHERE o.account_id = ?
+        AND o.subject_id = ?
+        AND o.active = 1
+      ORDER BY o.created_at DESC
+      LIMIT 1
+    `, [accountId, subjectId]);
+  } catch (error) {
+    if (
+      isMissingTableError(error, 'content_operation_account_overrides')
+      || isMissingTableError(error, 'content_operation_releases')
+    ) {
+      return null;
+    }
+    throw error;
+  }
+}
+
 async function readSpellingRuntimeContentBundle(db, accountId, subjectId = 'spelling', {
   includeAccountContent = true,
+  includeGlobalContent = true,
 } = {}) {
-  if (!includeAccountContent) return readSeededSpellingRuntimeContentBundle(subjectId);
+  if (!includeAccountContent) {
+    if (!includeGlobalContent) return readSeededSpellingRuntimeContentBundle(subjectId);
+    const releaseRow = await readPublishedContentOperationReleaseRow(db, subjectId);
+    if (!releaseRow) return readSeededSpellingRuntimeContentBundle(subjectId);
+    const key = spellingRuntimeContentReleaseKey(releaseRow, subjectId);
+    const cached = readCachedSpellingRuntimeContent(key);
+    if (cached) return cached;
+    const fullReleaseRow = await readPublishedContentOperationReleaseRow(db, subjectId, {
+      includeSnapshot: true,
+      releaseId: releaseRow.release_id,
+    });
+    return rememberSpellingRuntimeContent(key, await buildSpellingRuntimeContentFromRelease(fullReleaseRow, subjectId));
+  }
+
+  const overrideRow = await readActiveContentOperationOverrideReleaseRow(db, accountId, subjectId);
+  if (overrideRow) {
+    const key = spellingRuntimeContentReleaseKey(overrideRow, subjectId, 'override');
+    const cached = readCachedSpellingRuntimeContent(key);
+    if (cached) return cached;
+    const fullOverrideRow = await readPublishedContentOperationReleaseRow(db, subjectId, {
+      includeSnapshot: true,
+      releaseId: overrideRow.release_id,
+    });
+    return rememberSpellingRuntimeContent(key, await buildSpellingRuntimeContentFromRelease(fullOverrideRow, subjectId));
+  }
+
+  const accountRow = await first(db, `
+    SELECT
+      account_id,
+      subject_id,
+      updated_at,
+      length(content_json) AS content_length,
+      NULL AS content_json
+    FROM account_subject_content
+    WHERE account_id = ? AND subject_id = ?
+    LIMIT 1
+  `, [accountId, subjectId]);
+  if (accountRow) {
+    const key = spellingRuntimeContentRowKey(accountRow, subjectId);
+    const cached = readCachedSpellingRuntimeContent(key);
+    if (cached) return cached;
+
+    const contentRow = await first(db, `
+      SELECT
+        account_id,
+        subject_id,
+        updated_at,
+        length(content_json) AS content_length,
+        content_json
+      FROM account_subject_content
+      WHERE account_id = ? AND subject_id = ?
+    `, [accountId, subjectId]);
+    return rememberSpellingRuntimeContent(key, await buildSpellingRuntimeContent(contentRow, subjectId));
+  }
+
+  if (includeGlobalContent) {
+    const releaseRow = await readPublishedContentOperationReleaseRow(db, subjectId);
+    if (releaseRow) {
+      const key = spellingRuntimeContentReleaseKey(releaseRow, subjectId);
+      const cached = readCachedSpellingRuntimeContent(key);
+      if (cached) return cached;
+      const fullReleaseRow = await readPublishedContentOperationReleaseRow(db, subjectId, {
+        includeSnapshot: true,
+        releaseId: releaseRow.release_id,
+      });
+      return rememberSpellingRuntimeContent(key, await buildSpellingRuntimeContentFromRelease(fullReleaseRow, subjectId));
+    }
+  }
 
   const row = await first(db, `
     SELECT account_id, subject_id, updated_at, content_length, NULL AS content_json
@@ -729,6 +862,18 @@ function spellingRuntimeContentRowKey(row, subjectId) {
   ].join(':');
 }
 
+function spellingRuntimeContentReleaseKey(row, subjectId, prefix = 'release') {
+  if (!row) return spellingRuntimeContentSeedKey(subjectId);
+  return [
+    prefix,
+    subjectId,
+    row.release_id || '',
+    row.snapshot_hash || '',
+    row.published_at || 0,
+    row.created_at || 0,
+  ].join(':');
+}
+
 function rememberSpellingRuntimeContent(key, value) {
   if (spellingRuntimeContentCache.has(key)) spellingRuntimeContentCache.delete(key);
   spellingRuntimeContentCache.set(key, value);
@@ -779,6 +924,31 @@ async function buildSpellingRuntimeContent(row, subjectId) {
     snapshot,
     summary: runtimeContentSummary(content, snapshot),
   };
+}
+
+async function buildSpellingRuntimeContentFromRelease(row, subjectId) {
+  if (!row?.snapshot_json) {
+    return buildSeededSpellingRuntimeContent(subjectId);
+  }
+
+  try {
+    const seededBundle = await readSeededSpellingContentBundle();
+    const content = normaliseSpellingContentBundle(JSON.parse(row.snapshot_json));
+    const snapshot = runtimeSnapshotForBundle(content, seededBundle);
+    return {
+      subjectId,
+      content,
+      snapshot,
+      summary: runtimeContentSummary(content, snapshot),
+    };
+  } catch (error) {
+    logMutation('warn', 'content_operation_release.runtime_fallback', {
+      subjectId,
+      releaseId: row?.release_id || '',
+      error: error?.message || String(error),
+    });
+    return buildSeededSpellingRuntimeContent(subjectId);
+  }
 }
 
 async function buildSeededSpellingRuntimeContent(subjectId) {
@@ -7458,7 +7628,10 @@ async function bootstrapBundle(db, accountId, {
   ));
   const publicSpellingContent = await measureBootstrapPhase(capacity, BOOTSTRAP_PHASE_TIMING.readModel, () => (
     publicReadModels && subjectRows.some((row) => row.subject_id === 'spelling')
-      ? readSpellingRuntimeContentBundle(db, accountId, 'spelling', { includeAccountContent: false })
+      ? readSpellingRuntimeContentBundle(db, accountId, 'spelling', {
+        includeAccountContent: false,
+        includeGlobalContent: false,
+      })
       : null
   ));
   const publicReadModelNow = Date.now();
@@ -8868,8 +9041,10 @@ export function createWorkerRepository({ env = {}, now = Date.now, capacity = nu
       // Structured logs are best-effort.
     }
   }
+  const contentOperations = createContentOperationsRepository({ db, now: nowFactory });
 
   return {
+    ...contentOperations,
     async ensureAccount(session) {
       const nowTs = nowFactory();
       // U6 queryCount budget: the inner `ensureAccount` helper already
@@ -10007,7 +10182,10 @@ export function createWorkerRepository({ env = {}, now = Date.now, capacity = nu
       `, [learnerId]);
       const result = {};
       const spellingContent = accountId && rows.some((row) => row.subject_id === 'spelling')
-        ? await readSpellingRuntimeContentBundle(db, accountId, 'spelling', { includeAccountContent: false })
+        ? await readSpellingRuntimeContentBundle(db, accountId, 'spelling', {
+          includeAccountContent: false,
+          includeGlobalContent: false,
+        })
         : null;
       for (const row of rows) {
         const rawRecord = subjectStateRowToRecord(row);


### PR DESCRIPTION
## Scope
- Captures the Content Operations Centre requirements and implementation plan as the contract for the full manager.
- Adds D1 foundation tables for content-operation packages, operations, candidates, approvals, releases, events, audio jobs, asset uploads, and account overrides.
- Adds spelling operation normalisation, merge, and conflict helpers plus a Worker repository lifecycle for create -> candidate -> approve -> publish.
- Bridges published global spelling content-operation releases into the spelling runtime without adding account-content reads to bootstrap or hero hot paths.

## Safety
- Package mutation invalidates existing approvals in the same D1 batch.
- Candidate approval is blocked when conflicts are present or the package base release has drifted.
- Publish rechecks the latest release id and rejects stale approvals before writing an immutable release.

## Not in this PR
- Admin UI editor, TTS batch queue UI, asset upload manager, and reward/monster binding screens.
- These are ticketed in `docs/plans/2026-06-11-feat-content-operations-centre-plan.md`.

## Verification
- `node --test tests/worker-migration-0020.test.js tests/content-operations-merge.test.js tests/content-operations-repository.test.js tests/worker-subject-runtime.test.js tests/worker-query-budget.test.js`
- `npm test` (111,666 pass, 0 fail, 12 skipped)
- `npm run check`
- `git diff --cached --check`
- `agent-browser` static root smoke passed. Local Worker browser smoke was attempted but blocked by a Wrangler generated-manifest watch loop; Worker runtime coverage is included in node tests.