### PR TITLE
feat(content-ops): add spelling release seed workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "content:generate": "node scripts/generate-spelling-content.mjs",
     "content:export": "node scripts/export-spelling-content.mjs",
     "content:import": "node scripts/import-spelling-content.mjs",
+    "content:operations:seed": "node scripts/migrate-spelling-content-to-global-release.mjs",
     "db:migration:create": "node ./scripts/wrangler-oauth.mjs d1 migrations create ks2-mastery-db",
     "db:migrate:local": "node ./scripts/wrangler-oauth.mjs d1 migrations apply ks2-mastery-db --local",
     "db:migrate:remote": "CI=true node ./scripts/wrangler-oauth.mjs d1 migrations apply ks2-mastery-db --remote",

--- a/scripts/migrate-spelling-content-to-global-release.mjs
+++ b/scripts/migrate-spelling-content-to-global-release.mjs
@@ -13,6 +13,9 @@ import {
   contentOperationHash,
 } from '../src/subjects/spelling/content/operations-model.js';
 import {
+  encodeContentOperationSnapshot,
+} from '../src/subjects/spelling/content/release-snapshot-codec.js';
+import {
   readSeededSpellingContentBundle,
 } from '../worker/src/generated-spelling-content-seed.js';
 
@@ -38,13 +41,66 @@ function sqlInteger(value) {
   return String(Math.trunc(number));
 }
 
