### PR TITLE
Add content operations admin API routes

### DIFF
--- a/tests/admin-safe-copy.test.js
+++ b/tests/admin-safe-copy.test.js
@@ -22,6 +22,9 @@ import {
   maskEmail,
   maskId,
 } from '../src/platform/hubs/admin-safe-copy.js';
+import {
+  buildContentOperationBlockerEnvelope,
+} from '../worker/src/content-operations/serialisers.js';
 
 // ---------------------------------------------------------------------------
 // 1. admin_only — full passthrough (minus auth tokens + request bodies)
@@ -47,6 +50,42 @@ test('admin_only audience passes full bundle JSON through', () => {
   assert.equal(parsed.internalNotes, 'Some internal note');
   // Stack preserved for admin.
   assert.equal(parsed.stack, 'Error\n  at fn (/path/file.js:10:5)');
+});
+
+test('admin_only audience preserves content operations blocker envelopes', () => {
+  const blockers = buildContentOperationBlockerEnvelope({
+    validation: {
+      ok: false,
+      errors: [{ code: 'word_family_missing', wordSlug: 'accommodate' }],
+      warnings: [],
+    },
+    conflicts: [{ code: 'same_field_conflict', entityId: 'accommodate' }],
+    audio: {
+      status: 'blocked',
+      blockers: ['word_audio_missing'],
+      warnings: [],
+    },
+  });
+  const result = prepareSafeCopy({
+    title: 'Content operations package blockers',
+    blockers,
+  }, COPY_AUDIENCE.ADMIN_ONLY);
+
+  assert.equal(result.ok, true);
+  const parsed = JSON.parse(result.text);
+  assert.deepEqual(Object.keys(parsed.blockers), [
+    'validation',
+    'conflicts',
+    'audio',
+    'assets',
+    'rewards',
+    'visibility',
+    'exposure',
+    'publishReadiness',
+  ]);
+  assert.equal(parsed.blockers.validation.status, 'blocked');
+  assert.equal(parsed.blockers.conflicts.count, 1);
+  assert.deepEqual(parsed.blockers.audio.blockers, ['word_audio_missing']);
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/content-operations-api.test.js
+++ b/tests/content-operations-api.test.js
@@ -1,0 +1,317 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createWorkerRepository } from '../worker/src/repository.js';
+import {
+  readSeededSpellingContentBundle,
+} from '../worker/src/generated-spelling-content-seed.js';
+import { createWorkerRepositoryServer } from './helpers/worker-server.js';
+
+const BASE_URL = 'https://repo.test';
+const ADMIN_ID = 'admin-a';
+const NOW = Date.UTC(2026, 5, 11, 12, 0, 0);
+
+function seedAdultAccount(DB, {
+  accountId = ADMIN_ID,
+  platformRole = 'admin',
+} = {}) {
+  DB.db.prepare(`
+    INSERT INTO adult_accounts (id, email, display_name, platform_role, selected_learner_id, created_at, updated_at, repo_revision)
+    VALUES (?, ?, ?, ?, NULL, ?, ?, 0)
+    ON CONFLICT(id) DO UPDATE SET
+      platform_role = excluded.platform_role,
+      updated_at = excluded.updated_at
+  `).run(accountId, `${accountId}@example.test`, accountId, platformRole, NOW, NOW);
+}
+
+function jsonInit(method, body = {}) {
+  return {
+    method,
+    headers: {
+      'content-type': 'application/json',
+      'sec-fetch-site': 'same-origin',
+    },
+    body: JSON.stringify(body),
+  };
+}
+
+function adminHeaders() {
+  return {
+    'x-ks2-dev-platform-role': 'admin',
+    'sec-fetch-site': 'same-origin',
+  };
+}
+
+async function readPayload(response) {
+  return response.json();
+}
+
+async function createPackage(server, body = {}) {
+  const response = await server.fetchAs(
+    ADMIN_ID,
+    `${BASE_URL}/api/admin/content-operations/subjects/spelling/packages`,
+    jsonInit('POST', {
+      title: 'API spelling edit package',
+      templateId: 'edit-spelling-word',
+      ...body,
+    }),
+    adminHeaders(),
+  );
+  assert.equal(response.status, 201);
+  return readPayload(response);
+}
+
+async function appendWordExplanationOperation(server, packageId, word, payload) {
+  const response = await server.fetchAs(
+    ADMIN_ID,
+    `${BASE_URL}/api/admin/content-operations/packages/${packageId}/operations`,
+    jsonInit('POST', {
+      operation: {
+        entityType: 'spelling.word',
+        entityId: word.slug,
+        fieldPath: 'explanation',
+        action: 'set',
+        payload,
+      },
+    }),
+    adminHeaders(),
+  );
+  assert.equal(response.status, 201);
+  return readPayload(response);
+}
+
+async function validatePackage(server, packageId, body = {}) {
+  const response = await server.fetchAs(
+    ADMIN_ID,
+    `${BASE_URL}/api/admin/content-operations/packages/${packageId}/validate`,
+    jsonInit('POST', body),
+    adminHeaders(),
+  );
+  assert.equal(response.status, 200);
+  return readPayload(response);
+}
+
+async function approvePackage(server, packageId, candidateId) {
+  const response = await server.fetchAs(
+    ADMIN_ID,
+    `${BASE_URL}/api/admin/content-operations/packages/${packageId}/approve`,
+    jsonInit('POST', {
+      candidateId,
+      notes: 'Reviewed in the content operations API test.',
+    }),
+    adminHeaders(),
+  );
+  assert.equal(response.status, 200);
+  return readPayload(response);
+}
+
+test('content operations API requires the admin platform role', async () => {
+  const server = createWorkerRepositoryServer({ now: () => NOW });
+  try {
+    seedAdultAccount(server.DB, { accountId: 'ops-a', platformRole: 'ops' });
+
+    const response = await server.fetchAs(
+      'ops-a',
+      `${BASE_URL}/api/admin/content-operations/subjects/spelling/overview`,
+      {
+        method: 'GET',
+        headers: { 'sec-fetch-site': 'same-origin' },
+      },
+      { 'x-ks2-dev-platform-role': 'ops' },
+    );
+    const payload = await readPayload(response);
+
+    assert.equal(response.status, 403);
+    assert.equal(payload.code, 'content_operations_forbidden');
+    assert.equal(payload.capability, 'content_operations.view');
+    assert.equal(payload.required, 'platform_role:admin');
+  } finally {
+    server.close();
+  }
+});
+
+test('content operations API supports admin package lifecycle through separate approve and publish actions', async () => {
+  const server = createWorkerRepositoryServer({ now: () => NOW });
+  try {
+    seedAdultAccount(server.DB, { accountId: ADMIN_ID, platformRole: 'admin' });
+    const repository = createWorkerRepository({
+      env: server.env,
+      now: () => NOW,
+    });
+    await repository.seedFirstContentOperationRelease({
+      seededByAccountId: ADMIN_ID,
+      proof: { source: 'content-operations-api-test' },
+    });
+    const seeded = await readSeededSpellingContentBundle();
+    const word = seeded.draft.words[0];
+
+    const created = await createPackage(server);
+    const packageId = created.package.packageId;
+    assert.equal(created.actor.capabilities['content_operations.edit'], true);
+    assert.equal(created.package.state, 'draft');
+
+    const patchResponse = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/packages/${packageId}`,
+      jsonInit('PATCH', {
+        title: 'API spelling edit package renamed',
+        description: 'Managed through the content operations API.',
+      }),
+      adminHeaders(),
+    );
+    const patched = await readPayload(patchResponse);
+    assert.equal(patchResponse.status, 200);
+    assert.equal(patched.package.title, 'API spelling edit package renamed');
+    assert.equal(patched.package.description, 'Managed through the content operations API.');
+
+    const throwaway = await appendWordExplanationOperation(
+      server,
+      packageId,
+      word,
+      'Temporary explanation that will be deleted before validation.',
+    );
+    const deleteResponse = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/packages/${packageId}/operations/${throwaway.operation.operationId}`,
+      {
+        method: 'DELETE',
+        headers: { 'sec-fetch-site': 'same-origin' },
+      },
+      adminHeaders(),
+    );
+    const deleted = await readPayload(deleteResponse);
+    assert.equal(deleteResponse.status, 200);
+    assert.equal(deleted.deleted, true);
+    assert.equal(deleted.operation.operationId, throwaway.operation.operationId);
+
+    const explanation = `API-reviewed explanation for ${word.word}.`;
+    await appendWordExplanationOperation(server, packageId, word, explanation);
+
+    const validated = await validatePackage(server, packageId);
+    assert.equal(validated.candidate.validation.status, 'passed');
+    assert.equal(validated.candidate.blockers.publishReadiness.status, 'not_ready');
+
+    const approved = await approvePackage(server, packageId, validated.candidate.candidateId);
+    assert.equal(approved.approval.candidateId, validated.candidate.candidateId);
+    assert.equal(approved.approval.approvedByAccountId, ADMIN_ID);
+
+    const publishResponse = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/packages/${packageId}/publish`,
+      jsonInit('POST', {
+        proof: { source: 'content-operations-api-test', reviewer: ADMIN_ID },
+      }),
+      adminHeaders(),
+    );
+    const published = await readPayload(publishResponse);
+    assert.equal(publishResponse.status, 200);
+    assert.equal(published.release.packageId, packageId);
+    assert.equal(published.release.publishedByAccountId, ADMIN_ID);
+
+    const releaseDetailResponse = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/subjects/spelling/releases/${published.release.releaseId}?includeSnapshot=true`,
+      { method: 'GET', headers: { 'sec-fetch-site': 'same-origin' } },
+      adminHeaders(),
+    );
+    const releaseDetail = await readPayload(releaseDetailResponse);
+    assert.equal(releaseDetailResponse.status, 200);
+    assert.equal(
+      releaseDetail.release.snapshot.draft.words.find((entry) => entry.slug === word.slug).explanation,
+      explanation,
+    );
+
+    const detailResponse = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/packages/${packageId}`,
+      { method: 'GET', headers: { 'sec-fetch-site': 'same-origin' } },
+      adminHeaders(),
+    );
+    const detail = await readPayload(detailResponse);
+    assert.equal(detailResponse.status, 200);
+    assert.equal(detail.package.state, 'published');
+    assert.ok(detail.events.some((event) => event.eventType === 'package.approved'));
+    assert.ok(detail.events.some((event) => event.eventType === 'package.published'));
+
+    const overviewResponse = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/subjects/spelling/overview`,
+      { method: 'GET', headers: { 'sec-fetch-site': 'same-origin' } },
+      adminHeaders(),
+    );
+    const overview = await readPayload(overviewResponse);
+    assert.equal(overviewResponse.status, 200);
+    assert.equal(overview.overview.latestRelease.releaseId, published.release.releaseId);
+    assert.equal(overview.overview.actor.capabilities['content_operations.approve'], true);
+    assert.equal(overview.overview.actor.capabilities['content_operations.publish'], true);
+  } finally {
+    server.close();
+  }
+});
+
+test('content operations API returns a structured first-release publish blocker', async () => {
+  const server = createWorkerRepositoryServer({ now: () => NOW });
+  try {
+    seedAdultAccount(server.DB, { accountId: ADMIN_ID, platformRole: 'admin' });
+    const seeded = await readSeededSpellingContentBundle();
+    const word = seeded.draft.words[0];
+    const created = await createPackage(server, { title: 'Unseeded publish package' });
+    const packageId = created.package.packageId;
+
+    await appendWordExplanationOperation(
+      server,
+      packageId,
+      word,
+      `Unseeded API explanation for ${word.word}.`,
+    );
+    const validated = await validatePackage(server, packageId);
+    await approvePackage(server, packageId, validated.candidate.candidateId);
+
+    const publishResponse = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/packages/${packageId}/publish`,
+      jsonInit('POST', { proof: { source: 'unseeded-api-test' } }),
+      adminHeaders(),
+    );
+    const payload = await readPayload(publishResponse);
+
+    assert.equal(publishResponse.status, 409);
+    assert.equal(payload.code, 'content_operation_first_release_required');
+    assert.equal(payload.packageId, packageId);
+  } finally {
+    server.close();
+  }
+});
+
+test('content operations API exposes stable blocker envelopes for later batch routes', async () => {
+  const server = createWorkerRepositoryServer({ now: () => NOW });
+  try {
+    seedAdultAccount(server.DB, { accountId: ADMIN_ID, platformRole: 'admin' });
+    const created = await createPackage(server, { title: 'Audio scan package' });
+
+    const response = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/packages/${created.package.packageId}/scan-audio`,
+      jsonInit('POST', { requestId: 'scan-audio-api-test' }),
+      adminHeaders(),
+    );
+    const payload = await readPayload(response);
+
+    assert.equal(response.status, 501);
+    assert.equal(payload.code, 'content_operation_route_not_implemented');
+    assert.equal(payload.stub.action, 'scan-audio');
+    assert.deepEqual(Object.keys(payload.blockers), [
+      'validation',
+      'conflicts',
+      'audio',
+      'assets',
+      'rewards',
+      'visibility',
+      'exposure',
+      'publishReadiness',
+    ]);
+    assert.deepEqual(payload.blockers.publishReadiness.blockers, ['route_not_implemented']);
+  } finally {
+    server.close();
+  }
+});

