### PR TITLE
Add spelling sentence and list editors

### DIFF
--- a/src/platform/hubs/admin-content-operations.js
+++ b/src/platform/hubs/admin-content-operations.js
@@ -313,6 +313,9 @@ function normaliseSpellingBrowseWord(row = null) {
     variantWords: asArray(safe.variantWords),
     variantAccepted: asArray(safe.variantAccepted),
     familySize: Number(safe.familySize) || 0,
+    active: safe.active === false ? false : true,
+    retired: Boolean(safe.retired),
+    retirement: isPlainObject(safe.retirement) ? { ...safe.retirement } : null,
     draftState: asString(safe.draftState, 'unchanged'),
     validationState: normaliseBlockerSection(safe.validationState),
     hasCurrent: safe.hasCurrent !== false,
@@ -330,7 +333,15 @@ function normaliseSpellingWordList(row = null) {
     spellingPool: asString(safe.spellingPool, 'core'),
     coverageTier: asString(safe.coverageTier),
     yearGroups: asArray(safe.yearGroups),
+    tags: asArray(safe.tags),
+    wordSlugs: asArray(safe.wordSlugs),
+    sourceNote: asString(safe.sourceNote),
+    provenance: isPlainObject(safe.provenance) ? { ...safe.provenance } : null,
+    active: safe.active === false ? false : true,
+    retired: Boolean(safe.retired),
+    retirement: isPlainObject(safe.retirement) ? { ...safe.retirement } : null,
     wordCount: Number(safe.wordCount) || 0,
+    totalWordCount: Number(safe.totalWordCount ?? safe.wordCount) || 0,
     draftState: asString(safe.draftState, 'unchanged'),
   };
 }
@@ -340,6 +351,7 @@ function normaliseSpellingPoolSummary(row = null) {
   return {
     pool: asString(safe.pool, 'core'),
     wordCount: Number(safe.wordCount) || 0,
+    totalWordCount: Number(safe.totalWordCount ?? safe.wordCount) || 0,
     sentenceCount: Number(safe.sentenceCount) || 0,
     variantCount: Number(safe.variantCount) || 0,
     draftStateCounts: isPlainObject(safe.draftStateCounts) ? { ...safe.draftStateCounts } : {},
@@ -409,6 +421,11 @@ function normaliseSpellingSentence(sentence = null) {
     text: asString(safe.text),
     variantLabel: asString(safe.variantLabel),
     tags: asArray(safe.tags),
+    sourceNote: asString(safe.sourceNote),
+    provenance: isPlainObject(safe.provenance) ? { ...safe.provenance } : null,
+    active: safe.active === false ? false : true,
+    retired: Boolean(safe.retired),
+    retirement: isPlainObject(safe.retirement) ? { ...safe.retirement } : null,
     word: isPlainObject(safe.word) ? { ...safe.word } : null,
   };
 }

--- a/src/subjects/spelling/content/editor-read-model.js
+++ b/src/subjects/spelling/content/editor-read-model.js
@@ -180,17 +180,30 @@ function compactSentence(sentence) {
     text: sentence.text,
     variantLabel: sentence.variantLabel || '',
     tags: asArray(sentence.tags),
+    sourceNote: sentence.sourceNote || '',
+    provenance: sentence.provenance || null,
+    active: sentence.active !== false,
+    retired: Boolean(sentence.retired),
+    retirement: sentence.retirement || null,
   };
 }
 
