### PR TITLE
Add spelling audio readiness gates

### DIFF
--- a/src/platform/hubs/admin-content-operations.js
+++ b/src/platform/hubs/admin-content-operations.js
@@ -159,9 +159,11 @@ export function normaliseContentOperationCandidate(entry = null) {
     operationsHash: asString(safe.operationsHash),
     candidateHash: asString(safe.candidateHash),
     validation,
+    audioScan: isPlainObject(safe.audioScan) ? safe.audioScan : null,
     blockers: normaliseContentOperationBlockers(safe.blockers),
     conflicts: asArray(safe.conflicts),
     createdAt: asTs(safe.createdAt),
+    ...(Object.prototype.hasOwnProperty.call(safe, 'candidate') ? { candidate: safe.candidate || null } : {}),
   };
 }
 

--- a/src/subjects/spelling/content/audio-readiness.js
+++ b/src/subjects/spelling/content/audio-readiness.js
@@ -1,0 +1,934 @@
+import {
+  BUFFERED_AUDIO_SPEED_OPTIONS,
+  BUFFERED_GEMINI_VOICE_OPTIONS,
+  SPELLING_AUDIO_MODEL,
+  SPELLING_AUDIO_ROOT_PREFIX,
+  buildAudioAssetKey,
+  buildWordAudioAssetKey,
+} from '../../../../shared/spelling-audio.js';
+import {
+  normaliseContentOperation,
+} from './operations-model.js';
+import {
+  normaliseSpellingContentBundle,
+} from './model.js';
+
+export const SPELLING_AUDIO_REQUIREMENT_PROFILE_VERSION = 'spelling-audio-profile-v1';
+
+const WORD_AUDIO_BLOCKING_STATUSES = new Set([
+  'missing',
+  'stale',
+  'generated',
+  'failed',
+  'skipped',
+  'override_requested',
+]);
+
+const AUDIO_STATUS_BLOCKER_CODES = Object.freeze({
+  word: Object.freeze({
+    missing: 'word_audio_missing',
+    stale: 'word_audio_stale',
+    generated: 'word_audio_not_uploaded',
+    failed: 'word_audio_failed',
+    skipped: 'word_audio_skipped',
+    override_requested: 'word_audio_override_requested',
+  }),
+  sentence: Object.freeze({
+    missing: 'sentence_audio_missing',
+    stale: 'sentence_audio_stale',
+    generated: 'sentence_audio_not_uploaded',
+    failed: 'sentence_audio_failed',
+    skipped: 'sentence_audio_skipped',
+    override_requested: 'sentence_audio_override_requested',
+  }),
+});
+
+const AUDIO_IMPACTFUL_WORD_FIELDS = new Set([
+  'word',
+  'sentenceEntryIds',
+  'variants',
+  'active',
+  'retired',
+  'retirement',
+  'spellingPool',
+  'listId',
+]);
+
+const AUDIO_IMPACTFUL_SENTENCE_FIELDS = new Set([
+  'text',
+  'wordSlug',
+  'active',
+  'retired',
+  'retirement',
+]);
+
+const AUDIO_IMPACTFUL_WORD_LIST_FIELDS = new Set([
+  'active',
+  'retired',
+  'retirement',
+  'spellingPool',
+  'wordSlugs',
+]);
+
+const AUDIO_IMPACTFUL_POOL_FIELDS = new Set([
+  'active',
+  'retired',
+  'retirement',
+  'visibility',
+]);
+
+const AUDIO_IMPACTFUL_VARIANT_FIELDS = new Set([
+  'word',
+  'sentenceEntryIds',
+  'active',
+  'retired',
+  'retirement',
+]);
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function normaliseString(value, fallback = '') {
+  return typeof value === 'string' && value.trim() ? value.trim() : fallback;
+}
+
+function cleanText(value) {
+  return String(value || '').replace(/\s+/g, ' ').trim();
+}
+
+function uniqueStrings(values) {
+  const output = [];
+  const seen = new Set();
+  for (const value of asArray(values)) {
+    const next = normaliseString(value);
+    if (!next || seen.has(next)) continue;
+    seen.add(next);
+    output.push(next);
+  }
+  return output;
+}
+
+function voiceRoleFor(voiceId) {
+  return BUFFERED_GEMINI_VOICE_OPTIONS.find((voice) => voice.id === voiceId)?.role || 'unknown';
+}
+
+function defaultVoiceByRole(role, fallbackIndex) {
+  return BUFFERED_GEMINI_VOICE_OPTIONS.find((voice) => voice.role === role)?.id
+    || BUFFERED_GEMINI_VOICE_OPTIONS[fallbackIndex]?.id
+    || BUFFERED_GEMINI_VOICE_OPTIONS[0]?.id
+    || '';
+}
+
+function defaultSpeedById(speedId) {
+  return BUFFERED_AUDIO_SPEED_OPTIONS.find((speed) => speed.id === speedId) || null;
+}
+
+function defaultWordProfiles() {
+  const maleVoice = defaultVoiceByRole('male', 0);
+  const femaleVoice = defaultVoiceByRole('female', 1);
+  return [
+    {
+      profileId: 'male.natural',
+      lane: 'word',
+      voiceId: maleVoice,
+      voiceRole: voiceRoleFor(maleVoice),
+      paceId: 'natural',
+      speedId: '',
+      slow: false,
+      required: true,
+    },
+    {
+      profileId: 'female.natural',
+      lane: 'word',
+      voiceId: femaleVoice,
+      voiceRole: voiceRoleFor(femaleVoice),
+      paceId: 'natural',
+      speedId: '',
+      slow: false,
+      required: true,
+    },
+  ];
+}
+
+function defaultSentenceProfiles() {
+  const maleVoice = defaultVoiceByRole('male', 0);
+  const femaleVoice = defaultVoiceByRole('female', 1);
+  const standard = defaultSpeedById('standard') || { id: 'standard', slow: false };
+  const slow = defaultSpeedById('slow') || { id: 'slow', slow: true };
+  return [
+    {
+      profileId: 'male.normal',
+      lane: 'sentence',
+      voiceId: maleVoice,
+      voiceRole: voiceRoleFor(maleVoice),
+      paceId: 'standard',
+      speedId: standard.id,
+      slow: Boolean(standard.slow),
+      required: true,
+    },
+    {
+      profileId: 'male.slow',
+      lane: 'sentence',
+      voiceId: maleVoice,
+      voiceRole: voiceRoleFor(maleVoice),
+      paceId: 'slow',
+      speedId: slow.id,
+      slow: Boolean(slow.slow),
+      required: true,
+    },
+    {
+      profileId: 'female.normal',
+      lane: 'sentence',
+      voiceId: femaleVoice,
+      voiceRole: voiceRoleFor(femaleVoice),
+      paceId: 'standard',
+      speedId: standard.id,
+      slow: Boolean(standard.slow),
+      required: true,
+    },
+    {
+      profileId: 'female.slow',
+      lane: 'sentence',
+      voiceId: femaleVoice,
+      voiceRole: voiceRoleFor(femaleVoice),
+      paceId: 'slow',
+      speedId: slow.id,
+      slow: Boolean(slow.slow),
+      required: true,
+    },
+  ];
+}
+
+export const DEFAULT_SPELLING_WORD_AUDIO_PROFILES = Object.freeze(
+  defaultWordProfiles().map((profile) => Object.freeze(profile)),
+);
+
+export const DEFAULT_SPELLING_SENTENCE_AUDIO_PROFILES = Object.freeze(
+  defaultSentenceProfiles().map((profile) => Object.freeze(profile)),
+);
+
+function normaliseProfileEntries(rawEntries, defaults, lane) {
+  if (!Array.isArray(rawEntries) || rawEntries.length === 0) return defaults.map((entry) => ({ ...entry }));
+  const defaultsById = new Map(defaults.map((entry) => [entry.profileId, entry]));
+  const output = [];
+  for (const rawEntry of rawEntries) {
+    const raw = typeof rawEntry === 'string' ? { profileId: rawEntry } : (isPlainObject(rawEntry) ? rawEntry : {});
+    const profileId = normaliseString(raw.profileId || raw.id);
+    const fallback = defaultsById.get(profileId) || null;
+    const voiceId = normaliseString(raw.voiceId || raw.voice, fallback?.voiceId || '');
+    const speedId = lane === 'sentence'
+      ? normaliseString(raw.speedId || raw.speed, fallback?.speedId || 'standard')
+      : '';
+    const paceId = normaliseString(raw.paceId || raw.pace, fallback?.paceId || (lane === 'word' ? 'natural' : speedId));
+    if (!profileId || !voiceId) continue;
+    output.push({
+      profileId,
+      lane,
+      voiceId,
+      voiceRole: normaliseString(raw.voiceRole || raw.role, fallback?.voiceRole || voiceRoleFor(voiceId)),
+      paceId,
+      speedId,
+      slow: lane === 'sentence'
+        ? Boolean(raw.slow ?? fallback?.slow ?? defaultSpeedById(speedId)?.slow)
+        : false,
+      required: raw.required === false ? false : (fallback?.required !== false),
+    });
+  }
+  return output.length ? output : defaults.map((entry) => ({ ...entry }));
+}
+
+export function normaliseSpellingAudioRequirementProfile(rawProfile = null) {
+  const raw = isPlainObject(rawProfile) ? rawProfile : {};
+  const wordProfiles = normaliseProfileEntries(raw.wordProfiles, DEFAULT_SPELLING_WORD_AUDIO_PROFILES, 'word');
+  const sentenceProfiles = normaliseProfileEntries(
+    raw.sentenceProfiles,
+    DEFAULT_SPELLING_SENTENCE_AUDIO_PROFILES,
+    'sentence',
+  );
+  const modelId = normaliseString(raw.modelId || raw.model, SPELLING_AUDIO_MODEL);
+  return {
+    profileVersion: normaliseString(raw.profileVersion || raw.version, SPELLING_AUDIO_REQUIREMENT_PROFILE_VERSION),
+    modelId,
+    wordProfiles,
+    sentenceProfiles,
+    strict: raw.strict === false ? false : true,
+  };
+}
+
+function base64Url(bytes) {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  const base64 = typeof btoa === 'function'
+    ? btoa(binary)
+    : (typeof Buffer !== 'undefined' ? Buffer.from(bytes).toString('base64') : '');
+  if (!base64) throw new Error('Base64 encoding is not available for spelling audio readiness.');
+  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+async function sha256Base64Url(value) {
+  const subtle = globalThis.crypto?.subtle;
+  if (!subtle) throw new Error('WebCrypto SHA-256 is required for spelling audio readiness.');
+  const digest = await subtle.digest('SHA-256', new TextEncoder().encode(value));
+  return base64Url(new Uint8Array(digest));
+}
+
+export async function computeSpellingWordAudioContentKey(slug, word) {
+  return sha256Base64Url([
+    'spelling-audio-word-v1',
+    cleanText(slug).toLowerCase(),
+    cleanText(word),
+  ].join('|'));
+}
+
+export async function computeSpellingSentenceAudioContentKey(slug, sentenceIndex, word, sentence) {
+  return sha256Base64Url([
+    'spelling-audio-content-v2',
+    cleanText(slug).toLowerCase(),
+    String(Number(sentenceIndex)),
+    cleanText(word),
+    cleanText(sentence),
+  ].join('|'));
+}
+
+function draftMaps(bundle) {
+  return {
+    poolsById: new Map(bundle.draft.pools.map((entry) => [entry.id, entry])),
+    wordListsById: new Map(bundle.draft.wordLists.map((entry) => [entry.id, entry])),
+    wordsBySlug: new Map(bundle.draft.words.map((entry) => [entry.slug, entry])),
+    sentencesById: new Map(bundle.draft.sentences.map((entry) => [entry.id, entry])),
+  };
+}
+
+function activeVisibleWord(word, maps) {
+  if (!word || word.active === false || word.retired) return false;
+  const list = maps.wordListsById.get(word.listId);
+  if (list && (list.active === false || list.retired)) return false;
+  const pool = maps.poolsById.get(word.spellingPool);
+  if (pool && (pool.active === false || pool.retired || pool.visibility?.state !== 'visible')) return false;
+  return true;
+}
+
+function activeSentence(sentence) {
+  return Boolean(sentence) && sentence.active !== false && !sentence.retired && Boolean(cleanText(sentence.text));
+}
+
+function operationFirstField(operation) {
+  return normaliseString(operation?.fieldPath).split('.').filter(Boolean)[0] || '';
+}
+
+function operationFieldParts(operation) {
+  return normaliseString(operation?.fieldPath).split('.').filter(Boolean);
+}
+
+function operationPayloadActivates(operation) {
+  if (operation?.action !== 'set') return true;
+  const field = operationFirstField(operation);
+  if (field === 'active') return operation.payload !== false;
+  if (field === 'retired') return operation.payload !== true;
+  return true;
+}
+
+function wordFieldImpactsAudio(operation) {
+  const pathParts = operationFieldParts(operation);
+  const firstField = pathParts[0] || '';
+  if (!AUDIO_IMPACTFUL_WORD_FIELDS.has(firstField)) return false;
+  if (firstField !== 'variants') return true;
+  if (pathParts.length <= 2) return true;
+  return AUDIO_IMPACTFUL_VARIANT_FIELDS.has(pathParts[2]);
+}
+
+function affectedAudioTargets(rawOperations = []) {
+  let affectedAll = false;
+  const affectedSlugs = new Set();
+  const affectedSentenceIds = new Set();
+  const affectedListIds = new Set();
+  const affectedPoolIds = new Set();
+  const operations = asArray(rawOperations)
+    .map((operation) => {
+      try {
+        return normaliseContentOperation(operation, { now: () => 0 });
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean);
+
+  for (const operation of operations) {
+    const firstField = operationFirstField(operation);
+    if (operation.entityType === 'spelling.audioRequirementProfile') {
+      affectedAll = true;
+      continue;
+    }
+    if (operation.entityType === 'spelling.pool') {
+      const structural = ['create', 'upsert', 'replace'].includes(operation.action);
+      const fieldImpactsAudio = operation.action === 'set' && AUDIO_IMPACTFUL_POOL_FIELDS.has(firstField);
+      if ((structural || fieldImpactsAudio) && operationPayloadActivates(operation)) {
+        affectedPoolIds.add(operation.entityId);
+      }
+      continue;
+    }
+    if (operation.entityType === 'spelling.wordList') {
+      const structural = ['create', 'upsert', 'replace'].includes(operation.action);
+      const fieldImpactsAudio = operation.action === 'set' && AUDIO_IMPACTFUL_WORD_LIST_FIELDS.has(firstField);
+      if ((structural || fieldImpactsAudio) && operationPayloadActivates(operation)) {
+        affectedListIds.add(operation.entityId);
+      }
+      continue;
+    }
+    if (operation.entityType === 'spelling.word') {
+      const structural = ['create', 'upsert', 'replace'].includes(operation.action);
+      const fieldImpactsAudio = operation.action === 'set' && wordFieldImpactsAudio(operation);
+      if ((structural || fieldImpactsAudio) && operationPayloadActivates(operation)) {
+        affectedSlugs.add(operation.entityId);
+      }
+      continue;
+    }
+    if (operation.entityType === 'spelling.sentenceEntry') {
+      const structural = ['create', 'upsert', 'replace'].includes(operation.action);
+      const fieldImpactsAudio = operation.action === 'set' && AUDIO_IMPACTFUL_SENTENCE_FIELDS.has(firstField);
+      if ((structural || fieldImpactsAudio) && operationPayloadActivates(operation)) {
+        affectedSentenceIds.add(operation.entityId);
+      }
+    }
+  }
+
+  return {
+    affectedAll,
+    affectedSlugs,
+    affectedSentenceIds,
+    affectedListIds,
+    affectedPoolIds,
+    operationCount: operations.length,
+  };
+}
+
+function wordUsesAffectedSentence(word, affectedSentenceIds) {
+  if (!affectedSentenceIds.size) return false;
+  if (asArray(word.sentenceEntryIds).some((id) => affectedSentenceIds.has(id))) return true;
+  return asArray(word.variants).some((variant) => (
+    asArray(variant.sentenceEntryIds).some((id) => affectedSentenceIds.has(id))
+  ));
+}
+
+function shouldScanWord({
+  word,
+  maps,
+  scope,
+  affectedAll,
+  affectedSlugs,
+  affectedSentenceIds,
+  affectedListIds,
+  affectedPoolIds,
+}) {
+  if (!activeVisibleWord(word, maps)) return false;
+  if (scope === 'all') return true;
+  if (affectedAll) return true;
+  return affectedSlugs.has(word.slug)
+    || wordUsesAffectedSentence(word, affectedSentenceIds)
+    || affectedListIds.has(word.listId)
+    || affectedPoolIds.has(word.spellingPool);
+}
+
+function sentenceEntriesFor(ids, maps) {
+  return uniqueStrings(ids)
+    .map((id) => maps.sentencesById.get(id))
+    .filter(activeSentence)
+    .sort((left, right) => left.sortIndex - right.sortIndex || left.id.localeCompare(right.id));
+}
+
+function parseSpellingAudioKey(key) {
+  const value = normaliseString(key);
+  if (!value || !value.startsWith(`${SPELLING_AUDIO_ROOT_PREFIX}/`)) return null;
+  const parts = value.split('/').map((part) => decodeURIComponent(part));
+  if (parts.length < 7) return null;
+  const [, , modelId, voiceId, fourth] = parts;
+  if (fourth === 'word') {
+    const contentKey = parts[5] || '';
+    const filename = parts[6] || '';
+    const slug = filename.replace(/\.[^.]+$/, '');
+    return {
+      key: value,
+      lane: 'word',
+      modelId,
+      voiceId,
+      paceId: 'natural',
+      speedId: '',
+      contentKey,
+      slug,
+      sentenceIndex: null,
+    };
+  }
+  if (parts.length < 8) return null;
+  const speedId = fourth;
+  const contentKey = parts[5] || '';
+  const slug = parts[6] || '';
+  const sentenceIndex = Number((parts[7] || '').replace(/\.[^.]+$/, ''));
+  return {
+    key: value,
+    lane: 'sentence',
+    modelId,
+    voiceId,
+    paceId: speedId,
+    speedId,
+    contentKey,
+    slug,
+    sentenceIndex: Number.isInteger(sentenceIndex) ? sentenceIndex : null,
+  };
+}
+
+function normaliseInventory(inventory = []) {
+  const entries = [];
+  for (const raw of inventory instanceof Set ? [...inventory] : asArray(inventory)) {
+    const key = typeof raw === 'string' ? raw : normaliseString(raw?.key || raw?.r2Key || raw?.r2_key);
+    const parsed = parseSpellingAudioKey(key);
+    if (parsed) entries.push(parsed);
+  }
+  const byKey = new Set(entries.map((entry) => entry.key));
+  return { entries, byKey };
+}
+
+function normaliseJobStatus(status) {
+  const value = normaliseString(status).toLowerCase().replace(/-/g, '_');
+  if (['uploaded', 'complete', 'completed', 'stored', 'present'].includes(value)) return 'present';
+  if (['override_requested', 'override'].includes(value)) return 'override_requested';
+  if (['generated', 'failed', 'skipped'].includes(value)) return value;
+  return '';
+}
+
+function normaliseJobs(jobs = []) {
+  return asArray(jobs)
+    .map((raw) => {
+      const status = normaliseJobStatus(raw?.status);
+      if (!status) return null;
+      return {
+        lane: normaliseString(raw.lane),
+        entityType: normaliseString(raw.entityType || raw.entity_type),
+        entityId: normaliseString(raw.entityId || raw.entity_id),
+        voiceId: normaliseString(raw.voiceId || raw.voice_id || raw.voice),
+        paceId: normaliseString(raw.paceId || raw.pace_id || raw.speedId || raw.speed_id || raw.speed),
+        modelId: normaliseString(raw.modelId || raw.model_id || raw.model, SPELLING_AUDIO_MODEL),
+        profileVersion: normaliseString(raw.profileVersion || raw.profile_version),
+        contentKey: normaliseString(raw.contentKey || raw.content_key),
+        status,
+        r2Key: normaliseString(raw.r2Key || raw.r2_key || raw.key),
+        error: raw.error || raw.errorJson || raw.error_json || null,
+      };
+    })
+    .filter(Boolean);
+}
+
+function sameRequirementScope(parsedKey, requirement) {
+  if (!parsedKey || parsedKey.lane !== requirement.lane) return false;
+  if (parsedKey.modelId !== requirement.modelId) return false;
+  if (parsedKey.voiceId !== requirement.voiceId) return false;
+  if (parsedKey.slug !== requirement.slug) return false;
+  if (requirement.lane === 'word') return parsedKey.paceId === 'natural';
+  return parsedKey.speedId === requirement.speedId
+    && parsedKey.sentenceIndex === requirement.sentenceIndex;
+}
+
+function sameJobScope(job, requirement) {
+  if (!job || job.lane !== requirement.lane) return false;
+  if (job.modelId !== requirement.modelId) return false;
+  if (job.voiceId !== requirement.voiceId) return false;
+  if (job.paceId !== requirement.paceId && job.paceId !== requirement.speedId) return false;
+  if (job.contentKey === requirement.contentKey) return true;
+  if (job.r2Key) {
+    const parsed = parseSpellingAudioKey(job.r2Key);
+    return sameRequirementScope(parsed, requirement);
+  }
+  return false;
+}
+
+function statusForRequirement(requirement, inventory, jobs) {
+  if (inventory.byKey.has(requirement.r2Key)) return { status: 'present', r2Key: requirement.r2Key };
+  const matchingJob = jobs.find((job) => sameJobScope(job, requirement) && job.contentKey === requirement.contentKey);
+  if (matchingJob) {
+    return {
+      status: matchingJob.status,
+      r2Key: matchingJob.r2Key || requirement.r2Key,
+      job: matchingJob,
+    };
+  }
+  const staleInventory = inventory.entries.find((entry) => (
+    sameRequirementScope(entry, requirement) && entry.contentKey !== requirement.contentKey
+  ));
+  if (staleInventory) {
+    return { status: 'stale', r2Key: staleInventory.key, staleContentKey: staleInventory.contentKey };
+  }
+  const staleJob = jobs.find((job) => {
+    if (job.contentKey === requirement.contentKey) return false;
+    if (!job.r2Key) return false;
+    const parsed = parseSpellingAudioKey(job.r2Key);
+    return sameRequirementScope(parsed, requirement);
+  });
+  if (staleJob) {
+    return {
+      status: 'stale',
+      r2Key: staleJob.r2Key,
+      staleContentKey: staleJob.contentKey,
+      job: staleJob,
+    };
+  }
+  return { status: 'missing', r2Key: requirement.r2Key };
+}
+
+function itemBlockerCode(item) {
+  if (!item.required) return '';
+  return AUDIO_STATUS_BLOCKER_CODES[item.lane]?.[item.status] || '';
+}
+
+function summariseItems(items, lane = null) {
+  const scoped = lane ? items.filter((item) => item.lane === lane) : items;
+  const statusCounts = {};
+  for (const item of scoped) {
+    statusCounts[item.status] = (statusCounts[item.status] || 0) + 1;
+  }
+  const blockers = uniqueStrings(scoped.map(itemBlockerCode).filter(Boolean));
+  const warnings = [];
+  const requiredCount = scoped.filter((item) => item.required).length;
+  const status = blockers.length ? 'blocked' : (warnings.length ? 'warning' : 'passed');
+  return {
+    status,
+    blockers,
+    warnings,
+    requiredCount,
+    totalRequired: requiredCount,
+    presentCount: statusCounts.present || 0,
+    missingCount: statusCounts.missing || 0,
+    staleCount: statusCounts.stale || 0,
+    generatedCount: statusCounts.generated || 0,
+    failedCount: statusCounts.failed || 0,
+    skippedCount: statusCounts.skipped || 0,
+    overrideRequestedCount: statusCounts.override_requested || 0,
+    statusCounts,
+  };
+}
+
+function bySlugSummary(items) {
+  const bySlug = {};
+  for (const item of items) {
+    if (!bySlug[item.slug]) bySlug[item.slug] = { slug: item.slug, items: [] };
+    bySlug[item.slug].items.push(item);
+  }
+  for (const [slug, entry] of Object.entries(bySlug)) {
+    const wordItems = entry.items.filter((item) => item.lane === 'word');
+    const sentenceItems = entry.items.filter((item) => item.lane === 'sentence');
+    const summary = summariseItems(entry.items);
+    bySlug[slug] = {
+      slug,
+      status: summary.status,
+      blockers: summary.blockers,
+      warnings: summary.warnings,
+      wordAudioRequired: wordItems.filter((item) => item.required).length,
+      sentenceAudioRequired: sentenceItems.filter((item) => item.required).length,
+      totalRequired: summary.totalRequired,
+      presentCount: summary.presentCount,
+      missingCount: summary.missingCount,
+      staleCount: summary.staleCount,
+      generatedCount: summary.generatedCount,
+      failedCount: summary.failedCount,
+      skippedCount: summary.skippedCount,
+      overrideRequestedCount: summary.overrideRequestedCount,
+      items: entry.items,
+    };
+  }
+  return bySlug;
+}
+
+async function wordRequirementItems({ word, surface, profile, maps }) {
+  const contentKey = await computeSpellingWordAudioContentKey(word.slug, surface.wordText);
+  return profile.wordProfiles.map((audioProfile) => {
+    const r2Key = buildWordAudioAssetKey({
+      model: profile.modelId,
+      voice: audioProfile.voiceId,
+      contentKey,
+      slug: word.slug,
+    });
+    return {
+      itemId: `word:${word.slug}:${surface.surfaceId}:${audioProfile.profileId}`,
+      lane: 'word',
+      profileId: audioProfile.profileId,
+      profileVersion: profile.profileVersion,
+      modelId: profile.modelId,
+      voiceId: audioProfile.voiceId,
+      voiceRole: audioProfile.voiceRole,
+      paceId: audioProfile.paceId,
+      speedId: audioProfile.speedId,
+      slow: audioProfile.slow,
+      required: audioProfile.required !== false && activeVisibleWord(word, maps),
+      slug: word.slug,
+      word: surface.wordText,
+      surface: surface.surface,
+      variantIndex: surface.variantIndex,
+      variantWord: surface.variantWord,
+      contentKey,
+      r2Key,
+    };
+  });
+}
+
+async function sentenceRequirementItems({ word, sentence, sentenceIndex, surface, profile, maps }) {
+  const contentKey = await computeSpellingSentenceAudioContentKey(
+    word.slug,
+    sentenceIndex,
+    surface.wordText,
+    sentence.text,
+  );
+  return profile.sentenceProfiles.map((audioProfile) => {
+    const r2Key = buildAudioAssetKey({
+      model: profile.modelId,
+      voice: audioProfile.voiceId,
+      speed: audioProfile.speedId,
+      contentKey,
+      slug: word.slug,
+      sentenceIndex,
+    });
+    return {
+      itemId: `sentence:${word.slug}:${sentence.id}:${surface.surfaceId}:${audioProfile.profileId}`,
+      lane: 'sentence',
+      profileId: audioProfile.profileId,
+      profileVersion: profile.profileVersion,
+      modelId: profile.modelId,
+      voiceId: audioProfile.voiceId,
+      voiceRole: audioProfile.voiceRole,
+      paceId: audioProfile.paceId,
+      speedId: audioProfile.speedId,
+      slow: audioProfile.slow,
+      required: audioProfile.required !== false && activeVisibleWord(word, maps),
+      slug: word.slug,
+      word: surface.wordText,
+      sentenceId: sentence.id,
+      sentence: sentence.text,
+      sentenceIndex,
+      surface: surface.surface,
+      variantIndex: surface.variantIndex,
+      variantWord: surface.variantWord,
+      contentKey,
+      r2Key,
+    };
+  });
+}
+
+async function requirementItemsForWord({ word, maps, profile }) {
+  const items = [];
+  const baseSurface = {
+    surfaceId: 'base',
+    surface: 'base',
+    variantIndex: null,
+    variantWord: '',
+    wordText: word.word,
+  };
+  items.push(...await wordRequirementItems({ word, surface: baseSurface, profile, maps }));
+  const baseSentences = sentenceEntriesFor(word.sentenceEntryIds, maps);
+  for (const [sentenceIndex, sentence] of baseSentences.entries()) {
+    items.push(...await sentenceRequirementItems({
+      word,
+      sentence,
+      sentenceIndex,
+      surface: baseSurface,
+      profile,
+      maps,
+    }));
+  }
+
+  for (const [variantIndex, variant] of asArray(word.variants).entries()) {
+    const wordText = cleanText(variant.word);
+    if (!wordText) continue;
+    const variantSurface = {
+      surfaceId: `variant-${variantIndex}`,
+      surface: 'variant',
+      variantIndex,
+      variantWord: wordText,
+      wordText,
+    };
+    items.push(...await wordRequirementItems({ word, surface: variantSurface, profile, maps }));
+    const variantSentences = sentenceEntriesFor(variant.sentenceEntryIds, maps);
+    for (const sentence of variantSentences) {
+      items.push(...await sentenceRequirementItems({
+        word,
+        sentence,
+        sentenceIndex: 0,
+        surface: variantSurface,
+        profile,
+        maps,
+      }));
+    }
+  }
+  return items;
+}
+
+export function buildDefaultSpellingAudioReadinessSummary(
+  word,
+  baseSentenceCount,
+  variantSentenceCount,
+  rawProfile = null,
+) {
+  const profile = normaliseSpellingAudioRequirementProfile(rawProfile);
+  const variantCount = asArray(word?.variants).length;
+  const wordAudioRequired = (1 + variantCount) * profile.wordProfiles.length;
+  const sentenceAudioRequired = (Number(baseSentenceCount) + Number(variantSentenceCount)) * profile.sentenceProfiles.length;
+  return {
+    status: 'not_scanned',
+    profileVersion: profile.profileVersion,
+    modelId: profile.modelId,
+    wordProfiles: profile.wordProfiles.map((entry) => entry.profileId),
+    sentenceProfiles: profile.sentenceProfiles.map((entry) => entry.profileId),
+    wordAudioRequired,
+    sentenceAudioRequired,
+    totalRequired: wordAudioRequired + sentenceAudioRequired,
+    presentCount: 0,
+    missingCount: 0,
+    staleCount: 0,
+    generatedCount: 0,
+    failedCount: 0,
+    skippedCount: 0,
+    overrideRequestedCount: 0,
+    blockers: [],
+    warnings: [],
+  };
+}
+
+export function audioReadinessSummaryForWord(
+  word,
+  baseSentenceCount,
+  variantSentenceCount,
+  scan = null,
+) {
+  const fallback = buildDefaultSpellingAudioReadinessSummary(
+    word,
+    baseSentenceCount,
+    variantSentenceCount,
+    scan?.profile,
+  );
+  const slugSummary = scan?.bySlug?.[word?.slug];
+  if (!slugSummary) return fallback;
+  return {
+    ...fallback,
+    status: slugSummary.status || fallback.status,
+    wordAudioRequired: Number(slugSummary.wordAudioRequired) || 0,
+    sentenceAudioRequired: Number(slugSummary.sentenceAudioRequired) || 0,
+    totalRequired: Number(slugSummary.totalRequired) || 0,
+    presentCount: Number(slugSummary.presentCount) || 0,
+    missingCount: Number(slugSummary.missingCount) || 0,
+    staleCount: Number(slugSummary.staleCount) || 0,
+    generatedCount: Number(slugSummary.generatedCount) || 0,
+    failedCount: Number(slugSummary.failedCount) || 0,
+    skippedCount: Number(slugSummary.skippedCount) || 0,
+    overrideRequestedCount: Number(slugSummary.overrideRequestedCount) || 0,
+    blockers: asArray(slugSummary.blockers),
+    warnings: asArray(slugSummary.warnings),
+    items: asArray(slugSummary.items),
+  };
+}
+
+export function audioReadinessHasBlockingItems(scan = null) {
+  if (!scan || !isPlainObject(scan)) return false;
+  if (asArray(scan.blockers).length > 0) return true;
+  return asArray(scan.items).some((item) => (
+    item.required !== false
+    && WORD_AUDIO_BLOCKING_STATUSES.has(item.status)
+  ));
+}
+
+export async function scanSpellingAudioReadiness(rawBundle, {
+  operations = null,
+  scope = null,
+  profile = null,
+  inventory = [],
+  jobs = [],
+} = {}) {
+  const bundle = normaliseSpellingContentBundle(rawBundle);
+  const maps = draftMaps(bundle);
+  const requirementProfile = normaliseSpellingAudioRequirementProfile(
+    profile ?? bundle.draft.audioRequirementProfile ?? null,
+  );
+  const {
+    affectedAll,
+    affectedSlugs,
+    affectedSentenceIds,
+    affectedListIds,
+    affectedPoolIds,
+    operationCount,
+  } = affectedAudioTargets(operations);
+  const scanScope = scope || (Array.isArray(operations) ? 'affected' : 'all');
+  const plannedItems = [];
+
+  for (const word of bundle.draft.words) {
+    if (!shouldScanWord({
+      word,
+      maps,
+      scope: scanScope,
+      affectedAll,
+      affectedSlugs,
+      affectedSentenceIds,
+      affectedListIds,
+      affectedPoolIds,
+    })) {
+      continue;
+    }
+    const wordItems = await requirementItemsForWord({ word, maps, profile: requirementProfile });
+    const selectedOnlyBySentence = scanScope === 'affected'
+      && !affectedAll
+      && !affectedSlugs.has(word.slug)
+      && !affectedListIds.has(word.listId)
+      && !affectedPoolIds.has(word.spellingPool)
+      && affectedSentenceIds.size;
+    if (selectedOnlyBySentence) {
+      plannedItems.push(...wordItems.filter((item) => (
+        item.lane === 'sentence' && affectedSentenceIds.has(item.sentenceId)
+      )));
+    } else {
+      plannedItems.push(...wordItems);
+    }
+  }
+
+  const normalisedInventory = normaliseInventory(inventory);
+  const normalisedJobs = normaliseJobs(jobs);
+  const items = plannedItems.map((item) => {
+    const state = statusForRequirement(item, normalisedInventory, normalisedJobs);
+    return {
+      ...item,
+      status: state.status,
+      r2Key: state.r2Key || item.r2Key,
+      ...(state.staleContentKey ? { staleContentKey: state.staleContentKey } : {}),
+      ...(state.job?.error ? { error: state.job.error } : {}),
+      blocker: AUDIO_STATUS_BLOCKER_CODES[item.lane]?.[state.status] || '',
+    };
+  });
+  const summary = summariseItems(items);
+  const wordLane = summariseItems(items, 'word');
+  const sentenceLane = summariseItems(items, 'sentence');
+
+  return {
+    status: summary.status,
+    profileVersion: requirementProfile.profileVersion,
+    modelId: requirementProfile.modelId,
+    profile: requirementProfile,
+    scope: scanScope,
+    operationCount,
+    scannedWordCount: new Set(items.map((item) => item.slug)).size,
+    requiredCount: summary.requiredCount,
+    totalRequired: summary.totalRequired,
+    presentCount: summary.presentCount,
+    missingCount: summary.missingCount,
+    staleCount: summary.staleCount,
+    generatedCount: summary.generatedCount,
+    failedCount: summary.failedCount,
+    skippedCount: summary.skippedCount,
+    overrideRequestedCount: summary.overrideRequestedCount,
+    blockers: summary.blockers,
+    warnings: summary.warnings,
+    lanes: {
+      word: wordLane,
+      sentence: sentenceLane,
+    },
+    items,
+    bySlug: bySlugSummary(items),
+  };
+}

--- a/src/subjects/spelling/content/editor-read-model.js
+++ b/src/subjects/spelling/content/editor-read-model.js
@@ -4,16 +4,12 @@ import {
 import {
   stableContentOperationStringify,
 } from './operations-model.js';
+import {
+  audioReadinessSummaryForWord,
+} from './audio-readiness.js';
 
 const DEFAULT_BROWSE_LIMIT = 75;
 const MAX_BROWSE_LIMIT = 250;
-const WORD_AUDIO_PROFILES = Object.freeze(['male.natural', 'female.natural']);
-const SENTENCE_AUDIO_PROFILES = Object.freeze([
-  'male.normal',
-  'male.slow',
-  'female.normal',
-  'female.slow',
-]);
 
 function isPlainObject(value) {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
@@ -295,20 +291,6 @@ function packageDraftState(currentValue, packageValue) {
   return compareValue(currentValue, packageValue) ? 'unchanged' : 'modified';
 }
 
-function audioReadinessForWord(word, baseSentenceCount, variantSentenceCount) {
-  const variantCount = asArray(word?.variants).length;
-  const wordAudioRequired = (1 + variantCount) * WORD_AUDIO_PROFILES.length;
-  const sentenceAudioRequired = (baseSentenceCount + variantSentenceCount) * SENTENCE_AUDIO_PROFILES.length;
-  return {
-    status: 'not_scanned',
-    wordProfiles: [...WORD_AUDIO_PROFILES],
-    sentenceProfiles: [...SENTENCE_AUDIO_PROFILES],
-    wordAudioRequired,
-    sentenceAudioRequired,
-    totalRequired: wordAudioRequired + sentenceAudioRequired,
-  };
-}
-
 function rewardImpactForWord(word, familySize) {
   return {
     status: 'not_mapped',
@@ -332,6 +314,7 @@ function compactWordRow({
   packageComparable,
   draftState,
   validationState,
+  audioScan = null,
 }) {
   const list = maps.wordListsById.get(word.listId) || null;
   const sentences = sentenceEntriesForWord(word, maps);
@@ -363,7 +346,7 @@ function compactWordRow({
     validationState,
     hasCurrent: Boolean(currentComparable),
     hasPackageDraft: Boolean(packageComparable),
-    audioReadiness: audioReadinessForWord(word, sentences.length, variantSentenceCount),
+    audioReadiness: audioReadinessSummaryForWord(word, sentences.length, variantSentenceCount, audioScan),
     rewardImpact: rewardImpactForWord(word, familyMembers.length),
   };
 }
@@ -525,6 +508,7 @@ export function buildSpellingContentBrowseModel({
       packageComparable,
       draftState: packageBundle ? packageDraftState(currentComparable, packageComparable) : 'unchanged',
       validationState,
+      audioScan: packageCandidate?.audioScan || null,
     });
   }).sort((left, right) => (
     left.spellingPool.localeCompare(right.spellingPool)
@@ -572,7 +556,7 @@ export function buildSpellingContentBrowseModel({
   };
 }
 
-function detailedWord(bundle, maps, slug) {
+function detailedWord(bundle, maps, slug, audioScan = null) {
   const word = maps.wordsBySlug.get(slug);
   if (!word) return null;
   const list = maps.wordListsById.get(word.listId) || null;
@@ -602,7 +586,7 @@ function detailedWord(bundle, maps, slug) {
     sentences,
     variants,
     familyMembers,
-    audioReadiness: audioReadinessForWord(word, sentences.length, variantSentenceCount),
+    audioReadiness: audioReadinessSummaryForWord(word, sentences.length, variantSentenceCount, audioScan),
     rewardImpact: rewardImpactForWord(word, familyMembers.length),
   };
 }
@@ -621,8 +605,10 @@ export function buildSpellingContentWordDetail({
   const packageBundle = packageContent ? normaliseSpellingContentBundle(packageContent) : null;
   const currentMaps = draftMaps(currentBundle);
   const packageMaps = packageBundle ? draftMaps(packageBundle) : null;
-  const current = detailedWord(currentBundle, currentMaps, safeSlug);
-  const packageDraft = packageBundle ? detailedWord(packageBundle, packageMaps, safeSlug) : null;
+  const current = detailedWord(currentBundle, currentMaps, safeSlug, null);
+  const packageDraft = packageBundle
+    ? detailedWord(packageBundle, packageMaps, safeSlug, packageCandidate?.audioScan || null)
+    : null;
   return {
     type: 'word',
     slug: safeSlug,

--- a/src/subjects/spelling/content/model.js
+++ b/src/subjects/spelling/content/model.js
@@ -458,6 +458,9 @@ function normaliseDraft(rawValue) {
     provenance: normaliseProvenance(raw.provenance, raw.sourceNote || 'spelling draft'),
     createdAt: normaliseTimestamp(raw.createdAt, updatedAt),
     updatedAt,
+    ...(isPlainObject(raw.audioRequirementProfile)
+      ? { audioRequirementProfile: cloneSerialisable(raw.audioRequirementProfile) }
+      : {}),
     pools,
     wordLists,
     words: (Array.isArray(raw.words) ? raw.words : []).map((entry, index) => normaliseWordEntry(entry, index, wordListsById)),

--- a/src/subjects/spelling/content/operations-model.js
+++ b/src/subjects/spelling/content/operations-model.js
@@ -19,6 +19,7 @@ export const CONTENT_OPERATION_PACKAGE_STATES = Object.freeze({
 });
 
 export const CONTENT_OPERATION_ENTITY_TYPES = Object.freeze([
+  'spelling.audioRequirementProfile',
   'spelling.pool',
   'spelling.word',
   'spelling.sentenceEntry',
@@ -37,6 +38,8 @@ export const CONTENT_OPERATION_ACTIONS = Object.freeze([
 const ENTITY_TYPE_SET = new Set(CONTENT_OPERATION_ENTITY_TYPES);
 const ACTION_SET = new Set(CONTENT_OPERATION_ACTIONS);
 const STRUCTURAL_ACTIONS = new Set(['create', 'upsert', 'replace', 'remove', 'retire']);
+const AUDIO_REQUIREMENT_PROFILE_ENTITY_TYPE = 'spelling.audioRequirementProfile';
+const AUDIO_REQUIREMENT_PROFILE_ENTITY_ID = 'default';
 
 const EDITABLE_COLLECTIONS = Object.freeze({
   'spelling.pool': Object.freeze({ collectionPath: ['draft', 'pools'], idField: 'id' }),
@@ -118,6 +121,32 @@ function findEntity(collection, idField, entityId) {
 }
 
 function applyCollectionOperation(bundle, operation) {
+  if (operation.entityType === AUDIO_REQUIREMENT_PROFILE_ENTITY_TYPE) {
+    if (operation.entityId !== AUDIO_REQUIREMENT_PROFILE_ENTITY_ID) {
+      throw new Error(`Unsupported audio requirement profile "${operation.entityId}".`);
+    }
+    if (['create', 'upsert', 'replace'].includes(operation.action)) {
+      bundle.draft.audioRequirementProfile = cloneSerialisable(operation.payload) || {};
+      return;
+    }
+    if (operation.action === 'remove' || operation.action === 'retire') {
+      delete bundle.draft.audioRequirementProfile;
+      return;
+    }
+    if (operation.action === 'set') {
+      const pathParts = splitFieldPath(operation.fieldPath);
+      if (!pathParts.length) {
+        throw new Error('Set operations require a fieldPath.');
+      }
+      const next = isPlainObject(bundle.draft.audioRequirementProfile)
+        ? cloneSerialisable(bundle.draft.audioRequirementProfile)
+        : {};
+      setAtPath(next, pathParts, operation.payload);
+      bundle.draft.audioRequirementProfile = next;
+      return;
+    }
+  }
+
   const descriptor = collectionFor(bundle, operation.entityType);
   if (!descriptor) {
     throw new Error(`Unsupported content operation entity type "${operation.entityType}".`);
@@ -311,6 +340,13 @@ export function detectContentOperationConflicts(leftOperations = [], rightOperat
 
 export function readContentOperationField(bundle, operation) {
   const normalised = normaliseContentOperation(operation, { now: () => 0 });
+  if (normalised.entityType === AUDIO_REQUIREMENT_PROFILE_ENTITY_TYPE) {
+    if (normalised.entityId !== AUDIO_REQUIREMENT_PROFILE_ENTITY_ID) return undefined;
+    return getAtPath(
+      normaliseSpellingContentBundle(bundle).draft.audioRequirementProfile || {},
+      splitFieldPath(normalised.fieldPath),
+    );
+  }
   const descriptor = collectionFor(normaliseSpellingContentBundle(bundle), normalised.entityType);
   if (!descriptor) return undefined;
   const { entity } = findEntity(descriptor.collection, descriptor.idField, normalised.entityId);

--- a/tests/admin-content-operations-v2.test.js
+++ b/tests/admin-content-operations-v2.test.js
@@ -670,12 +670,18 @@ describe('Content Operations Centre normalisers', () => {
 
   it('normalises candidate review metadata for lifecycle controls', () => {
     const candidate = normaliseContentOperationCandidate(CONTENT_OPS_PACKAGE.latestCandidate);
+    const snapshotCandidate = normaliseContentOperationCandidate({
+      ...CONTENT_OPS_PACKAGE.latestCandidate,
+      candidate: { draft: { words: [{ slug: 'accident' }] } },
+    });
 
     assert.equal(candidate.candidateId, 'cand-draft-1');
     assert.equal(candidate.candidateHash, 'candidate-hash-1');
     assert.equal(candidate.validation.status, 'passed');
     assert.deepEqual(candidate.blockers.blockingSections, ['publishReadiness']);
     assert.equal(candidate.blockers.publishReadiness.blockers[0], 'approval_required');
+    assert.equal(Object.prototype.hasOwnProperty.call(candidate, 'candidate'), false);
+    assert.deepEqual(snapshotCandidate.candidate, { draft: { words: [{ slug: 'accident' }] } });
   });
 
   it('keeps compact package operation counts unknown instead of inventing zero', () => {

--- a/tests/build-spelling-word-audio-plan.test.js
+++ b/tests/build-spelling-word-audio-plan.test.js
@@ -45,6 +45,9 @@ import {
 } from '../scripts/build-spelling-word-audio.mjs';
 import { WORDS } from '../src/subjects/spelling/data/word-data.js';
 import { SEEDED_SPELLING_PUBLISHED_SNAPSHOT } from '../src/subjects/spelling/data/content-data.js';
+import {
+  computeSpellingWordAudioContentKey,
+} from '../src/subjects/spelling/content/audio-readiness.js';
 
 // Pinned fixture values — same digests/keys assertion `tests/spelling-word-prompt.test.js`
 // pins on the worker side. If the encoding or hash input shape changes,
@@ -327,6 +330,13 @@ test('computeWordContentKey applies cleanText collapse identically to Worker', a
   const clean = await computeWordContentKey('accident', 'accident demo');
   assert.equal(dirty, clean);
   assert.equal(dirty, ACCIDENT_DEMO_DIGEST);
+});
+
+test('content-operations audio readiness word content key matches the batch generator', async () => {
+  const scriptKey = await computeWordContentKey('accident', 'accident');
+  const scannerKey = await computeSpellingWordAudioContentKey('accident', 'accident');
+  assert.equal(scannerKey, scriptKey);
+  assert.equal(scannerKey, ACCIDENT_DIGEST);
 });
 
 // INTEGRATION: R2 key byte-equality vs `buildWordAudioAssetKey` (shared helper).

--- a/tests/content-operations-api.test.js
+++ b/tests/content-operations-api.test.js
@@ -5,6 +5,9 @@ import { createWorkerRepository } from '../worker/src/repository.js';
 import {
   readSeededSpellingContentBundle,
 } from '../worker/src/generated-spelling-content-seed.js';
+import {
+  listContentOperationAudioJobs,
+} from '../worker/src/content-operations/audio.js';
 import { createWorkerRepositoryServer } from './helpers/worker-server.js';
 
 const BASE_URL = 'https://repo.test';
@@ -131,6 +134,60 @@ async function publishPackage(server, packageId, body = {}) {
   return readPayload(response);
 }
 
+function seedUploadedAudioJobs(DB, {
+  packageId,
+  candidateId,
+  items = [],
+  accountId = ADMIN_ID,
+  now = NOW,
+  status = 'uploaded',
+} = {}) {
+  const requiredItems = items.filter((item) => item?.required !== false);
+  const statement = DB.db.prepare(`
+    INSERT INTO content_operation_audio_jobs (
+      job_id,
+      package_id,
+      candidate_id,
+      lane,
+      entity_type,
+      entity_id,
+      voice_id,
+      pace_id,
+      model_id,
+      profile_version,
+      content_key,
+      status,
+      r2_key,
+      error_json,
+      requested_by_account_id,
+      completed_at,
+      created_at
+    )
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?)
+  `);
+  for (const [index, item] of requiredItems.entries()) {
+    const lane = item.lane === 'sentence' ? 'sentence' : 'word';
+    statement.run(
+      `audio-job-${packageId}-${index}`,
+      packageId,
+      candidateId,
+      lane,
+      lane === 'sentence' ? 'spelling.sentenceEntry' : 'spelling.word',
+      lane === 'sentence' ? item.sentenceId : item.slug,
+      item.voiceId,
+      item.paceId || item.speedId || 'natural',
+      item.modelId,
+      item.profileVersion,
+      item.contentKey,
+      status,
+      item.r2Key,
+      accountId,
+      now + index,
+      now + index,
+    );
+  }
+}
+
 async function resolveConflictResponse(server, packageId, body = {}) {
   return server.fetchAs(
     ADMIN_ID,
@@ -145,6 +202,54 @@ async function resolveConflict(server, packageId, body = {}) {
   assert.equal(response.status, 200);
   return readPayload(response);
 }
+
+test('content operation audio job listing returns the full package ledger by default', async () => {
+  const server = createWorkerRepositoryServer({ now: () => NOW });
+  try {
+    const packageId = 'copkg-audio-ledger-full';
+    const statement = server.DB.db.prepare(`
+      INSERT INTO content_operation_audio_jobs (
+        job_id,
+        package_id,
+        candidate_id,
+        lane,
+        entity_type,
+        entity_id,
+        voice_id,
+        pace_id,
+        model_id,
+        profile_version,
+        content_key,
+        status,
+        r2_key,
+        error_json,
+        requested_by_account_id,
+        completed_at,
+        created_at
+      )
+      VALUES (?, ?, ?, 'word', 'spelling.word', ?, 'puck', 'natural', 'gemini-2.5-flash-preview-tts',
+        'spelling-audio-profile-v1', ?, 'uploaded', ?, NULL, ?, ?, ?)
+    `);
+    for (let index = 0; index < 1005; index += 1) {
+      statement.run(
+        `audio-ledger-job-${index}`,
+        packageId,
+        'cocand-audio-ledger',
+        `word-${index}`,
+        `content-key-${index}`,
+        `spelling/audio/word-${index}.wav`,
+        ADMIN_ID,
+        NOW + index,
+        NOW + index,
+      );
+    }
+
+    const jobs = await listContentOperationAudioJobs(server.DB, { packageId });
+    assert.equal(jobs.length, 1005);
+  } finally {
+    server.close();
+  }
+});
 
 test('content operations API requires the admin platform role', async () => {
   const server = createWorkerRepositoryServer({ now: () => NOW });
@@ -353,10 +458,62 @@ test('content operations API publishes linked sentence-entry operations through 
       payload: [...word.sentenceEntryIds, sentenceId],
     });
 
-    const validated = await validatePackage(server, packageId);
+    const blocked = await validatePackage(server, packageId);
+    assert.equal(blocked.candidate.validation.status, 'passed');
+    assert.equal(blocked.candidate.blockers.audio.status, 'blocked');
+
+    seedUploadedAudioJobs(server.DB, {
+      packageId,
+      candidateId: blocked.candidate.candidateId,
+      items: blocked.candidate.audioScan.items,
+    });
+
+    const validated = await validatePackage(server, packageId, { includeSnapshot: true });
     assert.equal(validated.candidate.validation.status, 'passed');
+    assert.equal(validated.candidate.blockers.audio.status, 'passed');
 
     await approvePackage(server, packageId, validated.candidate.candidateId);
+    server.DB.db.prepare(`
+      UPDATE content_operation_audio_jobs
+      SET status = 'failed', error_json = ?
+      WHERE package_id = ?
+        AND job_id = (
+          SELECT job_id
+          FROM content_operation_audio_jobs
+          WHERE package_id = ?
+          ORDER BY created_at ASC, job_id ASC
+          LIMIT 1
+        )
+    `).run(JSON.stringify({ message: 'Regression guard failed.' }), packageId, packageId);
+
+    const blockedPublishResponse = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/packages/${packageId}/publish`,
+      jsonInit('POST', {
+        includeSnapshot: false,
+        proof: { source: 'content-operations-api-linked-sentence-drift-test' },
+      }),
+      adminHeaders(),
+    );
+    const blockedPublishPayload = await readPayload(blockedPublishResponse);
+    assert.equal(blockedPublishResponse.status, 409);
+    assert.equal(blockedPublishPayload.code, 'content_operation_candidate_audio_blocked');
+    assert.equal(blockedPublishPayload.audioScan.failedCount, 1);
+
+    const persistedBlockedPublishRow = server.DB.db.prepare(`
+      SELECT audio_scan_json
+      FROM content_operation_package_candidates
+      WHERE candidate_id = ?
+    `).get(validated.candidate.candidateId);
+    const persistedBlockedPublishScan = JSON.parse(persistedBlockedPublishRow.audio_scan_json);
+    assert.equal(persistedBlockedPublishScan.failedCount, 1);
+
+    server.DB.db.prepare(`
+      UPDATE content_operation_audio_jobs
+      SET status = 'uploaded', error_json = NULL
+      WHERE package_id = ?
+    `).run(packageId);
+
     const published = await publishPackage(server, packageId, {
       includeSnapshot: true,
       proof: { source: 'content-operations-api-linked-sentence-test' },
@@ -367,6 +524,87 @@ test('content operations API publishes linked sentence-entry operations through 
     assert.ok(publishedWord.sentenceEntryIds.includes(sentenceId));
     assert.equal(publishedSentence.text, sentenceText);
     assert.equal(publishedSentence.wordSlug, word.slug);
+  } finally {
+    server.close();
+  }
+});
+
+test('content operations API applies package-scoped audio requirement profiles to candidates', async () => {
+  const server = createWorkerRepositoryServer({ now: () => NOW });
+  try {
+    seedAdultAccount(server.DB, { accountId: ADMIN_ID, platformRole: 'admin' });
+    const repository = createWorkerRepository({
+      env: server.env,
+      now: () => NOW,
+    });
+    await repository.seedFirstContentOperationRelease({
+      seededByAccountId: ADMIN_ID,
+      proof: { source: 'content-operations-api-audio-profile-test' },
+    });
+
+    const profile = {
+      wordProfiles: ['male.natural'],
+      sentenceProfiles: ['female.slow'],
+    };
+    const created = await createPackage(server, { title: 'Audio profile package' });
+    const packageId = created.package.packageId;
+
+    await appendContentOperation(server, packageId, {
+      entityType: 'spelling.audioRequirementProfile',
+      entityId: 'default',
+      fieldPath: '',
+      action: 'replace',
+      payload: profile,
+    });
+
+    const validated = await validatePackage(server, packageId, { includeSnapshot: true });
+    assert.equal(validated.candidate.validation.status, 'passed');
+    assert.equal(validated.candidate.blockers.audio.status, 'blocked');
+    assert.deepEqual(validated.candidate.audioScan.profile.wordProfiles.map((entry) => entry.profileId), ['male.natural']);
+    assert.deepEqual(validated.candidate.audioScan.profile.sentenceProfiles.map((entry) => entry.profileId), ['female.slow']);
+    assert.deepEqual(validated.candidate.candidate.draft.audioRequirementProfile, profile);
+    assert.equal(
+      validated.candidate.audioScan.totalRequired,
+      validated.candidate.audioScan.lanes.word.totalRequired + validated.candidate.audioScan.lanes.sentence.totalRequired,
+    );
+  } finally {
+    server.close();
+  }
+});
+
+test('content operations API returns a content-operation envelope for unsupported audio profile ids', async () => {
+  const server = createWorkerRepositoryServer({ now: () => NOW });
+  try {
+    seedAdultAccount(server.DB, { accountId: ADMIN_ID, platformRole: 'admin' });
+    const repository = createWorkerRepository({
+      env: server.env,
+      now: () => NOW,
+    });
+    await repository.seedFirstContentOperationRelease({
+      seededByAccountId: ADMIN_ID,
+      proof: { source: 'content-operations-api-invalid-audio-profile-test' },
+    });
+
+    const created = await createPackage(server, { title: 'Invalid audio profile package' });
+    const packageId = created.package.packageId;
+    await appendContentOperation(server, packageId, {
+      entityType: 'spelling.audioRequirementProfile',
+      entityId: 'secondary',
+      fieldPath: '',
+      action: 'replace',
+      payload: { wordProfiles: ['male.natural'] },
+    });
+
+    const response = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/packages/${packageId}/validate`,
+      jsonInit('POST', { includeSnapshot: true }),
+      adminHeaders(),
+    );
+    const payload = await readPayload(response);
+    assert.equal(response.status, 400);
+    assert.equal(payload.code, 'content_operation_invalid');
+    assert.match(payload.detail, /Unsupported audio requirement profile/);
   } finally {
     server.close();
   }
@@ -607,8 +845,8 @@ test('content operations API supports admin package lifecycle through separate a
       WHERE candidate_id = ?
     `).run(
       JSON.stringify({
-        status: 'blocked',
-        blockers: ['word_audio_missing'],
+        status: 'warning',
+        blockers: [],
         warnings: ['slow_sentence_missing'],
       }),
       JSON.stringify({
@@ -628,7 +866,7 @@ test('content operations API supports admin package lifecycle through separate a
     const packageList = await readPayload(packageListResponse);
     assert.equal(packageListResponse.status, 200);
     const packageSummary = packageList.packages.find((entry) => entry.packageId === packageId);
-    assert.deepEqual(packageSummary.blockers.audio.blockers, ['word_audio_missing']);
+    assert.deepEqual(packageSummary.blockers.audio.blockers, []);
     assert.deepEqual(packageSummary.blockers.audio.warnings, ['slow_sentence_missing']);
     assert.deepEqual(packageSummary.blockers.assets.warnings, ['monster_asset_pending']);
 
@@ -647,7 +885,7 @@ test('content operations API supports admin package lifecycle through separate a
     const approvedSummary = prePublishOverview.overview.lanes.approvedPendingPublish.find(
       (entry) => entry.packageId === packageId,
     );
-    assert.deepEqual(approvedSummary.blockers.audio.blockers, ['word_audio_missing']);
+    assert.deepEqual(approvedSummary.blockers.audio.blockers, []);
     assert.deepEqual(approvedSummary.blockers.assets.warnings, ['monster_asset_pending']);
 
     const publishResponse = await server.fetchAs(
@@ -705,6 +943,77 @@ test('content operations API supports admin package lifecycle through separate a
     assert.equal(overview.overview.latestRelease.releaseId, published.release.releaseId);
     assert.equal(overview.overview.actor.capabilities['content_operations.approve'], true);
     assert.equal(overview.overview.actor.capabilities['content_operations.publish'], true);
+  } finally {
+    server.close();
+  }
+});
+
+test('content operations API blocks approval when affected sentence audio is missing', async () => {
+  const server = createWorkerRepositoryServer({ now: () => NOW });
+  try {
+    seedAdultAccount(server.DB, { accountId: ADMIN_ID, platformRole: 'admin' });
+    const seeded = await readSeededSpellingContentBundle();
+    const word = seeded.draft.words.find((entry) => entry.sentenceEntryIds?.length);
+    const sentenceId = word.sentenceEntryIds[0];
+    const sentence = seeded.draft.sentences.find((entry) => entry.id === sentenceId);
+    const created = await createPackage(server, { title: 'Sentence audio blocker package' });
+    const packageId = created.package.packageId;
+
+    await appendContentOperation(server, packageId, {
+      entityType: 'spelling.sentenceEntry',
+      entityId: sentenceId,
+      fieldPath: 'text',
+      action: 'set',
+      payload: `${sentence.text} This edited sentence needs regenerated speech.`,
+    });
+
+    const validated = await validatePackage(server, packageId);
+    assert.equal(validated.candidate.validation.status, 'passed');
+    assert.equal(validated.candidate.blockers.audio.status, 'blocked');
+    assert.ok(validated.candidate.blockers.audio.blockers.includes('sentence_audio_missing'));
+    assert.equal(validated.candidate.audioScan.lanes.sentence.totalRequired, 4);
+
+    server.DB.db.prepare(`
+      UPDATE content_operation_package_candidates
+      SET audio_scan_json = NULL
+      WHERE candidate_id = ?
+    `).run(validated.candidate.candidateId);
+
+    const approveResponse = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/packages/${packageId}/approve`,
+      jsonInit('POST', {
+        candidateId: validated.candidate.candidateId,
+        notes: 'Audio has not been generated yet.',
+      }),
+      adminHeaders(),
+    );
+    const approvePayload = await readPayload(approveResponse);
+    assert.equal(approveResponse.status, 409);
+    assert.equal(approvePayload.code, 'content_operation_candidate_audio_blocked');
+    assert.equal(approvePayload.audioScan.lanes.sentence.missingCount, 4);
+
+    const persistedScanRow = server.DB.db.prepare(`
+      SELECT audio_scan_json
+      FROM content_operation_package_candidates
+      WHERE candidate_id = ?
+    `).get(validated.candidate.candidateId);
+    const persistedScan = JSON.parse(persistedScanRow.audio_scan_json);
+    assert.equal(persistedScan.lanes.sentence.missingCount, 4);
+
+    const fallbackResponse = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/packages/${packageId}/approve`,
+      jsonInit('POST', {
+        candidateId: validated.candidate.candidateId,
+        notes: 'Attempt a temporary audio fallback.',
+        audioFallback: { reason: 'Operator override requested.' },
+      }),
+      adminHeaders(),
+    );
+    const fallbackPayload = await readPayload(fallbackResponse);
+    assert.equal(fallbackResponse.status, 400);
+    assert.equal(fallbackPayload.code, 'content_operation_audio_fallback_not_supported');
   } finally {
     server.close();
   }

--- a/tests/content-operations-audio-readiness.test.js
+++ b/tests/content-operations-audio-readiness.test.js
@@ -1,0 +1,306 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  SPELLING_AUDIO_MODEL,
+  buildAudioAssetKey,
+} from '../shared/spelling-audio.js';
+import {
+  computeSpellingSentenceAudioContentKey,
+  scanSpellingAudioReadiness,
+} from '../src/subjects/spelling/content/audio-readiness.js';
+
+function spellingBundle() {
+  return {
+    draft: {
+      pools: [{
+        id: 'core',
+        title: 'Core',
+        type: 'statutory',
+        visibility: { state: 'visible', learnerVisible: true },
+        sourceNote: 'Test source.',
+        provenance: { source: 'test', note: 'test', importedAt: 1 },
+        sortIndex: 0,
+      }],
+      wordLists: [{
+        id: 'core-list',
+        title: 'Core list',
+        spellingPool: 'core',
+        coverageTier: 'statutory-core',
+        yearGroups: ['Y3', 'Y4'],
+        wordSlugs: ['early'],
+        sourceNote: 'Test source.',
+        provenance: { source: 'test', note: 'test', importedAt: 1 },
+        sortIndex: 0,
+      }],
+      words: [{
+        slug: 'early',
+        word: 'early',
+        family: 'early',
+        listId: 'core-list',
+        spellingPool: 'core',
+        coverageTier: 'statutory-core',
+        yearGroups: ['Y3', 'Y4'],
+        accepted: ['early'],
+        explanation: 'A time word meaning before the expected time.',
+        sentenceEntryIds: ['early-base'],
+        variants: [{
+          word: 'earlier',
+          accepted: ['earlier'],
+          explanation: 'A related form for comparisons of time.',
+          sentenceEntryIds: ['early-variant'],
+          progressKey: 'earlier',
+          sourceNote: 'Test source.',
+          provenance: { source: 'test', note: 'test', importedAt: 1 },
+        }],
+        sourceNote: 'Test source.',
+        provenance: { source: 'test', note: 'test', importedAt: 1 },
+        progressKey: 'early',
+        sortIndex: 0,
+      }],
+      sentences: [{
+        id: 'early-base',
+        wordSlug: 'early',
+        text: 'The early train arrived before sunrise.',
+        variantLabel: 'base',
+        sourceNote: 'Test source.',
+        provenance: { source: 'test', note: 'test', importedAt: 1 },
+        sortIndex: 0,
+      }, {
+        id: 'early-variant',
+        wordSlug: 'early',
+        text: 'The earlier bus stopped outside school.',
+        variantLabel: 'variant',
+        sourceNote: 'Test source.',
+        provenance: { source: 'test', note: 'test', importedAt: 1 },
+        sortIndex: 1,
+      }],
+      updatedAt: 1,
+    },
+    releases: [],
+    publication: { currentReleaseId: '' },
+  };
+}
+
+test('audio readiness scanner plans word, variant, and sentence profiles with strict missing blockers', async () => {
+  const scan = await scanSpellingAudioReadiness(spellingBundle(), { scope: 'all' });
+
+  assert.equal(scan.status, 'blocked');
+  assert.equal(scan.modelId, SPELLING_AUDIO_MODEL);
+  assert.deepEqual(scan.profile.wordProfiles.map((entry) => entry.profileId), ['male.natural', 'female.natural']);
+  assert.deepEqual(scan.profile.sentenceProfiles.map((entry) => entry.profileId), [
+    'male.normal',
+    'male.slow',
+    'female.normal',
+    'female.slow',
+  ]);
+  assert.equal(scan.lanes.word.totalRequired, 4);
+  assert.equal(scan.lanes.sentence.totalRequired, 8);
+  assert.equal(scan.totalRequired, 12);
+  assert.ok(scan.blockers.includes('word_audio_missing'));
+  assert.ok(scan.blockers.includes('sentence_audio_missing'));
+
+  const variantSentence = scan.items.find((item) => (
+    item.lane === 'sentence'
+    && item.surface === 'variant'
+    && item.profileId === 'female.slow'
+  ));
+  assert.ok(variantSentence);
+  assert.equal(variantSentence.variantWord, 'earlier');
+  assert.equal(variantSentence.sentenceId, 'early-variant');
+  assert.equal(variantSentence.sentenceIndex, 0);
+});
+
+test('audio readiness scanner marks inventory hits present and same-scope old content keys stale', async () => {
+  const baseline = await scanSpellingAudioReadiness(spellingBundle(), { scope: 'all' });
+  const presentItem = baseline.items.find((item) => item.lane === 'word' && item.profileId === 'male.natural');
+  const staleTarget = baseline.items.find((item) => item.lane === 'sentence' && item.profileId === 'male.normal');
+  const staleKey = buildAudioAssetKey({
+    model: staleTarget.modelId,
+    voice: staleTarget.voiceId,
+    speed: staleTarget.speedId,
+    contentKey: 'old-content-key',
+    slug: staleTarget.slug,
+    sentenceIndex: staleTarget.sentenceIndex,
+  });
+
+  const scan = await scanSpellingAudioReadiness(spellingBundle(), {
+    scope: 'all',
+    inventory: [presentItem.r2Key, staleKey],
+  });
+
+  const present = scan.items.find((item) => item.itemId === presentItem.itemId);
+  const stale = scan.items.find((item) => item.itemId === staleTarget.itemId);
+  assert.equal(present.status, 'present');
+  assert.equal(stale.status, 'stale');
+  assert.equal(stale.staleContentKey, 'old-content-key');
+  assert.ok(scan.blockers.includes('sentence_audio_stale'));
+});
+
+test('audio readiness scanner consumes package audio jobs for generated, failed, skipped, and override states', async () => {
+  const baseline = await scanSpellingAudioReadiness(spellingBundle(), { scope: 'all' });
+  const [generated, failed, skipped, override] = baseline.items
+    .filter((item) => item.lane === 'word')
+    .slice(0, 4);
+
+  const scan = await scanSpellingAudioReadiness(spellingBundle(), {
+    scope: 'all',
+    jobs: [
+      { ...generated, status: 'generated', r2Key: generated.r2Key },
+      { ...failed, status: 'failed', r2Key: failed.r2Key, error: { message: 'Provider failed.' } },
+      { ...skipped, status: 'skipped', r2Key: skipped.r2Key },
+      { ...override, status: 'override_requested', r2Key: override.r2Key },
+    ],
+  });
+
+  assert.equal(scan.items.find((item) => item.itemId === generated.itemId).status, 'generated');
+  assert.equal(scan.items.find((item) => item.itemId === failed.itemId).status, 'failed');
+  assert.equal(scan.items.find((item) => item.itemId === skipped.itemId).status, 'skipped');
+  assert.equal(scan.items.find((item) => item.itemId === override.itemId).status, 'override_requested');
+  assert.ok(scan.blockers.includes('word_audio_not_uploaded'));
+  assert.ok(scan.blockers.includes('word_audio_failed'));
+  assert.ok(scan.blockers.includes('word_audio_skipped'));
+  assert.ok(scan.blockers.includes('word_audio_override_requested'));
+});
+
+test('audio readiness affected scope ignores editorial-only word changes but scans sentence text edits', async () => {
+  const editorialOnly = await scanSpellingAudioReadiness(spellingBundle(), {
+    operations: [{
+      entityType: 'spelling.word',
+      entityId: 'early',
+      action: 'set',
+      fieldPath: 'explanation',
+      payload: 'An improved learner-facing explanation.',
+    }],
+  });
+  assert.equal(editorialOnly.status, 'passed');
+  assert.equal(editorialOnly.totalRequired, 0);
+
+  const sentenceEdit = await scanSpellingAudioReadiness(spellingBundle(), {
+    operations: [{
+      entityType: 'spelling.sentenceEntry',
+      entityId: 'early-base',
+      action: 'set',
+      fieldPath: 'text',
+      payload: 'The early train arrived before sunrise.',
+    }],
+  });
+  assert.equal(sentenceEdit.status, 'blocked');
+  assert.equal(sentenceEdit.bySlug.early.wordAudioRequired, 0);
+  assert.equal(sentenceEdit.bySlug.early.sentenceAudioRequired, 4);
+});
+
+test('audio readiness affected scope handles exposure, profile, and nested variant paths', async () => {
+  const variantMetadata = await scanSpellingAudioReadiness(spellingBundle(), {
+    operations: [{
+      entityType: 'spelling.word',
+      entityId: 'early',
+      action: 'set',
+      fieldPath: 'variants.0.explanation',
+      payload: 'A clearer editor-only explanation for this variant.',
+    }],
+  });
+  assert.equal(variantMetadata.status, 'passed');
+  assert.equal(variantMetadata.totalRequired, 0);
+
+  const variantWord = await scanSpellingAudioReadiness(spellingBundle(), {
+    operations: [{
+      entityType: 'spelling.word',
+      entityId: 'early',
+      action: 'set',
+      fieldPath: 'variants.0.word',
+      payload: 'earliest',
+    }],
+  });
+  assert.equal(variantWord.status, 'blocked');
+  assert.equal(variantWord.totalRequired, 12);
+
+  const poolExposure = await scanSpellingAudioReadiness(spellingBundle(), {
+    operations: [{
+      entityType: 'spelling.pool',
+      entityId: 'core',
+      action: 'set',
+      fieldPath: 'visibility.state',
+      payload: 'visible',
+    }],
+  });
+  assert.equal(poolExposure.status, 'blocked');
+  assert.equal(poolExposure.totalRequired, 12);
+
+  const mixedExposureAndSentence = await scanSpellingAudioReadiness(spellingBundle(), {
+    operations: [
+      {
+        entityType: 'spelling.pool',
+        entityId: 'core',
+        action: 'set',
+        fieldPath: 'visibility.state',
+        payload: 'visible',
+      },
+      {
+        entityType: 'spelling.sentenceEntry',
+        entityId: 'early-base',
+        action: 'set',
+        fieldPath: 'text',
+        payload: 'The early train arrived before sunrise.',
+      },
+    ],
+  });
+  assert.equal(mixedExposureAndSentence.status, 'blocked');
+  assert.equal(mixedExposureAndSentence.lanes.word.totalRequired, poolExposure.lanes.word.totalRequired);
+  assert.equal(mixedExposureAndSentence.totalRequired, poolExposure.totalRequired);
+
+  const listExposure = await scanSpellingAudioReadiness(spellingBundle(), {
+    operations: [{
+      entityType: 'spelling.wordList',
+      entityId: 'core-list',
+      action: 'set',
+      fieldPath: 'active',
+      payload: true,
+    }],
+  });
+  assert.equal(listExposure.status, 'blocked');
+  assert.equal(listExposure.totalRequired, 12);
+
+  const profile = {
+    wordProfiles: ['male.natural'],
+    sentenceProfiles: ['female.slow'],
+  };
+  const bundle = spellingBundle();
+  bundle.draft.audioRequirementProfile = profile;
+  const profileScan = await scanSpellingAudioReadiness(bundle, {
+    operations: [{
+      entityType: 'spelling.audioRequirementProfile',
+      entityId: 'default',
+      action: 'replace',
+      fieldPath: '',
+      payload: profile,
+    }],
+  });
+  assert.equal(profileScan.status, 'blocked');
+  assert.deepEqual(profileScan.profile.wordProfiles.map((entry) => entry.profileId), ['male.natural']);
+  assert.deepEqual(profileScan.profile.sentenceProfiles.map((entry) => entry.profileId), ['female.slow']);
+  assert.equal(profileScan.lanes.word.totalRequired, 2);
+  assert.equal(profileScan.lanes.sentence.totalRequired, 2);
+  assert.equal(profileScan.totalRequired, 4);
+});
+
+test('sentence content key matches the shared R2 key helper for candidate scan items', async () => {
+  const scan = await scanSpellingAudioReadiness(spellingBundle(), { scope: 'all' });
+  const sentence = scan.items.find((item) => item.lane === 'sentence' && item.profileId === 'male.normal');
+  const contentKey = await computeSpellingSentenceAudioContentKey(
+    sentence.slug,
+    sentence.sentenceIndex,
+    sentence.word,
+    sentence.sentence,
+  );
+
+  assert.equal(sentence.contentKey, contentKey);
+  assert.equal(sentence.r2Key, buildAudioAssetKey({
+    model: SPELLING_AUDIO_MODEL,
+    voice: sentence.voiceId,
+    speed: sentence.speedId,
+    contentKey,
+    slug: sentence.slug,
+    sentenceIndex: sentence.sentenceIndex,
+  }));
+});

--- a/worker/src/content-operations/audio.js
+++ b/worker/src/content-operations/audio.js
@@ -1,0 +1,79 @@
+import {
+  scanSpellingAudioReadiness,
+} from '../../../src/subjects/spelling/content/audio-readiness.js';
+import {
+  all,
+} from '../d1.js';
+
+function normaliseString(value, fallback = '') {
+  return typeof value === 'string' && value.trim() ? value.trim() : fallback;
+}
+
+function parseJson(value, fallback = null) {
+  if (value == null || value === '') return fallback;
+  if (typeof value !== 'string') return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return fallback;
+  }
+}
+
+function audioJobRowToRecord(row) {
+  if (!row) return null;
+  return {
+    jobId: row.job_id,
+    packageId: row.package_id || null,
+    candidateId: row.candidate_id || null,
+    lane: row.lane,
+    entityType: row.entity_type,
+    entityId: row.entity_id,
+    voiceId: row.voice_id,
+    paceId: row.pace_id,
+    modelId: row.model_id,
+    profileVersion: row.profile_version,
+    contentKey: row.content_key,
+    status: row.status,
+    r2Key: row.r2_key || '',
+    error: parseJson(row.error_json, null),
+    requestedByAccountId: row.requested_by_account_id,
+    completedAt: row.completed_at == null ? null : Number(row.completed_at),
+    createdAt: Number(row.created_at) || 0,
+  };
+}
+
+export async function listContentOperationAudioJobs(db, {
+  packageId = '',
+  limit = null,
+} = {}) {
+  const safePackageId = normaliseString(packageId);
+  if (!safePackageId) return [];
+  const safeLimit = Number(limit);
+  const hasLimit = Number.isFinite(safeLimit) && safeLimit > 0;
+  const rows = await all(db, `
+    SELECT *
+    FROM content_operation_audio_jobs
+    WHERE package_id = ?
+    ORDER BY created_at DESC, job_id DESC
+    ${hasLimit ? 'LIMIT ?' : ''}
+  `, hasLimit ? [safePackageId, Math.floor(safeLimit)] : [safePackageId]);
+  return rows.map(audioJobRowToRecord).filter(Boolean);
+}
+
+export async function buildContentOperationAudioScan({
+  db,
+  packageId = '',
+  candidate,
+  operations = [],
+  profile = null,
+  inventory = [],
+} = {}) {
+  const jobs = await listContentOperationAudioJobs(db, { packageId });
+  return scanSpellingAudioReadiness(candidate, {
+    operations,
+    profile: profile || candidate?.draft?.audioRequirementProfile || null,
+    inventory,
+    jobs,
+    scope: 'affected',
+  });
+}

--- a/worker/src/content-operations/repository.js
+++ b/worker/src/content-operations/repository.js
@@ -15,6 +15,9 @@ import {
   validateSpellingContentBundle,
 } from '../../../src/subjects/spelling/content/model.js';
 import {
+  audioReadinessHasBlockingItems,
+} from '../../../src/subjects/spelling/content/audio-readiness.js';
+import {
   decodeContentOperationSnapshot,
   encodeContentOperationSnapshot,
 } from '../../../src/subjects/spelling/content/release-snapshot-codec.js';
@@ -33,6 +36,9 @@ import {
   ConflictError,
   NotFoundError,
 } from '../errors.js';
+import {
+  buildContentOperationAudioScan,
+} from './audio.js';
 
 function parseJson(value, fallback = null) {
   if (value == null || value === '') return fallback;
@@ -127,6 +133,18 @@ async function candidateRowToRecordAsync(row, { includeSnapshot = false } = {}) 
     ...record,
     candidate: parseJson(snapshotJson, null),
   };
+}
+
+async function persistCandidateAudioScan(db, candidateId, audioScan) {
+  if (!candidateId) return;
+  await run(db, `
+    UPDATE content_operation_package_candidates
+    SET audio_scan_json = ?
+    WHERE candidate_id = ?
+  `, [
+    JSON.stringify(audioScan || null),
+    candidateId,
+  ]);
 }
 
 async function readLatestCandidateForPackage(db, packageId) {
@@ -1040,6 +1058,12 @@ export function createContentOperationsRepository({ db, now }) {
         ...releaseConflicts,
         driftConflict,
       ].filter(Boolean);
+      const audioScan = await buildContentOperationAudioScan({
+        db,
+        packageId,
+        candidate: candidate.candidate,
+        operations,
+      });
       const candidateId = uid('cocand');
       const nowTs = Number(nowFactory());
       const validationSummary = {
@@ -1059,7 +1083,7 @@ export function createContentOperationsRepository({ db, now }) {
             validation_json, audio_scan_json, asset_scan_json, reward_scan_json,
             visibility_scan_json, conflicts_json, created_at
           )
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, ?, ?)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, ?, ?)
         `, [
           candidateId,
           packageId,
@@ -1069,6 +1093,7 @@ export function createContentOperationsRepository({ db, now }) {
           candidate.candidateHash,
           encodedCandidateSnapshot,
           JSON.stringify(validationSummary),
+          JSON.stringify(audioScan),
           JSON.stringify(conflicts),
           nowTs,
         ]),
@@ -1098,6 +1123,11 @@ export function createContentOperationsRepository({ db, now }) {
             candidateHash: candidate.candidateHash,
             operationsHash: candidate.operationsHash,
             validation: validationSummary,
+            audio: {
+              status: audioScan.status,
+              blockers: audioScan.blockers,
+              requiredCount: audioScan.requiredCount,
+            },
           }),
           nowTs,
         ]),
@@ -1112,6 +1142,7 @@ export function createContentOperationsRepository({ db, now }) {
         candidateHash: candidate.candidateHash,
         candidate: candidate.candidate,
         validation: validationSummary,
+        audioScan,
         conflicts,
         createdAt: nowTs,
       };
@@ -1246,7 +1277,14 @@ export function createContentOperationsRepository({ db, now }) {
           candidateId,
         });
       }
-      const candidate = candidateRowToRecord(candidateRow);
+      const candidate = await candidateRowToRecordAsync(candidateRow, { includeSnapshot: true });
+      if (!candidate?.candidate) {
+        throw new ConflictError('Content operation candidate snapshot is unavailable.', {
+          code: 'content_operation_candidate_snapshot_missing',
+          packageId,
+          candidateId,
+        });
+      }
       if (candidate.operationsHash !== currentOperationsHash) {
         throw new ConflictError('Content operation candidate was built from stale package operations.', {
           code: 'content_operation_candidate_operations_stale',
@@ -1273,6 +1311,21 @@ export function createContentOperationsRepository({ db, now }) {
           validation: candidate.validation,
         });
       }
+      const currentAudioScan = await buildContentOperationAudioScan({
+        db,
+        packageId,
+        candidate: candidate.candidate,
+        operations,
+      });
+      if (audioReadinessHasBlockingItems(currentAudioScan)) {
+        await persistCandidateAudioScan(db, candidateId, currentAudioScan);
+        throw new ConflictError('Content operation candidate has audio readiness blockers.', {
+          code: 'content_operation_candidate_audio_blocked',
+          packageId,
+          candidateId,
+          audioScan: currentAudioScan,
+        });
+      }
       if (Array.isArray(candidate.conflicts) && candidate.conflicts.length) {
         throw new ConflictError('Content operation candidate has unresolved conflicts.', {
           code: 'content_operation_candidate_conflicted',
@@ -1289,6 +1342,14 @@ export function createContentOperationsRepository({ db, now }) {
           DELETE FROM content_operation_package_approvals
           WHERE package_id = ?
         `, [packageId]),
+        bindStatement(db, `
+          UPDATE content_operation_package_candidates
+          SET audio_scan_json = ?
+          WHERE candidate_id = ?
+        `, [
+          JSON.stringify(currentAudioScan),
+          candidateId,
+        ]),
         bindStatement(db, `
           INSERT INTO content_operation_package_approvals (
             approval_id, package_id, candidate_id, candidate_hash,
@@ -1337,6 +1398,11 @@ export function createContentOperationsRepository({ db, now }) {
             candidateHash: candidate.candidateHash,
             notes: normaliseString(notes),
             validationSummary: candidate.validation,
+            audio: {
+              status: currentAudioScan.status,
+              blockers: currentAudioScan.blockers,
+              requiredCount: currentAudioScan.requiredCount,
+            },
             audioFallback,
             assetSummary,
           }),
@@ -1399,6 +1465,17 @@ export function createContentOperationsRepository({ db, now }) {
           packageId,
         });
       }
+      const operations = await listPackageOperations(db, packageId);
+      const currentOperationsHash = packageOperationsHash(operations);
+      if (candidate.operationsHash !== currentOperationsHash) {
+        throw new ConflictError('Content operation candidate was built from stale package operations.', {
+          code: 'content_operation_candidate_operations_stale',
+          packageId,
+          candidateId: candidate.candidateId,
+          candidateOperationsHash: candidate.operationsHash,
+          currentOperationsHash,
+        });
+      }
       const currentReleaseRow = await readLatestReleaseRow(db, packageRow.subject_id);
       if (!currentReleaseRow) {
         throw new ConflictError('First global content operation release must be seeded before package publish.', {
@@ -1421,6 +1498,21 @@ export function createContentOperationsRepository({ db, now }) {
           code: 'content_operation_candidate_invalid',
           packageId,
           validation,
+        });
+      }
+      const currentAudioScan = await buildContentOperationAudioScan({
+        db,
+        packageId,
+        candidate: candidate.candidate,
+        operations,
+      });
+      if (audioReadinessHasBlockingItems(currentAudioScan)) {
+        await persistCandidateAudioScan(db, candidate.candidateId, currentAudioScan);
+        throw new ConflictError('Approved candidate has audio readiness blockers.', {
+          code: 'content_operation_candidate_audio_blocked',
+          packageId,
+          candidateId: candidate.candidateId,
+          audioScan: currentAudioScan,
         });
       }
       const releaseId = uid('corel');
@@ -1459,6 +1551,14 @@ export function createContentOperationsRepository({ db, now }) {
             CONTENT_OPERATION_PACKAGE_STATES.APPROVED,
             currentReleaseRow.release_id,
             packageRow.subject_id,
+          ]),
+          bindStatement(db, `
+            UPDATE content_operation_package_candidates
+            SET audio_scan_json = ?
+            WHERE candidate_id = ?
+          `, [
+            JSON.stringify(currentAudioScan),
+            candidate.candidateId,
           ]),
           bindStatement(db, `
             UPDATE content_operation_packages
@@ -1518,7 +1618,7 @@ export function createContentOperationsRepository({ db, now }) {
         throw error;
       }
 
-      if (mutationChangeCount(publishResults[0]) < 1 || mutationChangeCount(publishResults[1]) < 1) {
+      if (mutationChangeCount(publishResults[0]) < 1 || mutationChangeCount(publishResults[2]) < 1) {
         const latestPackageRow = await requirePackage(db, packageId);
         if (latestPackageRow.state === CONTENT_OPERATION_PACKAGE_STATES.PUBLISHED) {
           throw new ConflictError('Content operation package was already published.', {

--- a/worker/src/content-operations/routes.js
+++ b/worker/src/content-operations/routes.js
@@ -112,6 +112,7 @@ function badContentOperation(error) {
   const message = String(error?.message || error || 'Invalid content operation.');
   if (
     message.startsWith('Unsupported content operation')
+    || message.startsWith('Unsupported audio requirement profile')
     || message.startsWith('Content operations require')
     || message.startsWith('Set operations require')
     || message.startsWith('Cannot ')
@@ -573,10 +574,16 @@ export async function handleContentOperationsAdminRequest({
             packageId,
           });
         }
+        if (body.audioFallback != null) {
+          throw new BadRequestError('Content operation audio fallback approvals are not supported.', {
+            code: 'content_operation_audio_fallback_not_supported',
+            packageId,
+            candidateId,
+          });
+        }
         const approval = await repository.approveContentOperationCandidate(packageId, candidateId, {
           approvedByAccountId: actor.id,
           notes: body.notes,
-          audioFallback: body.audioFallback ?? null,
           assetSummary: body.assetSummary ?? null,
         });
         return json({

--- a/worker/src/content-operations/serialisers.js
+++ b/worker/src/content-operations/serialisers.js
@@ -242,6 +242,7 @@ export function serialiseContentOperationCandidate(candidate = {}, { includeSnap
     operationsHash: candidate.operationsHash || '',
     candidateHash: candidate.candidateHash || '',
     validation: normaliseValidation(candidate.validation),
+    audioScan: candidate.audioScan || null,
     blockers: buildContentOperationBlockerEnvelope({
       validation: candidate.validation,
       conflicts: candidate.conflicts,


### PR DESCRIPTION
## Summary
- add spelling audio readiness scanning for word, variant, and sentence requirements
- wire package audio jobs into candidate validation, approval, and publish gates
- expose audio scan metadata through Content Operations Centre normalisers and API envelopes

## Verification
- node --test tests/content-operations-audio-readiness.test.js tests/build-spelling-word-audio-plan.test.js tests/precache-spelling-audio.test.js tests/content-operations-api.test.js tests/admin-content-operations-v2.test.js tests/react-admin-content-operations.test.js tests/spelling-content-operations-model.test.js tests/content-operations-merge.test.js tests/content-operations-seed-script.test.js tests/spelling-content.test.js tests/spelling-content-patterns.test.js tests/button-label-consistency.test.js tests/worker-tts.test.js
- npm test
- npm run check
- pre-push npm test