--- a/worker/src/app.js
+++ b/worker/src/app.js
@@ -46,6 +46,7 @@ import { consumeRateLimit, rateLimitResponse, rateLimitSubject } from './rate-li
 import { getReadModelDerivedWriteBreaker } from './circuit-breaker-server.js';
 import { isResetableBreakerName } from '../../src/platform/core/circuit-breaker.js';
 import { handleHeroReadModel } from './hero/routes.js';
+import { handleContentOperationsAdminRequest } from './content-operations/routes.js';
 import { resolveHeroStartTaskCommand } from './hero/launch.js';
 import { resolveHeroClaimCommand } from './hero/claim.js';
 import { resolveHeroCampCommand } from './hero/camp.js';
@@ -2381,6 +2382,15 @@ export function createWorkerApp({
           });
           return json({ ok: true, ...result });
         }
+
+        const contentOperationsResponse = await handleContentOperationsAdminRequest({
+          url,
+          request,
+          env,
+          session,
+          repository,
+        });
+        if (contentOperationsResponse) return contentOperationsResponse;
 
         // P6 U8: Generic asset CAS routes — delegate to asset-specific handlers
         // keyed by assetId. Currently supports 'monster-visual-config'; additional

--- a/worker/src/content-operations/repository.js
+++ b/worker/src/content-operations/repository.js
@@ -566,6 +566,70 @@ export function createContentOperationsRepository({ db, now }) {
       return record;
     },
 
