### PR TITLE
Add content operations TTS audio generation service

### DIFF
--- a/scripts/build-spelling-word-audio.mjs
+++ b/scripts/build-spelling-word-audio.mjs
@@ -35,6 +35,7 @@ import { fileURLToPath } from 'node:url';
 
 import { WORDS } from '../src/subjects/spelling/data/word-data.js';
 import { SEEDED_SPELLING_PUBLISHED_SNAPSHOT } from '../src/subjects/spelling/data/content-data.js';
+import { SPELLING_AUDIO_REQUIREMENT_PROFILE_VERSION } from '../src/subjects/spelling/content/audio-readiness.js';
 import {
   buildAudioAssetKey,
   buildBufferedDictationTranscript,
@@ -122,6 +123,9 @@ export function parseArgs(argv) {
     dryRun: false,
     skipUpload: false,
     fromR2Inventory: false,
+    packageId: '',
+    candidateId: '',
+    requestedByAccountId: '',
     json: false,
   };
 
@@ -178,6 +182,18 @@ export function parseArgs(argv) {
       }
       case '--run-id':
         flags.runId = readValue(index, arg);
+        index += 1;
+        break;
+      case '--package-id':
+        flags.packageId = readValue(index, arg);
+        index += 1;
+        break;
+      case '--candidate-id':
+        flags.candidateId = readValue(index, arg);
+        index += 1;
+        break;
+      case '--requested-by-account-id':
+        flags.requestedByAccountId = readValue(index, arg);
         index += 1;
         break;
       case '--dry-run':
@@ -517,6 +533,44 @@ export function summariseState(entries) {
     else totals.pending += 1;
   }
   return totals;
+}
+
+export function buildContentOperationAudioLedgerEntries({
+  entries = [],
+  requestedByAccountId = '',
+  generatedAt = Date.now(),
+  sourceIdentity = 'operator-script',
+  model = SPELLING_AUDIO_MODEL,
+  profileVersion = SPELLING_AUDIO_REQUIREMENT_PROFILE_VERSION,
+} = {}) {
+  const accountId = cleanText(requestedByAccountId);
+  const generatedAtMs = Number.isFinite(Number(generatedAt)) ? Number(generatedAt) : Date.now();
+  return entries
+    .filter((entry) => entry?.status === 'uploaded')
+    .map((entry) => {
+      const slug = cleanText(entry.slug).toLowerCase();
+      const voiceId = cleanText(entry.voice);
+      const contentKey = cleanText(entry.contentKey);
+      const r2Key = cleanText(entry.key);
+      if (!slug || !voiceId || !contentKey || !r2Key) return null;
+      return {
+        itemId: `word:${slug}:${voiceId}:${contentKey}`,
+        lane: 'word',
+        entityId: slug,
+        slug,
+        voiceId,
+        paceId: 'natural',
+        speedId: '',
+        modelId: cleanText(entry.model || model),
+        profileVersion: cleanText(entry.profileVersion || profileVersion),
+        contentKey,
+        r2Key,
+        sourceIdentity,
+        generatedByAccountId: accountId,
+        generatedAt: generatedAtMs,
+      };
+    })
+    .filter(Boolean);
 }
 
 // `auditTokenMatches` pins the substring-match contract that
@@ -989,6 +1043,42 @@ export async function commandStatus({ runId } = {}) {
   return { runId, statePath, summary, failures };
 }
 
+export async function commandContentOperationAudioLedger({
+  runId,
+  packageId,
+  candidateId = '',
+  requestedByAccountId,
+  now = Date.now(),
+} = {}) {
+  if (!runId) throw new Error('--run-id is required for content-operations-ledger.');
+  if (!packageId) throw new Error('--package-id is required for content-operations-ledger.');
+  if (!requestedByAccountId) throw new Error('--requested-by-account-id is required for content-operations-ledger.');
+  const statePath = statePathFor(runId);
+  const state = await readStateFile(statePath);
+  if (!state) throw new Error(`No state file for run ${runId} (expected ${statePath}).`);
+  const entries = buildContentOperationAudioLedgerEntries({
+    entries: state.entries || [],
+    requestedByAccountId,
+    generatedAt: now,
+    model: state.model || SPELLING_AUDIO_MODEL,
+    profileVersion: state.profileVersion || SPELLING_AUDIO_REQUIREMENT_PROFILE_VERSION,
+  });
+  return {
+    packageId,
+    candidateId: candidateId || null,
+    requestedByAccountId,
+    sourceKind: 'operator-script',
+    runId,
+    statePath,
+    summary: {
+      ...summariseState(state.entries || []),
+      ledgerEntries: entries.length,
+      skippedNotUploaded: Math.max(0, (state.entries || []).length - entries.length),
+    },
+    entries,
+  };
+}
+
 // `commandGenerate` is the production driver. With `dryRun: true` it stops
 // just before the Gemini call (writes the planned state file). With normal
 // flags it runs the pipeline with concurrency + retry. Side effects are all
