### PR TITLE
Content Operations T7: package approval workflow

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2717,6 +2717,9 @@ function buildSurfaceActions() {
     readOverview: hubApi.readContentOperationsOverview?.bind(hubApi),
     readPackages: hubApi.readContentOperationPackages?.bind(hubApi),
     readPackage: hubApi.readContentOperationPackage?.bind(hubApi),
+    validatePackage: hubApi.validateContentOperationPackage?.bind(hubApi),
+    approvePackage: hubApi.approveContentOperationPackage?.bind(hubApi),
+    publishPackage: hubApi.publishContentOperationPackage?.bind(hubApi),
     readReleases: hubApi.readContentOperationReleases?.bind(hubApi),
     readRelease: hubApi.readContentOperationRelease?.bind(hubApi),
   } : null;

--- a/src/platform/hubs/admin-content-operations.js
+++ b/src/platform/hubs/admin-content-operations.js
@@ -145,6 +145,26 @@ export function normaliseContentOperationActor(actor = null) {
   };
 }
 
+export function normaliseContentOperationCandidate(entry = null) {
+  const safe = isPlainObject(entry) ? entry : {};
+  const validation = normaliseBlockerSection(safe.validation);
+  if (!safe.validation?.status && typeof safe.validation?.ok === 'boolean') {
+    validation.status = safe.validation.ok ? 'passed' : 'blocked';
+  }
+  return {
+    candidateId: asString(safe.candidateId),
+    packageId: asString(safe.packageId),
+    baseReleaseId: asNullableString(safe.baseReleaseId),
+    currentReleaseId: asNullableString(safe.currentReleaseId),
+    operationsHash: asString(safe.operationsHash),
+    candidateHash: asString(safe.candidateHash),
+    validation,
+    blockers: normaliseContentOperationBlockers(safe.blockers),
+    conflicts: asArray(safe.conflicts),
+    createdAt: asTs(safe.createdAt),
+  };
+}
+
 export function normaliseContentOperationPackage(entry = null) {
   const safe = isPlainObject(entry) ? entry : {};
   const state = asString(safe.state, 'draft');
@@ -174,6 +194,7 @@ export function normaliseContentOperationPackage(entry = null) {
     supersededByPackageId: asNullableString(safe.supersededByPackageId),
     operationCount,
     operations,
+    latestCandidate: safe.latestCandidate ? normaliseContentOperationCandidate(safe.latestCandidate) : null,
     blockers: normaliseContentOperationBlockers(safe.blockers),
   };
 }