+    async updateContentOperationPackage(packageId, {
+      templateId = undefined,
+      title = undefined,
+      description = undefined,
+    } = {}, { actorAccountId } = {}) {
+      const packageRow = await requirePackage(db, packageId);
+      assertPackageIsNotPublished(packageRow, packageId);
+      const actor = normaliseString(actorAccountId);
+      if (!actor) throw new BadRequestError('Content operation package updates require an actor account id.');
+      const nowTs = Number(nowFactory());
+      const nextTemplateId = templateId === undefined
+        ? packageRow.template_id
+        : normaliseString(templateId, packageRow.template_id);
+      const nextTitle = title === undefined
+        ? packageRow.title
+        : normaliseString(title, packageRow.title || 'Untitled content package');
+      const nextDescription = description === undefined
+        ? (packageRow.description || '')
+        : normaliseString(description);
+
+      await batch(db, [
+        bindStatement(db, `
+          DELETE FROM content_operation_package_approvals
+          WHERE package_id = ?
+        `, [packageId]),
+        bindStatement(db, `
+          UPDATE content_operation_packages
+          SET template_id = ?, title = ?, description = ?,
+              state = ?, approved_at = NULL,
+              updated_by_account_id = ?, updated_at = ?
+          WHERE package_id = ?
+        `, [
+          nextTemplateId,
+          nextTitle,
+          nextDescription,
+          CONTENT_OPERATION_PACKAGE_STATES.DRAFT,
+          actor,
+          nowTs,
+          packageId,
+        ]),
+        bindStatement(db, `
+          INSERT INTO content_operation_events (
+            event_id, package_id, release_id, subject_id, event_type,
+            actor_account_id, event_json, created_at
+          )
+          VALUES (?, ?, NULL, ?, ?, ?, ?, ?)
+        `, [
+          uid('coevt'),
+          packageId,
+          packageRow.subject_id,
+          'package.updated',
+          actor,
+          JSON.stringify({
+            templateId: nextTemplateId,
+            title: nextTitle,
+            description: nextDescription,
+          }),
+          nowTs,
+        ]),
+      ]);
+
+      return packageRowToRecord(await requirePackage(db, packageId));
+    },
+
     async listContentOperationPackages({ subjectId = CONTENT_OPERATION_SUBJECT_ID, state = null, limit = 50 } = {}) {
       const resolvedSubjectId = normaliseSubjectId(subjectId);
       const safeLimit = Math.max(1, Math.min(100, Number(limit) || 50));
@@ -664,6 +728,76 @@ export function createContentOperationsRepository({ db, now }) {
       ]);
 
       return { ...operation, packageId, operationOrder: nextOrder };
