### PR TITLE
feat(content-ops): add admin operations shell

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2713,8 +2713,16 @@ function buildCodexModel(appState, context) {
 }
 
 function buildSurfaceActions() {
+  const contentOperationsApi = hubApi ? {
+    readOverview: hubApi.readContentOperationsOverview?.bind(hubApi),
+    readPackages: hubApi.readContentOperationPackages?.bind(hubApi),
+    readPackage: hubApi.readContentOperationPackage?.bind(hubApi),
+    readReleases: hubApi.readContentOperationReleases?.bind(hubApi),
+    readRelease: hubApi.readContentOperationRelease?.bind(hubApi),
+  } : null;
   return {
     dispatch: dispatchAction,
+    contentOperationsApi,
     flushSpellingDeferredAudio: () => controller.flushDeferredAudio(),
     toggleTheme: () => dispatchAction('toggle-theme'),
     selectLearner: (value) => dispatchAction('learner-select', { value }),

--- a/src/platform/hubs/admin-content-operations.js
+++ b/src/platform/hubs/admin-content-operations.js
@@ -1,0 +1,248 @@
+const PACKAGE_STATE_LABELS = Object.freeze({
+  draft: 'Draft',
+  ready_for_approval: 'Ready for approval',
+  approved: 'Approved',
+  published: 'Published',
+  rejected: 'Rejected',
+  blocked: 'Blocked',
+  reverted: 'Reverted',
+  superseded: 'Superseded',
+});
+
+const PACKAGE_STATE_CHIP_CLASS = Object.freeze({
+  draft: '',
+  ready_for_approval: 'warn',
+  approved: 'good',
+  published: 'good',
+  rejected: 'bad',
+  blocked: 'bad',
+  reverted: 'warn',
+  superseded: '',
+});
+
+export const CONTENT_OPERATION_LANES = Object.freeze([
+  {
+    key: 'blocked',
+    label: 'Blocked',
+    emptyLabel: 'No blocked packages',
+    chipClass: 'bad',
+  },
+  {
+    key: 'readyForApproval',
+    label: 'Ready for approval',
+    emptyLabel: 'Nothing waiting for approval',
+    chipClass: 'warn',
+  },
+  {
+    key: 'approvedPendingPublish',
+    label: 'Approved pending publish',
+    emptyLabel: 'Nothing approved for publish',
+    chipClass: 'good',
+  },
+  {
+    key: 'drafts',
+    label: 'Open drafts',
+    emptyLabel: 'No open draft packages',
+    chipClass: '',
+  },
+]);
+
+export const CONTENT_OPERATION_DETAIL_TABS = Object.freeze([
+  { key: 'spelling', label: 'Spelling' },
+  { key: 'audio', label: 'Audio' },
+  { key: 'poolsRewards', label: 'Pools & Rewards' },
+  { key: 'monstersAssets', label: 'Monsters & Assets' },
+  { key: 'heroCodex', label: 'Hero / Codex' },
+  { key: 'approvals', label: 'Approvals' },
+  { key: 'audit', label: 'Audit' },
+]);
+
+const BLOCKER_SECTION_KEYS = Object.freeze([
+  'validation',
+  'conflicts',
+  'audio',
+  'assets',
+  'rewards',
+  'visibility',
+  'exposure',
+  'publishReadiness',
+]);
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function asString(value, fallback = '') {
+  return typeof value === 'string' && value ? value : fallback;
+}
+
+function asNullableString(value) {
+  return typeof value === 'string' && value ? value : null;
+}
+
+function asTs(value) {
+  const ts = Number(value);
+  return Number.isFinite(ts) && ts > 0 ? ts : null;
+}
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function normaliseBlockerSection(section = null) {
+  const safe = isPlainObject(section) ? section : {};
+  const blockers = asArray(safe.blockers);
+  const warnings = asArray(safe.warnings);
+  const errors = asArray(safe.errors);
+  const validationErrors = Number(safe.errorCount ?? errors.length) || 0;
+  const conflictCount = Number(safe.count) || 0;
+  const count = blockers.length + validationErrors + conflictCount;
+  return {
+    status: asString(safe.status, 'not_run'),
+    count,
+    blockers,
+    warnings,
+    errors,
+    errorCount: validationErrors,
+    warningCount: Number(safe.warningCount ?? warnings.length) || 0,
+    items: asArray(safe.items),
+  };
+}
+
+export function normaliseContentOperationBlockers(blockers = null) {
+  const safe = isPlainObject(blockers) ? blockers : {};
+  const sections = Object.fromEntries(
+    BLOCKER_SECTION_KEYS.map((key) => [key, normaliseBlockerSection(safe[key])]),
+  );
+  const blockingSections = BLOCKER_SECTION_KEYS.filter((key) => sections[key].count > 0);
+  const warningSections = BLOCKER_SECTION_KEYS.filter((key) => (
+    sections[key].warningCount > 0 || sections[key].warnings.length > 0
+  ));
+  return {
+    ...sections,
+    blockingSections,
+    warningSections,
+    blockerCount: blockingSections.length,
+    warningCount: warningSections.length,
+  };
+}
+
+export function packageStateLabel(state) {
+  return PACKAGE_STATE_LABELS[state] || 'Unknown';
+}
+
+export function packageStateChipClass(state) {
+  return PACKAGE_STATE_CHIP_CLASS[state] || '';
+}
+
+export function normaliseContentOperationActor(actor = null) {
+  const safe = isPlainObject(actor) ? actor : {};
+  const capabilities = isPlainObject(safe.capabilities) ? safe.capabilities : {};
+  return {
+    accountId: asNullableString(safe.accountId),
+    platformRole: asString(safe.platformRole, 'parent'),
+    capabilities: { ...capabilities },
+  };
+}
+
+export function normaliseContentOperationPackage(entry = null) {
+  const safe = isPlainObject(entry) ? entry : {};
+  const state = asString(safe.state, 'draft');
+  const operations = asArray(safe.operations);
+  const explicitOperationCount = Number(safe.operationCount);
+  const hasExplicitOperationCount = safe.operationCount !== null && safe.operationCount !== undefined;
+  const operationCount = hasExplicitOperationCount && Number.isFinite(explicitOperationCount) && explicitOperationCount >= 0
+    ? Math.floor(explicitOperationCount)
+    : (operations.length ? operations.length : null);
+  return {
+    packageId: asString(safe.packageId),
+    subjectId: asString(safe.subjectId, 'spelling'),
+    templateId: asString(safe.templateId, 'general'),
+    title: asString(safe.title, 'Untitled package'),
+    description: asString(safe.description),
+    baseReleaseId: asNullableString(safe.baseReleaseId),
+    baseReleaseHash: asNullableString(safe.baseReleaseHash),
+    state,
+    stateLabel: packageStateLabel(state),
+    chipClass: packageStateChipClass(state),
+    createdByAccountId: asNullableString(safe.createdByAccountId),
+    updatedByAccountId: asNullableString(safe.updatedByAccountId),
+    createdAt: asTs(safe.createdAt),
+    updatedAt: asTs(safe.updatedAt),
+    approvedAt: asTs(safe.approvedAt),
+    publishedAt: asTs(safe.publishedAt),
+    supersededByPackageId: asNullableString(safe.supersededByPackageId),
+    operationCount,
+    operations,
+    blockers: normaliseContentOperationBlockers(safe.blockers),
+  };
+}
+
+export function normaliseContentOperationRelease(entry = null) {
+  const safe = isPlainObject(entry) ? entry : {};
+  return {
+    releaseId: asString(safe.releaseId),
+    subjectId: asString(safe.subjectId, 'spelling'),
+    status: asString(safe.status, 'unknown'),
+    snapshotHash: asString(safe.snapshotHash),
+    baseReleaseId: asNullableString(safe.baseReleaseId),
+    packageId: asNullableString(safe.packageId),
+    publishedAt: asTs(safe.publishedAt),
+    publishedByAccountId: asNullableString(safe.publishedByAccountId),
+    rollbackOfReleaseId: asNullableString(safe.rollbackOfReleaseId),
+    proof: safe.proof ?? null,
+    createdAt: asTs(safe.createdAt),
+  };
+}
+
+function normaliseLanePackages(lanes, key) {
+  return asArray(lanes?.[key]).map(normaliseContentOperationPackage);
+}
+
+export function normaliseContentOperationsOverview(payload = null) {
+  const overview = isPlainObject(payload?.overview) ? payload.overview : payload;
+  const safe = isPlainObject(overview) ? overview : {};
+  const lanes = isPlainObject(safe.lanes) ? safe.lanes : {};
+  const normalisedLanes = Object.fromEntries(
+    CONTENT_OPERATION_LANES.map((lane) => [lane.key, normaliseLanePackages(lanes, lane.key)]),
+  );
+  const latestRelease = safe.latestRelease ? normaliseContentOperationRelease(safe.latestRelease) : null;
+  const recentReleases = asArray(lanes.recentReleases).map(normaliseContentOperationRelease);
+  const packageCounts = isPlainObject(safe.packageCounts) ? { ...safe.packageCounts } : {};
+  const actor = normaliseContentOperationActor(safe.actor || payload?.actor);
+  const laneCounts = Object.fromEntries(
+    CONTENT_OPERATION_LANES.map((lane) => [lane.key, normalisedLanes[lane.key].length]),
+  );
+  return {
+    subjectId: asString(safe.subjectId, 'spelling'),
+    latestRelease,
+    packageCounts,
+    lanes: normalisedLanes,
+    laneCounts,
+    recentReleases,
+    actor,
+    sections: asArray(safe.sections),
+    openPackageCount: CONTENT_OPERATION_LANES
+      .reduce((sum, lane) => sum + normalisedLanes[lane.key].length, 0),
+  };
+}
+
+export function normaliseContentOperationsPackageList(payload = null) {
+  const list = Array.isArray(payload) ? payload : payload?.packages;
+  return asArray(list).map(normaliseContentOperationPackage);
+}
+
+export function normaliseContentOperationsReleaseList(payload = null) {
+  const list = Array.isArray(payload) ? payload : payload?.releases;
+  return asArray(list).map(normaliseContentOperationRelease);
+}
+
+export function normaliseContentOperationsPackageDetail(payload = null) {
+  const safe = isPlainObject(payload) ? payload : {};
+  const contentPackage = safe.package || (safe.packageId ? safe : null);
+  return {
+    package: contentPackage ? normaliseContentOperationPackage(contentPackage) : null,
+    events: asArray(safe.events),
+    actor: normaliseContentOperationActor(safe.actor),
+  };
+}

--- a/src/platform/hubs/api.js
+++ b/src/platform/hubs/api.js
@@ -262,6 +262,50 @@ export function createHubApi({
         body: JSON.stringify({ version, expectedPublishedVersion, mutation }),
       }, authSession);
     },
+    async readContentOperationsOverview({ limit = 30 } = {}) {
+      const url = buildRequestUrl(
+        baseUrl,
+        '/api/admin/content-operations/subjects/spelling/overview',
+        { limit },
+      );
+      return fetchHubJson(fetch, url, { method: 'GET' }, authSession);
+    },
+    async readContentOperationPackages({ state = null, limit = 50 } = {}) {
+      const url = buildRequestUrl(baseUrl, '/api/admin/content-operations/packages', {
+        state,
+        limit,
+      });
+      return fetchHubJson(fetch, url, { method: 'GET' }, authSession);
+    },
+    async readContentOperationPackage({ packageId } = {}) {
+      if (!packageId) throw new TypeError('Content operation package id is required.');
+      const safePackageId = encodeURIComponent(String(packageId));
+      const url = buildRequestUrl(baseUrl, `/api/admin/content-operations/packages/${safePackageId}`);
+      return fetchHubJson(fetch, url, { method: 'GET' }, authSession);
+    },
+    async readContentOperationReleases({ limit = 20, includeSnapshot = false } = {}) {
+      const url = buildRequestUrl(
+        baseUrl,
+        '/api/admin/content-operations/subjects/spelling/releases',
+        {
+          limit,
+          includeSnapshot: includeSnapshot ? 'true' : null,
+        },
+      );
+      return fetchHubJson(fetch, url, { method: 'GET' }, authSession);
+    },
+    async readContentOperationRelease({ releaseId, includeSnapshot = false } = {}) {
+      if (!releaseId) throw new TypeError('Content operation release id is required.');
+      const safeReleaseId = encodeURIComponent(String(releaseId));
+      const url = buildRequestUrl(
+        baseUrl,
+        `/api/admin/content-operations/subjects/spelling/releases/${safeReleaseId}`,
+        {
+          includeSnapshot: includeSnapshot ? 'true' : null,
+        },
+      );
+      return fetchHubJson(fetch, url, { method: 'GET' }, authSession);
+    },
     async readAdminOpsKpi() {
       const url = buildRequestUrl(baseUrl, '/api/admin/ops/kpi');
       return fetchHubJson(fetch, url, { method: 'GET' }, authSession);

--- a/src/surfaces/hubs/AdminContentOperationsSection.jsx
+++ b/src/surfaces/hubs/AdminContentOperationsSection.jsx
@@ -1,0 +1,740 @@
+import React from 'react';
+import { AdminPanelFrame } from './AdminPanelFrame.jsx';
+import { formatTimestamp } from './hub-utils.js';
+import {
+  CONTENT_OPERATION_DETAIL_TABS,
+  CONTENT_OPERATION_LANES,
+  normaliseContentOperationPackage,
+  normaliseContentOperationsOverview,
+  normaliseContentOperationsPackageDetail,
+  normaliseContentOperationsPackageList,
+  normaliseContentOperationsReleaseList,
+} from '../../platform/hubs/admin-content-operations.js';
+
+const CENTRE_TABS = Object.freeze([
+  { key: 'overview', label: 'Overview' },
+  { key: 'packages', label: 'Packages' },
+  { key: 'spelling', label: 'Spelling' },
+  { key: 'audio', label: 'Audio' },
+  { key: 'poolsRewards', label: 'Pools & Rewards' },
+  { key: 'monstersAssets', label: 'Monsters & Assets' },
+  { key: 'heroCodex', label: 'Hero / Codex' },
+  { key: 'approvals', label: 'Approvals' },
+  { key: 'releases', label: 'Release history' },
+]);
+
+const DETAIL_TAB_BLOCKER_SECTIONS = Object.freeze({
+  spelling: 'validation',
+  audio: 'audio',
+  poolsRewards: 'rewards',
+  monstersAssets: 'assets',
+  heroCodex: 'exposure',
+});
+
+function collectLanePackages(overview) {
+  const seen = new Set();
+  const packages = [];
+  for (const lane of CONTENT_OPERATION_LANES) {
+    for (const entry of overview.lanes[lane.key] || []) {
+      if (!entry.packageId || seen.has(entry.packageId)) continue;
+      seen.add(entry.packageId);
+      packages.push(entry);
+    }
+  }
+  return packages;
+}
+
+function initialPackageId({ packageDetail, initialActiveTab, initialSelectedPackageId }) {
+  if (initialSelectedPackageId) return initialSelectedPackageId;
+  if (initialActiveTab !== 'detail') return '';
+  const detail = normaliseContentOperationsPackageDetail(packageDetail);
+  return detail.package?.packageId || '';
+}
+
+function errorEnvelope(error, fallbackCode = 'content_operations_fetch_failed') {
+  if (!error) return null;
+  return {
+    code: error.code || fallbackCode,
+    message: error.message || 'Content operations could not be loaded.',
+    at: Date.now(),
+  };
+}
+
+function operationCountLabel(contentPackage, variant = 'short') {
+  const rawCount = contentPackage?.operationCount;
+  const count = Number(rawCount);
+  if (rawCount === null || rawCount === undefined || !Number.isFinite(count)) {
+    if (variant === 'table') return 'Pending';
+    if (variant === 'long') return 'Operation count pending';
+    return 'Pending ops';
+  }
+  if (variant === 'table') return String(count);
+  if (variant === 'long') return `${String(count)} ${count === 1 ? 'operation' : 'operations'}`;
+  return `${String(count)} ops`;
+}
+
+function blockerSectionHasSignals(section) {
+  return Boolean(section && (
+    section.count > 0
+      || section.warningCount > 0
+      || section.blockers?.length
+      || section.errors?.length
+      || section.warnings?.length
+  ));
+}
+
+function hasAudioOrAssetSignals(contentPackage) {
+  return blockerSectionHasSignals(contentPackage.blockers?.audio)
+    || blockerSectionHasSignals(contentPackage.blockers?.assets);
+}
+
+function PackageStateChip({ contentPackage }) {
+  return (
+    <span className={`chip ${contentPackage.chipClass}`} data-package-state={contentPackage.state}>
+      {contentPackage.stateLabel}
+    </span>
+  );
+}
+
+function MetricTile({ label, value, detail }) {
+  return (
+    <div className="content-ops-metric">
+      <span className="small muted">{label}</span>
+      <strong>{value}</strong>
+      {detail ? <span className="small muted">{detail}</span> : null}
+    </div>
+  );
+}
+
+function CentreTabNav({ activeTab, onSelect }) {
+  return (
+    <div className="content-ops-tabs" role="tablist" aria-label="Content operations views">
+      {CENTRE_TABS.map((tab) => (
+        <button
+          key={tab.key}
+          className="content-ops-tab"
+          type="button"
+          role="tab"
+          aria-selected={activeTab === tab.key ? 'true' : 'false'}
+          data-active={activeTab === tab.key ? 'true' : undefined}
+          onClick={() => onSelect(tab.key)}
+        >
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function DetailTabNav({ activeTab, onSelect }) {
+  return (
+    <div className="content-ops-detail-tabs" role="tablist" aria-label="Package detail domains">
+      {CONTENT_OPERATION_DETAIL_TABS.map((tab) => (
+        <button
+          key={tab.key}
+          className="content-ops-detail-tab"
+          type="button"
+          role="tab"
+          aria-selected={activeTab === tab.key ? 'true' : 'false'}
+          data-active={activeTab === tab.key ? 'true' : undefined}
+          onClick={() => onSelect(tab.key)}
+        >
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function PackageSummary({ contentPackage, onSelect }) {
+  return (
+    <button
+      type="button"
+      className="content-ops-package-summary"
+      onClick={() => onSelect(contentPackage.packageId)}
+      data-package-id={contentPackage.packageId}
+    >
+      <span className="content-ops-package-summary-main">
+        <strong>{contentPackage.title}</strong>
+        <span className="small muted">{contentPackage.packageId || 'package pending'}</span>
+      </span>
+      <span className="chip-row content-ops-package-summary-meta">
+        <PackageStateChip contentPackage={contentPackage} />
+        <span className="chip">{operationCountLabel(contentPackage)}</span>
+      </span>
+    </button>
+  );
+}
+
+function OverviewLanes({ overview, onSelectPackage }) {
+  const warningPackages = collectLanePackages(overview).filter(hasAudioOrAssetSignals);
+  return (
+    <div className="content-ops-lanes">
+      {CONTENT_OPERATION_LANES.map((lane) => {
+        const packages = overview.lanes[lane.key] || [];
+        return (
+          <article className="content-ops-lane" key={lane.key} data-lane={lane.key}>
+            <div className="content-ops-lane-header">
+              <span className={`chip ${lane.chipClass}`}>{lane.label}</span>
+              <strong>{packages.length}</strong>
+            </div>
+            <div className="content-ops-lane-body">
+              {packages.length ? packages.slice(0, 4).map((contentPackage) => (
+                <PackageSummary
+                  key={contentPackage.packageId}
+                  contentPackage={contentPackage}
+                  onSelect={onSelectPackage}
+                />
+              )) : (
+                <span className="small muted">{lane.emptyLabel}</span>
+              )}
+            </div>
+          </article>
+        );
+      })}
+      <article className="content-ops-lane" data-lane="audioAssetWarnings">
+        <div className="content-ops-lane-header">
+          <span className="chip warn">Audio / asset warnings</span>
+          <strong>{warningPackages.length}</strong>
+        </div>
+        <div className="content-ops-lane-body">
+          {warningPackages.length ? warningPackages.slice(0, 4).map((contentPackage) => (
+            <PackageSummary
+              key={contentPackage.packageId}
+              contentPackage={contentPackage}
+              onSelect={onSelectPackage}
+            />
+          )) : (
+            <span className="small muted">No missing audio or asset warnings</span>
+          )}
+        </div>
+      </article>
+      <article className="content-ops-lane" data-lane="recentReleases">
+        <div className="content-ops-lane-header">
+          <span className="chip good">Recent releases</span>
+          <strong>{overview.recentReleases.length}</strong>
+        </div>
+        <div className="content-ops-lane-body">
+          {overview.recentReleases.length ? overview.recentReleases.slice(0, 4).map((release) => (
+            <div className="content-ops-release-summary" key={release.releaseId}>
+              <strong>{release.releaseId}</strong>
+              <span className="small muted">{formatTimestamp(release.publishedAt || release.createdAt)}</span>
+            </div>
+          )) : (
+            <span className="small muted">No recent releases</span>
+          )}
+        </div>
+      </article>
+    </div>
+  );
+}
+
+function BlockerSummary({ blockers, sectionKey }) {
+  const section = blockers?.[sectionKey] || null;
+  if (!section) return null;
+  const hasBlockers = section.count > 0 || section.blockers?.length || section.errors?.length;
+  const hasWarnings = section.warningCount > 0 || section.warnings?.length;
+  if (!hasBlockers && !hasWarnings) {
+    return <span className="chip good">{section.status || 'Ready'}</span>;
+  }
+  return (
+    <div className="content-ops-blocker-summary">
+      <div className="chip-row content-ops-chip-wrap">
+        <span className={`chip ${hasBlockers ? 'bad' : 'warn'}`}>{section.status || 'Review'}</span>
+        {hasBlockers ? <span className="chip bad">{String(section.count)} blockers</span> : null}
+        {hasWarnings ? <span className="chip warn">{String(section.warningCount || section.warnings.length)} warnings</span> : null}
+      </div>
+      {section.blockers?.length ? (
+        <ul className="content-ops-operation-list">
+          {section.blockers.slice(0, 3).map((blocker) => <li key={blocker}>{blocker}</li>)}
+        </ul>
+      ) : null}
+    </div>
+  );
+}
+
+function PackageTable({ packages, selectedPackageId, onSelectPackage }) {
+  if (!packages.length) {
+    return (
+      <div className="feedback admin-note-spaced" data-content-ops-empty-packages="true">
+        No content operation packages yet.
+      </div>
+    );
+  }
+  return (
+    <div className="content-ops-table-scroll">
+      <table className="admin-overview-table content-ops-table" aria-label="Content operation packages">
+        <thead>
+          <tr className="admin-overview-thead-row">
+            <th className="small admin-overview-th-first">Package</th>
+            <th className="small admin-overview-th">State</th>
+            <th className="small admin-overview-th-right">Operations</th>
+            <th className="small admin-overview-th">Updated</th>
+            <th className="small admin-overview-th">Readiness</th>
+          </tr>
+        </thead>
+        <tbody>
+          {packages.map((contentPackage) => (
+            <tr
+              key={contentPackage.packageId}
+              className="admin-overview-tbody-row"
+              data-selected={contentPackage.packageId === selectedPackageId ? 'true' : undefined}
+              data-package-state={contentPackage.state}
+            >
+              <td className="admin-overview-td-first">
+                <button
+                  className="content-ops-row-button"
+                  type="button"
+                  onClick={() => onSelectPackage(contentPackage.packageId)}
+                >
+                  {contentPackage.title}
+                </button>
+                <div className="small muted">{contentPackage.packageId}</div>
+              </td>
+              <td className="admin-overview-td">
+                <PackageStateChip contentPackage={contentPackage} />
+              </td>
+              <td className="admin-overview-td-right">{operationCountLabel(contentPackage, 'table')}</td>
+              <td className="admin-overview-td small">{formatTimestamp(contentPackage.updatedAt)}</td>
+              <td className="admin-overview-td">
+                {contentPackage.blockers.blockerCount ? (
+                  <span className="chip bad">{String(contentPackage.blockers.blockerCount)} blocker sections</span>
+                ) : (
+                  <span className="chip good">No blocker sections</span>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function PublishedAreaPanel({ activeTab, latestRelease, selectedPackageId, selectedSummary }) {
+  const tab = CENTRE_TABS.find((entry) => entry.key === activeTab);
+  const blockerSection = DETAIL_TAB_BLOCKER_SECTIONS[activeTab] || null;
+  return (
+    <div className="content-ops-area-panel" data-content-ops-area={activeTab}>
+      <div className="content-ops-detail-header">
+        <div>
+          <div className="eyebrow">Published state</div>
+          <h4 className="section-title admin-section-title">{tab?.label || 'Content area'}</h4>
+          <p className="small muted admin-note-spaced">
+            Latest release {latestRelease?.releaseId || 'bundled fallback'}
+          </p>
+        </div>
+        <div className="chip-row content-ops-chip-wrap">
+          <span className="chip">Browse mode</span>
+          {selectedPackageId ? <span className="chip">Package {selectedPackageId}</span> : <span className="chip warn">No package selected</span>}
+        </div>
+      </div>
+      {blockerSection && selectedSummary ? (
+        <BlockerSummary blockers={selectedSummary.blockers} sectionKey={blockerSection} />
+      ) : null}
+      <div className="content-ops-domain-placeholder">
+        <span className="chip">No mutation controls</span>
+        <span className="small muted">Package selection is required before this area can create operations.</span>
+      </div>
+    </div>
+  );
+}
+
+function PackageDetailBody({ contentPackage, activeTab, events }) {
+  if (activeTab === 'spelling') {
+    return (
+      <div>
+        <h5>Spelling operations</h5>
+        {contentPackage.operations.length ? (
+          <ul className="content-ops-operation-list">
+            {contentPackage.operations.map((operation) => (
+              <li key={operation.operationId}>
+                <strong>{operation.action}</strong>
+                {' '}
+                {operation.entityType}
+                {' '}
+                <code>{operation.entityId}</code>
+                {operation.fieldPath ? <span className="small muted"> - {operation.fieldPath}</span> : null}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <span className="small muted">No spelling operations recorded.</span>
+        )}
+      </div>
+    );
+  }
+
+  if (activeTab === 'approvals') {
+    return (
+      <div className="chip-row content-ops-chip-wrap">
+        <span className="chip">Approved {formatTimestamp(contentPackage.approvedAt)}</span>
+        <span className="chip">Published {formatTimestamp(contentPackage.publishedAt)}</span>
+      </div>
+    );
+  }
+
+  if (activeTab === 'audit') {
+    return (
+      <div>
+        {events.length ? (
+          <ul className="content-ops-operation-list">
+            {events.map((event) => (
+              <li key={event.eventId}>
+                <strong>{event.eventType}</strong>
+                <span className="small muted"> - {formatTimestamp(event.createdAt)}</span>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <span className="small muted">No audit events recorded.</span>
+        )}
+      </div>
+    );
+  }
+
+  const tab = CONTENT_OPERATION_DETAIL_TABS.find((entry) => entry.key === activeTab);
+  const blockerSection = DETAIL_TAB_BLOCKER_SECTIONS[activeTab];
+  return (
+    <div className="content-ops-domain-placeholder">
+      <span className="chip">Package-scoped</span>
+      {tab ? <strong>{tab.label}</strong> : null}
+      {blockerSection ? (
+        <BlockerSummary blockers={contentPackage.blockers} sectionKey={blockerSection} />
+      ) : null}
+    </div>
+  );
+}
+
+function PackageDetail({
+  detail,
+  selectedPackageId,
+  loadingDetailId,
+  detailErrorId,
+  activeTab,
+  onSelectTab,
+}) {
+  const contentPackage = detail?.package || null;
+  if (!selectedPackageId) {
+    return (
+      <div className="feedback admin-note-spaced" data-content-ops-no-package="true">
+        No package selected.
+      </div>
+    );
+  }
+  if (detailErrorId === selectedPackageId) {
+    return (
+      <div className="feedback warn admin-note-spaced" data-content-ops-detail-error="true">
+        Package detail could not be loaded.
+      </div>
+    );
+  }
+  if (!contentPackage || loadingDetailId === selectedPackageId) {
+    return (
+      <div className="feedback warn admin-note-spaced" data-content-ops-detail-loading="true">
+        Package detail is loading.
+      </div>
+    );
+  }
+
+  const events = Array.isArray(detail.events) ? detail.events : [];
+  return (
+    <div className="content-ops-detail" data-package-detail={contentPackage.packageId}>
+      <div className="content-ops-detail-header">
+        <div>
+          <div className="eyebrow">Package detail</div>
+          <h4 className="section-title admin-section-title">{contentPackage.title}</h4>
+          <p className="small muted admin-note-spaced">
+            {contentPackage.packageId} - base {contentPackage.baseReleaseId || 'first release'}
+          </p>
+        </div>
+        <div className="chip-row content-ops-chip-wrap">
+          <PackageStateChip contentPackage={contentPackage} />
+          <span className="chip">{operationCountLabel(contentPackage, 'long')}</span>
+          {contentPackage.blockers.warningCount ? (
+            <span className="chip warn">{String(contentPackage.blockers.warningCount)} warning sections</span>
+          ) : null}
+        </div>
+      </div>
+      <DetailTabNav activeTab={activeTab} onSelect={onSelectTab} />
+      <div className="content-ops-detail-body" role="tabpanel">
+        <PackageDetailBody
+          contentPackage={contentPackage}
+          activeTab={activeTab}
+          events={events}
+        />
+      </div>
+    </div>
+  );
+}
+
+function ReleaseTable({ releases }) {
+  if (!releases.length) {
+    return (
+      <div className="feedback admin-note-spaced" data-content-ops-empty-releases="true">
+        No global content operation releases yet.
+      </div>
+    );
+  }
+  return (
+    <div className="content-ops-table-scroll">
+      <table className="admin-overview-table content-ops-table" aria-label="Content operation releases">
+        <thead>
+          <tr className="admin-overview-thead-row">
+            <th className="small admin-overview-th-first">Release</th>
+            <th className="small admin-overview-th">Status</th>
+            <th className="small admin-overview-th">Package</th>
+            <th className="small admin-overview-th">Published</th>
+            <th className="small admin-overview-th">Proof</th>
+          </tr>
+        </thead>
+        <tbody>
+          {releases.map((release) => (
+            <tr key={release.releaseId} className="admin-overview-tbody-row">
+              <td className="admin-overview-td-first">
+                {release.releaseId}
+                <div className="small muted">{release.snapshotHash || 'hash pending'}</div>
+              </td>
+              <td className="admin-overview-td">
+                <span className={`chip ${release.status === 'published' ? 'good' : ''}`}>
+                  {release.status}
+                </span>
+              </td>
+              <td className="admin-overview-td small">{release.packageId || 'seeded'}</td>
+              <td className="admin-overview-td small">{formatTimestamp(release.publishedAt || release.createdAt)}</td>
+              <td className="admin-overview-td">
+                {release.proof ? <span className="chip good">Recorded</span> : <span className="chip warn">Missing</span>}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export function AdminContentOperationsSection({
+  model,
+  actions,
+  initialOverview = null,
+  initialPackages = null,
+  initialReleases = null,
+  initialPackageDetail = null,
+  initialSelectedPackageId = '',
+  initialActiveTab = 'overview',
+  initialDetailTab = 'spelling',
+}) {
+  const seedOverview = initialOverview || model?.contentOperations?.overview || null;
+  const seedPackages = initialPackages || model?.contentOperations?.packages || null;
+  const seedReleases = initialReleases || model?.contentOperations?.releases || null;
+  const seedPackageDetail = initialPackageDetail || model?.contentOperations?.packageDetail || null;
+  const hasSeedData = Boolean(seedOverview || seedPackages || seedReleases || seedPackageDetail);
+  const [overviewPayload, setOverviewPayload] = React.useState(seedOverview);
+  const [packageListPayload, setPackageListPayload] = React.useState(seedPackages);
+  const [releaseListPayload, setReleaseListPayload] = React.useState(seedReleases);
+  const [detailPayload, setDetailPayload] = React.useState(seedPackageDetail);
+  const [selectedPackageId, setSelectedPackageId] = React.useState(initialPackageId({
+    packageDetail: seedPackageDetail,
+    initialActiveTab,
+    initialSelectedPackageId,
+  }));
+  const [activeTab, setActiveTab] = React.useState(initialActiveTab);
+  const [activeDetailTab, setActiveDetailTab] = React.useState(initialDetailTab);
+  const [loading, setLoading] = React.useState(Boolean(actions?.contentOperationsApi?.readOverview && !hasSeedData));
+  const [loadingDetailId, setLoadingDetailId] = React.useState('');
+  const [detailErrorId, setDetailErrorId] = React.useState('');
+  const [refreshError, setRefreshError] = React.useState(null);
+  const [refreshedAt, setRefreshedAt] = React.useState(hasSeedData ? Date.now() : null);
+  const detailRequestRef = React.useRef({ id: '', seq: 0 });
+  const refreshRequestRef = React.useRef(0);
+  const api = actions?.contentOperationsApi || null;
+
+  const overview = React.useMemo(
+    () => normaliseContentOperationsOverview(overviewPayload),
+    [overviewPayload],
+  );
+  const packages = React.useMemo(() => {
+    const listed = normaliseContentOperationsPackageList(packageListPayload);
+    return listed.length ? listed : collectLanePackages(overview);
+  }, [overview, packageListPayload]);
+  const releases = React.useMemo(() => {
+    const listed = normaliseContentOperationsReleaseList(releaseListPayload);
+    return listed.length ? listed : overview.recentReleases;
+  }, [overview.recentReleases, releaseListPayload]);
+  const detail = React.useMemo(
+    () => normaliseContentOperationsPackageDetail(detailPayload),
+    [detailPayload],
+  );
+
+  const loadPackageDetail = React.useCallback(async (packageId) => {
+    if (!api?.readPackage || !packageId) return;
+    const seq = detailRequestRef.current.seq + 1;
+    detailRequestRef.current = { id: packageId, seq };
+    setLoadingDetailId(packageId);
+    setDetailErrorId('');
+    try {
+      const payload = await api.readPackage({ packageId });
+      if (detailRequestRef.current.id !== packageId || detailRequestRef.current.seq !== seq) return;
+      setDetailPayload(payload);
+      setRefreshError((current) => (
+        current?.code === 'content_operations_detail_fetch_failed' ? null : current
+      ));
+    } catch (error) {
+      if (detailRequestRef.current.id !== packageId || detailRequestRef.current.seq !== seq) return;
+      setDetailPayload(null);
+      setDetailErrorId(packageId);
+      setRefreshError(errorEnvelope(error, 'content_operations_detail_fetch_failed'));
+    } finally {
+      if (detailRequestRef.current.id === packageId && detailRequestRef.current.seq === seq) {
+        setLoadingDetailId('');
+      }
+    }
+  }, [api]);
+
+  const selectPackage = React.useCallback((packageId) => {
+    setSelectedPackageId(packageId);
+    setActiveTab('detail');
+    setDetailErrorId('');
+    if (api?.readPackage) {
+      setDetailPayload((current) => (
+        normaliseContentOperationsPackageDetail(current).package?.packageId === packageId ? current : null
+      ));
+      loadPackageDetail(packageId);
+    } else {
+      setDetailPayload({ package: packages.find((entry) => entry.packageId === packageId) || null, events: [] });
+    }
+  }, [api, loadPackageDetail, packages]);
+
+  const refresh = React.useCallback(async () => {
+    if (!api?.readOverview) return;
+    const seq = refreshRequestRef.current + 1;
+    refreshRequestRef.current = seq;
+    setLoading(true);
+    setRefreshError(null);
+    try {
+      const [nextOverview, nextPackages, nextReleases] = await Promise.all([
+        api.readOverview({ limit: 30 }),
+        api.readPackages?.({ limit: 50 }),
+        api.readReleases?.({ limit: 20 }),
+      ]);
+      if (refreshRequestRef.current !== seq) return;
+      setOverviewPayload(nextOverview);
+      setPackageListPayload(nextPackages);
+      setReleaseListPayload(nextReleases);
+      setRefreshedAt(Date.now());
+      if (selectedPackageId && api.readPackage) {
+        await loadPackageDetail(selectedPackageId);
+      }
+    } catch (error) {
+      if (refreshRequestRef.current !== seq) return;
+      setRefreshError(errorEnvelope(error));
+    } finally {
+      if (refreshRequestRef.current === seq) {
+        setLoading(false);
+      }
+    }
+  }, [api, loadPackageDetail, selectedPackageId]);
+
+  React.useEffect(() => {
+    if (!api?.readOverview) return;
+    if (overviewPayload || packageListPayload || releaseListPayload) return;
+    refresh();
+  }, [api, overviewPayload, packageListPayload, refresh, releaseListPayload]);
+
+  React.useEffect(() => {
+    if (activeTab !== 'detail') return;
+    if (!selectedPackageId || !api?.readPackage) return;
+    if (loadingDetailId === selectedPackageId || detailErrorId === selectedPackageId) return;
+    if (detail.package?.packageId === selectedPackageId) return;
+    loadPackageDetail(selectedPackageId);
+  }, [
+    activeTab,
+    api,
+    detail.package?.packageId,
+    detailErrorId,
+    loadPackageDetail,
+    loadingDetailId,
+    selectedPackageId,
+  ]);
+
+  const latestRelease = overview.latestRelease;
+  const primaryData = overview.openPackageCount || packages.length || releases.length || latestRelease ? {
+    overview,
+    packages,
+    releases,
+    latestRelease,
+  } : null;
+  const selectedSummary = packages.find((entry) => entry.packageId === selectedPackageId);
+  const detailMatchesSelected = detail.package?.packageId === selectedPackageId;
+  const safeDetail = detailMatchesSelected
+    ? detail
+    : (!api?.readPackage && selectedSummary
+      ? { package: normaliseContentOperationPackage(selectedSummary), events: [] }
+      : { package: null, events: [] });
+  const warningSectionCount = packages.reduce((sum, entry) => sum + entry.blockers.warningCount, 0);
+
+  return (
+    <AdminPanelFrame
+      eyebrow="Content Operations Centre"
+      title="Spelling package workflow"
+      subtitle="Global spelling release packages and readiness."
+      refreshedAt={refreshedAt}
+      refreshError={refreshError}
+      onRefresh={api?.readOverview ? refresh : undefined}
+      loading={loading}
+      data={primaryData}
+      emptyState={(
+        <div className="feedback" data-content-ops-empty="true">
+          No content operation package data.
+        </div>
+      )}
+    >
+      <div className="content-ops-metric-grid">
+        <MetricTile
+          label="Latest release"
+          value={latestRelease?.releaseId || 'None'}
+          detail={latestRelease ? formatTimestamp(latestRelease.publishedAt || latestRelease.createdAt) : 'Bundled fallback active'}
+        />
+        <MetricTile label="Open packages" value={String(overview.openPackageCount || packages.length)} detail="Drafts and review lanes" />
+        <MetricTile label="Approved" value={String(overview.laneCounts.approvedPendingPublish || 0)} detail="Pending publish" />
+        <MetricTile label="Warnings" value={String(warningSectionCount)} detail="Audio, assets, rewards, visibility" />
+      </div>
+
+      <CentreTabNav activeTab={activeTab} onSelect={setActiveTab} />
+
+      {activeTab === 'overview' ? (
+        <OverviewLanes overview={overview} onSelectPackage={selectPackage} />
+      ) : null}
+
+      {activeTab === 'packages' ? (
+        <PackageTable
+          packages={packages}
+          selectedPackageId={selectedPackageId}
+          onSelectPackage={selectPackage}
+        />
+      ) : null}
+
+      {['spelling', 'audio', 'poolsRewards', 'monstersAssets', 'heroCodex', 'approvals'].includes(activeTab) ? (
+        <PublishedAreaPanel
+          activeTab={activeTab}
+          latestRelease={latestRelease}
+          selectedPackageId={selectedPackageId}
+          selectedSummary={selectedSummary}
+        />
+      ) : null}
+
+      {activeTab === 'detail' ? (
+        <PackageDetail
+          detail={safeDetail}
+          selectedPackageId={selectedPackageId}
+          loadingDetailId={loadingDetailId}
+          detailErrorId={detailErrorId}
+          activeTab={activeDetailTab}
+          onSelectTab={setActiveDetailTab}
+        />
+      ) : null}
+
+      {activeTab === 'releases' ? <ReleaseTable releases={releases} /> : null}
+    </AdminPanelFrame>
+  );
+}

--- a/src/surfaces/hubs/AdminContentSection.jsx
+++ b/src/surfaces/hubs/AdminContentSection.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { formatTimestamp, isBlocked } from './hub-utils.js';
+import { AdminContentOperationsSection } from './AdminContentOperationsSection.jsx';
 import { MonsterVisualConfigPanel } from './MonsterVisualConfigPanel.jsx';
 import { AdminConfirmAction } from './AdminConfirmAction.jsx';
 import { AdultConfidenceChip } from '../../subjects/grammar/components/AdultConfidenceChip.jsx';
@@ -1187,6 +1188,7 @@ export function AdminContentSection({ model, appState, accessContext, actions })
       <ContentQualitySummaryPanel model={model} />
       <ContentQualitySignalsPanel model={model} />
       <ContentReleaseAndImport model={model} accessContext={accessContext} actions={actions} />
+      <AdminContentOperationsSection model={model} actions={actions} />
       <PostMegaSpellingDebugPanel debug={model.postMasteryDebug} />
       <PostMegaSeedHarnessPanel model={model} actions={actions} />
       <GrammarConceptConfidencePanel evidence={selectedGrammarEvidence} />

--- a/styles/app.css
+++ b/styles/app.css
@@ -12228,6 +12228,199 @@ html { scroll-behavior: smooth; }
   margin-top: 8px;
 }
 
+/* -- content operations centre ------------------------------------------- */
+
+.content-ops-metric-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+  margin: 14px 0 16px;
+}
+
+.content-ops-metric {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--panel);
+}
+
+.content-ops-metric strong {
+  overflow-wrap: anywhere;
+}
+
+.content-ops-tabs,
+.content-ops-detail-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 8px 0 14px;
+}
+
+.content-ops-tab,
+.content-ops-detail-tab {
+  border: 1px solid var(--line);
+  background: var(--panel);
+  color: var(--ink);
+  border-radius: 6px;
+  padding: 7px 10px;
+  cursor: pointer;
+}
+
+.content-ops-tab[data-active="true"],
+.content-ops-detail-tab[data-active="true"] {
+  border-color: var(--brand);
+  color: var(--brand-ink, var(--brand));
+  font-weight: 700;
+}
+
+.content-ops-lanes {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.content-ops-lane,
+.content-ops-area-panel,
+.content-ops-detail {
+  min-width: 0;
+  padding: 10px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--panel);
+}
+
+.content-ops-area-panel,
+.content-ops-detail {
+  padding: 12px;
+}
+
+.content-ops-lane-header,
+.content-ops-detail-header,
+.content-ops-package-summary {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.content-ops-lane-body {
+  display: grid;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.content-ops-package-summary {
+  width: 100%;
+  text-align: left;
+  border: 1px solid var(--line);
+  background: var(--panel-soft);
+  border-radius: 6px;
+  padding: 8px;
+  cursor: pointer;
+}
+
+.content-ops-release-summary {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+  border: 1px solid var(--line);
+  background: var(--panel-soft);
+  border-radius: 6px;
+  padding: 8px;
+}
+
+.content-ops-package-summary-main {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.content-ops-package-summary-main strong,
+.content-ops-package-summary-main span {
+  overflow-wrap: anywhere;
+}
+
+.content-ops-package-summary-meta {
+  justify-content: flex-end;
+  flex-shrink: 0;
+}
+
+.content-ops-row-button {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--brand-ink, var(--brand));
+  font: inherit;
+  font-weight: 700;
+  text-align: left;
+  cursor: pointer;
+}
+
+.content-ops-table-scroll {
+  overflow-x: auto;
+}
+
+.content-ops-table {
+  min-width: 720px;
+}
+
+.content-ops-table .admin-overview-tbody-row[data-selected="true"] {
+  background: color-mix(in oklab, var(--brand) 8%, transparent);
+}
+
+.content-ops-detail-body {
+  border-top: 1px solid var(--line);
+  padding-top: 12px;
+}
+
+.content-ops-operation-list {
+  margin: 8px 0 0;
+  padding-left: 18px;
+}
+
+.content-ops-operation-list li + li {
+  margin-top: 6px;
+}
+
+.content-ops-chip-wrap {
+  flex-wrap: wrap;
+}
+
+.content-ops-domain-placeholder,
+.content-ops-blocker-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.content-ops-blocker-summary {
+  margin-top: 8px;
+}
+
+@media (max-width: 900px) {
+  .content-ops-metric-grid,
+  .content-ops-lanes {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .content-ops-metric-grid,
+  .content-ops-lanes {
+    grid-template-columns: 1fr;
+  }
+
+  .content-ops-package-summary,
+  .content-ops-detail-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+
 /* -- debug bundle panel --------------------------------------------------- */
 
 .admin-bundle-table {

--- a/tests/admin-content-operations-v2.test.js
+++ b/tests/admin-content-operations-v2.test.js
@@ -27,6 +27,18 @@ import {
   normaliseSubjectStatus,
 } from '../src/platform/hubs/admin-content-overview.js';
 
+import { createHubApi } from '../src/platform/hubs/api.js';
+
+import {
+  CONTENT_OPERATION_DETAIL_TABS,
+  CONTENT_OPERATION_LANES,
+  normaliseContentOperationPackage,
+  normaliseContentOperationsOverview,
+  normaliseContentOperationsPackageDetail,
+  normaliseContentOperationsPackageList,
+  normaliseContentOperationsReleaseList,
+} from '../src/platform/hubs/admin-content-operations.js';
+
 // ─── Fixtures ────────────────────────────────────────────────────────────────
 
 const LIVE_SPELLING_WITH_BLOCKERS = {
@@ -383,5 +395,199 @@ describe('RELEASE_READINESS enum', () => {
     assert.equal(RELEASE_READINESS.BLOCKED, 'blocked');
     assert.equal(RELEASE_READINESS.WARNINGS_ONLY, 'warnings_only');
     assert.equal(RELEASE_READINESS.NOT_APPLICABLE, 'not_applicable');
+  });
+});
+
+// --- Content Operations Centre shell contract ------------------------------
+
+const CONTENT_OPS_PACKAGE = {
+  packageId: 'pkg-draft-1',
+  subjectId: 'spelling',
+  templateId: 'word-family',
+  title: 'Word family update',
+  state: 'draft',
+  operationCount: 2,
+  updatedAt: Date.UTC(2026, 5, 11, 10, 0, 0),
+  operations: [
+    {
+      operationId: 'op-1',
+      entityType: 'spelling.word',
+      entityId: 'metamorphosis',
+      fieldPath: 'explanation',
+      action: 'set',
+    },
+  ],
+  blockers: {
+    validation: { status: 'passed', errorCount: 0, warningCount: 0, errors: [], warnings: [] },
+    audio: { status: 'blocked', blockers: ['word_audio_missing'], warnings: [] },
+    assets: { status: 'not_scanned', blockers: [], warnings: ['asset_scan_pending'] },
+    rewards: { status: 'passed', blockers: [], warnings: [] },
+    visibility: { status: 'passed', blockers: [], warnings: [] },
+    exposure: { status: 'passed', blockers: [], warnings: [] },
+    publishReadiness: { status: 'not_ready', blockers: ['approval_required'], warnings: [] },
+  },
+};
+
+const CONTENT_OPS_OVERVIEW = {
+  ok: true,
+  overview: {
+    subjectId: 'spelling',
+    latestRelease: {
+      releaseId: 'rel-global-1',
+      subjectId: 'spelling',
+      status: 'published',
+      snapshotHash: 'hash-1',
+      publishedAt: Date.UTC(2026, 5, 11, 9, 0, 0),
+      proof: { source: 'test' },
+    },
+    packageCounts: { draft: 1, blocked: 1, approved: 1 },
+    lanes: {
+      blocked: [{ ...CONTENT_OPS_PACKAGE, packageId: 'pkg-blocked-1', title: 'Blocked pool edit', state: 'blocked' }],
+      readyForApproval: [{ ...CONTENT_OPS_PACKAGE, packageId: 'pkg-ready-1', title: 'Ready word edit', state: 'ready_for_approval' }],
+      approvedPendingPublish: [{ ...CONTENT_OPS_PACKAGE, packageId: 'pkg-approved-1', title: 'Approved audio edit', state: 'approved' }],
+      drafts: [CONTENT_OPS_PACKAGE],
+      recentReleases: [
+        {
+          releaseId: 'rel-global-1',
+          subjectId: 'spelling',
+          status: 'published',
+          snapshotHash: 'hash-1',
+          publishedAt: Date.UTC(2026, 5, 11, 9, 0, 0),
+          proof: { source: 'test' },
+        },
+      ],
+    },
+    actor: {
+      accountId: 'admin-a',
+      platformRole: 'admin',
+      capabilities: {
+        'content_operations.edit': true,
+        'content_operations.approve': true,
+        'content_operations.publish': true,
+      },
+    },
+  },
+};
+
+function jsonResponse(payload, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('Content Operations Centre normalisers', () => {
+  it('pins the required home lanes and package detail domain tabs', () => {
+    assert.deepEqual(CONTENT_OPERATION_LANES.map((lane) => lane.label), [
+      'Blocked',
+      'Ready for approval',
+      'Approved pending publish',
+      'Open drafts',
+    ]);
+    assert.deepEqual(CONTENT_OPERATION_DETAIL_TABS.map((tab) => tab.label), [
+      'Spelling',
+      'Audio',
+      'Pools & Rewards',
+      'Monsters & Assets',
+      'Hero / Codex',
+      'Approvals',
+      'Audit',
+    ]);
+  });
+
+  it('normalises overview lanes, warning sections, releases, and actor capabilities', () => {
+    const overview = normaliseContentOperationsOverview(CONTENT_OPS_OVERVIEW);
+
+    assert.equal(overview.subjectId, 'spelling');
+    assert.equal(overview.latestRelease.releaseId, 'rel-global-1');
+    assert.equal(overview.openPackageCount, 4);
+    assert.equal(overview.laneCounts.blocked, 1);
+    assert.equal(overview.laneCounts.readyForApproval, 1);
+    assert.equal(overview.laneCounts.approvedPendingPublish, 1);
+    assert.equal(overview.laneCounts.drafts, 1);
+    assert.equal(overview.lanes.drafts[0].stateLabel, 'Draft');
+    assert.equal(overview.lanes.drafts[0].blockers.warningCount, 1);
+    assert.equal(overview.recentReleases[0].proof.source, 'test');
+    assert.equal(overview.actor.capabilities['content_operations.approve'], true);
+  });
+
+  it('normalises package lists, release lists, and package detail array payloads', () => {
+    const packages = normaliseContentOperationsPackageList([CONTENT_OPS_PACKAGE]);
+    const releases = normaliseContentOperationsReleaseList({
+      releases: CONTENT_OPS_OVERVIEW.overview.lanes.recentReleases,
+    });
+    const detail = normaliseContentOperationsPackageDetail({
+      package: CONTENT_OPS_PACKAGE,
+      events: [{ eventId: 'event-1', eventType: 'package.created', createdAt: Date.UTC(2026, 5, 11) }],
+    });
+
+    assert.equal(packages[0].packageId, 'pkg-draft-1');
+    assert.equal(packages[0].blockers.blockingSections.includes('audio'), true);
+    assert.equal(releases[0].releaseId, 'rel-global-1');
+    assert.equal(detail.package.operations[0].fieldPath, 'explanation');
+    assert.equal(detail.events[0].eventType, 'package.created');
+  });
+
+  it('keeps compact package operation counts unknown instead of inventing zero', () => {
+    const missingCountPackage = normaliseContentOperationPackage({
+      packageId: 'pkg-summary-only',
+      title: 'Summary only package',
+      state: 'draft',
+    });
+    const nullCountPackage = normaliseContentOperationPackage({
+      packageId: 'pkg-summary-null',
+      title: 'Summary null package',
+      state: 'draft',
+      operationCount: null,
+    });
+
+    assert.equal(missingCountPackage.operationCount, null);
+    assert.equal(nullCountPackage.operationCount, null);
+  });
+});
+
+describe('Content Operations Centre hub API client', () => {
+  it('calls read-only Content Operations Centre endpoints with compact queries', async () => {
+    const calls = [];
+    const api = createHubApi({
+      baseUrl: 'https://repo.test',
+      fetch: async (url, init = {}) => {
+        calls.push({ url: String(url), method: init.method });
+        return jsonResponse({ ok: true });
+      },
+    });
+
+    await api.readContentOperationsOverview({ limit: 7 });
+    await api.readContentOperationPackages({ state: 'draft', limit: 11 });
+    await api.readContentOperationPackage({ packageId: 'pkg/with/slash' });
+    await api.readContentOperationReleases({ limit: 5, includeSnapshot: true });
+    await api.readContentOperationRelease({ releaseId: 'rel/with/slash', includeSnapshot: true });
+
+    assert.equal(new URL(calls[0].url).pathname, '/api/admin/content-operations/subjects/spelling/overview');
+    assert.equal(new URL(calls[0].url).searchParams.get('limit'), '7');
+    assert.equal(new URL(calls[1].url).pathname, '/api/admin/content-operations/packages');
+    assert.equal(new URL(calls[1].url).searchParams.get('state'), 'draft');
+    assert.equal(new URL(calls[2].url).pathname, '/api/admin/content-operations/packages/pkg%2Fwith%2Fslash');
+    assert.equal(new URL(calls[3].url).pathname, '/api/admin/content-operations/subjects/spelling/releases');
+    assert.equal(new URL(calls[3].url).searchParams.get('includeSnapshot'), 'true');
+    assert.equal(new URL(calls[4].url).pathname, '/api/admin/content-operations/subjects/spelling/releases/rel%2Fwith%2Fslash');
+    assert.equal(new URL(calls[4].url).searchParams.get('includeSnapshot'), 'true');
+    assert.deepEqual(calls.map((call) => call.method), ['GET', 'GET', 'GET', 'GET', 'GET']);
+  });
+
+  it('rejects package and release detail reads without explicit ids', async () => {
+    const api = createHubApi({
+      baseUrl: 'https://repo.test',
+      fetch: async () => jsonResponse({ ok: true }),
+    });
+
+    await assert.rejects(
+      () => api.readContentOperationPackage({ packageId: '' }),
+      /Content operation package id is required/,
+    );
+    await assert.rejects(
+      () => api.readContentOperationRelease({ releaseId: '' }),
+      /Content operation release id is required/,
+    );
   });
 });

--- a/tests/content-operations-api.test.js
+++ b/tests/content-operations-api.test.js
@@ -190,10 +190,54 @@ test('content operations API supports admin package lifecycle through separate a
     const validated = await validatePackage(server, packageId);
     assert.equal(validated.candidate.validation.status, 'passed');
     assert.equal(validated.candidate.blockers.publishReadiness.status, 'not_ready');
+    server.DB.db.prepare(`
+      UPDATE content_operation_package_candidates
+      SET audio_scan_json = ?, asset_scan_json = ?
+      WHERE candidate_id = ?
+    `).run(
+      JSON.stringify({
+        status: 'blocked',
+        blockers: ['word_audio_missing'],
+        warnings: ['slow_sentence_missing'],
+      }),
+      JSON.stringify({
+        status: 'warning',
+        blockers: [],
+        warnings: ['monster_asset_pending'],
+      }),
+      validated.candidate.candidateId,
+    );
+
+    const packageListResponse = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/packages`,
+      { method: 'GET', headers: { 'sec-fetch-site': 'same-origin' } },
+      adminHeaders(),
+    );
+    const packageList = await readPayload(packageListResponse);
+    assert.equal(packageListResponse.status, 200);
+    const packageSummary = packageList.packages.find((entry) => entry.packageId === packageId);
+    assert.deepEqual(packageSummary.blockers.audio.blockers, ['word_audio_missing']);
+    assert.deepEqual(packageSummary.blockers.audio.warnings, ['slow_sentence_missing']);
+    assert.deepEqual(packageSummary.blockers.assets.warnings, ['monster_asset_pending']);
 
     const approved = await approvePackage(server, packageId, validated.candidate.candidateId);
     assert.equal(approved.approval.candidateId, validated.candidate.candidateId);
     assert.equal(approved.approval.approvedByAccountId, ADMIN_ID);
+
+    const prePublishOverviewResponse = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/subjects/spelling/overview`,
+      { method: 'GET', headers: { 'sec-fetch-site': 'same-origin' } },
+      adminHeaders(),
+    );
+    const prePublishOverview = await readPayload(prePublishOverviewResponse);
+    assert.equal(prePublishOverviewResponse.status, 200);
+    const approvedSummary = prePublishOverview.overview.lanes.approvedPendingPublish.find(
+      (entry) => entry.packageId === packageId,
+    );
+    assert.deepEqual(approvedSummary.blockers.audio.blockers, ['word_audio_missing']);
+    assert.deepEqual(approvedSummary.blockers.assets.warnings, ['monster_asset_pending']);
 
     const publishResponse = await server.fetchAs(
       ADMIN_ID,

--- a/tests/react-admin-content-operations.test.js
+++ b/tests/react-admin-content-operations.test.js
@@ -1,0 +1,980 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+const CONTENT_OPS_SECTION_PATH = JSON.stringify(
+  path.join(rootDir, 'src/surfaces/hubs/AdminContentOperationsSection.jsx'),
+);
+
+const CONTENT_SECTION_PATH = JSON.stringify(
+  path.join(rootDir, 'src/surfaces/hubs/AdminContentSection.jsx'),
+);
+
+function nodePaths() {
+  const candidates = [path.join(rootDir, 'node_modules')];
+  let current = rootDir;
+  for (let i = 0; i < 10; i += 1) {
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    candidates.push(path.join(parent, 'node_modules'));
+    current = parent;
+  }
+  return [
+    ...candidates,
+    ...String(process.env.NODE_PATH || '').split(path.delimiter),
+  ].filter((entry) => entry && existsSync(entry));
+}
+
+function normaliseLineEndings(value) {
+  return String(value).replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+}
+
+const contentPackage = {
+  packageId: 'pkg-draft-1',
+  subjectId: 'spelling',
+  templateId: 'word-family',
+  title: 'Word family update',
+  state: 'draft',
+  operationCount: 1,
+  updatedAt: Date.UTC(2026, 5, 11, 10, 0, 0),
+  operations: [
+    {
+      operationId: 'op-1',
+      entityType: 'spelling.word',
+      entityId: 'metamorphosis',
+      fieldPath: 'explanation',
+      action: 'set',
+    },
+  ],
+  blockers: {
+    validation: { status: 'passed', errorCount: 0, warningCount: 0, errors: [], warnings: [] },
+    audio: { status: 'blocked', blockers: ['word_audio_missing'], warnings: [] },
+    assets: { status: 'not_scanned', blockers: [], warnings: ['asset_scan_pending'] },
+    rewards: { status: 'passed', blockers: [], warnings: [] },
+    visibility: { status: 'passed', blockers: [], warnings: [] },
+    exposure: { status: 'passed', blockers: [], warnings: [] },
+    publishReadiness: { status: 'not_ready', blockers: ['approval_required'], warnings: [] },
+  },
+};
+
+const release = {
+  releaseId: 'rel-global-1',
+  subjectId: 'spelling',
+  status: 'published',
+  snapshotHash: 'hash-1',
+  publishedAt: Date.UTC(2026, 5, 11, 9, 0, 0),
+  proof: { source: 'test' },
+};
+
+const overview = {
+  subjectId: 'spelling',
+  latestRelease: release,
+  packageCounts: { draft: 1, blocked: 1, approved: 1 },
+  lanes: {
+    blocked: [{ ...contentPackage, packageId: 'pkg-blocked-1', title: 'Blocked pool edit', state: 'blocked' }],
+    readyForApproval: [{ ...contentPackage, packageId: 'pkg-ready-1', title: 'Ready word edit', state: 'ready_for_approval' }],
+    approvedPendingPublish: [{ ...contentPackage, packageId: 'pkg-approved-1', title: 'Approved audio edit', state: 'approved' }],
+    drafts: [contentPackage],
+    recentReleases: [release],
+  },
+  actor: {
+    accountId: 'admin-a',
+    platformRole: 'admin',
+    capabilities: {
+      'content_operations.edit': true,
+      'content_operations.approve': true,
+      'content_operations.publish': true,
+    },
+  },
+};
+
+function baseActions() {
+  return `{ dispatch() {}, navigateHome() {}, openSubject() {} }`;
+}
+
+function baseAppState() {
+  return {
+    learners: { selectedId: '', byId: {}, allIds: [] },
+    persistence: { mode: 'remote-sync' },
+    toasts: [],
+    monsterCelebrations: { queue: [] },
+  };
+}
+
+function baseAccessContext() {
+  return { shellAccess: { source: 'worker-session' }, activeAdultLearnerContext: null };
+}
+
+function baseModel(overrides = {}) {
+  return {
+    account: { id: 'adult-admin', repoRevision: 1, selectedLearnerId: '' },
+    permissions: {
+      canViewAdminHub: true,
+      platformRole: 'admin',
+      platformRoleLabel: 'Admin',
+      canManageMonsterVisualConfig: true,
+    },
+    monsterVisualConfig: {
+      permissions: { canManageMonsterVisualConfig: true, canViewMonsterVisualConfig: true },
+      status: {
+        schemaVersion: 2,
+        manifestHash: 'abc123def456',
+        draftRevision: 7,
+        draftUpdatedAt: Date.UTC(2026, 3, 27),
+        draftUpdatedByAccountId: 'adult-admin',
+        publishedVersion: 3,
+        publishedAt: Date.UTC(2026, 3, 26),
+        publishedByAccountId: 'adult-admin',
+        validation: { ok: true, errorCount: 0, warningCount: 0, errors: [], warnings: [] },
+      },
+      draft: { manifestHash: 'abc123def456', assets: {} },
+      published: { manifestHash: 'prev-hash', assets: {} },
+      versions: [{ version: 3, publishedAt: Date.UTC(2026, 3, 26) }],
+      mutation: {},
+    },
+    contentReleaseStatus: {
+      publishedVersion: 1,
+      publishedReleaseId: 'rel-001',
+      runtimeWordCount: 120,
+      runtimeSentenceCount: 40,
+      currentDraftId: 'draft-001',
+      currentDraftVersion: 2,
+      draftUpdatedAt: Date.UTC(2026, 3, 27),
+    },
+    importValidationStatus: {
+      ok: true,
+      errorCount: 0,
+      warningCount: 0,
+      source: 'bundled baseline',
+      importedAt: Date.UTC(2026, 3, 20),
+      errors: [],
+    },
+    learnerSupport: {
+      selectedLearnerId: '',
+      accessibleLearners: [],
+      selectedDiagnostics: null,
+      punctuationReleaseDiagnostics: null,
+      entryPoints: [],
+    },
+    postMegaSeedHarness: { shapes: [] },
+    contentOverview: {
+      subjects: [
+        {
+          subjectKey: 'spelling',
+          displayName: 'Spelling',
+          status: 'live',
+          releaseVersion: '3',
+          validationErrors: 0,
+          errorCount7d: 2,
+          supportLoadSignal: 'low',
+        },
+      ],
+    },
+    contentOperations: {
+      overview,
+      packages: { packages: [contentPackage] },
+      releases: { releases: [release] },
+      packageDetail: {
+        package: contentPackage,
+        events: [{ eventId: 'event-1', eventType: 'package.created', createdAt: Date.UTC(2026, 5, 11) }],
+      },
+    },
+    ...overrides,
+  };
+}
+
+async function renderEntry(entrySource) {
+  const tmpDir = await mkdtemp(path.join(tmpdir(), 'ks2-content-ops-ssr-'));
+  const entryPath = path.join(tmpDir, 'entry.jsx');
+  const bundlePath = path.join(tmpDir, 'entry.cjs');
+  try {
+    await writeFile(entryPath, entrySource);
+    await build({
+      absWorkingDir: rootDir,
+      entryPoints: [entryPath],
+      outfile: bundlePath,
+      bundle: true,
+      platform: 'node',
+      format: 'cjs',
+      target: ['node24'],
+      jsx: 'automatic',
+      jsxImportSource: 'react',
+      loader: { '.js': 'jsx' },
+      nodePaths: nodePaths(),
+      logLevel: 'silent',
+    });
+    const output = execFileSync(process.execPath, [bundlePath], {
+      cwd: rootDir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return normaliseLineEndings(output).replace(/\n+$/, '');
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
+async function runClientEntry(entrySource) {
+  const tmpDir = await mkdtemp(path.join(tmpdir(), 'ks2-content-ops-client-'));
+  const entryPath = path.join(tmpDir, 'entry.jsx');
+  const bundlePath = path.join(tmpDir, 'entry.cjs');
+  try {
+    await writeFile(entryPath, entrySource);
+    await build({
+      absWorkingDir: rootDir,
+      entryPoints: [entryPath],
+      outfile: bundlePath,
+      bundle: true,
+      platform: 'node',
+      format: 'cjs',
+      target: ['node24'],
+      jsx: 'automatic',
+      jsxImportSource: 'react',
+      loader: { '.js': 'jsx' },
+      external: ['jsdom'],
+      nodePaths: nodePaths(),
+      logLevel: 'silent',
+    });
+    const output = execFileSync(process.execPath, [bundlePath], {
+      cwd: rootDir,
+      env: {
+        ...process.env,
+        NODE_PATH: nodePaths().join(path.delimiter),
+      },
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 10_000,
+    });
+    return normaliseLineEndings(output).replace(/\n+$/, '');
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
+function buildContentOpsEntry(props = {}) {
+  const allProps = {
+    model: baseModel(),
+    actions: {},
+    ...props,
+  };
+  return `
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { AdminContentOperationsSection } from ${CONTENT_OPS_SECTION_PATH};
+    const props = ${JSON.stringify(allProps)};
+    const html = renderToStaticMarkup(<AdminContentOperationsSection {...props} />);
+    process.stdout.write(html);
+  `;
+}
+
+function buildAdminContentEntry(model = baseModel()) {
+  return `
+    import React from 'react';
+    import { renderToStaticMarkup } from 'react-dom/server';
+    import { AdminContentSection } from ${CONTENT_SECTION_PATH};
+    const model = ${JSON.stringify(model)};
+    const actions = ${baseActions()};
+    const appState = ${JSON.stringify(baseAppState())};
+    const accessContext = ${JSON.stringify(baseAccessContext())};
+    const html = renderToStaticMarkup(
+      <AdminContentSection
+        model={model}
+        appState={appState}
+        accessContext={accessContext}
+        actions={actions}
+      />
+    );
+    process.stdout.write(html);
+  `;
+}
+
+test('Content Operations Centre SSR renders home lanes and required top-level areas', async () => {
+  const html = await renderEntry(buildContentOpsEntry());
+
+  assert.match(html, /Content Operations Centre/);
+  assert.match(html, /Spelling package workflow/);
+  assert.match(html, /Blocked/);
+  assert.match(html, /Ready for approval/);
+  assert.match(html, /Approved pending publish/);
+  assert.match(html, /Open drafts/);
+  assert.match(html, /Audio \/ asset warnings/);
+  assert.match(html, /Recent releases/);
+  assert.match(html, /Word family update/);
+  assert.match(html, /Blocked pool edit/);
+  assert.match(html, /rel-global-1/);
+  assert.match(html, /Release history/);
+  assert.doesNotMatch(html, />Package detail<\/button>/);
+  for (const label of ['Packages', 'Spelling', 'Audio', 'Pools &amp; Rewards', 'Monsters &amp; Assets', 'Hero / Codex', 'Approvals']) {
+    assert.match(html, new RegExp(label));
+  }
+});
+
+test('Content Operations Centre SSR renders package-scoped domain tabs and audit state', async () => {
+  const html = await renderEntry(buildContentOpsEntry({
+    initialActiveTab: 'detail',
+    initialDetailTab: 'spelling',
+  }));
+
+  assert.match(html, /data-package-detail="pkg-draft-1"/);
+  assert.match(html, /Package detail/);
+  assert.match(html, /Spelling operations/);
+  assert.match(html, /metamorphosis/);
+  assert.match(html, /explanation/);
+  for (const label of ['Spelling', 'Audio', 'Pools &amp; Rewards', 'Monsters &amp; Assets', 'Hero / Codex', 'Approvals', 'Audit']) {
+    assert.match(html, new RegExp(label));
+  }
+});
+
+test('Content Operations Centre area pages browse without package mutation controls', async () => {
+  const html = await renderEntry(buildContentOpsEntry({
+    model: baseModel({
+      contentOperations: {
+        overview: {
+          ...overview,
+          lanes: {
+            blocked: [],
+            readyForApproval: [],
+            approvedPendingPublish: [],
+            drafts: [],
+            recentReleases: [release],
+          },
+        },
+        packages: { packages: [] },
+        releases: { releases: [release] },
+        packageDetail: null,
+      },
+    }),
+    initialActiveTab: 'audio',
+  }));
+
+  assert.match(html, /Published state/);
+  assert.match(html, /Audio/);
+  assert.match(html, /No package selected/);
+  assert.match(html, /No mutation controls/);
+  assert.doesNotMatch(html, /scan-audio/);
+  assert.doesNotMatch(html, /generate-audio/);
+});
+
+test('Content Operations Centre area pages show selected package readiness without mutation controls', async () => {
+  const audioHtml = await renderEntry(buildContentOpsEntry({
+    initialActiveTab: 'audio',
+    initialSelectedPackageId: 'pkg-draft-1',
+  }));
+  assert.match(audioHtml, /Published state/);
+  assert.match(audioHtml, /Package pkg-draft-1/);
+  assert.match(audioHtml, /blocked/);
+  assert.match(audioHtml, /1 blockers/);
+  assert.match(audioHtml, /word_audio_missing/);
+  assert.match(audioHtml, /No mutation controls/);
+
+  const assetHtml = await renderEntry(buildContentOpsEntry({
+    initialActiveTab: 'monstersAssets',
+    initialSelectedPackageId: 'pkg-draft-1',
+  }));
+  assert.match(assetHtml, /Monsters &amp; Assets/);
+  assert.match(assetHtml, /1 warnings/);
+  assert.match(assetHtml, /No mutation controls/);
+});
+
+test('Content Operations Centre SSR handles missing local data without breaking the panel', async () => {
+  const html = await renderEntry(buildContentOpsEntry({
+    model: baseModel({ contentOperations: null }),
+    actions: {},
+  }));
+
+  assert.match(html, /Content Operations Centre/);
+  assert.match(html, /No content operation package data/);
+});
+
+test('Admin Content section keeps existing overview and asset registry with the new centre', async () => {
+  const html = await renderEntry(buildAdminContentEntry());
+
+  assert.match(html, /data-panel="subject-overview"/);
+  assert.match(html, /Content Operations Centre/);
+  assert.match(html, /data-panel="asset-registry"/);
+  assert.match(html, /Content release status/);
+  assert.ok(
+    html.indexOf('data-panel="subject-overview"') < html.indexOf('Content Operations Centre'),
+    'Subject Overview should remain before the Content Operations Centre',
+  );
+  assert.ok(
+    html.indexOf('Content release status') < html.indexOf('Content Operations Centre'),
+    'Existing content release controls should remain before the Content Operations Centre',
+  );
+  assert.ok(
+    html.indexOf('Content Operations Centre') < html.indexOf('data-panel="asset-registry"'),
+    'Asset registry should remain reachable after the Content Operations Centre',
+  );
+});
+
+test('Content Operations Centre mounted shell loads API data without implicit package selection', async () => {
+  const output = await runClientEntry(`
+    const { JSDOM } = require('jsdom');
+
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+    const dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
+      url: 'https://ks2.eugnel.uk/admin',
+    });
+    globalThis.window = dom.window;
+    globalThis.document = dom.window.document;
+    globalThis.navigator = dom.window.navigator;
+    globalThis.HTMLElement = dom.window.HTMLElement;
+    globalThis.Event = dom.window.Event;
+
+    const React = require('react');
+    const { createRoot } = require('react-dom/client');
+    const { AdminContentOperationsSection } = require(${CONTENT_OPS_SECTION_PATH});
+    const { act } = React;
+
+    const model = ${JSON.stringify(baseModel({ contentOperations: null }))};
+    const overview = ${JSON.stringify(overview)};
+    const contentPackage = ${JSON.stringify(contentPackage)};
+    const compactPackage = { ...contentPackage };
+    delete compactPackage.operationCount;
+    delete compactPackage.operations;
+    const release = ${JSON.stringify(release)};
+    const calls = [];
+    const actions = {
+      contentOperationsApi: {
+        async readOverview(args) {
+          calls.push({ method: 'overview', args });
+          return overview;
+        },
+        async readPackages(args) {
+          calls.push({ method: 'packages', args });
+          return { packages: [compactPackage] };
+        },
+        async readReleases(args) {
+          calls.push({ method: 'releases', args });
+          return { releases: [release] };
+        },
+      },
+    };
+
+    async function flush() {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+    }
+
+    async function main() {
+      const root = createRoot(document.getElementById('root'));
+      await act(async () => {
+        root.render(React.createElement(AdminContentOperationsSection, { model, actions }));
+      });
+      await flush();
+      await flush();
+
+      const overviewText = document.body.textContent;
+      const packagesTab = Array.from(document.querySelectorAll('[role="tab"]'))
+        .find((entry) => entry.textContent === 'Packages');
+      await act(async () => {
+        packagesTab.click();
+      });
+      const selectedRows = document.querySelectorAll('[data-selected="true"]').length;
+      const packageTableText = document.body.textContent;
+      process.stdout.write(JSON.stringify({ calls, overviewText, packageTableText, selectedRows }));
+
+      await act(async () => {
+        root.unmount();
+      });
+      dom.window.close();
+      process.exit(0);
+    }
+
+    main().catch((error) => {
+      process.stderr.write(error.stack || error.message);
+      process.exitCode = 1;
+    });
+  `);
+  const result = JSON.parse(output);
+
+  assert.deepEqual(result.calls, [
+    { method: 'overview', args: { limit: 30 } },
+    { method: 'packages', args: { limit: 50 } },
+    { method: 'releases', args: { limit: 20 } },
+  ]);
+  assert.match(result.overviewText, /Word family update/);
+  assert.match(result.overviewText, /Audio \/ asset warnings/);
+  assert.match(result.overviewText, /rel-global-1/);
+  assert.match(result.packageTableText, /Pending/);
+  assert.equal(result.selectedRows, 0);
+});
+
+test('Content Operations Centre mounted package detail ignores stale out-of-order reads', async () => {
+  const packageA = {
+    ...contentPackage,
+    packageId: 'pkg-a',
+    title: 'Alpha package',
+    operations: [{ operationId: 'op-a', entityType: 'spelling.word', entityId: 'alpha', action: 'set' }],
+    operationCount: 1,
+  };
+  const packageB = {
+    ...contentPackage,
+    packageId: 'pkg-b',
+    title: 'Beta package',
+    operations: [{ operationId: 'op-b', entityType: 'spelling.word', entityId: 'beta', action: 'set' }],
+    operationCount: 1,
+  };
+  const raceOverview = {
+    ...overview,
+    lanes: {
+      blocked: [],
+      readyForApproval: [],
+      approvedPendingPublish: [],
+      drafts: [packageA, packageB],
+      recentReleases: [],
+    },
+  };
+  const output = await runClientEntry(`
+    const { JSDOM } = require('jsdom');
+
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+    const dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
+      url: 'https://ks2.eugnel.uk/admin',
+    });
+    globalThis.window = dom.window;
+    globalThis.document = dom.window.document;
+    globalThis.navigator = dom.window.navigator;
+    globalThis.HTMLElement = dom.window.HTMLElement;
+    globalThis.Event = dom.window.Event;
+
+    const React = require('react');
+    const { createRoot } = require('react-dom/client');
+    const { AdminContentOperationsSection } = require(${CONTENT_OPS_SECTION_PATH});
+    const { act } = React;
+
+    function deferred() {
+      const holder = {};
+      holder.promise = new Promise((resolve, reject) => {
+        holder.resolve = resolve;
+        holder.reject = reject;
+      });
+      return holder;
+    }
+
+    const packageA = ${JSON.stringify(packageA)};
+    const packageB = ${JSON.stringify(packageB)};
+    const defers = { 'pkg-a': deferred(), 'pkg-b': deferred() };
+    const calls = [];
+    const model = ${JSON.stringify(baseModel({
+      contentOperations: {
+        overview: raceOverview,
+        packages: { packages: [packageA, packageB] },
+        releases: { releases: [] },
+        packageDetail: null,
+      },
+    }))};
+    const actions = {
+      contentOperationsApi: {
+        readPackage({ packageId }) {
+          calls.push(packageId);
+          return defers[packageId].promise;
+        },
+      },
+    };
+
+    async function flush() {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+    }
+
+    async function main() {
+      const root = createRoot(document.getElementById('root'));
+      await act(async () => {
+        root.render(React.createElement(AdminContentOperationsSection, { model, actions }));
+      });
+
+      const summaries = Array.from(document.querySelectorAll('.content-ops-package-summary'));
+      await act(async () => {
+        summaries[0].click();
+        summaries[1].click();
+      });
+
+      await act(async () => {
+        defers['pkg-a'].resolve({ package: packageA, events: [] });
+      });
+      await flush();
+      const textAfterA = document.body.textContent;
+
+      await act(async () => {
+        defers['pkg-b'].resolve({ package: packageB, events: [] });
+      });
+      await flush();
+      const detail = document.querySelector('[data-package-detail]');
+      process.stdout.write(JSON.stringify({
+        calls,
+        textAfterA,
+        textAfterB: document.body.textContent,
+        detailPackageId: detail?.getAttribute('data-package-detail') || '',
+      }));
+
+      await act(async () => {
+        root.unmount();
+      });
+      dom.window.close();
+      process.exit(0);
+    }
+
+    main().catch((error) => {
+      process.stderr.write(error.stack || error.message);
+      process.exitCode = 1;
+    });
+  `);
+  const result = JSON.parse(output);
+
+  assert.deepEqual(result.calls, ['pkg-a', 'pkg-b']);
+  assert.doesNotMatch(result.textAfterA, /alpha/);
+  assert.match(result.textAfterA, /Package detail is loading/);
+  assert.equal(result.detailPackageId, 'pkg-b');
+  assert.match(result.textAfterB, /beta/);
+  assert.doesNotMatch(result.textAfterB, /alpha/);
+});
+
+test('Content Operations Centre mounted refresh ignores stale out-of-order overview reads', async () => {
+  const oldPackage = {
+    ...contentPackage,
+    packageId: 'pkg-old',
+    title: 'Old package state',
+    operations: [{ operationId: 'op-old', entityType: 'spelling.word', entityId: 'old', action: 'set' }],
+    operationCount: 1,
+  };
+  const newPackage = {
+    ...contentPackage,
+    packageId: 'pkg-new',
+    title: 'New package state',
+    operations: [{ operationId: 'op-new', entityType: 'spelling.word', entityId: 'new', action: 'set' }],
+    operationCount: 1,
+  };
+  const oldOverview = {
+    ...overview,
+    lanes: { ...overview.lanes, drafts: [oldPackage], recentReleases: [] },
+  };
+  const newOverview = {
+    ...overview,
+    lanes: { ...overview.lanes, drafts: [newPackage], recentReleases: [] },
+  };
+  const output = await runClientEntry(`
+    const { JSDOM } = require('jsdom');
+
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+    const dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
+      url: 'https://ks2.eugnel.uk/admin',
+    });
+    globalThis.window = dom.window;
+    globalThis.document = dom.window.document;
+    globalThis.navigator = dom.window.navigator;
+    globalThis.HTMLElement = dom.window.HTMLElement;
+    globalThis.Event = dom.window.Event;
+
+    const React = require('react');
+    const { createRoot } = require('react-dom/client');
+    const { AdminContentOperationsSection } = require(${CONTENT_OPS_SECTION_PATH});
+    const { act } = React;
+
+    function deferred() {
+      const holder = {};
+      holder.promise = new Promise((resolve, reject) => {
+        holder.resolve = resolve;
+        holder.reject = reject;
+      });
+      return holder;
+    }
+
+    const oldOverview = ${JSON.stringify(oldOverview)};
+    const newOverview = ${JSON.stringify(newOverview)};
+    const oldPackage = ${JSON.stringify(oldPackage)};
+    const newPackage = ${JSON.stringify(newPackage)};
+    const defers = [deferred(), deferred()];
+    const calls = [];
+    let refreshIndex = -1;
+    const model = ${JSON.stringify(baseModel())};
+    const actions = {
+      contentOperationsApi: {
+        readOverview(args) {
+          refreshIndex += 1;
+          calls.push({ method: 'overview', args, refreshIndex });
+          return defers[refreshIndex].promise;
+        },
+        readPackages(args) {
+          calls.push({ method: 'packages', args, refreshIndex });
+          return Promise.resolve({ packages: [refreshIndex === 0 ? oldPackage : newPackage] });
+        },
+        readReleases(args) {
+          calls.push({ method: 'releases', args, refreshIndex });
+          return Promise.resolve({ releases: [] });
+        },
+      },
+    };
+
+    async function flush() {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+    }
+
+    async function main() {
+      const root = createRoot(document.getElementById('root'));
+      await act(async () => {
+        root.render(React.createElement(AdminContentOperationsSection, { model, actions }));
+      });
+      const refreshButton = Array.from(document.querySelectorAll('button'))
+        .find((entry) => entry.textContent === 'Refresh');
+      await act(async () => {
+        refreshButton.click();
+        refreshButton.click();
+      });
+
+      await act(async () => {
+        defers[1].resolve(newOverview);
+      });
+      await flush();
+      const textAfterNew = document.body.textContent;
+
+      await act(async () => {
+        defers[0].resolve(oldOverview);
+      });
+      await flush();
+
+      process.stdout.write(JSON.stringify({
+        calls,
+        textAfterNew,
+        finalText: document.body.textContent,
+      }));
+
+      await act(async () => {
+        root.unmount();
+      });
+      dom.window.close();
+      process.exit(0);
+    }
+
+    main().catch((error) => {
+      process.stderr.write(error.stack || error.message);
+      process.exitCode = 1;
+    });
+  `);
+  const result = JSON.parse(output);
+
+  assert.equal(result.calls.filter((entry) => entry.method === 'overview').length, 2);
+  assert.match(result.textAfterNew, /New package state/);
+  assert.match(result.finalText, /New package state/);
+  assert.doesNotMatch(result.finalText, /Old package state/);
+});
+
+test('Content Operations Centre mounted package detail exposes read errors', async () => {
+  const output = await runClientEntry(`
+    const { JSDOM } = require('jsdom');
+
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+    const dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
+      url: 'https://ks2.eugnel.uk/admin',
+    });
+    globalThis.window = dom.window;
+    globalThis.document = dom.window.document;
+    globalThis.navigator = dom.window.navigator;
+    globalThis.HTMLElement = dom.window.HTMLElement;
+    globalThis.Event = dom.window.Event;
+
+    const React = require('react');
+    const { createRoot } = require('react-dom/client');
+    const { AdminContentOperationsSection } = require(${CONTENT_OPS_SECTION_PATH});
+    const { act } = React;
+
+    const contentPackage = ${JSON.stringify(contentPackage)};
+    const model = ${JSON.stringify(baseModel({
+      contentOperations: {
+        overview: {
+          ...overview,
+          lanes: {
+            blocked: [],
+            readyForApproval: [],
+            approvedPendingPublish: [],
+            drafts: [contentPackage],
+            recentReleases: [],
+          },
+        },
+        packages: { packages: [contentPackage] },
+        releases: { releases: [] },
+        packageDetail: null,
+      },
+    }))};
+    const calls = [];
+    const actions = {
+      contentOperationsApi: {
+        async readPackage({ packageId }) {
+          calls.push(packageId);
+          throw new Error('package detail unavailable');
+        },
+      },
+    };
+
+    async function flush() {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+    }
+
+    async function main() {
+      const root = createRoot(document.getElementById('root'));
+      await act(async () => {
+        root.render(React.createElement(AdminContentOperationsSection, { model, actions }));
+      });
+      const summary = document.querySelector('.content-ops-package-summary');
+      await act(async () => {
+        summary.click();
+      });
+      await flush();
+      process.stdout.write(JSON.stringify({
+        calls,
+        text: document.body.textContent,
+        hasError: Boolean(document.querySelector('[data-content-ops-detail-error="true"]')),
+      }));
+
+      await act(async () => {
+        root.unmount();
+      });
+      dom.window.close();
+      process.exit(0);
+    }
+
+    main().catch((error) => {
+      process.stderr.write(error.stack || error.message);
+      process.exitCode = 1;
+    });
+  `);
+  const result = JSON.parse(output);
+
+  assert.deepEqual(result.calls, ['pkg-draft-1']);
+  assert.equal(result.hasError, true);
+  assert.match(result.text, /Package detail could not be loaded/);
+});
+
+test('Content Operations Centre mounted package detail success clears stale detail errors', async () => {
+  const packageA = {
+    ...contentPackage,
+    packageId: 'pkg-fail',
+    title: 'Failing package',
+    operations: [{ operationId: 'op-fail', entityType: 'spelling.word', entityId: 'fail', action: 'set' }],
+    operationCount: 1,
+  };
+  const packageB = {
+    ...contentPackage,
+    packageId: 'pkg-success',
+    title: 'Recovered package',
+    operations: [{ operationId: 'op-success', entityType: 'spelling.word', entityId: 'recover', action: 'set' }],
+    operationCount: 1,
+  };
+  const output = await runClientEntry(`
+    const { JSDOM } = require('jsdom');
+
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+    const dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
+      url: 'https://ks2.eugnel.uk/admin',
+    });
+    globalThis.window = dom.window;
+    globalThis.document = dom.window.document;
+    globalThis.navigator = dom.window.navigator;
+    globalThis.HTMLElement = dom.window.HTMLElement;
+    globalThis.Event = dom.window.Event;
+
+    const React = require('react');
+    const { createRoot } = require('react-dom/client');
+    const { AdminContentOperationsSection } = require(${CONTENT_OPS_SECTION_PATH});
+    const { act } = React;
+
+    const packageA = ${JSON.stringify(packageA)};
+    const packageB = ${JSON.stringify(packageB)};
+    const model = ${JSON.stringify(baseModel({
+      contentOperations: {
+        overview: {
+          ...overview,
+          lanes: {
+            blocked: [],
+            readyForApproval: [],
+            approvedPendingPublish: [],
+            drafts: [packageA, packageB],
+            recentReleases: [],
+          },
+        },
+        packages: { packages: [packageA, packageB] },
+        releases: { releases: [] },
+        packageDetail: null,
+      },
+    }))};
+    const calls = [];
+    const actions = {
+      contentOperationsApi: {
+        async readPackage({ packageId }) {
+          calls.push(packageId);
+          if (packageId === 'pkg-fail') throw new Error('package detail unavailable');
+          return { package: packageB, events: [] };
+        },
+      },
+    };
+
+    async function flush() {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+    }
+
+    async function main() {
+      const root = createRoot(document.getElementById('root'));
+      await act(async () => {
+        root.render(React.createElement(AdminContentOperationsSection, { model, actions }));
+      });
+      const summaries = Array.from(document.querySelectorAll('.content-ops-package-summary'));
+      await act(async () => {
+        summaries[0].click();
+      });
+      await flush();
+      const textAfterFailure = document.body.textContent;
+      const overviewTab = Array.from(document.querySelectorAll('[role="tab"]'))
+        .find((entry) => entry.textContent === 'Overview');
+      await act(async () => {
+        overviewTab.click();
+      });
+      const successSummary = document.querySelector('[data-package-id="pkg-success"]');
+      await act(async () => {
+        successSummary.click();
+      });
+      await flush();
+      process.stdout.write(JSON.stringify({
+        calls,
+        textAfterFailure,
+        finalText: document.body.textContent,
+        hasPartialFailure: document.body.textContent.includes('A more recent refresh failed'),
+        hasDetailError: Boolean(document.querySelector('[data-content-ops-detail-error="true"]')),
+      }));
+
+      await act(async () => {
+        root.unmount();
+      });
+      dom.window.close();
+      process.exit(0);
+    }
+
+    main().catch((error) => {
+      process.stderr.write(error.stack || error.message);
+      process.exitCode = 1;
+    });
+  `);
+  const result = JSON.parse(output);
+
+  assert.deepEqual(result.calls, ['pkg-fail', 'pkg-success']);
+  assert.match(result.textAfterFailure, /Package detail could not be loaded/);
+  assert.match(result.finalText, /Recovered package/);
+  assert.match(result.finalText, /recover/);
+  assert.equal(result.hasDetailError, false);
+  assert.equal(result.hasPartialFailure, false);
+});

--- a/worker/src/content-operations/repository.js
+++ b/worker/src/content-operations/repository.js
@@ -125,6 +125,40 @@ async function candidateRowToRecordAsync(row, { includeSnapshot = false } = {}) 
   };
 }
 
+async function readLatestCandidateForPackage(db, packageId) {
+  const row = await first(db, `
+    SELECT *
+    FROM content_operation_package_candidates
+    WHERE package_id = ?
+    ORDER BY created_at DESC, candidate_id DESC
+    LIMIT 1
+  `, [packageId]);
+  return candidateRowToRecord(row);
+}
+
+async function attachLatestCandidatesToPackages(db, packages = []) {
+  if (!packages.length) return packages;
+  const packageIds = packages.map((contentPackage) => contentPackage.packageId).filter(Boolean);
+  if (!packageIds.length) return packages;
+  const placeholders = packageIds.map(() => '?').join(', ');
+  const rows = await all(db, `
+    SELECT *
+    FROM content_operation_package_candidates
+    WHERE package_id IN (${placeholders})
+    ORDER BY package_id ASC, created_at DESC, candidate_id DESC
+  `, packageIds);
+  const latestByPackageId = new Map();
+  for (const row of rows) {
+    if (!latestByPackageId.has(row.package_id)) {
+      latestByPackageId.set(row.package_id, candidateRowToRecord(row));
+    }
+  }
+  return packages.map((contentPackage) => ({
+    ...contentPackage,
+    latestCandidate: latestByPackageId.get(contentPackage.packageId) || null,
+  }));
+}
+
 function releaseRowToRecord(row, { includeSnapshot = false } = {}) {
   if (!row) return null;
   return {
@@ -560,6 +594,7 @@ export function createContentOperationsRepository({ db, now }) {
     async readContentOperationPackage(packageId, { includeOperations = true } = {}) {
       const row = await requirePackage(db, packageId);
       const record = packageRowToRecord(row);
+      record.latestCandidate = await readLatestCandidateForPackage(db, packageId);
       if (includeOperations) {
         record.operations = await listPackageOperations(db, packageId);
       }
@@ -647,7 +682,7 @@ export function createContentOperationsRepository({ db, now }) {
         ORDER BY updated_at DESC
         LIMIT ?
       `, params);
-      return rows.map(packageRowToRecord);
+      return attachLatestCandidatesToPackages(db, rows.map(packageRowToRecord));
     },
 
     async appendContentOperation(packageId, rawOperation, { actorAccountId } = {}) {

--- a/worker/src/content-operations/serialisers.js
+++ b/worker/src/content-operations/serialisers.js
@@ -180,7 +180,14 @@ export function serialiseContentOperationActor(actor = {}) {
 }
 
 export function serialiseContentOperationPackage(contentPackage = {}, { compact = false } = {}) {
+  const latestCandidate = contentPackage.latestCandidate || null;
   const envelope = buildContentOperationBlockerEnvelope({
+    validation: latestCandidate?.validation || null,
+    conflicts: latestCandidate?.conflicts || null,
+    audio: latestCandidate?.audioScan || null,
+    assets: latestCandidate?.assetScan || null,
+    rewards: latestCandidate?.rewardScan || null,
+    visibility: latestCandidate?.visibilityScan || null,
     publishReadiness: packagePublishReadiness(contentPackage),
   });
   const base = {


### PR DESCRIPTION
## Summary
- Add the read-only Content Operations Centre shell inside Admin Content for spelling package oversight.
- Add package/release API client helpers, normalisers, tabs, warning lanes, detail panes, and responsive table styling.
- Hydrate package summaries with the latest candidate blocker signals so future audio/asset scans surface in overview and package lists.
- Cover the shell, API client, stale request guards, detail error recovery, and backend compact blocker envelopes with tests.

## Verification
- git diff --check
- npm run check
- node --test tests/content-operations-api.test.js tests/content-operations-repository.test.js tests/admin-content-operations-v2.test.js tests/react-admin-content-operations.test.js
- npm test: 111,709 pass, 0 fail, 12 skipped
- pre-push npm test: 111,709 pass, 0 fail, 12 skipped