### PR TITLE
feat(content-ops): add spelling browse read models

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2715,6 +2715,9 @@ function buildCodexModel(appState, context) {
 function buildSurfaceActions() {
   const contentOperationsApi = hubApi ? {
     readOverview: hubApi.readContentOperationsOverview?.bind(hubApi),
+    readSpellingBrowse: hubApi.readContentOperationSpellingBrowse?.bind(hubApi),
+    readSpellingWord: hubApi.readContentOperationSpellingWord?.bind(hubApi),
+    readSpellingSentence: hubApi.readContentOperationSpellingSentence?.bind(hubApi),
     readPackages: hubApi.readContentOperationPackages?.bind(hubApi),
     readPackage: hubApi.readContentOperationPackage?.bind(hubApi),
     validatePackage: hubApi.validateContentOperationPackage?.bind(hubApi),

--- a/src/platform/hubs/admin-content-operations.js
+++ b/src/platform/hubs/admin-content-operations.js
@@ -267,3 +267,204 @@ export function normaliseContentOperationsPackageDetail(payload = null) {
     actor: normaliseContentOperationActor(safe.actor),
   };
 }
+
+function normaliseAudioReadiness(value = null) {
+  const safe = isPlainObject(value) ? value : {};
+  return {
+    status: asString(safe.status, 'not_scanned'),
+    profiles: asArray(safe.profiles),
+    wordProfiles: asArray(safe.wordProfiles),
+    sentenceProfiles: asArray(safe.sentenceProfiles),
+    wordAudioRequired: Number(safe.wordAudioRequired) || 0,
+    sentenceAudioRequired: Number(safe.sentenceAudioRequired) || 0,
+    totalRequired: Number(safe.totalRequired) || 0,
+  };
+}
+
+function normaliseRewardImpact(value = null) {
+  const safe = isPlainObject(value) ? value : {};
+  return {
+    status: asString(safe.status, 'not_mapped'),
+    spellingPool: asString(safe.spellingPool, 'core'),
+    coverageTier: asString(safe.coverageTier),
+    familySize: Number(safe.familySize) || 0,
+    wordListId: asString(safe.wordListId),
+    monsterBinding: isPlainObject(safe.monsterBinding) ? { ...safe.monsterBinding } : null,
+  };
+}
+
+function normaliseSpellingBrowseWord(row = null) {
+  const safe = isPlainObject(row) ? row : {};
+  return {
+    slug: asString(safe.slug),
+    word: asString(safe.word),
+    family: asString(safe.family),
+    listId: asString(safe.listId),
+    listTitle: asString(safe.listTitle),
+    spellingPool: asString(safe.spellingPool, 'core'),
+    coverageTier: asString(safe.coverageTier),
+    yearGroups: asArray(safe.yearGroups),
+    tags: asArray(safe.tags),
+    patternIds: asArray(safe.patternIds),
+    acceptedCount: Number(safe.acceptedCount) || 0,
+    sentenceCount: Number(safe.sentenceCount) || 0,
+    variantCount: Number(safe.variantCount) || 0,
+    variantSentenceCount: Number(safe.variantSentenceCount) || 0,
+    variantWords: asArray(safe.variantWords),
+    variantAccepted: asArray(safe.variantAccepted),
+    familySize: Number(safe.familySize) || 0,
+    draftState: asString(safe.draftState, 'unchanged'),
+    validationState: normaliseBlockerSection(safe.validationState),
+    hasCurrent: safe.hasCurrent !== false,
+    hasPackageDraft: Boolean(safe.hasPackageDraft),
+    audioReadiness: normaliseAudioReadiness(safe.audioReadiness),
+    rewardImpact: normaliseRewardImpact(safe.rewardImpact),
+  };
+}
+
+function normaliseSpellingWordList(row = null) {
+  const safe = isPlainObject(row) ? row : {};
+  return {
+    id: asString(safe.id),
+    title: asString(safe.title),
+    spellingPool: asString(safe.spellingPool, 'core'),
+    coverageTier: asString(safe.coverageTier),
+    yearGroups: asArray(safe.yearGroups),
+    wordCount: Number(safe.wordCount) || 0,
+    draftState: asString(safe.draftState, 'unchanged'),
+  };
+}
+
+function normaliseSpellingPoolSummary(row = null) {
+  const safe = isPlainObject(row) ? row : {};
+  return {
+    pool: asString(safe.pool, 'core'),
+    wordCount: Number(safe.wordCount) || 0,
+    sentenceCount: Number(safe.sentenceCount) || 0,
+    variantCount: Number(safe.variantCount) || 0,
+    draftStateCounts: isPlainObject(safe.draftStateCounts) ? { ...safe.draftStateCounts } : {},
+  };
+}
+
+function normaliseSpellingPackageDraft(value = null) {
+  const safe = isPlainObject(value) ? value : {};
+  return {
+    active: Boolean(safe.active),
+    status: asString(safe.status, 'inactive'),
+    packageId: asString(safe.packageId),
+    packageTitle: asString(safe.packageTitle),
+    packageState: asString(safe.packageState),
+    candidateId: asString(safe.candidateId),
+    candidateHash: asString(safe.candidateHash),
+    staleReasons: asArray(safe.staleReasons),
+    latestReleaseId: asString(safe.latestReleaseId),
+    expectedOperationsHash: asString(safe.expectedOperationsHash),
+    validation: normaliseBlockerSection(safe.validation),
+  };
+}
+
+export function normaliseContentOperationsSpellingBrowse(payload = null) {
+  const browse = isPlainObject(payload?.browse) ? payload.browse : payload;
+  const safe = isPlainObject(browse) ? browse : {};
+  const filters = isPlainObject(safe.filters) ? safe.filters : {};
+  const totals = isPlainObject(safe.totals) ? safe.totals : {};
+  const release = isPlainObject(safe.release) ? safe.release : {};
+  return {
+    subjectId: asString(safe.subjectId, 'spelling'),
+    release: {
+      releaseId: asString(release.releaseId),
+      snapshotHash: asString(release.snapshotHash),
+      publishedAt: asTs(release.publishedAt),
+      source: asString(release.source, 'seeded_fallback'),
+    },
+    packageDraft: normaliseSpellingPackageDraft(safe.packageDraft),
+    filters: {
+      query: asString(filters.query),
+      pool: asString(filters.pool, 'all'),
+      listId: asString(filters.listId),
+      limit: Number(filters.limit) || 75,
+    },
+    totals: {
+      words: Number(totals.words) || 0,
+      displayedWords: Number(totals.displayedWords) || 0,
+      matchedWords: Number(totals.matchedWords) || 0,
+      wordLists: Number(totals.wordLists) || 0,
+      sentences: Number(totals.sentences) || 0,
+      variants: Number(totals.variants) || 0,
+      families: Number(totals.families) || 0,
+    },
+    draftStateCounts: isPlainObject(safe.draftStateCounts) ? { ...safe.draftStateCounts } : {},
+    pools: asArray(safe.pools).map(normaliseSpellingPoolSummary),
+    wordLists: asArray(safe.wordLists).map(normaliseSpellingWordList),
+    words: asArray(safe.words).map(normaliseSpellingBrowseWord),
+    actor: normaliseContentOperationActor(payload?.actor),
+  };
+}
+
+function normaliseSpellingSentence(sentence = null) {
+  const safe = isPlainObject(sentence) ? sentence : {};
+  return {
+    id: asString(safe.id),
+    wordSlug: asString(safe.wordSlug),
+    text: asString(safe.text),
+    variantLabel: asString(safe.variantLabel),
+    tags: asArray(safe.tags),
+    word: isPlainObject(safe.word) ? { ...safe.word } : null,
+  };
+}
+
+function normaliseSpellingSentenceValue(sentence = null) {
+  return isPlainObject(sentence) ? normaliseSpellingSentence(sentence) : null;
+}
+
+function normaliseSpellingWordDetailValue(value = null) {
+  const safe = isPlainObject(value) ? value : null;
+  if (!safe) return null;
+  return {
+    slug: asString(safe.slug),
+    word: asString(safe.word),
+    family: asString(safe.family),
+    list: isPlainObject(safe.list) ? normaliseSpellingWordList(safe.list) : null,
+    spellingPool: asString(safe.spellingPool, 'core'),
+    coverageTier: asString(safe.coverageTier),
+    yearGroups: asArray(safe.yearGroups),
+    tags: asArray(safe.tags),
+    patternIds: asArray(safe.patternIds),
+    accepted: asArray(safe.accepted),
+    explanation: asString(safe.explanation),
+    sentenceEntryIds: asArray(safe.sentenceEntryIds),
+    sentences: asArray(safe.sentences).map(normaliseSpellingSentence),
+    variants: asArray(safe.variants),
+    familyMembers: asArray(safe.familyMembers),
+    audioReadiness: normaliseAudioReadiness(safe.audioReadiness),
+    rewardImpact: normaliseRewardImpact(safe.rewardImpact),
+  };
+}
+
+export function normaliseContentOperationsSpellingItemDetail(payload = null) {
+  const detail = isPlainObject(payload?.detail) ? payload.detail : payload;
+  const safe = isPlainObject(detail) ? detail : {};
+  const release = isPlainObject(safe.release) ? safe.release : {};
+  return {
+    type: asString(safe.type),
+    slug: asString(safe.slug),
+    sentenceId: asString(safe.sentenceId),
+    found: Boolean(safe.found),
+    draftState: asString(safe.draftState, 'unchanged'),
+    release: {
+      releaseId: asString(release.releaseId),
+      snapshotHash: asString(release.snapshotHash),
+      publishedAt: asTs(release.publishedAt),
+      source: asString(release.source, 'seeded_fallback'),
+    },
+    packageDraft: normaliseSpellingPackageDraft(safe.packageDraft),
+    validationState: normaliseBlockerSection(safe.validationState),
+    current: safe.type === 'sentence'
+      ? normaliseSpellingSentenceValue(safe.current)
+      : normaliseSpellingWordDetailValue(safe.current),
+    packageValue: safe.type === 'sentence'
+      ? normaliseSpellingSentenceValue(safe.packageValue)
+      : normaliseSpellingWordDetailValue(safe.packageValue),
+    actor: normaliseContentOperationActor(payload?.actor),
+  };
+}

--- a/src/platform/hubs/api.js
+++ b/src/platform/hubs/api.js
@@ -270,6 +270,46 @@ export function createHubApi({
       );
       return fetchHubJson(fetch, url, { method: 'GET' }, authSession);
     },
+    async readContentOperationSpellingBrowse({
+      packageId = null,
+      query = '',
+      pool = null,
+      listId = null,
+      limit = 75,
+    } = {}) {
+      const url = buildRequestUrl(
+        baseUrl,
+        '/api/admin/content-operations/subjects/spelling/browse',
+        {
+          packageId,
+          query,
+          pool,
+          listId,
+          limit,
+        },
+      );
+      return fetchHubJson(fetch, url, { method: 'GET' }, authSession);
+    },
+    async readContentOperationSpellingWord({ slug, packageId = null } = {}) {
+      if (!slug) throw new TypeError('Spelling word slug is required.');
+      const safeSlug = encodeURIComponent(String(slug));
+      const url = buildRequestUrl(
+        baseUrl,
+        `/api/admin/content-operations/subjects/spelling/words/${safeSlug}`,
+        { packageId },
+      );
+      return fetchHubJson(fetch, url, { method: 'GET' }, authSession);
+    },
+    async readContentOperationSpellingSentence({ sentenceId, packageId = null } = {}) {
+      if (!sentenceId) throw new TypeError('Spelling sentence id is required.');
+      const safeSentenceId = encodeURIComponent(String(sentenceId));
+      const url = buildRequestUrl(
+        baseUrl,
+        `/api/admin/content-operations/subjects/spelling/sentences/${safeSentenceId}`,
+        { packageId },
+      );
+      return fetchHubJson(fetch, url, { method: 'GET' }, authSession);
+    },
     async readContentOperationPackages({ state = null, limit = 50 } = {}) {
       const url = buildRequestUrl(baseUrl, '/api/admin/content-operations/packages', {
         state,

--- a/src/subjects/spelling/content/editor-read-model.js
+++ b/src/subjects/spelling/content/editor-read-model.js
@@ -1,0 +1,610 @@
+import {
+  normaliseSpellingContentBundle,
+} from './model.js';
+import {
+  stableContentOperationStringify,
+} from './operations-model.js';
+
+const DEFAULT_BROWSE_LIMIT = 75;
+const MAX_BROWSE_LIMIT = 250;
+const WORD_AUDIO_PROFILES = Object.freeze(['male.natural', 'female.natural']);
+const SENTENCE_AUDIO_PROFILES = Object.freeze([
+  'male.normal',
+  'male.slow',
+  'female.normal',
+  'female.slow',
+]);
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function asString(value, fallback = '') {
+  return typeof value === 'string' && value.trim() ? value.trim() : fallback;
+}
+
+function normaliseLimit(value) {
+  const limit = Number(value);
+  if (!Number.isFinite(limit) || limit <= 0) return DEFAULT_BROWSE_LIMIT;
+  return Math.max(1, Math.min(MAX_BROWSE_LIMIT, Math.floor(limit)));
+}
+
+function normaliseFilters(filters = {}) {
+  const safe = isPlainObject(filters) ? filters : {};
+  const pool = asString(safe.pool || safe.spellingPool, 'all').toLowerCase();
+  return {
+    query: asString(safe.query || safe.q).toLowerCase(),
+    pool: ['core', 'extra'].includes(pool) ? pool : 'all',
+    listId: asString(safe.listId),
+    limit: normaliseLimit(safe.limit),
+  };
+}
+
+function validationSummary(validation = null) {
+  const safe = isPlainObject(validation) ? validation : {};
+  const errors = asArray(safe.errors);
+  const warnings = asArray(safe.warnings);
+  const ok = typeof safe.ok === 'boolean' ? safe.ok : errors.length === 0;
+  return {
+    status: ok ? 'passed' : 'blocked',
+    ok,
+    errorCount: Number(safe.errorCount ?? errors.length) || 0,
+    warningCount: Number(safe.warningCount ?? warnings.length) || 0,
+    errors,
+    warnings,
+  };
+}
+
+function draftMaps(bundle) {
+  const wordListsById = new Map(bundle.draft.wordLists.map((entry) => [entry.id, entry]));
+  const wordsBySlug = new Map(bundle.draft.words.map((entry) => [entry.slug, entry]));
+  const sentencesById = new Map(bundle.draft.sentences.map((entry) => [entry.id, entry]));
+  return { wordListsById, wordsBySlug, sentencesById };
+}
+
+function sentenceEntriesForWord(word, maps) {
+  return asArray(word?.sentenceEntryIds)
+    .map((id) => maps.sentencesById.get(id))
+    .filter(Boolean)
+    .sort((left, right) => left.sortIndex - right.sortIndex);
+}
+
+function variantSummaries(word, maps) {
+  return asArray(word?.variants).map((variant) => {
+    const sentences = asArray(variant.sentenceEntryIds)
+      .map((id) => maps.sentencesById.get(id))
+      .filter(Boolean)
+      .sort((left, right) => left.sortIndex - right.sortIndex);
+    return {
+      word: variant.word,
+      accepted: asArray(variant.accepted),
+      explanation: variant.explanation || '',
+      sentenceEntryIds: asArray(variant.sentenceEntryIds),
+      sentenceCount: sentences.length,
+      sentences: sentences.map(compactSentence),
+    };
+  });
+}
+
+function validationStateForPackageCandidate(
+  packageCandidate = null,
+  packageContent = null,
+  { packageActive = false } = {},
+) {
+  if (!packageCandidate) {
+    if (packageActive) {
+      return {
+        status: 'candidate_required',
+        ok: false,
+        errorCount: 1,
+        warningCount: 0,
+        errors: [{
+          code: 'candidate_required',
+          message: 'Package candidate must be validated before draft values can be browsed.',
+        }],
+        warnings: [],
+      };
+    }
+    return {
+      status: 'published',
+      ok: true,
+      errorCount: 0,
+      warningCount: 0,
+      errors: [],
+      warnings: [],
+    };
+  }
+  const validation = validationSummary(packageCandidate.validation);
+  if (packageCandidate.isCurrent === false || (packageCandidate.staleReasons || []).length) {
+    return {
+      status: 'stale_candidate',
+      ok: false,
+      errorCount: Math.max(1, validation.errorCount),
+      warningCount: validation.warningCount,
+      errors: [
+        ...validation.errors,
+        {
+          code: 'stale_candidate',
+          message: 'Package candidate must be rebuilt before draft values can be browsed.',
+          reasons: asArray(packageCandidate.staleReasons),
+        },
+      ],
+      warnings: validation.warnings,
+    };
+  }
+  if (!packageContent) {
+    return {
+      status: 'candidate_required',
+      ok: false,
+      errorCount: Math.max(1, validation.errorCount),
+      warningCount: validation.warningCount,
+      errors: [
+        ...validation.errors,
+        {
+          code: 'candidate_required',
+          message: 'Package candidate must be validated before draft values can be browsed.',
+        },
+      ],
+      warnings: validation.warnings,
+    };
+  }
+  return validation;
+}
+
+function familyMembersFor(word, bundle) {
+  if (!word?.family) return [];
+  return bundle.draft.words
+    .filter((entry) => (
+      entry.family === word.family
+      && entry.spellingPool === word.spellingPool
+      && entry.coverageTier === word.coverageTier
+    ))
+    .sort((left, right) => left.sortIndex - right.sortIndex || left.word.localeCompare(right.word))
+    .map((entry) => ({
+      slug: entry.slug,
+      word: entry.word,
+    }));
+}
+
+function compactSentence(sentence) {
+  return {
+    id: sentence.id,
+    wordSlug: sentence.wordSlug,
+    text: sentence.text,
+    variantLabel: sentence.variantLabel || '',
+    tags: asArray(sentence.tags),
+  };
+}
+
+function compactWordList(list, wordCount, draftState = 'unchanged') {
+  return {
+    id: list.id,
+    title: list.title,
+    spellingPool: list.spellingPool,
+    coverageTier: list.coverageTier,
+    yearGroups: asArray(list.yearGroups),
+    wordCount,
+    draftState,
+  };
+}
+
+function comparableWordList(list) {
+  if (!list) return null;
+  return {
+    id: list.id,
+    title: list.title,
+    spellingPool: list.spellingPool,
+    coverageTier: list.coverageTier,
+    yearGroups: asArray(list.yearGroups),
+    tags: asArray(list.tags),
+    sourceNote: list.sourceNote || '',
+  };
+}
+
+function comparableWord(bundle, maps, slug) {
+  const word = maps.wordsBySlug.get(slug);
+  if (!word) return null;
+  const sentences = sentenceEntriesForWord(word, maps).map(compactSentence);
+  const list = maps.wordListsById.get(word.listId) || null;
+  return {
+    word,
+    list: comparableWordList(list),
+    sentences,
+    variants: variantSummaries(word, maps),
+  };
+}
+
+function compareValue(left, right) {
+  return stableContentOperationStringify(left) === stableContentOperationStringify(right);
+}
+
+function packageDraftState(currentValue, packageValue) {
+  if (!packageValue && !currentValue) return 'missing';
+  if (!currentValue && packageValue) return 'added';
+  if (currentValue && !packageValue) return 'removed';
+  return compareValue(currentValue, packageValue) ? 'unchanged' : 'modified';
+}
+
+function audioReadinessForWord(word, baseSentenceCount, variantSentenceCount) {
+  const variantCount = asArray(word?.variants).length;
+  const wordAudioRequired = (1 + variantCount) * WORD_AUDIO_PROFILES.length;
+  const sentenceAudioRequired = (baseSentenceCount + variantSentenceCount) * SENTENCE_AUDIO_PROFILES.length;
+  return {
+    status: 'not_scanned',
+    wordProfiles: [...WORD_AUDIO_PROFILES],
+    sentenceProfiles: [...SENTENCE_AUDIO_PROFILES],
+    wordAudioRequired,
+    sentenceAudioRequired,
+    totalRequired: wordAudioRequired + sentenceAudioRequired,
+  };
+}
+
+function rewardImpactForWord(word, familySize) {
+  return {
+    status: 'not_mapped',
+    spellingPool: word.spellingPool,
+    coverageTier: word.coverageTier,
+    familySize,
+    wordListId: word.listId,
+    monsterBinding: {
+      mode: 'pool',
+      poolId: word.spellingPool,
+      assignment: 'unresolved',
+    },
+  };
+}
+
+function compactWordRow({
+  word,
+  bundle,
+  maps,
+  currentComparable,
+  packageComparable,
+  draftState,
+  validationState,
+}) {
+  const list = maps.wordListsById.get(word.listId) || null;
+  const sentences = sentenceEntriesForWord(word, maps);
+  const variants = variantSummaries(word, maps);
+  const variantSentenceCount = variants.reduce((sum, variant) => sum + variant.sentenceCount, 0);
+  const familyMembers = familyMembersFor(word, bundle);
+  return {
+    slug: word.slug,
+    word: word.word,
+    family: word.family,
+    listId: word.listId,
+    listTitle: list?.title || '',
+    spellingPool: word.spellingPool,
+    coverageTier: word.coverageTier,
+    yearGroups: asArray(word.yearGroups),
+    tags: asArray(word.tags),
+    patternIds: asArray(word.patternIds),
+    acceptedCount: asArray(word.accepted).length,
+    sentenceCount: sentences.length,
+    variantCount: variants.length,
+    variantSentenceCount,
+    variantWords: variants.map((variant) => variant.word).filter(Boolean),
+    variantAccepted: variants.flatMap((variant) => asArray(variant.accepted)),
+    familySize: familyMembers.length,
+    draftState,
+    validationState,
+    hasCurrent: Boolean(currentComparable),
+    hasPackageDraft: Boolean(packageComparable),
+    audioReadiness: audioReadinessForWord(word, sentences.length, variantSentenceCount),
+    rewardImpact: rewardImpactForWord(word, familyMembers.length),
+  };
+}
+
+function rowMatchesFilters(row, filters) {
+  if (filters.pool !== 'all' && row.spellingPool !== filters.pool) return false;
+  if (filters.listId && row.listId !== filters.listId) return false;
+  if (!filters.query) return true;
+  const haystack = [
+    row.slug,
+    row.word,
+    row.family,
+    row.listId,
+    row.listTitle,
+    row.coverageTier,
+    ...row.tags,
+    ...row.patternIds,
+    ...asArray(row.variantWords),
+    ...asArray(row.variantAccepted),
+  ].join(' ').toLowerCase();
+  return haystack.includes(filters.query);
+}
+
+function draftStateCounts(rows) {
+  const counts = {
+    added: 0,
+    modified: 0,
+    removed: 0,
+    unchanged: 0,
+  };
+  for (const row of rows) {
+    if (Object.prototype.hasOwnProperty.call(counts, row.draftState)) {
+      counts[row.draftState] += 1;
+    }
+  }
+  return counts;
+}
+
+function poolSummaries(rows) {
+  return ['core', 'extra'].map((pool) => {
+    const poolRows = rows.filter((row) => row.spellingPool === pool);
+    return {
+      pool,
+      wordCount: poolRows.length,
+      sentenceCount: poolRows.reduce((sum, row) => sum + row.sentenceCount + row.variantSentenceCount, 0),
+      variantCount: poolRows.reduce((sum, row) => sum + row.variantCount, 0),
+      draftStateCounts: draftStateCounts(poolRows),
+    };
+  });
+}
+
+function compactWordLists({ currentBundle, packageBundle, currentMaps, packageMaps }) {
+  const displayBundle = packageBundle || currentBundle;
+  const displayMaps = packageMaps || currentMaps;
+  const listIds = new Set([
+    ...currentBundle.draft.wordLists.map((entry) => entry.id),
+    ...asArray(packageBundle?.draft?.wordLists).map((entry) => entry.id),
+  ]);
+  return [...listIds].map((id) => {
+    const currentList = currentMaps.wordListsById.get(id) || null;
+    const packageList = packageMaps?.wordListsById.get(id) || null;
+    const display = packageList || currentList;
+    const wordCount = displayBundle.draft.words.filter((word) => word.listId === id).length;
+    return compactWordList(
+      display,
+      wordCount,
+      packageBundle ? packageDraftState(currentList, packageList) : 'unchanged',
+    );
+  }).sort((left, right) => left.spellingPool.localeCompare(right.spellingPool) || left.title.localeCompare(right.title));
+}
+
+function packageDraftEnvelope({ packageId = '', packageRecord = null, packageCandidate = null, packageContent = null } = {}) {
+  const validation = validationStateForPackageCandidate(packageCandidate, packageContent, {
+    packageActive: Boolean(packageId),
+  });
+  if (!packageId) {
+    return {
+      active: false,
+      status: 'inactive',
+      packageId: '',
+      candidateId: '',
+      candidateHash: '',
+      staleReasons: [],
+      validation,
+    };
+  }
+  const staleReasons = asArray(packageCandidate?.staleReasons);
+  return {
+    active: true,
+    status: staleReasons.length || packageCandidate?.isCurrent === false
+      ? 'stale_candidate'
+      : (packageContent ? 'available' : 'candidate_required'),
+    packageId,
+    packageTitle: packageRecord?.title || '',
+    packageState: packageRecord?.state || '',
+    candidateId: packageCandidate?.candidateId || '',
+    candidateHash: packageCandidate?.candidateHash || '',
+    staleReasons,
+    latestReleaseId: packageCandidate?.latestReleaseId || '',
+    expectedOperationsHash: packageCandidate?.expectedOperationsHash || '',
+    validation,
+  };
+}
+
+function releaseEnvelope(releaseInfo = {}) {
+  return {
+    releaseId: releaseInfo?.releaseId || '',
+    snapshotHash: releaseInfo?.snapshotHash || '',
+    publishedAt: Number(releaseInfo?.publishedAt) || 0,
+    source: releaseInfo?.source || (releaseInfo?.releaseId ? 'latest_release' : 'seeded_fallback'),
+  };
+}
+
+export function buildSpellingContentBrowseModel({
+  publishedContent,
+  packageContent = null,
+  packageCandidate = null,
+  packageRecord = null,
+  packageId = '',
+  releaseInfo = {},
+  filters = {},
+} = {}) {
+  const currentBundle = normaliseSpellingContentBundle(publishedContent);
+  const packageBundle = packageContent ? normaliseSpellingContentBundle(packageContent) : null;
+  const currentMaps = draftMaps(currentBundle);
+  const packageMaps = packageBundle ? draftMaps(packageBundle) : null;
+  const displayBundle = packageBundle || currentBundle;
+  const normalisedFilters = normaliseFilters(filters);
+  const validationState = validationStateForPackageCandidate(packageCandidate, packageBundle, {
+    packageActive: Boolean(packageId),
+  });
+  const slugs = new Set([
+    ...currentBundle.draft.words.map((word) => word.slug),
+    ...asArray(packageBundle?.draft?.words).map((word) => word.slug),
+  ]);
+  const rows = [...slugs].map((slug) => {
+    const currentComparable = comparableWord(currentBundle, currentMaps, slug);
+    const packageComparable = packageBundle ? comparableWord(packageBundle, packageMaps, slug) : null;
+    const displayWord = (packageComparable?.word || currentComparable?.word);
+    const displayMapsForWord = packageComparable ? packageMaps : currentMaps;
+    const displayBundleForWord = packageComparable ? packageBundle : currentBundle;
+    return compactWordRow({
+      word: displayWord,
+      bundle: displayBundleForWord,
+      maps: displayMapsForWord,
+      currentComparable,
+      packageComparable,
+      draftState: packageBundle ? packageDraftState(currentComparable, packageComparable) : 'unchanged',
+      validationState,
+    });
+  }).sort((left, right) => (
+    left.spellingPool.localeCompare(right.spellingPool)
+    || left.listTitle.localeCompare(right.listTitle)
+    || left.word.localeCompare(right.word)
+  ));
+  const filteredRows = rows.filter((row) => rowMatchesFilters(row, normalisedFilters));
+  const limitedRows = filteredRows.slice(0, normalisedFilters.limit);
+  const sentenceCount = displayBundle.draft.sentences.length;
+  const variantCount = displayBundle.draft.words.reduce((sum, word) => sum + asArray(word.variants).length, 0);
+  return {
+    subjectId: 'spelling',
+    release: releaseEnvelope(releaseInfo),
+    packageDraft: packageDraftEnvelope({
+      packageId,
+      packageRecord,
+      packageCandidate,
+      packageContent,
+    }),
+    filters: normalisedFilters,
+    totals: {
+      words: rows.length,
+      displayedWords: limitedRows.length,
+      matchedWords: filteredRows.length,
+      wordLists: displayBundle.draft.wordLists.length,
+      sentences: sentenceCount,
+      variants: variantCount,
+      families: new Set(displayBundle.draft.words.map((word) => `${word.spellingPool}:${word.coverageTier}:${word.family}`)).size,
+    },
+    draftStateCounts: draftStateCounts(rows),
+    pools: poolSummaries(rows),
+    wordLists: compactWordLists({
+      currentBundle,
+      packageBundle,
+      currentMaps,
+      packageMaps,
+    }),
+    words: limitedRows,
+  };
+}
+
+function detailedWord(bundle, maps, slug) {
+  const word = maps.wordsBySlug.get(slug);
+  if (!word) return null;
+  const list = maps.wordListsById.get(word.listId) || null;
+  const sentences = sentenceEntriesForWord(word, maps).map(compactSentence);
+  const variants = variantSummaries(word, maps);
+  const variantSentenceCount = variants.reduce((sum, variant) => sum + variant.sentenceCount, 0);
+  const familyMembers = familyMembersFor(word, bundle);
+  return {
+    slug: word.slug,
+    word: word.word,
+    family: word.family,
+    list: list ? compactWordList(list, list.wordSlugs.length) : null,
+    spellingPool: word.spellingPool,
+    coverageTier: word.coverageTier,
+    yearGroups: asArray(word.yearGroups),
+    tags: asArray(word.tags),
+    patternIds: asArray(word.patternIds),
+    accepted: asArray(word.accepted),
+    explanation: word.explanation || '',
+    sentenceEntryIds: asArray(word.sentenceEntryIds),
+    sentences,
+    variants,
+    familyMembers,
+    audioReadiness: audioReadinessForWord(word, sentences.length, variantSentenceCount),
+    rewardImpact: rewardImpactForWord(word, familyMembers.length),
+  };
+}
+
+export function buildSpellingContentWordDetail({
+  publishedContent,
+  packageContent = null,
+  packageCandidate = null,
+  packageRecord = null,
+  packageId = '',
+  releaseInfo = {},
+  slug = '',
+} = {}) {
+  const safeSlug = asString(slug).toLowerCase();
+  const currentBundle = normaliseSpellingContentBundle(publishedContent);
+  const packageBundle = packageContent ? normaliseSpellingContentBundle(packageContent) : null;
+  const currentMaps = draftMaps(currentBundle);
+  const packageMaps = packageBundle ? draftMaps(packageBundle) : null;
+  const current = detailedWord(currentBundle, currentMaps, safeSlug);
+  const packageDraft = packageBundle ? detailedWord(packageBundle, packageMaps, safeSlug) : null;
+  return {
+    type: 'word',
+    slug: safeSlug,
+    found: Boolean(current || packageDraft),
+    release: releaseEnvelope(releaseInfo),
+    packageDraft: packageDraftEnvelope({
+      packageId,
+      packageRecord,
+      packageCandidate,
+      packageContent,
+    }),
+    draftState: packageBundle
+      ? packageDraftState(
+        comparableWord(currentBundle, currentMaps, safeSlug),
+        comparableWord(packageBundle, packageMaps, safeSlug),
+      )
+      : 'unchanged',
+    current,
+    packageValue: packageDraft,
+    validationState: validationStateForPackageCandidate(packageCandidate, packageBundle, {
+      packageActive: Boolean(packageId),
+    }),
+  };
+}
+
+function sentenceDetail(bundle, maps, sentenceId) {
+  const sentence = maps.sentencesById.get(sentenceId);
+  if (!sentence) return null;
+  const word = maps.wordsBySlug.get(sentence.wordSlug) || null;
+  return {
+    ...compactSentence(sentence),
+    word: word ? {
+      slug: word.slug,
+      word: word.word,
+      family: word.family,
+      spellingPool: word.spellingPool,
+      coverageTier: word.coverageTier,
+    } : null,
+  };
+}
+
+export function buildSpellingContentSentenceDetail({
+  publishedContent,
+  packageContent = null,
+  packageCandidate = null,
+  packageRecord = null,
+  packageId = '',
+  releaseInfo = {},
+  sentenceId = '',
+} = {}) {
+  const safeSentenceId = asString(sentenceId);
+  const currentBundle = normaliseSpellingContentBundle(publishedContent);
+  const packageBundle = packageContent ? normaliseSpellingContentBundle(packageContent) : null;
+  const currentMaps = draftMaps(currentBundle);
+  const packageMaps = packageBundle ? draftMaps(packageBundle) : null;
+  const current = sentenceDetail(currentBundle, currentMaps, safeSentenceId);
+  const packageValue = packageBundle ? sentenceDetail(packageBundle, packageMaps, safeSentenceId) : null;
+  return {
+    type: 'sentence',
+    sentenceId: safeSentenceId,
+    found: Boolean(current || packageValue),
+    release: releaseEnvelope(releaseInfo),
+    packageDraft: packageDraftEnvelope({
+      packageId,
+      packageRecord,
+      packageCandidate,
+      packageContent,
+    }),
+    draftState: packageBundle
+      ? packageDraftState(current, packageValue)
+      : 'unchanged',
+    current,
+    packageValue,
+    validationState: validationStateForPackageCandidate(packageCandidate, packageBundle, {
+      packageActive: Boolean(packageId),
+    }),
+  };
+}

--- a/src/surfaces/hubs/AdminContentOperationsSection.jsx
+++ b/src/surfaces/hubs/AdminContentOperationsSection.jsx
@@ -10,6 +10,8 @@ import {
   normaliseContentOperationsPackageDetail,
   normaliseContentOperationsPackageList,
   normaliseContentOperationsReleaseList,
+  normaliseContentOperationsSpellingBrowse,
+  normaliseContentOperationsSpellingItemDetail,
 } from '../../platform/hubs/admin-content-operations.js';
 
 const CENTRE_TABS = Object.freeze([
@@ -197,6 +199,31 @@ function MetricTile({ label, value, detail }) {
       {detail ? <span className="small muted">{detail}</span> : null}
     </div>
   );
+}
+
+function draftStateChipClass(state) {
+  if (state === 'added') return 'good';
+  if (state === 'modified') return 'warn';
+  if (state === 'removed') return 'bad';
+  return '';
+}
+
+function draftStateLabel(state) {
+  if (state === 'added') return 'Added';
+  if (state === 'modified') return 'Modified';
+  if (state === 'removed') return 'Removed';
+  return 'Published';
+}
+
+function statusChipClass(status) {
+  if (['available', 'passed', 'published'].includes(status)) return 'good';
+  if (['blocked', 'stale_candidate'].includes(status)) return 'bad';
+  if (['candidate_required', 'not_ready', 'warning', 'warnings_only'].includes(status)) return 'warn';
+  return '';
+}
+
+function statusLabel(status) {
+  return String(status || 'unknown').replace(/_/g, ' ');
 }
 
 function CentreTabNav({ activeTab, onSelect }) {
@@ -428,6 +455,243 @@ function PublishedAreaPanel({ activeTab, latestRelease, selectedPackageId, selec
       <div className="content-ops-domain-placeholder">
         <span className="chip">No mutation controls</span>
         <span className="small muted">Package selection is required before this area can create operations.</span>
+      </div>
+    </div>
+  );
+}
+
+function SpellingBrowsePanel({
+  browse,
+  itemDetail,
+  filters,
+  selectedWordSlug,
+  selectedPackageId,
+  loadingBrowse,
+  loadingItem,
+  error,
+  onFilterChange,
+  onApplyFilters,
+  onSelectWord,
+}) {
+  const selectedRow = browse.words.find((row) => row.slug === selectedWordSlug) || browse.words[0] || null;
+  const packageDraft = browse.packageDraft;
+  const selectedDetail = itemDetail?.found
+    && itemDetail.slug === selectedRow?.slug
+    && (itemDetail.packageDraft?.packageId || '') === (packageDraft.packageId || '')
+    && (itemDetail.packageDraft?.candidateId || '') === (packageDraft.candidateId || '')
+    && (itemDetail.release?.releaseId || '') === (browse.release.releaseId || '')
+    ? itemDetail
+    : null;
+  const currentWord = selectedDetail?.current || null;
+  const packageWord = selectedDetail?.packageValue || null;
+  const releaseLabel = browse.release.releaseId || 'bundled fallback';
+  const detailValidation = selectedDetail?.validationState || selectedRow?.validationState || packageDraft.validation;
+  return (
+    <div className="content-ops-area-panel" data-content-ops-area="spelling" data-content-ops-spelling-browse="true">
+      <div className="content-ops-detail-header">
+        <div>
+          <div className="eyebrow">Published state</div>
+          <h4 className="section-title admin-section-title">Spelling browse</h4>
+          <p className="small muted admin-note-spaced">
+            Latest release {releaseLabel}
+          </p>
+        </div>
+        <div className="chip-row content-ops-chip-wrap">
+          <span className="chip">Words {String(browse.totals.words)}</span>
+          <span className="chip">Families {String(browse.totals.families)}</span>
+          {packageDraft.active ? (
+            <span className={`chip ${statusChipClass(packageDraft.status)}`}>
+              Package draft {statusLabel(packageDraft.status)}
+            </span>
+          ) : selectedPackageId ? (
+            <span className="chip warn">Package {selectedPackageId}</span>
+          ) : (
+            <span className="chip">Published only</span>
+          )}
+          {packageDraft.active ? (
+            <span className={`chip ${statusChipClass(packageDraft.validation.status)}`}>
+              Validation {statusLabel(packageDraft.validation.status)}
+            </span>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="content-ops-metric-grid content-ops-spelling-metrics">
+        {browse.pools.map((pool) => (
+          <MetricTile
+            key={pool.pool}
+            label={`${pool.pool === 'extra' ? 'Extra' : 'Core'} pool`}
+            value={String(pool.wordCount)}
+            detail={`${String(pool.sentenceCount)} sentence audio units`}
+          />
+        ))}
+        <MetricTile label="Word lists" value={String(browse.totals.wordLists)} detail={`${String(browse.totals.variants)} variants`} />
+        <MetricTile label="Matched" value={String(browse.totals.matchedWords)} detail={`${String(browse.totals.displayedWords)} displayed`} />
+      </div>
+
+      <form className="content-ops-browse-toolbar" onSubmit={onApplyFilters}>
+        <label>
+          <span className="small muted">Search</span>
+          <input
+            type="search"
+            value={filters.query}
+            onChange={(event) => onFilterChange({ query: event.target.value })}
+            data-content-ops-spelling-query="true"
+          />
+        </label>
+        <label>
+          <span className="small muted">Pool</span>
+          <select
+            value={filters.pool}
+            onChange={(event) => onFilterChange({ pool: event.target.value })}
+            data-content-ops-spelling-pool="true"
+          >
+            <option value="all">All</option>
+            <option value="core">Core</option>
+            <option value="extra">Extra</option>
+          </select>
+        </label>
+        <label>
+          <span className="small muted">List</span>
+          <select
+            value={filters.listId}
+            onChange={(event) => onFilterChange({ listId: event.target.value })}
+            data-content-ops-spelling-list="true"
+          >
+            <option value="">All lists</option>
+            {browse.wordLists.map((list) => (
+              <option key={list.id} value={list.id}>{list.title}</option>
+            ))}
+          </select>
+        </label>
+        <button type="submit" className="btn secondary" disabled={loadingBrowse}>
+          Apply filters
+        </button>
+      </form>
+
+      {error ? (
+        <div className="feedback warn admin-note-spaced" data-content-ops-spelling-error="true">
+          <strong>{error.code}</strong>
+          <div>{error.message}</div>
+        </div>
+      ) : null}
+
+      <div className="content-ops-spelling-browser">
+        <div className="content-ops-table-scroll">
+          <table className="admin-overview-table content-ops-table content-ops-spelling-table" aria-label="Spelling words">
+            <thead>
+              <tr className="admin-overview-thead-row">
+                <th className="small admin-overview-th-first">Word</th>
+                <th className="small admin-overview-th">Pool</th>
+                <th className="small admin-overview-th">Family</th>
+                <th className="small admin-overview-th-right">Audio</th>
+                <th className="small admin-overview-th">Validation</th>
+                <th className="small admin-overview-th">Draft</th>
+              </tr>
+            </thead>
+            <tbody>
+              {browse.words.map((row) => (
+                <tr
+                  key={row.slug}
+                  className="admin-overview-tbody-row"
+                  data-selected={row.slug === selectedRow?.slug ? 'true' : undefined}
+                  data-spelling-draft-state={row.draftState}
+                >
+                  <td className="admin-overview-td-first">
+                    <button
+                      type="button"
+                      className="content-ops-row-button"
+                      onClick={() => onSelectWord(row.slug)}
+                      data-content-ops-spelling-word={row.slug}
+                    >
+                      {row.word}
+                    </button>
+                    <div className="small muted">{row.listTitle || row.listId}</div>
+                  </td>
+                  <td className="admin-overview-td">
+                    <span className="chip">{row.spellingPool}</span>
+                  </td>
+                  <td className="admin-overview-td small">{row.family || 'No family'}</td>
+                  <td className="admin-overview-td-right small">{String(row.audioReadiness.totalRequired)}</td>
+                  <td className="admin-overview-td">
+                    <span className={`chip ${statusChipClass(row.validationState.status)}`}>
+                      {statusLabel(row.validationState.status)}
+                    </span>
+                  </td>
+                  <td className="admin-overview-td">
+                    <span className={`chip ${draftStateChipClass(row.draftState)}`}>
+                      {draftStateLabel(row.draftState)}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <aside className="content-ops-spelling-detail" aria-label="Spelling word detail">
+          {selectedRow ? (
+            <>
+              <div className="content-ops-spelling-detail-header">
+                <div>
+                  <div className="eyebrow">Word detail</div>
+                  <h5>{currentWord?.word || packageWord?.word || selectedRow.word}</h5>
+                </div>
+                <span className={`chip ${draftStateChipClass(selectedDetail?.draftState || selectedRow.draftState)}`}>
+                  {draftStateLabel(selectedDetail?.draftState || selectedRow.draftState)}
+                </span>
+              </div>
+              <div className="content-ops-spelling-detail-grid">
+                <MetricTile
+                  label="Family"
+                  value={currentWord?.family || packageWord?.family || selectedRow.family || 'None'}
+                  detail={`${String(currentWord?.familyMembers?.length || selectedRow.familySize)} related words`}
+                />
+                <MetricTile
+                  label="Sentences"
+                  value={String(currentWord?.sentences?.length || selectedRow.sentenceCount)}
+                  detail={`${String(selectedRow.variantSentenceCount)} variant sentences`}
+                />
+                <MetricTile
+                  label="Audio required"
+                  value={String((currentWord?.audioReadiness || selectedRow.audioReadiness).totalRequired)}
+                  detail={(currentWord?.audioReadiness || selectedRow.audioReadiness).status}
+                />
+                <MetricTile
+                  label="Validation"
+                  value={statusLabel(detailValidation.status)}
+                  detail={`${String(detailValidation.errorCount || 0)} errors, ${String(detailValidation.warningCount || 0)} warnings`}
+                />
+                <MetricTile
+                  label="Reward impact"
+                  value={(currentWord?.rewardImpact || selectedRow.rewardImpact).spellingPool}
+                  detail={(currentWord?.rewardImpact || selectedRow.rewardImpact).status}
+                />
+              </div>
+              {loadingItem ? <div className="small muted admin-note-spaced">Word detail is loading.</div> : null}
+              {currentWord?.sentences?.length ? (
+                <ul className="content-ops-operation-list">
+                  {currentWord.sentences.slice(0, 3).map((sentence) => (
+                    <li key={sentence.id}>
+                      <strong>{sentence.id}</strong>
+                      <span className="small muted"> - {sentence.text}</span>
+                    </li>
+                  ))}
+                </ul>
+              ) : null}
+              {packageWord && selectedDetail?.draftState !== 'unchanged' ? (
+                <div className="content-ops-spelling-draft-compare">
+                  <span className="chip warn">Package draft</span>
+                  <span className="small muted">{packageWord.explanation || 'Draft value available'}</span>
+                </div>
+              ) : null}
+            </>
+          ) : (
+            <div className="feedback admin-note-spaced" data-content-ops-spelling-empty="true">
+              No spelling words match the current filters.
+            </div>
+          )}
+        </aside>
       </div>
     </div>
   );
@@ -879,6 +1143,8 @@ export function AdminContentOperationsSection({
   initialPackages = null,
   initialReleases = null,
   initialPackageDetail = null,
+  initialSpellingBrowse = null,
+  initialSpellingItemDetail = null,
   initialSelectedPackageId = '',
   initialActiveTab = 'overview',
   initialDetailTab = 'spelling',
@@ -887,11 +1153,24 @@ export function AdminContentOperationsSection({
   const seedPackages = initialPackages || model?.contentOperations?.packages || null;
   const seedReleases = initialReleases || model?.contentOperations?.releases || null;
   const seedPackageDetail = initialPackageDetail || model?.contentOperations?.packageDetail || null;
-  const hasSeedData = Boolean(seedOverview || seedPackages || seedReleases || seedPackageDetail);
+  const seedSpellingBrowse = initialSpellingBrowse || model?.contentOperations?.spellingBrowse || null;
+  const seedSpellingItemDetail = initialSpellingItemDetail || model?.contentOperations?.spellingItemDetail || null;
+  const hasSeedData = Boolean(seedOverview || seedPackages || seedReleases || seedPackageDetail || seedSpellingBrowse);
   const [overviewPayload, setOverviewPayload] = React.useState(seedOverview);
   const [packageListPayload, setPackageListPayload] = React.useState(seedPackages);
   const [releaseListPayload, setReleaseListPayload] = React.useState(seedReleases);
   const [detailPayload, setDetailPayload] = React.useState(seedPackageDetail);
+  const [spellingBrowsePayload, setSpellingBrowsePayload] = React.useState(seedSpellingBrowse);
+  const [spellingItemPayload, setSpellingItemPayload] = React.useState(seedSpellingItemDetail);
+  const [spellingFilters, setSpellingFilters] = React.useState({
+    query: '',
+    pool: 'all',
+    listId: '',
+    limit: 75,
+  });
+  const [selectedWordSlug, setSelectedWordSlug] = React.useState(
+    normaliseContentOperationsSpellingItemDetail(seedSpellingItemDetail).slug,
+  );
   const [selectedPackageId, setSelectedPackageId] = React.useState(initialPackageId({
     packageDetail: seedPackageDetail,
     initialActiveTab,
@@ -900,9 +1179,12 @@ export function AdminContentOperationsSection({
   const [activeTab, setActiveTab] = React.useState(initialActiveTab);
   const [activeDetailTab, setActiveDetailTab] = React.useState(initialDetailTab);
   const [loading, setLoading] = React.useState(Boolean(actions?.contentOperationsApi?.readOverview && !hasSeedData));
+  const [loadingSpellingBrowse, setLoadingSpellingBrowse] = React.useState(false);
+  const [loadingSpellingItem, setLoadingSpellingItem] = React.useState(false);
   const [loadingDetailId, setLoadingDetailId] = React.useState('');
   const [detailErrorId, setDetailErrorId] = React.useState('');
   const [refreshError, setRefreshError] = React.useState(null);
+  const [spellingError, setSpellingError] = React.useState(null);
   const [refreshedAt, setRefreshedAt] = React.useState(hasSeedData ? Date.now() : null);
   const [lifecycleState, setLifecycleState] = React.useState({
     packageId: '',
@@ -915,6 +1197,8 @@ export function AdminContentOperationsSection({
     release: null,
   });
   const detailRequestRef = React.useRef({ id: '', seq: 0 });
+  const spellingBrowseRequestRef = React.useRef(0);
+  const spellingItemRequestRef = React.useRef({ slug: '', seq: 0 });
   const refreshRequestRef = React.useRef(0);
   const api = actions?.contentOperationsApi || null;
 
@@ -933,6 +1217,14 @@ export function AdminContentOperationsSection({
   const detail = React.useMemo(
     () => normaliseContentOperationsPackageDetail(detailPayload),
     [detailPayload],
+  );
+  const spellingBrowse = React.useMemo(
+    () => normaliseContentOperationsSpellingBrowse(spellingBrowsePayload),
+    [spellingBrowsePayload],
+  );
+  const spellingItemDetail = React.useMemo(
+    () => normaliseContentOperationsSpellingItemDetail(spellingItemPayload),
+    [spellingItemPayload],
   );
 
   const loadPackageDetail = React.useCallback(async (packageId) => {
@@ -960,7 +1252,22 @@ export function AdminContentOperationsSection({
     }
   }, [api]);
 
+  const invalidateSpellingBrowse = React.useCallback(() => {
+    spellingBrowseRequestRef.current += 1;
+    spellingItemRequestRef.current = {
+      slug: '',
+      seq: spellingItemRequestRef.current.seq + 1,
+    };
+    setSpellingBrowsePayload(null);
+    setSpellingItemPayload(null);
+    setSelectedWordSlug('');
+    setSpellingError(null);
+    setLoadingSpellingBrowse(false);
+    setLoadingSpellingItem(false);
+  }, []);
+
   const selectPackage = React.useCallback((packageId) => {
+    invalidateSpellingBrowse();
     setSelectedPackageId(packageId);
     setActiveTab('detail');
     setDetailErrorId('');
@@ -972,7 +1279,74 @@ export function AdminContentOperationsSection({
     } else {
       setDetailPayload({ package: packages.find((entry) => entry.packageId === packageId) || null, events: [] });
     }
-  }, [api, loadPackageDetail, packages]);
+  }, [api, invalidateSpellingBrowse, loadPackageDetail, packages]);
+
+  const loadSpellingBrowse = React.useCallback(async () => {
+    if (!api?.readSpellingBrowse) return;
+    const seq = spellingBrowseRequestRef.current + 1;
+    spellingBrowseRequestRef.current = seq;
+    setLoadingSpellingBrowse(true);
+    setSpellingError(null);
+    try {
+      const payload = await api.readSpellingBrowse({
+        packageId: selectedPackageId || null,
+        query: spellingFilters.query,
+        pool: spellingFilters.pool === 'all' ? null : spellingFilters.pool,
+        listId: spellingFilters.listId || null,
+        limit: spellingFilters.limit,
+      });
+      if (spellingBrowseRequestRef.current !== seq) return;
+      setSpellingBrowsePayload(payload);
+      const nextBrowse = normaliseContentOperationsSpellingBrowse(payload);
+      const firstSlug = nextBrowse.words[0]?.slug || '';
+      setSelectedWordSlug((current) => (
+        current && nextBrowse.words.some((row) => row.slug === current) ? current : firstSlug
+      ));
+      setRefreshedAt(Date.now());
+    } catch (error) {
+      if (spellingBrowseRequestRef.current !== seq) return;
+      setSpellingError(errorEnvelope(error, 'content_operations_spelling_browse_failed'));
+    } finally {
+      if (spellingBrowseRequestRef.current === seq) {
+        setLoadingSpellingBrowse(false);
+      }
+    }
+  }, [api, selectedPackageId, spellingFilters]);
+
+  const selectSpellingWord = React.useCallback(async (slug) => {
+    const safeSlug = String(slug || '');
+    setSelectedWordSlug(safeSlug);
+    setSpellingItemPayload(null);
+    if (!api?.readSpellingWord || !safeSlug) return;
+    const seq = spellingItemRequestRef.current.seq + 1;
+    spellingItemRequestRef.current = { slug: safeSlug, seq };
+    setLoadingSpellingItem(true);
+    setSpellingError(null);
+    try {
+      const payload = await api.readSpellingWord({
+        slug: safeSlug,
+        packageId: selectedPackageId || null,
+      });
+      if (spellingItemRequestRef.current.slug !== safeSlug || spellingItemRequestRef.current.seq !== seq) return;
+      setSpellingItemPayload(payload);
+    } catch (error) {
+      if (spellingItemRequestRef.current.slug !== safeSlug || spellingItemRequestRef.current.seq !== seq) return;
+      setSpellingError(errorEnvelope(error, 'content_operations_spelling_word_failed'));
+    } finally {
+      if (spellingItemRequestRef.current.slug === safeSlug && spellingItemRequestRef.current.seq === seq) {
+        setLoadingSpellingItem(false);
+      }
+    }
+  }, [api, selectedPackageId]);
+
+  const updateSpellingFilters = React.useCallback((patch) => {
+    setSpellingFilters((current) => ({ ...current, ...patch }));
+  }, []);
+
+  const applySpellingFilters = React.useCallback((event) => {
+    event?.preventDefault?.();
+    loadSpellingBrowse();
+  }, [loadSpellingBrowse]);
 
   const refresh = React.useCallback(async () => {
     if (!api?.readOverview) return;
@@ -1009,6 +1383,13 @@ export function AdminContentOperationsSection({
     if (overviewPayload || packageListPayload || releaseListPayload) return;
     refresh();
   }, [api, overviewPayload, packageListPayload, refresh, releaseListPayload]);
+
+  React.useEffect(() => {
+    if (activeTab !== 'spelling') return;
+    if (!api?.readSpellingBrowse) return;
+    if (spellingBrowsePayload) return;
+    loadSpellingBrowse();
+  }, [activeTab, api, loadSpellingBrowse, spellingBrowsePayload]);
 
   React.useEffect(() => {
     if (activeTab !== 'detail') return;
@@ -1101,6 +1482,7 @@ export function AdminContentOperationsSection({
         approval: payload?.approval || null,
         release: payload?.release || null,
       }));
+      invalidateSpellingBrowse();
       if (api.readPackage) {
         await loadPackageDetail(packageId);
       }
@@ -1117,14 +1499,15 @@ export function AdminContentOperationsSection({
         error: errorEnvelope(error, `content_operations_${action}_failed`),
       }));
     }
-  }, [api, loadPackageDetail, refresh]);
+  }, [api, invalidateSpellingBrowse, loadPackageDetail, refresh]);
 
   const latestRelease = overview.latestRelease;
-  const primaryData = overview.openPackageCount || packages.length || releases.length || latestRelease ? {
+  const primaryData = overview.openPackageCount || packages.length || releases.length || latestRelease || spellingBrowse.words.length ? {
     overview,
     packages,
     releases,
     latestRelease,
+    spellingBrowse,
   } : null;
   const selectedSummary = packages.find((entry) => entry.packageId === selectedPackageId);
   const detailMatchesSelected = detail.package?.packageId === selectedPackageId;
@@ -1183,7 +1566,23 @@ export function AdminContentOperationsSection({
         />
       ) : null}
 
-      {['spelling', 'audio', 'poolsRewards', 'monstersAssets', 'heroCodex', 'approvals'].includes(activeTab) ? (
+      {activeTab === 'spelling' ? (
+        <SpellingBrowsePanel
+          browse={spellingBrowse}
+          itemDetail={spellingItemDetail}
+          filters={spellingFilters}
+          selectedWordSlug={selectedWordSlug}
+          selectedPackageId={selectedPackageId}
+          loadingBrowse={loadingSpellingBrowse}
+          loadingItem={loadingSpellingItem}
+          error={spellingError}
+          onFilterChange={updateSpellingFilters}
+          onApplyFilters={applySpellingFilters}
+          onSelectWord={selectSpellingWord}
+        />
+      ) : null}
+
+      {['audio', 'poolsRewards', 'monstersAssets', 'heroCodex', 'approvals'].includes(activeTab) ? (
         <PublishedAreaPanel
           activeTab={activeTab}
           latestRelease={latestRelease}

--- a/styles/app.css
+++ b/styles/app.css
@@ -12371,6 +12371,70 @@ html { scroll-behavior: smooth; }
   background: color-mix(in oklab, var(--brand) 8%, transparent);
 }
 
+.content-ops-browse-toolbar {
+  display: grid;
+  grid-template-columns: minmax(180px, 1fr) minmax(120px, 160px) minmax(180px, 240px) auto;
+  gap: 10px;
+  align-items: end;
+  margin: 10px 0 14px;
+}
+
+.content-ops-browse-toolbar label {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.content-ops-browse-toolbar input,
+.content-ops-browse-toolbar select {
+  width: 100%;
+}
+
+.content-ops-spelling-browser {
+  display: grid;
+  grid-template-columns: minmax(0, 1.7fr) minmax(280px, 0.9fr);
+  gap: 12px;
+  align-items: start;
+}
+
+.content-ops-spelling-table {
+  min-width: 780px;
+}
+
+.content-ops-spelling-detail {
+  display: grid;
+  gap: 10px;
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 10px;
+  background: var(--panel-soft);
+}
+
+.content-ops-spelling-detail-header,
+.content-ops-spelling-draft-compare {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.content-ops-spelling-detail-header h5 {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.content-ops-spelling-detail-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.content-ops-spelling-draft-compare {
+  border-top: 1px solid var(--line);
+  padding-top: 10px;
+}
+
 .content-ops-detail-body {
   border-top: 1px solid var(--line);
   padding-top: 12px;
@@ -12489,22 +12553,31 @@ html { scroll-behavior: smooth; }
 @media (max-width: 900px) {
   .content-ops-metric-grid,
   .content-ops-candidate-grid,
-  .content-ops-lanes {
+  .content-ops-lanes,
+  .content-ops-spelling-detail-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .content-ops-browse-toolbar,
+  .content-ops-spelling-browser {
+    grid-template-columns: 1fr;
   }
 }
 
 @media (max-width: 640px) {
   .content-ops-metric-grid,
   .content-ops-candidate-grid,
-  .content-ops-lanes {
+  .content-ops-lanes,
+  .content-ops-spelling-detail-grid {
     grid-template-columns: 1fr;
   }
 
   .content-ops-package-summary,
   .content-ops-detail-header,
   .content-ops-lifecycle-header,
-  .content-ops-lifecycle-controls {
+  .content-ops-lifecycle-controls,
+  .content-ops-spelling-detail-header,
+  .content-ops-spelling-draft-compare {
     flex-direction: column;
     align-items: stretch;
   }

--- a/tests/admin-content-operations-v2.test.js
+++ b/tests/admin-content-operations-v2.test.js
@@ -38,6 +38,8 @@ import {
   normaliseContentOperationsPackageDetail,
   normaliseContentOperationsPackageList,
   normaliseContentOperationsReleaseList,
+  normaliseContentOperationsSpellingBrowse,
+  normaliseContentOperationsSpellingItemDetail,
 } from '../src/platform/hubs/admin-content-operations.js';
 
 // ─── Fixtures ────────────────────────────────────────────────────────────────
@@ -491,6 +493,119 @@ const CONTENT_OPS_OVERVIEW = {
   },
 };
 
+const CONTENT_OPS_SPELLING_BROWSE = {
+  ok: true,
+  actor: CONTENT_OPS_OVERVIEW.overview.actor,
+  browse: {
+    subjectId: 'spelling',
+    release: {
+      releaseId: 'rel-global-1',
+      snapshotHash: 'hash-1',
+      publishedAt: Date.UTC(2026, 5, 11, 9, 0, 0),
+      source: 'latest_release',
+    },
+    packageDraft: {
+      active: true,
+      status: 'available',
+      packageId: 'pkg-draft-1',
+      packageTitle: 'Word family update',
+      packageState: 'draft',
+      candidateId: 'cand-draft-1',
+      candidateHash: 'candidate-hash-1',
+      validation: { status: 'passed', ok: true, errorCount: 0, warningCount: 0, errors: [], warnings: [] },
+    },
+    filters: { query: 'meta', pool: 'extra', listId: 'extra-greek', limit: 75 },
+    totals: { words: 1, displayedWords: 1, matchedWords: 1, wordLists: 1, sentences: 2, variants: 1, families: 1 },
+    draftStateCounts: { modified: 1, added: 0, removed: 0, unchanged: 0 },
+    pools: [{ pool: 'extra', wordCount: 1, sentenceCount: 2, variantCount: 1, draftStateCounts: { modified: 1 } }],
+    wordLists: [{
+      id: 'extra-greek',
+      title: 'Extra Greek roots',
+      spellingPool: 'extra',
+      coverageTier: 'enrichment-extra',
+      yearGroups: [],
+      wordCount: 1,
+      draftState: 'unchanged',
+    }],
+    words: [{
+      slug: 'metamorphosis',
+      word: 'metamorphosis',
+      family: 'shape-change',
+      listId: 'extra-greek',
+      listTitle: 'Extra Greek roots',
+      spellingPool: 'extra',
+      coverageTier: 'enrichment-extra',
+      yearGroups: [],
+      tags: ['roots'],
+      patternIds: [],
+      acceptedCount: 1,
+      sentenceCount: 1,
+      variantCount: 1,
+      variantSentenceCount: 1,
+      familySize: 2,
+      draftState: 'modified',
+      hasCurrent: true,
+      hasPackageDraft: true,
+      audioReadiness: {
+        status: 'not_scanned',
+        wordProfiles: ['male.natural', 'female.natural'],
+        sentenceProfiles: ['male.normal', 'male.slow', 'female.normal', 'female.slow'],
+        wordAudioRequired: 4,
+        sentenceAudioRequired: 8,
+        totalRequired: 12,
+      },
+      validationState: { status: 'passed', ok: true, errorCount: 0, warningCount: 0, errors: [], warnings: [] },
+      rewardImpact: {
+        status: 'not_mapped',
+        spellingPool: 'extra',
+        coverageTier: 'enrichment-extra',
+        familySize: 2,
+        wordListId: 'extra-greek',
+        monsterBinding: { mode: 'pool', poolId: 'extra', assignment: 'unresolved' },
+      },
+    }],
+  },
+};
+
+const CONTENT_OPS_SPELLING_WORD_DETAIL = {
+  ok: true,
+  actor: CONTENT_OPS_OVERVIEW.overview.actor,
+  detail: {
+    type: 'word',
+    slug: 'metamorphosis',
+    found: true,
+    draftState: 'modified',
+    release: CONTENT_OPS_SPELLING_BROWSE.browse.release,
+    packageDraft: CONTENT_OPS_SPELLING_BROWSE.browse.packageDraft,
+    validationState: { status: 'passed', ok: true, errorCount: 0, warningCount: 0, errors: [], warnings: [] },
+    current: {
+      slug: 'metamorphosis',
+      word: 'metamorphosis',
+      family: 'shape-change',
+      spellingPool: 'extra',
+      coverageTier: 'enrichment-extra',
+      sentences: [{ id: 'meta-s1', wordSlug: 'metamorphosis', text: 'A tadpole changes.', tags: [] }],
+      variants: [{ word: 'metamorphic', sentenceCount: 1 }],
+      familyMembers: [{ slug: 'metamorphosis', word: 'metamorphosis' }],
+      audioReadiness: CONTENT_OPS_SPELLING_BROWSE.browse.words[0].audioReadiness,
+      rewardImpact: CONTENT_OPS_SPELLING_BROWSE.browse.words[0].rewardImpact,
+    },
+    packageValue: {
+      slug: 'metamorphosis',
+      word: 'metamorphosis',
+      family: 'shape-change',
+      spellingPool: 'extra',
+      coverageTier: 'enrichment-extra',
+      explanation: 'Package draft explanation.',
+      sentences: [{ id: 'meta-s1', wordSlug: 'metamorphosis', text: 'A tadpole changes completely.', tags: [] }],
+      variants: [{ word: 'metamorphic', sentenceCount: 1 }],
+      familyMembers: [{ slug: 'metamorphosis', word: 'metamorphosis' }],
+      audioReadiness: CONTENT_OPS_SPELLING_BROWSE.browse.words[0].audioReadiness,
+      rewardImpact: CONTENT_OPS_SPELLING_BROWSE.browse.words[0].rewardImpact,
+    },
+  },
+};
+
 function jsonResponse(payload, status = 200) {
   return new Response(JSON.stringify(payload), {
     status,
@@ -579,6 +694,65 @@ describe('Content Operations Centre normalisers', () => {
     assert.equal(missingCountPackage.operationCount, null);
     assert.equal(nullCountPackage.operationCount, null);
   });
+
+  it('normalises spelling browse rows with package draft, audio, and reward metadata', () => {
+    const browse = normaliseContentOperationsSpellingBrowse(CONTENT_OPS_SPELLING_BROWSE);
+
+    assert.equal(browse.release.releaseId, 'rel-global-1');
+    assert.equal(browse.packageDraft.status, 'available');
+    assert.equal(browse.packageDraft.validation.status, 'passed');
+    assert.equal(browse.totals.variants, 1);
+    assert.equal(browse.pools[0].draftStateCounts.modified, 1);
+    assert.equal(browse.wordLists[0].title, 'Extra Greek roots');
+    assert.equal(browse.words[0].draftState, 'modified');
+    assert.deepEqual(browse.words[0].audioReadiness.wordProfiles, ['male.natural', 'female.natural']);
+    assert.deepEqual(browse.words[0].audioReadiness.sentenceProfiles, ['male.normal', 'male.slow', 'female.normal', 'female.slow']);
+    assert.equal(browse.words[0].audioReadiness.totalRequired, 12);
+    assert.equal(browse.words[0].validationState.status, 'passed');
+    assert.equal(browse.words[0].rewardImpact.monsterBinding.poolId, 'extra');
+    assert.equal(browse.actor.platformRole, 'admin');
+  });
+
+  it('normalises stale spelling package draft metadata', () => {
+    const browse = normaliseContentOperationsSpellingBrowse({
+      browse: {
+        ...CONTENT_OPS_SPELLING_BROWSE.browse,
+        packageDraft: {
+          ...CONTENT_OPS_SPELLING_BROWSE.browse.packageDraft,
+          status: 'stale_candidate',
+          staleReasons: ['operations_stale'],
+          latestReleaseId: 'rel-global-2',
+          expectedOperationsHash: 'ops-current',
+          validation: {
+            status: 'stale_candidate',
+            ok: false,
+            errorCount: 1,
+            warningCount: 0,
+            errors: [{ code: 'stale_candidate', message: 'Rebuild required.' }],
+            warnings: [],
+          },
+        },
+      },
+    });
+
+    assert.equal(browse.packageDraft.status, 'stale_candidate');
+    assert.deepEqual(browse.packageDraft.staleReasons, ['operations_stale']);
+    assert.equal(browse.packageDraft.latestReleaseId, 'rel-global-2');
+    assert.equal(browse.packageDraft.expectedOperationsHash, 'ops-current');
+    assert.equal(browse.packageDraft.validation.errorCount, 1);
+  });
+
+  it('normalises spelling item details with current and package values', () => {
+    const detail = normaliseContentOperationsSpellingItemDetail(CONTENT_OPS_SPELLING_WORD_DETAIL);
+
+    assert.equal(detail.type, 'word');
+    assert.equal(detail.slug, 'metamorphosis');
+    assert.equal(detail.draftState, 'modified');
+    assert.equal(detail.current.sentences[0].id, 'meta-s1');
+    assert.equal(detail.packageValue.explanation, 'Package draft explanation.');
+    assert.equal(detail.packageDraft.candidateId, 'cand-draft-1');
+    assert.equal(detail.validationState.status, 'passed');
+  });
 });
 
 describe('Content Operations Centre hub API client', () => {
@@ -595,6 +769,15 @@ describe('Content Operations Centre hub API client', () => {
     await api.readContentOperationsOverview({ limit: 7 });
     await api.readContentOperationPackages({ state: 'draft', limit: 11 });
     await api.readContentOperationPackage({ packageId: 'pkg/with/slash' });
+    await api.readContentOperationSpellingBrowse({
+      packageId: 'pkg/with/slash',
+      query: 'meta',
+      pool: 'extra',
+      listId: 'extra-greek',
+      limit: 25,
+    });
+    await api.readContentOperationSpellingWord({ slug: 'meta/morphosis', packageId: 'pkg/with/slash' });
+    await api.readContentOperationSpellingSentence({ sentenceId: 'sentence/1', packageId: 'pkg/with/slash' });
     await api.readContentOperationReleases({ limit: 5, includeSnapshot: true });
     await api.readContentOperationRelease({ releaseId: 'rel/with/slash', includeSnapshot: true });
 
@@ -603,11 +786,19 @@ describe('Content Operations Centre hub API client', () => {
     assert.equal(new URL(calls[1].url).pathname, '/api/admin/content-operations/packages');
     assert.equal(new URL(calls[1].url).searchParams.get('state'), 'draft');
     assert.equal(new URL(calls[2].url).pathname, '/api/admin/content-operations/packages/pkg%2Fwith%2Fslash');
-    assert.equal(new URL(calls[3].url).pathname, '/api/admin/content-operations/subjects/spelling/releases');
-    assert.equal(new URL(calls[3].url).searchParams.get('includeSnapshot'), 'true');
-    assert.equal(new URL(calls[4].url).pathname, '/api/admin/content-operations/subjects/spelling/releases/rel%2Fwith%2Fslash');
-    assert.equal(new URL(calls[4].url).searchParams.get('includeSnapshot'), 'true');
-    assert.deepEqual(calls.map((call) => call.method), ['GET', 'GET', 'GET', 'GET', 'GET']);
+    assert.equal(new URL(calls[3].url).pathname, '/api/admin/content-operations/subjects/spelling/browse');
+    assert.equal(new URL(calls[3].url).searchParams.get('packageId'), 'pkg/with/slash');
+    assert.equal(new URL(calls[3].url).searchParams.get('query'), 'meta');
+    assert.equal(new URL(calls[3].url).searchParams.get('pool'), 'extra');
+    assert.equal(new URL(calls[3].url).searchParams.get('listId'), 'extra-greek');
+    assert.equal(new URL(calls[4].url).pathname, '/api/admin/content-operations/subjects/spelling/words/meta%2Fmorphosis');
+    assert.equal(new URL(calls[4].url).searchParams.get('packageId'), 'pkg/with/slash');
+    assert.equal(new URL(calls[5].url).pathname, '/api/admin/content-operations/subjects/spelling/sentences/sentence%2F1');
+    assert.equal(new URL(calls[6].url).pathname, '/api/admin/content-operations/subjects/spelling/releases');
+    assert.equal(new URL(calls[6].url).searchParams.get('includeSnapshot'), 'true');
+    assert.equal(new URL(calls[7].url).pathname, '/api/admin/content-operations/subjects/spelling/releases/rel%2Fwith%2Fslash');
+    assert.equal(new URL(calls[7].url).searchParams.get('includeSnapshot'), 'true');
+    assert.deepEqual(calls.map((call) => call.method), ['GET', 'GET', 'GET', 'GET', 'GET', 'GET', 'GET', 'GET']);
   });
 
   it('calls lifecycle mutation endpoints with package, candidate, and proof payloads', async () => {
@@ -675,6 +866,14 @@ describe('Content Operations Centre hub API client', () => {
     await assert.rejects(
       () => api.readContentOperationRelease({ releaseId: '' }),
       /Content operation release id is required/,
+    );
+    await assert.rejects(
+      () => api.readContentOperationSpellingWord({ slug: '' }),
+      /Spelling word slug is required/,
+    );
+    await assert.rejects(
+      () => api.readContentOperationSpellingSentence({ sentenceId: '' }),
+      /Spelling sentence id is required/,
     );
     await assert.rejects(
       () => api.validateContentOperationPackage({ packageId: '' }),

--- a/tests/content-operations-api.test.js
+++ b/tests/content-operations-api.test.js
@@ -160,6 +160,145 @@ test('content operations API requires the admin platform role', async () => {
   }
 });
 
+test('content operations API exposes spelling browse and item detail with package draft overlays', async () => {
+  const server = createWorkerRepositoryServer({ now: () => NOW });
+  try {
+    seedAdultAccount(server.DB, { accountId: ADMIN_ID, platformRole: 'admin' });
+    const repository = createWorkerRepository({
+      env: server.env,
+      now: () => NOW,
+    });
+    await repository.seedFirstContentOperationRelease({
+      seededByAccountId: ADMIN_ID,
+      proof: { source: 'content-operations-api-browse-test' },
+    });
+    const seeded = await readSeededSpellingContentBundle();
+    const word = seeded.draft.words[0];
+    const sentenceId = word.sentenceEntryIds[0];
+    const explanation = `Browse package explanation for ${word.word}.`;
+
+    const created = await createPackage(server, { title: 'Browse package' });
+    const packageId = created.package.packageId;
+
+    const candidateRequiredResponse = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/subjects/spelling/browse?packageId=${packageId}&query=${word.slug}&limit=10`,
+      { method: 'GET', headers: { 'sec-fetch-site': 'same-origin' } },
+      adminHeaders(),
+    );
+    const candidateRequiredPayload = await readPayload(candidateRequiredResponse);
+    assert.equal(candidateRequiredResponse.status, 200);
+    assert.equal(candidateRequiredPayload.browse.packageDraft.status, 'candidate_required');
+    assert.equal(candidateRequiredPayload.browse.packageDraft.validation.status, 'candidate_required');
+    assert.equal(candidateRequiredPayload.browse.packageDraft.validation.ok, false);
+    const candidateRequiredRow = candidateRequiredPayload.browse.words.find((entry) => entry.slug === word.slug);
+    assert.equal(candidateRequiredRow.validationState.status, 'candidate_required');
+    assert.equal(candidateRequiredRow.validationState.ok, false);
+
+    await appendWordExplanationOperation(server, packageId, word, explanation);
+    const validated = await validatePackage(server, packageId);
+
+    const browseResponse = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/subjects/spelling/browse?packageId=${packageId}&query=${word.slug}&limit=10`,
+      { method: 'GET', headers: { 'sec-fetch-site': 'same-origin' } },
+      adminHeaders(),
+    );
+    const browsePayload = await readPayload(browseResponse);
+    assert.equal(browseResponse.status, 200);
+    assert.equal(browsePayload.actor.capabilities['content_operations.view'], true);
+    assert.equal(browsePayload.browse.packageDraft.status, 'available');
+    assert.equal(browsePayload.browse.packageDraft.candidateId, validated.candidate.candidateId);
+    const row = browsePayload.browse.words.find((entry) => entry.slug === word.slug);
+    assert.equal(row.draftState, 'modified');
+    assert.equal(row.family, word.family);
+    assert.ok(row.audioReadiness.totalRequired >= 8);
+    assert.equal(Object.prototype.hasOwnProperty.call(browsePayload.browse, 'snapshot'), false);
+
+    const wordResponse = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/subjects/spelling/words/${word.slug}?packageId=${packageId}`,
+      { method: 'GET', headers: { 'sec-fetch-site': 'same-origin' } },
+      adminHeaders(),
+    );
+    const wordPayload = await readPayload(wordResponse);
+    assert.equal(wordResponse.status, 200);
+    assert.equal(wordPayload.detail.current.slug, word.slug);
+    assert.equal(wordPayload.detail.packageValue.explanation, explanation);
+    assert.equal(wordPayload.detail.draftState, 'modified');
+
+    const sentenceResponse = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/subjects/spelling/sentences/${sentenceId}?packageId=${packageId}`,
+      { method: 'GET', headers: { 'sec-fetch-site': 'same-origin' } },
+      adminHeaders(),
+    );
+    const sentencePayload = await readPayload(sentenceResponse);
+    assert.equal(sentenceResponse.status, 200);
+    assert.equal(sentencePayload.detail.type, 'sentence');
+    assert.equal(sentencePayload.detail.current.id, sentenceId);
+    assert.equal(sentencePayload.detail.packageValue.id, sentenceId);
+
+    await appendWordExplanationOperation(
+      server,
+      packageId,
+      word,
+      `A newer operation after validation for ${word.word}.`,
+    );
+
+    const staleBrowseResponse = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/subjects/spelling/browse?packageId=${packageId}&query=${word.slug}&limit=10`,
+      { method: 'GET', headers: { 'sec-fetch-site': 'same-origin' } },
+      adminHeaders(),
+    );
+    const staleBrowsePayload = await readPayload(staleBrowseResponse);
+    assert.equal(staleBrowseResponse.status, 200);
+    assert.equal(staleBrowsePayload.browse.packageDraft.status, 'stale_candidate');
+    assert.deepEqual(staleBrowsePayload.browse.packageDraft.staleReasons, ['operations_stale']);
+    const staleRow = staleBrowsePayload.browse.words.find((entry) => entry.slug === word.slug);
+    assert.equal(staleRow.draftState, 'unchanged');
+    assert.equal(staleRow.hasPackageDraft, false);
+    assert.equal(staleRow.validationState.status, 'stale_candidate');
+
+    const staleWordResponse = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/subjects/spelling/words/${word.slug}?packageId=${packageId}`,
+      { method: 'GET', headers: { 'sec-fetch-site': 'same-origin' } },
+      adminHeaders(),
+    );
+    const staleWordPayload = await readPayload(staleWordResponse);
+    assert.equal(staleWordResponse.status, 200);
+    assert.equal(staleWordPayload.detail.packageDraft.status, 'stale_candidate');
+    assert.equal(staleWordPayload.detail.packageValue, null);
+    assert.equal(staleWordPayload.detail.draftState, 'unchanged');
+
+    const missingWordResponse = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/subjects/spelling/words/not-a-real-word?packageId=${packageId}`,
+      { method: 'GET', headers: { 'sec-fetch-site': 'same-origin' } },
+      adminHeaders(),
+    );
+    const missingWordPayload = await readPayload(missingWordResponse);
+    assert.equal(missingWordResponse.status, 404);
+    assert.equal(missingWordPayload.code, 'spelling_content_word_not_found');
+    assert.equal(missingWordPayload.message, 'Spelling content word was not found.');
+
+    const missingSentenceResponse = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/subjects/spelling/sentences/not-a-real-sentence?packageId=${packageId}`,
+      { method: 'GET', headers: { 'sec-fetch-site': 'same-origin' } },
+      adminHeaders(),
+    );
+    const missingSentencePayload = await readPayload(missingSentenceResponse);
+    assert.equal(missingSentenceResponse.status, 404);
+    assert.equal(missingSentencePayload.code, 'spelling_content_sentence_not_found');
+    assert.equal(missingSentencePayload.message, 'Spelling content sentence was not found.');
+  } finally {
+    server.close();
+  }
+});
+
 test('content operations API supports admin package lifecycle through separate approve and publish actions', async () => {
   const server = createWorkerRepositoryServer({ now: () => NOW });
   try {

--- a/tests/react-admin-content-operations.test.js
+++ b/tests/react-admin-content-operations.test.js
@@ -151,6 +151,111 @@ const overview = {
   },
 };
 
+const spellingBrowse = {
+  browse: {
+    subjectId: 'spelling',
+    release,
+    packageDraft: {
+      active: true,
+      status: 'available',
+      packageId: 'pkg-draft-1',
+      packageTitle: 'Word family update',
+      packageState: 'draft',
+      candidateId: 'cand-ready-1',
+      candidateHash: 'candidate-ready-1',
+      validation: { status: 'passed', ok: true, errorCount: 0, warningCount: 0, errors: [], warnings: [] },
+    },
+    filters: { query: '', pool: 'all', listId: '', limit: 75 },
+    totals: { words: 1, displayedWords: 1, matchedWords: 1, wordLists: 1, sentences: 2, variants: 1, families: 1 },
+    draftStateCounts: { added: 0, modified: 1, removed: 0, unchanged: 0 },
+    pools: [{ pool: 'extra', wordCount: 1, sentenceCount: 2, variantCount: 1, draftStateCounts: { modified: 1 } }],
+    wordLists: [{
+      id: 'extra-greek',
+      title: 'Extra Greek roots',
+      spellingPool: 'extra',
+      coverageTier: 'enrichment-extra',
+      yearGroups: [],
+      wordCount: 1,
+      draftState: 'unchanged',
+    }],
+    words: [{
+      slug: 'metamorphosis',
+      word: 'metamorphosis',
+      family: 'shape-change',
+      listId: 'extra-greek',
+      listTitle: 'Extra Greek roots',
+      spellingPool: 'extra',
+      coverageTier: 'enrichment-extra',
+      yearGroups: [],
+      tags: [],
+      patternIds: [],
+      acceptedCount: 1,
+      sentenceCount: 1,
+      variantCount: 1,
+      variantSentenceCount: 1,
+      familySize: 1,
+      draftState: 'modified',
+      hasCurrent: true,
+      hasPackageDraft: true,
+      audioReadiness: {
+        status: 'not_scanned',
+        wordProfiles: ['male.natural', 'female.natural'],
+        sentenceProfiles: ['male.normal', 'male.slow', 'female.normal', 'female.slow'],
+        wordAudioRequired: 4,
+        sentenceAudioRequired: 8,
+        totalRequired: 12,
+      },
+      validationState: { status: 'passed', ok: true, errorCount: 0, warningCount: 0, errors: [], warnings: [] },
+      rewardImpact: {
+        status: 'not_mapped',
+        spellingPool: 'extra',
+        coverageTier: 'enrichment-extra',
+        familySize: 1,
+        wordListId: 'extra-greek',
+        monsterBinding: { mode: 'pool', poolId: 'extra', assignment: 'unresolved' },
+      },
+    }],
+  },
+};
+
+const spellingWordDetail = {
+  detail: {
+    type: 'word',
+    slug: 'metamorphosis',
+    found: true,
+    draftState: 'modified',
+    release,
+    packageDraft: spellingBrowse.browse.packageDraft,
+    validationState: { status: 'passed', ok: true, errorCount: 0, warningCount: 0, errors: [], warnings: [] },
+    current: {
+      slug: 'metamorphosis',
+      word: 'metamorphosis',
+      family: 'shape-change',
+      spellingPool: 'extra',
+      coverageTier: 'enrichment-extra',
+      explanation: 'Current release explanation.',
+      sentences: [{ id: 'meta-s1', wordSlug: 'metamorphosis', text: 'The tadpole changes.', tags: [] }],
+      variants: [{ word: 'metamorphic', sentenceCount: 1 }],
+      familyMembers: [{ slug: 'metamorphosis', word: 'metamorphosis' }],
+      audioReadiness: spellingBrowse.browse.words[0].audioReadiness,
+      rewardImpact: spellingBrowse.browse.words[0].rewardImpact,
+    },
+    packageValue: {
+      slug: 'metamorphosis',
+      word: 'metamorphosis',
+      family: 'shape-change',
+      spellingPool: 'extra',
+      coverageTier: 'enrichment-extra',
+      explanation: 'Package draft explanation.',
+      sentences: [{ id: 'meta-s1', wordSlug: 'metamorphosis', text: 'The tadpole changes completely.', tags: [] }],
+      variants: [{ word: 'metamorphic', sentenceCount: 1 }],
+      familyMembers: [{ slug: 'metamorphosis', word: 'metamorphosis' }],
+      audioReadiness: spellingBrowse.browse.words[0].audioReadiness,
+      rewardImpact: spellingBrowse.browse.words[0].rewardImpact,
+    },
+  },
+};
+
 function baseActions() {
   return `{ dispatch() {}, navigateHome() {}, openSubject() {} }`;
 }
@@ -562,6 +667,265 @@ test('Content Operations Centre mounted shell loads API data without implicit pa
   assert.match(result.overviewText, /rel-global-1/);
   assert.match(result.packageTableText, /Pending/);
   assert.equal(result.selectedRows, 0);
+});
+
+test('Content Operations Centre spelling tab browses words and loads package draft detail', async () => {
+  const output = await runClientEntry(`
+    const { JSDOM } = require('jsdom');
+
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+    const dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
+      url: 'https://ks2.eugnel.uk/admin',
+    });
+    globalThis.window = dom.window;
+    globalThis.document = dom.window.document;
+    globalThis.navigator = dom.window.navigator;
+    globalThis.HTMLElement = dom.window.HTMLElement;
+    globalThis.Event = dom.window.Event;
+
+    const React = require('react');
+    const { createRoot } = require('react-dom/client');
+    const { AdminContentOperationsSection } = require(${CONTENT_OPS_SECTION_PATH});
+    const { act } = React;
+
+    const calls = [];
+    const model = ${JSON.stringify(baseModel({
+      contentOperations: {
+        overview,
+        packages: { packages: [contentPackage] },
+        releases: { releases: [release] },
+        spellingBrowse,
+        spellingItemDetail: null,
+      },
+    }))};
+    const actions = {
+      contentOperationsApi: {
+        async readSpellingWord(args) {
+          calls.push({ method: 'readSpellingWord', args });
+          return ${JSON.stringify(spellingWordDetail)};
+        },
+      },
+    };
+
+    async function flush() {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+    }
+
+    async function main() {
+      const root = createRoot(document.getElementById('root'));
+      await act(async () => {
+        root.render(React.createElement(AdminContentOperationsSection, {
+          model,
+          actions,
+          initialActiveTab: 'spelling',
+          initialSelectedPackageId: 'pkg-draft-1',
+        }));
+      });
+      await flush();
+
+      const beforeClickText = document.body.textContent;
+      const wordButton = document.querySelector('[data-content-ops-spelling-word="metamorphosis"]');
+      await act(async () => {
+        wordButton.click();
+      });
+      await flush();
+      const afterClickText = document.body.textContent;
+      process.stdout.write(JSON.stringify({ calls, beforeClickText, afterClickText }));
+
+      await act(async () => {
+        root.unmount();
+      });
+      dom.window.close();
+      process.exit(0);
+    }
+
+    main().catch((error) => {
+      process.stderr.write(error.stack || error.message);
+      process.exitCode = 1;
+    });
+  `);
+  const result = JSON.parse(output);
+
+  assert.match(result.beforeClickText, /Spelling browse/);
+  assert.match(result.beforeClickText, /Extra Greek roots/);
+  assert.match(result.beforeClickText, /Package draft available/);
+  assert.deepEqual(result.calls, [
+    { method: 'readSpellingWord', args: { slug: 'metamorphosis', packageId: 'pkg-draft-1' } },
+  ]);
+  assert.match(result.afterClickText, /Package draft explanation/);
+  assert.match(result.afterClickText, /The tadpole changes/);
+});
+
+test('Content Operations Centre spelling tab reloads browse data after package selection changes', async () => {
+  const packageB = {
+    ...contentPackage,
+    packageId: 'pkg-draft-2',
+    title: 'Second word package',
+    operations: [{ operationId: 'op-b', entityType: 'spelling.word', entityId: 'beta', action: 'set' }],
+    operationCount: 1,
+  };
+  const spellingBrowseB = {
+    browse: {
+      ...spellingBrowse.browse,
+      packageDraft: {
+        ...spellingBrowse.browse.packageDraft,
+        packageId: 'pkg-draft-2',
+        packageTitle: 'Second word package',
+        candidateId: 'cand-ready-2',
+        candidateHash: 'candidate-ready-2',
+      },
+      totals: { words: 1, displayedWords: 1, matchedWords: 1, wordLists: 1, sentences: 1, variants: 0, families: 1 },
+      draftStateCounts: { added: 0, modified: 1, removed: 0, unchanged: 0 },
+      pools: [{ pool: 'core', wordCount: 1, sentenceCount: 1, variantCount: 0, draftStateCounts: { modified: 1 } }],
+      wordLists: [{
+        id: 'core-y34',
+        title: 'Second core list',
+        spellingPool: 'core',
+        coverageTier: 'statutory-core',
+        yearGroups: ['Y3', 'Y4'],
+        wordCount: 1,
+        draftState: 'unchanged',
+      }],
+      words: [{
+        ...spellingBrowse.browse.words[0],
+        slug: 'beta',
+        word: 'beta',
+        family: 'greek-root',
+        listId: 'core-y34',
+        listTitle: 'Second core list',
+        spellingPool: 'core',
+        coverageTier: 'statutory-core',
+        variantCount: 0,
+        variantSentenceCount: 0,
+        audioReadiness: {
+          status: 'not_scanned',
+          wordProfiles: ['male.natural', 'female.natural'],
+          sentenceProfiles: ['male.normal', 'male.slow', 'female.normal', 'female.slow'],
+          wordAudioRequired: 2,
+          sentenceAudioRequired: 4,
+          totalRequired: 6,
+        },
+      }],
+    },
+  };
+  const output = await runClientEntry(`
+    const { JSDOM } = require('jsdom');
+
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+    const dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
+      url: 'https://ks2.eugnel.uk/admin',
+    });
+    globalThis.window = dom.window;
+    globalThis.document = dom.window.document;
+    globalThis.navigator = dom.window.navigator;
+    globalThis.HTMLElement = dom.window.HTMLElement;
+    globalThis.Event = dom.window.Event;
+
+    const React = require('react');
+    const { createRoot } = require('react-dom/client');
+    const { AdminContentOperationsSection } = require(${CONTENT_OPS_SECTION_PATH});
+    const { act } = React;
+
+    const packageB = ${JSON.stringify(packageB)};
+    const spellingBrowseB = ${JSON.stringify(spellingBrowseB)};
+    const calls = [];
+    const model = ${JSON.stringify(baseModel({
+      contentOperations: {
+        overview: {
+          ...overview,
+          lanes: {
+            blocked: [],
+            readyForApproval: [],
+            approvedPendingPublish: [],
+            drafts: [contentPackage, packageB],
+            recentReleases: [release],
+          },
+        },
+        packages: { packages: [contentPackage, packageB] },
+        releases: { releases: [release] },
+        packageDetail: null,
+        spellingBrowse,
+        spellingItemDetail: null,
+      },
+    }))};
+    const actions = {
+      contentOperationsApi: {
+        async readPackage({ packageId }) {
+          calls.push({ method: 'readPackage', packageId });
+          return { package: packageB, events: [] };
+        },
+        async readSpellingBrowse(args) {
+          calls.push({ method: 'readSpellingBrowse', args });
+          return spellingBrowseB;
+        },
+      },
+    };
+
+    async function flush() {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+    }
+
+    async function main() {
+      const root = createRoot(document.getElementById('root'));
+      await act(async () => {
+        root.render(React.createElement(AdminContentOperationsSection, {
+          model,
+          actions,
+          initialActiveTab: 'spelling',
+          initialSelectedPackageId: 'pkg-draft-1',
+        }));
+      });
+      const packageTab = Array.from(document.querySelectorAll('[role="tab"]'))
+        .find((entry) => entry.textContent === 'Packages');
+      await act(async () => {
+        packageTab.click();
+      });
+      const packageButton = Array.from(document.querySelectorAll('.content-ops-row-button'))
+        .find((entry) => entry.textContent === 'Second word package');
+      await act(async () => {
+        packageButton.click();
+      });
+      await flush();
+      const spellingTab = Array.from(document.querySelectorAll('[role="tab"]'))
+        .find((entry) => entry.textContent === 'Spelling');
+      await act(async () => {
+        spellingTab.click();
+      });
+      await flush();
+      await flush();
+      process.stdout.write(JSON.stringify({
+        calls,
+        text: document.body.textContent,
+      }));
+
+      await act(async () => {
+        root.unmount();
+      });
+      dom.window.close();
+      process.exit(0);
+    }
+
+    main().catch((error) => {
+      process.stderr.write(error.stack || error.message);
+      process.exitCode = 1;
+    });
+  `);
+  const result = JSON.parse(output);
+
+  assert.deepEqual(result.calls, [
+    { method: 'readPackage', packageId: 'pkg-draft-2' },
+    {
+      method: 'readSpellingBrowse',
+      args: { packageId: 'pkg-draft-2', query: '', pool: null, listId: null, limit: 75 },
+    },
+  ]);
+  assert.match(result.text, /Second core list/);
+  assert.match(result.text, /Package draft available/);
+  assert.doesNotMatch(result.text, /Extra Greek roots/);
 });
 
 test('Content Operations Centre mounted package detail runs validate, approve, and publish actions', async () => {

--- a/tests/spelling-content-operations-model.test.js
+++ b/tests/spelling-content-operations-model.test.js
@@ -1,0 +1,278 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildSpellingContentBrowseModel,
+  buildSpellingContentSentenceDetail,
+  buildSpellingContentWordDetail,
+} from '../src/subjects/spelling/content/editor-read-model.js';
+
+const NOW = Date.UTC(2026, 5, 11, 12, 0, 0);
+
+function contentBundle(overrides = {}) {
+  return {
+    modelVersion: 6,
+    subjectId: 'spelling',
+    draft: {
+      id: 'main',
+      state: 'draft',
+      version: 1,
+      title: 'Spelling editorial test draft',
+      createdAt: NOW,
+      updatedAt: NOW,
+      wordLists: [
+        {
+          id: 'core-y34',
+          title: 'Core Y3/4',
+          spellingPool: 'core',
+          coverageTier: 'statutory-core',
+          yearGroups: ['Y3', 'Y4'],
+          wordSlugs: ['alpha', 'beta'],
+          sortIndex: 0,
+        },
+        {
+          id: 'extra-greek',
+          title: 'Extra Greek roots',
+          spellingPool: 'extra',
+          coverageTier: 'enrichment-extra',
+          yearGroups: [],
+          wordSlugs: ['metamorphosis'],
+          sortIndex: 1,
+        },
+      ],
+      words: [
+        {
+          slug: 'alpha',
+          word: 'alpha',
+          family: 'greek-root',
+          listId: 'core-y34',
+          spellingPool: 'core',
+          coverageTier: 'statutory-core',
+          yearGroups: ['Y3', 'Y4'],
+          accepted: ['alpha'],
+          patternIds: ['prefix-alpha'],
+          explanation: 'Alpha has a clear root explanation.',
+          sentenceEntryIds: ['alpha-s1', 'alpha-s2'],
+          sortIndex: 0,
+        },
+        {
+          slug: 'beta',
+          word: 'beta',
+          family: 'greek-root',
+          listId: 'core-y34',
+          spellingPool: 'core',
+          coverageTier: 'statutory-core',
+          yearGroups: ['Y3', 'Y4'],
+          accepted: ['beta'],
+          patternIds: ['prefix-beta'],
+          explanation: 'Beta has a clear root explanation.',
+          sentenceEntryIds: ['beta-s1'],
+          sortIndex: 1,
+        },
+        {
+          slug: 'metamorphosis',
+          word: 'metamorphosis',
+          family: 'shape-change',
+          listId: 'extra-greek',
+          spellingPool: 'extra',
+          coverageTier: 'enrichment-extra',
+          yearGroups: [],
+          accepted: ['metamorphosis'],
+          explanation: 'Metamorphosis describes a complete change.',
+          sentenceEntryIds: ['meta-s1'],
+          variants: [
+            {
+              word: 'metamorphic',
+              accepted: ['metamorphic'],
+              explanation: 'Metamorphic shares the same changing root.',
+              sentenceEntryIds: ['meta-v1'],
+              sortIndex: 0,
+            },
+          ],
+          sortIndex: 2,
+        },
+      ],
+      sentences: [
+        { id: 'alpha-s1', wordSlug: 'alpha', text: 'The alpha example starts the list.', variantLabel: 'default', sortIndex: 0 },
+        { id: 'alpha-s2', wordSlug: 'alpha', text: 'A second alpha sentence supports audio.', variantLabel: 'slow', sortIndex: 1 },
+        { id: 'beta-s1', wordSlug: 'beta', text: 'The beta example follows alpha.', variantLabel: 'default', sortIndex: 2 },
+        { id: 'meta-s1', wordSlug: 'metamorphosis', text: 'The tadpole begins metamorphosis.', variantLabel: 'default', sortIndex: 3 },
+        { id: 'meta-v1', wordSlug: 'metamorphosis', text: 'Metamorphic rock changes under pressure.', variantLabel: 'variant', sortIndex: 4 },
+      ],
+    },
+    releases: [],
+    publication: { currentReleaseId: '', publishedVersion: 0, updatedAt: NOW },
+    ...overrides,
+  };
+}
+
+function packageBundle() {
+  const bundle = contentBundle();
+  return {
+    ...bundle,
+    draft: {
+      ...bundle.draft,
+      words: [
+        {
+          ...bundle.draft.words[0],
+          explanation: 'Alpha has a package draft explanation for editors.',
+        },
+        bundle.draft.words[1],
+        bundle.draft.words[2],
+        {
+          slug: 'gamma',
+          word: 'gamma',
+          family: 'greek-root',
+          listId: 'core-y34',
+          spellingPool: 'core',
+          coverageTier: 'statutory-core',
+          yearGroups: ['Y3', 'Y4'],
+          accepted: ['gamma'],
+          patternIds: ['prefix-gamma'],
+          explanation: 'Gamma has a clear root explanation.',
+          sentenceEntryIds: ['gamma-s1'],
+          sortIndex: 3,
+        },
+      ],
+      sentences: [
+        ...bundle.draft.sentences,
+        { id: 'gamma-s1', wordSlug: 'gamma', text: 'Gamma joins the package draft.', variantLabel: 'default', sortIndex: 5 },
+      ],
+      wordLists: bundle.draft.wordLists.map((list) => (
+        list.id === 'core-y34'
+          ? { ...list, wordSlugs: [...list.wordSlugs, 'gamma'] }
+          : list
+      )),
+    },
+  };
+}
+
+test('spelling content operations browse summarises families, pools, and audio requirements', () => {
+  const browse = buildSpellingContentBrowseModel({
+    publishedContent: contentBundle(),
+    releaseInfo: { releaseId: 'rel-1', snapshotHash: 'hash-1', publishedAt: NOW },
+    filters: { pool: 'all', limit: 20 },
+  });
+
+  const alpha = browse.words.find((row) => row.slug === 'alpha');
+  const extra = browse.words.find((row) => row.slug === 'metamorphosis');
+
+  assert.equal(browse.release.releaseId, 'rel-1');
+  assert.equal(browse.totals.words, 3);
+  assert.equal(browse.totals.families, 2);
+  assert.equal(alpha.familySize, 2);
+  assert.equal(alpha.audioReadiness.wordAudioRequired, 2);
+  assert.equal(alpha.audioReadiness.sentenceAudioRequired, 8);
+  assert.equal(extra.variantCount, 1);
+  assert.equal(extra.audioReadiness.wordAudioRequired, 4);
+  assert.equal(extra.audioReadiness.sentenceAudioRequired, 8);
+  assert.equal(browse.pools.find((pool) => pool.pool === 'extra').variantCount, 1);
+});
+
+test('spelling content operations browse filters by variant words and accepted spellings', () => {
+  const browse = buildSpellingContentBrowseModel({
+    publishedContent: contentBundle(),
+    filters: { query: 'metamorphic', limit: 20 },
+  });
+
+  assert.deepEqual(browse.words.map((row) => row.slug), ['metamorphosis']);
+  assert.deepEqual(browse.words[0].variantWords, ['metamorphic']);
+  assert.deepEqual(browse.words[0].variantAccepted, ['metamorphic']);
+});
+
+test('spelling content operations browse marks package draft additions and modifications', () => {
+  const browse = buildSpellingContentBrowseModel({
+    publishedContent: contentBundle(),
+    packageContent: packageBundle(),
+    packageId: 'pkg-1',
+    packageRecord: { packageId: 'pkg-1', title: 'Greek root package', state: 'draft' },
+    packageCandidate: {
+      candidateId: 'cand-1',
+      candidateHash: 'candidate-1',
+      validation: { ok: true, errors: [], warnings: [] },
+    },
+    filters: { query: 'greek', limit: 20 },
+  });
+
+  assert.equal(browse.packageDraft.status, 'available');
+  assert.equal(browse.draftStateCounts.modified, 1);
+  assert.equal(browse.draftStateCounts.added, 1);
+  assert.equal(browse.words.find((row) => row.slug === 'alpha').draftState, 'modified');
+  assert.equal(browse.words.find((row) => row.slug === 'gamma').draftState, 'added');
+});
+
+test('spelling content operations browse requires validation for active packages without candidates', () => {
+  const browse = buildSpellingContentBrowseModel({
+    publishedContent: contentBundle(),
+    packageContent: null,
+    packageId: 'pkg-1',
+    packageRecord: { packageId: 'pkg-1', title: 'Greek root package', state: 'draft' },
+    packageCandidate: null,
+    filters: { query: 'alpha', limit: 20 },
+  });
+
+  const row = browse.words.find((entry) => entry.slug === 'alpha');
+  assert.equal(browse.packageDraft.status, 'candidate_required');
+  assert.equal(browse.packageDraft.validation.status, 'candidate_required');
+  assert.equal(browse.packageDraft.validation.ok, false);
+  assert.equal(row.validationState.status, 'candidate_required');
+  assert.equal(row.validationState.ok, false);
+});
+
+test('spelling content operations browse marks stale package candidates without applying old draft values', () => {
+  const browse = buildSpellingContentBrowseModel({
+    publishedContent: contentBundle(),
+    packageContent: null,
+    packageId: 'pkg-1',
+    packageRecord: { packageId: 'pkg-1', title: 'Greek root package', state: 'draft' },
+    packageCandidate: {
+      candidateId: 'cand-1',
+      candidateHash: 'candidate-1',
+      validation: { ok: true, errors: [], warnings: [] },
+      isCurrent: false,
+      staleReasons: ['operations_stale'],
+      expectedOperationsHash: 'ops-current',
+      latestReleaseId: 'rel-current',
+    },
+    filters: { query: 'alpha', limit: 20 },
+  });
+
+  const row = browse.words.find((entry) => entry.slug === 'alpha');
+  assert.equal(browse.packageDraft.status, 'stale_candidate');
+  assert.deepEqual(browse.packageDraft.staleReasons, ['operations_stale']);
+  assert.equal(browse.packageDraft.validation.status, 'stale_candidate');
+  assert.equal(row.draftState, 'unchanged');
+  assert.equal(row.hasPackageDraft, false);
+  assert.equal(row.validationState.status, 'stale_candidate');
+});
+
+test('spelling content operations detail exposes current and package draft word values', () => {
+  const detail = buildSpellingContentWordDetail({
+    publishedContent: contentBundle(),
+    packageContent: packageBundle(),
+    packageId: 'pkg-1',
+    packageCandidate: { candidateId: 'cand-1', candidateHash: 'candidate-1', validation: { ok: true } },
+    slug: 'alpha',
+  });
+
+  assert.equal(detail.found, true);
+  assert.equal(detail.draftState, 'modified');
+  assert.equal(detail.current.explanation, 'Alpha has a clear root explanation.');
+  assert.equal(detail.packageValue.explanation, 'Alpha has a package draft explanation for editors.');
+  assert.equal(detail.current.sentences.length, 2);
+  assert.equal(detail.current.familyMembers.length, 2);
+});
+
+test('spelling content operations sentence detail supports id lookups', () => {
+  const detail = buildSpellingContentSentenceDetail({
+    publishedContent: contentBundle(),
+    packageContent: packageBundle(),
+    sentenceId: 'gamma-s1',
+    packageId: 'pkg-1',
+  });
+
+  assert.equal(detail.found, true);
+  assert.equal(detail.draftState, 'added');
+  assert.equal(detail.current, null);
+  assert.equal(detail.packageValue.word.slug, 'gamma');
+});

--- a/worker/src/content-operations/read-models.js
+++ b/worker/src/content-operations/read-models.js
@@ -1,0 +1,99 @@
+import {
+  buildSpellingContentBrowseModel,
+  buildSpellingContentSentenceDetail,
+  buildSpellingContentWordDetail,
+} from '../../../src/subjects/spelling/content/editor-read-model.js';
+import {
+  CONTENT_OPERATION_SUBJECT_ID,
+} from '../../../src/subjects/spelling/content/operations-model.js';
+import {
+  readSeededSpellingContentBundle,
+} from '../generated-spelling-content-seed.js';
+
+function normaliseString(value, fallback = '') {
+  return typeof value === 'string' && value.trim() ? value.trim() : fallback;
+}
+
+async function readSpellingContentSources({
+  repository,
+  subjectId = CONTENT_OPERATION_SUBJECT_ID,
+  packageId = '',
+} = {}) {
+  const latestRelease = await repository.readLatestContentOperationRelease(subjectId, {
+    includeSnapshot: true,
+  });
+  const publishedContent = latestRelease?.snapshot || await readSeededSpellingContentBundle();
+  const packageRecord = packageId
+    ? await repository.readContentOperationPackage(packageId, { includeOperations: false })
+    : null;
+  const packageCandidate = packageId
+    ? await repository.readLatestContentOperationCandidate(packageId, {
+      includeSnapshot: true,
+      requireCurrent: true,
+    })
+    : null;
+  return {
+    publishedContent,
+    packageContent: packageCandidate?.isCurrent === false ? null : packageCandidate?.candidate || null,
+    packageCandidate,
+    packageRecord,
+    packageId,
+    releaseInfo: {
+      releaseId: latestRelease?.releaseId || '',
+      snapshotHash: latestRelease?.snapshotHash || '',
+      publishedAt: latestRelease?.publishedAt || 0,
+      source: latestRelease ? 'latest_release' : 'seeded_fallback',
+    },
+  };
+}
+
+export async function readSpellingContentBrowseModel({
+  repository,
+  subjectId = CONTENT_OPERATION_SUBJECT_ID,
+  packageId = '',
+  filters = {},
+} = {}) {
+  const sources = await readSpellingContentSources({
+    repository,
+    subjectId,
+    packageId: normaliseString(packageId),
+  });
+  return buildSpellingContentBrowseModel({
+    ...sources,
+    filters,
+  });
+}
+
+export async function readSpellingContentWordDetailModel({
+  repository,
+  subjectId = CONTENT_OPERATION_SUBJECT_ID,
+  packageId = '',
+  slug = '',
+} = {}) {
+  const sources = await readSpellingContentSources({
+    repository,
+    subjectId,
+    packageId: normaliseString(packageId),
+  });
+  return buildSpellingContentWordDetail({
+    ...sources,
+    slug,
+  });
+}
+
+export async function readSpellingContentSentenceDetailModel({
+  repository,
+  subjectId = CONTENT_OPERATION_SUBJECT_ID,
+  packageId = '',
+  sentenceId = '',
+} = {}) {
+  const sources = await readSpellingContentSources({
+    repository,
+    subjectId,
+    packageId: normaliseString(packageId),
+  });
+  return buildSpellingContentSentenceDetail({
+    ...sources,
+    sentenceId,
+  });
+}

--- a/worker/src/content-operations/repository.js
+++ b/worker/src/content-operations/repository.js
@@ -694,6 +694,48 @@ export function createContentOperationsRepository({ db, now }) {
       return record;
     },
 
+    async readLatestContentOperationCandidate(packageId, {
+      includeSnapshot = false,
+      requireCurrent = false,
+    } = {}) {
+      const packageRow = await requirePackage(db, packageId);
+      const row = await first(db, `
+        SELECT *
+        FROM content_operation_package_candidates
+        WHERE package_id = ?
+        ORDER BY created_at DESC, candidate_id DESC
+        LIMIT 1
+      `, [packageId]);
+      if (!row) return null;
+      if (!requireCurrent) {
+        return candidateRowToRecordAsync(row, { includeSnapshot });
+      }
+      const record = candidateRowToRecord(row, { includeSnapshot: false });
+
+      const operations = await listPackageOperations(db, packageId);
+      const currentOperationsHash = packageOperationsHash(operations);
+      const currentReleaseRow = await readLatestReleaseRow(db, packageRow.subject_id);
+      const latestReleaseId = currentReleaseRow?.release_id || null;
+      const staleReasons = [];
+      if (record.operationsHash !== currentOperationsHash) {
+        staleReasons.push('operations_stale');
+      }
+      if ((record.currentReleaseId || null) !== latestReleaseId) {
+        staleReasons.push('release_stale');
+      }
+      const candidate = staleReasons.length || !includeSnapshot
+        ? null
+        : (await candidateRowToRecordAsync(row, { includeSnapshot: true }))?.candidate || null;
+      return {
+        ...record,
+        candidate,
+        isCurrent: staleReasons.length === 0,
+        staleReasons,
+        expectedOperationsHash: currentOperationsHash,
+        latestReleaseId,
+      };
+    },
+
     async updateContentOperationPackage(packageId, {
       templateId = undefined,
       title = undefined,

--- a/worker/src/content-operations/routes.js
+++ b/worker/src/content-operations/routes.js
@@ -17,6 +17,11 @@ import {
   serialiseContentOperationRelease,
   serialiseContentOperationStub,
 } from './serialisers.js';
+import {
+  readSpellingContentBrowseModel,
+  readSpellingContentSentenceDetailModel,
+  readSpellingContentWordDetailModel,
+} from './read-models.js';
 
 const CONTENT_OPERATIONS_ROUTE_PREFIX = '/api/admin/content-operations';
 const CONTENT_OPERATIONS_SUBJECT_ID = 'spelling';
@@ -49,6 +54,11 @@ function normaliseLimit(value, fallback, maximum) {
 function includeSnapshot(url, body = {}) {
   const value = url.searchParams.get('includeSnapshot') ?? body.includeSnapshot;
   return value === true || value === 'true' || value === '1';
+}
+
+function optionalQueryString(url, key) {
+  const value = url.searchParams.get(key);
+  return typeof value === 'string' && value.trim() ? value.trim() : '';
 }
 
 function decodePathSegment(value, label) {
@@ -199,6 +209,98 @@ export async function handleContentOperationsAdminRequest({
         actor,
       }),
     });
+  }
+
+  if (request.method === 'GET' && relativePath === '/subjects/spelling/browse') {
+    const actor = await requireRouteActor({
+      repository,
+      session,
+      request,
+      env,
+      capability: CONTENT_OPERATION_CAPABILITIES.VIEW,
+    });
+    const browse = await readSpellingContentBrowseModel({
+      repository,
+      subjectId: CONTENT_OPERATIONS_SUBJECT_ID,
+      packageId: optionalQueryString(url, 'packageId'),
+      filters: {
+        query: optionalQueryString(url, 'query') || optionalQueryString(url, 'q'),
+        pool: optionalQueryString(url, 'pool'),
+        listId: optionalQueryString(url, 'listId'),
+        limit: normaliseLimit(url.searchParams.get('limit'), 75, 250),
+      },
+    });
+    return json({
+      ok: true,
+      actor: serialiseContentOperationActor(actor),
+      browse,
+    });
+  }
+
+  {
+    const wordDetailMatch = /^\/subjects\/spelling\/words\/([^/]+)$/.exec(relativePath);
+    if (request.method === 'GET' && wordDetailMatch) {
+      const actor = await requireRouteActor({
+        repository,
+        session,
+        request,
+        env,
+        capability: CONTENT_OPERATION_CAPABILITIES.VIEW,
+      });
+      const slug = decodePathSegment(wordDetailMatch[1], 'word_slug');
+      const detail = await readSpellingContentWordDetailModel({
+        repository,
+        subjectId: CONTENT_OPERATIONS_SUBJECT_ID,
+        packageId: optionalQueryString(url, 'packageId'),
+        slug,
+      });
+      if (!detail.found) {
+        return json({
+          ok: false,
+          code: 'spelling_content_word_not_found',
+          message: 'Spelling content word was not found.',
+          slug,
+        }, 404);
+      }
+      return json({
+        ok: true,
+        actor: serialiseContentOperationActor(actor),
+        detail,
+      });
+    }
+  }
+
+  {
+    const sentenceDetailMatch = /^\/subjects\/spelling\/sentences\/([^/]+)$/.exec(relativePath);
+    if (request.method === 'GET' && sentenceDetailMatch) {
+      const actor = await requireRouteActor({
+        repository,
+        session,
+        request,
+        env,
+        capability: CONTENT_OPERATION_CAPABILITIES.VIEW,
+      });
+      const sentenceId = decodePathSegment(sentenceDetailMatch[1], 'sentence_id');
+      const detail = await readSpellingContentSentenceDetailModel({
+        repository,
+        subjectId: CONTENT_OPERATIONS_SUBJECT_ID,
+        packageId: optionalQueryString(url, 'packageId'),
+        sentenceId,
+      });
+      if (!detail.found) {
+        return json({
+          ok: false,
+          code: 'spelling_content_sentence_not_found',
+          message: 'Spelling content sentence was not found.',
+          sentenceId,
+        }, 404);
+      }
+      return json({
+        ok: true,
+        actor: serialiseContentOperationActor(actor),
+        detail,
+      });
+    }
   }
 
   if (request.method === 'GET' && relativePath === '/subjects/spelling/releases') {


### PR DESCRIPTION
## Summary
- Add spelling content browse/read-models with package overlay, stale-candidate guarding, word-family/search/audio/reward metadata.
- Add worker admin endpoints for browse, word detail, and sentence detail.
- Wire the Content Operations Centre UI/API to browse spelling words, load details, and invalidate package-scoped cache correctly.

## Verification
- `node --test tests/spelling-content-operations-model.test.js tests/content-operations-api.test.js tests/admin-content-operations-v2.test.js tests/react-admin-content-operations.test.js`
- `npm run check`
- `npm test` — 111731 pass, 0 fail, 12 skipped
- pre-push `npm test` — 111731 pass, 0 fail, 12 skipped

## Review
- Independent T9 review loops closed: Socrates, Pascal, and Godel findings all addressed and re-checked green.