+    },
+
+    async deleteContentOperation(packageId, operationId, { actorAccountId } = {}) {
+      const packageRow = await requirePackage(db, packageId);
+      assertPackageIsNotPublished(packageRow, packageId);
+      const actor = normaliseString(actorAccountId);
+      if (!actor) throw new BadRequestError('Content operation deletes require an actor account id.');
+      const operationRow = await first(db, `
+        SELECT *
+        FROM content_operation_package_operations
+        WHERE package_id = ? AND operation_id = ?
+      `, [packageId, operationId]);
+      if (!operationRow) {
+        throw new NotFoundError('Content operation was not found.', {
+          code: 'content_operation_not_found',
+          packageId,
+          operationId,
+        });
+      }
+      const operation = operationRowToRecord(operationRow);
+      const nowTs = Number(nowFactory());
+
+      await batch(db, [
+        bindStatement(db, `
+          DELETE FROM content_operation_package_operations
+          WHERE package_id = ? AND operation_id = ?
+        `, [packageId, operationId]),
+        bindStatement(db, `
+          DELETE FROM content_operation_package_approvals
+          WHERE package_id = ?
+        `, [packageId]),
+        bindStatement(db, `
+          UPDATE content_operation_packages
+          SET state = ?, approved_at = NULL, updated_by_account_id = ?, updated_at = ?
+          WHERE package_id = ?
+        `, [
+          CONTENT_OPERATION_PACKAGE_STATES.DRAFT,
+          actor,
+          nowTs,
+          packageId,
+        ]),
+        bindStatement(db, `
+          INSERT INTO content_operation_events (
+            event_id, package_id, release_id, subject_id, event_type,
+            actor_account_id, event_json, created_at
+          )
+          VALUES (?, ?, NULL, ?, ?, ?, ?, ?)
+        `, [
+          uid('coevt'),
+          packageId,
+          packageRow.subject_id,
+          'operation.deleted',
+          actor,
+          JSON.stringify({
+            operationId: operation.operationId,
+            entityType: operation.entityType,
+            entityId: operation.entityId,
+            fieldPath: operation.fieldPath,
+            action: operation.action,
+          }),
+          nowTs,
+        ]),
+      ]);
+
+      return {
+        packageId,
+        operationId,
+        deleted: true,
+        operation,
+      };
     },
 
     async buildContentOperationCandidate(packageId, { actorAccountId = null } = {}) {

--- a/worker/src/content-operations/routes.js
+++ b/worker/src/content-operations/routes.js
@@ -1,0 +1,505 @@
+import { requireMutationCapability } from '../auth.js';
+import { requireSameOrigin } from '../demo/sessions.js';
+import {
+  BadRequestError,
+  ForbiddenError,
+} from '../errors.js';
+import { json, readJson } from '../http.js';
+import {
+  CONTENT_OPERATION_CAPABILITIES,
+  serialiseContentOperation,
+  serialiseContentOperationActor,
+  serialiseContentOperationApproval,
+  serialiseContentOperationCandidate,
+  serialiseContentOperationEvent,
+  serialiseContentOperationOverview,
+  serialiseContentOperationPackage,
+  serialiseContentOperationRelease,
+  serialiseContentOperationStub,
+} from './serialisers.js';
+
+const CONTENT_OPERATIONS_ROUTE_PREFIX = '/api/admin/content-operations';
+const CONTENT_OPERATIONS_SUBJECT_ID = 'spelling';
+const STUBBED_CONTENT_OPERATION_ROUTES = Object.freeze({
+  rebase: { ticket: 'T6', capability: CONTENT_OPERATION_CAPABILITIES.EDIT },
+  'scan-audio': { ticket: 'T7', capability: CONTENT_OPERATION_CAPABILITIES.EDIT },
+  'generate-audio': { ticket: 'T7', capability: CONTENT_OPERATION_CAPABILITIES.EDIT },
+  'upload-monster-asset': { ticket: 'T8', capability: CONTENT_OPERATION_CAPABILITIES.EDIT },
+  'create-revert': { ticket: 'T9', capability: CONTENT_OPERATION_CAPABILITIES.ROLLBACK },
+});
+
+function mutationFromRequest(body = {}, request) {
+  const mutation = body?.mutation && typeof body.mutation === 'object' ? body.mutation : {};
+  return {
+    requestId: body?.requestId || mutation.requestId || request.headers.get('x-ks2-request-id') || null,
+    correlationId: body?.correlationId || mutation.correlationId || request.headers.get('x-ks2-correlation-id') || null,
+  };
+}
+
+function normaliseBody(value) {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+}
+
+function normaliseLimit(value, fallback, maximum) {
+  const limit = Number(value);
+  if (!Number.isFinite(limit) || limit <= 0) return fallback;
+  return Math.min(maximum, Math.max(1, Math.floor(limit)));
+}
+
+function includeSnapshot(url, body = {}) {
+  const value = url.searchParams.get('includeSnapshot') ?? body.includeSnapshot;
+  return value === true || value === 'true' || value === '1';
+}
+
+function decodePathSegment(value, label) {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    throw new BadRequestError(`Invalid ${label}.`, {
+      code: `invalid_${label}`,
+    });
+  }
+}
+
+function isContentOperationPath(pathname) {
+  return pathname === CONTENT_OPERATIONS_ROUTE_PREFIX
+    || pathname.startsWith(`${CONTENT_OPERATIONS_ROUTE_PREFIX}/`);
+}
+
+function relativeContentOperationPath(pathname) {
+  const relative = pathname.slice(CONTENT_OPERATIONS_ROUTE_PREFIX.length);
+  return relative || '/';
+}
+
+function operationPayloadFromBody(body) {
+  if (body.operation && typeof body.operation === 'object' && !Array.isArray(body.operation)) {
+    return body.operation;
+  }
+  return {
+    entityType: body.entityType,
+    entityId: body.entityId,
+    fieldPath: body.fieldPath,
+    action: body.action,
+    payload: Object.prototype.hasOwnProperty.call(body, 'payload') ? body.payload : null,
+    beforeHash: body.beforeHash,
+    afterHash: body.afterHash,
+  };
+}
+
+function proofFromRequest(body, request, action) {
+  if (body.proof && typeof body.proof === 'object' && !Array.isArray(body.proof)) return body.proof;
+  const mutation = mutationFromRequest(body, request);
+  return {
+    source: 'content-operations-api',
+    action,
+    requestId: mutation.requestId,
+    correlationId: mutation.correlationId,
+  };
+}
+
+function badContentOperation(error) {
+  if (error?.status) throw error;
+  const message = String(error?.message || error || 'Invalid content operation.');
+  if (
+    message.startsWith('Unsupported content operation')
+    || message.startsWith('Content operations require')
+    || message.startsWith('Set operations require')
+    || message.startsWith('Cannot ')
+  ) {
+    throw new BadRequestError('Invalid content operation.', {
+      code: 'content_operation_invalid',
+      detail: message,
+    });
+  }
+  throw error;
+}
+
+async function requireContentOperationsActor({ repository, session, capability }) {
+  const actor = await repository.assertAdminHubActorForBundle(session.accountId);
+  if (actor.platformRole !== 'admin') {
+    throw new ForbiddenError('Content operations require admin platform role.', {
+      code: 'content_operations_forbidden',
+      capability,
+      required: 'platform_role:admin',
+      platformRole: actor.platformRole,
+    });
+  }
+  return {
+    ...actor,
+    id: session.accountId,
+    accountId: session.accountId,
+  };
+}
+
+async function requireRouteActor({
+  repository,
+  session,
+  request,
+  env,
+  capability,
+  mutation = false,
+}) {
+  requireSameOrigin(request, env);
+  if (mutation) requireMutationCapability(session);
+  return requireContentOperationsActor({ repository, session, capability });
+}
+
+async function contentOperationPackageDetail(repository, packageId) {
+  const [contentPackage, events] = await Promise.all([
+    repository.readContentOperationPackage(packageId, { includeOperations: true }),
+    repository.listContentOperationEvents({ packageId, limit: 50 }),
+  ]);
+  return {
+    package: serialiseContentOperationPackage(contentPackage),
+    events: events.map(serialiseContentOperationEvent),
+  };
+}
+
+function notFoundRoute() {
+  return json({
+    ok: false,
+    code: 'content_operation_route_not_found',
+    message: 'Content operation route was not found.',
+  }, 404);
+}
+
+export async function handleContentOperationsAdminRequest({
+  url,
+  request,
+  env,
+  session,
+  repository,
+}) {
+  if (!isContentOperationPath(url.pathname)) return null;
+
+  const relativePath = relativeContentOperationPath(url.pathname);
+  requireSameOrigin(request, env);
+
+  if (request.method === 'GET' && relativePath === '/subjects/spelling/overview') {
+    const actor = await requireRouteActor({
+      repository,
+      session,
+      request,
+      env,
+      capability: CONTENT_OPERATION_CAPABILITIES.VIEW,
+    });
+    const limit = normaliseLimit(url.searchParams.get('limit'), 30, 100);
+    const [latestRelease, packages, releases] = await Promise.all([
+      repository.readLatestContentOperationRelease(CONTENT_OPERATIONS_SUBJECT_ID, { includeSnapshot: false }),
+      repository.listContentOperationPackages({ subjectId: CONTENT_OPERATIONS_SUBJECT_ID, limit }),
+      repository.listContentOperationReleases({ subjectId: CONTENT_OPERATIONS_SUBJECT_ID, limit: 10 }),
+    ]);
+    return json({
+      ok: true,
+      overview: serialiseContentOperationOverview({
+        subjectId: CONTENT_OPERATIONS_SUBJECT_ID,
+        latestRelease,
+        packages,
+        releases,
+        actor,
+      }),
+    });
+  }
+
+  if (request.method === 'GET' && relativePath === '/subjects/spelling/releases') {
+    const actor = await requireRouteActor({
+      repository,
+      session,
+      request,
+      env,
+      capability: CONTENT_OPERATION_CAPABILITIES.VIEW,
+    });
+    const releases = await repository.listContentOperationReleases({
+      subjectId: CONTENT_OPERATIONS_SUBJECT_ID,
+      includeSnapshot: includeSnapshot(url),
+      limit: normaliseLimit(url.searchParams.get('limit'), 20, 100),
+    });
+    return json({
+      ok: true,
+      actor: serialiseContentOperationActor(actor),
+      releases: releases.map((release) => serialiseContentOperationRelease(release, {
+        includeSnapshot: includeSnapshot(url),
+      })),
+    });
+  }
+
+  {
+    const releaseMatch = /^\/subjects\/spelling\/releases\/([^/]+)$/.exec(relativePath);
+    if (request.method === 'GET' && releaseMatch) {
+      const actor = await requireRouteActor({
+        repository,
+        session,
+        request,
+        env,
+        capability: CONTENT_OPERATION_CAPABILITIES.VIEW,
+      });
+      const releaseId = decodePathSegment(releaseMatch[1], 'release_id');
+      const release = await repository.readContentOperationRelease(CONTENT_OPERATIONS_SUBJECT_ID, releaseId, {
+        includeSnapshot: includeSnapshot(url),
+      });
+      if (!release) return notFoundRoute();
+      return json({
+        ok: true,
+        actor: serialiseContentOperationActor(actor),
+        release: serialiseContentOperationRelease(release, { includeSnapshot: includeSnapshot(url) }),
+      });
+    }
+  }
+
+  if (request.method === 'POST' && relativePath === '/subjects/spelling/packages') {
+    const actor = await requireRouteActor({
+      repository,
+      session,
+      request,
+      env,
+      capability: CONTENT_OPERATION_CAPABILITIES.EDIT,
+      mutation: true,
+    });
+    const body = normaliseBody(await readJson(request));
+    const contentPackage = await repository.createContentOperationPackage({
+      subjectId: CONTENT_OPERATIONS_SUBJECT_ID,
+      templateId: body.templateId,
+      title: body.title,
+      description: body.description,
+      createdByAccountId: actor.id,
+    });
+    return json({
+      ok: true,
+      actor: serialiseContentOperationActor(actor),
+      package: serialiseContentOperationPackage(contentPackage),
+    }, 201);
+  }
+
+  if (request.method === 'GET' && relativePath === '/packages') {
+    const actor = await requireRouteActor({
+      repository,
+      session,
+      request,
+      env,
+      capability: CONTENT_OPERATION_CAPABILITIES.VIEW,
+    });
+    const state = url.searchParams.get('state');
+    const packages = await repository.listContentOperationPackages({
+      subjectId: CONTENT_OPERATIONS_SUBJECT_ID,
+      state: state && state !== 'all' ? state : null,
+      limit: normaliseLimit(url.searchParams.get('limit'), 50, 100),
+    });
+    return json({
+      ok: true,
+      actor: serialiseContentOperationActor(actor),
+      packages: packages.map((contentPackage) => serialiseContentOperationPackage(contentPackage, { compact: true })),
+    });
+  }
+
+  {
+    const packageDetailMatch = /^\/packages\/([^/]+)$/.exec(relativePath);
+    if (request.method === 'GET' && packageDetailMatch) {
+      const actor = await requireRouteActor({
+        repository,
+        session,
+        request,
+        env,
+        capability: CONTENT_OPERATION_CAPABILITIES.VIEW,
+      });
+      const packageId = decodePathSegment(packageDetailMatch[1], 'package_id');
+      const detail = await contentOperationPackageDetail(repository, packageId);
+      return json({
+        ok: true,
+        actor: serialiseContentOperationActor(actor),
+        ...detail,
+      });
+    }
+
+    if (request.method === 'PATCH' && packageDetailMatch) {
+      const actor = await requireRouteActor({
+        repository,
+        session,
+        request,
+        env,
+        capability: CONTENT_OPERATION_CAPABILITIES.EDIT,
+        mutation: true,
+      });
+      const packageId = decodePathSegment(packageDetailMatch[1], 'package_id');
+      const body = normaliseBody(await readJson(request));
+      const contentPackage = await repository.updateContentOperationPackage(packageId, {
+        templateId: body.templateId,
+        title: body.title,
+        description: body.description,
+      }, {
+        actorAccountId: actor.id,
+      });
+      return json({
+        ok: true,
+        actor: serialiseContentOperationActor(actor),
+        package: serialiseContentOperationPackage(contentPackage),
+      });
+    }
+  }
+
+  {
+    const operationsMatch = /^\/packages\/([^/]+)\/operations$/.exec(relativePath);
+    if (request.method === 'POST' && operationsMatch) {
+      const actor = await requireRouteActor({
+        repository,
+        session,
+        request,
+        env,
+        capability: CONTENT_OPERATION_CAPABILITIES.EDIT,
+        mutation: true,
+      });
+      const packageId = decodePathSegment(operationsMatch[1], 'package_id');
+      const body = normaliseBody(await readJson(request));
+      try {
+        const operation = await repository.appendContentOperation(packageId, operationPayloadFromBody(body), {
+          actorAccountId: actor.id,
+        });
+        return json({
+          ok: true,
+          actor: serialiseContentOperationActor(actor),
+          operation: serialiseContentOperation(operation),
+        }, 201);
+      } catch (error) {
+        badContentOperation(error);
+      }
+    }
+  }
+
+  {
+    const deleteOperationMatch = /^\/packages\/([^/]+)\/operations\/([^/]+)$/.exec(relativePath);
+    if (request.method === 'DELETE' && deleteOperationMatch) {
+      const actor = await requireRouteActor({
+        repository,
+        session,
+        request,
+        env,
+        capability: CONTENT_OPERATION_CAPABILITIES.EDIT,
+        mutation: true,
+      });
+      const packageId = decodePathSegment(deleteOperationMatch[1], 'package_id');
+      const operationId = decodePathSegment(deleteOperationMatch[2], 'operation_id');
+      const result = await repository.deleteContentOperation(packageId, operationId, {
+        actorAccountId: actor.id,
+      });
+      return json({
+        ok: true,
+        actor: serialiseContentOperationActor(actor),
+        deleted: result.deleted,
+        operation: serialiseContentOperation(result.operation),
+      });
+    }
+  }
+
+  {
+    const actionMatch = /^\/packages\/([^/]+)\/(validate|approve|publish|rebase|scan-audio|generate-audio|upload-monster-asset|create-revert)$/.exec(relativePath);
+    if (request.method === 'POST' && actionMatch) {
+      const packageId = decodePathSegment(actionMatch[1], 'package_id');
+      const action = actionMatch[2];
+      const stub = STUBBED_CONTENT_OPERATION_ROUTES[action];
+      const capability = action === 'approve'
+        ? CONTENT_OPERATION_CAPABILITIES.APPROVE
+        : (action === 'publish' ? CONTENT_OPERATION_CAPABILITIES.PUBLISH : (stub?.capability || CONTENT_OPERATION_CAPABILITIES.EDIT));
+      const actor = await requireRouteActor({
+        repository,
+        session,
+        request,
+        env,
+        capability,
+        mutation: true,
+      });
+
+      if (stub) {
+        return json(serialiseContentOperationStub({
+          action,
+          ticket: stub.ticket,
+          capability,
+        }), 501);
+      }
+
+      const body = normaliseBody(await readJson(request));
+      if (action === 'validate') {
+        let candidate;
+        try {
+          candidate = await repository.buildContentOperationCandidate(packageId, {
+            actorAccountId: actor.id,
+          });
+        } catch (error) {
+          badContentOperation(error);
+        }
+        return json({
+          ok: true,
+          actor: serialiseContentOperationActor(actor),
+          candidate: serialiseContentOperationCandidate(candidate, {
+            includeSnapshot: includeSnapshot(url, body),
+          }),
+        });
+      }
+
+      if (action === 'approve') {
+        const candidateId = body.candidateId || body.candidate_id;
+        if (!candidateId) {
+          throw new BadRequestError('Content operation approval requires a candidate id.', {
+            code: 'content_operation_candidate_id_required',
+            packageId,
+          });
+        }
+        const approval = await repository.approveContentOperationCandidate(packageId, candidateId, {
+          approvedByAccountId: actor.id,
+          notes: body.notes,
+          audioFallback: body.audioFallback ?? null,
+          assetSummary: body.assetSummary ?? null,
+        });
+        return json({
+          ok: true,
+          actor: serialiseContentOperationActor(actor),
+          approval: serialiseContentOperationApproval(approval),
+        });
+      }
+
+      const release = await repository.publishContentOperationPackage(packageId, {
+        publishedByAccountId: actor.id,
+        proof: proofFromRequest(body, request, action),
+      });
+      return json({
+        ok: true,
+        actor: serialiseContentOperationActor(actor),
+        release: serialiseContentOperationRelease(release, {
+          includeSnapshot: includeSnapshot(url, body),
+        }),
+      });
+    }
+  }
+
+  {
+    const rollbackMatch = /^\/releases\/([^/]+)\/rollback$/.exec(relativePath);
+    if (request.method === 'POST' && rollbackMatch) {
+      const actor = await requireRouteActor({
+        repository,
+        session,
+        request,
+        env,
+        capability: CONTENT_OPERATION_CAPABILITIES.ROLLBACK,
+        mutation: true,
+      });
+      const releaseId = decodePathSegment(rollbackMatch[1], 'release_id');
+      const body = normaliseBody(await readJson(request));
+      const release = await repository.rollbackContentOperationRelease(CONTENT_OPERATIONS_SUBJECT_ID, releaseId, {
+        rolledBackByAccountId: actor.id,
+        proof: proofFromRequest(body, request, 'rollback'),
+      });
+      return json({
+        ok: true,
+        actor: serialiseContentOperationActor(actor),
+        release: serialiseContentOperationRelease(release, {
+          includeSnapshot: includeSnapshot(url, body),
+        }),
+      });
+    }
+  }
+
+  await requireContentOperationsActor({
+    repository,
+    session,
+    capability: CONTENT_OPERATION_CAPABILITIES.VIEW,
+  });
+  return notFoundRoute();
+}