-function compactWordList(list, wordCount, draftState = 'unchanged') {
+function compactWordList(list, wordCount, draftState = 'unchanged', totalWordCount = wordCount) {
   return {
     id: list.id,
     title: list.title,
     spellingPool: list.spellingPool,
     coverageTier: list.coverageTier,
     yearGroups: asArray(list.yearGroups),
+    tags: asArray(list.tags),
+    wordSlugs: asArray(list.wordSlugs),
+    sourceNote: list.sourceNote || '',
+    provenance: list.provenance || null,
+    active: list.active !== false,
+    retired: Boolean(list.retired),
+    retirement: list.retirement || null,
     wordCount,
+    totalWordCount,
     draftState,
   };
 }
@@ -293,6 +306,9 @@ function compactWordRow({
     variantWords: variants.map((variant) => variant.word).filter(Boolean),
     variantAccepted: variants.flatMap((variant) => asArray(variant.accepted)),
     familySize: familyMembers.length,
+    active: word.active !== false,
+    retired: Boolean(word.retired),
+    retirement: word.retirement || null,
     draftState,
     validationState,
     hasCurrent: Boolean(currentComparable),
@@ -339,11 +355,13 @@ function draftStateCounts(rows) {
 function poolSummaries(rows) {
   return ['core', 'extra'].map((pool) => {
     const poolRows = rows.filter((row) => row.spellingPool === pool);
+    const activePoolRows = poolRows.filter((row) => row.active !== false && !row.retired);
     return {
       pool,
-      wordCount: poolRows.length,
-      sentenceCount: poolRows.reduce((sum, row) => sum + row.sentenceCount + row.variantSentenceCount, 0),
-      variantCount: poolRows.reduce((sum, row) => sum + row.variantCount, 0),
+      wordCount: activePoolRows.length,
+      totalWordCount: poolRows.length,
+      sentenceCount: activePoolRows.reduce((sum, row) => sum + row.sentenceCount + row.variantSentenceCount, 0),
+      variantCount: activePoolRows.reduce((sum, row) => sum + row.variantCount, 0),
       draftStateCounts: draftStateCounts(poolRows),
     };
   });
@@ -360,11 +378,13 @@ function compactWordLists({ currentBundle, packageBundle, currentMaps, packageMa
     const currentList = currentMaps.wordListsById.get(id) || null;
     const packageList = packageMaps?.wordListsById.get(id) || null;
     const display = packageList || currentList;
-    const wordCount = displayBundle.draft.words.filter((word) => word.listId === id).length;
+    const listWords = displayBundle.draft.words.filter((word) => word.listId === id);
+    const wordCount = listWords.filter((word) => word.active !== false && !word.retired).length;
     return compactWordList(
       display,
       wordCount,
       packageBundle ? packageDraftState(currentList, packageList) : 'unchanged',
+      listWords.length,
     );
   }).sort((left, right) => left.spellingPool.localeCompare(right.spellingPool) || left.title.localeCompare(right.title));
 }

--- a/src/subjects/spelling/content/model.js
+++ b/src/subjects/spelling/content/model.js
@@ -167,6 +167,9 @@ function normaliseWordList(rawValue, index = 0) {
     wordSlugs: uniqueStrings(raw.wordSlugs, { lowerCase: true }),
     sourceNote: normaliseString(raw.sourceNote),
     provenance: normaliseProvenance(raw.provenance, raw.sourceNote || 'spelling word list'),
+    active: raw.active === false ? false : true,
+    retired: Boolean(raw.retired),
+    ...(raw.retired || raw.active === false || raw.retirement ? { retirement: normaliseRetirement(raw.retirement) } : {}),
     sortIndex: Number.isInteger(Number(raw.sortIndex)) && Number(raw.sortIndex) >= 0 ? Number(raw.sortIndex) : index,
   };
 }
@@ -234,6 +237,9 @@ function normaliseSentenceEntry(rawValue, index = 0) {
     tags: normaliseTags(raw.tags),
     sourceNote: normaliseString(raw.sourceNote),
     provenance: normaliseProvenance(raw.provenance, raw.sourceNote || 'spelling sentence'),
+    active: raw.active === false ? false : true,
+    retired: Boolean(raw.retired),
+    ...(raw.retired || raw.active === false || raw.retirement ? { retirement: normaliseRetirement(raw.retirement) } : {}),
     sortIndex: Number.isInteger(Number(raw.sortIndex)) && Number(raw.sortIndex) >= 0 ? Number(raw.sortIndex) : index,
   };
 }
@@ -499,6 +505,8 @@ export function validateSpellingContentBundle(rawBundle) {
     const wordList = word.listId ? wordListsById.get(word.listId) : null;
     if (!word.listId || !wordList) {
       errors.push(issue('error', 'malformed_entry', `draft.words[${index}].listId`, `Word "${word.slug}" must point at a valid word list.`));
+    } else if (wordList.active === false || wordList.retired) {
+      errors.push(issue('error', 'retired_word_list_reference', `draft.words[${index}].listId`, `Word "${word.slug}" points at retired word list "${word.listId}".`));
     } else if (word.spellingPool !== wordList.spellingPool) {
       errors.push(issue('error', 'pool_mismatch', `draft.words[${index}].spellingPool`, `Word "${word.slug}" uses pool "${word.spellingPool}" but list "${word.listId}" uses pool "${wordList.spellingPool}".`));
     } else if (word.coverageTier !== wordList.coverageTier) {
@@ -566,6 +574,10 @@ export function validateSpellingContentBundle(rawBundle) {
         errors.push(issue('error', 'broken_sentence_reference', `draft.words[${index}].sentenceEntryIds[${position}]`, `Word "${word.slug}" references missing sentence id "${sentenceId}".`));
         return;
       }
+      if (sentence.active === false || sentence.retired) {
+        errors.push(issue('error', 'retired_sentence_reference', `draft.words[${index}].sentenceEntryIds[${position}]`, `Word "${word.slug}" references retired sentence id "${sentenceId}".`));
+        return;
+      }
       if (sentence.wordSlug !== word.slug) {
         errors.push(issue('error', 'broken_sentence_reference', `draft.words[${index}].sentenceEntryIds[${position}]`, `Sentence "${sentenceId}" belongs to word "${sentence.wordSlug}", not "${word.slug}".`));
       }
@@ -576,6 +588,10 @@ export function validateSpellingContentBundle(rawBundle) {
         const sentence = sentencesById.get(sentenceId);
         if (!sentence) {
           errors.push(issue('error', 'broken_sentence_reference', `draft.words[${index}].variants[${variantIndex}].sentenceEntryIds[${position}]`, `Variant "${variant.word || variantIndex + 1}" for word "${word.slug}" references missing sentence id "${sentenceId}".`));
+          return;
+        }
+        if (sentence.active === false || sentence.retired) {
+          errors.push(issue('error', 'retired_sentence_reference', `draft.words[${index}].variants[${variantIndex}].sentenceEntryIds[${position}]`, `Variant "${variant.word || variantIndex + 1}" for word "${word.slug}" references retired sentence id "${sentenceId}".`));
           return;
         }
         if (sentence.wordSlug !== word.slug) {

--- a/src/subjects/spelling/content/package-operations.js
+++ b/src/subjects/spelling/content/package-operations.js
@@ -91,8 +91,30 @@ function validationResult(errors, warnings, word = null) {
   };
 }
 
+function sentenceValidationResult(errors, warnings, sentence = null) {
+  return {
+    ok: errors.length === 0,
+    errors,
+    warnings,
+    sentence,
+  };
+}
+
+function wordListValidationResult(errors, warnings, wordList = null) {
+  return {
+    ok: errors.length === 0,
+    errors,
+    warnings,
+    wordList,
+  };
+}
+
 function findWordList(wordLists, listId) {
   return (Array.isArray(wordLists) ? wordLists : []).find((entry) => entry?.id === listId) || null;
+}
+
+function findWord(words, slug) {
+  return (Array.isArray(words) ? words : []).find((entry) => entry?.slug === slug) || null;
 }
 
 function normaliseAcceptedSpellings(rawValue, existingValue, defaultValue) {
@@ -246,6 +268,118 @@ export function validateSpellingWordEditorInput(rawValue = {}, options = {}) {
   return validationResult(errors, warnings, word);
 }
 
+export function normaliseSpellingSentenceEditorInput(rawValue = {}, {
+  existingSentence = null,
+} = {}) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  const existing = isPlainObject(existingSentence) ? existingSentence : {};
+  return {
+    id: normaliseString(raw.id, existing.id),
+    wordSlug: normaliseString(raw.wordSlug, existing.wordSlug).toLowerCase(),
+    text: normaliseString(raw.text, existing.text),
+    variantLabel: normaliseString(raw.variantLabel, existing.variantLabel || 'default'),
+    tags: uniqueStrings(hasExplicitList(raw.tags) ? raw.tags : existing.tags, { lowerCase: true }),
+    sourceNote: normaliseString(raw.sourceNote, existing.sourceNote),
+    provenance: normaliseProvenance(raw.provenance, existing.provenance),
+    sortIndex: Number.isInteger(Number(raw.sortIndex)) && Number(raw.sortIndex) >= 0
+      ? Number(raw.sortIndex)
+      : (Number.isInteger(Number(existing.sortIndex)) ? Number(existing.sortIndex) : 0),
+  };
+}
+
+export function validateSpellingSentenceEditorInput(rawValue = {}, options = {}) {
+  const errors = [];
+  const warnings = [];
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  const existing = isPlainObject(options.existingSentence) ? options.existingSentence : null;
+  const sentence = normaliseSpellingSentenceEditorInput(raw, options);
+  const word = findWord(options.words, sentence.wordSlug);
+
+  if (!sentence.id) errors.push(issue('id', 'Sentence id is required.', 'invalid_sentence_operation'));
+  if (!sentence.wordSlug) {
+    errors.push(issue('wordSlug', 'Sentence word slug is required.', 'invalid_sentence_operation'));
+  } else if (Array.isArray(options.words) && !word) {
+    errors.push(issue('wordSlug', `Sentence must point at an existing word slug "${sentence.wordSlug}".`, 'invalid_sentence_operation'));
+  } else if (word && (word.active === false || word.retired)) {
+    errors.push(issue('wordSlug', `Sentence cannot point at retired word "${sentence.wordSlug}".`, 'invalid_sentence_operation'));
+  }
+  if (!sentence.text || sentence.text.length < 12) {
+    errors.push(issue('text', 'Sentence text is required.', 'invalid_sentence_operation'));
+  }
+  if (!hasExplicitProvenance(raw, existing)) {
+    errors.push(issue('provenance', 'Sentence provenance or source notes are required.', 'invalid_sentence_operation'));
+  }
+
+  return sentenceValidationResult(errors, warnings, sentence);
+}
+
+export function normaliseSpellingWordListEditorInput(rawValue = {}, {
+  existingWordList = null,
+} = {}) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  const existing = isPlainObject(existingWordList) ? existingWordList : {};
+  const spellingPool = normaliseSpellingPool(raw.spellingPool, existing.spellingPool || 'core');
+  return {
+    id: normaliseString(raw.id, existing.id),
+    title: normaliseString(raw.title, existing.title),
+    spellingPool,
+    coverageTier: normaliseCoverageTier(raw.coverageTier, existing.coverageTier, spellingPool),
+    yearGroups: uniqueStrings(hasExplicitList(raw.yearGroups) ? raw.yearGroups : existing.yearGroups),
+    tags: uniqueStrings(hasExplicitList(raw.tags) ? raw.tags : existing.tags, { lowerCase: true }),
+    wordSlugs: uniqueStrings(hasExplicitList(raw.wordSlugs) ? raw.wordSlugs : existing.wordSlugs, { lowerCase: true }),
+    sourceNote: normaliseString(raw.sourceNote, existing.sourceNote),
+    provenance: normaliseProvenance(raw.provenance, existing.provenance),
+    sortIndex: Number.isInteger(Number(raw.sortIndex)) && Number(raw.sortIndex) >= 0
+      ? Number(raw.sortIndex)
+      : (Number.isInteger(Number(existing.sortIndex)) ? Number(existing.sortIndex) : 0),
+  };
+}
+
+export function validateSpellingWordListEditorInput(rawValue = {}, options = {}) {
+  const errors = [];
+  const warnings = [];
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  const existing = isPlainObject(options.existingWordList) ? options.existingWordList : null;
+  const wordList = normaliseSpellingWordListEditorInput(raw, options);
+  const wordsBySlug = new Map((Array.isArray(options.words) ? options.words : []).map((entry) => [entry.slug, entry]));
+
+  if (!wordList.id) errors.push(issue('id', 'Word-list id is required.', 'invalid_word_list_operation'));
+  if (!wordList.title) errors.push(issue('title', 'Word-list title is required.', 'invalid_word_list_operation'));
+  if (wordList.spellingPool === 'core' && !wordList.yearGroups.length) {
+    errors.push(issue('yearGroups', 'Core word lists require year-group metadata.', 'invalid_word_list_operation'));
+  }
+  if (wordList.spellingPool === 'extra' && wordList.coverageTier !== 'enrichment-extra') {
+    errors.push(issue('coverageTier', 'Extra word lists must use enrichment-extra coverage.', 'invalid_word_list_operation'));
+  }
+  if (wordList.spellingPool === 'core' && wordList.coverageTier === 'enrichment-extra') {
+    errors.push(issue('coverageTier', 'Core word lists cannot use enrichment-extra coverage.', 'invalid_word_list_operation'));
+  }
+  if (!hasExplicitProvenance(raw, existing)) {
+    errors.push(issue('provenance', 'Word-list provenance or source notes are required.', 'invalid_word_list_operation'));
+  }
+  if (Array.isArray(options.words)) {
+    wordList.wordSlugs.forEach((slug) => {
+      const word = wordsBySlug.get(slug);
+      if (!word) {
+        errors.push(issue('wordSlugs', `Word-list membership references missing word slug "${slug}".`, 'invalid_word_list_operation'));
+        return;
+      }
+      if (word.active === false || word.retired) {
+        errors.push(issue('wordSlugs', `Word-list membership references retired word "${slug}".`, 'invalid_word_list_operation'));
+        return;
+      }
+      if (word.spellingPool !== wordList.spellingPool) {
+        errors.push(issue('wordSlugs', `Word "${slug}" uses pool "${word.spellingPool}", not "${wordList.spellingPool}".`, 'invalid_word_list_operation'));
+      }
+      if (word.coverageTier !== wordList.coverageTier) {
+        errors.push(issue('wordSlugs', `Word "${slug}" uses coverage "${word.coverageTier}", not "${wordList.coverageTier}".`, 'invalid_word_list_operation'));
+      }
+    });
+  }
+
+  return wordListValidationResult(errors, warnings, wordList);
+}
+
 function throwIfInvalid(validation) {
   if (validation.ok) return;
   const error = new TypeError(validation.errors[0]?.message || 'Spelling word operation is invalid.');
@@ -262,6 +396,30 @@ export function buildSpellingWordUpsertOperation(rawValue = {}, options = {}) {
     fieldPath: '',
     action: 'upsert',
     payload: validation.word,
+  };
+}
+
+export function buildSpellingSentenceUpsertOperation(rawValue = {}, options = {}) {
+  const validation = validateSpellingSentenceEditorInput(rawValue, options);
+  throwIfInvalid(validation);
+  return {
+    entityType: 'spelling.sentenceEntry',
+    entityId: validation.sentence.id,
+    fieldPath: '',
+    action: 'upsert',
+    payload: validation.sentence,
+  };
+}
+
+export function buildSpellingWordListUpsertOperation(rawValue = {}, options = {}) {
+  const validation = validateSpellingWordListEditorInput(rawValue, options);
+  throwIfInvalid(validation);
+  return {
+    entityType: 'spelling.wordList',
+    entityId: validation.wordList.id,
+    fieldPath: '',
+    action: 'upsert',
+    payload: validation.wordList,
   };
 }
 
@@ -289,6 +447,74 @@ export function buildSpellingWordDeleteOrRetireOperation(rawValue = {}, {
   return {
     entityType: 'spelling.word',
     entityId: slug,
+    fieldPath: '',
+    action: 'retire',
+    payload: {
+      reason: normaliseString(reason, normaliseString(raw.reason, 'Retired through Content Operations Centre.')),
+      retiredAt: Number(now()),
+      source: 'content-operations-centre',
+    },
+  };
+}
+
+export function buildSpellingSentenceDeleteOrRetireOperation(rawValue = {}, {
+  publishedSentenceIds = [],
+  reason = '',
+  now = () => Date.now(),
+} = {}) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  const id = normaliseString(raw.id || raw.entityId || raw.sentenceId);
+  if (!id) throw new TypeError('Sentence id is required.');
+  const publishedSet = publishedSentenceIds instanceof Set
+    ? publishedSentenceIds
+    : new Set((Array.isArray(publishedSentenceIds) ? publishedSentenceIds : []).map((entry) => String(entry)));
+  const published = Boolean(raw.published || raw.hasCurrent || publishedSet.has(id));
+  if (!published) {
+    return {
+      entityType: 'spelling.sentenceEntry',
+      entityId: id,
+      fieldPath: '',
+      action: 'remove',
+      payload: null,
+    };
+  }
+  return {
+    entityType: 'spelling.sentenceEntry',
+    entityId: id,
+    fieldPath: '',
+    action: 'retire',
+    payload: {
+      reason: normaliseString(reason, normaliseString(raw.reason, 'Retired through Content Operations Centre.')),
+      retiredAt: Number(now()),
+      source: 'content-operations-centre',
+    },
+  };
+}
+
+export function buildSpellingWordListDeleteOrRetireOperation(rawValue = {}, {
+  publishedWordListIds = [],
+  reason = '',
+  now = () => Date.now(),
+} = {}) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  const id = normaliseString(raw.id || raw.entityId || raw.listId);
+  if (!id) throw new TypeError('Word-list id is required.');
+  const publishedSet = publishedWordListIds instanceof Set
+    ? publishedWordListIds
+    : new Set((Array.isArray(publishedWordListIds) ? publishedWordListIds : []).map((entry) => String(entry)));
+  const published = Boolean(raw.published || raw.hasCurrent || publishedSet.has(id));
+  if (!published) {
+    return {
+      entityType: 'spelling.wordList',
+      entityId: id,
+      fieldPath: '',
+      action: 'remove',
+      payload: null,
+    };
+  }
+  return {
+    entityType: 'spelling.wordList',
+    entityId: id,
     fieldPath: '',
     action: 'retire',
     payload: {

--- a/src/surfaces/hubs/AdminContentOperationsSection.jsx
+++ b/src/surfaces/hubs/AdminContentOperationsSection.jsx
@@ -14,6 +14,10 @@ import {
   normaliseContentOperationsSpellingItemDetail,
 } from '../../platform/hubs/admin-content-operations.js';
 import {
+  buildSpellingSentenceDeleteOrRetireOperation,
+  buildSpellingSentenceUpsertOperation,
+  buildSpellingWordListDeleteOrRetireOperation,
+  buildSpellingWordListUpsertOperation,
   buildSpellingWordDeleteOrRetireOperation,
   buildSpellingWordUpsertOperation,
 } from '../../subjects/spelling/content/package-operations.js';
@@ -157,6 +161,104 @@ function operationInputFromWordForm(form) {
       },
       progressKey: variant.progressKey,
     })),
+  };
+}
+
+function emptySentenceEditorForm(selectedRow = null) {
+  return {
+    id: '',
+    wordSlug: selectedRow?.slug || '',
+    text: '',
+    variantLabel: 'default',
+    tags: '',
+    sourceNote: '',
+    provenanceSource: '',
+    provenanceNote: '',
+    retirementReason: '',
+  };
+}
+
+function sentenceEditorFormFromSentence(sentence, selectedRow = null) {
+  if (!sentence) return emptySentenceEditorForm(selectedRow);
+  return {
+    id: sentence.id || '',
+    wordSlug: sentence.wordSlug || selectedRow?.slug || '',
+    text: sentence.text || '',
+    variantLabel: sentence.variantLabel || 'default',
+    tags: csvValue(sentence.tags),
+    sourceNote: sentence.sourceNote || '',
+    provenanceSource: provenanceField(sentence.provenance, 'source'),
+    provenanceNote: provenanceField(sentence.provenance, 'note'),
+    retirementReason: '',
+  };
+}
+
+function operationInputFromSentenceForm(form) {
+  return {
+    id: form.id,
+    wordSlug: form.wordSlug,
+    text: form.text,
+    variantLabel: form.variantLabel,
+    tags: form.tags,
+    sourceNote: form.sourceNote,
+    provenance: {
+      source: form.provenanceSource,
+      note: form.provenanceNote,
+    },
+  };
+}
+
+function emptyWordListEditorForm(wordLists = [], selectedRow = null) {
+  const preferredList = selectedRow?.listId
+    ? wordLists.find((entry) => entry.id === selectedRow.listId)
+    : wordLists[0];
+  const spellingPool = preferredList?.spellingPool || selectedRow?.spellingPool || 'core';
+  return {
+    id: '',
+    title: '',
+    spellingPool,
+    coverageTier: preferredList?.coverageTier || selectedRow?.coverageTier || (spellingPool === 'extra' ? 'enrichment-extra' : 'statutory-core'),
+    yearGroups: spellingPool === 'core' ? 'Y3, Y4' : '',
+    tags: '',
+    wordSlugs: selectedRow?.slug || '',
+    sourceNote: '',
+    provenanceSource: '',
+    provenanceNote: '',
+    retirementReason: '',
+  };
+}
+
+function wordListEditorFormFromList(list, selectedRow = null, wordLists = []) {
+  if (!list) return emptyWordListEditorForm(wordLists, selectedRow);
+  return {
+    id: list.id || '',
+    title: list.title || '',
+    spellingPool: list.spellingPool || selectedRow?.spellingPool || 'core',
+    coverageTier: list.coverageTier || selectedRow?.coverageTier || '',
+    yearGroups: csvValue(list.yearGroups),
+    tags: csvValue(list.tags),
+    wordSlugs: csvValue(list.wordSlugs),
+    sourceNote: list.sourceNote || '',
+    provenanceSource: provenanceField(list.provenance, 'source'),
+    provenanceNote: provenanceField(list.provenance, 'note'),
+    retirementReason: '',
+  };
+}
+
+function operationInputFromWordListForm(form) {
+  return {
+    id: form.id,
+    title: form.title,
+    spellingPool: form.spellingPool,
+    coverageTier: form.coverageTier,
+    yearGroups: form.yearGroups,
+    tags: form.tags,
+    wordSlugs: form.wordSlugs,
+    sourceNote: form.sourceNote,
+    provenance: {
+      source: form.provenanceSource,
+      note: form.provenanceNote,
+    },
   };
 }
 
@@ -575,15 +677,15 @@ function SpellingBrowsePanel({
   selectedWordSlug,
   selectedPackageId,
   canEdit,
-  wordOperationAvailable,
-  wordOperationState,
+  spellingOperationAvailable,
+  spellingOperationState,
   loadingBrowse,
   loadingItem,
   error,
   onFilterChange,
   onApplyFilters,
   onSelectWord,
-  onSubmitWordOperation,
+  onSubmitSpellingOperation,
 }) {
   const selectedRow = browse.words.find((row) => row.slug === selectedWordSlug) || browse.words[0] || null;
   const packageDraft = browse.packageDraft;
@@ -597,19 +699,41 @@ function SpellingBrowsePanel({
   const currentWord = selectedDetail?.current || null;
   const packageWord = selectedDetail?.packageValue || null;
   const editorSourceWord = packageWord || currentWord || null;
+  const selectedList = browse.wordLists.find((list) => list.id === selectedRow?.listId) || browse.wordLists[0] || null;
+  const sentenceOptions = React.useMemo(() => {
+    const seen = new Set();
+    const output = [];
+    for (const sentence of [
+      ...((packageWord?.sentences || [])),
+      ...((currentWord?.sentences || [])),
+    ]) {
+      if (!sentence?.id || seen.has(sentence.id)) continue;
+      seen.add(sentence.id);
+      output.push(sentence);
+    }
+    return output;
+  }, [currentWord, packageWord]);
   const releaseLabel = browse.release.releaseId || 'bundled fallback';
   const detailValidation = selectedDetail?.validationState || selectedRow?.validationState || packageDraft.validation;
   const [editorMode, setEditorMode] = React.useState('edit');
   const [wordForm, setWordForm] = React.useState(() => emptyWordEditorForm(browse.wordLists, selectedRow));
+  const [sentenceMode, setSentenceMode] = React.useState('edit');
+  const [selectedSentenceId, setSelectedSentenceId] = React.useState('');
+  const [sentenceForm, setSentenceForm] = React.useState(() => emptySentenceEditorForm(selectedRow));
+  const [wordListMode, setWordListMode] = React.useState('edit');
+  const [wordListForm, setWordListForm] = React.useState(() => emptyWordListEditorForm(browse.wordLists, selectedRow));
   const [formError, setFormError] = React.useState('');
   const formDisabled = !selectedPackageId
     || !canEdit
-    || !wordOperationAvailable
-    || Boolean(wordOperationState?.running);
+    || !spellingOperationAvailable
+    || Boolean(spellingOperationState?.running);
   const formBlockedReason = !selectedPackageId
     ? 'Select a package'
-    : (!canEdit ? 'Edit locked' : (!wordOperationAvailable ? 'API unavailable' : ''));
+    : (!canEdit ? 'Edit locked' : (!spellingOperationAvailable ? 'API unavailable' : ''));
   const removeLabel = selectedRow?.hasCurrent ? 'Retire word' : 'Delete draft';
+  const selectedSentence = sentenceOptions.find((sentence) => sentence.id === selectedSentenceId)
+    || sentenceOptions[0]
+    || null;
 
   React.useEffect(() => {
     if (editorMode === 'create') return;
@@ -621,6 +745,32 @@ function SpellingBrowsePanel({
     editorSourceWord,
     selectedRow,
     selectedRow?.slug,
+  ]);
+
+  React.useEffect(() => {
+    if (sentenceMode === 'create') return;
+    setFormError('');
+    const nextSentence = selectedSentence || sentenceOptions[0] || null;
+    setSelectedSentenceId(nextSentence?.id || '');
+    setSentenceForm(sentenceEditorFormFromSentence(nextSentence, selectedRow));
+  }, [
+    sentenceMode,
+    selectedRow,
+    selectedRow?.slug,
+    selectedSentence,
+    sentenceOptions,
+  ]);
+
+  React.useEffect(() => {
+    if (wordListMode === 'create') return;
+    setFormError('');
+    setWordListForm(wordListEditorFormFromList(selectedList, selectedRow, browse.wordLists));
+  }, [
+    browse.wordLists,
+    selectedList,
+    selectedRow,
+    selectedRow?.listId,
+    wordListMode,
   ]);
 
   const updateWordForm = React.useCallback((patch) => {
@@ -637,6 +787,23 @@ function SpellingBrowsePanel({
       return next;
     });
   }, [browse.wordLists]);
+
+  const updateSentenceForm = React.useCallback((patch) => {
+    setFormError('');
+    setSentenceForm((current) => ({ ...current, ...patch }));
+  }, []);
+
+  const updateWordListForm = React.useCallback((patch) => {
+    setFormError('');
+    setWordListForm((current) => {
+      const next = { ...current, ...patch };
+      if (Object.prototype.hasOwnProperty.call(patch, 'spellingPool')) {
+        next.coverageTier = patch.spellingPool === 'extra' ? 'enrichment-extra' : 'statutory-core';
+        if (patch.spellingPool === 'extra') next.yearGroups = '';
+      }
+      return next;
+    });
+  }, []);
 
   const updateVariant = React.useCallback((index, patch) => {
     setFormError('');
@@ -690,22 +857,49 @@ function SpellingBrowsePanel({
     setWordForm(wordEditorFormFromWord(editorSourceWord, selectedRow, browse.wordLists));
   }, [browse.wordLists, editorSourceWord, selectedRow]);
 
+  const startCreateSentence = React.useCallback(() => {
+    setSentenceMode('create');
+    setSelectedSentenceId('');
+    setFormError('');
+    setSentenceForm(emptySentenceEditorForm(selectedRow));
+  }, [selectedRow]);
+
+  const startEditSentence = React.useCallback((sentenceId = '') => {
+    const nextSentence = sentenceOptions.find((sentence) => sentence.id === sentenceId) || sentenceOptions[0] || null;
+    setSentenceMode('edit');
+    setSelectedSentenceId(nextSentence?.id || '');
+    setFormError('');
+    setSentenceForm(sentenceEditorFormFromSentence(nextSentence, selectedRow));
+  }, [selectedRow, sentenceOptions]);
+
+  const startCreateWordList = React.useCallback(() => {
+    setWordListMode('create');
+    setFormError('');
+    setWordListForm(emptyWordListEditorForm(browse.wordLists, selectedRow));
+  }, [browse.wordLists, selectedRow]);
+
+  const startEditWordList = React.useCallback(() => {
+    setWordListMode('edit');
+    setFormError('');
+    setWordListForm(wordListEditorFormFromList(selectedList, selectedRow, browse.wordLists));
+  }, [browse.wordLists, selectedList, selectedRow]);
+
   const submitWordForm = React.useCallback((event) => {
     event?.preventDefault?.();
-    if (!onSubmitWordOperation) return;
+    if (!onSubmitSpellingOperation) return;
     try {
       const operation = buildSpellingWordUpsertOperation(operationInputFromWordForm(wordForm), {
         existingWord: editorMode === 'edit' ? editorSourceWord : null,
         wordLists: browse.wordLists,
       });
-      onSubmitWordOperation(operation, { slug: operation.entityId, action: 'word-upsert' });
+      onSubmitSpellingOperation(operation, { slug: operation.entityId, action: 'word-upsert' });
     } catch (submitError) {
       setFormError(submitError?.validation?.errors?.[0]?.message || submitError?.message || 'Word operation is invalid.');
     }
-  }, [browse.wordLists, editorMode, editorSourceWord, onSubmitWordOperation, wordForm]);
+  }, [browse.wordLists, editorMode, editorSourceWord, onSubmitSpellingOperation, wordForm]);
 
   const submitRemoval = React.useCallback(() => {
-    if (!onSubmitWordOperation || !selectedRow) return;
+    if (!onSubmitSpellingOperation || !selectedRow) return;
     try {
       const operation = buildSpellingWordDeleteOrRetireOperation({
         slug: wordForm.slug || selectedRow.slug,
@@ -714,11 +908,70 @@ function SpellingBrowsePanel({
       }, {
         reason: wordForm.retirementReason,
       });
-      onSubmitWordOperation(operation, { slug: operation.entityId, action: operation.action });
+      onSubmitSpellingOperation(operation, { slug: operation.entityId, action: operation.action });
     } catch (submitError) {
       setFormError(submitError?.message || 'Word operation is invalid.');
     }
-  }, [onSubmitWordOperation, selectedRow, wordForm.retirementReason, wordForm.slug]);
+  }, [onSubmitSpellingOperation, selectedRow, wordForm.retirementReason, wordForm.slug]);
+
+  const submitSentenceForm = React.useCallback((event) => {
+    event?.preventDefault?.();
+    if (!onSubmitSpellingOperation) return;
+    try {
+      const operation = buildSpellingSentenceUpsertOperation(operationInputFromSentenceForm(sentenceForm), {
+        existingSentence: sentenceMode === 'edit' ? selectedSentence : null,
+      });
+      onSubmitSpellingOperation(operation, { slug: sentenceForm.wordSlug || selectedRow?.slug, action: 'sentence-upsert' });
+    } catch (submitError) {
+      setFormError(submitError?.validation?.errors?.[0]?.message || submitError?.message || 'Sentence operation is invalid.');
+    }
+  }, [onSubmitSpellingOperation, selectedRow?.slug, selectedSentence, sentenceForm, sentenceMode]);
+
+  const submitSentenceRemoval = React.useCallback(() => {
+    if (!onSubmitSpellingOperation || !selectedSentence) return;
+    try {
+      const hasCurrent = Boolean(currentWord?.sentences?.some((sentence) => sentence.id === selectedSentence.id));
+      const operation = buildSpellingSentenceDeleteOrRetireOperation({
+        id: sentenceForm.id || selectedSentence.id,
+        hasCurrent,
+        reason: sentenceForm.retirementReason,
+      }, {
+        reason: sentenceForm.retirementReason,
+      });
+      onSubmitSpellingOperation(operation, { slug: selectedSentence.wordSlug || selectedRow?.slug, action: `sentence-${operation.action}` });
+    } catch (submitError) {
+      setFormError(submitError?.message || 'Sentence operation is invalid.');
+    }
+  }, [currentWord?.sentences, onSubmitSpellingOperation, selectedRow?.slug, selectedSentence, sentenceForm.id, sentenceForm.retirementReason]);
+
+  const submitWordListForm = React.useCallback((event) => {
+    event?.preventDefault?.();
+    if (!onSubmitSpellingOperation) return;
+    try {
+      const operation = buildSpellingWordListUpsertOperation(operationInputFromWordListForm(wordListForm), {
+        existingWordList: wordListMode === 'edit' ? selectedList : null,
+      });
+      onSubmitSpellingOperation(operation, { slug: selectedRow?.slug, action: 'word-list-upsert' });
+    } catch (submitError) {
+      setFormError(submitError?.validation?.errors?.[0]?.message || submitError?.message || 'Word-list operation is invalid.');
+    }
+  }, [onSubmitSpellingOperation, selectedList, selectedRow?.slug, wordListForm, wordListMode]);
+
+  const submitWordListRemoval = React.useCallback(() => {
+    if (!onSubmitSpellingOperation || !selectedList) return;
+    try {
+      const operation = buildSpellingWordListDeleteOrRetireOperation({
+        id: wordListForm.id || selectedList.id,
+        hasCurrent: selectedList.draftState !== 'added',
+        reason: wordListForm.retirementReason,
+      }, {
+        reason: wordListForm.retirementReason,
+      });
+      onSubmitSpellingOperation(operation, { slug: selectedRow?.slug, action: `word-list-${operation.action}` });
+    } catch (submitError) {
+      setFormError(submitError?.message || 'Word-list operation is invalid.');
+    }
+  }, [onSubmitSpellingOperation, selectedList, selectedRow?.slug, wordListForm.id, wordListForm.retirementReason]);
 
   return (
     <div className="content-ops-area-panel" data-content-ops-area="spelling" data-content-ops-spelling-browse="true">
@@ -943,14 +1196,14 @@ function SpellingBrowsePanel({
                     {formBlockedReason}
                   </div>
                 ) : null}
-                {formError || wordOperationState?.error ? (
+                {formError || spellingOperationState?.error ? (
                   <div className="feedback warn" data-content-ops-word-editor-error="true">
-                    {formError || wordOperationState.error.message}
+                    {formError || spellingOperationState.error.message}
                   </div>
                 ) : null}
-                {wordOperationState?.message ? (
+                {spellingOperationState?.message ? (
                   <div className="feedback good" data-content-ops-word-editor-message="true">
-                    {wordOperationState.message}
+                    {spellingOperationState.message}
                   </div>
                 ) : null}
                 <div className="content-ops-word-editor-grid">
@@ -1227,6 +1480,277 @@ function SpellingBrowsePanel({
                     data-content-ops-word-remove="true"
                   >
                     {removeLabel}
+                  </button>
+                </div>
+              </form>
+              <form
+                className="content-ops-word-editor"
+                data-content-ops-sentence-editor="true"
+                onSubmit={submitSentenceForm}
+              >
+                <div className="content-ops-word-editor-header">
+                  <div>
+                    <div className="eyebrow">Sentence editor</div>
+                    <strong>{sentenceMode === 'create' ? 'New sentence' : (sentenceForm.id || 'Selected sentence')}</strong>
+                  </div>
+                  <div className="chip-row content-ops-chip-wrap">
+                    {sentenceOptions.length ? (
+                      <select
+                        value={selectedSentence?.id || ''}
+                        onChange={(event) => startEditSentence(event.target.value)}
+                        disabled={formDisabled}
+                        data-content-ops-sentence-select="true"
+                      >
+                        {sentenceOptions.map((sentence) => (
+                          <option key={sentence.id} value={sentence.id}>{sentence.id}</option>
+                        ))}
+                      </select>
+                    ) : null}
+                    <button type="button" className="btn secondary compact" onClick={() => startEditSentence(selectedSentence?.id)} disabled={!sentenceOptions.length}>
+                      Edit sentence
+                    </button>
+                    <button type="button" className="btn secondary compact" onClick={startCreateSentence}>
+                      New sentence
+                    </button>
+                  </div>
+                </div>
+                <div className="content-ops-word-editor-grid">
+                  <label>
+                    <span className="small muted">Sentence ID</span>
+                    <input
+                      value={sentenceForm.id}
+                      onChange={(event) => updateSentenceForm({ id: event.target.value })}
+                      disabled={formDisabled || sentenceMode !== 'create'}
+                      data-content-ops-sentence-field="id"
+                    />
+                  </label>
+                  <label>
+                    <span className="small muted">Word slug</span>
+                    <input
+                      value={sentenceForm.wordSlug}
+                      onChange={(event) => updateSentenceForm({ wordSlug: event.target.value })}
+                      disabled={formDisabled}
+                      data-content-ops-sentence-field="wordSlug"
+                    />
+                  </label>
+                  <label>
+                    <span className="small muted">Variant label</span>
+                    <input
+                      value={sentenceForm.variantLabel}
+                      onChange={(event) => updateSentenceForm({ variantLabel: event.target.value })}
+                      disabled={formDisabled}
+                      data-content-ops-sentence-field="variantLabel"
+                    />
+                  </label>
+                  <label>
+                    <span className="small muted">Tags</span>
+                    <input
+                      value={sentenceForm.tags}
+                      onChange={(event) => updateSentenceForm({ tags: event.target.value })}
+                      disabled={formDisabled}
+                      data-content-ops-sentence-field="tags"
+                    />
+                  </label>
+                  <label className="content-ops-word-editor-wide">
+                    <span className="small muted">Sentence text</span>
+                    <textarea
+                      value={sentenceForm.text}
+                      onChange={(event) => updateSentenceForm({ text: event.target.value })}
+                      disabled={formDisabled}
+                      rows={2}
+                      data-content-ops-sentence-field="text"
+                    />
+                  </label>
+                  <label className="content-ops-word-editor-wide">
+                    <span className="small muted">Source notes</span>
+                    <textarea
+                      value={sentenceForm.sourceNote}
+                      onChange={(event) => updateSentenceForm({ sourceNote: event.target.value })}
+                      disabled={formDisabled}
+                      rows={2}
+                      data-content-ops-sentence-field="sourceNote"
+                    />
+                  </label>
+                  <label>
+                    <span className="small muted">Provenance source</span>
+                    <input
+                      value={sentenceForm.provenanceSource}
+                      onChange={(event) => updateSentenceForm({ provenanceSource: event.target.value })}
+                      disabled={formDisabled}
+                      data-content-ops-sentence-field="provenanceSource"
+                    />
+                  </label>
+                  <label>
+                    <span className="small muted">Provenance note</span>
+                    <input
+                      value={sentenceForm.provenanceNote}
+                      onChange={(event) => updateSentenceForm({ provenanceNote: event.target.value })}
+                      disabled={formDisabled}
+                      data-content-ops-sentence-field="provenanceNote"
+                    />
+                  </label>
+                  <label className="content-ops-word-editor-wide">
+                    <span className="small muted">Retirement reason</span>
+                    <input
+                      value={sentenceForm.retirementReason}
+                      onChange={(event) => updateSentenceForm({ retirementReason: event.target.value })}
+                      disabled={formDisabled || sentenceMode === 'create'}
+                      data-content-ops-sentence-field="retirementReason"
+                    />
+                  </label>
+                </div>
+                <div className="content-ops-word-editor-actions">
+                  <button type="submit" className="btn primary compact" disabled={formDisabled}>
+                    Save sentence
+                  </button>
+                  <button
+                    type="button"
+                    className="btn secondary compact"
+                    onClick={submitSentenceRemoval}
+                    disabled={formDisabled || sentenceMode === 'create' || !selectedSentence}
+                    data-content-ops-sentence-remove="true"
+                  >
+                    {currentWord?.sentences?.some((sentence) => sentence.id === selectedSentence?.id) ? 'Retire sentence' : 'Delete draft sentence'}
+                  </button>
+                </div>
+              </form>
+              <form
+                className="content-ops-word-editor"
+                data-content-ops-word-list-editor="true"
+                onSubmit={submitWordListForm}
+              >
+                <div className="content-ops-word-editor-header">
+                  <div>
+                    <div className="eyebrow">Word-list editor</div>
+                    <strong>{wordListMode === 'create' ? 'New word list' : (wordListForm.title || selectedList?.title || 'Selected list')}</strong>
+                  </div>
+                  <div className="chip-row content-ops-chip-wrap">
+                    <button type="button" className="btn secondary compact" onClick={startEditWordList} disabled={!selectedList}>
+                      Edit list
+                    </button>
+                    <button type="button" className="btn secondary compact" onClick={startCreateWordList}>
+                      New list
+                    </button>
+                  </div>
+                </div>
+                <div className="content-ops-word-editor-grid">
+                  <label>
+                    <span className="small muted">List ID</span>
+                    <input
+                      value={wordListForm.id}
+                      onChange={(event) => updateWordListForm({ id: event.target.value })}
+                      disabled={formDisabled || wordListMode !== 'create'}
+                      data-content-ops-word-list-field="id"
+                    />
+                  </label>
+                  <label>
+                    <span className="small muted">Title</span>
+                    <input
+                      value={wordListForm.title}
+                      onChange={(event) => updateWordListForm({ title: event.target.value })}
+                      disabled={formDisabled}
+                      data-content-ops-word-list-field="title"
+                    />
+                  </label>
+                  <label>
+                    <span className="small muted">Pool</span>
+                    <select
+                      value={wordListForm.spellingPool}
+                      onChange={(event) => updateWordListForm({ spellingPool: event.target.value })}
+                      disabled={formDisabled}
+                      data-content-ops-word-list-field="spellingPool"
+                    >
+                      <option value="core">Core</option>
+                      <option value="extra">Extra</option>
+                    </select>
+                  </label>
+                  <label>
+                    <span className="small muted">Coverage</span>
+                    <input
+                      value={wordListForm.coverageTier}
+                      onChange={(event) => updateWordListForm({ coverageTier: event.target.value })}
+                      disabled={formDisabled}
+                      data-content-ops-word-list-field="coverageTier"
+                    />
+                  </label>
+                  <label>
+                    <span className="small muted">Year groups</span>
+                    <input
+                      value={wordListForm.yearGroups}
+                      onChange={(event) => updateWordListForm({ yearGroups: event.target.value })}
+                      disabled={formDisabled}
+                      data-content-ops-word-list-field="yearGroups"
+                    />
+                  </label>
+                  <label>
+                    <span className="small muted">Tags</span>
+                    <input
+                      value={wordListForm.tags}
+                      onChange={(event) => updateWordListForm({ tags: event.target.value })}
+                      disabled={formDisabled}
+                      data-content-ops-word-list-field="tags"
+                    />
+                  </label>
+                  <label className="content-ops-word-editor-wide">
+                    <span className="small muted">Word slugs</span>
+                    <textarea
+                      value={wordListForm.wordSlugs}
+                      onChange={(event) => updateWordListForm({ wordSlugs: event.target.value })}
+                      disabled={formDisabled}
+                      rows={2}
+                      data-content-ops-word-list-field="wordSlugs"
+                    />
+                  </label>
+                  <label className="content-ops-word-editor-wide">
+                    <span className="small muted">Source notes</span>
+                    <textarea
+                      value={wordListForm.sourceNote}
+                      onChange={(event) => updateWordListForm({ sourceNote: event.target.value })}
+                      disabled={formDisabled}
+                      rows={2}
+                      data-content-ops-word-list-field="sourceNote"
+                    />
+                  </label>
+                  <label>
+                    <span className="small muted">Provenance source</span>
+                    <input
+                      value={wordListForm.provenanceSource}
+                      onChange={(event) => updateWordListForm({ provenanceSource: event.target.value })}
+                      disabled={formDisabled}
+                      data-content-ops-word-list-field="provenanceSource"
+                    />
+                  </label>
+                  <label>
+                    <span className="small muted">Provenance note</span>
+                    <input
+                      value={wordListForm.provenanceNote}
+                      onChange={(event) => updateWordListForm({ provenanceNote: event.target.value })}
+                      disabled={formDisabled}
+                      data-content-ops-word-list-field="provenanceNote"
+                    />
+                  </label>
+                  <label className="content-ops-word-editor-wide">
+                    <span className="small muted">Retirement reason</span>
+                    <input
+                      value={wordListForm.retirementReason}
+                      onChange={(event) => updateWordListForm({ retirementReason: event.target.value })}
+                      disabled={formDisabled || wordListMode === 'create'}
+                      data-content-ops-word-list-field="retirementReason"
+                    />
+                  </label>
+                </div>
+                <div className="content-ops-word-editor-actions">
+                  <button type="submit" className="btn primary compact" disabled={formDisabled}>
+                    Save list
+                  </button>
+                  <button
+                    type="button"
+                    className="btn secondary compact"
+                    onClick={submitWordListRemoval}
+                    disabled={formDisabled || wordListMode === 'create' || !selectedList}
+                    data-content-ops-word-list-remove="true"
+                  >
+                    {selectedList?.draftState === 'added' ? 'Delete draft list' : 'Retire list'}
                   </button>
                 </div>
               </form>
@@ -1741,7 +2265,7 @@ export function AdminContentOperationsSection({
     approval: null,
     release: null,
   });
-  const [wordOperationState, setWordOperationState] = React.useState({
+  const [spellingOperationState, setSpellingOperationState] = React.useState({
     packageId: '',
     action: '',
     running: false,
@@ -1900,12 +2424,12 @@ export function AdminContentOperationsSection({
     loadSpellingBrowse();
   }, [loadSpellingBrowse]);
 
-  const runSpellingWordOperation = React.useCallback(async (operation, {
+  const runSpellingOperation = React.useCallback(async (operation, {
     slug = '',
-    action = 'word-operation',
+    action = 'spelling-operation',
   } = {}) => {
     if (!api?.appendOperation || !selectedPackageId) return;
-    setWordOperationState({
+    setSpellingOperationState({
       packageId: selectedPackageId,
       action,
       running: true,
@@ -1918,13 +2442,16 @@ export function AdminContentOperationsSection({
         operation,
         mutation: contentOperationMutation(action, selectedPackageId),
       });
-      setWordOperationState({
+      const noun = operation.entityType === 'spelling.sentenceEntry'
+        ? 'Sentence'
+        : (operation.entityType === 'spelling.wordList' ? 'Word list' : 'Word');
+      setSpellingOperationState({
         packageId: selectedPackageId,
         action,
         running: false,
         message: operation.action === 'remove'
-          ? 'Draft word deleted.'
-          : (operation.action === 'retire' ? 'Word retired.' : 'Word operation saved.'),
+          ? `Draft ${noun.toLowerCase()} deleted.`
+          : (operation.action === 'retire' ? `${noun} retired.` : `${noun} operation saved.`),
         error: null,
       });
       if (api.readPackage) {
@@ -1935,12 +2462,12 @@ export function AdminContentOperationsSection({
         await selectSpellingWord(slug);
       }
     } catch (opError) {
-      setWordOperationState({
+      setSpellingOperationState({
         packageId: selectedPackageId,
         action,
         running: false,
         message: '',
-        error: errorEnvelope(opError, 'content_operations_word_operation_failed'),
+        error: errorEnvelope(opError, 'content_operations_spelling_operation_failed'),
       });
     }
   }, [api, loadPackageDetail, loadSpellingBrowse, selectSpellingWord, selectedPackageId]);
@@ -2172,15 +2699,15 @@ export function AdminContentOperationsSection({
           selectedWordSlug={selectedWordSlug}
           selectedPackageId={selectedPackageId}
           canEdit={actorCan(spellingActor, CONTENT_OPERATION_CAPABILITIES.EDIT)}
-          wordOperationAvailable={Boolean(api?.appendOperation)}
-          wordOperationState={wordOperationState}
+          spellingOperationAvailable={Boolean(api?.appendOperation)}
+          spellingOperationState={spellingOperationState}
           loadingBrowse={loadingSpellingBrowse}
           loadingItem={loadingSpellingItem}
           error={spellingError}
           onFilterChange={updateSpellingFilters}
           onApplyFilters={applySpellingFilters}
           onSelectWord={selectSpellingWord}
-          onSubmitWordOperation={runSpellingWordOperation}
+          onSubmitSpellingOperation={runSpellingOperation}
         />
       ) : null}
 

--- a/tests/button-label-consistency.test.js
+++ b/tests/button-label-consistency.test.js
@@ -545,6 +545,12 @@ test('button labels: every statically extractable label is classified', () => {
     'Add variant',
     'Remove variant',
     'Save word',
+    'Edit sentence',
+    'New sentence',
+    'Save sentence',
+    'Edit list',
+    'New list',
+    'Save list',
     // Reasoning launch: delayed SATs-style sets use "Mark set" and "Save
     // answers" to distinguish full-set marking from single-question submit.
     // "Partly worked support" is the child-facing scaffold request, matching

--- a/tests/content-operations-api.test.js
+++ b/tests/content-operations-api.test.js
@@ -80,6 +80,17 @@ async function appendWordExplanationOperation(server, packageId, word, payload) 
   return readPayload(response);
 }
 
+async function appendContentOperation(server, packageId, operation) {
+  const response = await server.fetchAs(
+    ADMIN_ID,
+    `${BASE_URL}/api/admin/content-operations/packages/${packageId}/operations`,
+    jsonInit('POST', { operation }),
+    adminHeaders(),
+  );
+  assert.equal(response.status, 201);
+  return readPayload(response);
+}
+
 async function validatePackage(server, packageId, body = {}) {
   const response = await server.fetchAs(
     ADMIN_ID,
@@ -294,6 +305,138 @@ test('content operations API exposes spelling browse and item detail with packag
     assert.equal(missingSentenceResponse.status, 404);
     assert.equal(missingSentencePayload.code, 'spelling_content_sentence_not_found');
     assert.equal(missingSentencePayload.message, 'Spelling content sentence was not found.');
+  } finally {
+    server.close();
+  }
+});
+
+test('content operations API publishes linked sentence-entry operations through the package workflow', async () => {
+  const server = createWorkerRepositoryServer({ now: () => NOW });
+  try {
+    seedAdultAccount(server.DB, { accountId: ADMIN_ID, platformRole: 'admin' });
+    const repository = createWorkerRepository({
+      env: server.env,
+      now: () => NOW,
+    });
+    await repository.seedFirstContentOperationRelease({
+      seededByAccountId: ADMIN_ID,
+      proof: { source: 'content-operations-api-sentence-test' },
+    });
+    const seeded = await readSeededSpellingContentBundle();
+    const word = seeded.draft.words[0];
+    const sentenceId = `${word.slug}-t11-api-sentence`;
+    const sentenceText = `The ${word.word} sentence was added through content operations.`;
+
+    const created = await createPackage(server, { title: 'API sentence package' });
+    const packageId = created.package.packageId;
+
+    await appendContentOperation(server, packageId, {
+      entityType: 'spelling.sentenceEntry',
+      entityId: sentenceId,
+      fieldPath: '',
+      action: 'upsert',
+      payload: {
+        id: sentenceId,
+        wordSlug: word.slug,
+        text: sentenceText,
+        variantLabel: 'default',
+        tags: ['api-test'],
+        sourceNote: 'Added by content operations API test.',
+        provenance: { source: 'api-test', note: 'T11 linked sentence' },
+      },
+    });
+    await appendContentOperation(server, packageId, {
+      entityType: 'spelling.word',
+      entityId: word.slug,
+      fieldPath: 'sentenceEntryIds',
+      action: 'set',
+      payload: [...word.sentenceEntryIds, sentenceId],
+    });
+
+    const validated = await validatePackage(server, packageId);
+    assert.equal(validated.candidate.validation.status, 'passed');
+
+    await approvePackage(server, packageId, validated.candidate.candidateId);
+    const published = await publishPackage(server, packageId, {
+      includeSnapshot: true,
+      proof: { source: 'content-operations-api-linked-sentence-test' },
+    });
+    const publishedWord = published.release.snapshot.draft.words.find((entry) => entry.slug === word.slug);
+    const publishedSentence = published.release.snapshot.draft.sentences.find((entry) => entry.id === sentenceId);
+
+    assert.ok(publishedWord.sentenceEntryIds.includes(sentenceId));
+    assert.equal(publishedSentence.text, sentenceText);
+    assert.equal(publishedSentence.wordSlug, word.slug);
+  } finally {
+    server.close();
+  }
+});
+
+test('content operations API blocks referenced sentence and active word-list retirements', async () => {
+  const server = createWorkerRepositoryServer({ now: () => NOW });
+  try {
+    seedAdultAccount(server.DB, { accountId: ADMIN_ID, platformRole: 'admin' });
+    const repository = createWorkerRepository({
+      env: server.env,
+      now: () => NOW,
+    });
+    await repository.seedFirstContentOperationRelease({
+      seededByAccountId: ADMIN_ID,
+      proof: { source: 'content-operations-api-retirement-test' },
+    });
+    const seeded = await readSeededSpellingContentBundle();
+    const baseWord = seeded.draft.words.find((entry) => entry.sentenceEntryIds.length);
+    const variantWord = seeded.draft.words.find((entry) => entry.variants?.some((variant) => variant.sentenceEntryIds?.length));
+    const variantSentenceId = variantWord?.variants?.find((variant) => variant.sentenceEntryIds?.length)?.sentenceEntryIds[0];
+    assert.ok(baseWord, 'seeded spelling content should include a base sentence reference');
+    assert.ok(variantWord, 'seeded spelling content should include a variant sentence reference');
+    assert.ok(variantSentenceId, 'seeded variant should include a sentence reference');
+
+    const sentencePackage = await createPackage(server, { title: 'Retire referenced sentence package' });
+    await appendContentOperation(server, sentencePackage.package.packageId, {
+      entityType: 'spelling.sentenceEntry',
+      entityId: baseWord.sentenceEntryIds[0],
+      fieldPath: '',
+      action: 'retire',
+      payload: {
+        reason: 'API test retirement should be blocked.',
+        source: 'content-operations-api-test',
+        retiredAt: NOW,
+      },
+    });
+    await appendContentOperation(server, sentencePackage.package.packageId, {
+      entityType: 'spelling.sentenceEntry',
+      entityId: variantSentenceId,
+      fieldPath: '',
+      action: 'retire',
+      payload: {
+        reason: 'API test variant retirement should be blocked.',
+        source: 'content-operations-api-test',
+        retiredAt: NOW,
+      },
+    });
+    const sentenceValidated = await validatePackage(server, sentencePackage.package.packageId);
+    assert.equal(sentenceValidated.candidate.validation.status, 'blocked');
+    assert.ok(sentenceValidated.candidate.validation.errors.some((entry) => entry.code === 'retired_sentence_reference'));
+    assert.ok(sentenceValidated.candidate.validation.errors.some((entry) => (
+      entry.code === 'retired_sentence_reference' && entry.path.includes('variants')
+    )));
+
+    const listPackage = await createPackage(server, { title: 'Retire active word-list package' });
+    await appendContentOperation(server, listPackage.package.packageId, {
+      entityType: 'spelling.wordList',
+      entityId: baseWord.listId,
+      fieldPath: '',
+      action: 'retire',
+      payload: {
+        reason: 'API test list retirement should be blocked.',
+        source: 'content-operations-api-test',
+        retiredAt: NOW,
+      },
+    });
+    const listValidated = await validatePackage(server, listPackage.package.packageId);
+    assert.equal(listValidated.candidate.validation.status, 'blocked');
+    assert.ok(listValidated.candidate.validation.errors.some((entry) => entry.code === 'retired_word_list_reference'));
   } finally {
     server.close();
   }

--- a/tests/react-admin-content-operations.test.js
+++ b/tests/react-admin-content-operations.test.js
@@ -910,6 +910,254 @@ test('Content Operations Centre spelling word editor appends word upsert operati
   assert.match(result.text, /Word operation saved/);
 });
 
+test('Content Operations Centre spelling sentence editor appends sentence upsert operations', async () => {
+  const output = await runClientEntry(`
+    const { JSDOM } = require('jsdom');
+
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+    const dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
+      url: 'https://ks2.eugnel.uk/admin',
+    });
+    globalThis.window = dom.window;
+    globalThis.document = dom.window.document;
+    globalThis.navigator = dom.window.navigator;
+    globalThis.HTMLElement = dom.window.HTMLElement;
+    globalThis.Event = dom.window.Event;
+
+    const React = require('react');
+    const { createRoot } = require('react-dom/client');
+    const { AdminContentOperationsSection } = require(${CONTENT_OPS_SECTION_PATH});
+    const { act } = React;
+
+    const calls = [];
+    const model = ${JSON.stringify(baseModel({
+      contentOperations: {
+        overview,
+        packages: { packages: [contentPackage] },
+        releases: { releases: [release] },
+        spellingBrowse,
+        spellingItemDetail: null,
+      },
+    }))};
+    const actions = {
+      contentOperationsApi: {
+        async readSpellingWord(args) {
+          calls.push({ method: 'readSpellingWord', args });
+          return ${JSON.stringify(spellingWordDetail)};
+        },
+        async appendOperation(args) {
+          calls.push({ method: 'appendOperation', args });
+          return { ok: true, operation: { operationId: 'op-sentence-save-1', ...args.operation } };
+        },
+      },
+    };
+
+    async function flush() {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+    }
+
+    async function setControl(selector, value) {
+      const control = document.querySelector(selector);
+      const prototype = control.tagName === 'TEXTAREA'
+        ? dom.window.HTMLTextAreaElement.prototype
+        : dom.window.HTMLInputElement.prototype;
+      const valueSetter = Object.getOwnPropertyDescriptor(prototype, 'value').set;
+      valueSetter.call(control, value);
+      await act(async () => {
+        control.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
+        control.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+      });
+    }
+
+    async function main() {
+      const root = createRoot(document.getElementById('root'));
+      await act(async () => {
+        root.render(React.createElement(AdminContentOperationsSection, {
+          model,
+          actions,
+          initialActiveTab: 'spelling',
+          initialSelectedPackageId: 'pkg-draft-1',
+        }));
+      });
+      await flush();
+
+      const wordButton = document.querySelector('[data-content-ops-spelling-word="metamorphosis"]');
+      await act(async () => {
+        wordButton.click();
+      });
+      await flush();
+
+      const newSentenceButton = Array.from(document.querySelectorAll('button'))
+        .find((button) => button.textContent === 'New sentence');
+      await act(async () => {
+        newSentenceButton.click();
+      });
+      await setControl('[data-content-ops-sentence-field="id"]', 'meta-s2');
+      await setControl('[data-content-ops-sentence-field="wordSlug"]', 'metamorphosis');
+      await setControl('[data-content-ops-sentence-field="text"]', 'The moth completes metamorphosis in the summer.');
+      await setControl('[data-content-ops-sentence-field="variantLabel"]', 'default');
+      await setControl('[data-content-ops-sentence-field="tags"]', 'dictation, extra');
+      await setControl('[data-content-ops-sentence-field="sourceNote"]', 'Added in Content Operations Centre.');
+      await setControl('[data-content-ops-sentence-field="provenanceSource"]', 'admin-editor');
+      const saveButton = Array.from(document.querySelectorAll('button'))
+        .find((button) => button.textContent === 'Save sentence');
+      await act(async () => {
+        saveButton.click();
+      });
+      await flush();
+      await flush();
+
+      process.stdout.write(JSON.stringify({
+        calls,
+        text: document.body.textContent,
+      }));
+
+      await act(async () => {
+        root.unmount();
+      });
+      dom.window.close();
+      process.exit(0);
+    }
+
+    main().catch((error) => {
+      process.stderr.write(error.stack || error.message);
+      process.exitCode = 1;
+    });
+  `);
+  const result = JSON.parse(output);
+  const appendCall = result.calls.find((entry) => entry.method === 'appendOperation');
+
+  assert.ok(appendCall, 'sentence editor should append an operation');
+  assert.equal(appendCall.args.packageId, 'pkg-draft-1');
+  assert.equal(appendCall.args.operation.entityType, 'spelling.sentenceEntry');
+  assert.equal(appendCall.args.operation.action, 'upsert');
+  assert.equal(appendCall.args.operation.entityId, 'meta-s2');
+  assert.equal(appendCall.args.operation.payload.wordSlug, 'metamorphosis');
+  assert.equal(appendCall.args.operation.payload.text, 'The moth completes metamorphosis in the summer.');
+  assert.deepEqual(appendCall.args.operation.payload.tags, ['dictation', 'extra']);
+  assert.equal(appendCall.args.mutation.requestId.startsWith('content-ops-sentence-upsert-pkg-draft-1-'), true);
+  assert.match(result.text, /Sentence operation saved/);
+});
+
+test('Content Operations Centre spelling word-list editor appends list upsert operations', async () => {
+  const output = await runClientEntry(`
+    const { JSDOM } = require('jsdom');
+
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+    const dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
+      url: 'https://ks2.eugnel.uk/admin',
+    });
+    globalThis.window = dom.window;
+    globalThis.document = dom.window.document;
+    globalThis.navigator = dom.window.navigator;
+    globalThis.HTMLElement = dom.window.HTMLElement;
+    globalThis.Event = dom.window.Event;
+
+    const React = require('react');
+    const { createRoot } = require('react-dom/client');
+    const { AdminContentOperationsSection } = require(${CONTENT_OPS_SECTION_PATH});
+    const { act } = React;
+
+    const calls = [];
+    const model = ${JSON.stringify(baseModel({
+      contentOperations: {
+        overview,
+        packages: { packages: [contentPackage] },
+        releases: { releases: [release] },
+        spellingBrowse,
+        spellingItemDetail: spellingWordDetail,
+      },
+    }))};
+    const actions = {
+      contentOperationsApi: {
+        async readSpellingWord(args) {
+          calls.push({ method: 'readSpellingWord', args });
+          return ${JSON.stringify(spellingWordDetail)};
+        },
+        async appendOperation(args) {
+          calls.push({ method: 'appendOperation', args });
+          return { ok: true, operation: { operationId: 'op-list-save-1', ...args.operation } };
+        },
+      },
+    };
+
+    async function flush() {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+    }
+
+    async function setControl(selector, value) {
+      const control = document.querySelector(selector);
+      const prototype = control.tagName === 'TEXTAREA'
+        ? dom.window.HTMLTextAreaElement.prototype
+        : dom.window.HTMLInputElement.prototype;
+      const valueSetter = Object.getOwnPropertyDescriptor(prototype, 'value').set;
+      valueSetter.call(control, value);
+      await act(async () => {
+        control.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
+        control.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+      });
+    }
+
+    async function main() {
+      const root = createRoot(document.getElementById('root'));
+      await act(async () => {
+        root.render(React.createElement(AdminContentOperationsSection, {
+          model,
+          actions,
+          initialActiveTab: 'spelling',
+          initialSelectedPackageId: 'pkg-draft-1',
+        }));
+      });
+      await flush();
+
+      await setControl('[data-content-ops-word-list-field="title"]', 'Extra Greek roots revised');
+      await setControl('[data-content-ops-word-list-field="wordSlugs"]', 'metamorphosis');
+      await setControl('[data-content-ops-word-list-field="sourceNote"]', 'Edited in Content Operations Centre.');
+      await setControl('[data-content-ops-word-list-field="provenanceSource"]', 'admin-editor');
+      const saveButton = Array.from(document.querySelectorAll('button'))
+        .find((button) => button.textContent === 'Save list');
+      await act(async () => {
+        saveButton.click();
+      });
+      await flush();
+      await flush();
+
+      process.stdout.write(JSON.stringify({
+        calls,
+        text: document.body.textContent,
+      }));
+
+      await act(async () => {
+        root.unmount();
+      });
+      dom.window.close();
+      process.exit(0);
+    }
+
+    main().catch((error) => {
+      process.stderr.write(error.stack || error.message);
+      process.exitCode = 1;
+    });
+  `);
+  const result = JSON.parse(output);
+  const appendCall = result.calls.find((entry) => entry.method === 'appendOperation');
+
+  assert.ok(appendCall, 'word-list editor should append an operation');
+  assert.equal(appendCall.args.packageId, 'pkg-draft-1');
+  assert.equal(appendCall.args.operation.entityType, 'spelling.wordList');
+  assert.equal(appendCall.args.operation.action, 'upsert');
+  assert.equal(appendCall.args.operation.entityId, 'extra-greek');
+  assert.equal(appendCall.args.operation.payload.title, 'Extra Greek roots revised');
+  assert.deepEqual(appendCall.args.operation.payload.wordSlugs, ['metamorphosis']);
+  assert.equal(Object.prototype.hasOwnProperty.call(appendCall.args.operation.payload, 'sentences'), false);
+  assert.equal(appendCall.args.mutation.requestId.startsWith('content-ops-word-list-upsert-pkg-draft-1-'), true);
+  assert.match(result.text, /Word list operation saved/);
+});
+
 test('Content Operations Centre spelling tab reloads browse data after package selection changes', async () => {
   const packageB = {
     ...contentPackage,

--- a/tests/spelling-content-operations-model.test.js
+++ b/tests/spelling-content-operations-model.test.js
@@ -14,8 +14,14 @@ import {
   buildPublishedSnapshotFromDraft,
 } from '../src/subjects/spelling/content/model.js';
 import {
+  buildSpellingSentenceDeleteOrRetireOperation,
+  buildSpellingSentenceUpsertOperation,
+  buildSpellingWordListDeleteOrRetireOperation,
+  buildSpellingWordListUpsertOperation,
   buildSpellingWordDeleteOrRetireOperation,
   buildSpellingWordUpsertOperation,
+  validateSpellingSentenceEditorInput,
+  validateSpellingWordListEditorInput,
   validateSpellingWordEditorInput,
 } from '../src/subjects/spelling/content/package-operations.js';
 
@@ -193,6 +199,33 @@ test('spelling content operations browse filters by variant words and accepted s
   assert.deepEqual(browse.words.map((row) => row.slug), ['metamorphosis']);
   assert.deepEqual(browse.words[0].variantWords, ['metamorphic']);
   assert.deepEqual(browse.words[0].variantAccepted, ['metamorphic']);
+});
+
+test('spelling content operations browse keeps retired words out of active pool and list totals', () => {
+  const retiredBundle = contentBundle();
+  retiredBundle.draft.words = retiredBundle.draft.words.map((word) => (
+    word.slug === 'alpha'
+      ? {
+          ...word,
+          active: false,
+          retired: true,
+          retirement: { reason: 'Retired by test.', source: 'test', retiredAt: NOW },
+        }
+      : word
+  ));
+  const browse = buildSpellingContentBrowseModel({
+    publishedContent: retiredBundle,
+    filters: { pool: 'all', limit: 20 },
+  });
+  const corePool = browse.pools.find((pool) => pool.pool === 'core');
+  const coreList = browse.wordLists.find((list) => list.id === 'core-y34');
+  const retiredRow = browse.words.find((row) => row.slug === 'alpha');
+
+  assert.equal(corePool.wordCount, 1);
+  assert.equal(corePool.totalWordCount, 2);
+  assert.equal(coreList.wordCount, 1);
+  assert.equal(coreList.totalWordCount, 2);
+  assert.equal(retiredRow.retired, true);
 });
 
 test('spelling content operations browse marks package draft additions and modifications', () => {
@@ -414,4 +447,129 @@ test('spelling word delete-or-retire operation hard deletes drafts and retires p
   assert.equal(retiredAlpha.retirement.reason, 'Retired by test.');
   assert.equal(snapshot.words.some((word) => word.slug === 'alpha'), false);
   assert.equal(snapshot.words.some((word) => word.slug === 'beta'), true);
+});
+
+test('spelling sentence editor builder creates stable-id sentence upsert operations', () => {
+  const bundle = contentBundle();
+  const operation = buildSpellingSentenceUpsertOperation({
+    id: 'alpha-s3',
+    wordSlug: 'alpha',
+    text: 'A third alpha sentence gives editors another dictation choice.',
+    variantLabel: 'default',
+    tags: 'dictation, core',
+    sourceNote: 'Added in Content Operations Centre.',
+    provenance: { source: 'admin-editor', note: 'T11 sentence test' },
+  }, {
+    words: bundle.draft.words,
+  });
+  const candidate = buildSpellingContentOperationCandidate(bundle, [operation]);
+
+  assert.equal(operation.entityType, 'spelling.sentenceEntry');
+  assert.equal(operation.action, 'upsert');
+  assert.equal(operation.entityId, 'alpha-s3');
+  assert.deepEqual(operation.payload.tags, ['dictation', 'core']);
+  assert.equal(candidate.validation.ok, true);
+  assert.equal(
+    candidate.candidate.draft.sentences.find((sentence) => sentence.id === 'alpha-s3').text,
+    'A third alpha sentence gives editors another dictation choice.',
+  );
+});
+
+test('spelling sentence editor validation blocks missing text, owner, and provenance', () => {
+  const bundle = contentBundle();
+  const result = validateSpellingSentenceEditorInput({
+    id: 'alpha-s4',
+    wordSlug: 'missing-word',
+    text: '',
+  }, {
+    words: bundle.draft.words,
+  });
+
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((entry) => entry.field === 'wordSlug'));
+  assert.ok(result.errors.some((entry) => entry.field === 'text'));
+  assert.ok(result.errors.some((entry) => entry.field === 'provenance'));
+});
+
+test('spelling sentence delete-or-retire operation removes drafts and blocks retiring active references', () => {
+  const bundle = contentBundle();
+  const draftDelete = buildSpellingSentenceDeleteOrRetireOperation({ id: 'draft-sentence' });
+  const retire = buildSpellingSentenceDeleteOrRetireOperation({ id: 'alpha-s1', hasCurrent: true }, {
+    reason: 'Retired by test.',
+    now: () => NOW,
+  });
+  const candidate = buildSpellingContentOperationCandidate(bundle, [retire]);
+  const retiredSentence = candidate.candidate.draft.sentences.find((sentence) => sentence.id === 'alpha-s1');
+
+  assert.equal(draftDelete.action, 'remove');
+  assert.equal(retire.action, 'retire');
+  assert.equal(retiredSentence.active, false);
+  assert.equal(retiredSentence.retired, true);
+  assert.equal(retiredSentence.retirement.reason, 'Retired by test.');
+  assert.equal(candidate.validation.ok, false);
+  assert.ok(candidate.validation.errors.some((entry) => entry.code === 'retired_sentence_reference'));
+});
+
+test('spelling word-list editor builder manages list metadata and membership without sentence text', () => {
+  const bundle = contentBundle();
+  const operation = buildSpellingWordListUpsertOperation({
+    id: 'extra-greek',
+    title: 'Extra Greek roots revised',
+    spellingPool: 'extra',
+    coverageTier: 'enrichment-extra',
+    wordSlugs: 'metamorphosis',
+    tags: 'roots, enrichment',
+    sourceNote: 'Edited in Content Operations Centre.',
+    provenance: { source: 'admin-editor', note: 'T11 list test' },
+  }, {
+    existingWordList: bundle.draft.wordLists.find((list) => list.id === 'extra-greek'),
+    words: bundle.draft.words,
+  });
+  const candidate = buildSpellingContentOperationCandidate(bundle, [operation]);
+  const list = candidate.candidate.draft.wordLists.find((entry) => entry.id === 'extra-greek');
+
+  assert.equal(operation.entityType, 'spelling.wordList');
+  assert.equal(operation.action, 'upsert');
+  assert.deepEqual(operation.payload.wordSlugs, ['metamorphosis']);
+  assert.equal(Object.prototype.hasOwnProperty.call(operation.payload, 'sentences'), false);
+  assert.equal(candidate.validation.ok, true);
+  assert.equal(list.title, 'Extra Greek roots revised');
+});
+
+test('spelling word-list editor validation blocks missing metadata and invalid membership', () => {
+  const bundle = contentBundle();
+  const result = validateSpellingWordListEditorInput({
+    id: 'core-empty',
+    title: '',
+    spellingPool: 'core',
+    coverageTier: 'statutory-core',
+    wordSlugs: 'missing-word',
+  }, {
+    words: bundle.draft.words,
+  });
+
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((entry) => entry.field === 'title'));
+  assert.ok(result.errors.some((entry) => entry.field === 'yearGroups'));
+  assert.ok(result.errors.some((entry) => entry.field === 'wordSlugs'));
+  assert.ok(result.errors.some((entry) => entry.field === 'provenance'));
+});
+
+test('spelling word-list delete-or-retire operation removes drafts and blocks retiring active lists', () => {
+  const bundle = contentBundle();
+  const draftDelete = buildSpellingWordListDeleteOrRetireOperation({ id: 'draft-list' });
+  const retire = buildSpellingWordListDeleteOrRetireOperation({ id: 'core-y34', hasCurrent: true }, {
+    reason: 'Retired by test.',
+    now: () => NOW,
+  });
+  const candidate = buildSpellingContentOperationCandidate(bundle, [retire]);
+  const retiredList = candidate.candidate.draft.wordLists.find((list) => list.id === 'core-y34');
+
+  assert.equal(draftDelete.action, 'remove');
+  assert.equal(retire.action, 'retire');
+  assert.equal(retiredList.active, false);
+  assert.equal(retiredList.retired, true);
+  assert.equal(retiredList.retirement.reason, 'Retired by test.');
+  assert.equal(candidate.validation.ok, false);
+  assert.ok(candidate.validation.errors.some((entry) => entry.code === 'retired_word_list_reference'));
 });


### PR DESCRIPTION
Summary
- Add spelling sentence and word-list operation builders for Content Operations packages.
- Surface sentence and word-list editor forms in the spelling admin browse panel.
- Preserve retired/provenance metadata in spelling read models and block retired sentence/list references during package validation.

Tests
- node --test tests/spelling-content-operations-model.test.js tests/react-admin-content-operations.test.js tests/content-operations-api.test.js tests/button-label-consistency.test.js
- node --test tests/content-operations-repository.test.js tests/admin-content-operations-v2.test.js tests/button-label-consistency.test.js
- npm test
- npm run check
- pre-push npm test