### PR TITLE
T12: add spelling pool editorial manager

### DIFF
--- a/src/platform/hubs/admin-content-operations.js
+++ b/src/platform/hubs/admin-content-operations.js
@@ -348,13 +348,33 @@ function normaliseSpellingWordList(row = null) {
 
 function normaliseSpellingPoolSummary(row = null) {
   const safe = isPlainObject(row) ? row : {};
+  const visibility = isPlainObject(safe.visibility) ? safe.visibility : {};
+  const poolId = asString(safe.id || safe.pool, 'core');
   return {
-    pool: asString(safe.pool, 'core'),
+    id: poolId,
+    pool: poolId,
+    title: asString(safe.title, poolId),
+    type: asString(safe.type, 'custom'),
+    visibility: {
+      state: asString(visibility.state, 'hidden'),
+      learnerVisible: Boolean(visibility.learnerVisible),
+      scheduledAt: asTs(visibility.scheduledAt),
+      rolloutFlag: asString(visibility.rolloutFlag),
+    },
+    sourceNote: asString(safe.sourceNote),
+    provenance: isPlainObject(safe.provenance) ? { ...safe.provenance } : null,
+    tags: asArray(safe.tags),
+    active: safe.active === false ? false : true,
+    retired: Boolean(safe.retired),
+    retirement: isPlainObject(safe.retirement) ? { ...safe.retirement } : null,
+    noRewardException: isPlainObject(safe.noRewardException) ? { ...safe.noRewardException } : null,
+    rewardTrack: isPlainObject(safe.rewardTrack) ? { ...safe.rewardTrack } : null,
     wordCount: Number(safe.wordCount) || 0,
     totalWordCount: Number(safe.totalWordCount ?? safe.wordCount) || 0,
     sentenceCount: Number(safe.sentenceCount) || 0,
     variantCount: Number(safe.variantCount) || 0,
     draftStateCounts: isPlainObject(safe.draftStateCounts) ? { ...safe.draftStateCounts } : {},
+    draftState: asString(safe.draftState, 'unchanged'),
   };
 }
 

--- a/src/subjects/spelling/content/editor-read-model.js
+++ b/src/subjects/spelling/content/editor-read-model.js
@@ -27,6 +27,10 @@ function asString(value, fallback = '') {
   return typeof value === 'string' && value.trim() ? value.trim() : fallback;
 }
 
+function isValidPoolId(value) {
+  return typeof value === 'string' && /^[a-z][a-z0-9-]{1,63}$/.test(value) && value !== 'all';
+}
+
 function normaliseLimit(value) {
   const limit = Number(value);
   if (!Number.isFinite(limit) || limit <= 0) return DEFAULT_BROWSE_LIMIT;
@@ -38,7 +42,7 @@ function normaliseFilters(filters = {}) {
   const pool = asString(safe.pool || safe.spellingPool, 'all').toLowerCase();
   return {
     query: asString(safe.query || safe.q).toLowerCase(),
-    pool: ['core', 'extra'].includes(pool) ? pool : 'all',
+    pool: isValidPoolId(pool) ? pool : 'all',
     listId: asString(safe.listId),
     limit: normaliseLimit(safe.limit),
   };
@@ -60,10 +64,11 @@ function validationSummary(validation = null) {
 }
 
 function draftMaps(bundle) {
+  const poolsById = new Map(bundle.draft.pools.map((entry) => [entry.id, entry]));
   const wordListsById = new Map(bundle.draft.wordLists.map((entry) => [entry.id, entry]));
   const wordsBySlug = new Map(bundle.draft.words.map((entry) => [entry.slug, entry]));
   const sentencesById = new Map(bundle.draft.sentences.map((entry) => [entry.id, entry]));
-  return { wordListsById, wordsBySlug, sentencesById };
+  return { poolsById, wordListsById, wordsBySlug, sentencesById };
 }
 
 function sentenceEntriesForWord(word, maps) {
@@ -205,6 +210,51 @@ function compactWordList(list, wordCount, draftState = 'unchanged', totalWordCou
     wordCount,
     totalWordCount,
     draftState,
+  };
+}
+
+function compactPool(pool, rows, draftState = 'unchanged') {
+  const poolRows = rows.filter((row) => row.spellingPool === pool.id);
+  const activePoolRows = pool.active !== false && !pool.retired && pool.visibility?.state === 'visible'
+    ? poolRows.filter((row) => row.active !== false && !row.retired)
+    : [];
+  return {
+    id: pool.id,
+    pool: pool.id,
+    title: pool.title,
+    type: pool.type || 'custom',
+    visibility: pool.visibility || { state: 'hidden', learnerVisible: false },
+    sourceNote: pool.sourceNote || '',
+    provenance: pool.provenance || null,
+    tags: asArray(pool.tags),
+    active: pool.active !== false,
+    retired: Boolean(pool.retired),
+    retirement: pool.retirement || null,
+    noRewardException: pool.noRewardException || null,
+    rewardTrack: pool.rewardTrack || null,
+    wordCount: activePoolRows.length,
+    totalWordCount: poolRows.length,
+    sentenceCount: activePoolRows.reduce((sum, row) => sum + row.sentenceCount + row.variantSentenceCount, 0),
+    variantCount: activePoolRows.reduce((sum, row) => sum + row.variantCount, 0),
+    draftStateCounts: draftStateCounts(poolRows),
+    draftState,
+    sortIndex: Number.isInteger(Number(pool.sortIndex)) ? Number(pool.sortIndex) : 0,
+  };
+}
+
+function comparablePool(pool) {
+  if (!pool) return null;
+  return {
+    id: pool.id,
+    title: pool.title,
+    type: pool.type,
+    visibility: pool.visibility || null,
+    sourceNote: pool.sourceNote || '',
+    tags: asArray(pool.tags),
+    active: pool.active !== false,
+    retired: Boolean(pool.retired),
+    noRewardException: pool.noRewardException || null,
+    rewardTrack: pool.rewardTrack || null,
   };
 }
 
@@ -352,19 +402,22 @@ function draftStateCounts(rows) {
   return counts;
 }
 
-function poolSummaries(rows) {
-  return ['core', 'extra'].map((pool) => {
-    const poolRows = rows.filter((row) => row.spellingPool === pool);
-    const activePoolRows = poolRows.filter((row) => row.active !== false && !row.retired);
-    return {
-      pool,
-      wordCount: activePoolRows.length,
-      totalWordCount: poolRows.length,
-      sentenceCount: activePoolRows.reduce((sum, row) => sum + row.sentenceCount + row.variantSentenceCount, 0),
-      variantCount: activePoolRows.reduce((sum, row) => sum + row.variantCount, 0),
-      draftStateCounts: draftStateCounts(poolRows),
-    };
-  });
+function poolSummaries({ currentBundle, packageBundle, currentMaps, packageMaps, rows }) {
+  const poolIds = new Set([
+    ...currentBundle.draft.pools.map((entry) => entry.id),
+    ...asArray(packageBundle?.draft?.pools).map((entry) => entry.id),
+    ...rows.map((row) => row.spellingPool),
+  ]);
+  return [...poolIds].map((id) => {
+    const currentPool = currentMaps.poolsById.get(id) || null;
+    const packagePool = packageMaps?.poolsById.get(id) || null;
+    const display = packagePool || currentPool || { id, title: id, type: 'custom', visibility: { state: 'hidden' } };
+    return compactPool(
+      display,
+      rows,
+      packageBundle ? packageDraftState(comparablePool(currentPool), comparablePool(packagePool)) : 'unchanged',
+    );
+  }).sort((left, right) => left.sortIndex - right.sortIndex || left.title.localeCompare(right.title));
 }
 
 function compactWordLists({ currentBundle, packageBundle, currentMaps, packageMaps }) {
@@ -379,7 +432,12 @@ function compactWordLists({ currentBundle, packageBundle, currentMaps, packageMa
     const packageList = packageMaps?.wordListsById.get(id) || null;
     const display = packageList || currentList;
     const listWords = displayBundle.draft.words.filter((word) => word.listId === id);
-    const wordCount = listWords.filter((word) => word.active !== false && !word.retired).length;
+    const pool = displayMaps.poolsById.get(display?.spellingPool) || null;
+    const poolLearnerVisible = !pool || (pool.active !== false && !pool.retired && pool.visibility?.state === 'visible');
+    const listLearnerVisible = display?.active !== false && !display?.retired && poolLearnerVisible;
+    const wordCount = listLearnerVisible
+      ? listWords.filter((word) => word.active !== false && !word.retired).length
+      : 0;
     return compactWordList(
       display,
       wordCount,
@@ -497,7 +555,13 @@ export function buildSpellingContentBrowseModel({
       families: new Set(displayBundle.draft.words.map((word) => `${word.spellingPool}:${word.coverageTier}:${word.family}`)).size,
     },
     draftStateCounts: draftStateCounts(rows),
-    pools: poolSummaries(rows),
+    pools: poolSummaries({
+      currentBundle,
+      packageBundle,
+      currentMaps,
+      packageMaps,
+      rows,
+    }),
     wordLists: compactWordLists({
       currentBundle,
       packageBundle,

--- a/src/subjects/spelling/content/model.js
+++ b/src/subjects/spelling/content/model.js
@@ -17,16 +17,36 @@ export const SPELLING_CONTENT_SUBJECT_ID = 'spelling';
  * a cached bundle — runtime consumers treat `modelVersion < MODEL_VERSION`
  * as "normalise and rewrite" on next save.
  */
-export const SPELLING_CONTENT_MODEL_VERSION = 6;
+export const SPELLING_CONTENT_MODEL_VERSION = 8;
 export const SPELLING_CONTENT_EXPORT_KIND = 'ks2-spelling-content';
 export const SPELLING_CONTENT_EXPORT_VERSION = 1;
 export const SPELLING_CONTENT_POOLS = Object.freeze(['core', 'extra']);
 
 const VALID_YEAR_GROUPS = new Set(['Y3', 'Y4', 'Y5', 'Y6']);
-const VALID_SPELLING_POOLS = new Set(SPELLING_CONTENT_POOLS);
+const LEGACY_SPELLING_POOLS = new Set(SPELLING_CONTENT_POOLS);
 const VALID_DRAFT_STATES = new Set(['draft']);
 const VALID_RELEASE_STATES = new Set(['published']);
+const VALID_POOL_TYPES = new Set(['statutory', 'enrichment', 'extension', 'custom']);
+const VALID_POOL_VISIBILITY_STATES = new Set(['visible', 'hidden', 'staged']);
+const RESERVED_POOL_IDS = new Set(['all']);
 const MIN_WORD_EXPLANATION_LENGTH = 12;
+
+const DEFAULT_POOL_METADATA = Object.freeze({
+  core: Object.freeze({
+    id: 'core',
+    title: 'Core spelling',
+    type: 'statutory',
+    visibility: Object.freeze({ state: 'visible' }),
+    sourceNote: 'Bundled legacy core spelling pool.',
+  }),
+  extra: Object.freeze({
+    id: 'extra',
+    title: 'Extra spelling',
+    type: 'enrichment',
+    visibility: Object.freeze({ state: 'visible' }),
+    sourceNote: 'Bundled legacy extra spelling pool.',
+  }),
+});
 
 function isPlainObject(value) {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
@@ -36,10 +56,21 @@ function normaliseString(value, fallback = '') {
   return typeof value === 'string' ? value.trim() || fallback : fallback;
 }
 
-function normaliseSpellingPool(value, fallback = 'core') {
-  const safeFallback = VALID_SPELLING_POOLS.has(fallback) ? fallback : 'core';
+function isValidPoolId(value) {
+  return typeof value === 'string'
+    && /^[a-z][a-z0-9-]{1,63}$/.test(value)
+    && !RESERVED_POOL_IDS.has(value);
+}
+
+function normalisePoolIdCandidate(value, fallback = '') {
   const candidate = normaliseString(value).toLowerCase();
-  return VALID_SPELLING_POOLS.has(candidate) ? candidate : safeFallback;
+  return candidate || fallback;
+}
+
+function normaliseSpellingPool(value, fallback = 'core') {
+  const safeFallback = isValidPoolId(fallback) ? fallback : 'core';
+  const candidate = normaliseString(value).toLowerCase();
+  return isValidPoolId(candidate) ? candidate : safeFallback;
 }
 
 function normaliseTimestamp(value, fallback = 0) {
@@ -136,6 +167,88 @@ function normaliseRetirement(rawValue = null) {
   };
 }
 
+function defaultCoverageTierForPool(poolId, pool = null) {
+  if (poolId === 'core') return 'statutory-core';
+  if (poolId === 'extra' || pool?.type === 'enrichment') return 'enrichment-extra';
+  return 'secure-extension';
+}
+
+function normalisePoolVisibility(rawValue = null, fallback = null) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  const safeFallback = isPlainObject(fallback) ? fallback : {};
+  const state = VALID_POOL_VISIBILITY_STATES.has(normaliseString(raw.state).toLowerCase())
+    ? normaliseString(raw.state).toLowerCase()
+    : (VALID_POOL_VISIBILITY_STATES.has(normaliseString(safeFallback.state).toLowerCase())
+        ? normaliseString(safeFallback.state).toLowerCase()
+        : 'hidden');
+  return {
+    state,
+    learnerVisible: state === 'visible',
+    scheduledAt: normaliseTimestamp(raw.scheduledAt ?? safeFallback.scheduledAt, 0),
+    rolloutFlag: normaliseString(raw.rolloutFlag, safeFallback.rolloutFlag || ''),
+  };
+}
+
+function normaliseNoRewardException(rawValue = null) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  return {
+    approved: raw.approved === true,
+    reason: normaliseString(raw.reason),
+    approvedBy: normaliseString(raw.approvedBy),
+    approvedAt: normaliseTimestamp(raw.approvedAt, 0),
+  };
+}
+
+function normaliseRewardTrack(rawValue = null) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  return {
+    id: normaliseString(raw.id || raw.rewardTrackId || raw.trackId),
+    approved: raw.approved === true,
+    source: normaliseString(raw.source),
+    note: normaliseString(raw.note),
+    approvedBy: normaliseString(raw.approvedBy),
+    approvedAt: normaliseTimestamp(raw.approvedAt, 0),
+  };
+}
+
+function normaliseSpellingPoolMetadata(rawValue, index = 0) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  const id = normalisePoolIdCandidate(raw.id || raw.pool || raw.spellingPool, index === 0 ? 'core' : `pool-${index + 1}`);
+  const defaults = DEFAULT_POOL_METADATA[id] || {};
+  const typeCandidate = normaliseString(raw.type || raw.poolType, defaults.type || 'custom').toLowerCase();
+  const type = VALID_POOL_TYPES.has(typeCandidate) ? typeCandidate : 'custom';
+  return {
+    id,
+    title: normaliseString(raw.title, defaults.title || `Pool ${index + 1}`),
+    type,
+    sourceNote: normaliseString(raw.sourceNote, defaults.sourceNote || ''),
+    provenance: normaliseProvenance(raw.provenance, raw.sourceNote || defaults.sourceNote || 'spelling pool'),
+    visibility: normalisePoolVisibility(raw.visibility, defaults.visibility || { state: 'hidden' }),
+    tags: normaliseTags(raw.tags),
+    active: raw.active === false ? false : true,
+    retired: Boolean(raw.retired),
+    ...(raw.retired || raw.active === false || raw.retirement ? { retirement: normaliseRetirement(raw.retirement) } : {}),
+    ...(raw.noRewardException ? { noRewardException: normaliseNoRewardException(raw.noRewardException) } : {}),
+    ...(raw.rewardTrack ? { rewardTrack: normaliseRewardTrack(raw.rewardTrack) } : {}),
+    sortIndex: Number.isInteger(Number(raw.sortIndex)) && Number(raw.sortIndex) >= 0 ? Number(raw.sortIndex) : index,
+  };
+}
+
+function normalisePoolCollection(rawPools) {
+  const sources = [];
+  const seen = new Set();
+  const remember = (entry) => {
+    const rawPool = entry?.id || entry?.pool || entry?.spellingPool;
+    const pool = normalisePoolIdCandidate(rawPool, normaliseSpellingPool(rawPool, sources.length === 0 ? 'core' : `pool-${sources.length + 1}`));
+    if (seen.has(pool)) return;
+    seen.add(pool);
+    sources.push({ ...(DEFAULT_POOL_METADATA[pool] || {}), ...(isPlainObject(entry) ? entry : {}), id: pool });
+  };
+  if (Array.isArray(rawPools)) rawPools.forEach(remember);
+  SPELLING_CONTENT_POOLS.forEach((id) => remember(DEFAULT_POOL_METADATA[id]));
+  return sources.map((entry, index) => normaliseSpellingPoolMetadata(entry, index));
+}
+
 function yearBandFromGroups(yearGroups) {
   const groups = normaliseYearGroups(yearGroups);
   const y34 = groups.filter((entry) => entry === 'Y3' || entry === 'Y4');
@@ -154,14 +267,18 @@ function familyKeyForRuntime(word) {
   return `${word.spellingPool || 'core'}::${coverageTierForWord(word)}::${word.year}::${word.family}`;
 }
 
-function normaliseWordList(rawValue, index = 0) {
+function normaliseWordList(rawValue, index = 0, poolsById = new Map()) {
   const raw = isPlainObject(rawValue) ? rawValue : {};
   const spellingPool = normaliseSpellingPool(raw.spellingPool);
+  const pool = poolsById.get(spellingPool) || null;
   return {
     id: normaliseString(raw.id, `list-${index + 1}`),
     title: normaliseString(raw.title, `Word list ${index + 1}`),
     spellingPool,
-    coverageTier: normaliseCoverageTier(raw.coverageTier, { spellingPool }),
+    coverageTier: normaliseCoverageTier(raw.coverageTier, {
+      spellingPool,
+      fallback: defaultCoverageTierForPool(spellingPool, pool),
+    }),
     yearGroups: normaliseYearGroups(raw.yearGroups),
     tags: normaliseTags(raw.tags),
     wordSlugs: uniqueStrings(raw.wordSlugs, { lowerCase: true }),
@@ -327,7 +444,9 @@ function normalisePublishedSnapshot(rawValue) {
 function normaliseDraft(rawValue) {
   const raw = isPlainObject(rawValue) ? rawValue : {};
   const updatedAt = normaliseTimestamp(raw.updatedAt, 0);
-  const wordLists = (Array.isArray(raw.wordLists) ? raw.wordLists : []).map((entry, index) => normaliseWordList(entry, index));
+  const pools = normalisePoolCollection(raw.pools);
+  const poolsById = new Map(pools.map((pool) => [pool.id, pool]));
+  const wordLists = (Array.isArray(raw.wordLists) ? raw.wordLists : []).map((entry, index) => normaliseWordList(entry, index, poolsById));
   const wordListsById = new Map(wordLists.map((list) => [list.id, list]));
   return {
     id: normaliseString(raw.id, 'main'),
@@ -339,6 +458,7 @@ function normaliseDraft(rawValue) {
     provenance: normaliseProvenance(raw.provenance, raw.sourceNote || 'spelling draft'),
     createdAt: normaliseTimestamp(raw.createdAt, updatedAt),
     updatedAt,
+    pools,
     wordLists,
     words: (Array.isArray(raw.words) ? raw.words : []).map((entry, index) => normaliseWordEntry(entry, index, wordListsById)),
     sentences: (Array.isArray(raw.sentences) ? raw.sentences : []).map((entry, index) => normaliseSentenceEntry(entry, index)),
@@ -440,6 +560,7 @@ export function validateSpellingContentBundle(rawBundle) {
   const errors = [];
   const warnings = [];
   const wordListsById = new Map();
+  const poolsById = new Map();
   const wordsBySlug = new Map();
   const wordTextKeys = new Set();
   const sentencesById = new Map();
@@ -454,9 +575,34 @@ export function validateSpellingContentBundle(rawBundle) {
     errors.push(issue('error', 'invalid_publish_state', 'draft.state', 'Draft content must use the state "draft".'));
   }
 
-  if (!bundle.draft.wordLists.length) {
-    warnings.push(issue('warn', 'missing_word_lists', 'draft.wordLists', 'No word lists are defined in the draft.'));
-  }
+  bundle.draft.pools.forEach((pool, index) => {
+    if (poolsById.has(pool.id)) {
+      errors.push(issue('error', 'duplicate_pool', `draft.pools[${index}]`, `Duplicate pool id "${pool.id}".`));
+      return;
+    }
+    poolsById.set(pool.id, pool);
+    if (!isValidPoolId(pool.id)) {
+      errors.push(issue('error', 'invalid_pool_id', `draft.pools[${index}].id`, `Pool "${pool.id}" must use a stable lowercase id.`));
+    }
+    if (!pool.title) {
+      errors.push(issue('error', 'missing_pool_metadata', `draft.pools[${index}].title`, `Pool "${pool.id}" is missing a title.`));
+    }
+    if (!VALID_POOL_TYPES.has(pool.type)) {
+      errors.push(issue('error', 'missing_pool_metadata', `draft.pools[${index}].type`, `Pool "${pool.id}" is missing a valid type.`));
+    }
+    if (pool.id !== 'core' && pool.type === 'statutory') {
+      errors.push(issue('error', 'pool_type_mismatch', `draft.pools[${index}].type`, `Only the core pool can use statutory type.`));
+    }
+    if (pool.retired && pool.visibility?.state === 'visible') {
+      warnings.push(issue('warn', 'retired_pool_visible', `draft.pools[${index}].visibility.state`, `Retired pool "${pool.id}" keeps visible metadata for history but is hidden from new sessions.`));
+    }
+    const learnerVisible = pool.active !== false && !pool.retired && pool.visibility?.state === 'visible';
+    const noRewardApproved = pool.noRewardException?.approved === true;
+    const rewardTrackApproved = pool.rewardTrack?.approved === true;
+    if (learnerVisible && !LEGACY_SPELLING_POOLS.has(pool.id) && !noRewardApproved && !rewardTrackApproved) {
+      errors.push(issue('error', 'pool_reward_required', `draft.pools[${index}].visibility.state`, `Learner-visible pool "${pool.id}" requires a reward track or approved no-reward exception before publish.`));
+    }
+  });
 
   bundle.draft.wordLists.forEach((list, index) => {
     if (wordListsById.has(list.id)) {
@@ -464,6 +610,12 @@ export function validateSpellingContentBundle(rawBundle) {
       return;
     }
     wordListsById.set(list.id, list);
+    const pool = poolsById.get(list.spellingPool);
+    if (!pool) {
+      errors.push(issue('error', 'missing_pool', `draft.wordLists[${index}].spellingPool`, `Word list "${list.id}" points at missing pool "${list.spellingPool}".`));
+    } else if (pool.active === false || pool.retired) {
+      warnings.push(issue('warn', 'retired_pool_reference', `draft.wordLists[${index}].spellingPool`, `Word list "${list.id}" points at retired pool "${list.spellingPool}" and will be hidden from new sessions.`));
+    }
     if (list.spellingPool === 'core' && !list.yearGroups.length) {
       errors.push(issue('error', 'missing_year_group_metadata', `draft.wordLists[${index}].yearGroups`, `Word list "${list.id}" is missing year-group metadata.`));
     }
@@ -472,6 +624,9 @@ export function validateSpellingContentBundle(rawBundle) {
     }
     if (list.spellingPool === 'core' && list.coverageTier === 'enrichment-extra') {
       errors.push(issue('error', 'coverage_tier_mismatch', `draft.wordLists[${index}].coverageTier`, `Core word list "${list.id}" cannot use the enrichment-extra coverage tier.`));
+    }
+    if (list.spellingPool !== 'core' && list.coverageTier === 'statutory-core') {
+      errors.push(issue('error', 'coverage_tier_mismatch', `draft.wordLists[${index}].coverageTier`, `Non-core word list "${list.id}" cannot use the statutory-core coverage tier.`));
     }
   });
 
@@ -498,6 +653,9 @@ export function validateSpellingContentBundle(rawBundle) {
     }
     if (word.spellingPool === 'core' && word.coverageTier === 'enrichment-extra') {
       errors.push(issue('error', 'coverage_tier_mismatch', `draft.words[${index}].coverageTier`, `Core word "${word.slug}" cannot use the enrichment-extra coverage tier.`));
+    }
+    if (word.spellingPool !== 'core' && word.coverageTier === 'statutory-core') {
+      errors.push(issue('error', 'coverage_tier_mismatch', `draft.words[${index}].coverageTier`, `Non-core word "${word.slug}" cannot use the statutory-core coverage tier.`));
     }
     if (!hasUsableWordExplanation(word.explanation)) {
       errors.push(issue('error', 'missing_word_explanation', `draft.words[${index}].explanation`, `Word "${word.slug}" must include a learner-facing explanation.`));
@@ -728,10 +886,19 @@ function orderedDraftWords(draft) {
 
 export function buildPublishedSnapshotFromDraft(rawDraft, { generatedAt = Date.now() } = {}) {
   const draft = normaliseDraft(rawDraft);
+  const poolById = new Map(draft.pools.map((entry) => [entry.id, entry]));
+  const listById = new Map(draft.wordLists.map((entry) => [entry.id, entry]));
   const sentenceById = new Map(draft.sentences.map((entry) => [entry.id, entry]));
   const familyMap = new Map();
   const orderedWords = orderedDraftWords(draft)
-    .filter((word) => word.active !== false && !word.retired);
+    .filter((word) => {
+      if (word.active === false || word.retired) return false;
+      const pool = poolById.get(word.spellingPool);
+      if (pool && (pool.active === false || pool.retired || pool.visibility?.state !== 'visible')) return false;
+      const list = listById.get(word.listId);
+      if (list && (list.active === false || list.retired)) return false;
+      return true;
+    });
 
   const runtimeWords = orderedWords.map((word, index) => {
     const sentences = word.sentenceEntryIds

--- a/src/subjects/spelling/content/operations-model.js
+++ b/src/subjects/spelling/content/operations-model.js
@@ -19,6 +19,7 @@ export const CONTENT_OPERATION_PACKAGE_STATES = Object.freeze({
 });
 
 export const CONTENT_OPERATION_ENTITY_TYPES = Object.freeze([
+  'spelling.pool',
   'spelling.word',
   'spelling.sentenceEntry',
   'spelling.wordList',
@@ -38,6 +39,7 @@ const ACTION_SET = new Set(CONTENT_OPERATION_ACTIONS);
 const STRUCTURAL_ACTIONS = new Set(['create', 'upsert', 'replace', 'remove', 'retire']);
 
 const EDITABLE_COLLECTIONS = Object.freeze({
+  'spelling.pool': Object.freeze({ collectionPath: ['draft', 'pools'], idField: 'id' }),
   'spelling.word': Object.freeze({ collectionPath: ['draft', 'words'], idField: 'slug' }),
   'spelling.sentenceEntry': Object.freeze({ collectionPath: ['draft', 'sentences'], idField: 'id' }),
   'spelling.wordList': Object.freeze({ collectionPath: ['draft', 'wordLists'], idField: 'id' }),

--- a/src/subjects/spelling/content/package-operations.js
+++ b/src/subjects/spelling/content/package-operations.js
@@ -1,4 +1,7 @@
-const VALID_SPELLING_POOLS = new Set(['core', 'extra']);
+const LEGACY_SPELLING_POOLS = new Set(['core', 'extra']);
+const RESERVED_POOL_IDS = new Set(['all']);
+const VALID_POOL_TYPES = new Set(['statutory', 'enrichment', 'extension', 'custom']);
+const VALID_POOL_VISIBILITY_STATES = new Set(['visible', 'hidden', 'staged']);
 const DEFAULT_COVERAGE_BY_POOL = Object.freeze({
   core: 'statutory-core',
   extra: 'enrichment-extra',
@@ -43,14 +46,31 @@ function hasExplicitList(rawValue) {
   return typeof rawValue === 'string' && rawValue.trim().length > 0;
 }
 
-function normaliseSpellingPool(value, fallback = 'core') {
-  const safeFallback = VALID_SPELLING_POOLS.has(fallback) ? fallback : 'core';
+function isValidPoolId(value) {
+  return typeof value === 'string'
+    && /^[a-z][a-z0-9-]{1,63}$/.test(value)
+    && !RESERVED_POOL_IDS.has(value);
+}
+
+function normalisePoolIdCandidate(value, fallback = '') {
   const candidate = normaliseString(value).toLowerCase();
-  return VALID_SPELLING_POOLS.has(candidate) ? candidate : safeFallback;
+  return candidate || fallback;
+}
+
+function normaliseSpellingPool(value, fallback = 'core') {
+  const safeFallback = isValidPoolId(fallback) ? fallback : 'core';
+  const candidate = normaliseString(value).toLowerCase();
+  return isValidPoolId(candidate) ? candidate : safeFallback;
 }
 
 function normaliseCoverageTier(value, fallback, spellingPool) {
   return normaliseString(value, fallback || DEFAULT_COVERAGE_BY_POOL[spellingPool] || 'statutory-core');
+}
+
+function defaultCoverageForPool(poolId, pool = null) {
+  if (poolId === 'core') return 'statutory-core';
+  if (poolId === 'extra' || pool?.type === 'enrichment') return 'enrichment-extra';
+  return 'secure-extension';
 }
 
 function normaliseProvenance(rawValue = {}, fallback = {}) {
@@ -109,8 +129,21 @@ function wordListValidationResult(errors, warnings, wordList = null) {
   };
 }
 
+function poolValidationResult(errors, warnings, pool = null) {
+  return {
+    ok: errors.length === 0,
+    errors,
+    warnings,
+    pool,
+  };
+}
+
 function findWordList(wordLists, listId) {
   return (Array.isArray(wordLists) ? wordLists : []).find((entry) => entry?.id === listId) || null;
+}
+
+function findPool(pools, poolId) {
+  return (Array.isArray(pools) ? pools : []).find((entry) => entry?.id === poolId) || null;
 }
 
 function findWord(words, slug) {
@@ -315,15 +348,17 @@ export function validateSpellingSentenceEditorInput(rawValue = {}, options = {})
 
 export function normaliseSpellingWordListEditorInput(rawValue = {}, {
   existingWordList = null,
+  pools = [],
 } = {}) {
   const raw = isPlainObject(rawValue) ? rawValue : {};
   const existing = isPlainObject(existingWordList) ? existingWordList : {};
   const spellingPool = normaliseSpellingPool(raw.spellingPool, existing.spellingPool || 'core');
+  const pool = findPool(pools, spellingPool);
   return {
     id: normaliseString(raw.id, existing.id),
     title: normaliseString(raw.title, existing.title),
     spellingPool,
-    coverageTier: normaliseCoverageTier(raw.coverageTier, existing.coverageTier, spellingPool),
+    coverageTier: normaliseCoverageTier(raw.coverageTier, existing.coverageTier || defaultCoverageForPool(spellingPool, pool), spellingPool),
     yearGroups: uniqueStrings(hasExplicitList(raw.yearGroups) ? raw.yearGroups : existing.yearGroups),
     tags: uniqueStrings(hasExplicitList(raw.tags) ? raw.tags : existing.tags, { lowerCase: true }),
     wordSlugs: uniqueStrings(hasExplicitList(raw.wordSlugs) ? raw.wordSlugs : existing.wordSlugs, { lowerCase: true }),
@@ -342,9 +377,15 @@ export function validateSpellingWordListEditorInput(rawValue = {}, options = {})
   const existing = isPlainObject(options.existingWordList) ? options.existingWordList : null;
   const wordList = normaliseSpellingWordListEditorInput(raw, options);
   const wordsBySlug = new Map((Array.isArray(options.words) ? options.words : []).map((entry) => [entry.slug, entry]));
+  const pool = findPool(options.pools, wordList.spellingPool);
 
   if (!wordList.id) errors.push(issue('id', 'Word-list id is required.', 'invalid_word_list_operation'));
   if (!wordList.title) errors.push(issue('title', 'Word-list title is required.', 'invalid_word_list_operation'));
+  if (Array.isArray(options.pools) && !pool) {
+    errors.push(issue('spellingPool', `Word-list pool "${wordList.spellingPool}" is not defined.`, 'invalid_word_list_operation'));
+  } else if (pool && (pool.active === false || pool.retired)) {
+    errors.push(issue('spellingPool', `Word-list pool "${wordList.spellingPool}" is retired.`, 'invalid_word_list_operation'));
+  }
   if (wordList.spellingPool === 'core' && !wordList.yearGroups.length) {
     errors.push(issue('yearGroups', 'Core word lists require year-group metadata.', 'invalid_word_list_operation'));
   }
@@ -353,6 +394,9 @@ export function validateSpellingWordListEditorInput(rawValue = {}, options = {})
   }
   if (wordList.spellingPool === 'core' && wordList.coverageTier === 'enrichment-extra') {
     errors.push(issue('coverageTier', 'Core word lists cannot use enrichment-extra coverage.', 'invalid_word_list_operation'));
+  }
+  if (wordList.spellingPool !== 'core' && wordList.coverageTier === 'statutory-core') {
+    errors.push(issue('coverageTier', 'Non-core word lists cannot use statutory-core coverage.', 'invalid_word_list_operation'));
   }
   if (!hasExplicitProvenance(raw, existing)) {
     errors.push(issue('provenance', 'Word-list provenance or source notes are required.', 'invalid_word_list_operation'));
@@ -378,6 +422,125 @@ export function validateSpellingWordListEditorInput(rawValue = {}, options = {})
   }
 
   return wordListValidationResult(errors, warnings, wordList);
+}
+
+function normalisePoolVisibility(rawValue = {}, existingVisibility = null) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  const existing = isPlainObject(existingVisibility) ? existingVisibility : {};
+  const state = VALID_POOL_VISIBILITY_STATES.has(normaliseString(raw.state, existing.state).toLowerCase())
+    ? normaliseString(raw.state, existing.state).toLowerCase()
+    : 'hidden';
+  return {
+    state,
+    learnerVisible: state === 'visible',
+    scheduledAt: Number.isFinite(Number(raw.scheduledAt ?? existing.scheduledAt)) && Number(raw.scheduledAt ?? existing.scheduledAt) >= 0
+      ? Number(raw.scheduledAt ?? existing.scheduledAt)
+      : 0,
+    rolloutFlag: normaliseString(raw.rolloutFlag, existing.rolloutFlag),
+  };
+}
+
+function normaliseNoRewardException(rawValue = {}, existingException = null) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  const existing = isPlainObject(existingException) ? existingException : {};
+  const hasApprovedValue = Object.prototype.hasOwnProperty.call(raw, 'approved');
+  return {
+    approved: hasApprovedValue ? raw.approved === true : existing.approved === true,
+    reason: normaliseString(raw.reason, existing.reason),
+    approvedBy: normaliseString(raw.approvedBy, existing.approvedBy),
+    approvedAt: Number.isFinite(Number(raw.approvedAt ?? existing.approvedAt)) && Number(raw.approvedAt ?? existing.approvedAt) >= 0
+      ? Number(raw.approvedAt ?? existing.approvedAt)
+      : 0,
+  };
+}
+
+function normaliseRewardTrack(rawValue = {}, existingTrack = null) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  const existing = isPlainObject(existingTrack) ? existingTrack : {};
+  const hasApprovedValue = Object.prototype.hasOwnProperty.call(raw, 'approved');
+  return {
+    id: normaliseString(raw.id || raw.rewardTrackId || raw.trackId, existing.id || existing.rewardTrackId || existing.trackId),
+    approved: hasApprovedValue ? raw.approved === true : existing.approved === true,
+    source: normaliseString(raw.source, existing.source),
+    note: normaliseString(raw.note, existing.note),
+    approvedBy: normaliseString(raw.approvedBy, existing.approvedBy),
+    approvedAt: Number.isFinite(Number(raw.approvedAt ?? existing.approvedAt)) && Number(raw.approvedAt ?? existing.approvedAt) >= 0
+      ? Number(raw.approvedAt ?? existing.approvedAt)
+      : 0,
+  };
+}
+
+export function normaliseSpellingPoolEditorInput(rawValue = {}, {
+  existingPool = null,
+} = {}) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  const existing = isPlainObject(existingPool) ? existingPool : {};
+  const id = normalisePoolIdCandidate(raw.id || raw.poolId || raw.spellingPool, existing.id || '');
+  const type = VALID_POOL_TYPES.has(normaliseString(raw.type || raw.poolType, existing.type || 'custom').toLowerCase())
+    ? normaliseString(raw.type || raw.poolType, existing.type || 'custom').toLowerCase()
+    : 'custom';
+  const sourceNote = normaliseString(raw.sourceNote, existing.sourceNote);
+  const provenance = normaliseProvenance(raw.provenance, existing.provenance);
+  const noRewardException = raw.noRewardException || existing.noRewardException
+    ? normaliseNoRewardException(raw.noRewardException, existing.noRewardException)
+    : null;
+  const rewardTrack = raw.rewardTrack || existing.rewardTrack
+    ? normaliseRewardTrack(raw.rewardTrack, existing.rewardTrack)
+    : null;
+  return {
+    id,
+    title: normaliseString(raw.title, existing.title),
+    type,
+    sourceNote,
+    provenance,
+    visibility: normalisePoolVisibility(raw.visibility, existing.visibility),
+    tags: uniqueStrings(hasExplicitList(raw.tags) ? raw.tags : existing.tags, { lowerCase: true }),
+    active: raw.active === false ? false : (existing.active === false ? false : true),
+    retired: Boolean(raw.retired || existing.retired),
+    ...(raw.retirement || existing.retirement ? { retirement: raw.retirement || existing.retirement } : {}),
+    ...(noRewardException ? { noRewardException } : {}),
+    ...(rewardTrack ? { rewardTrack } : {}),
+    sortIndex: Number.isInteger(Number(raw.sortIndex)) && Number(raw.sortIndex) >= 0
+      ? Number(raw.sortIndex)
+      : (Number.isInteger(Number(existing.sortIndex)) ? Number(existing.sortIndex) : 0),
+  };
+}
+
+export function validateSpellingPoolEditorInput(rawValue = {}, options = {}) {
+  const errors = [];
+  const warnings = [];
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  const existing = isPlainObject(options.existingPool) ? options.existingPool : null;
+  const pool = normaliseSpellingPoolEditorInput(raw, options);
+  const duplicate = (Array.isArray(options.pools) ? options.pools : [])
+    .find((entry) => entry?.id === pool.id && entry?.id !== existing?.id);
+
+  if (!pool.id || !isValidPoolId(pool.id)) errors.push(issue('id', 'Pool id must be a stable lowercase id.', 'invalid_pool_operation'));
+  if (duplicate) errors.push(issue('id', `Pool id "${pool.id}" already exists.`, 'invalid_pool_operation'));
+  if (!pool.title) errors.push(issue('title', 'Pool title is required.', 'invalid_pool_operation'));
+  if (!VALID_POOL_TYPES.has(pool.type)) errors.push(issue('type', 'Pool type is required.', 'invalid_pool_operation'));
+  if (!hasExplicitProvenance(raw, existing)) {
+    errors.push(issue('provenance', 'Pool provenance or source notes are required.', 'invalid_pool_operation'));
+  }
+  if (pool.retired && pool.visibility.state === 'visible') {
+    errors.push(issue('visibility.state', 'Retired pools cannot be learner-visible.', 'invalid_pool_operation'));
+  }
+  if (pool.id !== 'core' && pool.type === 'statutory') {
+    errors.push(issue('type', 'Only the core pool can use statutory type.', 'invalid_pool_operation'));
+  }
+  if (
+    pool.visibility.state === 'visible'
+    && !LEGACY_SPELLING_POOLS.has(pool.id)
+    && pool.noRewardException?.approved !== true
+    && pool.rewardTrack?.approved !== true
+  ) {
+    errors.push(issue('visibility.state', 'Learner-visible future pools require a reward track or approved no-reward exception.', 'pool_reward_required'));
+  }
+  if (pool.visibility.state === 'staged' && !pool.visibility.scheduledAt && !pool.visibility.rolloutFlag) {
+    warnings.push(issue('visibility.state', 'Staged pools should include a schedule or rollout flag before publish.', 'invalid_pool_operation'));
+  }
+
+  return poolValidationResult(errors, warnings, pool);
 }
 
 function throwIfInvalid(validation) {
@@ -420,6 +583,18 @@ export function buildSpellingWordListUpsertOperation(rawValue = {}, options = {}
     fieldPath: '',
     action: 'upsert',
     payload: validation.wordList,
+  };
+}
+
+export function buildSpellingPoolUpsertOperation(rawValue = {}, options = {}) {
+  const validation = validateSpellingPoolEditorInput(rawValue, options);
+  throwIfInvalid(validation);
+  return {
+    entityType: 'spelling.pool',
+    entityId: validation.pool.id,
+    fieldPath: '',
+    action: 'upsert',
+    payload: validation.pool,
   };
 }
 
@@ -514,6 +689,41 @@ export function buildSpellingWordListDeleteOrRetireOperation(rawValue = {}, {
   }
   return {
     entityType: 'spelling.wordList',
+    entityId: id,
+    fieldPath: '',
+    action: 'retire',
+    payload: {
+      reason: normaliseString(reason, normaliseString(raw.reason, 'Retired through Content Operations Centre.')),
+      retiredAt: Number(now()),
+      source: 'content-operations-centre',
+    },
+  };
+}
+
+export function buildSpellingPoolDeleteOrRetireOperation(rawValue = {}, {
+  publishedPoolIds = [],
+  reason = '',
+  now = () => Date.now(),
+} = {}) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  const id = normalisePoolIdCandidate(raw.id || raw.entityId || raw.poolId);
+  if (!id) throw new TypeError('Pool id is required.');
+  if (!isValidPoolId(id)) throw new TypeError('Pool id must be a stable lowercase id.');
+  const publishedSet = publishedPoolIds instanceof Set
+    ? publishedPoolIds
+    : new Set((Array.isArray(publishedPoolIds) ? publishedPoolIds : []).map((entry) => String(entry)));
+  const published = Boolean(raw.published || raw.hasCurrent || publishedSet.has(id));
+  if (!published) {
+    return {
+      entityType: 'spelling.pool',
+      entityId: id,
+      fieldPath: '',
+      action: 'remove',
+      payload: null,
+    };
+  }
+  return {
+    entityType: 'spelling.pool',
     entityId: id,
     fieldPath: '',
     action: 'retire',

--- a/src/surfaces/hubs/AdminContentOperationsSection.jsx
+++ b/src/surfaces/hubs/AdminContentOperationsSection.jsx
@@ -14,6 +14,8 @@ import {
   normaliseContentOperationsSpellingItemDetail,
 } from '../../platform/hubs/admin-content-operations.js';
 import {
+  buildSpellingPoolDeleteOrRetireOperation,
+  buildSpellingPoolUpsertOperation,
   buildSpellingSentenceDeleteOrRetireOperation,
   buildSpellingSentenceUpsertOperation,
   buildSpellingWordListDeleteOrRetireOperation,
@@ -66,6 +68,33 @@ function csvValue(values) {
 
 function provenanceField(provenance, key) {
   return provenance && typeof provenance === 'object' ? String(provenance[key] || '') : '';
+}
+
+function spellingPoolOptionId(pool) {
+  return String(pool?.id || pool?.pool || '').trim();
+}
+
+function spellingPoolOptionLabel(pool) {
+  const id = spellingPoolOptionId(pool);
+  if (pool?.title) return pool.title;
+  if (id === 'core') return 'Core';
+  if (id === 'extra') return 'Extra';
+  return id || 'Pool';
+}
+
+function spellingPoolOptions(pools = []) {
+  const source = Array.isArray(pools) && pools.length
+    ? pools
+    : [{ id: 'core', title: 'Core' }, { id: 'extra', title: 'Extra' }];
+  const seen = new Set();
+  const output = [];
+  for (const pool of source) {
+    const id = spellingPoolOptionId(pool);
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    output.push({ id, label: spellingPoolOptionLabel(pool) });
+  }
+  return output;
 }
 
 function emptyWordEditorForm(wordLists = [], selectedRow = null) {
@@ -258,6 +287,70 @@ function operationInputFromWordListForm(form) {
     provenance: {
       source: form.provenanceSource,
       note: form.provenanceNote,
+    },
+  };
+}
+
+function emptyPoolEditorForm(pools = [], selectedRow = null) {
+  const preferredPool = selectedRow?.spellingPool
+    ? pools.find((entry) => entry.id === selectedRow.spellingPool || entry.pool === selectedRow.spellingPool)
+    : pools[0];
+  const poolId = preferredPool?.id || preferredPool?.pool || selectedRow?.spellingPool || 'extension';
+  return {
+    id: '',
+    title: '',
+    type: poolId === 'extra' ? 'enrichment' : (poolId === 'core' ? 'statutory' : 'extension'),
+    visibilityState: 'hidden',
+    scheduledAt: '',
+    rolloutFlag: '',
+    tags: '',
+    sourceNote: '',
+    provenanceSource: '',
+    provenanceNote: '',
+    noRewardExceptionApproved: false,
+    noRewardExceptionReason: '',
+    retirementReason: '',
+  };
+}
+
+function poolEditorFormFromPool(pool, selectedRow = null, pools = []) {
+  if (!pool) return emptyPoolEditorForm(pools, selectedRow);
+  return {
+    id: pool.id || pool.pool || '',
+    title: pool.title || '',
+    type: pool.type || 'custom',
+    visibilityState: pool.visibility?.state || 'hidden',
+    scheduledAt: pool.visibility?.scheduledAt ? String(pool.visibility.scheduledAt) : '',
+    rolloutFlag: pool.visibility?.rolloutFlag || '',
+    tags: csvValue(pool.tags),
+    sourceNote: pool.sourceNote || '',
+    provenanceSource: provenanceField(pool.provenance, 'source'),
+    provenanceNote: provenanceField(pool.provenance, 'note'),
+    noRewardExceptionApproved: pool.noRewardException?.approved === true,
+    noRewardExceptionReason: pool.noRewardException?.reason || '',
+    retirementReason: '',
+  };
+}
+
+function operationInputFromPoolForm(form) {
+  return {
+    id: form.id,
+    title: form.title,
+    type: form.type,
+    visibility: {
+      state: form.visibilityState,
+      scheduledAt: form.scheduledAt,
+      rolloutFlag: form.rolloutFlag,
+    },
+    tags: form.tags,
+    sourceNote: form.sourceNote,
+    provenance: {
+      source: form.provenanceSource,
+      note: form.provenanceNote,
+    },
+    noRewardException: {
+      approved: Boolean(form.noRewardExceptionApproved),
+      reason: form.noRewardExceptionReason,
     },
   };
 }
@@ -700,6 +793,10 @@ function SpellingBrowsePanel({
   const packageWord = selectedDetail?.packageValue || null;
   const editorSourceWord = packageWord || currentWord || null;
   const selectedList = browse.wordLists.find((list) => list.id === selectedRow?.listId) || browse.wordLists[0] || null;
+  const selectedPool = browse.pools.find((pool) => pool.id === selectedRow?.spellingPool || pool.pool === selectedRow?.spellingPool)
+    || browse.pools[0]
+    || null;
+  const poolOptions = React.useMemo(() => spellingPoolOptions(browse.pools), [browse.pools]);
   const sentenceOptions = React.useMemo(() => {
     const seen = new Set();
     const output = [];
@@ -722,6 +819,8 @@ function SpellingBrowsePanel({
   const [sentenceForm, setSentenceForm] = React.useState(() => emptySentenceEditorForm(selectedRow));
   const [wordListMode, setWordListMode] = React.useState('edit');
   const [wordListForm, setWordListForm] = React.useState(() => emptyWordListEditorForm(browse.wordLists, selectedRow));
+  const [poolMode, setPoolMode] = React.useState('edit');
+  const [poolForm, setPoolForm] = React.useState(() => emptyPoolEditorForm(browse.pools, selectedRow));
   const [formError, setFormError] = React.useState('');
   const formDisabled = !selectedPackageId
     || !canEdit
@@ -773,6 +872,18 @@ function SpellingBrowsePanel({
     wordListMode,
   ]);
 
+  React.useEffect(() => {
+    if (poolMode === 'create') return;
+    setFormError('');
+    setPoolForm(poolEditorFormFromPool(selectedPool, selectedRow, browse.pools));
+  }, [
+    browse.pools,
+    poolMode,
+    selectedPool,
+    selectedRow,
+    selectedRow?.spellingPool,
+  ]);
+
   const updateWordForm = React.useCallback((patch) => {
     setFormError('');
     setWordForm((current) => {
@@ -800,6 +911,18 @@ function SpellingBrowsePanel({
       if (Object.prototype.hasOwnProperty.call(patch, 'spellingPool')) {
         next.coverageTier = patch.spellingPool === 'extra' ? 'enrichment-extra' : 'statutory-core';
         if (patch.spellingPool === 'extra') next.yearGroups = '';
+      }
+      return next;
+    });
+  }, []);
+
+  const updatePoolForm = React.useCallback((patch) => {
+    setFormError('');
+    setPoolForm((current) => {
+      const next = { ...current, ...patch };
+      if (Object.prototype.hasOwnProperty.call(patch, 'type')) {
+        if (patch.type === 'statutory') next.visibilityState = next.id === 'core' ? next.visibilityState : 'hidden';
+        if (patch.type === 'enrichment' && !next.id) next.id = 'extra';
       }
       return next;
     });
@@ -884,6 +1007,19 @@ function SpellingBrowsePanel({
     setWordListForm(wordListEditorFormFromList(selectedList, selectedRow, browse.wordLists));
   }, [browse.wordLists, selectedList, selectedRow]);
 
+  const startCreatePool = React.useCallback(() => {
+    setPoolMode('create');
+    setFormError('');
+    setPoolForm(emptyPoolEditorForm(browse.pools, selectedRow));
+  }, [browse.pools, selectedRow]);
+
+  const startEditPool = React.useCallback((poolId = '') => {
+    const nextPool = browse.pools.find((pool) => pool.id === poolId || pool.pool === poolId) || selectedPool;
+    setPoolMode('edit');
+    setFormError('');
+    setPoolForm(poolEditorFormFromPool(nextPool, selectedRow, browse.pools));
+  }, [browse.pools, selectedPool, selectedRow]);
+
   const submitWordForm = React.useCallback((event) => {
     event?.preventDefault?.();
     if (!onSubmitSpellingOperation) return;
@@ -950,12 +1086,13 @@ function SpellingBrowsePanel({
     try {
       const operation = buildSpellingWordListUpsertOperation(operationInputFromWordListForm(wordListForm), {
         existingWordList: wordListMode === 'edit' ? selectedList : null,
+        pools: browse.pools,
       });
       onSubmitSpellingOperation(operation, { slug: selectedRow?.slug, action: 'word-list-upsert' });
     } catch (submitError) {
       setFormError(submitError?.validation?.errors?.[0]?.message || submitError?.message || 'Word-list operation is invalid.');
     }
-  }, [onSubmitSpellingOperation, selectedList, selectedRow?.slug, wordListForm, wordListMode]);
+  }, [browse.pools, onSubmitSpellingOperation, selectedList, selectedRow?.slug, wordListForm, wordListMode]);
 
   const submitWordListRemoval = React.useCallback(() => {
     if (!onSubmitSpellingOperation || !selectedList) return;
@@ -972,6 +1109,36 @@ function SpellingBrowsePanel({
       setFormError(submitError?.message || 'Word-list operation is invalid.');
     }
   }, [onSubmitSpellingOperation, selectedList, selectedRow?.slug, wordListForm.id, wordListForm.retirementReason]);
+
+  const submitPoolForm = React.useCallback((event) => {
+    event?.preventDefault?.();
+    if (!onSubmitSpellingOperation) return;
+    try {
+      const operation = buildSpellingPoolUpsertOperation(operationInputFromPoolForm(poolForm), {
+        existingPool: poolMode === 'edit' ? selectedPool : null,
+        pools: browse.pools,
+      });
+      onSubmitSpellingOperation(operation, { slug: selectedRow?.slug, action: 'pool-upsert' });
+    } catch (submitError) {
+      setFormError(submitError?.validation?.errors?.[0]?.message || submitError?.message || 'Pool operation is invalid.');
+    }
+  }, [browse.pools, onSubmitSpellingOperation, poolForm, poolMode, selectedPool, selectedRow?.slug]);
+
+  const submitPoolRemoval = React.useCallback(() => {
+    if (!onSubmitSpellingOperation || !selectedPool) return;
+    try {
+      const operation = buildSpellingPoolDeleteOrRetireOperation({
+        id: poolForm.id || selectedPool.id || selectedPool.pool,
+        hasCurrent: selectedPool.draftState !== 'added',
+        reason: poolForm.retirementReason,
+      }, {
+        reason: poolForm.retirementReason,
+      });
+      onSubmitSpellingOperation(operation, { slug: selectedRow?.slug, action: `pool-${operation.action}` });
+    } catch (submitError) {
+      setFormError(submitError?.message || 'Pool operation is invalid.');
+    }
+  }, [onSubmitSpellingOperation, poolForm.id, poolForm.retirementReason, selectedPool, selectedRow?.slug]);
 
   return (
     <div className="content-ops-area-panel" data-content-ops-area="spelling" data-content-ops-spelling-browse="true">
@@ -1006,15 +1173,191 @@ function SpellingBrowsePanel({
       <div className="content-ops-metric-grid content-ops-spelling-metrics">
         {browse.pools.map((pool) => (
           <MetricTile
-            key={pool.pool}
-            label={`${pool.pool === 'extra' ? 'Extra' : 'Core'} pool`}
+            key={pool.id || pool.pool}
+            label={pool.title || `${pool.pool} pool`}
             value={String(pool.wordCount)}
-            detail={`${String(pool.sentenceCount)} sentence audio units`}
+            detail={`${pool.type || 'custom'} - ${pool.visibility?.state || 'hidden'}`}
           />
         ))}
         <MetricTile label="Word lists" value={String(browse.totals.wordLists)} detail={`${String(browse.totals.variants)} variants`} />
         <MetricTile label="Matched" value={String(browse.totals.matchedWords)} detail={`${String(browse.totals.displayedWords)} displayed`} />
       </div>
+
+      <section className="content-ops-editor-panel" data-content-ops-pool-editor="true">
+        <div className="content-ops-word-editor-header">
+          <div>
+            <div className="eyebrow">Pool metadata</div>
+            <strong>{poolMode === 'create' ? 'New pool' : (poolForm.title || selectedPool?.title || 'Pool')}</strong>
+          </div>
+          <div className="chip-row content-ops-chip-wrap">
+            <button type="button" className="btn secondary compact" onClick={() => startEditPool(selectedPool?.id || selectedPool?.pool)} disabled={!selectedPool}>
+              Edit pool
+            </button>
+            <button type="button" className="btn secondary compact" onClick={startCreatePool}>
+              New pool
+            </button>
+          </div>
+        </div>
+        <div className="content-ops-table-scroll">
+          <table className="admin-overview-table content-ops-table" aria-label="Spelling pools">
+            <thead>
+              <tr className="admin-overview-thead-row">
+                <th className="small admin-overview-th-first">Pool</th>
+                <th className="small admin-overview-th">Type</th>
+                <th className="small admin-overview-th">Visibility</th>
+                <th className="small admin-overview-th-right">Words</th>
+                <th className="small admin-overview-th">Draft</th>
+              </tr>
+            </thead>
+            <tbody>
+              {browse.pools.map((pool) => (
+                <tr key={pool.id || pool.pool} className="admin-overview-tbody-row">
+                  <td className="admin-overview-td-first">
+                    <button
+                      type="button"
+                      className="content-ops-row-button"
+                      onClick={() => startEditPool(pool.id || pool.pool)}
+                      data-content-ops-pool-row={pool.id || pool.pool}
+                    >
+                      {pool.title || pool.pool}
+                    </button>
+                    <div className="small muted">{pool.id || pool.pool}</div>
+                  </td>
+                  <td className="admin-overview-td small">{pool.type || 'custom'}</td>
+                  <td className="admin-overview-td">
+                    <span className={`chip ${pool.retired ? 'bad' : (pool.visibility?.state === 'visible' ? 'good' : 'warn')}`}>
+                      {pool.retired ? 'retired' : (pool.visibility?.state || 'hidden')}
+                    </span>
+                  </td>
+                  <td className="admin-overview-td-right small">{String(pool.wordCount)} / {String(pool.totalWordCount)}</td>
+                  <td className="admin-overview-td">
+                    <span className={`chip ${draftStateChipClass(pool.draftState)}`}>
+                      {draftStateLabel(pool.draftState)}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <form className="content-ops-word-editor-grid" onSubmit={submitPoolForm}>
+          <label>
+            <span className="small muted">Pool id</span>
+            <input
+              value={poolForm.id}
+              onChange={(event) => updatePoolForm({ id: event.target.value })}
+              data-content-ops-pool-field="id"
+              disabled={poolMode === 'edit'}
+            />
+          </label>
+          <label>
+            <span className="small muted">Title</span>
+            <input
+              value={poolForm.title}
+              onChange={(event) => updatePoolForm({ title: event.target.value })}
+              data-content-ops-pool-field="title"
+            />
+          </label>
+          <label>
+            <span className="small muted">Type</span>
+            <select
+              value={poolForm.type}
+              onChange={(event) => updatePoolForm({ type: event.target.value })}
+              data-content-ops-pool-field="type"
+            >
+              <option value="statutory">Statutory</option>
+              <option value="enrichment">Enrichment</option>
+              <option value="extension">Extension</option>
+              <option value="custom">Custom</option>
+            </select>
+          </label>
+          <label>
+            <span className="small muted">Visibility</span>
+            <select
+              value={poolForm.visibilityState}
+              onChange={(event) => updatePoolForm({ visibilityState: event.target.value })}
+              data-content-ops-pool-field="visibilityState"
+            >
+              <option value="hidden">Hidden</option>
+              <option value="staged">Staged</option>
+              <option value="visible">Visible</option>
+            </select>
+          </label>
+          <label>
+            <span className="small muted">Scheduled at</span>
+            <input
+              value={poolForm.scheduledAt}
+              onChange={(event) => updatePoolForm({ scheduledAt: event.target.value })}
+              data-content-ops-pool-field="scheduledAt"
+            />
+          </label>
+          <label>
+            <span className="small muted">Rollout flag</span>
+            <input
+              value={poolForm.rolloutFlag}
+              onChange={(event) => updatePoolForm({ rolloutFlag: event.target.value })}
+              data-content-ops-pool-field="rolloutFlag"
+            />
+          </label>
+          <label>
+            <span className="small muted">Tags</span>
+            <input
+              value={poolForm.tags}
+              onChange={(event) => updatePoolForm({ tags: event.target.value })}
+              data-content-ops-pool-field="tags"
+            />
+          </label>
+          <label>
+            <span className="small muted">Source notes</span>
+            <input
+              value={poolForm.sourceNote}
+              onChange={(event) => updatePoolForm({ sourceNote: event.target.value })}
+              data-content-ops-pool-field="sourceNote"
+            />
+          </label>
+          <label>
+            <span className="small muted">Provenance source</span>
+            <input
+              value={poolForm.provenanceSource}
+              onChange={(event) => updatePoolForm({ provenanceSource: event.target.value })}
+              data-content-ops-pool-field="provenanceSource"
+            />
+          </label>
+          <label>
+            <span className="small muted">No-reward exception</span>
+            <input
+              type="checkbox"
+              checked={poolForm.noRewardExceptionApproved}
+              onChange={(event) => updatePoolForm({ noRewardExceptionApproved: event.target.checked })}
+              data-content-ops-pool-field="noRewardExceptionApproved"
+            />
+          </label>
+          <label className="content-ops-editor-wide">
+            <span className="small muted">No-reward reason</span>
+            <textarea
+              value={poolForm.noRewardExceptionReason}
+              onChange={(event) => updatePoolForm({ noRewardExceptionReason: event.target.value })}
+              data-content-ops-pool-field="noRewardExceptionReason"
+            />
+          </label>
+          <label className="content-ops-editor-wide">
+            <span className="small muted">Retirement reason</span>
+            <input
+              value={poolForm.retirementReason}
+              onChange={(event) => updatePoolForm({ retirementReason: event.target.value })}
+              data-content-ops-pool-field="retirementReason"
+            />
+          </label>
+          <div className="content-ops-editor-actions content-ops-editor-wide">
+            <button type="submit" className="btn primary" disabled={formDisabled}>
+              Save pool
+            </button>
+            <button type="button" className="btn secondary" onClick={submitPoolRemoval} disabled={formDisabled || !selectedPool}>
+              {selectedPool?.draftState === 'added' ? 'Delete draft pool' : 'Retire pool'}
+            </button>
+          </div>
+        </form>
+      </section>
 
       <form className="content-ops-browse-toolbar" onSubmit={onApplyFilters}>
         <label>
@@ -1034,8 +1377,9 @@ function SpellingBrowsePanel({
             data-content-ops-spelling-pool="true"
           >
             <option value="all">All</option>
-            <option value="core">Core</option>
-            <option value="extra">Extra</option>
+            {poolOptions.map((pool) => (
+              <option key={pool.id} value={pool.id}>{pool.label}</option>
+            ))}
           </select>
         </label>
         <label>
@@ -1256,8 +1600,9 @@ function SpellingBrowsePanel({
                       disabled={formDisabled}
                       data-content-ops-word-field="spellingPool"
                     >
-                      <option value="core">Core</option>
-                      <option value="extra">Extra</option>
+                      {poolOptions.map((pool) => (
+                        <option key={pool.id} value={pool.id}>{pool.label}</option>
+                      ))}
                     </select>
                   </label>
                   <label>
@@ -1660,8 +2005,9 @@ function SpellingBrowsePanel({
                       disabled={formDisabled}
                       data-content-ops-word-list-field="spellingPool"
                     >
-                      <option value="core">Core</option>
-                      <option value="extra">Extra</option>
+                      {poolOptions.map((pool) => (
+                        <option key={pool.id} value={pool.id}>{pool.label}</option>
+                      ))}
                     </select>
                   </label>
                   <label>
@@ -2444,7 +2790,9 @@ export function AdminContentOperationsSection({
       });
       const noun = operation.entityType === 'spelling.sentenceEntry'
         ? 'Sentence'
-        : (operation.entityType === 'spelling.wordList' ? 'Word list' : 'Word');
+        : (operation.entityType === 'spelling.wordList'
+            ? 'Word list'
+            : (operation.entityType === 'spelling.pool' ? 'Pool' : 'Word'));
       setSpellingOperationState({
         packageId: selectedPackageId,
         action,

--- a/styles/app.css
+++ b/styles/app.css
@@ -12442,8 +12442,16 @@ html { scroll-behavior: smooth; }
   padding-top: 10px;
 }
 
+.content-ops-editor-panel {
+  display: grid;
+  gap: 10px;
+  border-top: 1px solid var(--line);
+  padding-top: 12px;
+}
+
 .content-ops-word-editor-header,
-.content-ops-word-editor-actions {
+.content-ops-word-editor-actions,
+.content-ops-editor-actions {
   display: flex;
   gap: 8px;
   align-items: flex-start;
@@ -12458,6 +12466,7 @@ html { scroll-behavior: smooth; }
 }
 
 .content-ops-word-editor label,
+.content-ops-editor-panel label,
 .content-ops-word-variant-row label {
   display: grid;
   gap: 4px;
@@ -12466,11 +12475,15 @@ html { scroll-behavior: smooth; }
 
 .content-ops-word-editor input,
 .content-ops-word-editor select,
-.content-ops-word-editor textarea {
+.content-ops-word-editor textarea,
+.content-ops-editor-panel input,
+.content-ops-editor-panel select,
+.content-ops-editor-panel textarea {
   width: 100%;
 }
 
-.content-ops-word-editor-wide {
+.content-ops-word-editor-wide,
+.content-ops-editor-wide {
   grid-column: 1 / -1;
 }
 

--- a/tests/admin-content-operations-v2.test.js
+++ b/tests/admin-content-operations-v2.test.js
@@ -696,13 +696,31 @@ describe('Content Operations Centre normalisers', () => {
   });
 
   it('normalises spelling browse rows with package draft, audio, and reward metadata', () => {
-    const browse = normaliseContentOperationsSpellingBrowse(CONTENT_OPS_SPELLING_BROWSE);
+    const browse = normaliseContentOperationsSpellingBrowse({
+      browse: {
+        ...CONTENT_OPS_SPELLING_BROWSE.browse,
+        pools: [
+          ...CONTENT_OPS_SPELLING_BROWSE.browse.pools,
+          {
+            id: 'secure-vocabulary',
+            title: 'Secure vocabulary',
+            type: 'extension',
+            visibility: { state: 'hidden' },
+            rewardTrack: { id: 'secure-track', approved: true },
+          },
+        ],
+      },
+      actor: CONTENT_OPS_SPELLING_BROWSE.actor,
+    });
 
     assert.equal(browse.release.releaseId, 'rel-global-1');
     assert.equal(browse.packageDraft.status, 'available');
     assert.equal(browse.packageDraft.validation.status, 'passed');
     assert.equal(browse.totals.variants, 1);
     assert.equal(browse.pools[0].draftStateCounts.modified, 1);
+    assert.equal(browse.pools[1].id, 'secure-vocabulary');
+    assert.equal(browse.pools[1].pool, 'secure-vocabulary');
+    assert.equal(browse.pools[1].rewardTrack.approved, true);
     assert.equal(browse.wordLists[0].title, 'Extra Greek roots');
     assert.equal(browse.words[0].draftState, 'modified');
     assert.deepEqual(browse.words[0].audioReadiness.wordProfiles, ['male.natural', 'female.natural']);

--- a/tests/button-label-consistency.test.js
+++ b/tests/button-label-consistency.test.js
@@ -551,6 +551,9 @@ test('button labels: every statically extractable label is classified', () => {
     'Edit list',
     'New list',
     'Save list',
+    'Edit pool',
+    'New pool',
+    'Save pool',
     // Reasoning launch: delayed SATs-style sets use "Mark set" and "Save
     // answers" to distinguish full-set marking from single-question submit.
     // "Partly worked support" is the child-facing scaffold request, matching

--- a/tests/content-operations-api.test.js
+++ b/tests/content-operations-api.test.js
@@ -372,6 +372,105 @@ test('content operations API publishes linked sentence-entry operations through 
   }
 });
 
+test('content operations API validates package-scoped pool metadata operations', async () => {
+  const server = createWorkerRepositoryServer({ now: () => NOW });
+  try {
+    seedAdultAccount(server.DB, { accountId: ADMIN_ID, platformRole: 'admin' });
+    const repository = createWorkerRepository({
+      env: server.env,
+      now: () => NOW,
+    });
+    await repository.seedFirstContentOperationRelease({
+      seededByAccountId: ADMIN_ID,
+      proof: { source: 'content-operations-api-pool-test' },
+    });
+
+    const hiddenPackage = await createPackage(server, { title: 'Create hidden pool package' });
+    await appendContentOperation(server, hiddenPackage.package.packageId, {
+      entityType: 'spelling.pool',
+      entityId: 'secure-vocabulary',
+      fieldPath: '',
+      action: 'upsert',
+      payload: {
+        id: 'secure-vocabulary',
+        title: 'Secure vocabulary',
+        type: 'extension',
+        visibility: { state: 'hidden' },
+        sourceNote: 'Created by content operations API test.',
+        provenance: { source: 'content-operations-api-test' },
+      },
+    });
+    const hiddenValidated = await validatePackage(server, hiddenPackage.package.packageId, { includeSnapshot: true });
+    const hiddenPool = hiddenValidated.candidate.candidate.draft.pools.find((entry) => entry.id === 'secure-vocabulary');
+    assert.equal(hiddenValidated.candidate.validation.status, 'passed');
+    assert.equal(hiddenPool.type, 'extension');
+    assert.equal(hiddenPool.visibility.state, 'hidden');
+
+    const exceptionPackage = await createPackage(server, { title: 'Create visible no-reward exception pool package' });
+    await appendContentOperation(server, exceptionPackage.package.packageId, {
+      entityType: 'spelling.pool',
+      entityId: 'secure-visible-exception',
+      fieldPath: '',
+      action: 'upsert',
+      payload: {
+        id: 'secure-visible-exception',
+        title: 'Secure visible exception',
+        type: 'extension',
+        visibility: { state: 'visible' },
+        noRewardException: { approved: true, reason: 'Temporary editorial exception.' },
+        sourceNote: 'Created by content operations API test.',
+        provenance: { source: 'content-operations-api-test' },
+      },
+    });
+    const exceptionValidated = await validatePackage(server, exceptionPackage.package.packageId, { includeSnapshot: true });
+    const exceptionPool = exceptionValidated.candidate.candidate.draft.pools.find((entry) => entry.id === 'secure-visible-exception');
+    assert.equal(exceptionValidated.candidate.validation.status, 'passed');
+    assert.equal(exceptionPool.noRewardException.approved, true);
+
+    const rewardPackage = await createPackage(server, { title: 'Create visible rewarded pool package' });
+    await appendContentOperation(server, rewardPackage.package.packageId, {
+      entityType: 'spelling.pool',
+      entityId: 'secure-rewarded',
+      fieldPath: '',
+      action: 'upsert',
+      payload: {
+        id: 'secure-rewarded',
+        title: 'Secure rewarded',
+        type: 'extension',
+        visibility: { state: 'visible' },
+        rewardTrack: { id: 'secure-reward-track', approved: true, source: 'content-operations-api-test' },
+        sourceNote: 'Created by content operations API test.',
+        provenance: { source: 'content-operations-api-test' },
+      },
+    });
+    const rewardValidated = await validatePackage(server, rewardPackage.package.packageId, { includeSnapshot: true });
+    const rewardPool = rewardValidated.candidate.candidate.draft.pools.find((entry) => entry.id === 'secure-rewarded');
+    assert.equal(rewardValidated.candidate.validation.status, 'passed');
+    assert.equal(rewardPool.rewardTrack.approved, true);
+
+    const visiblePackage = await createPackage(server, { title: 'Create visible pool package' });
+    await appendContentOperation(server, visiblePackage.package.packageId, {
+      entityType: 'spelling.pool',
+      entityId: 'secure-visible',
+      fieldPath: '',
+      action: 'upsert',
+      payload: {
+        id: 'secure-visible',
+        title: 'Secure visible',
+        type: 'extension',
+        visibility: { state: 'visible' },
+        sourceNote: 'Created by content operations API test.',
+        provenance: { source: 'content-operations-api-test' },
+      },
+    });
+    const visibleValidated = await validatePackage(server, visiblePackage.package.packageId);
+    assert.equal(visibleValidated.candidate.validation.status, 'blocked');
+    assert.ok(visibleValidated.candidate.validation.errors.some((entry) => entry.code === 'pool_reward_required'));
+  } finally {
+    server.close();
+  }
+});
+
 test('content operations API blocks referenced sentence and active word-list retirements', async () => {
   const server = createWorkerRepositoryServer({ now: () => NOW });
   try {

--- a/tests/content-operations-merge.test.js
+++ b/tests/content-operations-merge.test.js
@@ -32,16 +32,26 @@ test('content operations produce stable hashes and normalised field edits', () =
   assert.equal(contentOperationHash(operation), contentOperationHash({ ...operation }));
 });
 
-test('content operations reject entity contracts that the candidate builder cannot apply yet', () => {
-  assert.throws(
-    () => normaliseContentOperation({
-      entityType: 'spelling.pool',
-      entityId: 'core-y5',
-      action: 'upsert',
-      payload: { id: 'core-y5', title: 'Core Year 5' },
-    }),
-    /Unsupported content operation entity type "spelling\.pool"/,
-  );
+test('content operations apply spelling pool metadata operations', async () => {
+  const bundle = await readSeededSpellingContentBundle();
+  const candidate = buildSpellingContentOperationCandidate(bundle, [{
+    entityType: 'spelling.pool',
+    entityId: 'secure-vocabulary',
+    action: 'upsert',
+    payload: {
+      id: 'secure-vocabulary',
+      title: 'Secure vocabulary',
+      type: 'extension',
+      visibility: { state: 'hidden' },
+      sourceNote: 'Created by content operations merge test.',
+      provenance: { source: 'content-operations-merge-test' },
+    },
+  }]);
+  const pool = candidate.candidate.draft.pools.find((entry) => entry.id === 'secure-vocabulary');
+
+  assert.equal(candidate.validation.ok, true);
+  assert.equal(pool.title, 'Secure vocabulary');
+  assert.equal(pool.visibility.state, 'hidden');
 });
 
 test('content operations detect same-field conflicts without blocking unrelated fields', () => {

--- a/tests/content-operations-seed-script.test.js
+++ b/tests/content-operations-seed-script.test.js
@@ -10,6 +10,9 @@ import {
   isEncodedContentOperationSnapshot,
 } from '../src/subjects/spelling/content/release-snapshot-codec.js';
 import {
+  SPELLING_CONTENT_MODEL_VERSION,
+} from '../src/subjects/spelling/content/model.js';
+import {
   readSeededSpellingContentBundle,
 } from '../worker/src/generated-spelling-content-seed.js';
 import { createMigratedSqliteD1Database } from './helpers/sqlite-d1.js';
@@ -50,7 +53,8 @@ test('content operations seed script builds idempotent first-release SQL', async
     assert.equal(releaseRows[0].published_by_account_id, 'admin-a');
     assert.equal(isEncodedContentOperationSnapshot(releaseRows[0].snapshot_json), true);
     const decoded = JSON.parse(await decodeContentOperationSnapshot(releaseRows[0].snapshot_json));
-    assert.equal(decoded.modelVersion, bundledContent.modelVersion);
+    assert.equal(decoded.modelVersion, SPELLING_CONTENT_MODEL_VERSION);
+    assert.ok(decoded.modelVersion >= bundledContent.modelVersion);
 
     const eventRows = DB.db.prepare(`
       SELECT event_id, event_type, actor_account_id

--- a/tests/react-admin-content-operations.test.js
+++ b/tests/react-admin-content-operations.test.js
@@ -1158,6 +1158,157 @@ test('Content Operations Centre spelling word-list editor appends list upsert op
   assert.match(result.text, /Word list operation saved/);
 });
 
+test('Content Operations Centre spelling pool editor appends pool upsert operations', async () => {
+  const spellingBrowseWithFuturePool = {
+    browse: {
+      ...spellingBrowse.browse,
+      pools: [
+        ...spellingBrowse.browse.pools,
+        {
+          id: 'secure-vocabulary',
+          pool: 'secure-vocabulary',
+          title: 'Secure vocabulary',
+          type: 'extension',
+          visibility: { state: 'hidden', learnerVisible: false },
+          wordCount: 0,
+          totalWordCount: 0,
+          sentenceCount: 0,
+          variantCount: 0,
+          draftStateCounts: {},
+          draftState: 'added',
+        },
+      ],
+    },
+  };
+  const output = await runClientEntry(`
+    const { JSDOM } = require('jsdom');
+
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+    const dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
+      url: 'https://ks2.eugnel.uk/admin',
+    });
+    globalThis.window = dom.window;
+    globalThis.document = dom.window.document;
+    globalThis.navigator = dom.window.navigator;
+    globalThis.HTMLElement = dom.window.HTMLElement;
+    globalThis.Event = dom.window.Event;
+
+    const React = require('react');
+    const { createRoot } = require('react-dom/client');
+    const { AdminContentOperationsSection } = require(${CONTENT_OPS_SECTION_PATH});
+    const { act } = React;
+
+    const calls = [];
+    const model = ${JSON.stringify(baseModel({
+      contentOperations: {
+        overview,
+        packages: { packages: [contentPackage] },
+        releases: { releases: [release] },
+        spellingBrowse: spellingBrowseWithFuturePool,
+        spellingItemDetail: spellingWordDetail,
+      },
+    }))};
+    const actions = {
+      contentOperationsApi: {
+        async readSpellingWord(args) {
+          calls.push({ method: 'readSpellingWord', args });
+          return ${JSON.stringify(spellingWordDetail)};
+        },
+        async appendOperation(args) {
+          calls.push({ method: 'appendOperation', args });
+          return { ok: true, operation: { operationId: 'op-pool-save-1', ...args.operation } };
+        },
+      },
+    };
+
+    async function flush() {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+    }
+
+    async function setControl(selector, value) {
+      const control = document.querySelector(selector);
+      const prototype = control.tagName === 'TEXTAREA'
+        ? dom.window.HTMLTextAreaElement.prototype
+        : (control.tagName === 'SELECT'
+            ? dom.window.HTMLSelectElement.prototype
+            : dom.window.HTMLInputElement.prototype);
+      const valueSetter = Object.getOwnPropertyDescriptor(prototype, 'value').set;
+      valueSetter.call(control, value);
+      await act(async () => {
+        control.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
+        control.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+      });
+    }
+
+    async function main() {
+      const root = createRoot(document.getElementById('root'));
+      await act(async () => {
+        root.render(React.createElement(AdminContentOperationsSection, {
+          model,
+          actions,
+          initialActiveTab: 'spelling',
+          initialSelectedPackageId: 'pkg-draft-1',
+        }));
+      });
+      await flush();
+      const optionValues = {
+        browse: Array.from(document.querySelector('[data-content-ops-spelling-pool="true"]').options).map((option) => option.value),
+        word: Array.from(document.querySelector('[data-content-ops-word-field="spellingPool"]').options).map((option) => option.value),
+        wordList: Array.from(document.querySelector('[data-content-ops-word-list-field="spellingPool"]').options).map((option) => option.value),
+      };
+
+      await setControl('[data-content-ops-pool-field="title"]', 'Extra spelling revised');
+      await setControl('[data-content-ops-pool-field="type"]', 'enrichment');
+      await setControl('[data-content-ops-pool-field="visibilityState"]', 'hidden');
+      await setControl('[data-content-ops-pool-field="sourceNote"]', 'Edited in Content Operations Centre.');
+      await setControl('[data-content-ops-pool-field="provenanceSource"]', 'admin-editor');
+      const saveButton = Array.from(document.querySelectorAll('button'))
+        .find((button) => button.textContent === 'Save pool');
+      await act(async () => {
+        saveButton.click();
+      });
+      await flush();
+      await flush();
+
+      process.stdout.write(JSON.stringify({
+        calls,
+        text: document.body.textContent,
+        optionValues,
+      }));
+
+      await act(async () => {
+        root.unmount();
+      });
+      dom.window.close();
+      process.exit(0);
+    }
+
+    main().catch((error) => {
+      process.stderr.write(error.stack || error.message);
+      process.exitCode = 1;
+    });
+  `);
+  const result = JSON.parse(output);
+  const appendCall = result.calls.find((entry) => entry.method === 'appendOperation');
+
+  assert.ok(appendCall, 'pool editor should append an operation');
+  assert.equal(appendCall.args.packageId, 'pkg-draft-1');
+  assert.equal(appendCall.args.operation.entityType, 'spelling.pool');
+  assert.equal(appendCall.args.operation.action, 'upsert');
+  assert.equal(appendCall.args.operation.entityId, 'extra');
+  assert.equal(appendCall.args.operation.payload.title, 'Extra spelling revised');
+  assert.equal(appendCall.args.operation.payload.type, 'enrichment');
+  assert.equal(appendCall.args.operation.payload.visibility.state, 'hidden');
+  assert.equal(appendCall.args.mutation.requestId.startsWith('content-ops-pool-upsert-pkg-draft-1-'), true);
+  assert.match(result.text, /Pool operation saved/);
+  assert.match(result.text, /Secure vocabulary/);
+  assert.ok(result.optionValues.browse.includes('secure-vocabulary'));
+  assert.ok(result.optionValues.word.includes('secure-vocabulary'));
+  assert.ok(result.optionValues.wordList.includes('secure-vocabulary'));
+});
+
 test('Content Operations Centre spelling tab reloads browse data after package selection changes', async () => {
   const packageB = {
     ...contentPackage,

--- a/tests/spelling-content-operations-model.test.js
+++ b/tests/spelling-content-operations-model.test.js
@@ -12,8 +12,11 @@ import {
 } from '../src/subjects/spelling/content/operations-model.js';
 import {
   buildPublishedSnapshotFromDraft,
+  validateSpellingContentBundle,
 } from '../src/subjects/spelling/content/model.js';
 import {
+  buildSpellingPoolDeleteOrRetireOperation,
+  buildSpellingPoolUpsertOperation,
   buildSpellingSentenceDeleteOrRetireOperation,
   buildSpellingSentenceUpsertOperation,
   buildSpellingWordListDeleteOrRetireOperation,
@@ -21,6 +24,7 @@ import {
   buildSpellingWordDeleteOrRetireOperation,
   buildSpellingWordUpsertOperation,
   validateSpellingSentenceEditorInput,
+  validateSpellingPoolEditorInput,
   validateSpellingWordListEditorInput,
   validateSpellingWordEditorInput,
 } from '../src/subjects/spelling/content/package-operations.js';
@@ -168,6 +172,64 @@ function packageBundle() {
   };
 }
 
+function addFuturePoolWord(bundle, {
+  poolId,
+  title,
+  visibilityState = 'hidden',
+  slug,
+  word,
+  noRewardException = null,
+  rewardTrack = null,
+}) {
+  bundle.draft.pools = [
+    ...(bundle.draft.pools || []),
+    {
+      id: poolId,
+      title,
+      type: 'extension',
+      visibility: { state: visibilityState },
+      sourceNote: `${title} test fixture.`,
+      provenance: { source: 'spelling-content-operations-model-test' },
+      ...(noRewardException ? { noRewardException } : {}),
+      ...(rewardTrack ? { rewardTrack } : {}),
+    },
+  ];
+  bundle.draft.wordLists.push({
+    id: `${poolId}-list`,
+    title: `${title} list`,
+    spellingPool: poolId,
+    coverageTier: 'secure-extension',
+    yearGroups: [],
+    wordSlugs: [slug],
+    sourceNote: `${title} list fixture.`,
+    provenance: { source: 'spelling-content-operations-model-test' },
+    sortIndex: bundle.draft.wordLists.length,
+  });
+  bundle.draft.words.push({
+    slug,
+    word,
+    family: `${poolId}-family`,
+    listId: `${poolId}-list`,
+    spellingPool: poolId,
+    coverageTier: 'secure-extension',
+    yearGroups: [],
+    accepted: [word.toLowerCase()],
+    tags: [poolId],
+    explanation: `${word} is a future-pool fixture word for content operations tests.`,
+    sentenceEntryIds: [`${slug}-s1`],
+    sourceNote: `${word} fixture.`,
+    provenance: { source: 'spelling-content-operations-model-test' },
+    sortIndex: bundle.draft.words.length,
+  });
+  bundle.draft.sentences.push({
+    id: `${slug}-s1`,
+    wordSlug: slug,
+    text: `${word} appears in a future spelling pool fixture sentence.`,
+    variantLabel: 'default',
+    sortIndex: bundle.draft.sentences.length,
+  });
+}
+
 test('spelling content operations browse summarises families, pools, and audio requirements', () => {
   const browse = buildSpellingContentBrowseModel({
     publishedContent: contentBundle(),
@@ -226,6 +288,253 @@ test('spelling content operations browse keeps retired words out of active pool 
   assert.equal(coreList.wordCount, 1);
   assert.equal(coreList.totalWordCount, 2);
   assert.equal(retiredRow.retired, true);
+});
+
+test('spelling content operations browse exposes pool metadata and future hidden pools', () => {
+  const bundle = contentBundle();
+  bundle.draft.pools = [
+    {
+      id: 'core',
+      title: 'Core statutory spelling',
+      type: 'statutory',
+      visibility: { state: 'visible' },
+      sourceNote: 'Seeded core pool.',
+    },
+    {
+      id: 'secure-vocabulary',
+      title: 'Secure vocabulary',
+      type: 'extension',
+      visibility: { state: 'hidden' },
+      sourceNote: 'Staged by editors.',
+    },
+  ];
+  bundle.draft.wordLists.push({
+    id: 'secure-list',
+    title: 'Secure extension',
+    spellingPool: 'secure-vocabulary',
+    coverageTier: 'secure-extension',
+    yearGroups: [],
+    wordSlugs: [],
+    sourceNote: 'Secure list fixture.',
+    sortIndex: 2,
+  });
+
+  const browse = buildSpellingContentBrowseModel({
+    publishedContent: bundle,
+    filters: { pool: 'secure-vocabulary', limit: 20 },
+  });
+  const securePool = browse.pools.find((pool) => pool.id === 'secure-vocabulary');
+  const secureList = browse.wordLists.find((list) => list.id === 'secure-list');
+
+  assert.equal(securePool.title, 'Secure vocabulary');
+  assert.equal(securePool.type, 'extension');
+  assert.equal(securePool.visibility.state, 'hidden');
+  assert.equal(securePool.wordCount, 0);
+  assert.equal(secureList.spellingPool, 'secure-vocabulary');
+  assert.equal(secureList.coverageTier, 'secure-extension');
+});
+
+test('spelling published snapshot filters hidden and staged pool words but keeps visible approved pool words', () => {
+  const bundle = contentBundle();
+  addFuturePoolWord(bundle, {
+    poolId: 'secure-hidden',
+    title: 'Secure hidden',
+    visibilityState: 'hidden',
+    slug: 'hiddenword',
+    word: 'hiddenword',
+  });
+  addFuturePoolWord(bundle, {
+    poolId: 'secure-staged',
+    title: 'Secure staged',
+    visibilityState: 'staged',
+    slug: 'stagedword',
+    word: 'stagedword',
+  });
+  addFuturePoolWord(bundle, {
+    poolId: 'secure-rewarded',
+    title: 'Secure rewarded',
+    visibilityState: 'visible',
+    slug: 'rewardedword',
+    word: 'rewardedword',
+    rewardTrack: { id: 'secure-reward-track', approved: true, source: 'test' },
+  });
+
+  const validation = validateSpellingContentBundle(bundle);
+  const snapshot = buildPublishedSnapshotFromDraft(validation.bundle.draft, { generatedAt: NOW });
+
+  assert.equal(validation.ok, true);
+  assert.equal(snapshot.wordBySlug.hiddenword, undefined);
+  assert.equal(snapshot.wordBySlug.stagedword, undefined);
+  assert.equal(snapshot.wordBySlug.rewardedword.spellingPool, 'secure-rewarded');
+});
+
+test('spelling pool editor allows hidden future pools and blocks visible pools without reward exception', () => {
+  const hiddenOperation = buildSpellingPoolUpsertOperation({
+    id: 'secure-vocabulary',
+    title: 'Secure vocabulary',
+    type: 'extension',
+    visibility: { state: 'hidden' },
+    sourceNote: 'Created by editor.',
+    provenance: { source: 'admin-editor', note: 'T12 hidden pool' },
+  });
+  const blocked = validateSpellingPoolEditorInput({
+    id: 'secure-visible',
+    title: 'Secure visible',
+    type: 'extension',
+    visibility: { state: 'visible' },
+    sourceNote: 'Created by editor.',
+    provenance: { source: 'admin-editor' },
+  });
+  const invalidId = validateSpellingPoolEditorInput({
+    id: 'Bad Pool!',
+    title: 'Bad pool',
+    type: 'extension',
+    visibility: { state: 'hidden' },
+    sourceNote: 'Created by editor.',
+    provenance: { source: 'admin-editor' },
+  });
+  const exceptionOperation = buildSpellingPoolUpsertOperation({
+    id: 'secure-visible-exception',
+    title: 'Secure visible exception',
+    type: 'extension',
+    visibility: { state: 'visible' },
+    sourceNote: 'Created by editor.',
+    provenance: { source: 'admin-editor' },
+    noRewardException: { approved: true, reason: 'Temporary no-reward pool.' },
+  });
+  const rewardTrackOperation = buildSpellingPoolUpsertOperation({
+    id: 'secure-rewarded',
+    title: 'Secure rewarded',
+    type: 'extension',
+    visibility: { state: 'visible' },
+    sourceNote: 'Created by editor.',
+    provenance: { source: 'admin-editor' },
+    rewardTrack: { id: 'secure-track', approved: true, source: 'reward-track-placeholder' },
+  });
+  const exceptionCandidate = buildSpellingContentOperationCandidate(contentBundle(), [exceptionOperation]);
+  const rewardedCandidate = buildSpellingContentOperationCandidate(contentBundle(), [rewardTrackOperation]);
+  const revokeExistingException = validateSpellingPoolEditorInput({
+    id: 'secure-visible-exception',
+    title: 'Secure visible exception',
+    type: 'extension',
+    visibility: { state: 'visible' },
+    sourceNote: 'Created by editor.',
+    provenance: { source: 'admin-editor' },
+    noRewardException: { approved: false, reason: '' },
+  }, {
+    existingPool: exceptionOperation.payload,
+  });
+
+  assert.equal(hiddenOperation.entityType, 'spelling.pool');
+  assert.equal(hiddenOperation.action, 'upsert');
+  assert.equal(hiddenOperation.payload.visibility.state, 'hidden');
+  assert.equal(blocked.ok, false);
+  assert.ok(blocked.errors.some((entry) => entry.code === 'pool_reward_required'));
+  assert.equal(invalidId.ok, false);
+  assert.equal(invalidId.pool.id, 'bad pool!');
+  assert.ok(invalidId.errors.some((entry) => entry.field === 'id'));
+  assert.throws(
+    () => buildSpellingPoolDeleteOrRetireOperation({ id: 'Bad Pool!' }),
+    /stable lowercase id/,
+  );
+  assert.equal(exceptionOperation.payload.noRewardException.approved, true);
+  assert.equal(exceptionCandidate.validation.ok, true);
+  assert.equal(rewardTrackOperation.payload.rewardTrack.approved, true);
+  assert.equal(rewardedCandidate.validation.ok, true);
+  assert.equal(revokeExistingException.ok, false);
+  assert.ok(revokeExistingException.errors.some((entry) => entry.code === 'pool_reward_required'));
+});
+
+test('spelling pool delete removes draft-only pools and blocks referenced pool removal', () => {
+  const draftOnlyBundle = contentBundle({
+    draft: {
+      ...contentBundle().draft,
+      pools: [{
+        id: 'draft-pool',
+        title: 'Draft pool',
+        type: 'extension',
+        visibility: { state: 'hidden' },
+        sourceNote: 'Draft pool fixture.',
+        provenance: { source: 'spelling-content-operations-model-test' },
+      }],
+    },
+  });
+  const remove = buildSpellingPoolDeleteOrRetireOperation({ id: 'draft-pool', hasCurrent: false });
+  const removedCandidate = buildSpellingContentOperationCandidate(draftOnlyBundle, [remove]);
+
+  const referencedBundle = contentBundle();
+  addFuturePoolWord(referencedBundle, {
+    poolId: 'draft-pool',
+    title: 'Draft pool',
+    visibilityState: 'hidden',
+    slug: 'draftpoolword',
+    word: 'draftpoolword',
+  });
+  const blockedCandidate = buildSpellingContentOperationCandidate(referencedBundle, [remove]);
+
+  assert.equal(remove.action, 'remove');
+  assert.equal(removedCandidate.validation.ok, true);
+  assert.equal(removedCandidate.candidate.draft.pools.some((pool) => pool.id === 'draft-pool'), false);
+  assert.equal(blockedCandidate.validation.ok, false);
+  assert.ok(blockedCandidate.validation.errors.some((entry) => entry.code === 'missing_pool'));
+});
+
+test('spelling candidate validation blocks implicit custom pools and non-core statutory pool types', () => {
+  const implicitPoolCandidate = buildSpellingContentOperationCandidate(contentBundle(), [{
+    entityType: 'spelling.wordList',
+    entityId: 'rogue-list',
+    fieldPath: '',
+    action: 'upsert',
+    payload: {
+      id: 'rogue-list',
+      title: 'Rogue list',
+      spellingPool: 'rogue-pool',
+      coverageTier: 'secure-extension',
+      yearGroups: [],
+      wordSlugs: [],
+      sourceNote: 'Raw package operation fixture.',
+      provenance: { source: 'spelling-content-operations-model-test' },
+    },
+  }]);
+  const statutoryFuturePool = buildSpellingContentOperationCandidate(contentBundle(), [{
+    entityType: 'spelling.pool',
+    entityId: 'secure-statutory',
+    fieldPath: '',
+    action: 'upsert',
+    payload: {
+      id: 'secure-statutory',
+      title: 'Secure statutory',
+      type: 'statutory',
+      visibility: { state: 'hidden' },
+      sourceNote: 'Raw package operation fixture.',
+      provenance: { source: 'spelling-content-operations-model-test' },
+    },
+  }]);
+
+  assert.equal(implicitPoolCandidate.validation.ok, false);
+  assert.ok(implicitPoolCandidate.validation.errors.some((entry) => entry.code === 'missing_pool'));
+  assert.equal(statutoryFuturePool.validation.ok, false);
+  assert.ok(statutoryFuturePool.validation.errors.some((entry) => entry.code === 'pool_type_mismatch'));
+});
+
+test('spelling pool retirement hides runtime words but preserves draft references', () => {
+  const bundle = contentBundle();
+  const retire = buildSpellingPoolDeleteOrRetireOperation({ id: 'extra', hasCurrent: true }, {
+    reason: 'Retired by test.',
+    now: () => NOW,
+  });
+  const candidate = buildSpellingContentOperationCandidate(bundle, [retire]);
+  const retiredPool = candidate.candidate.draft.pools.find((pool) => pool.id === 'extra');
+  const retainedList = candidate.candidate.draft.wordLists.find((list) => list.spellingPool === 'extra');
+  const snapshot = buildPublishedSnapshotFromDraft(candidate.candidate.draft, { generatedAt: NOW });
+
+  assert.equal(retire.action, 'retire');
+  assert.equal(candidate.validation.ok, true);
+  assert.equal(retiredPool.retired, true);
+  assert.equal(retiredPool.retirement.reason, 'Retired by test.');
+  assert.ok(retainedList, 'retired pool keeps word-list references for audit/history');
+  assert.equal(snapshot.words.some((word) => word.spellingPool === 'extra'), false);
+  assert.ok(candidate.validation.warnings.some((entry) => entry.code === 'retired_pool_reference'));
 });
 
 test('spelling content operations browse marks package draft additions and modifications', () => {

--- a/tests/spelling-content-patterns.test.js
+++ b/tests/spelling-content-patterns.test.js
@@ -305,8 +305,8 @@ test('H7 convention: content model even, service state odd', () => {
   assert.equal(SPELLING_SERVICE_STATE_VERSION % 2, 1, 'service state must be odd');
 });
 
-test('SPELLING_CONTENT_MODEL_VERSION skips 3 per H7 synthesis', () => {
-  assert.equal(SPELLING_CONTENT_MODEL_VERSION, 6);
+test('SPELLING_CONTENT_MODEL_VERSION keeps the even content-model lane', () => {
+  assert.equal(SPELLING_CONTENT_MODEL_VERSION, 8);
 });
 
 test('normaliser drops unknown patternIds without crashing', () => {

--- a/tests/spelling-content.test.js
+++ b/tests/spelling-content.test.js
@@ -201,7 +201,7 @@ test('seeded spelling content validates and round-trips through the portable exp
   const validation = content.validate();
   assert.equal(validation.ok, true);
   assert.equal(validation.bundle.modelVersion, SPELLING_CONTENT_MODEL_VERSION);
-  assert.equal(SPELLING_CONTENT_MODEL_VERSION, 6, 'Spelling content model keeps the even-version convention.');
+  assert.equal(SPELLING_CONTENT_MODEL_VERSION, 8, 'Spelling content model keeps the even-version convention.');
   assert.equal(validation.errors.length, 0);
   assert.equal(validation.bundle.releases.length, 7);
   assert.equal(validation.bundle.publication.publishedVersion, 7);


### PR DESCRIPTION
## Summary
- Add spelling pool metadata as a first-class Content Operations entity with draft/publish validation, lifecycle controls, retirement, visibility, and stable future pool ids.
- Add admin pool editorial UI for pool metadata, reward/no-reward gating, and dynamic pool choices across word and word-list editors.
- Preserve runtime safety by filtering hidden/staged/retired pool content from published spelling snapshots and blocking invalid non-core statutory semantics.

## Review fixes included
- Prevent deleted pools being recreated from word-list references during normalisation.
- Preserve approved reward-track metadata as an alternative to an explicit no-reward exception for visible future pools.
- Allow no-reward exception revocation from the UI and package operation payload.
- Cover pool delete/remove, hidden pool filtering, id-only pool summaries, non-core statutory blockers, and dynamic UI pool selects.

## Verification
- `node --test tests/spelling-content-operations-model.test.js tests/content-operations-api.test.js tests/react-admin-content-operations.test.js tests/admin-content-operations-v2.test.js tests/content-operations-merge.test.js tests/content-operations-seed-script.test.js tests/spelling-content.test.js tests/spelling-content-patterns.test.js tests/button-label-consistency.test.js`
- `npm test`
- `npm run check`
- Browser smoke: local app server opened `/admin#section=content`, rendered login gate without console errors; authenticated admin UI is covered by React mounted tests.
- Pre-push hook reran `npm test` successfully before pushing.