+function parseWranglerJsonOutput(stdout) {
+  const text = String(stdout || '').trim();
+  if (!text) throw new Error('Wrangler returned no JSON output.');
+  const start = text.indexOf('[');
+  const end = text.lastIndexOf(']');
+  if (start === -1 || end === -1 || end < start) {
+    throw new Error('Wrangler output did not contain a JSON array.');
+  }
+  return JSON.parse(text.slice(start, end + 1));
+}
+
+function parseJson(value, fallback = null) {
+  if (value == null || value === '') return fallback;
+  if (typeof value !== 'string') return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return fallback;
+  }
+}
+
+function chunkString(value, chunkSize = 80_000) {
+  const chunks = [];
+  const text = String(value || '');
+  for (let index = 0; index < text.length; index += chunkSize) {
+    chunks.push(text.slice(index, index + chunkSize));
+  }
+  return chunks.length ? chunks : [''];
+}
+
+function snapshotSqlExpression(snapshotValue) {
+  const chunks = chunkString(snapshotValue);
+  if (chunks.length === 1 && chunks[0].length < 80_000) {
+    return {
+      setupSql: [],
+      valueExpression: sqlString(chunks[0]),
+      teardownSql: [],
+      chunkCount: chunks.length,
+    };
+  }
+  return {
+    setupSql: [
+      'CREATE TEMP TABLE _content_operation_seed_snapshot_chunks (chunk_index INTEGER PRIMARY KEY, chunk_value TEXT NOT NULL);',
+      ...chunks.map((chunk, index) => (
+        `INSERT INTO _content_operation_seed_snapshot_chunks (chunk_index, chunk_value) VALUES (${sqlInteger(index)}, ${sqlString(chunk)});`
+      )),
+    ],
+    valueExpression: "(SELECT group_concat(chunk_value, '') FROM (SELECT chunk_value FROM _content_operation_seed_snapshot_chunks ORDER BY chunk_index ASC))",
+    teardownSql: ['DROP TABLE _content_operation_seed_snapshot_chunks;'],
+    chunkCount: chunks.length,
+  };
+}
+
 function usage() {
   return [
     'Usage: node scripts/migrate-spelling-content-to-global-release.mjs [--dry-run|--apply] [--local|--remote] [options]',
     '',
     'Options:',
-    '  --dry-run             Validate the bundled seed and print the planned release (default).',
-    '  --apply               Apply the idempotent seed SQL through scripts/wrangler-oauth.mjs.',
+    '  --dry-run             Validate and print the planned release (default; add --local or --remote to inspect D1 legacy content).',
+    '  --apply               Apply the idempotent seed SQL through scripts/wrangler-oauth.mjs after reading current D1 legacy content.',
     '  --local               Target the local D1 database (default for --apply).',
     '  --remote              Target the remote D1 database. Requires KS2_CONFIRM_CONTENT_OPERATION_SEED=seed-first-global-release.',
     '  --actor <account-id>  Account id recorded as the seed actor.',
@@ -114,14 +170,64 @@ export function parseArgs(argv = process.argv.slice(2)) {
   return options;
 }
 
+function runWranglerD1Json(command, options) {
+  const args = [
+    path.join(rootDir, 'scripts', 'wrangler-oauth.mjs'),
+    'd1',
+    'execute',
+    'ks2-mastery-db',
+    options.remote ? '--remote' : '--local',
+    '--json',
+    '--command',
+    command,
+  ];
+  const result = spawnSync(process.execPath, args, {
+    cwd: rootDir,
+    encoding: 'utf8',
+    maxBuffer: 32 * 1024 * 1024,
+    env: { ...process.env },
+  });
+  if (result.error) throw result.error;
+  if ((result.status ?? 1) !== 0) {
+    const stderr = String(result.stderr || '').trim();
+    throw new Error(`Wrangler D1 query exited with status ${result.status ?? 1}.${stderr ? `\n${stderr}` : ''}`);
+  }
+  return parseWranglerJsonOutput(result.stdout);
+}
+
+function readLatestLegacyContentSource(options) {
+  const resultSets = runWranglerD1Json(`
+    SELECT account_id, subject_id, content_json, updated_at, updated_by_account_id
+    FROM account_subject_content
+    WHERE subject_id = 'spelling'
+    ORDER BY updated_at DESC
+    LIMIT 1
+  `, options);
+  const row = resultSets.flatMap((entry) => Array.isArray(entry?.results) ? entry.results : [])[0] || null;
+  const bundle = parseJson(row?.content_json, null);
+  if (!bundle) return null;
+  return {
+    bundle,
+    source: {
+      type: 'account_subject_content',
+      accountId: row.account_id || null,
+      updatedAt: Number(row.updated_at) || 0,
+      updatedByAccountId: row.updated_by_account_id || null,
+      script: scriptRelativePath,
+    },
+  };
+}
+
 export async function buildFirstGlobalReleaseSeedPlan({
   now = () => Date.now(),
   releaseId = uid('corel'),
   eventId = uid('coevt'),
   actorAccountId = 'content-operations-seed-script',
+  sourceBundle = null,
+  source = null,
 } = {}) {
   const nowTs = Number(now());
-  const bundle = await readSeededSpellingContentBundle();
+  const bundle = sourceBundle || await readSeededSpellingContentBundle();
   const validation = validateSpellingContentBundle(bundle);
   if (!validation.ok) {
     const errors = validation.errors
@@ -132,35 +238,38 @@ export async function buildFirstGlobalReleaseSeedPlan({
 
   const summary = buildSpellingContentSummary(validation.bundle);
   const snapshotHash = contentOperationHash(validation.bundle, 'release');
-  const source = {
+  const seedSource = source || {
     type: 'bundled_fallback',
     script: scriptRelativePath,
   };
   const proof = {
     seed: {
-      source,
+      source: seedSource,
       summary,
     },
   };
-  const snapshotJson = JSON.stringify(validation.bundle);
+  const snapshotJson = await encodeContentOperationSnapshot(validation.bundle);
   const proofJson = JSON.stringify(proof);
   const eventJson = JSON.stringify({
     releaseId,
     snapshotHash,
-    source,
+    source: seedSource,
     summary,
   });
+  const snapshotSql = snapshotSqlExpression(snapshotJson);
 
   const sql = [
     'BEGIN TRANSACTION;',
     '',
+    ...snapshotSql.setupSql,
+    ...(snapshotSql.setupSql.length ? [''] : []),
     'INSERT INTO content_operation_releases (',
     '  release_id, subject_id, status, snapshot_json, snapshot_hash,',
     '  base_release_id, package_id, published_at, published_by_account_id,',
     '  rollback_of_release_id, proof_json, created_at',
     ')',
     'SELECT',
-    `  ${sqlString(releaseId)}, 'spelling', 'published', ${sqlString(snapshotJson)}, ${sqlString(snapshotHash)},`,
+    `  ${sqlString(releaseId)}, 'spelling', 'published', ${snapshotSql.valueExpression}, ${sqlString(snapshotHash)},`,
     `  NULL, NULL, ${sqlInteger(nowTs)}, ${sqlString(actorAccountId)},`,
     `  NULL, ${sqlString(proofJson)}, ${sqlInteger(nowTs)}`,
     'WHERE NOT EXISTS (',
@@ -184,6 +293,8 @@ export async function buildFirstGlobalReleaseSeedPlan({
     `  SELECT 1 FROM content_operation_events WHERE event_id = ${sqlString(eventId)}`,
     ');',
     '',
+    ...snapshotSql.teardownSql,
+    ...(snapshotSql.teardownSql.length ? [''] : []),
     'COMMIT;',
     '',
   ].join('\n');
@@ -198,6 +309,12 @@ export async function buildFirstGlobalReleaseSeedPlan({
     },
     summary,
     proof,
+    source: seedSource,
+    snapshotStorage: {
+      encoding: 'gzip-base64',
+      byteLength: Buffer.byteLength(snapshotJson, 'utf8'),
+      sqlChunkCount: snapshotSql.chunkCount,
+    },
     sql,
   };
 }
@@ -242,9 +359,18 @@ async function runCli(argv = process.argv.slice(2)) {
     console.log(usage());
     return;
   }
+  if (options.apply && options.remote && process.env.KS2_CONFIRM_CONTENT_OPERATION_SEED !== remoteConfirmation) {
+    throw new Error(`Refusing remote seed. Set KS2_CONFIRM_CONTENT_OPERATION_SEED=${remoteConfirmation} after taking a D1 backup.`);
+  }
+
+  const legacySource = (options.apply || options.local || options.remote)
+    ? readLatestLegacyContentSource(options)
+    : null;
 
   const plan = await buildFirstGlobalReleaseSeedPlan({
     actorAccountId: options.actorAccountId,
+    sourceBundle: legacySource?.bundle || null,
+    source: legacySource?.source || null,
   });
 
   if (options.outFile) {
@@ -258,6 +384,8 @@ async function runCli(argv = process.argv.slice(2)) {
     target: options.remote ? 'remote' : 'local',
     release: plan.release,
     summary: plan.summary,
+    source: plan.source,
+    snapshotStorage: plan.snapshotStorage,
     sqlFile: options.outFile,
     remoteConfirmation: options.remote && options.apply ? remoteConfirmation : null,
   }, null, 2));

--- a/scripts/migrate-spelling-content-to-global-release.mjs
+++ b/scripts/migrate-spelling-content-to-global-release.mjs
@@ -1,0 +1,275 @@
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { uid } from '../src/platform/core/utils.js';
+import {
+  buildSpellingContentSummary,
+  validateSpellingContentBundle,
+} from '../src/subjects/spelling/content/model.js';
+import {
+  contentOperationHash,
+} from '../src/subjects/spelling/content/operations-model.js';
+import {
+  readSeededSpellingContentBundle,
+} from '../worker/src/generated-spelling-content-seed.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve(__dirname, '..');
+const scriptRelativePath = 'scripts/migrate-spelling-content-to-global-release.mjs';
+const remoteConfirmation = 'seed-first-global-release';
+
+function readOptionValue(argv, index, flag) {
+  if (index + 1 >= argv.length) throw new Error(`${flag} requires a value.`);
+  return argv[index + 1];
+}
+
+function sqlString(value) {
+  if (value == null) return 'NULL';
+  return `'${String(value).replaceAll("'", "''")}'`;
+}
+
+function sqlInteger(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) throw new Error(`Invalid integer SQL value: ${value}`);
+  return String(Math.trunc(number));
+}
+
+function usage() {
+  return [
+    'Usage: node scripts/migrate-spelling-content-to-global-release.mjs [--dry-run|--apply] [--local|--remote] [options]',
+    '',
+    'Options:',
+    '  --dry-run             Validate the bundled seed and print the planned release (default).',
+    '  --apply               Apply the idempotent seed SQL through scripts/wrangler-oauth.mjs.',
+    '  --local               Target the local D1 database (default for --apply).',
+    '  --remote              Target the remote D1 database. Requires KS2_CONFIRM_CONTENT_OPERATION_SEED=seed-first-global-release.',
+    '  --actor <account-id>  Account id recorded as the seed actor.',
+    '  --out <file.sql>      Write the generated SQL for review or manual archiving.',
+    '  --yes                 Pass --yes through to Wrangler for non-interactive apply.',
+    '  --help                Show this help.',
+  ].join('\n');
+}
+
+export function parseArgs(argv = process.argv.slice(2)) {
+  const options = {
+    apply: false,
+    dryRun: true,
+    remote: false,
+    local: false,
+    yes: false,
+    actorAccountId: 'content-operations-seed-script',
+    outFile: null,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    switch (arg) {
+      case '--apply':
+        options.apply = true;
+        options.dryRun = false;
+        break;
+      case '--dry-run':
+        options.apply = false;
+        options.dryRun = true;
+        break;
+      case '--remote':
+        options.remote = true;
+        break;
+      case '--local':
+        options.local = true;
+        break;
+      case '--yes':
+        options.yes = true;
+        break;
+      case '--actor':
+        options.actorAccountId = readOptionValue(argv, index, arg).trim();
+        index += 1;
+        break;
+      case '--out':
+        options.outFile = path.resolve(process.cwd(), readOptionValue(argv, index, arg));
+        index += 1;
+        break;
+      case '--help':
+      case '-h':
+        options.help = true;
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}\n\n${usage()}`);
+    }
+  }
+
+  if (options.remote && options.local) {
+    throw new Error('Choose either --local or --remote, not both.');
+  }
+  if (!options.actorAccountId) {
+    throw new Error('--actor must not be blank.');
+  }
+  if (options.apply && !options.remote && !options.local) {
+    options.local = true;
+  }
+  return options;
+}
+
+export async function buildFirstGlobalReleaseSeedPlan({
+  now = () => Date.now(),
+  releaseId = uid('corel'),
+  eventId = uid('coevt'),
+  actorAccountId = 'content-operations-seed-script',
+} = {}) {
+  const nowTs = Number(now());
+  const bundle = await readSeededSpellingContentBundle();
+  const validation = validateSpellingContentBundle(bundle);
+  if (!validation.ok) {
+    const errors = validation.errors
+      .map((issue) => `- [${issue.code}] ${issue.path}: ${issue.message}`)
+      .join('\n');
+    throw new Error(`Refusing to seed invalid bundled spelling content.\n${errors}`);
+  }
+
+  const summary = buildSpellingContentSummary(validation.bundle);
+  const snapshotHash = contentOperationHash(validation.bundle, 'release');
+  const source = {
+    type: 'bundled_fallback',
+    script: scriptRelativePath,
+  };
+  const proof = {
+    seed: {
+      source,
+      summary,
+    },
+  };
+  const snapshotJson = JSON.stringify(validation.bundle);
+  const proofJson = JSON.stringify(proof);
+  const eventJson = JSON.stringify({
+    releaseId,
+    snapshotHash,
+    source,
+    summary,
+  });
+
+  const sql = [
+    'BEGIN TRANSACTION;',
+    '',
+    'INSERT INTO content_operation_releases (',
+    '  release_id, subject_id, status, snapshot_json, snapshot_hash,',
+    '  base_release_id, package_id, published_at, published_by_account_id,',
+    '  rollback_of_release_id, proof_json, created_at',
+    ')',
+    'SELECT',
+    `  ${sqlString(releaseId)}, 'spelling', 'published', ${sqlString(snapshotJson)}, ${sqlString(snapshotHash)},`,
+    `  NULL, NULL, ${sqlInteger(nowTs)}, ${sqlString(actorAccountId)},`,
+    `  NULL, ${sqlString(proofJson)}, ${sqlInteger(nowTs)}`,
+    'WHERE NOT EXISTS (',
+    "  SELECT 1 FROM content_operation_releases WHERE subject_id = 'spelling' AND status = 'published'",
+    ');',
+    '',
+    'INSERT INTO content_operation_events (',
+    '  event_id, package_id, release_id, subject_id, event_type,',
+    '  actor_account_id, event_json, created_at',
+    ')',
+    'SELECT',
+    `  ${sqlString(eventId)}, NULL, ${sqlString(releaseId)}, 'spelling', 'release.seeded',`,
+    `  ${sqlString(actorAccountId)}, ${sqlString(eventJson)}, ${sqlInteger(nowTs)}`,
+    'WHERE EXISTS (',
+    `  SELECT 1 FROM content_operation_releases WHERE release_id = ${sqlString(releaseId)}`,
+    ')',
+    'AND NOT EXISTS (',
+    `  SELECT 1 FROM content_operation_releases WHERE subject_id = 'spelling' AND status = 'published' AND release_id <> ${sqlString(releaseId)}`,
+    ')',
+    'AND NOT EXISTS (',
+    `  SELECT 1 FROM content_operation_events WHERE event_id = ${sqlString(eventId)}`,
+    ');',
+    '',
+    'COMMIT;',
+    '',
+  ].join('\n');
+
+  return {
+    release: {
+      releaseId,
+      subjectId: 'spelling',
+      publishedAt: nowTs,
+      publishedByAccountId: actorAccountId,
+      snapshotHash,
+    },
+    summary,
+    proof,
+    sql,
+  };
+}
+
+function applyPlan(plan, options) {
+  if (options.remote && process.env.KS2_CONFIRM_CONTENT_OPERATION_SEED !== remoteConfirmation) {
+    throw new Error(`Refusing remote seed. Set KS2_CONFIRM_CONTENT_OPERATION_SEED=${remoteConfirmation} after taking a D1 backup.`);
+  }
+
+  const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'ks2-content-ops-seed-'));
+  const sqlPath = path.join(tmpDir, 'seed-first-global-spelling-release.sql');
+  writeFileSync(sqlPath, plan.sql, 'utf8');
+  try {
+    const args = [
+      path.join(rootDir, 'scripts', 'wrangler-oauth.mjs'),
+      'd1',
+      'execute',
+      'ks2-mastery-db',
+      options.remote ? '--remote' : '--local',
+      '--file',
+      sqlPath,
+    ];
+    if (options.yes) args.push('--yes');
+
+    const result = spawnSync(process.execPath, args, {
+      cwd: rootDir,
+      stdio: 'inherit',
+      env: { ...process.env },
+    });
+    if (result.error) throw result.error;
+    if ((result.status ?? 1) !== 0) {
+      throw new Error(`Wrangler D1 seed exited with status ${result.status ?? 1}.`);
+    }
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+async function runCli(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  if (options.help) {
+    console.log(usage());
+    return;
+  }
+
+  const plan = await buildFirstGlobalReleaseSeedPlan({
+    actorAccountId: options.actorAccountId,
+  });
+
+  if (options.outFile) {
+    mkdirSync(path.dirname(options.outFile), { recursive: true });
+    writeFileSync(options.outFile, plan.sql, 'utf8');
+  }
+
+  console.log(JSON.stringify({
+    ok: true,
+    mode: options.apply ? 'apply' : 'dry-run',
+    target: options.remote ? 'remote' : 'local',
+    release: plan.release,
+    summary: plan.summary,
+    sqlFile: options.outFile,
+    remoteConfirmation: options.remote && options.apply ? remoteConfirmation : null,
+  }, null, 2));
+
+  if (options.apply) {
+    applyPlan(plan, options);
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  runCli().catch((error) => {
+    console.error(error?.message || String(error));
+    process.exit(1);
+  });
+}

--- a/src/subjects/spelling/content/release-snapshot-codec.js
+++ b/src/subjects/spelling/content/release-snapshot-codec.js
@@ -1,0 +1,62 @@
+const SNAPSHOT_GZIP_BASE64_PREFIX = 'gzip-base64:';
+
+function bytesToBase64(bytes) {
+  if (typeof btoa !== 'function') {
+    if (typeof Buffer !== 'undefined') return Buffer.from(bytes).toString('base64');
+    throw new Error('Base64 encoding is not available in this runtime.');
+  }
+  let binary = '';
+  const chunkSize = 0x8000;
+  for (let index = 0; index < bytes.length; index += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(index, index + chunkSize));
+  }
+  return btoa(binary);
+}
+
+function base64ToBytes(base64) {
+  if (typeof atob !== 'function') {
+    if (typeof Buffer !== 'undefined') return new Uint8Array(Buffer.from(base64, 'base64'));
+    throw new Error('Base64 decoding is not available in this runtime.');
+  }
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+}
+
+async function gzipBytes(bytes) {
+  if (typeof CompressionStream !== 'function') {
+    throw new Error('CompressionStream is not available in this runtime.');
+  }
+  const stream = new Blob([bytes]).stream().pipeThrough(new CompressionStream('gzip'));
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+
+async function gunzipBytes(bytes) {
+  if (typeof DecompressionStream !== 'function') {
+    throw new Error('DecompressionStream is not available in this runtime.');
+  }
+  const stream = new Blob([bytes]).stream().pipeThrough(new DecompressionStream('gzip'));
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+
+export async function encodeContentOperationSnapshot(value) {
+  const json = typeof value === 'string' ? value : JSON.stringify(value);
+  const bytes = new TextEncoder().encode(json);
+  const compressed = await gzipBytes(bytes);
+  return `${SNAPSHOT_GZIP_BASE64_PREFIX}${bytesToBase64(compressed)}`;
+}
+
+export async function decodeContentOperationSnapshot(encoded) {
+  const value = String(encoded || '');
+  if (!value.startsWith(SNAPSHOT_GZIP_BASE64_PREFIX)) return value;
+  const compressed = base64ToBytes(value.slice(SNAPSHOT_GZIP_BASE64_PREFIX.length));
+  const decompressed = await gunzipBytes(compressed);
+  return new TextDecoder().decode(decompressed);
+}
+
+export function isEncodedContentOperationSnapshot(value) {
+  return String(value || '').startsWith(SNAPSHOT_GZIP_BASE64_PREFIX);
+}

--- a/tests/content-operations-repository.test.js
+++ b/tests/content-operations-repository.test.js
@@ -13,6 +13,10 @@ async function publishWordEdit(repository, word, {
   fieldPath = 'explanation',
   payload = `Published learner-facing explanation for ${word?.word || 'word'}.`,
 } = {}) {
+  await repository.seedFirstContentOperationRelease({
+    seededByAccountId: actorAccountId,
+    proof: { source: 'repository-test-helper' },
+  });
   const contentPackage = await repository.createContentOperationPackage({
     templateId: 'edit-spelling-word',
     title,
@@ -39,6 +43,133 @@ async function publishWordEdit(repository, word, {
   return { contentPackage, candidate, release };
 }
 
+test('content operations repository blocks normal package publish before first global release seed', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const repository = createWorkerRepository({
+    env: { DB },
+    now: () => 1_777_000_000_000,
+  });
+
+  try {
+    const seeded = await readSeededSpellingContentBundle();
+    const word = seeded.draft.words[0];
+    const contentPackage = await repository.createContentOperationPackage({
+      templateId: 'edit-spelling-word',
+      title: 'Publish before cutover seed',
+      createdByAccountId: 'admin-a',
+    });
+    await repository.appendContentOperation(contentPackage.packageId, {
+      entityType: 'spelling.word',
+      entityId: word.slug,
+      fieldPath: 'explanation',
+      action: 'set',
+      payload: `Unseeded package explanation for ${word.word}.`,
+    }, {
+      actorAccountId: 'admin-a',
+    });
+    const candidate = await repository.buildContentOperationCandidate(contentPackage.packageId, {
+      actorAccountId: 'admin-a',
+    });
+    await repository.approveContentOperationCandidate(contentPackage.packageId, candidate.candidateId, {
+      approvedByAccountId: 'admin-a',
+    });
+
+    await assert.rejects(
+      () => repository.publishContentOperationPackage(contentPackage.packageId, {
+        publishedByAccountId: 'admin-a',
+      }),
+      (error) => {
+        assert.equal(error.extra?.code, 'content_operation_first_release_required');
+        assert.equal(error.extra?.packageId, contentPackage.packageId);
+        return true;
+      },
+    );
+  } finally {
+    DB.close();
+  }
+});
+
+test('content operations repository seeds the first global release idempotently from bundled content', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const repository = createWorkerRepository({
+    env: { DB },
+    now: () => 1_777_000_000_000,
+  });
+
+  try {
+    const seeded = await readSeededSpellingContentBundle();
+    const first = await repository.seedFirstContentOperationRelease({
+      seededByAccountId: 'admin-a',
+      proof: { source: 'seed-idempotency-test' },
+    });
+    const second = await repository.seedFirstContentOperationRelease({
+      seededByAccountId: 'admin-a',
+      proof: { source: 'seed-idempotency-test-repeat' },
+    });
+
+    assert.equal(first.seeded, true);
+    assert.equal(first.source.type, 'bundled_fallback');
+    assert.equal(first.snapshot.publication.currentReleaseId, seeded.publication.currentReleaseId);
+    assert.equal(second.seeded, false);
+    assert.equal(second.releaseId, first.releaseId);
+    assert.deepEqual(second.snapshot, first.snapshot);
+
+    const rows = DB.db.prepare(`
+      SELECT release_id
+      FROM content_operation_releases
+      WHERE subject_id = 'spelling'
+    `).all();
+    assert.equal(rows.length, 1);
+  } finally {
+    DB.close();
+  }
+});
+
+test('content operations repository rollback writes a new latest release pointing at the target', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const repository = createWorkerRepository({
+    env: { DB },
+    now: () => 1_777_000_000_000,
+  });
+
+  try {
+    const seeded = await readSeededSpellingContentBundle();
+    const seedRelease = await repository.seedFirstContentOperationRelease({
+      seededByAccountId: 'admin-a',
+      proof: { source: 'rollback-test-seed' },
+    });
+    const word = seeded.draft.words[0];
+    const changed = await publishWordEdit(repository, word, {
+      title: 'Release to roll back',
+      payload: `Temporary rollback test explanation for ${word.word}.`,
+    });
+
+    assert.notEqual(changed.release.snapshotHash, seedRelease.snapshotHash);
+
+    const rollback = await repository.rollbackContentOperationRelease('spelling', seedRelease.releaseId, {
+      rolledBackByAccountId: 'admin-a',
+      proof: { source: 'rollback-test' },
+    });
+    const latest = await repository.readLatestContentOperationRelease('spelling', {
+      includeSnapshot: true,
+    });
+
+    assert.equal(rollback.rollbackOfReleaseId, seedRelease.releaseId);
+    assert.equal(rollback.baseReleaseId, changed.release.releaseId);
+    assert.equal(rollback.snapshotHash, seedRelease.snapshotHash);
+    assert.deepEqual(rollback.snapshot, seedRelease.snapshot);
+    assert.equal(latest.releaseId, rollback.releaseId);
+    assert.equal(latest.rollbackOfReleaseId, seedRelease.releaseId);
+
+    const events = await repository.listContentOperationEvents({
+      releaseId: rollback.releaseId,
+    });
+    assert.ok(events.some((event) => event.eventType === 'release.rollback'));
+  } finally {
+    DB.close();
+  }
+});
+
 test('content operations repository publishes an approved package as a global release', async () => {
   const DB = createMigratedSqliteD1Database();
   const repository = createWorkerRepository({
@@ -48,6 +179,10 @@ test('content operations repository publishes an approved package as a global re
 
   try {
     const seeded = await readSeededSpellingContentBundle();
+    const seedRelease = await repository.seedFirstContentOperationRelease({
+      seededByAccountId: 'admin-a',
+      proof: { source: 'repository-lifecycle-test' },
+    });
     const word = seeded.draft.words[0];
     const explanation = `A package-approved learner-facing explanation for ${word.word}.`;
 
@@ -60,8 +195,8 @@ test('content operations repository publishes an approved package as a global re
     });
 
     assert.equal(contentPackage.state, 'draft');
-    assert.equal(contentPackage.baseReleaseId, null);
-    assert.equal(contentPackage.baseReleaseHash, null);
+    assert.equal(contentPackage.baseReleaseId, seedRelease.releaseId);
+    assert.equal(contentPackage.baseReleaseHash, seedRelease.snapshotHash);
 
     const operation = await repository.appendContentOperation(contentPackage.packageId, {
       entityType: 'spelling.word',
@@ -268,6 +403,10 @@ test('content operations repository blocks approving a candidate after release d
 
   try {
     const seeded = await readSeededSpellingContentBundle();
+    const seedRelease = await repository.seedFirstContentOperationRelease({
+      seededByAccountId: 'admin-a',
+      proof: { source: 'repository-release-drift-test' },
+    });
     const firstWord = seeded.draft.words[0];
     const secondWord = seeded.draft.words[1];
 
@@ -319,7 +458,7 @@ test('content operations repository blocks approving a candidate after release d
       }),
       (error) => {
         assert.equal(error.extra?.code, 'content_operation_candidate_release_drift');
-        assert.equal(error.extra?.candidateCurrentReleaseId, null);
+        assert.equal(error.extra?.candidateCurrentReleaseId, seedRelease.releaseId);
         assert.equal(error.extra?.currentReleaseId, newerRelease.releaseId);
         return true;
       },
@@ -338,6 +477,10 @@ test('content operations repository keeps published packages immutable', async (
 
   try {
     const seeded = await readSeededSpellingContentBundle();
+    await repository.seedFirstContentOperationRelease({
+      seededByAccountId: 'admin-a',
+      proof: { source: 'repository-immutability-test' },
+    });
     const word = seeded.draft.words[0];
     const contentPackage = await repository.createContentOperationPackage({
       templateId: 'edit-spelling-word',
@@ -400,6 +543,10 @@ test('content operations repository blocks stale package approval after release 
 
   try {
     const seeded = await readSeededSpellingContentBundle();
+    const seedRelease = await repository.seedFirstContentOperationRelease({
+      seededByAccountId: 'admin-a',
+      proof: { source: 'repository-stale-package-test' },
+    });
     const firstWord = seeded.draft.words[0];
     const secondWord = seeded.draft.words[1];
 
@@ -449,7 +596,7 @@ test('content operations repository blocks stale package approval after release 
     assert.equal(staleCandidate.currentReleaseId, newerRelease.releaseId);
     assert.equal(staleCandidate.conflicts.length, 1);
     assert.equal(staleCandidate.conflicts[0].code, 'base_release_changed');
-    assert.equal(staleCandidate.conflicts[0].packageBaseReleaseId, null);
+    assert.equal(staleCandidate.conflicts[0].packageBaseReleaseId, seedRelease.releaseId);
     assert.equal(staleCandidate.conflicts[0].currentReleaseId, newerRelease.releaseId);
 
     await assert.rejects(
@@ -472,6 +619,10 @@ test('content operations repository blocks publish when approval becomes stale',
 
   try {
     const seeded = await readSeededSpellingContentBundle();
+    const seedRelease = await repository.seedFirstContentOperationRelease({
+      seededByAccountId: 'admin-a',
+      proof: { source: 'repository-stale-publish-test' },
+    });
     const firstWord = seeded.draft.words[0];
     const secondWord = seeded.draft.words[1];
 
@@ -526,7 +677,7 @@ test('content operations repository blocks publish when approval becomes stale',
       }),
       (error) => {
         assert.equal(error.extra?.code, 'content_operation_release_drift');
-        assert.equal(error.extra?.candidateCurrentReleaseId, null);
+        assert.equal(error.extra?.candidateCurrentReleaseId, seedRelease.releaseId);
         assert.equal(error.extra?.currentReleaseId, newerRelease.releaseId);
         return true;
       },

--- a/tests/content-operations-repository.test.js
+++ b/tests/content-operations-repository.test.js
@@ -6,6 +6,9 @@ import { createMigratedSqliteD1Database } from './helpers/sqlite-d1.js';
 import {
   readSeededSpellingContentBundle,
 } from '../worker/src/generated-spelling-content-seed.js';
+import {
+  isEncodedContentOperationSnapshot,
+} from '../src/subjects/spelling/content/release-snapshot-codec.js';
 
 async function publishWordEdit(repository, word, {
   actorAccountId = 'admin-a',
@@ -115,11 +118,13 @@ test('content operations repository seeds the first global release idempotently 
     assert.deepEqual(second.snapshot, first.snapshot);
 
     const rows = DB.db.prepare(`
-      SELECT release_id
+      SELECT release_id, snapshot_json
       FROM content_operation_releases
       WHERE subject_id = 'spelling'
     `).all();
     assert.equal(rows.length, 1);
+    assert.equal(isEncodedContentOperationSnapshot(rows[0].snapshot_json), true);
+    assert.ok(Buffer.byteLength(rows[0].snapshot_json, 'utf8') < 2_000_000);
   } finally {
     DB.close();
   }
@@ -219,6 +224,13 @@ test('content operations repository publishes an approved package as a global re
     assert.equal(candidate.validation.ok, true);
     assert.equal(candidate.candidate.draft.words[0].explanation, explanation);
     assert.match(candidate.candidateHash, /^candidate-/);
+    const candidateStorage = DB.db.prepare(`
+      SELECT candidate_snapshot_json
+      FROM content_operation_package_candidates
+      WHERE candidate_id = ?
+    `).get(candidate.candidateId);
+    assert.equal(isEncodedContentOperationSnapshot(candidateStorage.candidate_snapshot_json), true);
+    assert.ok(Buffer.byteLength(candidateStorage.candidate_snapshot_json, 'utf8') < 2_000_000);
 
     const approval = await repository.approveContentOperationCandidate(
       contentPackage.packageId,
@@ -240,6 +252,13 @@ test('content operations repository publishes an approved package as a global re
     assert.equal(release.status, 'published');
     assert.equal(release.packageId, contentPackage.packageId);
     assert.equal(release.snapshot.draft.words[0].explanation, explanation);
+    const releaseStorage = DB.db.prepare(`
+      SELECT snapshot_json
+      FROM content_operation_releases
+      WHERE release_id = ?
+    `).get(release.releaseId);
+    assert.equal(isEncodedContentOperationSnapshot(releaseStorage.snapshot_json), true);
+    assert.ok(Buffer.byteLength(releaseStorage.snapshot_json, 'utf8') < 2_000_000);
 
     const latest = await repository.readLatestContentOperationRelease('spelling', {
       includeSnapshot: true,

--- a/tests/content-operations-seed-script.test.js
+++ b/tests/content-operations-seed-script.test.js
@@ -1,0 +1,64 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildFirstGlobalReleaseSeedPlan,
+  parseArgs,
+} from '../scripts/migrate-spelling-content-to-global-release.mjs';
+import { createMigratedSqliteD1Database } from './helpers/sqlite-d1.js';
+
+test('content operations seed script builds idempotent first-release SQL', async () => {
+  const DB = createMigratedSqliteD1Database();
+  try {
+    const plan = await buildFirstGlobalReleaseSeedPlan({
+      now: () => 1_777_000_000_000,
+      releaseId: 'corel-seed-script-test',
+      eventId: 'coevt-seed-script-test',
+      actorAccountId: 'admin-a',
+    });
+
+    assert.equal(plan.release.subjectId, 'spelling');
+    assert.equal(plan.release.publishedAt, 1_777_000_000_000);
+    assert.equal(plan.proof.seed.source.type, 'bundled_fallback');
+    assert.ok(plan.summary.wordCount > 0);
+    assert.match(plan.sql, /INSERT INTO content_operation_releases/);
+    assert.match(plan.sql, /WHERE NOT EXISTS/);
+
+    DB.db.exec(plan.sql);
+    DB.db.exec(plan.sql);
+
+    const releaseRows = DB.db.prepare(`
+      SELECT release_id, published_at, published_by_account_id
+      FROM content_operation_releases
+      WHERE subject_id = 'spelling'
+    `).all();
+    assert.equal(releaseRows.length, 1);
+    assert.equal(releaseRows[0].release_id, 'corel-seed-script-test');
+    assert.equal(releaseRows[0].published_at, 1_777_000_000_000);
+    assert.equal(releaseRows[0].published_by_account_id, 'admin-a');
+
+    const eventRows = DB.db.prepare(`
+      SELECT event_id, event_type, actor_account_id
+      FROM content_operation_events
+      WHERE release_id = ?
+    `).all('corel-seed-script-test');
+    assert.equal(eventRows.length, 1);
+    assert.equal(eventRows[0].event_id, 'coevt-seed-script-test');
+    assert.equal(eventRows[0].event_type, 'release.seeded');
+    assert.equal(eventRows[0].actor_account_id, 'admin-a');
+  } finally {
+    DB.close();
+  }
+});
+
+test('content operations seed script defaults apply target to local D1', () => {
+  assert.deepEqual(parseArgs(['--apply', '--actor', 'admin-a']), {
+    apply: true,
+    dryRun: false,
+    remote: false,
+    local: true,
+    yes: false,
+    actorAccountId: 'admin-a',
+    outFile: null,
+  });
+});

--- a/tests/content-operations-seed-script.test.js
+++ b/tests/content-operations-seed-script.test.js
@@ -5,6 +5,13 @@ import {
   buildFirstGlobalReleaseSeedPlan,
   parseArgs,
 } from '../scripts/migrate-spelling-content-to-global-release.mjs';
+import {
+  decodeContentOperationSnapshot,
+  isEncodedContentOperationSnapshot,
+} from '../src/subjects/spelling/content/release-snapshot-codec.js';
+import {
+  readSeededSpellingContentBundle,
+} from '../worker/src/generated-spelling-content-seed.js';
 import { createMigratedSqliteD1Database } from './helpers/sqlite-d1.js';
 
 test('content operations seed script builds idempotent first-release SQL', async () => {
@@ -16,19 +23,24 @@ test('content operations seed script builds idempotent first-release SQL', async
       eventId: 'coevt-seed-script-test',
       actorAccountId: 'admin-a',
     });
+    const bundledContent = await readSeededSpellingContentBundle();
 
     assert.equal(plan.release.subjectId, 'spelling');
     assert.equal(plan.release.publishedAt, 1_777_000_000_000);
     assert.equal(plan.proof.seed.source.type, 'bundled_fallback');
+    assert.equal(plan.snapshotStorage.encoding, 'gzip-base64');
+    assert.ok(plan.snapshotStorage.byteLength < 2_000_000);
+    assert.ok(plan.snapshotStorage.sqlChunkCount > 1);
     assert.ok(plan.summary.wordCount > 0);
     assert.match(plan.sql, /INSERT INTO content_operation_releases/);
     assert.match(plan.sql, /WHERE NOT EXISTS/);
+    assert.match(plan.sql, /_content_operation_seed_snapshot_chunks/);
 
     DB.db.exec(plan.sql);
     DB.db.exec(plan.sql);
 
     const releaseRows = DB.db.prepare(`
-      SELECT release_id, published_at, published_by_account_id
+      SELECT release_id, published_at, published_by_account_id, snapshot_json
       FROM content_operation_releases
       WHERE subject_id = 'spelling'
     `).all();
@@ -36,6 +48,9 @@ test('content operations seed script builds idempotent first-release SQL', async
     assert.equal(releaseRows[0].release_id, 'corel-seed-script-test');
     assert.equal(releaseRows[0].published_at, 1_777_000_000_000);
     assert.equal(releaseRows[0].published_by_account_id, 'admin-a');
+    assert.equal(isEncodedContentOperationSnapshot(releaseRows[0].snapshot_json), true);
+    const decoded = JSON.parse(await decodeContentOperationSnapshot(releaseRows[0].snapshot_json));
+    assert.equal(decoded.modelVersion, bundledContent.modelVersion);
 
     const eventRows = DB.db.prepare(`
       SELECT event_id, event_type, actor_account_id
@@ -46,6 +61,44 @@ test('content operations seed script builds idempotent first-release SQL', async
     assert.equal(eventRows[0].event_id, 'coevt-seed-script-test');
     assert.equal(eventRows[0].event_type, 'release.seeded');
     assert.equal(eventRows[0].actor_account_id, 'admin-a');
+  } finally {
+    DB.close();
+  }
+});
+
+test('content operations seed script can seed from supplied legacy content source', async () => {
+  const DB = createMigratedSqliteD1Database();
+  try {
+    const legacyContent = await readSeededSpellingContentBundle();
+    legacyContent.draft.notes = 'Legacy D1 content should win during cutover.';
+    const plan = await buildFirstGlobalReleaseSeedPlan({
+      now: () => 1_777_000_000_123,
+      releaseId: 'corel-legacy-seed-script-test',
+      eventId: 'coevt-legacy-seed-script-test',
+      actorAccountId: 'admin-a',
+      sourceBundle: legacyContent,
+      source: {
+        type: 'account_subject_content',
+        accountId: 'adult-a',
+        updatedAt: 1_777_000_000_111,
+        updatedByAccountId: 'admin-a',
+        script: 'test',
+      },
+    });
+
+    assert.equal(plan.proof.seed.source.type, 'account_subject_content');
+    assert.equal(plan.proof.seed.source.accountId, 'adult-a');
+
+    DB.db.exec(plan.sql);
+    const row = DB.db.prepare(`
+      SELECT snapshot_json, proof_json
+      FROM content_operation_releases
+      WHERE release_id = ?
+    `).get('corel-legacy-seed-script-test');
+    const decoded = JSON.parse(await decodeContentOperationSnapshot(row.snapshot_json));
+    const proof = JSON.parse(row.proof_json);
+    assert.equal(decoded.draft.notes, 'Legacy D1 content should win during cutover.');
+    assert.equal(proof.seed.source.type, 'account_subject_content');
   } finally {
     DB.close();
   }

--- a/tests/spelling-content-api.test.js
+++ b/tests/spelling-content-api.test.js
@@ -66,6 +66,15 @@ function seedAccountLearner(DB, { accountId = 'adult-a', learnerId = 'learner-a'
   `).run(accountId, learnerId, now, now);
 }
 
+function seedAdultAccount(DB, { accountId = 'adult-a', platformRole = 'admin' } = {}) {
+  const now = Date.UTC(2026, 0, 1);
+  DB.db.prepare(`
+    INSERT INTO adult_accounts (id, email, display_name, platform_role, selected_learner_id, created_at, updated_at, repo_revision)
+    VALUES (?, ?, ?, ?, NULL, ?, ?, 0)
+    ON CONFLICT(id) DO UPDATE SET platform_role = excluded.platform_role
+  `).run(accountId, `${accountId}@example.test`, accountId, platformRole, now, now);
+}
+
 function adminAuthSession(server, accountId = 'adult-a') {
   return server.authSessionFor(accountId, { platformRole: 'admin' });
 }
@@ -276,6 +285,44 @@ test('worker spelling content legacy write route is frozen after global release 
     assert.equal(response.status, 409);
     assert.equal(payload.code, 'subject_content_legacy_write_cutover');
     assert.equal(payload.releaseId, seedRelease.releaseId);
+  } finally {
+    server.close();
+  }
+});
+
+test('worker spelling content legacy GET exports the global release after cutover', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    const repository = createWorkerRepository({
+      env: server.env,
+      now: () => Date.UTC(2026, 4, 17),
+    });
+    const seedRelease = await repository.seedFirstContentOperationRelease({
+      seededByAccountId: 'admin-a',
+      proof: { source: 'legacy-get-cutover-test' },
+    });
+    seedAdultAccount(server.DB, { accountId: 'adult-a' });
+    seedAdultAccount(server.DB, { accountId: 'admin-a' });
+    const staleLegacy = cloneSerialisable(seedRelease.snapshot);
+    staleLegacy.draft.notes = 'Stale account_subject_content should not be exported after cutover.';
+    server.DB.db.prepare(`
+      INSERT INTO account_subject_content (account_id, subject_id, content_json, updated_at, updated_by_account_id)
+      VALUES ('adult-a', 'spelling', ?, ?, 'admin-a')
+      ON CONFLICT(account_id, subject_id) DO UPDATE SET
+        content_json = excluded.content_json,
+        updated_at = excluded.updated_at,
+        updated_by_account_id = excluded.updated_by_account_id
+    `).run(JSON.stringify(staleLegacy), Date.UTC(2026, 4, 17) + 1);
+
+    const response = await fetchAdmin(server, 'https://repo.test/api/content/spelling');
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.compatibility?.source, 'content_operation_release');
+    assert.equal(payload.compatibility?.releaseId, seedRelease.releaseId);
+    assert.equal(payload.compatibility?.legacyWriteDisabled, true);
+    assert.notEqual(payload.content.draft.notes, staleLegacy.draft.notes);
+    assert.deepEqual(payload.content, seedRelease.snapshot);
   } finally {
     server.close();
   }

--- a/tests/spelling-content-api.test.js
+++ b/tests/spelling-content-api.test.js
@@ -75,6 +75,22 @@ function seedAdultAccount(DB, { accountId = 'adult-a', platformRole = 'admin' } 
   `).run(accountId, `${accountId}@example.test`, accountId, platformRole, now, now);
 }
 
+function writeLegacySpellingContent(DB, {
+  accountId = 'adult-a',
+  bundle,
+  updatedAt,
+  updatedByAccountId = 'admin-a',
+} = {}) {
+  DB.db.prepare(`
+    INSERT INTO account_subject_content (account_id, subject_id, content_json, updated_at, updated_by_account_id)
+    VALUES (?, 'spelling', ?, ?, ?)
+    ON CONFLICT(account_id, subject_id) DO UPDATE SET
+      content_json = excluded.content_json,
+      updated_at = excluded.updated_at,
+      updated_by_account_id = excluded.updated_by_account_id
+  `).run(accountId, JSON.stringify(bundle), updatedAt, updatedByAccountId);
+}
+
 function adminAuthSession(server, accountId = 'adult-a') {
   return server.authSessionFor(accountId, { platformRole: 'admin' });
 }
@@ -141,6 +157,51 @@ function addExtraWordList(bundle) {
     sortIndex: 9999,
   });
   return next;
+}
+
+async function seedGlobalReleaseThenOverwriteStaleLegacy(server, {
+  accountId = 'adult-a',
+  updatedByAccountId = 'admin-a',
+} = {}) {
+  const seedTime = Date.UTC(2026, 4, 17);
+  const globalSource = publishSpellingContentBundle(addExtraWordList(SEEDED_SPELLING_CONTENT_BUNDLE), {
+    title: 'Global release cutover test',
+    notes: 'Publishes an extra word so stale legacy rows are detectable.',
+    publishedAt: seedTime,
+  });
+  writeLegacySpellingContent(server.DB, {
+    accountId,
+    bundle: globalSource,
+    updatedAt: seedTime,
+    updatedByAccountId,
+  });
+
+  const repository = createWorkerRepository({
+    env: server.env,
+    now: () => seedTime + 1,
+  });
+  const seedRelease = await repository.seedFirstContentOperationRelease({
+    seededByAccountId: updatedByAccountId,
+    proof: { source: 'stale-legacy-cutover-regression' },
+  });
+
+  const staleLegacy = cloneSerialisable(SEEDED_SPELLING_CONTENT_BUNDLE);
+  staleLegacy.draft.notes = 'Stale account_subject_content must not drive post-cutover reads.';
+  writeLegacySpellingContent(server.DB, {
+    accountId,
+    bundle: staleLegacy,
+    updatedAt: seedTime + 2,
+    updatedByAccountId,
+  });
+
+  const publishedSnapshot = seedRelease.snapshot.releases.at(-1).snapshot;
+  return {
+    seedRelease,
+    staleLegacy,
+    expectedWordCount: publishedSnapshot.words.length,
+    expectedCoreCount: publishedSnapshot.words.filter(isStatutoryCoreWord).length,
+    expectedPublishedVersion: String(Number(seedRelease.snapshot.publication.publishedVersion) || 0),
+  };
 }
 
 test('api spelling content repository hydrates the seeded published bundle and persists valid content changes', async () => {
@@ -323,6 +384,72 @@ test('worker spelling content legacy GET exports the global release after cutove
     assert.equal(payload.compatibility?.legacyWriteDisabled, true);
     assert.notEqual(payload.content.draft.notes, staleLegacy.draft.notes);
     assert.deepEqual(payload.content, seedRelease.snapshot);
+  } finally {
+    server.close();
+  }
+});
+
+test('parent and admin hubs derive spelling snapshots from the global release after cutover', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    seedAccountLearner(server.DB, { accountId: 'adult-a', learnerId: 'learner-a' });
+    seedAdultAccount(server.DB, { accountId: 'admin-a', platformRole: 'admin' });
+    const { expectedWordCount } = await seedGlobalReleaseThenOverwriteStaleLegacy(server);
+
+    const parentResponse = await server.fetchAs(
+      'adult-a',
+      'https://repo.test/api/hubs/parent?learnerId=learner-a',
+      {},
+      { 'x-ks2-dev-platform-role': 'parent' },
+    );
+    const parentPayload = await parentResponse.json();
+    const parentSpelling = parentPayload.parentHub.progressSnapshots
+      .find((entry) => entry.subjectId === 'spelling');
+
+    assert.equal(parentResponse.status, 200);
+    assert.equal(parentSpelling.totalPublishedWords, expectedWordCount);
+
+    const adminResponse = await server.fetchAs(
+      'admin-a',
+      'https://repo.test/api/hubs/admin',
+      {},
+      { 'x-ks2-dev-platform-role': 'admin' },
+    );
+    const adminPayload = await adminResponse.json();
+
+    assert.equal(adminResponse.status, 200);
+    assert.equal(adminPayload.adminHub.contentReleaseStatus.runtimeWordCount, expectedWordCount);
+  } finally {
+    server.close();
+  }
+});
+
+test('admin ops spelling metrics use the global release after cutover', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    seedAdultAccount(server.DB, { accountId: 'adult-a', platformRole: 'admin' });
+    seedAdultAccount(server.DB, { accountId: 'admin-a', platformRole: 'admin' });
+    const {
+      expectedWordCount,
+      expectedCoreCount,
+      expectedPublishedVersion,
+    } = await seedGlobalReleaseThenOverwriteStaleLegacy(server);
+
+    const overviewResponse = await fetchAdmin(server, 'https://repo.test/api/admin/ops/content-overview');
+    const overviewPayload = await overviewResponse.json();
+    const overviewSpelling = overviewPayload.subjects.find((entry) => entry.subjectKey === 'spelling');
+
+    assert.equal(overviewResponse.status, 200);
+    assert.equal(overviewSpelling.releaseVersion, expectedPublishedVersion);
+
+    const signalsResponse = await fetchAdmin(server, 'https://repo.test/api/admin/ops/content-quality-signals');
+    const signalsPayload = await signalsResponse.json();
+    const spelling = signalsPayload.subjectSignals.find((entry) => entry.subjectKey === 'spelling');
+
+    assert.equal(signalsResponse.status, 200);
+    assert.equal(spelling.signals.itemCoverage.status, 'available');
+    assert.equal(spelling.signals.itemCoverage.total, expectedWordCount);
+    assert.equal(spelling.signals.itemCoverage.value, expectedCoreCount);
   } finally {
     server.close();
   }

--- a/tests/spelling-content-api.test.js
+++ b/tests/spelling-content-api.test.js
@@ -5,6 +5,7 @@ import { readFile } from 'node:fs/promises';
 import {
   createApiPlatformRepositories,
 } from '../src/platform/core/repositories/index.js';
+import { createWorkerRepository } from '../worker/src/repository.js';
 import { cloneSerialisable } from '../src/platform/core/repositories/helpers.js';
 import {
   SPELLING_CONTENT_MODEL_VERSION,
@@ -236,6 +237,45 @@ test('worker spelling content route accepts valid Extra pool content without sta
     const reloadedResponse = await fetchAdmin(server, 'https://repo.test/api/content/spelling');
     const reloaded = await reloadedResponse.json();
     assert.equal(reloaded.content.draft.words.find((word) => word.slug === 'cephalopod').spellingPool, 'extra');
+  } finally {
+    server.close();
+  }
+});
+
+test('worker spelling content legacy write route is frozen after global release cutover', async () => {
+  const server = createWorkerRepositoryServer();
+  try {
+    const repository = createWorkerRepository({
+      env: server.env,
+      now: () => Date.UTC(2026, 4, 17),
+    });
+    const seedRelease = await repository.seedFirstContentOperationRelease({
+      seededByAccountId: 'admin-a',
+      proof: { source: 'legacy-write-cutover-test' },
+    });
+
+    const initialResponse = await fetchAdmin(server, 'https://repo.test/api/content/spelling');
+    const initial = await initialResponse.json();
+    const updated = cloneSerialisable(initial.content);
+    updated.draft.notes = 'This legacy write should be blocked after cutover.';
+
+    const response = await fetchAdmin(server, 'https://repo.test/api/content/spelling', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        content: updated,
+        mutation: {
+          requestId: 'content-legacy-cutover-blocked-1',
+          correlationId: 'content-legacy-cutover-blocked-1',
+          expectedAccountRevision: initial.mutation.accountRevision,
+        },
+      }),
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 409);
+    assert.equal(payload.code, 'subject_content_legacy_write_cutover');
+    assert.equal(payload.releaseId, seedRelease.releaseId);
   } finally {
     server.close();
   }

--- a/tests/worker-bootstrap-capacity.test.js
+++ b/tests/worker-bootstrap-capacity.test.js
@@ -334,7 +334,7 @@ test('production bootstrap keeps high-history public payloads bounded and redact
   // changed. PR799 follow-up 2026-04-30 bumped 3 -> 4 because the
   // Grammar public read-model representation changed and cached v3
   // revisions must miss the notModified probe.
-  assert.equal(payload.meta.capacity.bootstrapCapacity.version, 4);
+  assert.equal(payload.meta.capacity.bootstrapCapacity.version, 5);
   assert.equal(payload.meta.capacity.bootstrapCapacity.mode, 'public-bounded');
   assert.equal('bootstrapPhaseTimings' in payload.meta.capacity, false, 'phase timings stay out of child-facing meta.capacity.');
 
@@ -386,8 +386,8 @@ test('P7 public demo bootstrap reuses authenticated account snapshot and ratchet
     assert.equal(response.status, 200);
     assert.equal(payload.ok, true);
     assert.equal(payload.meta?.capacity?.bootstrapMode, 'selected-learner-bounded');
-    assert.equal(payload.meta?.capacity?.queryCount, 9,
-      'P7 removes the duplicate bootstrap account read and demo-active guard read from the 11-query P6 shape.');
+    assert.equal(payload.meta?.capacity?.queryCount, 10,
+      'Content Operations release revision tracking adds one bounded lookup while preserving the P7 account-read reduction.');
     assert.equal(payload.meta.capacity.d1RowsWritten, 0);
     assert.ok(payload.bootstrapCapacity, 'bootstrap capacity metadata remains present');
     assert.equal(payload.bootstrapCapacity.mode, 'public-bounded');

--- a/tests/worker-bootstrap-v2.test.js
+++ b/tests/worker-bootstrap-v2.test.js
@@ -170,6 +170,10 @@ async function publishSpellingWordEdit(repository, word, {
   action = 'set',
   payload = `Bootstrap content explanation for ${word?.word || 'word'}.`,
 } = {}) {
+  await repository.seedFirstContentOperationRelease({
+    seededByAccountId: actorAccountId,
+    proof: { source: 'worker-bootstrap-v2-test-helper' },
+  });
   const contentPackage = await repository.createContentOperationPackage({
     templateId: 'edit-spelling-word',
     title,

--- a/tests/worker-bootstrap-v2.test.js
+++ b/tests/worker-bootstrap-v2.test.js
@@ -215,8 +215,11 @@ test('U7 scenario 15: envelope shape snapshot matches BOOTSTRAP_CAPACITY_VERSION
   // public read-model. The version is part of the revision hash, so a
   // deployed read-model representation change must invalidate cached v3
   // `lastKnownRevision` values even when learner revisions are stable.
-  assert.equal(BOOTSTRAP_CAPACITY_VERSION, 4,
-    'PR799 follow-up: bumps BOOTSTRAP_CAPACITY_VERSION 3->4 so stale Grammar public read-model caches miss the notModified probe.');
+  //
+  // Content Operations Centre T5A: bumped 4 -> 5 when spelling public
+  // read-model revision hashes started including the active content release.
+  assert.equal(BOOTSTRAP_CAPACITY_VERSION, 5,
+    'Content Operations Centre T5A bumps BOOTSTRAP_CAPACITY_VERSION 4->5 so spelling content release changes miss the notModified probe.');
   // Closed union for meta.capacity.bootstrapMode (canonical U7 enum).
   assert.deepEqual(
     [...BOOTSTRAP_MODES].sort(),
@@ -1161,6 +1164,45 @@ test('public bootstrap uses the published global content operations release with
   }
 });
 
+test('public bootstrap notModified misses after a spelling content-operation release changes', async () => {
+  const server = createServer();
+  try {
+    insertLearner(server, 'adult-u7', { id: 'learner-a', name: 'Alpha', sortIndex: 0, selected: true });
+    insertSubjectStateFor(server, 'adult-u7', 'learner-a', 'spelling');
+
+    const firstResponse = await getBootstrap(server);
+    assert.equal(firstResponse.status, 200);
+    const firstPayload = await readJsonBody(firstResponse);
+    const firstHash = firstPayload.revision?.hash;
+    assert.match(firstHash, /^[0-9a-f]{32}$/);
+
+    const repository = createWorkerRepository({ env: server.env, now: () => NOW });
+    const seeded = await readSeededSpellingContentBundle();
+    const word = seeded.draft.words.find((entry) => entry.spellingPool !== 'extra') || seeded.draft.words[0];
+    await publishSpellingWordEdit(repository, word, {
+      title: 'Bootstrap notModified content release',
+      fieldPath: '',
+      action: 'retire',
+      payload: { reason: 'Bootstrap notModified regression test.' },
+    });
+
+    const runtime = await repository.readSpellingRuntimeContent('adult-u7', 'spelling', {
+      includeAccountContent: false,
+    });
+    const expectedCoreWordCount = runtime.snapshot.words.filter(isStatutoryCoreWord).length;
+
+    const response = await postBootstrap(server, { lastKnownRevision: firstHash });
+    assert.equal(response.status, 200);
+    const payload = await readJsonBody(response);
+    assert.notEqual(payload.notModified, true,
+      'content-only spelling release changes must invalidate the bootstrap notModified probe');
+    assert.notEqual(payload.revision?.hash, firstHash);
+    assert.equal(payload.subjectStates?.['learner-a::spelling']?.ui?.stats?.all?.total, expectedCoreWordCount);
+  } finally {
+    server.close();
+  }
+});
+
 test('fresh bootstrap hydrates Punctuation and Grammar public stats from stored subject state', async () => {
   const server = createServer();
   try {
@@ -1233,7 +1275,7 @@ test('PR799 follow-up: stale v3 Grammar hydration cache misses notModified after
       'stale v3 revision must not keep a raw pre-PR799 Grammar cache alive');
     assert.equal(payload.revision?.bootstrapCapacityVersion, BOOTSTRAP_CAPACITY_VERSION);
     assert.notEqual(payload.revision?.hash, staleV3Revision,
-      'server emits a fresh v4 hash after the read-model projection bump');
+      'server emits a fresh v5 hash after the read-model projection bump');
 
     const grammar = payload.subjectStates?.['learner-a::grammar'];
     assert.ok(grammar, 'full bundle includes grammar subject state after probe miss');

--- a/tests/worker-query-budget.test.js
+++ b/tests/worker-query-budget.test.js
@@ -30,16 +30,17 @@ import { createApiPlatformRepositories } from '../src/platform/core/repositories
 // child_subject_state unbounded + game_state + practice_sessions +
 // event_log + spelling content). P7 removed the duplicate account point read.
 // May 2026 hotfix removed the spelling content table read from bootstrap
-// public read-model hydration, so the measured runtime path is now 9.
-// Content Operations Centre restored learner-visible global release checks
-// without returning to account_subject_content, so the measured path is 11.
+// public read-model hydration, lowering the path to 9. Content Operations
+// Centre adds one bounded global release revision lookup, so the measured path
+// is back to 10 without returning to account_subject_content.
 // Headroom +1.
-const MEASURED_BOOTSTRAP_MULTI_LEARNER = 11;
+const MEASURED_BOOTSTRAP_MULTI_LEARNER = 10;
 const BUDGET_BOOTSTRAP_MULTI_LEARNER = MEASURED_BOOTSTRAP_MULTI_LEARNER + 1;
 
 // Measured: 5 queries for the notModified probe (ops_status JOIN +
-// ensureAccount upsert + account select + membership list +
-// list_revision). Short-circuit before any learner data is loaded.
+// ensureAccount upsert + membership list + list_revision +
+// content-operation release revision). Short-circuit before any learner data
+// is loaded.
 const BUDGET_BOOTSTRAP_NOT_MODIFIED = 6;
 
 // U6 established: projection hit path — zero event_log reads. Measured:
@@ -60,10 +61,11 @@ const BUDGET_PARENT_RECENT_SESSIONS = 7;
 // P7 measured: 10 queries for GET bootstrap full bundle. May 2026 hotfix
 // removed the spelling content table read from public read-model hydration,
 // leaving the route-level account snapshot reuse and 9 measured queries.
-// Content Operations Centre restored learner-visible global release checks
-// without returning to account_subject_content, so the measured path is 11.
+// Content Operations Centre adds one bounded global release revision lookup,
+// so the measured path is back to 10 without returning to
+// account_subject_content.
 // Headroom +1.
-const MEASURED_BOOTSTRAP_GET_FULL = 11;
+const MEASURED_BOOTSTRAP_GET_FULL = 10;
 const BUDGET_BOOTSTRAP_GET_FULL = MEASURED_BOOTSTRAP_GET_FULL + 1;
 const MEASURED_BOOTSTRAP_GET_WITH_CACHED_MONSTER_POINTER = MEASURED_BOOTSTRAP_GET_FULL - 1;
 

--- a/tests/worker-subject-runtime.test.js
+++ b/tests/worker-subject-runtime.test.js
@@ -55,6 +55,10 @@ async function publishSpellingWordEdit(repository, word, {
   action = 'set',
   payload = `Runtime content explanation for ${word?.word || 'word'}.`,
 } = {}) {
+  await repository.seedFirstContentOperationRelease({
+    seededByAccountId: actorAccountId,
+    proof: { source: 'worker-subject-runtime-test-helper' },
+  });
   const contentPackage = await repository.createContentOperationPackage({
     templateId: 'edit-spelling-word',
     title,
@@ -218,6 +222,10 @@ test('repository serves spelling runtime from the global content operations rele
   const repository = createWorkerRepository({ env: { DB }, now: () => 1_777_000_000_000 });
   try {
     const seeded = await readSeededSpellingContentBundle();
+    await repository.seedFirstContentOperationRelease({
+      seededByAccountId: 'admin-a',
+      proof: { source: 'worker-subject-runtime-global-release-test' },
+    });
     const word = seeded.draft.words[0];
     const explanation = `A global-release learner-facing explanation for ${word.word}.`;
     const contentPackage = await repository.createContentOperationPackage({
@@ -253,6 +261,41 @@ test('repository serves spelling runtime from the global content operations rele
     assert.equal(runtime.content.draft.words[0].explanation, explanation);
     assert.equal(runtime.content.draft.words.length, seeded.draft.words.length);
     assert.equal(runtime.summary.runtimeWordCount, seeded.releases.at(-1).snapshot.words.length);
+    assert.equal(accountContentReads.length, 0);
+  } finally {
+    DB.close();
+  }
+});
+
+test('repository runtime uses global release ahead of legacy account content after cutover', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const repository = createWorkerRepository({ env: { DB }, now: () => 1_777_000_000_000 });
+  try {
+    const seeded = await readSeededSpellingContentBundle();
+    const word = seeded.draft.words[0];
+    const globalExplanation = `Global cutover explanation for ${word.word}.`;
+    const legacyExplanation = `Legacy account content explanation for ${word.word}.`;
+    await publishSpellingWordEdit(repository, word, {
+      title: 'Global release should win over legacy content',
+      payload: globalExplanation,
+    });
+
+    const legacyContent = JSON.parse(JSON.stringify(seeded));
+    legacyContent.draft.words[0].explanation = legacyExplanation;
+    DB.db.prepare(`
+      INSERT INTO adult_accounts (id, email, display_name, platform_role, selected_learner_id, created_at, updated_at, repo_revision)
+      VALUES ('adult-a', 'adult-a@example.test', 'Adult A', 'admin', NULL, ?, ?, 0)
+    `).run(1_777_000_000_000, 1_777_000_000_000);
+    DB.db.prepare(`
+      INSERT INTO account_subject_content (account_id, subject_id, content_json, updated_at, updated_by_account_id)
+      VALUES ('adult-a', 'spelling', ?, ?, 'adult-a')
+    `).run(JSON.stringify(legacyContent), 1_777_000_000_100);
+
+    DB.clearQueryLog();
+    const runtime = await repository.readSpellingRuntimeContent('adult-a', 'spelling');
+    const accountContentReads = accountContentQueries(DB);
+
+    assert.equal(runtime.content.draft.words[0].explanation, globalExplanation);
     assert.equal(accountContentReads.length, 0);
   } finally {
     DB.close();

--- a/worker/src/bootstrap-repository.js
+++ b/worker/src/bootstrap-repository.js
@@ -37,10 +37,14 @@ export const PUBLIC_BOOTSTRAP_RECENT_EVENT_LIMIT_PER_LEARNER = 50;
 // The response's top-level keys did not change, but the cached
 // `subjectStates.*.ui` representation did; keeping v3 would let stable
 // accounts honour `notModified` forever and keep the stale raw Grammar cache.
+// Content Operations Centre T5A: bumped 4 -> 5 when the revision hash started
+// including the active spelling content-operation release token. Without this,
+// a published spelling content release could leave stable accounts on the
+// notModified short-circuit with stale public read-model stats.
 // Any additive required field on the bootstrap envelope MUST bump this in
 // the same PR. `tests/worker-bootstrap-v2.test.js` has a snapshot test that
 // fails if the envelope shape changes without a version bump (scenario 15).
-export const PUBLIC_BOOTSTRAP_CAPACITY_VERSION = 4;
+export const PUBLIC_BOOTSTRAP_CAPACITY_VERSION = 5;
 export const BOOTSTRAP_CAPACITY_VERSION = PUBLIC_BOOTSTRAP_CAPACITY_VERSION;
 
 // U7: closed union for `meta.capacity.bootstrapMode` when the public
@@ -121,7 +125,7 @@ export const BOOTSTRAP_V2_ENVELOPE_SHAPE = Object.freeze({
 // Changing this input format (or the truncation length) is equivalent to
 // bumping `BOOTSTRAP_CAPACITY_VERSION` — stale clients will silently
 // reject `notModified` responses via the schema check. The version bumps
-// from 2 -> 3 and 3 -> 4 force stale clients to miss once and re-bind.
+// from 2 -> 3, 3 -> 4, and 4 -> 5 force stale clients to miss once and re-bind.
 export async function computeBootstrapRevisionHash({
   accountId,
   accountRevision,
@@ -135,6 +139,10 @@ export async function computeBootstrapRevisionHash({
   // format still includes the `writableLearnerStatesDigest:` slot, so
   // callers get a deterministic value without reverting to a 4-input form.
   writableLearnerStatesDigest = '',
+  // Content Operations Centre T5A: public Spelling read-models are derived
+  // from the active content-operation release. Include that release token so
+  // content-only publishes invalidate the notModified short-circuit.
+  spellingContentRevision = '',
 }) {
   const input = [
     `accountId:${String(accountId || '')}`,
@@ -143,6 +151,7 @@ export async function computeBootstrapRevisionHash({
     `bootstrapCapacityVersion:${Number(bootstrapCapacityVersion) || 0}`,
     `accountLearnerListRevision:${Number(accountLearnerListRevision) || 0}`,
     `writableLearnerStatesDigest:${String(writableLearnerStatesDigest || '')}`,
+    `spellingContentRevision:${String(spellingContentRevision || '')}`,
   ].join(';');
   const bytes = new TextEncoder().encode(input);
   const digest = await globalThis.crypto.subtle.digest('SHA-256', bytes);

--- a/worker/src/content-operations/repository.js
+++ b/worker/src/content-operations/repository.js
@@ -129,6 +129,16 @@ function releaseRowToRecord(row, { includeSnapshot = false } = {}) {
   };
 }
 
+function validationSummary(validation) {
+  return {
+    ok: Boolean(validation?.ok),
+    errorCount: Array.isArray(validation?.errors) ? validation.errors.length : 0,
+    warningCount: Array.isArray(validation?.warnings) ? validation.warnings.length : 0,
+    errors: Array.isArray(validation?.errors) ? validation.errors : [],
+    warnings: Array.isArray(validation?.warnings) ? validation.warnings : [],
+  };
+}
+
 function approvalRowToRecord(row) {
   if (!row) return null;
   return {
@@ -217,6 +227,27 @@ async function readReleaseRowById(db, subjectId, releaseId, { includeSnapshot = 
   `, [subjectId, releaseId]);
 }
 
+async function readLegacySubjectContentBundle(db, subjectId) {
+  const row = await first(db, `
+    SELECT account_id, subject_id, content_json, updated_at, updated_by_account_id
+    FROM account_subject_content
+    WHERE subject_id = ?
+    ORDER BY updated_at DESC
+    LIMIT 1
+  `, [subjectId]);
+  const bundle = parseJson(row?.content_json, null);
+  if (!bundle) return null;
+  return {
+    bundle,
+    source: {
+      type: 'account_subject_content',
+      accountId: row.account_id || null,
+      updatedAt: Number(row.updated_at) || 0,
+      updatedByAccountId: row.updated_by_account_id || null,
+    },
+  };
+}
+
 async function requirePackage(db, packageId) {
   const row = await first(db, `
     SELECT *
@@ -294,6 +325,105 @@ export function createContentOperationsRepository({ db, now }) {
   const nowFactory = typeof now === 'function' ? now : () => Date.now();
 
   return {
+    async seedFirstContentOperationRelease({
+      subjectId = CONTENT_OPERATION_SUBJECT_ID,
+      seededByAccountId = null,
+      proof = null,
+    } = {}) {
+      const resolvedSubjectId = normaliseSubjectId(subjectId);
+      const existing = await readLatestReleaseRow(db, resolvedSubjectId, { includeSnapshot: true });
+      if (existing) {
+        return {
+          ...releaseRowToRecord(existing, { includeSnapshot: true }),
+          seeded: false,
+          source: { type: 'existing_release' },
+        };
+      }
+
+      const nowTs = Number(nowFactory());
+      const legacy = await readLegacySubjectContentBundle(db, resolvedSubjectId);
+      const seededBundle = legacy?.bundle || await readSeededSpellingContentBundle();
+      const validation = validateSpellingContentBundle(seededBundle);
+      if (!validation.ok) {
+        throw new BadRequestError('First content operation release seed source is invalid.', {
+          code: 'content_operation_seed_invalid',
+          subjectId: resolvedSubjectId,
+          validation: validationSummary(validation),
+        });
+      }
+
+      const summary = buildSpellingContentSummary(validation.bundle);
+      const releaseId = uid('corel');
+      const publishedAt = nowTs;
+      const snapshotHash = contentOperationHash(validation.bundle, 'release');
+      const actor = normaliseString(seededByAccountId) || legacy?.source?.updatedByAccountId || null;
+      const source = legacy?.source || { type: 'bundled_fallback' };
+      const releaseProof = {
+        ...(proof && typeof proof === 'object' && !Array.isArray(proof) ? proof : {}),
+        seed: {
+          source,
+          summary,
+        },
+      };
+
+      await batch(db, [
+        bindStatement(db, `
+          INSERT INTO content_operation_releases (
+            release_id, subject_id, status, snapshot_json, snapshot_hash,
+            base_release_id, package_id, published_at, published_by_account_id,
+            rollback_of_release_id, proof_json, created_at
+          )
+          VALUES (?, ?, 'published', ?, ?, NULL, NULL, ?, ?, NULL, ?, ?)
+        `, [
+          releaseId,
+          resolvedSubjectId,
+          JSON.stringify(validation.bundle),
+          snapshotHash,
+          publishedAt,
+          actor,
+          JSON.stringify(releaseProof),
+          nowTs,
+        ]),
+        bindStatement(db, `
+          INSERT INTO content_operation_events (
+            event_id, package_id, release_id, subject_id, event_type,
+            actor_account_id, event_json, created_at
+          )
+          VALUES (?, NULL, ?, ?, ?, ?, ?, ?)
+        `, [
+          uid('coevt'),
+          releaseId,
+          resolvedSubjectId,
+          'release.seeded',
+          actor,
+          JSON.stringify({
+            releaseId,
+            snapshotHash,
+            source,
+            summary,
+          }),
+          nowTs,
+        ]),
+      ]);
+
+      return {
+        releaseId,
+        subjectId: resolvedSubjectId,
+        status: 'published',
+        snapshotHash,
+        snapshot: validation.bundle,
+        baseReleaseId: null,
+        packageId: null,
+        publishedAt,
+        publishedByAccountId: actor,
+        rollbackOfReleaseId: null,
+        proof: releaseProof,
+        createdAt: nowTs,
+        seeded: true,
+        source,
+      };
+    },
+
     async createContentOperationPackage({
       subjectId = CONTENT_OPERATION_SUBJECT_ID,
       templateId = 'general',
@@ -739,6 +869,13 @@ export function createContentOperationsRepository({ db, now }) {
         });
       }
       const currentReleaseRow = await readLatestReleaseRow(db, packageRow.subject_id);
+      if (!currentReleaseRow) {
+        throw new ConflictError('First global content operation release must be seeded before package publish.', {
+          code: 'content_operation_first_release_required',
+          packageId,
+          subjectId: packageRow.subject_id,
+        });
+      }
       if ((candidate.currentReleaseId || null) !== (currentReleaseRow?.release_id || null)) {
         throw new ConflictError('A newer content operation release was published after approval.', {
           code: 'content_operation_release_drift',
@@ -871,6 +1008,105 @@ export function createContentOperationsRepository({ db, now }) {
         publishedAt: nowTs,
         publishedByAccountId: actor,
         proof,
+      };
+    },
+
+    async rollbackContentOperationRelease(subjectId = CONTENT_OPERATION_SUBJECT_ID, releaseId, {
+      rolledBackByAccountId,
+      proof = null,
+    } = {}) {
+      const resolvedSubjectId = normaliseSubjectId(subjectId);
+      const actor = normaliseString(rolledBackByAccountId);
+      if (!actor) throw new BadRequestError('Content operation rollback requires an actor account id.');
+      const targetRow = await readReleaseRowById(db, resolvedSubjectId, normaliseString(releaseId), {
+        includeSnapshot: true,
+      });
+      const target = releaseRowToRecord(targetRow, { includeSnapshot: true });
+      if (!target) {
+        throw new NotFoundError('Content operation rollback target release was not found.', {
+          code: 'content_operation_release_not_found',
+          subjectId: resolvedSubjectId,
+          releaseId,
+        });
+      }
+      const currentRow = await readLatestReleaseRow(db, resolvedSubjectId);
+      const validation = validateSpellingContentBundle(target.snapshot);
+      if (!validation.ok) {
+        throw new ConflictError('Rollback target no longer validates.', {
+          code: 'content_operation_rollback_target_invalid',
+          subjectId: resolvedSubjectId,
+          releaseId,
+          validation: validationSummary(validation),
+        });
+      }
+
+      const nowTs = Number(nowFactory());
+      const rollbackReleaseId = uid('corel');
+      const snapshotHash = contentOperationHash(validation.bundle, 'release');
+      const rollbackProof = {
+        ...(proof && typeof proof === 'object' && !Array.isArray(proof) ? proof : {}),
+        rollback: {
+          targetReleaseId: target.releaseId,
+          targetSnapshotHash: target.snapshotHash,
+          previousLatestReleaseId: currentRow?.release_id || null,
+        },
+      };
+
+      await batch(db, [
+        bindStatement(db, `
+          INSERT INTO content_operation_releases (
+            release_id, subject_id, status, snapshot_json, snapshot_hash,
+            base_release_id, package_id, published_at, published_by_account_id,
+            rollback_of_release_id, proof_json, created_at
+          )
+          VALUES (?, ?, 'published', ?, ?, ?, NULL, ?, ?, ?, ?, ?)
+        `, [
+          rollbackReleaseId,
+          resolvedSubjectId,
+          JSON.stringify(validation.bundle),
+          snapshotHash,
+          currentRow?.release_id || null,
+          nowTs,
+          actor,
+          target.releaseId,
+          JSON.stringify(rollbackProof),
+          nowTs,
+        ]),
+        bindStatement(db, `
+          INSERT INTO content_operation_events (
+            event_id, package_id, release_id, subject_id, event_type,
+            actor_account_id, event_json, created_at
+          )
+          VALUES (?, NULL, ?, ?, ?, ?, ?, ?)
+        `, [
+          uid('coevt'),
+          rollbackReleaseId,
+          resolvedSubjectId,
+          'release.rollback',
+          actor,
+          JSON.stringify({
+            releaseId: rollbackReleaseId,
+            rollbackOfReleaseId: target.releaseId,
+            previousLatestReleaseId: currentRow?.release_id || null,
+            snapshotHash,
+          }),
+          nowTs,
+        ]),
+      ]);
+
+      return {
+        releaseId: rollbackReleaseId,
+        subjectId: resolvedSubjectId,
+        status: 'published',
+        snapshotHash,
+        snapshot: validation.bundle,
+        baseReleaseId: currentRow?.release_id || null,
+        packageId: null,
+        publishedAt: nowTs,
+        publishedByAccountId: actor,
+        rollbackOfReleaseId: target.releaseId,
+        proof: rollbackProof,
+        createdAt: nowTs,
       };
     },
 

--- a/worker/src/content-operations/repository.js
+++ b/worker/src/content-operations/repository.js
@@ -11,6 +11,10 @@ import {
   validateSpellingContentBundle,
 } from '../../../src/subjects/spelling/content/model.js';
 import {
+  decodeContentOperationSnapshot,
+  encodeContentOperationSnapshot,
+} from '../../../src/subjects/spelling/content/release-snapshot-codec.js';
+import {
   readSeededSpellingContentBundle,
 } from '../generated-spelling-content-seed.js';
 import {
@@ -111,6 +115,16 @@ function candidateRowToRecord(row, { includeSnapshot = false } = {}) {
   };
 }
 
+async function candidateRowToRecordAsync(row, { includeSnapshot = false } = {}) {
+  const record = candidateRowToRecord(row, { includeSnapshot: false });
+  if (!record || !includeSnapshot) return record;
+  const snapshotJson = await decodeContentOperationSnapshot(row.candidate_snapshot_json);
+  return {
+    ...record,
+    candidate: parseJson(snapshotJson, null),
+  };
+}
+
 function releaseRowToRecord(row, { includeSnapshot = false } = {}) {
   if (!row) return null;
   return {
@@ -129,6 +143,16 @@ function releaseRowToRecord(row, { includeSnapshot = false } = {}) {
   };
 }
 
+async function releaseRowToRecordAsync(row, { includeSnapshot = false } = {}) {
+  const record = releaseRowToRecord(row, { includeSnapshot: false });
+  if (!record || !includeSnapshot) return record;
+  const snapshotJson = await decodeContentOperationSnapshot(row.snapshot_json);
+  return {
+    ...record,
+    snapshot: parseJson(snapshotJson, null),
+  };
+}
+
 function validationSummary(validation) {
   return {
     ok: Boolean(validation?.ok),
@@ -137,6 +161,16 @@ function validationSummary(validation) {
     errors: Array.isArray(validation?.errors) ? validation.errors : [],
     warnings: Array.isArray(validation?.warnings) ? validation.warnings : [],
   };
+}
+
+function latestPublishedReleaseIdSql() {
+  return `
+    SELECT release_id
+    FROM content_operation_releases
+    WHERE subject_id = ? AND status = 'published'
+    ORDER BY published_at DESC, created_at DESC, rowid DESC
+    LIMIT 1
+  `;
 }
 
 function approvalRowToRecord(row) {
@@ -334,7 +368,7 @@ export function createContentOperationsRepository({ db, now }) {
       const existing = await readLatestReleaseRow(db, resolvedSubjectId, { includeSnapshot: true });
       if (existing) {
         return {
-          ...releaseRowToRecord(existing, { includeSnapshot: true }),
+          ...await releaseRowToRecordAsync(existing, { includeSnapshot: true }),
           seeded: false,
           source: { type: 'existing_release' },
         };
@@ -356,6 +390,7 @@ export function createContentOperationsRepository({ db, now }) {
       const releaseId = uid('corel');
       const publishedAt = nowTs;
       const snapshotHash = contentOperationHash(validation.bundle, 'release');
+      const encodedSnapshot = await encodeContentOperationSnapshot(validation.bundle);
       const actor = normaliseString(seededByAccountId) || legacy?.source?.updatedByAccountId || null;
       const source = legacy?.source || { type: 'bundled_fallback' };
       const releaseProof = {
@@ -366,30 +401,46 @@ export function createContentOperationsRepository({ db, now }) {
         },
       };
 
-      await batch(db, [
+      const seedResults = await batch(db, [
         bindStatement(db, `
           INSERT INTO content_operation_releases (
             release_id, subject_id, status, snapshot_json, snapshot_hash,
             base_release_id, package_id, published_at, published_by_account_id,
             rollback_of_release_id, proof_json, created_at
           )
-          VALUES (?, ?, 'published', ?, ?, NULL, NULL, ?, ?, NULL, ?, ?)
+          SELECT ?, ?, 'published', ?, ?, NULL, NULL, ?, ?, NULL, ?, ?
+          WHERE NOT EXISTS (
+            SELECT 1
+            FROM content_operation_releases
+            WHERE subject_id = ? AND status = 'published'
+          )
         `, [
           releaseId,
           resolvedSubjectId,
-          JSON.stringify(validation.bundle),
+          encodedSnapshot,
           snapshotHash,
           publishedAt,
           actor,
           JSON.stringify(releaseProof),
           nowTs,
+          resolvedSubjectId,
         ]),
         bindStatement(db, `
           INSERT INTO content_operation_events (
             event_id, package_id, release_id, subject_id, event_type,
             actor_account_id, event_json, created_at
           )
-          VALUES (?, NULL, ?, ?, ?, ?, ?, ?)
+          SELECT ?, NULL, ?, ?, ?, ?, ?, ?
+          WHERE EXISTS (
+            SELECT 1
+            FROM content_operation_releases
+            WHERE release_id = ?
+          )
+          AND NOT EXISTS (
+            SELECT 1
+            FROM content_operation_releases
+            WHERE subject_id = ? AND status = 'published' AND release_id <> ?
+          )
         `, [
           uid('coevt'),
           releaseId,
@@ -403,8 +454,20 @@ export function createContentOperationsRepository({ db, now }) {
             summary,
           }),
           nowTs,
+          releaseId,
+          resolvedSubjectId,
+          releaseId,
         ]),
       ]);
+
+      if (mutationChangeCount(seedResults[0]) < 1) {
+        const winner = await readLatestReleaseRow(db, resolvedSubjectId, { includeSnapshot: true });
+        return {
+          ...await releaseRowToRecordAsync(winner, { includeSnapshot: true }),
+          seeded: false,
+          source: { type: 'existing_release' },
+        };
+      }
 
       return {
         releaseId,
@@ -614,8 +677,9 @@ export function createContentOperationsRepository({ db, now }) {
         packageRow.base_release_id,
         { includeSnapshot: true },
       );
-      const baseSnapshot = baseReleaseRow?.snapshot_json
-        ? parseJson(baseReleaseRow.snapshot_json, null)
+      const baseRelease = await releaseRowToRecordAsync(baseReleaseRow, { includeSnapshot: true });
+      const baseSnapshot = baseRelease?.snapshot
+        ? baseRelease.snapshot
         : await readSeededSpellingContentBundle();
       const candidate = buildSpellingContentOperationCandidate(baseSnapshot, operations);
       const conflicts = [
@@ -631,6 +695,7 @@ export function createContentOperationsRepository({ db, now }) {
         errors: candidate.validation.errors,
         warnings: candidate.validation.warnings,
       };
+      const encodedCandidateSnapshot = await encodeContentOperationSnapshot(candidate.candidate);
 
       await batch(db, [
         bindStatement(db, `
@@ -648,7 +713,7 @@ export function createContentOperationsRepository({ db, now }) {
           currentReleaseRow?.release_id || null,
           candidate.operationsHash,
           candidate.candidateHash,
-          JSON.stringify(candidate.candidate),
+          encodedCandidateSnapshot,
           JSON.stringify(validationSummary),
           JSON.stringify(conflicts),
           nowTs,
@@ -861,7 +926,7 @@ export function createContentOperationsRepository({ db, now }) {
         FROM content_operation_package_candidates
         WHERE package_id = ? AND candidate_id = ?
       `, [packageId, approval.candidateId]);
-      const candidate = candidateRowToRecord(candidateRow, { includeSnapshot: true });
+      const candidate = await candidateRowToRecordAsync(candidateRow, { includeSnapshot: true });
       if (!candidate || candidate.candidateHash !== approval.candidateHash) {
         throw new ConflictError('Content operation approval does not match the candidate hash.', {
           code: 'content_operation_approval_hash_mismatch',
@@ -895,6 +960,7 @@ export function createContentOperationsRepository({ db, now }) {
       const releaseId = uid('corel');
       const nowTs = Number(nowFactory());
       const snapshotHash = contentOperationHash(candidate.candidate, 'release');
+      const encodedSnapshot = await encodeContentOperationSnapshot(candidate.candidate);
 
       let publishResults = [];
       try {
@@ -911,10 +977,11 @@ export function createContentOperationsRepository({ db, now }) {
               FROM content_operation_packages
               WHERE package_id = ? AND state = ?
             )
+            AND ? = (${latestPublishedReleaseIdSql()})
           `, [
             releaseId,
             packageRow.subject_id,
-            JSON.stringify(candidate.candidate),
+            encodedSnapshot,
             snapshotHash,
             candidate.currentReleaseId || packageRow.base_release_id || null,
             packageId,
@@ -924,6 +991,8 @@ export function createContentOperationsRepository({ db, now }) {
             nowTs,
             packageId,
             CONTENT_OPERATION_PACKAGE_STATES.APPROVED,
+            currentReleaseRow.release_id,
+            packageRow.subject_id,
           ]),
           bindStatement(db, `
             UPDATE content_operation_packages
@@ -991,6 +1060,15 @@ export function createContentOperationsRepository({ db, now }) {
             packageId,
           });
         }
+        if (latestPackageRow.state === CONTENT_OPERATION_PACKAGE_STATES.APPROVED) {
+          const latestReleaseRow = await readLatestReleaseRow(db, packageRow.subject_id);
+          throw new ConflictError('A newer content operation release was published before this package could publish.', {
+            code: 'content_operation_release_drift',
+            packageId,
+            candidateCurrentReleaseId: candidate.currentReleaseId || null,
+            currentReleaseId: latestReleaseRow?.release_id || null,
+          });
+        }
         throw new ConflictError('Content operation package must be approved before publish.', {
           code: 'content_operation_package_not_approved',
           packageId,
@@ -1021,7 +1099,7 @@ export function createContentOperationsRepository({ db, now }) {
       const targetRow = await readReleaseRowById(db, resolvedSubjectId, normaliseString(releaseId), {
         includeSnapshot: true,
       });
-      const target = releaseRowToRecord(targetRow, { includeSnapshot: true });
+      const target = await releaseRowToRecordAsync(targetRow, { includeSnapshot: true });
       if (!target) {
         throw new NotFoundError('Content operation rollback target release was not found.', {
           code: 'content_operation_release_not_found',
@@ -1043,6 +1121,7 @@ export function createContentOperationsRepository({ db, now }) {
       const nowTs = Number(nowFactory());
       const rollbackReleaseId = uid('corel');
       const snapshotHash = contentOperationHash(validation.bundle, 'release');
+      const encodedSnapshot = await encodeContentOperationSnapshot(validation.bundle);
       const rollbackProof = {
         ...(proof && typeof proof === 'object' && !Array.isArray(proof) ? proof : {}),
         rollback: {
@@ -1052,18 +1131,19 @@ export function createContentOperationsRepository({ db, now }) {
         },
       };
 
-      await batch(db, [
+      const rollbackResults = await batch(db, [
         bindStatement(db, `
           INSERT INTO content_operation_releases (
             release_id, subject_id, status, snapshot_json, snapshot_hash,
             base_release_id, package_id, published_at, published_by_account_id,
             rollback_of_release_id, proof_json, created_at
           )
-          VALUES (?, ?, 'published', ?, ?, ?, NULL, ?, ?, ?, ?, ?)
+          SELECT ?, ?, 'published', ?, ?, ?, NULL, ?, ?, ?, ?, ?
+          WHERE ? = (${latestPublishedReleaseIdSql()})
         `, [
           rollbackReleaseId,
           resolvedSubjectId,
-          JSON.stringify(validation.bundle),
+          encodedSnapshot,
           snapshotHash,
           currentRow?.release_id || null,
           nowTs,
@@ -1071,13 +1151,20 @@ export function createContentOperationsRepository({ db, now }) {
           target.releaseId,
           JSON.stringify(rollbackProof),
           nowTs,
+          currentRow?.release_id || null,
+          resolvedSubjectId,
         ]),
         bindStatement(db, `
           INSERT INTO content_operation_events (
             event_id, package_id, release_id, subject_id, event_type,
             actor_account_id, event_json, created_at
           )
-          VALUES (?, NULL, ?, ?, ?, ?, ?, ?)
+          SELECT ?, NULL, ?, ?, ?, ?, ?, ?
+          WHERE EXISTS (
+            SELECT 1
+            FROM content_operation_releases
+            WHERE release_id = ?
+          )
         `, [
           uid('coevt'),
           rollbackReleaseId,
@@ -1091,8 +1178,20 @@ export function createContentOperationsRepository({ db, now }) {
             snapshotHash,
           }),
           nowTs,
+          rollbackReleaseId,
         ]),
       ]);
+
+      if (mutationChangeCount(rollbackResults[0]) < 1) {
+        const latestReleaseRow = await readLatestReleaseRow(db, resolvedSubjectId);
+        throw new ConflictError('A newer content operation release was published before rollback could complete.', {
+          code: 'content_operation_release_drift',
+          subjectId: resolvedSubjectId,
+          rollbackTargetReleaseId: target.releaseId,
+          previousLatestReleaseId: currentRow?.release_id || null,
+          currentReleaseId: latestReleaseRow?.release_id || null,
+        });
+      }
 
       return {
         releaseId: rollbackReleaseId,
@@ -1112,14 +1211,14 @@ export function createContentOperationsRepository({ db, now }) {
 
     async readLatestContentOperationRelease(subjectId = CONTENT_OPERATION_SUBJECT_ID, { includeSnapshot = false } = {}) {
       const row = await readLatestReleaseRow(db, normaliseSubjectId(subjectId), { includeSnapshot });
-      return releaseRowToRecord(row, { includeSnapshot });
+      return releaseRowToRecordAsync(row, { includeSnapshot });
     },
 
     async readContentOperationRelease(subjectId = CONTENT_OPERATION_SUBJECT_ID, releaseId, { includeSnapshot = false } = {}) {
       const row = await readReleaseRowById(db, normaliseSubjectId(subjectId), normaliseString(releaseId), {
         includeSnapshot,
       });
-      return releaseRowToRecord(row, { includeSnapshot });
+      return releaseRowToRecordAsync(row, { includeSnapshot });
     },
 
     async listContentOperationReleases({ subjectId = CONTENT_OPERATION_SUBJECT_ID, includeSnapshot = false, limit = 20 } = {}) {
@@ -1135,7 +1234,7 @@ export function createContentOperationsRepository({ db, now }) {
         ORDER BY published_at DESC, created_at DESC, rowid DESC
         LIMIT ?
       `, [normaliseSubjectId(subjectId), safeLimit]);
-      return rows.map((row) => releaseRowToRecord(row, { includeSnapshot }));
+      return Promise.all(rows.map((row) => releaseRowToRecordAsync(row, { includeSnapshot })));
     },
 
     async listContentOperationEvents({ packageId = null, releaseId = null, subjectId = CONTENT_OPERATION_SUBJECT_ID, limit = 50 } = {}) {

--- a/worker/src/repository.js
+++ b/worker/src/repository.js
@@ -618,12 +618,15 @@ async function readSpellingRuntimeContentBundle(db, accountId, subjectId = 'spel
     if (overrideRow) {
       return readSpellingRuntimeContentReleaseBundle(db, subjectId, overrideRow, 'override');
     }
+
+    const releaseRow = await readPublishedContentOperationReleaseRow(db, subjectId);
+    if (releaseRow) {
+      return readSpellingRuntimeContentReleaseBundle(db, subjectId, releaseRow);
+    }
   }
 
   if (!includeAccountContent) {
-    if (!includeGlobalContent) return readSeededSpellingRuntimeContentBundle(subjectId);
-    const releaseRow = await readPublishedContentOperationReleaseRow(db, subjectId);
-    return readSpellingRuntimeContentReleaseBundle(db, subjectId, releaseRow);
+    return readSeededSpellingRuntimeContentBundle(subjectId);
   }
 
   const accountRow = await first(db, `
@@ -9633,6 +9636,14 @@ export function createWorkerRepository({ env = {}, now = Date.now, capacity = nu
       const nowTs = nowFactory();
       const account = await first(db, 'SELECT id, platform_role FROM adult_accounts WHERE id = ?', [accountId]);
       requireSubjectContentWriteAccess(account);
+      const globalRelease = await readPublishedContentOperationReleaseRow(db, subjectId);
+      if (globalRelease) {
+        throw new ConflictError('Legacy spelling content writes are disabled after the global content operations cutover.', {
+          code: 'subject_content_legacy_write_cutover',
+          subjectId,
+          releaseId: globalRelease.release_id,
+        });
+      }
       const seededBundle = await readSeededSpellingContentBundle();
       const content = backfillSpellingWordExplanations(rawContent, seededBundle);
       const validation = validateSpellingContentBundle(content);

--- a/worker/src/repository.js
+++ b/worker/src/repository.js
@@ -484,8 +484,7 @@ async function mergePublicSpellingCodexState(db, accountId, subjectRows, gameSta
   const spellingRows = subjectRows.filter((row) => row.subject_id === 'spelling');
   if (!spellingRows.length) return gameState;
 
-  const seededBundle = await readSeededSpellingContentBundle();
-  const snapshot = runtimeSnapshot || runtimeSnapshotForBundle(await readSubjectContentBundle(db, accountId, 'spelling'), seededBundle);
+  const snapshot = runtimeSnapshot || (await readSpellingContentForReadModels(db, accountId)).runtimeSnapshot;
 
   for (const row of spellingRows) {
     const progress = spellingProgressFromSubjectRow(row);
@@ -786,6 +785,19 @@ async function readSpellingRuntimeContentBundle(db, accountId, subjectId = 'spel
   return rememberSpellingRuntimeContent(key, await buildSpellingRuntimeContent(contentRow, subjectId));
 }
 
+async function readSpellingContentForReadModels(db, accountId, subjectId = 'spelling', options = {}) {
+  const seededBundle = await readSeededSpellingContentBundle();
+  const runtimeContent = await readSpellingRuntimeContentBundle(db, accountId, subjectId, options);
+  const contentBundle = runtimeContent?.content || cloneSerialisable(seededBundle);
+  const runtimeSnapshot = runtimeContent?.snapshot || runtimeSnapshotForBundle(contentBundle, seededBundle);
+  const summary = runtimeContent?.summary || runtimeContentSummary(contentBundle, runtimeSnapshot);
+  return {
+    contentBundle,
+    runtimeSnapshot,
+    summary,
+  };
+}
+
 // writableRole → membership-repository.js
 
 // normaliseMutationInput, buildMutationMeta, staleWriteError,
@@ -992,7 +1004,10 @@ async function buildSpellingRuntimeContent(row, subjectId) {
     subjectId,
     content,
     snapshot,
-    summary: runtimeContentSummary(content, snapshot),
+    summary: {
+      ...runtimeContentSummary(content, snapshot),
+      sourceUpdatedAt: Number(row.updated_at) || 0,
+    },
   };
 }
 
@@ -2276,13 +2291,7 @@ async function readSubjectContentOverviewData(db, { now, actorAccountId, actor =
   // and uses existing tables. We soft-fail on missing tables so the hub
   // loads before the relevant migrations land.
 
-  // Spelling: release version + validation from account_subject_content, errors from ops_error_events.
-  // Note: account_id is intentionally omitted — for the cross-subject overview the
-  // admin wants to see "any" content state, not a specific account's content.
-  const spellingContentRowP = first(db,
-    `SELECT content_json, updated_at FROM account_subject_content WHERE subject_id = 'spelling' LIMIT 1`,
-    [],
-  ).catch(() => null);
+  const spellingContentP = readSpellingContentForReadModels(db, actorAccountId).catch(() => null);
 
   const spellingErrorsP = scalarCountSafe(db, `
     SELECT COUNT(*) AS value
@@ -2329,14 +2338,14 @@ async function readSubjectContentOverviewData(db, { now, actorAccountId, actor =
   `, [cutoff7d], 'ops_error_events');
 
   const [
-    spellingContentRow,
+    spellingContent,
     spellingErrors,
     grammarErrors,
     punctuationErrors,
     arithmeticErrors,
     readingErrors,
   ] = await Promise.all([
-    spellingContentRowP,
+    spellingContentP,
     spellingErrorsP,
     grammarErrorsP,
     punctuationErrorsP,
@@ -2344,28 +2353,25 @@ async function readSubjectContentOverviewData(db, { now, actorAccountId, actor =
     readingErrorsP,
   ]);
 
-  // Derive spelling release version and validation errors from content_json.
-  // The bundle stores publication.publishedVersion (numeric) set at publish time.
-  // Falls back to updated_at as a proxy release indicator when no version exists.
+  // Derive spelling release version and validation errors from the same
+  // global-release-aware runtime source used by learner-facing spelling reads.
   let spellingReleaseVersion = null;
   let spellingValidationErrors = 0;
-  if (spellingContentRow?.content_json) {
-    try {
-      const bundle = JSON.parse(spellingContentRow.content_json);
-      if (bundle && typeof bundle === 'object') {
-        const pubVersion = Number(bundle?.publication?.publishedVersion);
-        if (pubVersion > 0) {
-          spellingReleaseVersion = String(pubVersion);
-        } else if (spellingContentRow.updated_at) {
-          // No explicit version — use updated_at as a proxy release indicator
-          spellingReleaseVersion = `updated:${spellingContentRow.updated_at}`;
-        }
-        if (Array.isArray(bundle.errors)) {
-          spellingValidationErrors = bundle.errors.length;
-        }
-      }
-    } catch {
-      // Soft-fail: version and validation count stay at defaults.
+  const spellingBundle = spellingContent?.contentBundle;
+  if (spellingBundle && typeof spellingBundle === 'object') {
+    const pubVersion = Number(spellingContent?.summary?.publishedVersion || spellingBundle?.publication?.publishedVersion);
+    if (pubVersion > 0) {
+      spellingReleaseVersion = String(pubVersion);
+    } else {
+      const updatedAt = Number(
+        spellingContent?.summary?.publishedAt
+        || spellingBundle?.publication?.publishedAt
+        || spellingContent?.summary?.sourceUpdatedAt,
+      );
+      if (updatedAt > 0) spellingReleaseVersion = `updated:${updatedAt}`;
+    }
+    if (Array.isArray(spellingBundle.errors)) {
+      spellingValidationErrors = spellingBundle.errors.length;
     }
   }
 
@@ -2575,27 +2581,18 @@ async function readContentQualitySignalsData(db, { actorAccountId, actor = null 
     };
   });
 
-  // Spelling signals: word-bank coverage from account_subject_content.
+  // Spelling signals: word-bank coverage from the global-release-aware
+  // runtime content path. Legacy account_subject_content is fallback only
+  // before the first content operations release is seeded.
   const spellingSignals = await safeSignalSection('spelling', async () => {
     let wordCount = 0;
     let runtimeCoreCount = 0;
-    try {
-      const contentRow = await first(db,
-        `SELECT content_json FROM account_subject_content WHERE subject_id = 'spelling' LIMIT 1`,
-        [],
-      );
-      if (contentRow?.content_json) {
-        const seededBundle = await readSeededSpellingContentBundle();
-        const bundle = contentRowToBundle(contentRow, seededBundle);
-        const snapshot = runtimeSnapshotForBundle(bundle, seededBundle);
-        const summary = runtimeContentSummary(bundle, snapshot);
-        const words = Array.isArray(snapshot?.words) ? snapshot.words : [];
-        wordCount = Number(summary.runtimeWordCount) || words.length || 0;
-        runtimeCoreCount = coverageTierCounts(words).statutoryCore;
-      }
-    } catch {
-      // Soft-fail: content may not be available.
-    }
+    const spellingContent = await readSpellingContentForReadModels(db, actorAccountId);
+    const words = Array.isArray(spellingContent.runtimeSnapshot?.words)
+      ? spellingContent.runtimeSnapshot.words
+      : [];
+    wordCount = Number(spellingContent.summary?.runtimeWordCount) || words.length || 0;
+    runtimeCoreCount = coverageTierCounts(words).statutoryCore;
 
     return {
       subjectKey: 'spelling',
@@ -9829,8 +9826,7 @@ export function createWorkerRepository({ env = {}, now = Date.now, capacity = nu
         FROM learner_profiles l
         WHERE l.id = ?
       `, [resolvedLearnerId]);
-      const seededBundle = await readSeededSpellingContentBundle();
-      const contentBundle = await readSubjectContentBundle(db, accountId, 'spelling');
+      const spellingContent = await readSpellingContentForReadModels(db, accountId);
       const learnerBundle = await loadLearnerReadBundle(db, resolvedLearnerId);
       const model = buildParentHubReadModel({
         learner: learnerRowToRecord(learnerRow),
@@ -9842,7 +9838,7 @@ export function createWorkerRepository({ env = {}, now = Date.now, capacity = nu
         practiceSessions: learnerBundle.practiceSessions,
         eventLog: learnerBundle.eventLog,
         gameState: learnerBundle.gameState,
-        runtimeSnapshots: { spelling: runtimeSnapshotForBundle(contentBundle, seededBundle) },
+        runtimeSnapshots: { spelling: spellingContent.runtimeSnapshot },
         now: nowFactory,
       });
       return {
@@ -9858,11 +9854,10 @@ export function createWorkerRepository({ env = {}, now = Date.now, capacity = nu
       const account = actor;
 
       // Sequential: memberships depend on account lookup, learner bundles
-      // depend on membership list, content bundle is an independent read
+      // depend on membership list, spelling content is an independent read
       // but must complete before buildAdminHubReadModel.
       const memberships = await listMembershipRows(db, accountId, { writableOnly: false });
-      const seededBundle = await readSeededSpellingContentBundle();
-      const contentBundle = await readSubjectContentBundle(db, accountId, 'spelling');
+      const spellingContent = await readSpellingContentForReadModels(db, accountId);
       const learnerBundles = {};
       for (const row of memberships) {
         learnerBundles[row.id] = await loadLearnerReadBundle(db, row.id);
@@ -9933,10 +9928,10 @@ export function createWorkerRepository({ env = {}, now = Date.now, capacity = nu
           platformRole: accountPlatformRole(account),
         },
         platformRole: accountPlatformRole(account),
-        spellingContentBundle: contentBundle,
+        spellingContentBundle: spellingContent.contentBundle,
         memberships: memberships.map(membershipRowToModel),
         learnerBundles,
-        runtimeSnapshots: { spelling: runtimeSnapshotForBundle(contentBundle, seededBundle) },
+        runtimeSnapshots: { spelling: spellingContent.runtimeSnapshot },
         demoOperations,
         monsterVisualConfig,
         auditEntries: auditEntries.map((row) => ({

--- a/worker/src/repository.js
+++ b/worker/src/repository.js
@@ -20,6 +20,9 @@ import {
   validateSpellingContentBundle,
 } from '../../src/subjects/spelling/content/model.js';
 import {
+  decodeContentOperationSnapshot,
+} from '../../src/subjects/spelling/content/release-snapshot-codec.js';
+import {
   SEEDED_SPELLING_CONTENT_SUMMARY,
   readSeededSpellingContentBundle,
   readSeededSpellingPublishedSnapshot,
@@ -609,19 +612,91 @@ async function readActiveContentOperationOverrideReleaseRow(db, accountId, subje
   }
 }
 
+async function readResolvedContentOperationReleaseRow(db, accountId, subjectId = 'spelling', {
+  includeSnapshot = false,
+} = {}) {
+  try {
+    return await first(db, `
+      SELECT
+        release_id,
+        subject_id,
+        status,
+        snapshot_hash,
+        snapshot_json,
+        published_at,
+        created_at,
+        release_source
+      FROM (
+        SELECT
+          r.release_id,
+          r.subject_id,
+          r.status,
+          r.snapshot_hash,
+          ${includeSnapshot ? 'r.snapshot_json' : 'NULL'} AS snapshot_json,
+          r.published_at,
+          r.created_at,
+          'override' AS release_source,
+          0 AS precedence_rank,
+          o.created_at AS precedence_created_at,
+          r.rowid AS release_rowid
+        FROM content_operation_account_overrides o
+        JOIN content_operation_releases r
+          ON r.release_id = o.release_id
+         AND r.subject_id = o.subject_id
+         AND r.status = 'published'
+        WHERE o.account_id = ?
+          AND o.subject_id = ?
+          AND o.active = 1
+        UNION ALL
+        SELECT
+          r.release_id,
+          r.subject_id,
+          r.status,
+          r.snapshot_hash,
+          ${includeSnapshot ? 'r.snapshot_json' : 'NULL'} AS snapshot_json,
+          r.published_at,
+          r.created_at,
+          'global' AS release_source,
+          1 AS precedence_rank,
+          r.published_at AS precedence_created_at,
+          r.rowid AS release_rowid
+        FROM content_operation_releases r
+        WHERE r.subject_id = ?
+          AND r.status = 'published'
+      )
+      ORDER BY precedence_rank ASC, precedence_created_at DESC, published_at DESC, created_at DESC, release_rowid DESC
+      LIMIT 1
+    `, [accountId, subjectId, subjectId]);
+  } catch (error) {
+    if (
+      isMissingTableError(error, 'content_operation_account_overrides')
+      || isMissingTableError(error, 'content_operation_releases')
+    ) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+function contentOperationReleaseRevisionToken(row) {
+  if (!row) return 'bundled';
+  return [
+    row.release_source === 'override' ? 'override' : 'global',
+    row.release_id || '',
+    row.snapshot_hash || '',
+    Number(row.published_at) || 0,
+  ].join(':');
+}
+
 async function readSpellingRuntimeContentBundle(db, accountId, subjectId = 'spelling', {
   includeAccountContent = true,
   includeGlobalContent = true,
 } = {}) {
   if (includeGlobalContent) {
-    const overrideRow = await readActiveContentOperationOverrideReleaseRow(db, accountId, subjectId);
-    if (overrideRow) {
-      return readSpellingRuntimeContentReleaseBundle(db, subjectId, overrideRow, 'override');
-    }
-
-    const releaseRow = await readPublishedContentOperationReleaseRow(db, subjectId);
+    const releaseRow = await readResolvedContentOperationReleaseRow(db, accountId, subjectId);
     if (releaseRow) {
-      return readSpellingRuntimeContentReleaseBundle(db, subjectId, releaseRow);
+      const cachePrefix = releaseRow.release_source === 'override' ? 'override' : 'release';
+      return readSpellingRuntimeContentReleaseBundle(db, subjectId, releaseRow, cachePrefix);
     }
   }
 
@@ -928,7 +1003,8 @@ async function buildSpellingRuntimeContentFromRelease(row, subjectId) {
 
   try {
     const seededBundle = await readSeededSpellingContentBundle();
-    const content = normaliseSpellingContentBundle(JSON.parse(row.snapshot_json));
+    const snapshotJson = await decodeContentOperationSnapshot(row.snapshot_json);
+    const content = normaliseSpellingContentBundle(JSON.parse(snapshotJson));
     const snapshot = runtimeSnapshotForBundle(content, seededBundle);
     return {
       subjectId,
@@ -7442,6 +7518,11 @@ async function bootstrapBundle(db, accountId, {
   // triggers a Worker command. See docs/superpowers/specs/2026-04-26-
   // bootstrap-learner-stats-hotfix-design.md.
   const subjectStateLearnerIds = learnerIds;
+  const spellingContentReleaseRow = publicReadModels
+    ? await measureBootstrapPhase(capacity, BOOTSTRAP_PHASE_TIMING.readModel, () => (
+      readResolvedContentOperationReleaseRow(db, accountId, 'spelling')
+    ))
+    : null;
 
   // U7: precompute the revision-envelope ingredients so that both the
   // empty and non-empty branches can stamp them consistently. These
@@ -7462,6 +7543,9 @@ async function bootstrapBundle(db, accountId, {
     const writableLearnerStatesDigest = revisionEnvelope
       ? await computeWritableLearnerStatesDigest(membershipRows)
       : '';
+    const spellingContentRevision = revisionEnvelope && publicReadModels
+      ? contentOperationReleaseRevisionToken(spellingContentReleaseRow)
+      : '';
     const nextRevisionHash = revisionEnvelope
       ? await computeBootstrapRevisionHash({
         accountId,
@@ -7470,6 +7554,7 @@ async function bootstrapBundle(db, accountId, {
         bootstrapCapacityVersion: PUBLIC_BOOTSTRAP_CAPACITY_VERSION,
         accountLearnerListRevision: nextAccountLearnerListRevision,
         writableLearnerStatesDigest,
+        spellingContentRevision,
       })
       : null;
     return {
@@ -7623,10 +7708,14 @@ async function bootstrapBundle(db, accountId, {
   ));
   const publicSpellingContent = await measureBootstrapPhase(capacity, BOOTSTRAP_PHASE_TIMING.readModel, () => (
     publicReadModels && subjectRows.some((row) => row.subject_id === 'spelling')
-      ? readSpellingRuntimeContentBundle(db, accountId, 'spelling', {
-        includeAccountContent: false,
-        includeGlobalContent: true,
-      })
+      ? (spellingContentReleaseRow
+        ? readSpellingRuntimeContentReleaseBundle(
+          db,
+          'spelling',
+          spellingContentReleaseRow,
+          spellingContentReleaseRow.release_source === 'override' ? 'override' : 'release',
+        )
+        : readSeededSpellingRuntimeContentBundle('spelling'))
       : null
   ));
   const publicReadModelNow = Date.now();
@@ -7719,6 +7808,7 @@ async function bootstrapBundle(db, accountId, {
 async function bootstrapNotModifiedProbe(db, accountId, {
   lastKnownRevision,
   preferredLearnerId = null,
+  publicReadModels = false,
   accountSnapshot = null,
   capacity = null,
 }) {
@@ -7746,6 +7836,9 @@ async function bootstrapNotModifiedProbe(db, accountId, {
     // { writableOnly: true })`) for deterministic agreement between the
     // probe and the full-bundle hash.
     const writableLearnerStatesDigest = await computeWritableLearnerStatesDigest(membershipRows);
+    const spellingContentReleaseRow = publicReadModels
+      ? await readResolvedContentOperationReleaseRow(db, accountId, 'spelling')
+      : null;
     const serverHash = await computeBootstrapRevisionHash({
       accountId,
       accountRevision: accountRevisionValue,
@@ -7753,6 +7846,9 @@ async function bootstrapNotModifiedProbe(db, accountId, {
       bootstrapCapacityVersion: PUBLIC_BOOTSTRAP_CAPACITY_VERSION,
       accountLearnerListRevision,
       writableLearnerStatesDigest,
+      spellingContentRevision: publicReadModels
+        ? contentOperationReleaseRevisionToken(spellingContentReleaseRow)
+        : '',
     });
     if (serverHash !== lastKnownRevision) return null;
     return {
@@ -9078,6 +9174,7 @@ export function createWorkerRepository({ env = {}, now = Date.now, capacity = nu
         const probe = await bootstrapNotModifiedProbe(db, accountId, {
           lastKnownRevision,
           preferredLearnerId,
+          publicReadModels,
           accountSnapshot,
           capacity,
         });
@@ -9538,6 +9635,28 @@ export function createWorkerRepository({ env = {}, now = Date.now, capacity = nu
     async exportSubjectContent(accountId, subjectId = 'spelling') {
       const account = await first(db, 'SELECT id, repo_revision, platform_role FROM adult_accounts WHERE id = ?', [accountId]);
       requireSubjectContentExportAccess(account);
+      const globalRelease = await readPublishedContentOperationReleaseRow(db, subjectId, { includeSnapshot: true });
+      if (globalRelease) {
+        const releaseBundle = await buildSpellingRuntimeContentFromRelease(globalRelease, subjectId);
+        const content = releaseBundle.content || await readSeededSpellingContentBundle();
+        return {
+          subjectId,
+          content,
+          summary: buildSpellingContentSummary(content),
+          compatibility: {
+            source: 'content_operation_release',
+            releaseId: globalRelease.release_id,
+            snapshotHash: globalRelease.snapshot_hash,
+            legacyWriteDisabled: true,
+          },
+          mutation: {
+            policyVersion: MUTATION_POLICY_VERSION,
+            scopeType: 'account',
+            scopeId: accountId,
+            accountRevision: Number(account?.repo_revision) || 0,
+          },
+        };
+      }
       const content = await readSubjectContentBundle(db, accountId, subjectId);
       return {
         subjectId,


### PR DESCRIPTION
## Summary
- Seed the first published spelling content-operation release from legacy account content or the bundled fallback.
- Block normal package publishing until that first global release exists, and add a rollback writer for published release recovery.
- Resolve spelling runtime content as account override, global release, legacy account content, then bundled fallback.
- Freeze legacy `/api/content/spelling` writes after cutover and add an idempotent dry-run/apply seed script.

## Verification
- `node --test tests/content-operations-repository.test.js tests/content-operations-seed-script.test.js tests/worker-subject-runtime.test.js tests/worker-bootstrap-v2.test.js tests/spelling-content-api.test.js` (76/76)
- `node scripts/migrate-spelling-content-to-global-release.mjs --dry-run --actor admin-a`
- `npm run content:operations:seed`
- `npm test` (111682 pass, 0 fail, 12 skipped)
- `npm run check`
- Pre-push `npm test` (111682 pass, 0 fail, 12 skipped)