--- a/worker/src/content-operations/serialisers.js
+++ b/worker/src/content-operations/serialisers.js
@@ -1,0 +1,349 @@
+import {
+  CONTENT_OPERATION_PACKAGE_STATES,
+  CONTENT_OPERATION_SUBJECT_ID,
+} from '../../../src/subjects/spelling/content/operations-model.js';
+
+export const CONTENT_OPERATION_CAPABILITIES = Object.freeze({
+  VIEW: 'content_operations.view',
+  EDIT: 'content_operations.edit',
+  APPROVE: 'content_operations.approve',
+  PUBLISH: 'content_operations.publish',
+  ROLLBACK: 'content_operations.rollback',
+});
+
+export const CONTENT_OPERATION_CAPABILITY_LABELS = Object.freeze({
+  [CONTENT_OPERATION_CAPABILITIES.VIEW]: 'View content operations',
+  [CONTENT_OPERATION_CAPABILITIES.EDIT]: 'Edit content packages',
+  [CONTENT_OPERATION_CAPABILITIES.APPROVE]: 'Approve content packages',
+  [CONTENT_OPERATION_CAPABILITIES.PUBLISH]: 'Publish content packages',
+  [CONTENT_OPERATION_CAPABILITIES.ROLLBACK]: 'Roll back content releases',
+});
+
+const CONTENT_OPERATION_SECTION_KEYS = Object.freeze([
+  'validation',
+  'conflicts',
+  'audio',
+  'assets',
+  'rewards',
+  'visibility',
+  'exposure',
+  'publishReadiness',
+]);
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function normaliseValidation(validation = null) {
+  if (!validation || typeof validation !== 'object' || Array.isArray(validation)) {
+    return {
+      status: 'not_run',
+      ok: null,
+      errorCount: 0,
+      warningCount: 0,
+      errors: [],
+      warnings: [],
+    };
+  }
+  const errors = asArray(validation.errors);
+  const warnings = asArray(validation.warnings);
+  const ok = Boolean(validation.ok);
+  return {
+    status: ok ? 'passed' : 'blocked',
+    ok,
+    errorCount: Number(validation.errorCount ?? errors.length) || 0,
+    warningCount: Number(validation.warningCount ?? warnings.length) || 0,
+    errors,
+    warnings,
+  };
+}
+
+function normaliseConflictSection(conflicts = null) {
+  if (!Array.isArray(conflicts)) {
+    return {
+      status: 'not_run',
+      count: 0,
+      items: [],
+    };
+  }
+  return {
+    status: conflicts.length ? 'blocked' : 'passed',
+    count: conflicts.length,
+    items: conflicts,
+  };
+}
+
+function normaliseReadinessSection(value = null, fallbackStatus = 'not_scanned') {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {
+      status: fallbackStatus,
+      blockers: [],
+      warnings: [],
+    };
+  }
+  return {
+    status: typeof value.status === 'string' && value.status ? value.status : fallbackStatus,
+    blockers: asArray(value.blockers),
+    warnings: asArray(value.warnings),
+  };
+}
+
+export function buildContentOperationBlockerEnvelope({
+  validation = null,
+  conflicts = null,
+  audio = null,
+  assets = null,
+  rewards = null,
+  visibility = null,
+  exposure = null,
+  publishReadiness = null,
+} = {}) {
+  const validationSection = normaliseValidation(validation);
+  const conflictSection = normaliseConflictSection(conflicts);
+  const audioSection = normaliseReadinessSection(audio);
+  const assetSection = normaliseReadinessSection(assets);
+  const rewardSection = normaliseReadinessSection(rewards);
+  const visibilitySection = normaliseReadinessSection(visibility);
+  const exposureSection = normaliseReadinessSection(exposure);
+  const blockingSections = [
+    validationSection.errorCount ? 'validation' : null,
+    conflictSection.count ? 'conflicts' : null,
+    audioSection.blockers.length ? 'audio' : null,
+    assetSection.blockers.length ? 'assets' : null,
+    rewardSection.blockers.length ? 'rewards' : null,
+    visibilitySection.blockers.length ? 'visibility' : null,
+    exposureSection.blockers.length ? 'exposure' : null,
+  ].filter(Boolean);
+  const readinessSection = publishReadiness
+    ? normaliseReadinessSection(publishReadiness, 'not_ready')
+    : {
+      status: blockingSections.length ? 'blocked' : 'not_ready',
+      blockers: blockingSections,
+      warnings: [
+        ...validationSection.warnings,
+        ...audioSection.warnings,
+        ...assetSection.warnings,
+        ...rewardSection.warnings,
+        ...visibilitySection.warnings,
+        ...exposureSection.warnings,
+      ],
+    };
+
+  return {
+    validation: validationSection,
+    conflicts: conflictSection,
+    audio: audioSection,
+    assets: assetSection,
+    rewards: rewardSection,
+    visibility: visibilitySection,
+    exposure: exposureSection,
+    publishReadiness: readinessSection,
+  };
+}
+
+function packagePublishReadiness(contentPackage = {}) {
+  if (contentPackage.state === CONTENT_OPERATION_PACKAGE_STATES.PUBLISHED) {
+    return {
+      status: 'published',
+      blockers: ['already_published'],
+      warnings: [],
+    };
+  }
+  if (contentPackage.state === CONTENT_OPERATION_PACKAGE_STATES.APPROVED) {
+    return {
+      status: 'ready',
+      blockers: [],
+      warnings: [],
+    };
+  }
+  return {
+    status: 'not_ready',
+    blockers: ['approval_required'],
+    warnings: [],
+  };
+}
+
+export function serialiseContentOperationActor(actor = {}) {
+  const platformRole = actor?.platformRole || actor?.platform_role || 'parent';
+  const isAdmin = platformRole === 'admin';
+  return {
+    accountId: actor?.id || actor?.accountId || null,
+    platformRole,
+    capabilities: {
+      [CONTENT_OPERATION_CAPABILITIES.VIEW]: isAdmin,
+      [CONTENT_OPERATION_CAPABILITIES.EDIT]: isAdmin,
+      [CONTENT_OPERATION_CAPABILITIES.APPROVE]: isAdmin,
+      [CONTENT_OPERATION_CAPABILITIES.PUBLISH]: isAdmin,
+      [CONTENT_OPERATION_CAPABILITIES.ROLLBACK]: isAdmin,
+    },
+  };
+}
+
+export function serialiseContentOperationPackage(contentPackage = {}, { compact = false } = {}) {
+  const envelope = buildContentOperationBlockerEnvelope({
+    publishReadiness: packagePublishReadiness(contentPackage),
+  });
+  const base = {
+    packageId: contentPackage.packageId,
+    subjectId: contentPackage.subjectId || CONTENT_OPERATION_SUBJECT_ID,
+    templateId: contentPackage.templateId || 'general',
+    title: contentPackage.title || '',
+    description: compact ? undefined : (contentPackage.description || ''),
+    baseReleaseId: contentPackage.baseReleaseId || null,
+    baseReleaseHash: contentPackage.baseReleaseHash || null,
+    state: contentPackage.state || CONTENT_OPERATION_PACKAGE_STATES.DRAFT,
+    createdByAccountId: compact ? undefined : (contentPackage.createdByAccountId || null),
+    updatedByAccountId: compact ? undefined : (contentPackage.updatedByAccountId || null),
+    createdAt: Number(contentPackage.createdAt) || 0,
+    updatedAt: Number(contentPackage.updatedAt) || 0,
+    approvedAt: contentPackage.approvedAt ?? null,
+    publishedAt: contentPackage.publishedAt ?? null,
+    supersededByPackageId: contentPackage.supersededByPackageId || null,
+    operationCount: Array.isArray(contentPackage.operations) ? contentPackage.operations.length : undefined,
+    blockers: envelope,
+  };
+  if (!compact && Array.isArray(contentPackage.operations)) {
+    base.operations = contentPackage.operations.map(serialiseContentOperation);
+  }
+  return Object.fromEntries(Object.entries(base).filter(([, value]) => value !== undefined));
+}
+
+export function serialiseContentOperation(operation = {}) {
+  return {
+    operationId: operation.operationId,
+    packageId: operation.packageId,
+    operationOrder: Number(operation.operationOrder) || 0,
+    entityType: operation.entityType,
+    entityId: operation.entityId,
+    fieldPath: operation.fieldPath || '',
+    action: operation.action,
+    beforeHash: operation.beforeHash || '',
+    afterHash: operation.afterHash || '',
+    payload: operation.payload ?? null,
+    createdByAccountId: operation.createdByAccountId || null,
+    createdAt: Number(operation.createdAt) || 0,
+  };
+}
+
+export function serialiseContentOperationCandidate(candidate = {}, { includeSnapshot = false } = {}) {
+  return {
+    candidateId: candidate.candidateId,
+    packageId: candidate.packageId,
+    baseReleaseId: candidate.baseReleaseId || null,
+    currentReleaseId: candidate.currentReleaseId || null,
+    operationsHash: candidate.operationsHash || '',
+    candidateHash: candidate.candidateHash || '',
+    validation: normaliseValidation(candidate.validation),
+    blockers: buildContentOperationBlockerEnvelope({
+      validation: candidate.validation,
+      conflicts: candidate.conflicts,
+      audio: candidate.audioScan,
+      assets: candidate.assetScan,
+      rewards: candidate.rewardScan,
+      visibility: candidate.visibilityScan,
+    }),
+    conflicts: asArray(candidate.conflicts),
+    createdAt: Number(candidate.createdAt) || 0,
+    ...(includeSnapshot ? { candidate: candidate.candidate || null } : {}),
+  };
+}
+
+export function serialiseContentOperationApproval(approval = {}) {
+  return {
+    approvalId: approval.approvalId,
+    packageId: approval.packageId,
+    candidateId: approval.candidateId,
+    candidateHash: approval.candidateHash,
+    approvedByAccountId: approval.approvedByAccountId,
+    approvedAt: Number(approval.approvedAt) || 0,
+    notes: approval.notes || '',
+    validationSummary: normaliseValidation(approval.validationSummary),
+    audioFallback: approval.audioFallback ?? null,
+    assetSummary: approval.assetSummary ?? null,
+  };
+}
+
+export function serialiseContentOperationRelease(release = {}, { includeSnapshot = false } = {}) {
+  return {
+    releaseId: release.releaseId,
+    subjectId: release.subjectId || CONTENT_OPERATION_SUBJECT_ID,
+    status: release.status || 'unknown',
+    snapshotHash: release.snapshotHash || '',
+    baseReleaseId: release.baseReleaseId || null,
+    packageId: release.packageId || null,
+    publishedAt: release.publishedAt ?? null,
+    publishedByAccountId: release.publishedByAccountId || null,
+    rollbackOfReleaseId: release.rollbackOfReleaseId || null,
+    proof: release.proof ?? null,
+    createdAt: Number(release.createdAt) || 0,
+    ...(includeSnapshot ? { snapshot: release.snapshot || null } : {}),
+  };
+}
+
+export function serialiseContentOperationEvent(event = {}) {
+  return {
+    eventId: event.eventId,
+    packageId: event.packageId || null,
+    releaseId: event.releaseId || null,
+    subjectId: event.subjectId || CONTENT_OPERATION_SUBJECT_ID,
+    eventType: event.eventType || '',
+    actorAccountId: event.actorAccountId || null,
+    event: event.event || {},
+    createdAt: Number(event.createdAt) || 0,
+  };
+}
+
+export function serialiseContentOperationOverview({
+  subjectId = CONTENT_OPERATION_SUBJECT_ID,
+  latestRelease = null,
+  packages = [],
+  releases = [],
+  actor = null,
+} = {}) {
+  const packageCounts = packages.reduce((counts, contentPackage) => {
+    const state = contentPackage.state || 'unknown';
+    counts[state] = (counts[state] || 0) + 1;
+    return counts;
+  }, {});
+
+  return {
+    subjectId,
+    latestRelease: latestRelease ? serialiseContentOperationRelease(latestRelease) : null,
+    packageCounts,
+    lanes: {
+      blocked: packages.filter((entry) => entry.state === CONTENT_OPERATION_PACKAGE_STATES.BLOCKED).map((entry) => serialiseContentOperationPackage(entry, { compact: true })),
+      readyForApproval: packages.filter((entry) => entry.state === CONTENT_OPERATION_PACKAGE_STATES.READY_FOR_APPROVAL).map((entry) => serialiseContentOperationPackage(entry, { compact: true })),
+      approvedPendingPublish: packages.filter((entry) => entry.state === CONTENT_OPERATION_PACKAGE_STATES.APPROVED).map((entry) => serialiseContentOperationPackage(entry, { compact: true })),
+      drafts: packages.filter((entry) => entry.state === CONTENT_OPERATION_PACKAGE_STATES.DRAFT).map((entry) => serialiseContentOperationPackage(entry, { compact: true })),
+      recentReleases: releases.map((entry) => serialiseContentOperationRelease(entry)),
+    },
+    actor: actor ? serialiseContentOperationActor(actor) : null,
+    sections: [...CONTENT_OPERATION_SECTION_KEYS],
+  };
+}
+
+export function serialiseContentOperationStub({
+  action,
+  ticket,
+  capability,
+  message = 'This content operations route is reserved for a later ticket.',
+} = {}) {
+  return {
+    ok: false,
+    code: 'content_operation_route_not_implemented',
+    message,
+    stub: {
+      action,
+      ticket,
+      capability,
+      implemented: false,
+    },
+    blockers: buildContentOperationBlockerEnvelope({
+      publishReadiness: {
+        status: 'blocked',
+        blockers: ['route_not_implemented'],
+        warnings: [],
+      },
+    }),
+  };
+}


### PR DESCRIPTION
## Summary
- add the admin content operations API router for spelling package overview, package editing, validation, approval, publish, release detail, and rollback
- keep view/edit/approve/publish/rollback capability names distinct while mapping this ticket to the current admin platform role
- add compact serialisers plus stable blocker envelopes for validation, conflicts, audio, assets, rewards, visibility, exposure, and publish readiness
- add package update/delete helpers that invalidate approvals when draft contents change
- cover admin-only access, lifecycle API flow, first-release publish blockers, stubbed batch route envelopes, and safe-copy preservation

## Verification
- node --check worker/src/content-operations/routes.js
- node --check worker/src/content-operations/serialisers.js
- node --check worker/src/content-operations/repository.js
- node --check worker/src/app.js
- node --test tests/content-operations-api.test.js tests/content-operations-repository.test.js tests/admin-safe-copy.test.js
- node --test tests/content-operations-api.test.js
- npm test
- npm run check
- pre-push npm test