@@ -1237,6 +1327,8 @@ function printUsage() {
     '                                          [--concurrency 4] [--max-retries 3] [--dry-run]',
     '                                          [--skip-upload] [--from-r2-inventory] [--run-id <id>]',
     '  npm run spelling:word-audio -- status --run-id <id>',
+    '  npm run spelling:word-audio -- content-operations-ledger --run-id <id> --package-id <id>',
+    '                                          --requested-by-account-id <id> [--candidate-id <id>]',
     '',
     'Reads GEMINI_API_KEY (+ GEMINI_API_KEY_2..GEMINI_API_KEY_20, GEMINI_API_KEYS) from the environment.',
     'Reconcile + --from-r2-inventory require CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN.',
@@ -1314,6 +1406,16 @@ async function runCli(argv) {
       }
       case 'status': {
         const result = await commandStatus({ runId: parsed.flags.runId });
+        console.log(JSON.stringify(result, null, 2));
+        break;
+      }
+      case 'content-operations-ledger': {
+        const result = await commandContentOperationAudioLedger({
+          runId: parsed.flags.runId,
+          packageId: parsed.flags.packageId,
+          candidateId: parsed.flags.candidateId,
+          requestedByAccountId: parsed.flags.requestedByAccountId,
+        });
         console.log(JSON.stringify(result, null, 2));
         break;
       }

--- a/tests/build-spelling-word-audio-generate.test.js
+++ b/tests/build-spelling-word-audio-generate.test.js
@@ -33,12 +33,14 @@ import {
   applyInventoryToEntries,
   mergeWithExistingState,
   summariseState,
+  buildContentOperationAudioLedgerEntries,
   auditTokenMatches,
   listR2Objects,
   processEntry,
   commandList,
   commandGenerate,
   commandReconcile,
+  commandContentOperationAudioLedger,
   readStateFile,
   writeStateFile,
   statePathFor,
@@ -60,6 +62,7 @@ const ACCIDENT_KEY_IAPETUS = `spelling-audio/v1/${SPELLING_AUDIO_MODEL}/Iapetus/
 const ACCIDENT_KEY_SULAFAT = `spelling-audio/v1/${SPELLING_AUDIO_MODEL}/Sulafat/word/${ACCIDENT_DIGEST}/accident.mp3`;
 const ACCIDENTALLY_KEY_IAPETUS = `spelling-audio/v1/${SPELLING_AUDIO_MODEL}/Iapetus/word/${ACCIDENTALLY_DIGEST}/accidentally.mp3`;
 const ACCIDENTALLY_KEY_SULAFAT = `spelling-audio/v1/${SPELLING_AUDIO_MODEL}/Sulafat/word/${ACCIDENTALLY_DIGEST}/accidentally.mp3`;
+const LEDGER_NOW = Date.UTC(2026, 5, 12, 10, 0, 0);
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -188,10 +191,25 @@ test('audit substring matcher catches GEMINI_API_KEY_2 / _20 / GEMINI_API_KEYS /
 
 // PARSE ARGS: smoke for the CSV slug split + unknown flag behaviour.
 test('parseArgs splits CSV --slug values and rejects unknown flags', () => {
-  const parsed = parseArgs(['dry-run', '--slug', 'accident,beginning', '--voice', 'Iapetus']);
+  const parsed = parseArgs([
+    'dry-run',
+    '--slug',
+    'accident,beginning',
+    '--voice',
+    'Iapetus',
+    '--package-id',
+    'copkg-test',
+    '--candidate-id',
+    'cocand-test',
+    '--requested-by-account-id',
+    'admin-a',
+  ]);
   assert.equal(parsed.command, 'dry-run');
   assert.deepEqual(parsed.flags.slug, ['accident', 'beginning']);
   assert.equal(parsed.flags.voice, 'Iapetus');
+  assert.equal(parsed.flags.packageId, 'copkg-test');
+  assert.equal(parsed.flags.candidateId, 'cocand-test');
+  assert.equal(parsed.flags.requestedByAccountId, 'admin-a');
 
   assert.throws(
     () => parseArgs(['generate', '--made-up-flag']),
@@ -374,6 +392,89 @@ test('summariseState counts pending / generated / uploaded / failed correctly', 
     { status: 'failed' },
   ]);
   assert.deepEqual(summary, { planned: 5, pending: 2, generated: 1, uploaded: 1, failed: 1 });
+});
+
+test('buildContentOperationAudioLedgerEntries exports uploaded word audio provenance only', () => {
+  const entries = buildContentOperationAudioLedgerEntries({
+    requestedByAccountId: 'admin-a',
+    generatedAt: LEDGER_NOW,
+    entries: [
+      {
+        slug: 'accident',
+        voice: 'Iapetus',
+        key: ACCIDENT_KEY_IAPETUS,
+        contentKey: ACCIDENT_DIGEST,
+        status: 'uploaded',
+      },
+      {
+        slug: 'accidentally',
+        voice: 'Sulafat',
+        key: ACCIDENTALLY_KEY_SULAFAT,
+        contentKey: ACCIDENTALLY_DIGEST,
+        status: 'generated',
+      },
+    ],
+  });
+
+  assert.equal(entries.length, 1);
+  assert.deepEqual(entries[0], {
+    itemId: `word:accident:Iapetus:${ACCIDENT_DIGEST}`,
+    lane: 'word',
+    entityId: 'accident',
+    slug: 'accident',
+    voiceId: 'Iapetus',
+    paceId: 'natural',
+    speedId: '',
+    modelId: SPELLING_AUDIO_MODEL,
+    profileVersion: 'spelling-audio-profile-v1',
+    contentKey: ACCIDENT_DIGEST,
+    r2Key: ACCIDENT_KEY_IAPETUS,
+    sourceIdentity: 'operator-script',
+    generatedByAccountId: 'admin-a',
+    generatedAt: LEDGER_NOW,
+  });
+});
+
+test('content operations ledger command reads uploaded run state', async (t) => {
+  const runId = 'content-ops-ledger-fixture';
+  const statePath = statePathFor(runId);
+  t.after(async () => rm(path.dirname(statePath), { recursive: true, force: true }));
+
+  await writeStateFile(statePath, {
+    runId,
+    model: SPELLING_AUDIO_MODEL,
+    entries: [
+      {
+        slug: 'accident',
+        voice: 'Iapetus',
+        key: ACCIDENT_KEY_IAPETUS,
+        contentKey: ACCIDENT_DIGEST,
+        status: 'uploaded',
+      },
+      {
+        slug: 'accidentally',
+        voice: 'Sulafat',
+        key: ACCIDENTALLY_KEY_SULAFAT,
+        contentKey: ACCIDENTALLY_DIGEST,
+        status: 'failed',
+      },
+    ],
+  });
+
+  const result = await commandContentOperationAudioLedger({
+    runId,
+    packageId: 'copkg-test',
+    candidateId: 'cocand-test',
+    requestedByAccountId: 'admin-a',
+    now: LEDGER_NOW,
+  });
+
+  assert.equal(result.packageId, 'copkg-test');
+  assert.equal(result.candidateId, 'cocand-test');
+  assert.equal(result.requestedByAccountId, 'admin-a');
+  assert.equal(result.summary.ledgerEntries, 1);
+  assert.equal(result.summary.skippedNotUploaded, 1);
+  assert.equal(result.entries[0].r2Key, ACCIDENT_KEY_IAPETUS);
 });
 
 // CLEAN TEXT: parity with the Worker copy. NBSP is the canary.

--- a/tests/content-operations-api.test.js
+++ b/tests/content-operations-api.test.js
@@ -7,6 +7,7 @@ import {
 } from '../worker/src/generated-spelling-content-seed.js';
 import {
   listContentOperationAudioJobs,
+  reconcileContentOperationAudioJobs,
 } from '../worker/src/content-operations/audio.js';
 import { createWorkerRepositoryServer } from './helpers/worker-server.js';
 
@@ -47,6 +48,51 @@ function adminHeaders() {
 
 async function readPayload(response) {
   return response.json();
+}
+
+function geminiAudioResponse(bytes = [1, 2, 3, 4]) {
+  return new Response(JSON.stringify({
+    candidates: [{
+      content: {
+        parts: [{
+          inlineData: {
+            data: Buffer.from(bytes).toString('base64'),
+            mimeType: 'audio/L16;rate=24000',
+          },
+        }],
+      },
+    }],
+  }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function createMemoryR2Bucket() {
+  const objects = new Map();
+  return {
+    gets: [],
+    puts: [],
+    async get(key) {
+      this.gets.push(key);
+      const entry = objects.get(key);
+      if (!entry) return null;
+      return {
+        body: entry.bytes,
+        httpMetadata: { contentType: entry.contentType },
+        customMetadata: entry.customMetadata,
+      };
+    },
+    async put(key, bytes, options = {}) {
+      const storedBytes = bytes instanceof ArrayBuffer ? new Uint8Array(bytes) : bytes;
+      this.puts.push({ key, bytes: storedBytes, options });
+      objects.set(key, {
+        bytes: storedBytes,
+        contentType: options.httpMetadata?.contentType || 'application/octet-stream',
+        customMetadata: options.customMetadata || {},
+      });
+    },
+  };
 }
 
 async function createPackage(server, body = {}) {
@@ -249,6 +295,370 @@ test('content operation audio job listing returns the full package ledger by def
   } finally {
     server.close();
   }
+});
+
+test('content operations generate-audio uses TTS, stores R2 audio, and records authoritative provenance', async (t) => {
+  const originalFetch = globalThis.fetch;
+  const providerCalls = [];
+  globalThis.fetch = async (url, init = {}) => {
+    providerCalls.push({
+      url,
+      headers: init.headers,
+      body: JSON.parse(init.body),
+    });
+    return geminiAudioResponse();
+  };
+  const bucket = createMemoryR2Bucket();
+  const server = createWorkerRepositoryServer({
+    now: () => NOW,
+    env: {
+      GEMINI_API_KEY: 'test-gemini-key',
+      SPELLING_AUDIO_BUCKET: bucket,
+    },
+  });
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+    server.close();
+  });
+
+  seedAdultAccount(server.DB, { accountId: ADMIN_ID, platformRole: 'admin' });
+  const repository = createWorkerRepository({
+    env: server.env,
+    now: () => NOW,
+  });
+  await repository.seedFirstContentOperationRelease({
+    seededByAccountId: ADMIN_ID,
+    proof: { source: 'content-operations-api-generate-audio-test' },
+  });
+
+  const created = await createPackage(server, { title: 'Generate audio package' });
+  const packageId = created.package.packageId;
+  await appendContentOperation(server, packageId, {
+    entityType: 'spelling.audioRequirementProfile',
+    entityId: 'default',
+    fieldPath: '',
+    action: 'replace',
+    payload: {
+      wordProfiles: ['male.natural'],
+      sentenceProfiles: [{ profileId: 'female.slow', required: false }],
+    },
+  });
+  const validated = await validatePackage(server, packageId, { includeSnapshot: true });
+  const target = validated.candidate.audioScan.items.find((item) => item.lane === 'word' && item.required);
+  assert.ok(target, 'expected a required word audio item');
+
+  const response = await server.fetchAs(
+    ADMIN_ID,
+    `${BASE_URL}/api/admin/content-operations/packages/${packageId}/generate-audio`,
+    jsonInit('POST', {
+      candidateId: validated.candidate.candidateId,
+      itemIds: [target.itemId],
+      limit: 1,
+    }),
+    adminHeaders(),
+  );
+  const payload = await readPayload(response);
+  assert.equal(response.status, 200);
+  assert.equal(payload.ok, true);
+  assert.equal(payload.audio.summary.uploaded, 1);
+  assert.equal(payload.audio.summary.failed, 0);
+  assert.equal(providerCalls.length, 1);
+  assert.match(providerCalls[0].url, /generativelanguage\.googleapis\.com/);
+  assert.equal(providerCalls[0].headers['x-goog-api-key'], 'test-gemini-key');
+  assert.equal(providerCalls[0].body.generationConfig.speechConfig.voiceConfig.prebuiltVoiceConfig.voiceName, target.voiceId);
+  assert.equal(bucket.puts.length, 1);
+
+  const row = server.DB.db.prepare(`
+    SELECT *
+    FROM content_operation_audio_jobs
+    WHERE package_id = ?
+  `).get(packageId);
+  assert.equal(row.status, 'uploaded');
+  assert.equal(row.r2_key, bucket.puts[0].key);
+  assert.equal(row.requested_by_account_id, ADMIN_ID);
+  assert.ok(row.idempotency_key.includes(target.contentKey));
+  assert.equal(row.source_kind, 'content-operations-tts');
+  assert.equal(row.attempt_count, 1);
+  const provenance = JSON.parse(row.provenance_json);
+  assert.equal(provenance.sourceIdentity, 'content-operations-tts');
+  assert.equal(provenance.generatedByAccountId, ADMIN_ID);
+  assert.equal(provenance.lane, target.lane);
+  assert.equal(provenance.voiceId, target.voiceId);
+  assert.equal(provenance.modelId, target.modelId);
+  assert.equal(provenance.profileVersion, target.profileVersion);
+  assert.equal(provenance.contentKey, target.contentKey);
+
+  const refreshed = await validatePackage(server, packageId, { includeSnapshot: true });
+  const refreshedItem = refreshed.candidate.audioScan.items.find((item) => item.itemId === target.itemId);
+  assert.equal(refreshedItem.status, 'present');
+
+  const duplicateResponse = await server.fetchAs(
+    ADMIN_ID,
+    `${BASE_URL}/api/admin/content-operations/packages/${packageId}/generate-audio`,
+    jsonInit('POST', {
+      candidateId: refreshed.candidate.candidateId,
+      itemIds: [target.itemId],
+      limit: 1,
+    }),
+    adminHeaders(),
+  );
+  const duplicatePayload = await readPayload(duplicateResponse);
+  assert.equal(duplicateResponse.status, 200);
+  assert.equal(duplicatePayload.audio.summary.requested, 1);
+  assert.equal(duplicatePayload.audio.summary.uploaded, 0);
+  assert.equal(duplicatePayload.audio.summary.skippedExisting, 1);
+  assert.deepEqual(duplicatePayload.audio.jobs, []);
+  assert.equal(providerCalls.length, 1, 'idempotent duplicate should not call the provider again');
+  const rowCount = server.DB.db.prepare(`
+    SELECT COUNT(*) AS count
+    FROM content_operation_audio_jobs
+    WHERE package_id = ?
+  `).get(packageId).count;
+  assert.equal(rowCount, 1);
+
+  const overrideResponse = await server.fetchAs(
+    ADMIN_ID,
+    `${BASE_URL}/api/admin/content-operations/packages/${packageId}/generate-audio`,
+    jsonInit('POST', {
+      candidateId: refreshed.candidate.candidateId,
+      itemIds: [target.itemId],
+      limit: 1,
+      override: true,
+      reason: 'Refresh generated audio after editorial review.',
+    }),
+    adminHeaders(),
+  );
+  const overridePayload = await readPayload(overrideResponse);
+  assert.equal(overrideResponse.status, 200);
+  assert.equal(overridePayload.audio.summary.uploaded, 1);
+  assert.equal(overridePayload.audio.summary.skippedExisting, 0);
+  assert.equal(providerCalls.length, 2, 'override should bypass the cached R2 object and call the provider again');
+  assert.equal(bucket.puts.length, 2, 'override should overwrite the R2 object through the approved storage path');
+  const overrideRow = server.DB.db.prepare(`
+    SELECT *
+    FROM content_operation_audio_jobs
+    WHERE package_id = ?
+  `).get(packageId);
+  assert.equal(overrideRow.attempt_count, 2);
+  const overrideProvenance = JSON.parse(overrideRow.provenance_json);
+  assert.equal(overrideProvenance.override, true);
+  assert.equal(overrideProvenance.overrideReason, 'Refresh generated audio after editorial review.');
+  const overrideRowCount = server.DB.db.prepare(`
+    SELECT COUNT(*) AS count
+    FROM content_operation_audio_jobs
+    WHERE package_id = ?
+  `).get(packageId).count;
+  assert.equal(overrideRowCount, 1);
+
+  const batchOverrideResponse = await server.fetchAs(
+    ADMIN_ID,
+    `${BASE_URL}/api/admin/content-operations/packages/${packageId}/generate-audio`,
+    jsonInit('POST', {
+      limit: 1,
+      override: true,
+      reason: 'Refresh all generated audio after voice profile review.',
+    }),
+    adminHeaders(),
+  );
+  const batchOverridePayload = await readPayload(batchOverrideResponse);
+  assert.equal(batchOverrideResponse.status, 200);
+  assert.equal(batchOverridePayload.audio.summary.uploaded, 1);
+  assert.equal(batchOverridePayload.audio.summary.skippedExisting, 0);
+  assert.equal(providerCalls.length, 3, 'batch override should include present assets when itemIds are omitted');
+  assert.equal(bucket.puts.length, 3);
+  const batchOverrideRow = server.DB.db.prepare(`
+    SELECT *
+    FROM content_operation_audio_jobs
+    WHERE package_id = ?
+  `).get(packageId);
+  assert.equal(batchOverrideRow.attempt_count, 3);
+  const batchOverrideRowCount = server.DB.db.prepare(`
+    SELECT COUNT(*) AS count
+    FROM content_operation_audio_jobs
+    WHERE package_id = ?
+  `).get(packageId).count;
+  assert.equal(batchOverrideRowCount, 1);
+});
+
+test('content operations reconcile operator-script audio jobs into readiness scan', async (t) => {
+  const server = createWorkerRepositoryServer({
+    now: () => NOW,
+  });
+  t.after(() => server.close());
+
+  seedAdultAccount(server.DB, { accountId: ADMIN_ID, platformRole: 'admin' });
+  const repository = createWorkerRepository({
+    env: server.env,
+    now: () => NOW,
+  });
+  await repository.seedFirstContentOperationRelease({
+    seededByAccountId: ADMIN_ID,
+    proof: { source: 'content-operations-api-audio-reconcile-test' },
+  });
+
+  const created = await createPackage(server, { title: 'Operator audio package' });
+  const packageId = created.package.packageId;
+  await appendContentOperation(server, packageId, {
+    entityType: 'spelling.audioRequirementProfile',
+    entityId: 'default',
+    fieldPath: '',
+    action: 'replace',
+    payload: {
+      wordProfiles: ['male.natural'],
+      sentenceProfiles: [{ profileId: 'female.slow', required: false }],
+    },
+  });
+  const validated = await validatePackage(server, packageId, { includeSnapshot: true });
+  const target = validated.candidate.audioScan.items.find((item) => item.lane === 'word' && item.required);
+  assert.ok(target, 'expected a required word audio item');
+
+  const reconciliation = await reconcileContentOperationAudioJobs(server.DB, {
+    packageId,
+    candidateId: validated.candidate.candidateId,
+    requestedByAccountId: ADMIN_ID,
+    sourceKind: 'operator-script',
+    now: NOW,
+    entries: [{
+      itemId: target.itemId,
+      lane: target.lane,
+      slug: target.slug,
+      voiceId: target.voiceId,
+      paceId: target.paceId,
+      modelId: target.modelId,
+      profileVersion: target.profileVersion,
+      contentKey: target.contentKey,
+      r2Key: target.r2Key,
+      sourceIdentity: 'operator-script',
+      generatedByAccountId: ADMIN_ID,
+      generatedAt: NOW,
+    }],
+  });
+
+  assert.equal(reconciliation.summary.uploaded, 1);
+  assert.equal(reconciliation.jobs[0].sourceKind, 'operator-script');
+
+  const row = server.DB.db.prepare(`
+    SELECT *
+    FROM content_operation_audio_jobs
+    WHERE package_id = ?
+  `).get(packageId);
+  assert.equal(row.status, 'uploaded');
+  assert.equal(row.r2_key, target.r2Key);
+  assert.equal(row.source_kind, 'operator-script');
+  const provenance = JSON.parse(row.provenance_json);
+  assert.equal(provenance.sourceIdentity, 'operator-script');
+  assert.equal(provenance.generatedByAccountId, ADMIN_ID);
+  assert.equal(provenance.generatedAt, NOW);
+  assert.equal(provenance.lane, 'word');
+  assert.equal(provenance.voiceId, target.voiceId);
+  assert.equal(provenance.paceId, target.paceId);
+  assert.equal(provenance.modelId, target.modelId);
+  assert.equal(provenance.profileVersion, target.profileVersion);
+  assert.equal(provenance.r2Key, target.r2Key);
+
+  await reconcileContentOperationAudioJobs(server.DB, {
+    packageId,
+    candidateId: validated.candidate.candidateId,
+    requestedByAccountId: ADMIN_ID,
+    sourceKind: 'operator-script',
+    now: NOW + 1,
+    entries: [{
+      itemId: `word:${target.slug}:${target.voiceId}:${target.contentKey}`,
+      lane: target.lane,
+      slug: target.slug,
+      voiceId: target.voiceId,
+      paceId: target.paceId,
+      modelId: target.modelId,
+      profileVersion: target.profileVersion,
+      contentKey: target.contentKey,
+      r2Key: target.r2Key,
+      sourceIdentity: 'operator-script',
+      generatedByAccountId: ADMIN_ID,
+      generatedAt: NOW + 1,
+    }],
+  });
+  const rowCount = server.DB.db.prepare(`
+    SELECT COUNT(*) AS count
+    FROM content_operation_audio_jobs
+    WHERE package_id = ?
+  `).get(packageId).count;
+  assert.equal(rowCount, 1);
+
+  const refreshed = await validatePackage(server, packageId, { includeSnapshot: true });
+  const refreshedItem = refreshed.candidate.audioScan.items.find((item) => item.itemId === target.itemId);
+  assert.equal(refreshedItem.status, 'present');
+});
+
+test('content operations generate-audio records provider failures as retryable failed jobs', async (t) => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response(JSON.stringify({ error: { message: 'quota exceeded' } }), {
+    status: 429,
+    headers: { 'content-type': 'application/json' },
+  });
+  const server = createWorkerRepositoryServer({
+    now: () => NOW,
+    env: {
+      GEMINI_API_KEY: 'test-gemini-key',
+      SPELLING_AUDIO_BUCKET: createMemoryR2Bucket(),
+    },
+  });
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+    server.close();
+  });
+
+  seedAdultAccount(server.DB, { accountId: ADMIN_ID, platformRole: 'admin' });
+  const repository = createWorkerRepository({
+    env: server.env,
+    now: () => NOW,
+  });
+  await repository.seedFirstContentOperationRelease({
+    seededByAccountId: ADMIN_ID,
+    proof: { source: 'content-operations-api-generate-audio-failure-test' },
+  });
+
+  const created = await createPackage(server, { title: 'Failed audio package' });
+  const packageId = created.package.packageId;
+  await appendContentOperation(server, packageId, {
+    entityType: 'spelling.audioRequirementProfile',
+    entityId: 'default',
+    fieldPath: '',
+    action: 'replace',
+    payload: { wordProfiles: ['male.natural'] },
+  });
+  const validated = await validatePackage(server, packageId, { includeSnapshot: true });
+  const target = validated.candidate.audioScan.items.find((item) => item.lane === 'word' && item.required);
+
+  const response = await server.fetchAs(
+    ADMIN_ID,
+    `${BASE_URL}/api/admin/content-operations/packages/${packageId}/generate-audio`,
+    jsonInit('POST', {
+      candidateId: validated.candidate.candidateId,
+      itemIds: [target.itemId],
+      limit: 1,
+    }),
+    adminHeaders(),
+  );
+  const payload = await readPayload(response);
+  assert.equal(response.status, 200);
+  assert.equal(payload.audio.summary.failed, 1);
+  assert.equal(payload.audio.jobs[0].status, 'failed');
+
+  const row = server.DB.db.prepare(`
+    SELECT status, error_json, attempt_count
+    FROM content_operation_audio_jobs
+    WHERE package_id = ?
+  `).get(packageId);
+  assert.equal(row.status, 'failed');
+  assert.equal(row.attempt_count, 1);
+  const error = JSON.parse(row.error_json);
+  assert.equal(error.provider, 'gemini');
+  assert.equal(error.providerStatus, 429);
+
+  const refreshed = await validatePackage(server, packageId, { includeSnapshot: true });
+  const failedItem = refreshed.candidate.audioScan.items.find((item) => item.itemId === target.itemId);
+  assert.equal(failedItem.status, 'failed');
+  assert.equal(failedItem.error.providerStatus, 429);
 });
 
 test('content operations API requires the admin platform role', async () => {

--- a/tests/worker-migration-0021.test.js
+++ b/tests/worker-migration-0021.test.js
@@ -1,0 +1,103 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { SqliteD1Database } from './helpers/sqlite-d1.js';
+
+const migration0020Path = resolve(
+  import.meta.dirname || '.',
+  '../worker/migrations/0020_content_operations_centre.sql',
+);
+
+const migration0021Path = resolve(
+  import.meta.dirname || '.',
+  '../worker/migrations/0021_content_operations_audio_jobs_ledger.sql',
+);
+
+const migration0020Sql = readFileSync(migration0020Path, 'utf-8');
+const migration0021Sql = readFileSync(migration0021Path, 'utf-8');
+
+function columns(db) {
+  return db.db.prepare(`PRAGMA table_info(content_operation_audio_jobs)`).all()
+    .map((row) => ({ name: row.name, notnull: row.notnull, dflt_value: row.dflt_value }));
+}
+
+function indexes(db) {
+  return db.db.prepare(`PRAGMA index_list(content_operation_audio_jobs)`).all()
+    .map((row) => row.name)
+    .sort();
+}
+
+function insertLegacyAudioJob(db, jobId) {
+  db.db.prepare(`
+    INSERT INTO content_operation_audio_jobs (
+      job_id,
+      package_id,
+      candidate_id,
+      lane,
+      entity_type,
+      entity_id,
+      voice_id,
+      pace_id,
+      model_id,
+      profile_version,
+      content_key,
+      status,
+      r2_key,
+      error_json,
+      requested_by_account_id,
+      completed_at,
+      created_at
+    )
+    VALUES (?, 'copkg-legacy', 'cocand-legacy', 'word', 'spelling.word', ?, 'Iapetus', 'natural',
+      'gemini-2.5-flash-preview-tts', 'spelling-audio-profile-v1', ?, 'uploaded', ?, NULL,
+      'admin-a', 1800000000000, 1800000000000)
+  `).run(jobId, jobId, `content-key-${jobId}`, `spelling-audio/${jobId}.mp3`);
+}
+
+test('migration 0021 adds authoritative audio ledger columns and idempotency index', () => {
+  const db = new SqliteD1Database();
+  try {
+    db.db.exec(migration0020Sql);
+    insertLegacyAudioJob(db, 'audio-job-1');
+
+    db.db.exec(migration0021Sql);
+
+    const byName = new Map(columns(db).map((column) => [column.name, column]));
+    assert.equal(byName.get('idempotency_key')?.notnull, 0);
+    assert.equal(byName.get('source_kind')?.notnull, 0);
+    assert.equal(byName.get('provenance_json')?.notnull, 0);
+    assert.equal(byName.get('attempt_count')?.notnull, 1);
+    assert.equal(byName.get('attempt_count')?.dflt_value, '0');
+    assert.equal(byName.get('updated_at')?.notnull, 0);
+    assert.ok(indexes(db).includes('idx_content_operation_audio_jobs_idempotency'));
+
+    const legacy = db.db.prepare(`
+      SELECT idempotency_key, source_kind, provenance_json, attempt_count, updated_at
+      FROM content_operation_audio_jobs
+      WHERE job_id = 'audio-job-1'
+    `).get();
+    assert.equal(legacy.idempotency_key, null);
+    assert.equal(legacy.source_kind, null);
+    assert.equal(legacy.provenance_json, null);
+    assert.equal(legacy.attempt_count, 0);
+    assert.equal(legacy.updated_at, null);
+
+    insertLegacyAudioJob(db, 'audio-job-2');
+    db.db.prepare(`
+      UPDATE content_operation_audio_jobs
+      SET idempotency_key = 'content-operation-audio|copkg-legacy|generate|word|profile|model|voice|natural|content'
+      WHERE job_id = 'audio-job-1'
+    `).run();
+    assert.throws(() => {
+      db.db.prepare(`
+        UPDATE content_operation_audio_jobs
+        SET idempotency_key = 'content-operation-audio|copkg-legacy|generate|word|profile|model|voice|natural|content'
+        WHERE job_id = 'audio-job-2'
+      `).run();
+    }, /UNIQUE constraint failed/);
+  } finally {
+    db.close();
+  }
+});

--- a/worker/migrations/0021_content_operations_audio_jobs_ledger.sql
+++ b/worker/migrations/0021_content_operations_audio_jobs_ledger.sql
@@ -1,0 +1,9 @@
+ALTER TABLE content_operation_audio_jobs ADD COLUMN idempotency_key TEXT;
+ALTER TABLE content_operation_audio_jobs ADD COLUMN source_kind TEXT;
+ALTER TABLE content_operation_audio_jobs ADD COLUMN provenance_json TEXT;
+ALTER TABLE content_operation_audio_jobs ADD COLUMN attempt_count INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE content_operation_audio_jobs ADD COLUMN updated_at INTEGER;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_content_operation_audio_jobs_idempotency
+  ON content_operation_audio_jobs(idempotency_key);
+

--- a/worker/src/content-operations/audio.js
+++ b/worker/src/content-operations/audio.js
@@ -2,8 +2,33 @@ import {
   scanSpellingAudioReadiness,
 } from '../../../src/subjects/spelling/content/audio-readiness.js';
 import {
+  uid,
+} from '../../../src/platform/core/utils.js';
+import {
+  generateBufferedSpellingAudio,
+} from '../tts.js';
+import {
   all,
+  batch,
+  bindStatement,
+  first,
+  run,
 } from '../d1.js';
+import {
+  BadRequestError,
+} from '../errors.js';
+
+const CONTENT_OPERATION_AUDIO_SOURCE_KIND = 'content-operations-tts';
+const DEFAULT_AUDIO_GENERATION_LIMIT = 5;
+const MAX_AUDIO_GENERATION_LIMIT = 25;
+const GENERATABLE_AUDIO_STATUSES = new Set([
+  'missing',
+  'stale',
+  'generated',
+  'failed',
+  'skipped',
+  'override_requested',
+]);
 
 function normaliseString(value, fallback = '') {
   return typeof value === 'string' && value.trim() ? value.trim() : fallback;
@@ -36,9 +61,14 @@ function audioJobRowToRecord(row) {
     status: row.status,
     r2Key: row.r2_key || '',
     error: parseJson(row.error_json, null),
+    idempotencyKey: row.idempotency_key || '',
+    sourceKind: row.source_kind || '',
+    provenance: parseJson(row.provenance_json, null),
+    attemptCount: Number(row.attempt_count) || 0,
     requestedByAccountId: row.requested_by_account_id,
     completedAt: row.completed_at == null ? null : Number(row.completed_at),
     createdAt: Number(row.created_at) || 0,
+    updatedAt: row.updated_at == null ? null : Number(row.updated_at),
   };
 }
 
@@ -76,4 +106,604 @@ export async function buildContentOperationAudioScan({
     jobs,
     scope: 'affected',
   });
+}
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function normaliseLimit(value) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_AUDIO_GENERATION_LIMIT;
+  return Math.min(MAX_AUDIO_GENERATION_LIMIT, Math.max(1, Math.floor(parsed)));
+}
+
+function audioJobIdempotencyKey({
+  packageId,
+  item,
+  action = 'generate',
+} = {}) {
+  return [
+    'content-operation-audio',
+    normaliseString(packageId),
+    normaliseString(action, 'generate'),
+    normaliseString(item?.lane),
+    normaliseString(item?.profileVersion),
+    normaliseString(item?.modelId),
+    normaliseString(item?.voiceId),
+    normaliseString(item?.paceId || item?.speedId),
+    normaliseString(item?.contentKey),
+  ].join('|');
+}
+
+function entityTypeForAudioItem(item) {
+  return item?.lane === 'sentence' ? 'spelling.sentenceEntry' : 'spelling.word';
+}
+
+function entityIdForAudioItem(item) {
+  return item?.lane === 'sentence'
+    ? normaliseString(item?.sentenceId)
+    : normaliseString(item?.slug);
+}
+
+function audioPayloadForItem(item, accountId) {
+  if (item?.lane === 'word') {
+    return {
+      accountId,
+      slug: item.slug,
+      word: item.word,
+      transcript: item.word,
+      wordOnly: true,
+      bufferedGeminiVoice: item.voiceId,
+    };
+  }
+  return {
+    accountId,
+    slug: item.slug,
+    word: item.word,
+    sentence: item.sentence,
+    sentenceIndex: item.sentenceIndex,
+    slow: Boolean(item.slow),
+    bufferedGeminiVoice: item.voiceId,
+  };
+}
+
+function serialisableError(error) {
+  return {
+    name: normaliseString(error?.name, 'Error'),
+    message: normaliseString(error?.message || error, 'Audio generation failed.'),
+    ...(normaliseString(error?.provider) ? { provider: normaliseString(error.provider) } : {}),
+    ...(Number.isFinite(Number(error?.providerStatus)) ? { providerStatus: Number(error.providerStatus) } : {}),
+    ...(Number.isFinite(Number(error?.status)) ? { status: Number(error.status) } : {}),
+    ...(normaliseString(error?.extra?.code || error?.code) ? { code: normaliseString(error?.extra?.code || error?.code) } : {}),
+    ...(error?.timedOut || error?.extra?.providerTimedOut ? { providerTimedOut: true } : {}),
+    retryable: true,
+  };
+}
+
+function provenanceForItem({
+  item,
+  packageId,
+  candidateId,
+  accountId,
+  now,
+  r2Key = '',
+  cacheState = '',
+  override = false,
+  overrideReason = '',
+  status = '',
+} = {}) {
+  return {
+    sourceIdentity: CONTENT_OPERATION_AUDIO_SOURCE_KIND,
+    generatedByAccountId: accountId,
+    generatedAt: now,
+    packageId,
+    candidateId: candidateId || null,
+    itemId: item.itemId,
+    lane: item.lane,
+    entityType: entityTypeForAudioItem(item),
+    entityId: entityIdForAudioItem(item),
+    slug: item.slug,
+    sentenceId: item.sentenceId || null,
+    voiceId: item.voiceId,
+    paceId: item.paceId,
+    speedId: item.speedId,
+    modelId: item.modelId,
+    profileVersion: item.profileVersion,
+    contentKey: item.contentKey,
+    r2Key,
+    cacheState,
+    status,
+    override,
+    overrideReason: override ? overrideReason : '',
+  };
+}
+
+async function readAudioJobByIdempotencyKey(db, idempotencyKey) {
+  if (!idempotencyKey) return null;
+  const row = await first(db, `
+    SELECT *
+    FROM content_operation_audio_jobs
+    WHERE idempotency_key = ?
+    LIMIT 1
+  `, [idempotencyKey]);
+  return audioJobRowToRecord(row);
+}
+
+async function claimAudioJob(db, {
+  packageId,
+  candidateId,
+  item,
+  accountId,
+  now,
+  override = false,
+  overrideReason = '',
+} = {}) {
+  const idempotencyKey = audioJobIdempotencyKey({ packageId, candidateId, item, action: 'generate' });
+  const existing = await readAudioJobByIdempotencyKey(db, idempotencyKey);
+  if (existing?.status === 'uploaded' && !override) {
+    return { skippedExisting: true, job: existing };
+  }
+
+  const provenance = provenanceForItem({
+    item,
+    packageId,
+    candidateId,
+    accountId,
+    now,
+    override,
+    overrideReason,
+    status: 'queued',
+  });
+  if (existing) {
+    await run(db, `
+      UPDATE content_operation_audio_jobs
+      SET
+        candidate_id = ?,
+        status = 'queued',
+        error_json = NULL,
+        requested_by_account_id = ?,
+        completed_at = NULL,
+        source_kind = ?,
+        provenance_json = ?,
+        updated_at = ?
+      WHERE idempotency_key = ?
+    `, [
+      candidateId || null,
+      accountId,
+      CONTENT_OPERATION_AUDIO_SOURCE_KIND,
+      JSON.stringify(provenance),
+      now,
+      idempotencyKey,
+    ]);
+    return { skippedExisting: false, job: await readAudioJobByIdempotencyKey(db, idempotencyKey) };
+  }
+
+  const jobId = uid('coaud');
+  await run(db, `
+    INSERT INTO content_operation_audio_jobs (
+      job_id,
+      package_id,
+      candidate_id,
+      lane,
+      entity_type,
+      entity_id,
+      voice_id,
+      pace_id,
+      model_id,
+      profile_version,
+      content_key,
+      status,
+      r2_key,
+      error_json,
+      requested_by_account_id,
+      completed_at,
+      created_at,
+      idempotency_key,
+      source_kind,
+      provenance_json,
+      attempt_count,
+      updated_at
+    )
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'queued', NULL, NULL, ?, NULL, ?, ?, ?, ?, 0, ?)
+  `, [
+    jobId,
+    packageId,
+    candidateId || null,
+    item.lane,
+    entityTypeForAudioItem(item),
+    entityIdForAudioItem(item),
+    item.voiceId,
+    item.paceId || item.speedId || 'natural',
+    item.modelId,
+    item.profileVersion,
+    item.contentKey,
+    accountId,
+    now,
+    idempotencyKey,
+    CONTENT_OPERATION_AUDIO_SOURCE_KIND,
+    JSON.stringify(provenance),
+    now,
+  ]);
+  return { skippedExisting: false, job: await readAudioJobByIdempotencyKey(db, idempotencyKey) };
+}
+
+async function markAudioJobUploaded(db, {
+  idempotencyKey,
+  item,
+  packageId,
+  candidateId,
+  accountId,
+  now,
+  result,
+  override = false,
+  overrideReason = '',
+} = {}) {
+  const provenance = provenanceForItem({
+    item,
+    packageId,
+    candidateId,
+    accountId,
+    now,
+    r2Key: result.key,
+    cacheState: result.cacheState,
+    override,
+    overrideReason,
+    status: 'uploaded',
+  });
+  await run(db, `
+    UPDATE content_operation_audio_jobs
+    SET
+      status = 'uploaded',
+      r2_key = ?,
+      error_json = NULL,
+      completed_at = ?,
+      source_kind = ?,
+      provenance_json = ?,
+      attempt_count = attempt_count + 1,
+      updated_at = ?
+    WHERE idempotency_key = ?
+  `, [
+    result.key,
+    now,
+    CONTENT_OPERATION_AUDIO_SOURCE_KIND,
+    JSON.stringify(provenance),
+    now,
+    idempotencyKey,
+  ]);
+  return readAudioJobByIdempotencyKey(db, idempotencyKey);
+}
+
+async function markAudioJobFailed(db, {
+  idempotencyKey,
+  item,
+  packageId,
+  candidateId,
+  accountId,
+  now,
+  error,
+  override = false,
+  overrideReason = '',
+} = {}) {
+  const errorRecord = serialisableError(error);
+  const provenance = provenanceForItem({
+    item,
+    packageId,
+    candidateId,
+    accountId,
+    now,
+    override,
+    overrideReason,
+    status: 'failed',
+  });
+  await run(db, `
+    UPDATE content_operation_audio_jobs
+    SET
+      status = 'failed',
+      error_json = ?,
+      completed_at = ?,
+      source_kind = ?,
+      provenance_json = ?,
+      attempt_count = attempt_count + 1,
+      updated_at = ?
+    WHERE idempotency_key = ?
+  `, [
+    JSON.stringify(errorRecord),
+    now,
+    CONTENT_OPERATION_AUDIO_SOURCE_KIND,
+    JSON.stringify(provenance),
+    now,
+    idempotencyKey,
+  ]);
+  return readAudioJobByIdempotencyKey(db, idempotencyKey);
+}
+
+function selectAudioItemsForGeneration(scan, {
+  itemIds = [],
+  limit = DEFAULT_AUDIO_GENERATION_LIMIT,
+  override = false,
+} = {}) {
+  const requestedIds = new Set(asArray(itemIds).map((value) => normaliseString(value)).filter(Boolean));
+  const requiredItems = asArray(scan?.items).filter((item) => item?.required !== false);
+  const scoped = requestedIds.size
+    ? requiredItems.filter((item) => requestedIds.has(item.itemId))
+    : override
+      ? requiredItems
+      : requiredItems.filter((item) => GENERATABLE_AUDIO_STATUSES.has(item.status));
+  if (requestedIds.size) {
+    const found = new Set(scoped.map((item) => item.itemId));
+    const missing = [...requestedIds].filter((itemId) => !found.has(itemId));
+    if (missing.length) {
+      throw new BadRequestError('Requested content operation audio item was not found.', {
+        code: 'content_operation_audio_item_not_found',
+        itemIds: missing,
+      });
+    }
+  }
+  const generatable = (override || requestedIds.size)
+    ? scoped
+    : scoped.filter((item) => GENERATABLE_AUDIO_STATUSES.has(item.status));
+  return {
+    selected: generatable.slice(0, limit),
+    skippedDueLimit: Math.max(0, generatable.length - limit),
+    skippedPresent: requestedIds.size ? 0 : scoped.length - generatable.length,
+  };
+}
+
+function summariseGeneratedJobs(jobs, {
+  skippedExisting = 0,
+  skippedPresent = 0,
+  skippedDueLimit = 0,
+} = {}) {
+  const summary = {
+    requested: jobs.length + skippedExisting + skippedPresent + skippedDueLimit,
+    uploaded: 0,
+    failed: 0,
+    queued: 0,
+    skippedExisting,
+    skippedPresent,
+    skippedDueLimit,
+  };
+  for (const job of jobs) {
+    if (job.status === 'uploaded') summary.uploaded += 1;
+    else if (job.status === 'failed') summary.failed += 1;
+    else if (job.status === 'queued') summary.queued += 1;
+  }
+  return summary;
+}
+
+export async function generateContentOperationPackageAudio({
+  db,
+  env,
+  packageId,
+  candidate,
+  candidateId,
+  requestedByAccountId,
+  itemIds = [],
+  limit = DEFAULT_AUDIO_GENERATION_LIMIT,
+  override = false,
+  overrideReason = '',
+  fetchFn = fetch,
+  now = Date.now(),
+} = {}) {
+  const safePackageId = normaliseString(packageId);
+  const safeCandidateId = normaliseString(candidateId || candidate?.candidateId);
+  const accountId = normaliseString(requestedByAccountId);
+  if (!safePackageId) {
+    throw new BadRequestError('Content operation audio generation requires a package id.', {
+      code: 'content_operation_package_id_required',
+    });
+  }
+  if (!accountId) {
+    throw new BadRequestError('Content operation audio generation requires an account id.', {
+      code: 'content_operation_audio_account_required',
+      packageId: safePackageId,
+    });
+  }
+  if (override && !normaliseString(overrideReason)) {
+    throw new BadRequestError('Content operation audio override requires a reason.', {
+      code: 'content_operation_audio_override_reason_required',
+      packageId: safePackageId,
+    });
+  }
+  const safeLimit = normaliseLimit(limit);
+  const scan = candidate?.audioScan || await buildContentOperationAudioScan({
+    db,
+    packageId: safePackageId,
+    candidate: candidate?.candidate || candidate,
+    operations: [],
+  });
+  const selection = selectAudioItemsForGeneration(scan, {
+    itemIds,
+    limit: safeLimit,
+    override,
+  });
+  const jobs = [];
+  let skippedExisting = 0;
+
+  for (const item of selection.selected) {
+    const claim = await claimAudioJob(db, {
+      packageId: safePackageId,
+      candidateId: safeCandidateId,
+      item,
+      accountId,
+      now,
+      override,
+      overrideReason,
+    });
+    if (claim.skippedExisting) {
+      skippedExisting += 1;
+      continue;
+    }
+    const idempotencyKey = claim.job.idempotencyKey;
+    try {
+      const result = await generateBufferedSpellingAudio({
+        env,
+        accountId,
+        model: item.modelId,
+        voice: item.voiceId,
+        payload: audioPayloadForItem(item, accountId),
+        force: override,
+        fetchFn,
+      });
+      jobs.push(await markAudioJobUploaded(db, {
+        idempotencyKey,
+        item,
+        packageId: safePackageId,
+        candidateId: safeCandidateId,
+        accountId,
+        now,
+        result,
+        override,
+        overrideReason,
+      }));
+    } catch (error) {
+      jobs.push(await markAudioJobFailed(db, {
+        idempotencyKey,
+        item,
+        packageId: safePackageId,
+        candidateId: safeCandidateId,
+        accountId,
+        now,
+        error,
+        override,
+        overrideReason,
+      }));
+    }
+  }
+
+  return {
+    packageId: safePackageId,
+    candidateId: safeCandidateId || null,
+    sourceKind: CONTENT_OPERATION_AUDIO_SOURCE_KIND,
+    limit: safeLimit,
+    summary: summariseGeneratedJobs(jobs, {
+      skippedExisting,
+      skippedPresent: selection.skippedPresent,
+      skippedDueLimit: selection.skippedDueLimit,
+    }),
+    jobs,
+  };
+}
+
+export async function reconcileContentOperationAudioJobs(db, {
+  packageId,
+  candidateId = '',
+  requestedByAccountId,
+  entries = [],
+  sourceKind = 'operator-script',
+  now = Date.now(),
+} = {}) {
+  const safePackageId = normaliseString(packageId);
+  const accountId = normaliseString(requestedByAccountId);
+  if (!safePackageId || !accountId) {
+    throw new BadRequestError('Content operation audio reconciliation requires a package id and account id.', {
+      code: 'content_operation_audio_reconcile_invalid',
+      packageId: safePackageId,
+    });
+  }
+  const statements = [];
+  const jobs = [];
+  for (const entry of asArray(entries)) {
+    const item = {
+      itemId: normaliseString(entry.itemId || `${entry.lane || 'word'}:${entry.slug || entry.entityId}:${entry.voiceId || entry.voice}:${entry.contentKey}`),
+      lane: normaliseString(entry.lane, 'word'),
+      slug: normaliseString(entry.slug || entry.entityId),
+      sentenceId: normaliseString(entry.sentenceId || entry.entityId),
+      voiceId: normaliseString(entry.voiceId || entry.voice),
+      paceId: normaliseString(entry.paceId || entry.speedId || entry.speed, entry.lane === 'sentence' ? 'standard' : 'natural'),
+      speedId: normaliseString(entry.speedId || entry.speed),
+      modelId: normaliseString(entry.modelId || entry.model),
+      profileVersion: normaliseString(entry.profileVersion || entry.profile_version),
+      contentKey: normaliseString(entry.contentKey || entry.content_key),
+      r2Key: normaliseString(entry.r2Key || entry.r2_key || entry.key),
+    };
+    if (!item.contentKey || !item.r2Key || !item.voiceId || !item.modelId || !item.profileVersion) continue;
+    const idempotencyKey = audioJobIdempotencyKey({
+      packageId: safePackageId,
+      candidateId,
+      item,
+      action: 'generate',
+    });
+    const provenance = {
+      sourceIdentity: normaliseString(entry.sourceIdentity || entry.source_identity, sourceKind),
+      reconciledByAccountId: accountId,
+      reconciledAt: now,
+      generatedByAccountId: normaliseString(entry.generatedByAccountId || entry.generated_by_account_id, accountId),
+      generatedAt: Number.isFinite(Number(entry.generatedAt || entry.generated_at))
+        ? Number(entry.generatedAt || entry.generated_at)
+        : now,
+      packageId: safePackageId,
+      candidateId: candidateId || null,
+      itemId: item.itemId,
+      lane: item.lane,
+      voiceId: item.voiceId,
+      paceId: item.paceId,
+      speedId: item.speedId,
+      modelId: item.modelId,
+      profileVersion: item.profileVersion,
+      contentKey: item.contentKey,
+      r2Key: item.r2Key,
+    };
+    const jobId = uid('coaud');
+    statements.push(bindStatement(db, `
+      INSERT INTO content_operation_audio_jobs (
+        job_id, package_id, candidate_id, lane, entity_type, entity_id,
+        voice_id, pace_id, model_id, profile_version, content_key, status,
+        r2_key, error_json, requested_by_account_id, completed_at, created_at,
+        idempotency_key, source_kind, provenance_json, attempt_count, updated_at
+      )
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'uploaded', ?, NULL, ?, ?, ?, ?, ?, ?, 1, ?)
+      ON CONFLICT(idempotency_key) DO UPDATE SET
+        status = 'uploaded',
+        r2_key = excluded.r2_key,
+        error_json = NULL,
+        requested_by_account_id = excluded.requested_by_account_id,
+        completed_at = excluded.completed_at,
+        source_kind = excluded.source_kind,
+        provenance_json = excluded.provenance_json,
+        updated_at = excluded.updated_at
+    `, [
+      jobId,
+      safePackageId,
+      candidateId || null,
+      item.lane,
+      entityTypeForAudioItem(item),
+      entityIdForAudioItem(item),
+      item.voiceId,
+      item.paceId,
+      item.modelId,
+      item.profileVersion,
+      item.contentKey,
+      item.r2Key,
+      accountId,
+      now,
+      now,
+      idempotencyKey,
+      sourceKind,
+      JSON.stringify(provenance),
+      now,
+    ]));
+    jobs.push({
+      idempotencyKey,
+      packageId: safePackageId,
+      candidateId: candidateId || null,
+      status: 'uploaded',
+      r2Key: item.r2Key,
+      sourceKind,
+      provenance,
+    });
+  }
+  await batch(db, statements);
+  return {
+    packageId: safePackageId,
+    candidateId: candidateId || null,
+    sourceKind,
+    summary: {
+      requested: asArray(entries).length,
+      uploaded: jobs.length,
+      skippedInvalid: Math.max(0, asArray(entries).length - jobs.length),
+    },
+    jobs,
+  };
 }

--- a/worker/src/content-operations/routes.js
+++ b/worker/src/content-operations/routes.js
@@ -1,4 +1,5 @@
 import { requireMutationCapability } from '../auth.js';
+import { requireDatabase } from '../d1.js';
 import { requireSameOrigin } from '../demo/sessions.js';
 import {
   BadRequestError,
@@ -22,13 +23,15 @@ import {
   readSpellingContentSentenceDetailModel,
   readSpellingContentWordDetailModel,
 } from './read-models.js';
+import {
+  generateContentOperationPackageAudio,
+} from './audio.js';
 
 const CONTENT_OPERATIONS_ROUTE_PREFIX = '/api/admin/content-operations';
 const CONTENT_OPERATIONS_SUBJECT_ID = 'spelling';
 const STUBBED_CONTENT_OPERATION_ROUTES = Object.freeze({
   rebase: { ticket: 'T6', capability: CONTENT_OPERATION_CAPABILITIES.EDIT },
   'scan-audio': { ticket: 'T7', capability: CONTENT_OPERATION_CAPABILITIES.EDIT },
-  'generate-audio': { ticket: 'T7', capability: CONTENT_OPERATION_CAPABILITIES.EDIT },
   'upload-monster-asset': { ticket: 'T8', capability: CONTENT_OPERATION_CAPABILITIES.EDIT },
   'create-revert': { ticket: 'T9', capability: CONTENT_OPERATION_CAPABILITIES.ROLLBACK },
 });
@@ -563,6 +566,37 @@ export async function handleContentOperationsAdminRequest({
           candidate: serialiseContentOperationCandidate(result.candidate, {
             includeSnapshot: includeSnapshot(url, body),
           }),
+        });
+      }
+
+      if (action === 'generate-audio') {
+        let candidate;
+        try {
+          candidate = await repository.buildContentOperationCandidate(packageId, {
+            actorAccountId: actor.id,
+          });
+        } catch (error) {
+          badContentOperation(error);
+        }
+        const audio = await generateContentOperationPackageAudio({
+          db: requireDatabase(env),
+          env,
+          packageId,
+          candidate,
+          candidateId: body.candidateId || body.candidate_id || candidate.candidateId,
+          requestedByAccountId: actor.id,
+          itemIds: body.itemIds || body.item_ids || [],
+          limit: body.limit,
+          override: body.override === true,
+          overrideReason: body.reason || body.overrideReason || body.override_reason || '',
+        });
+        return json({
+          ok: true,
+          actor: serialiseContentOperationActor(actor),
+          candidate: serialiseContentOperationCandidate(candidate, {
+            includeSnapshot: includeSnapshot(url, body),
+          }),
+          audio,
         });
       }
 

--- a/worker/src/tts.js
+++ b/worker/src/tts.js
@@ -495,7 +495,7 @@ async function storeBufferedGeminiAudio(env, payload, response, options = {}) {
       metadata: cacheSlot?.metadata || null,
     };
   }
-  if (cacheSlot.object) {
+  if (cacheSlot.object && !options.force) {
     return {
       response: cachedGeminiAudioResponse(cacheSlot),
       cacheState: 'hit',
@@ -579,6 +579,71 @@ function geminiPrompt(payload = {}) {
 // the only consumer; production callers continue to reach `bufferedAudioKey`
 // only through `handleTextToSpeechRequest`.
 export { bufferedAudioMetadata, bufferedAudioKey, geminiPrompt };
+
+export async function generateBufferedSpellingAudio({
+  env,
+  payload,
+  accountId = '',
+  model = SPELLING_AUDIO_MODEL,
+  voice = '',
+  force = false,
+  fetchFn = fetch,
+} = {}) {
+  const generationPayload = {
+    ...(payload && typeof payload === 'object' ? payload : {}),
+    accountId: cleanText(accountId || payload?.accountId),
+    provider: 'gemini',
+    bufferedGeminiVoice: normaliseBufferedGeminiVoice(voice || payload?.bufferedGeminiVoice || payload?.cachedVoice),
+  };
+  const gemini = geminiConfig(env);
+  const config = {
+    ...gemini,
+    model: cleanGeminiModel(model) || gemini.model,
+    voice: generationPayload.bufferedGeminiVoice || gemini.voice,
+  };
+  if (!config.apiKey) throw missingProviderConfig('gemini');
+
+  const cacheHit = await readBufferedGeminiAudio(env, generationPayload, { model: config.model });
+  if (cacheHit?.cacheUnavailable) {
+    throw new BackendUnavailableError('Spelling audio R2 cache is not available.', {
+      code: 'tts_cache_unavailable',
+      provider: 'gemini',
+    });
+  }
+  if (!cacheHit?.metadata) {
+    throw new BadRequestError('Spelling audio payload is not cacheable.', {
+      code: 'tts_payload_uncacheable',
+      provider: 'gemini',
+    });
+  }
+  if (cacheHit.object && !force) {
+    return {
+      cacheState: 'hit',
+      key: cacheHit.key,
+      metadata: cacheHit.metadata,
+      contentType: cacheHit.contentType,
+    };
+  }
+
+  const response = await requestGeminiSpeech({ config, payload: generationPayload, fetchFn });
+  const stored = await storeBufferedGeminiAudio(env, generationPayload, response, {
+    model: config.model,
+    force,
+  });
+  if (stored.cacheState !== 'stored' && stored.cacheState !== 'hit') {
+    throw new BackendUnavailableError('Spelling audio could not be stored in R2.', {
+      code: 'tts_cache_store_failed',
+      provider: 'gemini',
+      cacheState: stored.cacheState,
+    });
+  }
+  return {
+    cacheState: stored.cacheState,
+    key: stored.key,
+    metadata: stored.metadata,
+    contentType: stored.response?.headers?.get?.('content-type') || 'audio/wav',
+  };
+}
 
 function base64ToBytes(value) {
   const binary = atob(value);


### PR DESCRIPTION
## Summary
- Add package-scoped Content Operations TTS generation with authoritative audio job ledger reconciliation.
- Add idempotent generate/override handling, R2-backed provenance, retryable failure recording, and operator-script ledger export.
- Add migration and coverage for Worker generation, script reconciliation, provider failures, override regeneration, and idempotency.

## Verification
- `node --test tests/content-operations-api.test.js`
- `node --test tests/build-spelling-word-audio-generate.test.js`
- `node --test tests/worker-migration-0021.test.js`
- `npm test`
- `npm run check`
- Pre-push `npm test`