--- a/src/platform/hubs/api.js
+++ b/src/platform/hubs/api.js
@@ -283,6 +283,62 @@ export function createHubApi({
       const url = buildRequestUrl(baseUrl, `/api/admin/content-operations/packages/${safePackageId}`);
       return fetchHubJson(fetch, url, { method: 'GET' }, authSession);
     },
+    async validateContentOperationPackage({ packageId, includeSnapshot = false, mutation } = {}) {
+      if (!packageId) throw new TypeError('Content operation package id is required.');
+      const safePackageId = encodeURIComponent(String(packageId));
+      const url = buildRequestUrl(baseUrl, `/api/admin/content-operations/packages/${safePackageId}/validate`);
+      return fetchHubJson(fetch, url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          includeSnapshot: Boolean(includeSnapshot),
+          mutation,
+        }),
+      }, authSession);
+    },
+    async approveContentOperationPackage({
+      packageId,
+      candidateId,
+      notes = '',
+      audioFallback = null,
+      assetSummary = null,
+      mutation,
+    } = {}) {
+      if (!packageId) throw new TypeError('Content operation package id is required.');
+      if (!candidateId) throw new TypeError('Content operation candidate id is required.');
+      const safePackageId = encodeURIComponent(String(packageId));
+      const url = buildRequestUrl(baseUrl, `/api/admin/content-operations/packages/${safePackageId}/approve`);
+      return fetchHubJson(fetch, url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          candidateId,
+          notes,
+          audioFallback,
+          assetSummary,
+          mutation,
+        }),
+      }, authSession);
+    },
+    async publishContentOperationPackage({
+      packageId,
+      proof = null,
+      includeSnapshot = false,
+      mutation,
+    } = {}) {
+      if (!packageId) throw new TypeError('Content operation package id is required.');
+      const safePackageId = encodeURIComponent(String(packageId));
+      const url = buildRequestUrl(baseUrl, `/api/admin/content-operations/packages/${safePackageId}/publish`);
+      return fetchHubJson(fetch, url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          proof,
+          includeSnapshot: Boolean(includeSnapshot),
+          mutation,
+        }),
+      }, authSession);
+    },
     async readContentOperationReleases({ limit = 20, includeSnapshot = false } = {}) {
       const url = buildRequestUrl(
         baseUrl,

--- a/src/surfaces/hubs/AdminContentOperationsSection.jsx
+++ b/src/surfaces/hubs/AdminContentOperationsSection.jsx
@@ -4,6 +4,7 @@ import { formatTimestamp } from './hub-utils.js';
 import {
   CONTENT_OPERATION_DETAIL_TABS,
   CONTENT_OPERATION_LANES,
+  normaliseContentOperationCandidate,
   normaliseContentOperationPackage,
   normaliseContentOperationsOverview,
   normaliseContentOperationsPackageDetail,
@@ -30,6 +31,31 @@ const DETAIL_TAB_BLOCKER_SECTIONS = Object.freeze({
   monstersAssets: 'assets',
   heroCodex: 'exposure',
 });
+
+const CONTENT_OPERATION_CAPABILITIES = Object.freeze({
+  EDIT: 'content_operations.edit',
+  APPROVE: 'content_operations.approve',
+  PUBLISH: 'content_operations.publish',
+});
+
+function actorCan(actor, capability) {
+  return Boolean(actor?.capabilities?.[capability]);
+}
+
+function contentOperationMutation(action, packageId) {
+  const safeAction = String(action || 'mutation').replace(/[^a-z0-9_-]/gi, '-').toLowerCase();
+  const safePackageId = String(packageId || 'package').replace(/[^a-z0-9_-]/gi, '-').toLowerCase();
+  return {
+    requestId: `content-ops-${safeAction}-${safePackageId}-${Date.now()}`,
+  };
+}
+
+function actionMessage(action) {
+  if (action === 'validate') return 'Candidate validated.';
+  if (action === 'approve') return 'Candidate approved.';
+  if (action === 'publish') return 'Package published.';
+  return 'Package action completed.';
+}
 
 function collectLanePackages(overview) {
   const seen = new Set();
@@ -86,6 +112,46 @@ function blockerSectionHasSignals(section) {
 function hasAudioOrAssetSignals(contentPackage) {
   return blockerSectionHasSignals(contentPackage.blockers?.audio)
     || blockerSectionHasSignals(contentPackage.blockers?.assets);
+}
+
+function latestCandidateForPackage(contentPackage, lifecycleState) {
+  if (
+    lifecycleState?.candidate
+    && lifecycleState.packageId === contentPackage.packageId
+  ) {
+    return normaliseContentOperationCandidate(lifecycleState.candidate);
+  }
+  return contentPackage.latestCandidate || null;
+}
+
+function candidateHasApprovalBlockers(candidate) {
+  if (!candidate) return true;
+  return candidate.blockers.blockingSections
+    .filter((section) => section !== 'publishReadiness')
+    .length > 0;
+}
+
+function formatCompactJson(value) {
+  if (value == null) return '';
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function eventDetailText(event) {
+  const payload = event?.event && typeof event.event === 'object' && !Array.isArray(event.event)
+    ? event.event
+    : null;
+  if (!payload) return '';
+  const parts = [
+    payload.candidateHash ? `candidate ${payload.candidateHash}` : '',
+    payload.snapshotHash ? `snapshot ${payload.snapshotHash}` : '',
+    payload.releaseId ? `release ${payload.releaseId}` : '',
+    payload.notes ? `notes: ${payload.notes}` : '',
+  ].filter(Boolean);
+  return parts.length ? parts.join(' - ') : formatCompactJson(payload);
 }
 
 function PackageStateChip({ contentPackage }) {
@@ -340,6 +406,147 @@ function PublishedAreaPanel({ activeTab, latestRelease, selectedPackageId, selec
   );
 }
 
+function PackageLifecyclePanel({
+  contentPackage,
+  actor,
+  lifecycleState,
+  actionAvailability = {},
+  onRunAction,
+}) {
+  const [notes, setNotes] = React.useState('');
+  const candidate = latestCandidateForPackage(contentPackage, lifecycleState);
+  const canEdit = actorCan(actor, CONTENT_OPERATION_CAPABILITIES.EDIT);
+  const canApprove = actorCan(actor, CONTENT_OPERATION_CAPABILITIES.APPROVE);
+  const canPublish = actorCan(actor, CONTENT_OPERATION_CAPABILITIES.PUBLISH);
+  const isRunning = Boolean(
+    lifecycleState?.running
+      && lifecycleState.packageId === contentPackage.packageId
+  );
+  const activeAction = isRunning ? lifecycleState.action : '';
+  const actionError = lifecycleState?.packageId === contentPackage.packageId
+    ? lifecycleState.error
+    : null;
+  const actionMessageText = lifecycleState?.packageId === contentPackage.packageId
+    ? lifecycleState.message
+    : '';
+  const approvalBlocked = candidateHasApprovalBlockers(candidate);
+  const validateDisabled = !actionAvailability.validate || !canEdit || isRunning || contentPackage.state === 'published';
+  const approveDisabled = !canApprove
+    || !actionAvailability.approve
+    || isRunning
+    || !candidate?.candidateId
+    || approvalBlocked
+    || contentPackage.state === 'published';
+  const publishDisabled = !canPublish
+    || !actionAvailability.publish
+    || isRunning
+    || contentPackage.state !== 'approved';
+
+  const run = (action) => {
+    if (!onRunAction) return;
+    onRunAction(action, {
+      packageId: contentPackage.packageId,
+      candidateId: candidate?.candidateId || '',
+      candidateHash: candidate?.candidateHash || '',
+      notes,
+    });
+  };
+
+  return (
+    <section className="content-ops-lifecycle" aria-label="Package lifecycle">
+      <div className="content-ops-lifecycle-header">
+        <div>
+          <div className="eyebrow">Lifecycle</div>
+          <h5>Validate, approve, publish</h5>
+        </div>
+        <div className="chip-row content-ops-chip-wrap">
+          <span className="chip">Edit {canEdit ? 'allowed' : 'locked'}</span>
+          <span className="chip">Approve {canApprove ? 'allowed' : 'locked'}</span>
+          <span className="chip">Publish {canPublish ? 'allowed' : 'locked'}</span>
+        </div>
+      </div>
+      <div className="content-ops-candidate-grid">
+        <MetricTile
+          label="Candidate"
+          value={candidate?.candidateId || 'Not built'}
+          detail={candidate?.createdAt ? formatTimestamp(candidate.createdAt) : 'Run validation first'}
+        />
+        <MetricTile
+          label="Candidate hash"
+          value={candidate?.candidateHash || 'Pending'}
+          detail={candidate?.operationsHash ? `Operations ${candidate.operationsHash}` : 'Operations hash pending'}
+        />
+        <MetricTile
+          label="Release base"
+          value={candidate?.baseReleaseId || contentPackage.baseReleaseId || 'First release'}
+          detail={`Current ${candidate?.currentReleaseId || 'bundled fallback'}`}
+        />
+        <MetricTile
+          label="Validation"
+          value={candidate?.validation?.status || contentPackage.blockers.validation.status}
+          detail={`${String(candidate?.validation?.errorCount || 0)} errors, ${String(candidate?.validation?.warningCount || 0)} warnings`}
+        />
+      </div>
+      <div className="content-ops-lifecycle-controls">
+        <label className="content-ops-notes-field">
+          <span className="small muted">Approval notes</span>
+          <textarea
+            value={notes}
+            onChange={(event) => setNotes(event.target.value)}
+            rows={3}
+            data-content-ops-approval-notes="true"
+          />
+        </label>
+        <div className="actions content-ops-lifecycle-actions">
+          <button
+            type="button"
+            className="btn secondary"
+            disabled={validateDisabled}
+            aria-busy={activeAction === 'validate' ? 'true' : undefined}
+            data-content-ops-action="validate"
+            onClick={() => run('validate')}
+          >
+            Validate candidate
+          </button>
+          <button
+            type="button"
+            className="btn secondary"
+            disabled={approveDisabled}
+            aria-busy={activeAction === 'approve' ? 'true' : undefined}
+            data-content-ops-action="approve"
+            onClick={() => run('approve')}
+          >
+            Approve candidate
+          </button>
+          <button
+            type="button"
+            className="btn primary"
+            disabled={publishDisabled}
+            aria-busy={activeAction === 'publish' ? 'true' : undefined}
+            data-content-ops-action="publish"
+            onClick={() => run('publish')}
+          >
+            Publish package
+          </button>
+        </div>
+      </div>
+      {approvalBlocked && candidate ? (
+        <BlockerSummary blockers={candidate.blockers} sectionKey="validation" />
+      ) : null}
+      {actionError ? (
+        <div className="feedback warn admin-note-spaced" data-content-ops-action-error="true">
+          <strong>{actionError.code}</strong>
+          <div>{actionError.message}</div>
+        </div>
+      ) : actionMessageText ? (
+        <div className="feedback good admin-note-spaced" data-content-ops-action-message="true">
+          {actionMessageText}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
 function PackageDetailBody({ contentPackage, activeTab, events }) {
   if (activeTab === 'spelling') {
     return (
@@ -383,6 +590,10 @@ function PackageDetailBody({ contentPackage, activeTab, events }) {
               <li key={event.eventId}>
                 <strong>{event.eventType}</strong>
                 <span className="small muted"> - {formatTimestamp(event.createdAt)}</span>
+                {event.actorAccountId ? <span className="small muted"> - {event.actorAccountId}</span> : null}
+                {eventDetailText(event) ? (
+                  <div className="small muted content-ops-event-detail">{eventDetailText(event)}</div>
+                ) : null}
               </li>
             ))}
           </ul>
@@ -413,6 +624,10 @@ function PackageDetail({
   detailErrorId,
   activeTab,
   onSelectTab,
+  actor,
+  lifecycleState,
+  lifecycleActionAvailability,
+  onRunLifecycleAction,
 }) {
   const contentPackage = detail?.package || null;
   if (!selectedPackageId) {
@@ -456,6 +671,13 @@ function PackageDetail({
           ) : null}
         </div>
       </div>
+      <PackageLifecyclePanel
+        contentPackage={contentPackage}
+        actor={actor}
+        lifecycleState={lifecycleState}
+        actionAvailability={lifecycleActionAvailability}
+        onRunAction={onRunLifecycleAction}
+      />
       <DetailTabNav activeTab={activeTab} onSelect={onSelectTab} />
       <div className="content-ops-detail-body" role="tabpanel">
         <PackageDetailBody
@@ -545,6 +767,16 @@ export function AdminContentOperationsSection({
   const [detailErrorId, setDetailErrorId] = React.useState('');
   const [refreshError, setRefreshError] = React.useState(null);
   const [refreshedAt, setRefreshedAt] = React.useState(hasSeedData ? Date.now() : null);
+  const [lifecycleState, setLifecycleState] = React.useState({
+    packageId: '',
+    action: '',
+    running: false,
+    message: '',
+    error: null,
+    candidate: null,
+    approval: null,
+    release: null,
+  });
   const detailRequestRef = React.useRef({ id: '', seq: 0 });
   const refreshRequestRef = React.useRef(0);
   const api = actions?.contentOperationsApi || null;
@@ -657,6 +889,84 @@ export function AdminContentOperationsSection({
     selectedPackageId,
   ]);
 
+  const runLifecycleAction = React.useCallback(async (action, {
+    packageId,
+    candidateId = '',
+    candidateHash = '',
+    notes = '',
+  } = {}) => {
+    if (!api || !packageId) return;
+    setLifecycleState((current) => ({
+      ...current,
+      packageId,
+      action,
+      running: true,
+      message: '',
+      error: null,
+    }));
+    try {
+      let payload = null;
+      if (action === 'validate') {
+        if (!api.validatePackage) throw new Error('Validate action is not available.');
+        payload = await api.validatePackage({
+          packageId,
+          includeSnapshot: false,
+          mutation: contentOperationMutation(action, packageId),
+        });
+      } else if (action === 'approve') {
+        if (!api.approvePackage) throw new Error('Approve action is not available.');
+        payload = await api.approvePackage({
+          packageId,
+          candidateId,
+          notes,
+          mutation: contentOperationMutation(action, packageId),
+        });
+      } else if (action === 'publish') {
+        if (!api.publishPackage) throw new Error('Publish action is not available.');
+        payload = await api.publishPackage({
+          packageId,
+          proof: {
+            source: 'content-operations-centre',
+            packageId,
+            candidateId: candidateId || null,
+            candidateHash: candidateHash || null,
+            approvalNotes: notes || null,
+          },
+          mutation: contentOperationMutation(action, packageId),
+        });
+      }
+      const nextCandidate = payload?.candidate
+        ? normaliseContentOperationCandidate(payload.candidate)
+        : null;
+      setLifecycleState((current) => ({
+        ...current,
+        packageId,
+        action,
+        running: false,
+        message: actionMessage(action),
+        error: null,
+        candidate: nextCandidate || (current.packageId === packageId ? current.candidate : null),
+        approval: payload?.approval || null,
+        release: payload?.release || null,
+      }));
+      if (api.readPackage) {
+        await loadPackageDetail(packageId);
+      }
+      if (action !== 'validate' && api.readOverview) {
+        await refresh();
+      }
+    } catch (error) {
+      setLifecycleState((current) => ({
+        ...current,
+        packageId,
+        action,
+        running: false,
+        message: '',
+        error: errorEnvelope(error, `content_operations_${action}_failed`),
+      }));
+    }
+  }, [api, loadPackageDetail, refresh]);
+
   const latestRelease = overview.latestRelease;
   const primaryData = overview.openPackageCount || packages.length || releases.length || latestRelease ? {
     overview,
@@ -672,6 +982,12 @@ export function AdminContentOperationsSection({
       ? { package: normaliseContentOperationPackage(selectedSummary), events: [] }
       : { package: null, events: [] });
   const warningSectionCount = packages.reduce((sum, entry) => sum + entry.blockers.warningCount, 0);
+  const detailActor = safeDetail.actor?.accountId ? safeDetail.actor : overview.actor;
+  const lifecycleActionAvailability = {
+    validate: Boolean(api?.validatePackage),
+    approve: Boolean(api?.approvePackage),
+    publish: Boolean(api?.publishPackage),
+  };
 
   return (
     <AdminPanelFrame
@@ -731,6 +1047,10 @@ export function AdminContentOperationsSection({
           detailErrorId={detailErrorId}
           activeTab={activeDetailTab}
           onSelectTab={setActiveDetailTab}
+          actor={detailActor}
+          lifecycleState={lifecycleState}
+          lifecycleActionAvailability={lifecycleActionAvailability}
+          onRunLifecycleAction={runLifecycleAction}
         />
       ) : null}
 

--- a/styles/app.css
+++ b/styles/app.css
@@ -12376,6 +12376,50 @@ html { scroll-behavior: smooth; }
   padding-top: 12px;
 }
 
+.content-ops-lifecycle {
+  display: grid;
+  gap: 12px;
+  border-top: 1px solid var(--line);
+  margin-top: 12px;
+  padding-top: 12px;
+}
+
+.content-ops-lifecycle-header,
+.content-ops-lifecycle-controls {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.content-ops-candidate-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.content-ops-notes-field {
+  display: grid;
+  gap: 4px;
+  flex: 1 1 280px;
+  min-width: min(100%, 260px);
+}
+
+.content-ops-notes-field textarea {
+  width: 100%;
+  resize: vertical;
+}
+
+.content-ops-lifecycle-actions {
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  margin-top: 18px;
+}
+
+.content-ops-event-detail {
+  overflow-wrap: anywhere;
+}
+
 .content-ops-operation-list {
   margin: 8px 0 0;
   padding-left: 18px;
@@ -12403,6 +12447,7 @@ html { scroll-behavior: smooth; }
 
 @media (max-width: 900px) {
   .content-ops-metric-grid,
+  .content-ops-candidate-grid,
   .content-ops-lanes {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -12410,12 +12455,15 @@ html { scroll-behavior: smooth; }
 
 @media (max-width: 640px) {
   .content-ops-metric-grid,
+  .content-ops-candidate-grid,
   .content-ops-lanes {
     grid-template-columns: 1fr;
   }
 
   .content-ops-package-summary,
-  .content-ops-detail-header {
+  .content-ops-detail-header,
+  .content-ops-lifecycle-header,
+  .content-ops-lifecycle-controls {
     flex-direction: column;
     align-items: stretch;
   }

--- a/tests/admin-content-operations-v2.test.js
+++ b/tests/admin-content-operations-v2.test.js
@@ -32,6 +32,7 @@ import { createHubApi } from '../src/platform/hubs/api.js';
 import {
   CONTENT_OPERATION_DETAIL_TABS,
   CONTENT_OPERATION_LANES,
+  normaliseContentOperationCandidate,
   normaliseContentOperationPackage,
   normaliseContentOperationsOverview,
   normaliseContentOperationsPackageDetail,
@@ -426,6 +427,27 @@ const CONTENT_OPS_PACKAGE = {
     exposure: { status: 'passed', blockers: [], warnings: [] },
     publishReadiness: { status: 'not_ready', blockers: ['approval_required'], warnings: [] },
   },
+  latestCandidate: {
+    candidateId: 'cand-draft-1',
+    packageId: 'pkg-draft-1',
+    baseReleaseId: 'rel-global-1',
+    currentReleaseId: 'rel-global-1',
+    operationsHash: 'ops-hash-1',
+    candidateHash: 'candidate-hash-1',
+    validation: { ok: true, errorCount: 0, warningCount: 0, errors: [], warnings: [] },
+    blockers: {
+      validation: { status: 'passed', errorCount: 0, warningCount: 0, errors: [], warnings: [] },
+      conflicts: { status: 'passed', count: 0, items: [] },
+      audio: { status: 'passed', blockers: [], warnings: [] },
+      assets: { status: 'passed', blockers: [], warnings: [] },
+      rewards: { status: 'passed', blockers: [], warnings: [] },
+      visibility: { status: 'passed', blockers: [], warnings: [] },
+      exposure: { status: 'passed', blockers: [], warnings: [] },
+      publishReadiness: { status: 'not_ready', blockers: ['approval_required'], warnings: [] },
+    },
+    conflicts: [],
+    createdAt: Date.UTC(2026, 5, 11, 10, 5, 0),
+  },
 };
 
 const CONTENT_OPS_OVERVIEW = {
@@ -507,6 +529,7 @@ describe('Content Operations Centre normalisers', () => {
     assert.equal(overview.laneCounts.drafts, 1);
     assert.equal(overview.lanes.drafts[0].stateLabel, 'Draft');
     assert.equal(overview.lanes.drafts[0].blockers.warningCount, 1);
+    assert.equal(overview.lanes.drafts[0].latestCandidate.candidateHash, 'candidate-hash-1');
     assert.equal(overview.recentReleases[0].proof.source, 'test');
     assert.equal(overview.actor.capabilities['content_operations.approve'], true);
   });
@@ -522,10 +545,22 @@ describe('Content Operations Centre normalisers', () => {
     });
 
     assert.equal(packages[0].packageId, 'pkg-draft-1');
+    assert.equal(packages[0].latestCandidate.candidateId, 'cand-draft-1');
     assert.equal(packages[0].blockers.blockingSections.includes('audio'), true);
     assert.equal(releases[0].releaseId, 'rel-global-1');
     assert.equal(detail.package.operations[0].fieldPath, 'explanation');
+    assert.equal(detail.package.latestCandidate.operationsHash, 'ops-hash-1');
     assert.equal(detail.events[0].eventType, 'package.created');
+  });
+
+  it('normalises candidate review metadata for lifecycle controls', () => {
+    const candidate = normaliseContentOperationCandidate(CONTENT_OPS_PACKAGE.latestCandidate);
+
+    assert.equal(candidate.candidateId, 'cand-draft-1');
+    assert.equal(candidate.candidateHash, 'candidate-hash-1');
+    assert.equal(candidate.validation.status, 'passed');
+    assert.deepEqual(candidate.blockers.blockingSections, ['publishReadiness']);
+    assert.equal(candidate.blockers.publishReadiness.blockers[0], 'approval_required');
   });
 
   it('keeps compact package operation counts unknown instead of inventing zero', () => {
@@ -575,6 +610,47 @@ describe('Content Operations Centre hub API client', () => {
     assert.deepEqual(calls.map((call) => call.method), ['GET', 'GET', 'GET', 'GET', 'GET']);
   });
 
+  it('calls lifecycle mutation endpoints with package, candidate, and proof payloads', async () => {
+    const calls = [];
+    const api = createHubApi({
+      baseUrl: 'https://repo.test',
+      fetch: async (url, init = {}) => {
+        calls.push({
+          url: String(url),
+          method: init.method,
+          body: init.body ? JSON.parse(init.body) : null,
+        });
+        return jsonResponse({ ok: true });
+      },
+    });
+
+    await api.validateContentOperationPackage({
+      packageId: 'pkg/with/slash',
+      includeSnapshot: true,
+      mutation: { requestId: 'validate-1' },
+    });
+    await api.approveContentOperationPackage({
+      packageId: 'pkg/with/slash',
+      candidateId: 'cand/with/slash',
+      notes: 'Reviewed candidate.',
+      mutation: { requestId: 'approve-1' },
+    });
+    await api.publishContentOperationPackage({
+      packageId: 'pkg/with/slash',
+      proof: { source: 'test' },
+      mutation: { requestId: 'publish-1' },
+    });
+
+    assert.equal(new URL(calls[0].url).pathname, '/api/admin/content-operations/packages/pkg%2Fwith%2Fslash/validate');
+    assert.equal(new URL(calls[1].url).pathname, '/api/admin/content-operations/packages/pkg%2Fwith%2Fslash/approve');
+    assert.equal(new URL(calls[2].url).pathname, '/api/admin/content-operations/packages/pkg%2Fwith%2Fslash/publish');
+    assert.deepEqual(calls.map((call) => call.method), ['POST', 'POST', 'POST']);
+    assert.equal(calls[0].body.includeSnapshot, true);
+    assert.equal(calls[1].body.candidateId, 'cand/with/slash');
+    assert.equal(calls[1].body.notes, 'Reviewed candidate.');
+    assert.equal(calls[2].body.proof.source, 'test');
+  });
+
   it('rejects package and release detail reads without explicit ids', async () => {
     const api = createHubApi({
       baseUrl: 'https://repo.test',
@@ -588,6 +664,18 @@ describe('Content Operations Centre hub API client', () => {
     await assert.rejects(
       () => api.readContentOperationRelease({ releaseId: '' }),
       /Content operation release id is required/,
+    );
+    await assert.rejects(
+      () => api.validateContentOperationPackage({ packageId: '' }),
+      /Content operation package id is required/,
+    );
+    await assert.rejects(
+      () => api.approveContentOperationPackage({ packageId: 'pkg-1', candidateId: '' }),
+      /Content operation candidate id is required/,
+    );
+    await assert.rejects(
+      () => api.publishContentOperationPackage({ packageId: '' }),
+      /Content operation package id is required/,
     );
   });
 });

--- a/tests/button-label-consistency.test.js
+++ b/tests/button-label-consistency.test.js
@@ -527,6 +527,12 @@ test('button labels: every statically extractable label is classified', () => {
     // opens a new incident from the error-centre context.
     'Add note',
     'Create incident',
+    // Content Operations Centre T7: package lifecycle CTAs are deliberately
+    // candidate/package-specific so operators can distinguish review gates
+    // from generic form validation or asset publishing controls.
+    'Validate candidate',
+    'Approve candidate',
+    'Publish package',
     // Reasoning launch: delayed SATs-style sets use "Mark set" and "Save
     // answers" to distinguish full-set marking from single-question submit.
     // "Partly worked support" is the child-facing scaffold request, matching

--- a/tests/content-operations-api.test.js
+++ b/tests/content-operations-api.test.js
@@ -274,7 +274,13 @@ test('content operations API supports admin package lifecycle through separate a
     const detail = await readPayload(detailResponse);
     assert.equal(detailResponse.status, 200);
     assert.equal(detail.package.state, 'published');
+    assert.equal(detail.package.latestCandidate.candidateId, validated.candidate.candidateId);
+    assert.equal(detail.package.latestCandidate.candidateHash, validated.candidate.candidateHash);
     assert.ok(detail.events.some((event) => event.eventType === 'package.approved'));
+    assert.ok(detail.events.some((event) => (
+      event.eventType === 'package.approved'
+        && event.event.candidateHash === validated.candidate.candidateHash
+    )));
     assert.ok(detail.events.some((event) => event.eventType === 'package.published'));
 
     const overviewResponse = await server.fetchAs(

--- a/tests/react-admin-content-operations.test.js
+++ b/tests/react-admin-content-operations.test.js
@@ -65,6 +65,30 @@ const contentPackage = {
   },
 };
 
+const cleanLifecycleBlockers = {
+  validation: { status: 'passed', errorCount: 0, warningCount: 0, errors: [], warnings: [] },
+  conflicts: { status: 'passed', count: 0, items: [] },
+  audio: { status: 'passed', blockers: [], warnings: [] },
+  assets: { status: 'passed', blockers: [], warnings: [] },
+  rewards: { status: 'passed', blockers: [], warnings: [] },
+  visibility: { status: 'passed', blockers: [], warnings: [] },
+  exposure: { status: 'passed', blockers: [], warnings: [] },
+  publishReadiness: { status: 'not_ready', blockers: ['approval_required'], warnings: [] },
+};
+
+const lifecycleCandidate = {
+  candidateId: 'cand-ready-1',
+  packageId: 'pkg-draft-1',
+  baseReleaseId: 'rel-global-1',
+  currentReleaseId: 'rel-global-1',
+  operationsHash: 'ops-ready-1',
+  candidateHash: 'candidate-ready-1',
+  validation: { ok: true, errorCount: 0, warningCount: 0, errors: [], warnings: [] },
+  blockers: cleanLifecycleBlockers,
+  conflicts: [],
+  createdAt: Date.UTC(2026, 5, 11, 10, 5, 0),
+};
+
 const release = {
   releaseId: 'rel-global-1',
   subjectId: 'spelling',
@@ -507,6 +531,235 @@ test('Content Operations Centre mounted shell loads API data without implicit pa
   assert.match(result.overviewText, /rel-global-1/);
   assert.match(result.packageTableText, /Pending/);
   assert.equal(result.selectedRows, 0);
+});
+
+test('Content Operations Centre mounted package detail runs validate, approve, and publish actions', async () => {
+  const output = await runClientEntry(`
+    const { JSDOM } = require('jsdom');
+
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+    const dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
+      url: 'https://ks2.eugnel.uk/admin',
+    });
+    globalThis.window = dom.window;
+    globalThis.document = dom.window.document;
+    globalThis.navigator = dom.window.navigator;
+    globalThis.HTMLElement = dom.window.HTMLElement;
+    globalThis.Event = dom.window.Event;
+
+    const React = require('react');
+    const { createRoot } = require('react-dom/client');
+    const { AdminContentOperationsSection } = require(${CONTENT_OPS_SECTION_PATH});
+    const { act } = React;
+
+    const candidate = ${JSON.stringify(lifecycleCandidate)};
+    const cleanBlockers = ${JSON.stringify(cleanLifecycleBlockers)};
+    const release = ${JSON.stringify(release)};
+    const basePackage = {
+      ...${JSON.stringify(contentPackage)},
+      blockers: cleanBlockers,
+      latestCandidate: null,
+    };
+    let packageState = 'draft';
+    let latestCandidate = null;
+    const calls = [];
+
+    function packageForState() {
+      return {
+        ...basePackage,
+        state: packageState,
+        latestCandidate,
+        approvedAt: packageState === 'approved' || packageState === 'published'
+          ? ${Date.UTC(2026, 5, 11, 10, 10, 0)}
+          : null,
+        publishedAt: packageState === 'published'
+          ? ${Date.UTC(2026, 5, 11, 10, 20, 0)}
+          : null,
+        blockers: {
+          ...cleanBlockers,
+          publishReadiness: packageState === 'approved'
+            ? { status: 'ready', blockers: [], warnings: [] }
+            : cleanBlockers.publishReadiness,
+        },
+      };
+    }
+
+    const model = ${JSON.stringify(baseModel({
+      contentOperations: {
+        overview: {
+          ...overview,
+          lanes: {
+            blocked: [],
+            readyForApproval: [],
+            approvedPendingPublish: [],
+            drafts: [],
+            recentReleases: [],
+          },
+        },
+        packages: { packages: [] },
+        releases: { releases: [] },
+        packageDetail: null,
+      },
+    }))};
+    model.contentOperations.overview.lanes.drafts = [basePackage];
+    model.contentOperations.packages.packages = [basePackage];
+    model.contentOperations.releases.releases = [release];
+    model.contentOperations.packageDetail = {
+      package: basePackage,
+      actor: model.contentOperations.overview.actor,
+      events: [{ eventId: 'event-created', eventType: 'package.created', createdAt: ${Date.UTC(2026, 5, 11, 10, 0, 0)}, event: {} }],
+    };
+
+    const actions = {
+      contentOperationsApi: {
+        async validatePackage(args) {
+          calls.push({ method: 'validate', args });
+          latestCandidate = candidate;
+          return { candidate };
+        },
+        async approvePackage(args) {
+          calls.push({ method: 'approve', args });
+          packageState = 'approved';
+          return {
+            approval: {
+              approvalId: 'approval-1',
+              packageId: basePackage.packageId,
+              candidateId: candidate.candidateId,
+              candidateHash: candidate.candidateHash,
+              approvedAt: ${Date.UTC(2026, 5, 11, 10, 10, 0)},
+              notes: args.notes,
+            },
+          };
+        },
+        async publishPackage(args) {
+          calls.push({ method: 'publish', args });
+          packageState = 'published';
+          return {
+            release: {
+              ...release,
+              releaseId: 'rel-published-1',
+              packageId: basePackage.packageId,
+              proof: args.proof,
+            },
+          };
+        },
+        async readPackage({ packageId }) {
+          calls.push({ method: 'readPackage', packageId, state: packageState });
+          return {
+            package: packageForState(),
+            actor: model.contentOperations.overview.actor,
+            events: [
+              { eventId: 'event-created', eventType: 'package.created', createdAt: ${Date.UTC(2026, 5, 11, 10, 0, 0)}, event: {} },
+              { eventId: 'event-approved', eventType: 'package.approved', actorAccountId: 'admin-a', createdAt: ${Date.UTC(2026, 5, 11, 10, 10, 0)}, event: { candidateHash: candidate.candidateHash, notes: 'Ready to publish.' } },
+            ],
+          };
+        },
+        async readOverview(args) {
+          calls.push({ method: 'overview', args, state: packageState });
+          const packageEntry = packageForState();
+          return {
+            ...model.contentOperations.overview,
+            latestRelease: packageState === 'published' ? { ...release, releaseId: 'rel-published-1' } : release,
+            lanes: {
+              blocked: [],
+              readyForApproval: [],
+              approvedPendingPublish: packageState === 'approved' ? [packageEntry] : [],
+              drafts: packageState === 'draft' ? [packageEntry] : [],
+              recentReleases: packageState === 'published' ? [{ ...release, releaseId: 'rel-published-1' }] : [],
+            },
+          };
+        },
+        async readPackages(args) {
+          calls.push({ method: 'packages', args, state: packageState });
+          return { packages: [packageForState()] };
+        },
+        async readReleases(args) {
+          calls.push({ method: 'releases', args, state: packageState });
+          return { releases: packageState === 'published' ? [{ ...release, releaseId: 'rel-published-1' }] : [release] };
+        },
+      },
+    };
+
+    async function flush() {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+    }
+
+    async function clickAction(action) {
+      const button = document.querySelector('[data-content-ops-action="' + action + '"]');
+      await act(async () => {
+        button.click();
+      });
+      await flush();
+      await flush();
+      await flush();
+    }
+
+    async function main() {
+      const root = createRoot(document.getElementById('root'));
+      await act(async () => {
+        root.render(React.createElement(AdminContentOperationsSection, {
+          model,
+          actions,
+          initialActiveTab: 'detail',
+        }));
+      });
+
+      const notes = document.querySelector('[data-content-ops-approval-notes="true"]');
+      const valueSetter = Object.getOwnPropertyDescriptor(dom.window.HTMLTextAreaElement.prototype, 'value').set;
+      valueSetter.call(notes, 'Ready to publish.');
+      await act(async () => {
+        notes.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
+        notes.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+      });
+
+      await clickAction('validate');
+      const textAfterValidate = document.body.textContent;
+      const approveDisabledAfterValidate = document.querySelector('[data-content-ops-action="approve"]').disabled;
+
+      await clickAction('approve');
+      const textAfterApprove = document.body.textContent;
+      const publishDisabledAfterApprove = document.querySelector('[data-content-ops-action="publish"]').disabled;
+
+      await clickAction('publish');
+      const textAfterPublish = document.body.textContent;
+
+      process.stdout.write(JSON.stringify({
+        calls,
+        textAfterValidate,
+        approveDisabledAfterValidate,
+        textAfterApprove,
+        publishDisabledAfterApprove,
+        textAfterPublish,
+      }));
+
+      await act(async () => {
+        root.unmount();
+      });
+      dom.window.close();
+      process.exit(0);
+    }
+
+    main().catch((error) => {
+      process.stderr.write(error.stack || error.message);
+      process.exitCode = 1;
+    });
+  `);
+  const result = JSON.parse(output);
+  const lifecycleCalls = result.calls.filter((entry) => ['validate', 'approve', 'publish'].includes(entry.method));
+
+  assert.deepEqual(lifecycleCalls.map((entry) => entry.method), ['validate', 'approve', 'publish']);
+  assert.equal(lifecycleCalls[0].args.packageId, 'pkg-draft-1');
+  assert.equal(lifecycleCalls[1].args.candidateId, 'cand-ready-1');
+  assert.equal(lifecycleCalls[1].args.notes, 'Ready to publish.');
+  assert.equal(lifecycleCalls[2].args.proof.candidateHash, 'candidate-ready-1');
+  assert.match(result.textAfterValidate, /candidate-ready-1/);
+  assert.equal(result.approveDisabledAfterValidate, false);
+  assert.match(result.textAfterApprove, /Candidate approved/);
+  assert.equal(result.publishDisabledAfterApprove, false);
+  assert.match(result.textAfterPublish, /Package published/);
+  assert.match(result.textAfterPublish, /rel-published-1/);
 });
 
 test('Content Operations Centre mounted package detail ignores stale out-of-order reads', async () => {

--- a/worker/src/content-operations/repository.js
+++ b/worker/src/content-operations/repository.js
@@ -1042,7 +1042,15 @@ export function createContentOperationsRepository({ db, now }) {
           packageRow.subject_id,
           'package.approved',
           actor,
-          JSON.stringify({ approvalId, candidateId, candidateHash: candidate.candidateHash }),
+          JSON.stringify({
+            approvalId,
+            candidateId,
+            candidateHash: candidate.candidateHash,
+            notes: normaliseString(notes),
+            validationSummary: candidate.validation,
+            audioFallback,
+            assetSummary,
+          }),
           nowTs,
         ]),
       ]);

--- a/worker/src/content-operations/serialisers.js
+++ b/worker/src/content-operations/serialisers.js
@@ -207,6 +207,7 @@ export function serialiseContentOperationPackage(contentPackage = {}, { compact 
     publishedAt: contentPackage.publishedAt ?? null,
     supersededByPackageId: contentPackage.supersededByPackageId || null,
     operationCount: Array.isArray(contentPackage.operations) ? contentPackage.operations.length : undefined,
+    latestCandidate: latestCandidate ? serialiseContentOperationCandidate(latestCandidate) : null,
     blockers: envelope,
   };
   if (!compact && Array.isArray(contentPackage.operations)) {


### PR DESCRIPTION
## Summary
- Add Content Operations package lifecycle controls for validate, approve, and publish from the package detail view.
- Surface latest candidate metadata, role-capability chips, approval notes, action errors, and approval audit event details.
- Wire the hub client/API boundary for lifecycle mutations and include latest candidate metadata in package serialisation.

## Scope notes
- This implements the supported T7 lifecycle path against the existing Worker routes: validate, approve, publish, audit/proof refresh.
- Explicit submit-for-approval, reject, and mark-blocked transitions are not introduced here because the server state machine does not expose those routes yet; they should land as a later ticket if still required.

## Verification
- node --test tests/admin-content-operations-v2.test.js
- node --test tests/react-admin-content-operations.test.js
- node --test tests/content-operations-api.test.js
- node --test tests/content-operations-repository.test.js
- node --test tests/button-label-consistency.test.js
- npm run check
- npm test
- pre-push npm test
- Playwright local visual smoke harness for the package lifecycle panel and approve/publish flow