### PR TITLE
Content Operations T8: package conflict resolver

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2720,6 +2720,7 @@ function buildSurfaceActions() {
     validatePackage: hubApi.validateContentOperationPackage?.bind(hubApi),
     approvePackage: hubApi.approveContentOperationPackage?.bind(hubApi),
     publishPackage: hubApi.publishContentOperationPackage?.bind(hubApi),
+    resolveConflict: hubApi.resolveContentOperationConflict?.bind(hubApi),
     readReleases: hubApi.readContentOperationReleases?.bind(hubApi),
     readRelease: hubApi.readContentOperationRelease?.bind(hubApi),
   } : null;

--- a/src/platform/hubs/api.js
+++ b/src/platform/hubs/api.js
@@ -339,6 +339,32 @@ export function createHubApi({
         }),
       }, authSession);
     },
+    async resolveContentOperationConflict({
+      packageId,
+      conflictId = '',
+      conflict = null,
+      resolution,
+      value,
+      includeSnapshot = false,
+      mutation,
+    } = {}) {
+      if (!packageId) throw new TypeError('Content operation package id is required.');
+      if (!resolution) throw new TypeError('Content operation conflict resolution is required.');
+      const safePackageId = encodeURIComponent(String(packageId));
+      const url = buildRequestUrl(baseUrl, `/api/admin/content-operations/packages/${safePackageId}/resolve-conflict`);
+      return fetchHubJson(fetch, url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          conflictId,
+          conflict,
+          resolution,
+          value,
+          includeSnapshot: Boolean(includeSnapshot),
+          mutation,
+        }),
+      }, authSession);
+    },
     async readContentOperationReleases({ limit = 20, includeSnapshot = false } = {}) {
       const url = buildRequestUrl(
         baseUrl,

--- a/src/subjects/spelling/content/operations-model.js
+++ b/src/subjects/spelling/content/operations-model.js
@@ -62,6 +62,10 @@ function hashPayload(value, prefix = 'co') {
   return `${prefix}-${stableHash(stableStringify(value)).toString(36)}`;
 }
 
+function operationValueHash(operation) {
+  return normaliseString(operation?.afterHash || operation?.after_hash, contentOperationValueHash(operation?.payload));
+}
+
 function splitFieldPath(fieldPath) {
   return normaliseString(fieldPath)
     .split('.')
@@ -186,6 +190,10 @@ export function contentOperationHash(value, prefix = 'co') {
   return hashPayload(value, prefix);
 }
 
+export function contentOperationValueHash(value) {
+  return hashPayload(value === undefined ? null : value, 'after');
+}
+
 export function normaliseContentOperation(rawValue = {}, {
   actorAccountId = '',
   now = null,
@@ -221,7 +229,7 @@ export function normaliseContentOperation(rawValue = {}, {
     actorAccountId,
   );
   const beforeHash = normaliseString(raw.beforeHash || raw.before_hash);
-  const afterHash = normaliseString(raw.afterHash || raw.after_hash, hashPayload(payload, 'after'));
+  const afterHash = normaliseString(raw.afterHash || raw.after_hash, contentOperationValueHash(payload));
 
   return {
     operationId: normaliseString(raw.operationId || raw.operation_id, operationId),
@@ -242,10 +250,21 @@ export function operationConflictKey(operation) {
   return `${normalised.entityType}::${normalised.entityId}::${normalised.fieldPath || '$'}`;
 }
 
+export function effectiveContentOperations(operations = []) {
+  const order = [];
+  const byKey = new Map();
+  for (const rawOperation of operations) {
+    const operation = normaliseContentOperation(rawOperation, { now: () => 0 });
+    const key = operationConflictKey(operation);
+    if (!byKey.has(key)) order.push(key);
+    byKey.set(key, operation);
+  }
+  return order.map((key) => byKey.get(key));
+}
+
 export function detectContentOperationConflicts(leftOperations = [], rightOperations = []) {
-  const normaliseForComparison = (operation) => normaliseContentOperation(operation, { now: () => 0 });
-  const left = leftOperations.map(normaliseForComparison);
-  const right = rightOperations.map(normaliseForComparison);
+  const left = effectiveContentOperations(leftOperations);
+  const right = effectiveContentOperations(rightOperations);
   const conflicts = [];
 
   for (const leftOperation of left) {
@@ -260,7 +279,21 @@ export function detectContentOperationConflicts(leftOperations = [], rightOperat
       const structural = isStructuralOperation(leftOperation) || isStructuralOperation(rightOperation);
       if (!sameField && !structural) continue;
       if (contentOperationHash(leftOperation) === contentOperationHash(rightOperation)) continue;
+      const leftValueHash = operationValueHash(leftOperation);
+      const rightValueHash = operationValueHash(rightOperation);
+      if (!structural && leftValueHash && rightValueHash && leftValueHash === rightValueHash) continue;
+      if (!structural && leftOperation.beforeHash && rightValueHash && leftOperation.beforeHash === rightValueHash) continue;
       conflicts.push({
+        conflictId: contentOperationHash({
+          code: conflictCodeFor(leftOperation, rightOperation),
+          entityType: leftOperation.entityType,
+          entityId: leftOperation.entityId,
+          fieldPath: sameField ? (leftOperation.fieldPath || rightOperation.fieldPath || '$') : '$',
+          leftOperationId: leftOperation.operationId,
+          rightOperationId: rightOperation.operationId,
+          leftValueHash,
+          rightValueHash,
+        }, 'conflict'),
         code: conflictCodeFor(leftOperation, rightOperation),
         entityType: leftOperation.entityType,
         entityId: leftOperation.entityId,
@@ -296,10 +329,11 @@ export function buildSpellingContentOperationCandidate(baseBundle, operations = 
   const normalisedOperations = operations.map((operation) => normaliseContentOperation(operation, { now: () => 0 }));
   const candidate = applyContentOperationsToSpellingContent(baseBundle, normalisedOperations);
   const validation = validateSpellingContentBundle(candidate);
+  const operationsHash = hashPayload(normalisedOperations, 'ops');
   return {
     baseHash: hashPayload(normaliseSpellingContentBundle(baseBundle), 'base'),
-    operationsHash: hashPayload(normalisedOperations, 'ops'),
-    candidateHash: hashPayload(candidate, 'candidate'),
+    operationsHash,
+    candidateHash: hashPayload({ snapshot: candidate, operationsHash }, 'candidate'),
     candidate,
     validation,
     conflicts: [],

--- a/src/surfaces/hubs/AdminContentOperationsSection.jsx
+++ b/src/surfaces/hubs/AdminContentOperationsSection.jsx
@@ -52,6 +52,7 @@ function contentOperationMutation(action, packageId) {
 
 function actionMessage(action) {
   if (action === 'validate') return 'Candidate validated.';
+  if (action === 'resolve-conflict') return 'Conflict resolved.';
   if (action === 'approve') return 'Candidate approved.';
   if (action === 'publish') return 'Package published.';
   return 'Package action completed.';
@@ -137,6 +138,32 @@ function formatCompactJson(value) {
     return JSON.stringify(value);
   } catch {
     return String(value);
+  }
+}
+
+function conflictKey(conflict, index = 0) {
+  return conflict?.conflictId
+    || `${conflict?.entityType || 'entity'}:${conflict?.entityId || 'id'}:${conflict?.fieldPath || '$'}:${index}`;
+}
+
+function formatConflictValue(value) {
+  if (value == null) return '';
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function parseConflictEditValue(text, conflict) {
+  const structured = [conflict?.packageValue, conflict?.currentValue, conflict?.baseValue]
+    .some((value) => value && typeof value === 'object');
+  if (!structured) return text;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
   }
 }
 
@@ -406,6 +433,95 @@ function PublishedAreaPanel({ activeTab, latestRelease, selectedPackageId, selec
   );
 }
 
+function ConflictResolverPanel({
+  conflicts,
+  disabled,
+  active,
+  onResolve,
+}) {
+  const [edits, setEdits] = React.useState({});
+  if (!conflicts.length) return null;
+
+  return (
+    <div className="content-ops-conflict-resolver" data-content-ops-conflict-resolver="true">
+      <div className="content-ops-conflict-header">
+        <div>
+          <div className="eyebrow">Conflict resolver</div>
+          <strong>{String(conflicts.length)} unresolved field {conflicts.length === 1 ? 'conflict' : 'conflicts'}</strong>
+        </div>
+        <span className="chip bad">Publish blocked</span>
+      </div>
+      {conflicts.map((conflict, index) => {
+        const key = conflictKey(conflict, index);
+        const editValue = Object.prototype.hasOwnProperty.call(edits, key)
+          ? edits[key]
+          : formatConflictValue(conflict.packageValue);
+        const resolve = (resolution, rawValue = undefined) => {
+          if (!onResolve) return;
+          onResolve(conflict, resolution, rawValue);
+        };
+        return (
+          <article className="content-ops-conflict-card" key={key} data-conflict-id={key}>
+            <div className="content-ops-conflict-meta">
+              <span className="chip bad">{conflict.code || 'conflict'}</span>
+              <strong>{conflict.entityType} / {conflict.entityId}</strong>
+              <code>{conflict.fieldPath || '$'}</code>
+            </div>
+            <div className="content-ops-conflict-values">
+              <div>
+                <span className="small muted">Package value</span>
+                <pre>{formatConflictValue(conflict.packageValue) || 'Empty'}</pre>
+              </div>
+              <div>
+                <span className="small muted">Current release value</span>
+                <pre>{formatConflictValue(conflict.currentValue) || 'Empty'}</pre>
+              </div>
+            </div>
+            <label className="content-ops-notes-field">
+              <span className="small muted">Merged value</span>
+              <textarea
+                value={editValue}
+                onChange={(event) => setEdits((current) => ({
+                  ...current,
+                  [key]: event.target.value,
+                }))}
+                rows={4}
+                data-content-ops-conflict-edit={key}
+              />
+            </label>
+            <div className="actions content-ops-lifecycle-actions">
+              <button
+                type="button"
+                className="btn secondary"
+                disabled={disabled || active}
+                onClick={() => resolve('package')}
+              >
+                Keep package value
+              </button>
+              <button
+                type="button"
+                className="btn secondary"
+                disabled={disabled || active}
+                onClick={() => resolve('current')}
+              >
+                Keep current value
+              </button>
+              <button
+                type="button"
+                className="btn primary"
+                disabled={disabled || active}
+                onClick={() => resolve('edit', parseConflictEditValue(editValue, conflict))}
+              >
+                Save merged value
+              </button>
+            </div>
+          </article>
+        );
+      })}
+    </div>
+  );
+}
+
 function PackageLifecyclePanel({
   contentPackage,
   actor,
@@ -418,6 +534,7 @@ function PackageLifecyclePanel({
   const canEdit = actorCan(actor, CONTENT_OPERATION_CAPABILITIES.EDIT);
   const canApprove = actorCan(actor, CONTENT_OPERATION_CAPABILITIES.APPROVE);
   const canPublish = actorCan(actor, CONTENT_OPERATION_CAPABILITIES.PUBLISH);
+  const conflicts = candidate?.conflicts || [];
   const isRunning = Boolean(
     lifecycleState?.running
       && lifecycleState.packageId === contentPackage.packageId
@@ -441,6 +558,10 @@ function PackageLifecyclePanel({
     || !actionAvailability.publish
     || isRunning
     || contentPackage.state !== 'approved';
+  const resolveDisabled = !canEdit
+    || !actionAvailability.resolveConflict
+    || isRunning
+    || contentPackage.state === 'published';
 
   const run = (action) => {
     if (!onRunAction) return;
@@ -449,6 +570,16 @@ function PackageLifecyclePanel({
       candidateId: candidate?.candidateId || '',
       candidateHash: candidate?.candidateHash || '',
       notes,
+    });
+  };
+  const resolveConflict = (conflict, resolution, value) => {
+    if (!onRunAction) return;
+    onRunAction('resolve-conflict', {
+      packageId: contentPackage.packageId,
+      conflictId: conflict?.conflictId || '',
+      conflict,
+      resolution,
+      value,
     });
   };
 
@@ -487,6 +618,12 @@ function PackageLifecyclePanel({
           detail={`${String(candidate?.validation?.errorCount || 0)} errors, ${String(candidate?.validation?.warningCount || 0)} warnings`}
         />
       </div>
+      <ConflictResolverPanel
+        conflicts={conflicts}
+        disabled={resolveDisabled}
+        active={activeAction === 'resolve-conflict'}
+        onResolve={resolveConflict}
+      />
       <div className="content-ops-lifecycle-controls">
         <label className="content-ops-notes-field">
           <span className="small muted">Approval notes</span>
@@ -893,6 +1030,10 @@ export function AdminContentOperationsSection({
     packageId,
     candidateId = '',
     candidateHash = '',
+    conflictId = '',
+    conflict = null,
+    resolution = '',
+    value = undefined,
     notes = '',
   } = {}) => {
     if (!api || !packageId) return;
@@ -910,6 +1051,17 @@ export function AdminContentOperationsSection({
         if (!api.validatePackage) throw new Error('Validate action is not available.');
         payload = await api.validatePackage({
           packageId,
+          includeSnapshot: false,
+          mutation: contentOperationMutation(action, packageId),
+        });
+      } else if (action === 'resolve-conflict') {
+        if (!api.resolveConflict) throw new Error('Resolve conflict action is not available.');
+        payload = await api.resolveConflict({
+          packageId,
+          conflictId,
+          conflict,
+          resolution,
+          value,
           includeSnapshot: false,
           mutation: contentOperationMutation(action, packageId),
         });
@@ -985,6 +1137,7 @@ export function AdminContentOperationsSection({
   const detailActor = safeDetail.actor?.accountId ? safeDetail.actor : overview.actor;
   const lifecycleActionAvailability = {
     validate: Boolean(api?.validatePackage),
+    resolveConflict: Boolean(api?.resolveConflict),
     approve: Boolean(api?.approvePackage),
     publish: Boolean(api?.publishPackage),
   };

--- a/styles/app.css
+++ b/styles/app.css
@@ -12416,6 +12416,47 @@ html { scroll-behavior: smooth; }
   margin-top: 18px;
 }
 
+.content-ops-conflict-resolver {
+  display: grid;
+  gap: 10px;
+}
+
+.content-ops-conflict-header,
+.content-ops-conflict-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.content-ops-conflict-card {
+  display: grid;
+  gap: 10px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 12px;
+}
+
+.content-ops-conflict-values {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.content-ops-conflict-values pre {
+  min-height: 76px;
+  max-height: 160px;
+  overflow: auto;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  margin: 4px 0 0;
+  padding: 8px;
+  background: var(--panel-soft);
+}
+
 .content-ops-event-detail {
   overflow-wrap: anywhere;
 }
@@ -12466,6 +12507,10 @@ html { scroll-behavior: smooth; }
   .content-ops-lifecycle-controls {
     flex-direction: column;
     align-items: stretch;
+  }
+
+  .content-ops-conflict-values {
+    grid-template-columns: 1fr;
   }
 }
 

--- a/tests/admin-content-operations-v2.test.js
+++ b/tests/admin-content-operations-v2.test.js
@@ -640,15 +640,26 @@ describe('Content Operations Centre hub API client', () => {
       proof: { source: 'test' },
       mutation: { requestId: 'publish-1' },
     });
+    await api.resolveContentOperationConflict({
+      packageId: 'pkg/with/slash',
+      conflictId: 'conflict/with/slash',
+      resolution: 'edit',
+      value: 'Merged value.',
+      mutation: { requestId: 'resolve-1' },
+    });
 
     assert.equal(new URL(calls[0].url).pathname, '/api/admin/content-operations/packages/pkg%2Fwith%2Fslash/validate');
     assert.equal(new URL(calls[1].url).pathname, '/api/admin/content-operations/packages/pkg%2Fwith%2Fslash/approve');
     assert.equal(new URL(calls[2].url).pathname, '/api/admin/content-operations/packages/pkg%2Fwith%2Fslash/publish');
-    assert.deepEqual(calls.map((call) => call.method), ['POST', 'POST', 'POST']);
+    assert.equal(new URL(calls[3].url).pathname, '/api/admin/content-operations/packages/pkg%2Fwith%2Fslash/resolve-conflict');
+    assert.deepEqual(calls.map((call) => call.method), ['POST', 'POST', 'POST', 'POST']);
     assert.equal(calls[0].body.includeSnapshot, true);
     assert.equal(calls[1].body.candidateId, 'cand/with/slash');
     assert.equal(calls[1].body.notes, 'Reviewed candidate.');
     assert.equal(calls[2].body.proof.source, 'test');
+    assert.equal(calls[3].body.conflictId, 'conflict/with/slash');
+    assert.equal(calls[3].body.resolution, 'edit');
+    assert.equal(calls[3].body.value, 'Merged value.');
   });
 
   it('rejects package and release detail reads without explicit ids', async () => {
@@ -676,6 +687,14 @@ describe('Content Operations Centre hub API client', () => {
     await assert.rejects(
       () => api.publishContentOperationPackage({ packageId: '' }),
       /Content operation package id is required/,
+    );
+    await assert.rejects(
+      () => api.resolveContentOperationConflict({ packageId: '', resolution: 'edit' }),
+      /Content operation package id is required/,
+    );
+    await assert.rejects(
+      () => api.resolveContentOperationConflict({ packageId: 'pkg-1', resolution: '' }),
+      /Content operation conflict resolution is required/,
     );
   });
 });

--- a/tests/button-label-consistency.test.js
+++ b/tests/button-label-consistency.test.js
@@ -533,6 +533,9 @@ test('button labels: every statically extractable label is classified', () => {
     'Validate candidate',
     'Approve candidate',
     'Publish package',
+    'Keep package value',
+    'Keep current value',
+    'Save merged value',
     // Reasoning launch: delayed SATs-style sets use "Mark set" and "Save
     // answers" to distinguish full-set marking from single-question submit.
     // "Partly worked support" is the child-facing scaffold request, matching

--- a/tests/content-operations-api.test.js
+++ b/tests/content-operations-api.test.js
@@ -105,6 +105,36 @@ async function approvePackage(server, packageId, candidateId) {
   return readPayload(response);
 }
 
+async function publishPackage(server, packageId, body = {}) {
+  const response = await server.fetchAs(
+    ADMIN_ID,
+    `${BASE_URL}/api/admin/content-operations/packages/${packageId}/publish`,
+    jsonInit('POST', {
+      ...body,
+      includeSnapshot: body.includeSnapshot ?? false,
+      proof: { source: 'content-operations-api-test', ...body.proof },
+    }),
+    adminHeaders(),
+  );
+  assert.equal(response.status, 200);
+  return readPayload(response);
+}
+
+async function resolveConflictResponse(server, packageId, body = {}) {
+  return server.fetchAs(
+    ADMIN_ID,
+    `${BASE_URL}/api/admin/content-operations/packages/${packageId}/resolve-conflict`,
+    jsonInit('POST', body),
+    adminHeaders(),
+  );
+}
+
+async function resolveConflict(server, packageId, body = {}) {
+  const response = await resolveConflictResponse(server, packageId, body);
+  assert.equal(response.status, 200);
+  return readPayload(response);
+}
+
 test('content operations API requires the admin platform role', async () => {
   const server = createWorkerRepositoryServer({ now: () => NOW });
   try {
@@ -294,6 +324,115 @@ test('content operations API supports admin package lifecycle through separate a
     assert.equal(overview.overview.latestRelease.releaseId, published.release.releaseId);
     assert.equal(overview.overview.actor.capabilities['content_operations.approve'], true);
     assert.equal(overview.overview.actor.capabilities['content_operations.publish'], true);
+  } finally {
+    server.close();
+  }
+});
+
+test('content operations API resolves same-field package conflicts before approval', async () => {
+  const server = createWorkerRepositoryServer({ now: () => NOW });
+  try {
+    seedAdultAccount(server.DB, { accountId: ADMIN_ID, platformRole: 'admin' });
+    const repository = createWorkerRepository({
+      env: server.env,
+      now: () => NOW,
+    });
+    await repository.seedFirstContentOperationRelease({
+      seededByAccountId: ADMIN_ID,
+      proof: { source: 'content-operations-api-conflict-test' },
+    });
+    const seeded = await readSeededSpellingContentBundle();
+    const word = seeded.draft.words[0];
+    const packageValue = `API package explanation for ${word.word}.`;
+    const currentValue = `API current explanation for ${word.word}.`;
+    const mergedValue = `API merged explanation for ${word.word}.`;
+
+    const conflicted = await createPackage(server, { title: 'API conflicted package' });
+    await appendWordExplanationOperation(server, conflicted.package.packageId, word, packageValue);
+
+    const current = await createPackage(server, { title: 'API current package' });
+    await appendWordExplanationOperation(server, current.package.packageId, word, currentValue);
+    const currentCandidate = await validatePackage(server, current.package.packageId);
+    await approvePackage(server, current.package.packageId, currentCandidate.candidate.candidateId);
+    await publishPackage(server, current.package.packageId);
+
+    const conflictedCandidate = await validatePackage(server, conflicted.package.packageId);
+    assert.equal(conflictedCandidate.candidate.conflicts.length, 1);
+    assert.equal(conflictedCandidate.candidate.conflicts[0].packageValue, packageValue);
+    assert.equal(conflictedCandidate.candidate.conflicts[0].currentValue, currentValue);
+
+    const resolved = await resolveConflict(server, conflicted.package.packageId, {
+      conflictId: conflictedCandidate.candidate.conflicts[0].conflictId,
+      resolution: 'edit',
+      value: mergedValue,
+    });
+    assert.equal(resolved.operation.payload, mergedValue);
+    assert.equal(resolved.candidate.conflicts.length, 0);
+    assert.notEqual(resolved.candidate.candidateHash, conflictedCandidate.candidate.candidateHash);
+
+    await approvePackage(server, conflicted.package.packageId, resolved.candidate.candidateId);
+    const published = await publishPackage(server, conflicted.package.packageId, {
+      includeSnapshot: true,
+      proof: { source: 'content-operations-api-conflict-resolution-test' },
+    });
+    assert.equal(published.release.snapshot.draft.words.find((entry) => entry.slug === word.slug).explanation, mergedValue);
+  } finally {
+    server.close();
+  }
+});
+
+test('content operations API rejects missing and stale conflict resolution requests', async () => {
+  const server = createWorkerRepositoryServer({ now: () => NOW });
+  try {
+    seedAdultAccount(server.DB, { accountId: ADMIN_ID, platformRole: 'admin' });
+    const repository = createWorkerRepository({
+      env: server.env,
+      now: () => NOW,
+    });
+    await repository.seedFirstContentOperationRelease({
+      seededByAccountId: ADMIN_ID,
+      proof: { source: 'content-operations-api-stale-conflict-test' },
+    });
+    const seeded = await readSeededSpellingContentBundle();
+    const word = seeded.draft.words[0];
+
+    const conflicted = await createPackage(server, { title: 'API stale conflicted package' });
+    await appendWordExplanationOperation(server, conflicted.package.packageId, word, `Stale package value for ${word.word}.`);
+
+    const current = await createPackage(server, { title: 'API first current package' });
+    await appendWordExplanationOperation(server, current.package.packageId, word, `First current value for ${word.word}.`);
+    const currentCandidate = await validatePackage(server, current.package.packageId);
+    await approvePackage(server, current.package.packageId, currentCandidate.candidate.candidateId);
+    await publishPackage(server, current.package.packageId);
+
+    const conflictedCandidate = await validatePackage(server, conflicted.package.packageId);
+    const oldConflict = conflictedCandidate.candidate.conflicts[0];
+    assert.ok(oldConflict.conflictId);
+
+    const missingValueResponse = await resolveConflictResponse(server, conflicted.package.packageId, {
+      conflictId: oldConflict.conflictId,
+      resolution: 'edit',
+    });
+    const missingValue = await readPayload(missingValueResponse);
+    assert.equal(missingValueResponse.status, 400);
+    assert.equal(missingValue.code, 'content_operation_conflict_resolution_value_required');
+
+    const newer = await createPackage(server, { title: 'API second current package' });
+    await appendWordExplanationOperation(server, newer.package.packageId, word, `Second current value for ${word.word}.`);
+    const newerCandidate = await validatePackage(server, newer.package.packageId);
+    await approvePackage(server, newer.package.packageId, newerCandidate.candidate.candidateId);
+    await publishPackage(server, newer.package.packageId);
+
+    const staleResponse = await resolveConflictResponse(server, conflicted.package.packageId, {
+      conflictId: oldConflict.conflictId,
+      conflict: oldConflict,
+      resolution: 'edit',
+      value: `Stale merged value for ${word.word}.`,
+    });
+    const stalePayload = await readPayload(staleResponse);
+    assert.equal(staleResponse.status, 404);
+    assert.equal(stalePayload.code, 'content_operation_conflict_not_found');
+    assert.equal(stalePayload.conflictId, oldConflict.conflictId);
   } finally {
     server.close();
   }

--- a/tests/content-operations-merge.test.js
+++ b/tests/content-operations-merge.test.js
@@ -75,9 +75,32 @@ test('content operations detect same-field conflicts without blocking unrelated 
   const conflicts = detectContentOperationConflicts(left, right);
   assert.equal(conflicts.length, 1);
   assert.equal(conflicts[0].code, 'same_field_conflict');
+  assert.match(conflicts[0].conflictId, /^conflict-/);
   assert.equal(conflicts[0].entityType, 'spelling.word');
   assert.equal(conflicts[0].entityId, 'receipt');
   assert.equal(conflicts[0].fieldPath, 'explanation');
+});
+
+test('content operations treat an acknowledged current value as resolved', () => {
+  const releaseEdit = normaliseContentOperation({
+    operationId: 'release-op',
+    entityType: 'spelling.word',
+    entityId: 'receipt',
+    fieldPath: 'explanation',
+    action: 'set',
+    payload: 'Current published explanation.',
+  });
+  const resolvedPackageEdit = normaliseContentOperation({
+    operationId: 'resolution-op',
+    entityType: 'spelling.word',
+    entityId: 'receipt',
+    fieldPath: 'explanation',
+    action: 'set',
+    beforeHash: releaseEdit.afterHash,
+    payload: 'Merged explanation chosen by the admin.',
+  });
+
+  assert.deepEqual(detectContentOperationConflicts([resolvedPackageEdit], [releaseEdit]), []);
 });
 
 test('structural operations conflict with child-field edits on the same entity', () => {

--- a/tests/content-operations-repository.test.js
+++ b/tests/content-operations-repository.test.js
@@ -553,7 +553,7 @@ test('content operations repository keeps published packages immutable', async (
   }
 });
 
-test('content operations repository blocks stale package approval after release drift', async () => {
+test('content operations repository auto-rebases unrelated package approval after release drift', async () => {
   const DB = createMigratedSqliteD1Database();
   const repository = createWorkerRepository({
     env: { DB },
@@ -562,7 +562,7 @@ test('content operations repository blocks stale package approval after release 
 
   try {
     const seeded = await readSeededSpellingContentBundle();
-    const seedRelease = await repository.seedFirstContentOperationRelease({
+    await repository.seedFirstContentOperationRelease({
       seededByAccountId: 'admin-a',
       proof: { source: 'repository-stale-package-test' },
     });
@@ -574,16 +574,18 @@ test('content operations repository blocks stale package approval after release 
       title: 'Package that starts before a newer release',
       createdByAccountId: 'admin-a',
     });
+    const staleExplanation = `Rebased package explanation for ${firstWord.word}.`;
     await repository.appendContentOperation(stalePackage.packageId, {
       entityType: 'spelling.word',
       entityId: firstWord.slug,
       fieldPath: 'explanation',
       action: 'set',
-      payload: `Stale package explanation for ${firstWord.word}.`,
+      payload: staleExplanation,
     }, {
       actorAccountId: 'admin-a',
     });
 
+    const newerSourceNote = `Newer package note for ${secondWord.word}.`;
     const newerPackage = await repository.createContentOperationPackage({
       templateId: 'edit-spelling-word',
       title: 'Newer package',
@@ -594,7 +596,7 @@ test('content operations repository blocks stale package approval after release 
       entityId: secondWord.slug,
       fieldPath: 'sourceNote',
       action: 'set',
-      payload: `Newer package note for ${secondWord.word}.`,
+      payload: newerSourceNote,
     }, {
       actorAccountId: 'admin-b',
     });
@@ -613,10 +615,96 @@ test('content operations repository blocks stale package approval after release 
     });
 
     assert.equal(staleCandidate.currentReleaseId, newerRelease.releaseId);
+    assert.equal(staleCandidate.conflicts.length, 0);
+    assert.equal(
+      staleCandidate.candidate.draft.words.find((entry) => entry.slug === firstWord.slug).explanation,
+      staleExplanation,
+    );
+    assert.equal(
+      staleCandidate.candidate.draft.words.find((entry) => entry.slug === secondWord.slug).sourceNote,
+      newerSourceNote,
+    );
+
+    await repository.approveContentOperationCandidate(stalePackage.packageId, staleCandidate.candidateId, {
+      approvedByAccountId: 'admin-a',
+    });
+    const release = await repository.publishContentOperationPackage(stalePackage.packageId, {
+      publishedByAccountId: 'admin-a',
+    });
+    assert.equal(release.baseReleaseId, newerRelease.releaseId);
+  } finally {
+    DB.close();
+  }
+});
+
+test('content operations repository records structural release drift conflicts without throwing', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const repository = createWorkerRepository({
+    env: { DB },
+    now: () => 1_777_000_000_000,
+  });
+
+  try {
+    const seeded = await readSeededSpellingContentBundle();
+    await repository.seedFirstContentOperationRelease({
+      seededByAccountId: 'admin-a',
+      proof: { source: 'repository-structural-conflict-test' },
+    });
+    const word = seeded.draft.words[0];
+    const baseSentence = seeded.draft.sentences[0];
+    const sentencePayload = {
+      ...baseSentence,
+      id: `${word.slug}__conflict_create`,
+      wordSlug: word.slug,
+      text: `A structural conflict sentence for ${word.word}.`,
+      sortIndex: 90_000,
+    };
+
+    const stalePackage = await repository.createContentOperationPackage({
+      templateId: 'edit-spelling-sentence',
+      title: 'Stale structural create',
+      createdByAccountId: 'admin-a',
+    });
+    await repository.appendContentOperation(stalePackage.packageId, {
+      entityType: 'spelling.sentenceEntry',
+      entityId: sentencePayload.id,
+      action: 'create',
+      payload: sentencePayload,
+    }, {
+      actorAccountId: 'admin-a',
+    });
+
+    const newerPackage = await repository.createContentOperationPackage({
+      templateId: 'edit-spelling-sentence',
+      title: 'Newer structural create',
+      createdByAccountId: 'admin-b',
+    });
+    await repository.appendContentOperation(newerPackage.packageId, {
+      entityType: 'spelling.sentenceEntry',
+      entityId: sentencePayload.id,
+      action: 'create',
+      payload: sentencePayload,
+    }, {
+      actorAccountId: 'admin-b',
+    });
+    const newerCandidate = await repository.buildContentOperationCandidate(newerPackage.packageId, {
+      actorAccountId: 'admin-b',
+    });
+    await repository.approveContentOperationCandidate(newerPackage.packageId, newerCandidate.candidateId, {
+      approvedByAccountId: 'admin-b',
+    });
+    const newerRelease = await repository.publishContentOperationPackage(newerPackage.packageId, {
+      publishedByAccountId: 'admin-b',
+    });
+
+    const staleCandidate = await repository.buildContentOperationCandidate(stalePackage.packageId, {
+      actorAccountId: 'admin-a',
+    });
+    assert.equal(staleCandidate.currentReleaseId, newerRelease.releaseId);
     assert.equal(staleCandidate.conflicts.length, 1);
-    assert.equal(staleCandidate.conflicts[0].code, 'base_release_changed');
-    assert.equal(staleCandidate.conflicts[0].packageBaseReleaseId, seedRelease.releaseId);
-    assert.equal(staleCandidate.conflicts[0].currentReleaseId, newerRelease.releaseId);
+    assert.equal(staleCandidate.conflicts[0].code, 'structural_conflict');
+    assert.equal(staleCandidate.conflicts[0].entityType, 'spelling.sentenceEntry');
+    assert.equal(staleCandidate.conflicts[0].entityId, sentencePayload.id);
 
     await assert.rejects(
       () => repository.approveContentOperationCandidate(stalePackage.packageId, staleCandidate.candidateId, {
@@ -624,6 +712,157 @@ test('content operations repository blocks stale package approval after release 
       }),
       /unresolved conflicts/,
     );
+  } finally {
+    DB.close();
+  }
+});
+
+test('content operations repository resolves same-field release drift conflicts', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const repository = createWorkerRepository({
+    env: { DB },
+    now: () => 1_777_000_000_000,
+  });
+
+  try {
+    const seeded = await readSeededSpellingContentBundle();
+    await repository.seedFirstContentOperationRelease({
+      seededByAccountId: 'admin-a',
+      proof: { source: 'repository-conflict-resolution-test' },
+    });
+    const word = seeded.draft.words[0];
+    const packageValue = `Package explanation for ${word.word}.`;
+    const currentValue = `Current release explanation for ${word.word}.`;
+    const mergedValue = `Merged explanation for ${word.word}.`;
+
+    const conflictedPackage = await repository.createContentOperationPackage({
+      templateId: 'edit-spelling-word',
+      title: 'Package with same-field conflict',
+      createdByAccountId: 'admin-a',
+    });
+    await repository.appendContentOperation(conflictedPackage.packageId, {
+      entityType: 'spelling.word',
+      entityId: word.slug,
+      fieldPath: 'explanation',
+      action: 'set',
+      payload: packageValue,
+    }, {
+      actorAccountId: 'admin-a',
+    });
+
+    const newerPackage = await repository.createContentOperationPackage({
+      templateId: 'edit-spelling-word',
+      title: 'Conflicting release',
+      createdByAccountId: 'admin-b',
+    });
+    await repository.appendContentOperation(newerPackage.packageId, {
+      entityType: 'spelling.word',
+      entityId: word.slug,
+      fieldPath: 'explanation',
+      action: 'set',
+      payload: currentValue,
+    }, {
+      actorAccountId: 'admin-b',
+    });
+    const newerCandidate = await repository.buildContentOperationCandidate(newerPackage.packageId, {
+      actorAccountId: 'admin-b',
+    });
+    await repository.approveContentOperationCandidate(newerPackage.packageId, newerCandidate.candidateId, {
+      approvedByAccountId: 'admin-b',
+    });
+    const newerRelease = await repository.publishContentOperationPackage(newerPackage.packageId, {
+      publishedByAccountId: 'admin-b',
+    });
+
+    const conflictedCandidate = await repository.buildContentOperationCandidate(conflictedPackage.packageId, {
+      actorAccountId: 'admin-a',
+    });
+    assert.equal(conflictedCandidate.currentReleaseId, newerRelease.releaseId);
+    assert.equal(conflictedCandidate.conflicts.length, 1);
+    assert.equal(conflictedCandidate.conflicts[0].code, 'same_field_conflict');
+    assert.equal(conflictedCandidate.conflicts[0].packageValue, packageValue);
+    assert.equal(conflictedCandidate.conflicts[0].currentValue, currentValue);
+
+    await assert.rejects(
+      () => repository.approveContentOperationCandidate(conflictedPackage.packageId, conflictedCandidate.candidateId, {
+        approvedByAccountId: 'admin-a',
+      }),
+      /unresolved conflicts/,
+    );
+
+    const resolved = await repository.resolveContentOperationConflict(conflictedPackage.packageId, {
+      conflictId: conflictedCandidate.conflicts[0].conflictId,
+      resolution: 'edit',
+      value: mergedValue,
+    }, {
+      actorAccountId: 'admin-a',
+    });
+    assert.equal(resolved.operation.fieldPath, 'explanation');
+    assert.equal(resolved.operation.payload, mergedValue);
+    assert.notEqual(resolved.candidate.candidateHash, conflictedCandidate.candidateHash);
+    assert.equal(resolved.candidate.conflicts.length, 0);
+
+    await repository.approveContentOperationCandidate(conflictedPackage.packageId, resolved.candidate.candidateId, {
+      approvedByAccountId: 'admin-a',
+    });
+    const release = await repository.publishContentOperationPackage(conflictedPackage.packageId, {
+      publishedByAccountId: 'admin-a',
+    });
+    assert.equal(
+      release.snapshot.draft.words.find((entry) => entry.slug === word.slug).explanation,
+      mergedValue,
+    );
+
+    const keepPackage = await repository.createContentOperationPackage({
+      templateId: 'edit-spelling-word',
+      title: 'Package-value conflict resolution',
+      createdByAccountId: 'admin-a',
+    });
+    await repository.appendContentOperation(keepPackage.packageId, {
+      entityType: 'spelling.word',
+      entityId: word.slug,
+      fieldPath: 'sourceNote',
+      action: 'set',
+      payload: `Package source note for ${word.word}.`,
+    }, {
+      actorAccountId: 'admin-a',
+    });
+    const newerSource = await repository.createContentOperationPackage({
+      templateId: 'edit-spelling-word',
+      title: 'Conflicting source note release',
+      createdByAccountId: 'admin-b',
+    });
+    await repository.appendContentOperation(newerSource.packageId, {
+      entityType: 'spelling.word',
+      entityId: word.slug,
+      fieldPath: 'sourceNote',
+      action: 'set',
+      payload: `Current source note for ${word.word}.`,
+    }, {
+      actorAccountId: 'admin-b',
+    });
+    const newerSourceCandidate = await repository.buildContentOperationCandidate(newerSource.packageId, {
+      actorAccountId: 'admin-b',
+    });
+    await repository.approveContentOperationCandidate(newerSource.packageId, newerSourceCandidate.candidateId, {
+      approvedByAccountId: 'admin-b',
+    });
+    await repository.publishContentOperationPackage(newerSource.packageId, {
+      publishedByAccountId: 'admin-b',
+    });
+
+    const packageConflict = await repository.buildContentOperationCandidate(keepPackage.packageId, {
+      actorAccountId: 'admin-a',
+    });
+    assert.equal(packageConflict.conflicts.length, 1);
+    const packageResolved = await repository.resolveContentOperationConflict(keepPackage.packageId, {
+      conflictId: packageConflict.conflicts[0].conflictId,
+      resolution: 'package',
+    }, {
+      actorAccountId: 'admin-a',
+    });
+    assert.equal(packageResolved.candidate.conflicts.length, 0);
+    assert.notEqual(packageResolved.candidate.candidateHash, packageConflict.candidateHash);
   } finally {
     DB.close();
   }

--- a/tests/react-admin-content-operations.test.js
+++ b/tests/react-admin-content-operations.test.js
@@ -89,6 +89,37 @@ const lifecycleCandidate = {
   createdAt: Date.UTC(2026, 5, 11, 10, 5, 0),
 };
 
+const conflictedLifecycleCandidate = {
+  ...lifecycleCandidate,
+  candidateId: 'cand-conflict-1',
+  operationsHash: 'ops-conflict-1',
+  candidateHash: 'candidate-conflict-1',
+  blockers: {
+    ...cleanLifecycleBlockers,
+    conflicts: {
+      status: 'blocked',
+      count: 1,
+      items: [{
+        conflictId: 'conflict-word-explanation',
+        code: 'same_field_conflict',
+        entityType: 'spelling.word',
+        entityId: 'metamorphosis',
+        fieldPath: 'explanation',
+      }],
+    },
+  },
+  conflicts: [{
+    conflictId: 'conflict-word-explanation',
+    code: 'same_field_conflict',
+    entityType: 'spelling.word',
+    entityId: 'metamorphosis',
+    fieldPath: 'explanation',
+    packageValue: 'Package explanation.',
+    currentValue: 'Current release explanation.',
+    baseValue: 'Original explanation.',
+  }],
+};
+
 const release = {
   releaseId: 'rel-global-1',
   subjectId: 'spelling',
@@ -275,7 +306,7 @@ async function runClientEntry(entrySource) {
       },
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'pipe'],
-      timeout: 10_000,
+      timeout: 20_000,
     });
     return normaliseLineEndings(output).replace(/\n+$/, '');
   } finally {
@@ -760,6 +791,183 @@ test('Content Operations Centre mounted package detail runs validate, approve, a
   assert.equal(result.publishDisabledAfterApprove, false);
   assert.match(result.textAfterPublish, /Package published/);
   assert.match(result.textAfterPublish, /rel-published-1/);
+});
+
+test('Content Operations Centre mounted package detail resolves same-field conflicts', async () => {
+  const output = await runClientEntry(`
+    const { JSDOM } = require('jsdom');
+
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+    const dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
+      url: 'https://ks2.eugnel.uk/admin',
+    });
+    globalThis.window = dom.window;
+    globalThis.document = dom.window.document;
+    globalThis.navigator = dom.window.navigator;
+    globalThis.HTMLElement = dom.window.HTMLElement;
+    globalThis.Event = dom.window.Event;
+
+    const React = require('react');
+    const { createRoot } = require('react-dom/client');
+    const { AdminContentOperationsSection } = require(${CONTENT_OPS_SECTION_PATH});
+    const { act } = React;
+
+    const conflictedCandidate = ${JSON.stringify(conflictedLifecycleCandidate)};
+    const resolvedCandidate = {
+      ...${JSON.stringify(lifecycleCandidate)},
+      candidateId: 'cand-resolved-1',
+      operationsHash: 'ops-resolved-1',
+      candidateHash: 'candidate-resolved-1',
+    };
+    const basePackage = {
+      ...${JSON.stringify(contentPackage)},
+      blockers: conflictedCandidate.blockers,
+      latestCandidate: conflictedCandidate,
+    };
+    let latestCandidate = conflictedCandidate;
+    const calls = [];
+    const model = ${JSON.stringify(baseModel({
+      contentOperations: {
+        overview,
+        packages: { packages: [] },
+        releases: { releases: [release] },
+        packageDetail: null,
+      },
+    }))};
+    model.contentOperations.overview.lanes.drafts = [basePackage];
+    model.contentOperations.packages.packages = [basePackage];
+    model.contentOperations.packageDetail = {
+      package: basePackage,
+      actor: model.contentOperations.overview.actor,
+      events: [],
+    };
+
+    function packageForState() {
+      return {
+        ...basePackage,
+        latestCandidate,
+        blockers: latestCandidate.blockers,
+      };
+    }
+
+    const actions = {
+      contentOperationsApi: {
+        async resolveConflict(args) {
+          calls.push({ method: 'resolve', args });
+          latestCandidate = resolvedCandidate;
+          return {
+            conflict: conflictedCandidate.conflicts[0],
+            resolution: args.resolution,
+            operation: {
+              operationId: 'op-resolution-1',
+              entityType: 'spelling.word',
+              entityId: 'metamorphosis',
+              fieldPath: 'explanation',
+              action: 'set',
+              payload: args.value,
+            },
+            candidate: resolvedCandidate,
+          };
+        },
+        async approvePackage(args) {
+          calls.push({ method: 'approve', args });
+          return { approval: { candidateId: args.candidateId } };
+        },
+        async readPackage({ packageId }) {
+          calls.push({ method: 'readPackage', packageId });
+          return {
+            package: packageForState(),
+            actor: model.contentOperations.overview.actor,
+            events: [],
+          };
+        },
+        async readOverview(args) {
+          calls.push({ method: 'overview', args });
+          return {
+            ...model.contentOperations.overview,
+            lanes: {
+              blocked: [],
+              readyForApproval: [packageForState()],
+              approvedPendingPublish: [],
+              drafts: [],
+              recentReleases: [${JSON.stringify(release)}],
+            },
+          };
+        },
+        async readPackages(args) {
+          calls.push({ method: 'packages', args });
+          return { packages: [packageForState()] };
+        },
+        async readReleases(args) {
+          calls.push({ method: 'releases', args });
+          return { releases: [${JSON.stringify(release)}] };
+        },
+      },
+    };
+
+    async function flush() {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+    }
+
+    async function main() {
+      const root = createRoot(document.getElementById('root'));
+      await act(async () => {
+        root.render(React.createElement(AdminContentOperationsSection, {
+          model,
+          actions,
+          initialActiveTab: 'detail',
+        }));
+      });
+
+      const approveDisabledBefore = document.querySelector('[data-content-ops-action="approve"]').disabled;
+      const editor = document.querySelector('[data-content-ops-conflict-edit="conflict-word-explanation"]');
+      const valueSetter = Object.getOwnPropertyDescriptor(dom.window.HTMLTextAreaElement.prototype, 'value').set;
+      valueSetter.call(editor, 'Merged explanation.');
+      await act(async () => {
+        editor.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
+        editor.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+      });
+      const saveButton = Array.from(document.querySelectorAll('button'))
+        .find((button) => button.textContent === 'Save merged value');
+      await act(async () => {
+        saveButton.click();
+      });
+      await flush();
+      await flush();
+      await flush();
+
+      const approveDisabledAfter = document.querySelector('[data-content-ops-action="approve"]').disabled;
+      process.stdout.write(JSON.stringify({
+        calls,
+        approveDisabledBefore,
+        approveDisabledAfter,
+        text: document.body.textContent,
+      }));
+
+      await act(async () => {
+        root.unmount();
+      });
+      dom.window.close();
+      process.exit(0);
+    }
+
+    main().catch((error) => {
+      process.stderr.write(error.stack || error.message);
+      process.exitCode = 1;
+    });
+  `);
+  const result = JSON.parse(output);
+  const resolveCall = result.calls.find((entry) => entry.method === 'resolve');
+
+  assert.equal(result.approveDisabledBefore, true);
+  assert.equal(resolveCall.args.conflictId, 'conflict-word-explanation');
+  assert.equal(resolveCall.args.resolution, 'edit');
+  assert.equal(resolveCall.args.value, 'Merged explanation.');
+  assert.match(result.text, /Conflict resolved/);
+  assert.match(result.text, /candidate-resolved-1/);
+  assert.equal(result.approveDisabledAfter, false);
 });
 
 test('Content Operations Centre mounted package detail ignores stale out-of-order reads', async () => {

--- a/worker/src/content-operations/repository.js
+++ b/worker/src/content-operations/repository.js
@@ -1,10 +1,14 @@
 import { uid } from '../../../src/platform/core/utils.js';
+import { cloneSerialisable } from '../../../src/platform/core/repositories/helpers.js';
 import {
   buildSpellingContentOperationCandidate,
   CONTENT_OPERATION_PACKAGE_STATES,
   CONTENT_OPERATION_SUBJECT_ID,
   contentOperationHash,
+  contentOperationValueHash,
+  detectContentOperationConflicts,
   normaliseContentOperation,
+  readContentOperationField,
 } from '../../../src/subjects/spelling/content/operations-model.js';
 import {
   buildSpellingContentSummary,
@@ -371,6 +375,95 @@ function releaseDriftConflict(packageRow, currentReleaseRow, baseReleaseRow) {
   }
 
   return null;
+}
+
+async function listReleaseOperationsAfterBase(db, subjectId, baseReleaseId, currentReleaseId) {
+  if (!currentReleaseId || baseReleaseId === currentReleaseId) {
+    return { complete: true, operations: [], releases: [] };
+  }
+  const releaseRows = await all(db, `
+    SELECT release_id, package_id, published_at, created_at, rowid AS release_rowid
+    FROM content_operation_releases
+    WHERE subject_id = ? AND status = 'published'
+    ORDER BY published_at ASC, created_at ASC, rowid ASC
+  `, [subjectId]);
+  const currentIndex = releaseRows.findIndex((row) => row.release_id === currentReleaseId);
+  if (currentIndex < 0) {
+    return {
+      complete: false,
+      operations: [],
+      releases: [],
+      reason: 'current_release_missing',
+    };
+  }
+  const baseIndex = baseReleaseId
+    ? releaseRows.findIndex((row) => row.release_id === baseReleaseId)
+    : -1;
+  if (baseReleaseId && baseIndex < 0) {
+    return {
+      complete: false,
+      operations: [],
+      releases: [],
+      reason: 'base_release_missing',
+    };
+  }
+  const driftRows = releaseRows.slice(baseIndex + 1, currentIndex + 1);
+  const operations = [];
+  for (const releaseRow of driftRows) {
+    if (!releaseRow.package_id) {
+      return {
+        complete: false,
+        operations,
+        releases: driftRows,
+        reason: 'release_without_package_operations',
+        releaseId: releaseRow.release_id,
+      };
+    }
+    const releasePackageOperations = await listPackageOperations(db, releaseRow.package_id);
+    operations.push(...releasePackageOperations.map((operation) => ({
+      ...operation,
+      releaseId: releaseRow.release_id,
+    })));
+  }
+  return {
+    complete: true,
+    operations,
+    releases: driftRows,
+  };
+}
+
+function conflictFieldValue(bundle, operation) {
+  if (!operation) return null;
+  if (!operation.fieldPath || operation.fieldPath === '$') {
+    return cloneSerialisable(operation.payload ?? null);
+  }
+  if (!bundle) return null;
+  const value = readContentOperationField(bundle, operation);
+  return cloneSerialisable(value === undefined ? null : value);
+}
+
+function enrichReleaseConflicts(conflicts, {
+  packageOperations = [],
+  releaseOperations = [],
+  baseSnapshot = null,
+  currentSnapshot = null,
+  candidateSnapshot = null,
+} = {}) {
+  const packageById = new Map(packageOperations.map((operation) => [operation.operationId, operation]));
+  const releaseById = new Map(releaseOperations.map((operation) => [operation.operationId, operation]));
+  return conflicts.map((conflict) => {
+    const packageOperation = packageById.get(conflict.leftOperationId) || null;
+    const currentOperation = releaseById.get(conflict.rightOperationId) || null;
+    const fieldOperation = packageOperation || currentOperation || conflict;
+    return {
+      ...conflict,
+      packageOperation,
+      currentOperation,
+      baseValue: conflictFieldValue(baseSnapshot, fieldOperation),
+      packageValue: conflictFieldValue(candidateSnapshot, fieldOperation),
+      currentValue: conflictFieldValue(currentSnapshot, fieldOperation),
+    };
+  });
 }
 
 function packageOperationsHash(operations = []) {
@@ -850,10 +943,60 @@ export function createContentOperationsRepository({ db, now }) {
       const baseSnapshot = baseRelease?.snapshot
         ? baseRelease.snapshot
         : await readSeededSpellingContentBundle();
-      const candidate = buildSpellingContentOperationCandidate(baseSnapshot, operations);
+      const currentRelease = await releaseRowToRecordAsync(currentReleaseRow, { includeSnapshot: true });
+      const currentSnapshot = currentRelease?.snapshot || baseSnapshot;
+      const packageBaseReleaseId = packageRow.base_release_id || null;
+      const currentReleaseId = currentReleaseRow?.release_id || null;
+      const releaseChanged = (
+        packageBaseReleaseId !== currentReleaseId
+        || (packageRow.base_release_hash || null) !== (currentReleaseRow?.snapshot_hash || null)
+      );
+      let candidateBaseSnapshot = baseSnapshot;
+      let releaseOperations = [];
+      let releaseConflicts = [];
+      let driftConflict = null;
+      let detectedReleaseConflicts = [];
+      if (releaseChanged && currentReleaseRow) {
+        const drift = await listReleaseOperationsAfterBase(
+          db,
+          packageRow.subject_id,
+          packageBaseReleaseId,
+          currentReleaseId,
+        );
+        if (drift.complete) {
+          releaseOperations = drift.operations;
+          detectedReleaseConflicts = detectContentOperationConflicts(operations, releaseOperations);
+          const hasStructuralReleaseConflict = detectedReleaseConflicts.some((conflict) => (
+            conflict.code === 'structural_conflict'
+            || !conflict.fieldPath
+            || conflict.fieldPath === '$'
+          ));
+          candidateBaseSnapshot = hasStructuralReleaseConflict ? baseSnapshot : currentSnapshot;
+        } else {
+          driftConflict = {
+            ...releaseDriftConflict(packageRow, currentReleaseRow, baseReleaseRow),
+            reason: drift.reason || 'release_drift_unresolved',
+            releaseId: drift.releaseId || null,
+          };
+        }
+      }
+      const candidate = buildSpellingContentOperationCandidate(candidateBaseSnapshot, operations);
+      if (releaseOperations.length) {
+        releaseConflicts = enrichReleaseConflicts(
+          detectedReleaseConflicts,
+          {
+            packageOperations: operations,
+            releaseOperations,
+            baseSnapshot,
+            currentSnapshot,
+            candidateSnapshot: candidate.candidate,
+          },
+        );
+      }
       const conflicts = [
         ...(candidate.conflicts || []),
-        releaseDriftConflict(packageRow, currentReleaseRow, baseReleaseRow),
+        ...releaseConflicts,
+        driftConflict,
       ].filter(Boolean);
       const candidateId = uid('cocand');
       const nowTs = Number(nowFactory());
@@ -929,6 +1072,110 @@ export function createContentOperationsRepository({ db, now }) {
         validation: validationSummary,
         conflicts,
         createdAt: nowTs,
+      };
+    },
+
+    async resolveContentOperationConflict(packageId, request = {}, { actorAccountId } = {}) {
+      const {
+        conflictId = '',
+        conflict = null,
+        resolution = '',
+        value = undefined,
+      } = request && typeof request === 'object' && !Array.isArray(request) ? request : {};
+      const actor = normaliseString(actorAccountId);
+      if (!actor) throw new BadRequestError('Content operation conflict resolution requires an actor account id.');
+      const requestedResolution = normaliseString(resolution).toLowerCase();
+      if (!['package', 'current', 'edit'].includes(requestedResolution)) {
+        throw new BadRequestError('Content operation conflict resolution is invalid.', {
+          code: 'content_operation_conflict_resolution_invalid',
+          resolution,
+        });
+      }
+      const requestedConflict = conflict && typeof conflict === 'object' && !Array.isArray(conflict)
+        ? conflict
+        : {};
+      const requestedConflictId = normaliseString(conflictId || requestedConflict.conflictId);
+      const candidateBefore = await this.buildContentOperationCandidate(packageId, {
+        actorAccountId: actor,
+      });
+      const match = requestedConflictId
+        ? candidateBefore.conflicts.find((entry) => entry.conflictId === requestedConflictId)
+        : candidateBefore.conflicts.find((entry) => (
+          entry.entityType === requestedConflict.entityType
+            && entry.entityId === requestedConflict.entityId
+            && (entry.fieldPath || '$') === (requestedConflict.fieldPath || '$')
+        ));
+      if (!match) {
+        throw new NotFoundError('Content operation conflict was not found.', {
+          code: 'content_operation_conflict_not_found',
+          packageId,
+          conflictId: requestedConflictId,
+        });
+      }
+      if (!match.fieldPath || match.fieldPath === '$' || match.code === 'structural_conflict') {
+        throw new BadRequestError('Only same-field content operation conflicts can be resolved in this workflow.', {
+          code: 'content_operation_conflict_not_resolvable',
+          packageId,
+          conflictId: match.conflictId,
+          conflictCode: match.code,
+        });
+      }
+
+      const hasExplicitValue = Object.prototype.hasOwnProperty.call(request || {}, 'value');
+      let payload;
+      if (requestedResolution === 'package') {
+        payload = cloneSerialisable(match.packageValue);
+      } else if (requestedResolution === 'current') {
+        payload = cloneSerialisable(match.currentValue);
+      } else {
+        if (!hasExplicitValue) {
+          throw new BadRequestError('Edited content operation conflict resolution requires a value.', {
+            code: 'content_operation_conflict_resolution_value_required',
+            packageId,
+            conflictId: match.conflictId,
+          });
+        }
+        payload = cloneSerialisable(value);
+      }
+
+      const operation = await this.appendContentOperation(packageId, {
+        entityType: match.entityType,
+        entityId: match.entityId,
+        fieldPath: match.fieldPath,
+        action: 'set',
+        payload,
+        beforeHash: contentOperationValueHash(match.currentValue),
+        afterHash: contentOperationValueHash(payload),
+      }, {
+        actorAccountId: actor,
+      });
+      const nowTs = Number(nowFactory());
+      await insertContentOperationEvent(db, {
+        packageId,
+        subjectId: CONTENT_OPERATION_SUBJECT_ID,
+        eventType: 'conflict.resolved',
+        actorAccountId: actor,
+        event: {
+          conflictId: match.conflictId,
+          resolution: requestedResolution,
+          operationId: operation.operationId,
+          entityType: match.entityType,
+          entityId: match.entityId,
+          fieldPath: match.fieldPath,
+          currentValueHash: contentOperationValueHash(match.currentValue),
+          resolvedValueHash: contentOperationValueHash(payload),
+        },
+        createdAt: nowTs,
+      });
+      const candidate = await this.buildContentOperationCandidate(packageId, {
+        actorAccountId: actor,
+      });
+      return {
+        packageId,
+        conflict: match,
+        operation,
+        candidate,
+        resolution: requestedResolution,
       };
     },
 
@@ -1260,6 +1507,7 @@ export function createContentOperationsRepository({ db, now }) {
         status: 'published',
         snapshotHash,
         snapshot: candidate.candidate,
+        baseReleaseId: candidate.currentReleaseId || packageRow.base_release_id || null,
         publishedAt: nowTs,
         publishedByAccountId: actor,
         proof,

--- a/worker/src/content-operations/routes.js
+++ b/worker/src/content-operations/routes.js
@@ -390,7 +390,7 @@ export async function handleContentOperationsAdminRequest({
   }
 
   {
-    const actionMatch = /^\/packages\/([^/]+)\/(validate|approve|publish|rebase|scan-audio|generate-audio|upload-monster-asset|create-revert)$/.exec(relativePath);
+    const actionMatch = /^\/packages\/([^/]+)\/(validate|approve|publish|resolve-conflict|rebase|scan-audio|generate-audio|upload-monster-asset|create-revert)$/.exec(relativePath);
     if (request.method === 'POST' && actionMatch) {
       const packageId = decodePathSegment(actionMatch[1], 'package_id');
       const action = actionMatch[2];
@@ -429,6 +429,35 @@ export async function handleContentOperationsAdminRequest({
           ok: true,
           actor: serialiseContentOperationActor(actor),
           candidate: serialiseContentOperationCandidate(candidate, {
+            includeSnapshot: includeSnapshot(url, body),
+          }),
+        });
+      }
+
+      if (action === 'resolve-conflict') {
+        let result;
+        try {
+          const resolveRequest = {
+            conflictId: body.conflictId,
+            conflict: body.conflict,
+            resolution: body.resolution,
+          };
+          if (Object.prototype.hasOwnProperty.call(body, 'value')) {
+            resolveRequest.value = body.value;
+          }
+          result = await repository.resolveContentOperationConflict(packageId, resolveRequest, {
+            actorAccountId: actor.id,
+          });
+        } catch (error) {
+          badContentOperation(error);
+        }
+        return json({
+          ok: true,
+          actor: serialiseContentOperationActor(actor),
+          conflict: result.conflict,
+          resolution: result.resolution,
+          operation: serialiseContentOperation(result.operation),
+          candidate: serialiseContentOperationCandidate(result.candidate, {
             includeSnapshot: includeSnapshot(url, body),
           }),
         });


### PR DESCRIPTION
## Summary
- Add same-field conflict detection and resolution for Content Operations packages.
- Auto-rebase unrelated release drift while blocking structural and same-field conflicts safely.
- Add the admin conflict resolver UI plus client and Worker endpoint coverage.

## Validation
- `git diff --check`
- `node --test tests/content-operations-merge.test.js tests/content-operations-repository.test.js tests/content-operations-api.test.js`
- `node --test tests/admin-content-operations-v2.test.js tests/react-admin-content-operations.test.js tests/button-label-consistency.test.js`
- `npm run check`
- `npm test` (111,730 tests; 111,718 pass; 0 fail; 12 skipped)
- Pre-push `npm test` (111,730 tests; 111,718 pass; 0 fail; 12 skipped)
- Independent re-checks: correctness PASS, API contract PASS, project standards PASS