### PR TITLE
Add content operations audio fallback approval

### DIFF
--- a/src/platform/hubs/admin-content-operations.js
+++ b/src/platform/hubs/admin-content-operations.js
@@ -96,6 +96,14 @@ function normaliseBlockerSection(section = null) {
   const errors = asArray(safe.errors);
   const validationErrors = Number(safe.errorCount ?? errors.length) || 0;
   const conflictCount = Number(safe.count) || 0;
+  const strictAudioReadiness = isPlainObject(safe.strictAudioReadiness)
+    ? {
+      status: asString(safe.strictAudioReadiness.status, 'not_scanned'),
+      blockers: asArray(safe.strictAudioReadiness.blockers),
+      affectedCount: Number(safe.strictAudioReadiness.affectedCount) || 0,
+      items: asArray(safe.strictAudioReadiness.items),
+    }
+    : null;
   const count = blockers.length + validationErrors + conflictCount;
   return {
     status: asString(safe.status, 'not_run'),
@@ -106,6 +114,8 @@ function normaliseBlockerSection(section = null) {
     errorCount: validationErrors,
     warningCount: Number(safe.warningCount ?? warnings.length) || 0,
     items: asArray(safe.items),
+    fallbackApproval: isPlainObject(safe.fallbackApproval) ? safe.fallbackApproval : null,
+    strictAudioReadiness,
   };
 }
 
@@ -201,8 +211,18 @@ export function normaliseContentOperationPackage(entry = null) {
   };
 }
 
+function releaseAudioMetadataFromProof(proof = null) {
+  const metadata = isPlainObject(proof?.contentOperationsAudio) ? proof.contentOperationsAudio : null;
+  return {
+    audioFallback: isPlainObject(metadata?.audioFallback) ? metadata.audioFallback : null,
+    audioWarnings: isPlainObject(metadata?.audioWarnings) ? metadata.audioWarnings : null,
+  };
+}
+
 export function normaliseContentOperationRelease(entry = null) {
   const safe = isPlainObject(entry) ? entry : {};
+  const proof = safe.proof ?? null;
+  const proofAudio = releaseAudioMetadataFromProof(proof);
   return {
     releaseId: asString(safe.releaseId),
     subjectId: asString(safe.subjectId, 'spelling'),
@@ -213,7 +233,13 @@ export function normaliseContentOperationRelease(entry = null) {
     publishedAt: asTs(safe.publishedAt),
     publishedByAccountId: asNullableString(safe.publishedByAccountId),
     rollbackOfReleaseId: asNullableString(safe.rollbackOfReleaseId),
-    proof: safe.proof ?? null,
+    proof,
+    audioFallback: isPlainObject(safe.audioFallback)
+      ? safe.audioFallback
+      : proofAudio.audioFallback,
+    audioWarnings: isPlainObject(safe.audioWarnings)
+      ? safe.audioWarnings
+      : proofAudio.audioWarnings,
     createdAt: asTs(safe.createdAt),
   };
 }

--- a/src/surfaces/hubs/AdminContentOperationsSection.jsx
+++ b/src/surfaces/hubs/AdminContentOperationsSection.jsx
@@ -672,6 +672,11 @@ function BlockerSummary({ blockers, sectionKey }) {
           {section.blockers.slice(0, 3).map((blocker) => <li key={blocker}>{blocker}</li>)}
         </ul>
       ) : null}
+      {section.warnings?.length ? (
+        <ul className="content-ops-operation-list">
+          {section.warnings.slice(0, 3).map((warning) => <li key={warning}>{warning}</li>)}
+        </ul>
+      ) : null}
     </div>
   );
 }
@@ -2209,11 +2214,17 @@ function PackageLifecyclePanel({
   onRunAction,
 }) {
   const [notes, setNotes] = React.useState('');
+  const [allowAudioFallback, setAllowAudioFallback] = React.useState(false);
+  const [audioFallbackReason, setAudioFallbackReason] = React.useState('');
   const candidate = latestCandidateForPackage(contentPackage, lifecycleState);
   const canEdit = actorCan(actor, CONTENT_OPERATION_CAPABILITIES.EDIT);
   const canApprove = actorCan(actor, CONTENT_OPERATION_CAPABILITIES.APPROVE);
   const canPublish = actorCan(actor, CONTENT_OPERATION_CAPABILITIES.PUBLISH);
   const conflicts = candidate?.conflicts || [];
+  React.useEffect(() => {
+    setAllowAudioFallback(false);
+    setAudioFallbackReason('');
+  }, [contentPackage.packageId, candidate?.candidateId]);
   const isRunning = Boolean(
     lifecycleState?.running
       && lifecycleState.packageId === contentPackage.packageId
@@ -2225,7 +2236,14 @@ function PackageLifecyclePanel({
   const actionMessageText = lifecycleState?.packageId === contentPackage.packageId
     ? lifecycleState.message
     : '';
-  const approvalBlocked = candidateHasApprovalBlockers(candidate);
+  const blockingSections = candidate?.blockers?.blockingSections || [];
+  const audioApprovalBlocked = blockingSections.includes('audio');
+  const nonAudioApprovalBlocked = blockingSections
+    .filter((section) => section !== 'publishReadiness' && section !== 'audio')
+    .length > 0;
+  const fallbackReason = audioFallbackReason.trim();
+  const fallbackReady = audioApprovalBlocked && allowAudioFallback && fallbackReason.length > 0;
+  const approvalBlocked = !candidate || nonAudioApprovalBlocked || (audioApprovalBlocked && !fallbackReady);
   const validateDisabled = !actionAvailability.validate || !canEdit || isRunning || contentPackage.state === 'published';
   const approveDisabled = !canApprove
     || !actionAvailability.approve
@@ -2249,6 +2267,9 @@ function PackageLifecyclePanel({
       candidateId: candidate?.candidateId || '',
       candidateHash: candidate?.candidateHash || '',
       notes,
+      audioFallback: action === 'approve' && fallbackReady
+        ? { reason: fallbackReason }
+        : null,
     });
   };
   const resolveConflict = (conflict, resolution, value) => {
@@ -2313,6 +2334,29 @@ function PackageLifecyclePanel({
             data-content-ops-approval-notes="true"
           />
         </label>
+        {audioApprovalBlocked ? (
+          <div className="content-ops-notes-field">
+            <label className="content-ops-checkbox-row">
+              <input
+                type="checkbox"
+                checked={allowAudioFallback}
+                onChange={(event) => setAllowAudioFallback(event.target.checked)}
+                data-content-ops-audio-fallback-toggle="true"
+              />
+              <span>Allow runtime TTS fallback</span>
+            </label>
+            <label>
+              <span className="small muted">Fallback reason</span>
+              <textarea
+                value={audioFallbackReason}
+                onChange={(event) => setAudioFallbackReason(event.target.value)}
+                rows={2}
+                disabled={!allowAudioFallback}
+                data-content-ops-audio-fallback-reason="true"
+              />
+            </label>
+          </div>
+        ) : null}
         <div className="actions content-ops-lifecycle-actions">
           <button
             type="button"
@@ -2347,7 +2391,15 @@ function PackageLifecyclePanel({
         </div>
       </div>
       {approvalBlocked && candidate ? (
-        <BlockerSummary blockers={candidate.blockers} sectionKey="validation" />
+        <>
+          <BlockerSummary blockers={candidate.blockers} sectionKey="validation" />
+          <BlockerSummary blockers={candidate.blockers} sectionKey="conflicts" />
+          <BlockerSummary blockers={candidate.blockers} sectionKey="audio" />
+          <BlockerSummary blockers={candidate.blockers} sectionKey="assets" />
+          <BlockerSummary blockers={candidate.blockers} sectionKey="rewards" />
+          <BlockerSummary blockers={candidate.blockers} sectionKey="visibility" />
+          <BlockerSummary blockers={candidate.blockers} sectionKey="exposure" />
+        </>
       ) : null}
       {actionError ? (
         <div className="feedback warn admin-note-spaced" data-content-ops-action-error="true">
@@ -2523,28 +2575,52 @@ function ReleaseTable({ releases }) {
             <th className="small admin-overview-th">Status</th>
             <th className="small admin-overview-th">Package</th>
             <th className="small admin-overview-th">Published</th>
+            <th className="small admin-overview-th">Audio</th>
             <th className="small admin-overview-th">Proof</th>
           </tr>
         </thead>
         <tbody>
-          {releases.map((release) => (
-            <tr key={release.releaseId} className="admin-overview-tbody-row">
-              <td className="admin-overview-td-first">
-                {release.releaseId}
-                <div className="small muted">{release.snapshotHash || 'hash pending'}</div>
-              </td>
-              <td className="admin-overview-td">
-                <span className={`chip ${release.status === 'published' ? 'good' : ''}`}>
-                  {release.status}
-                </span>
-              </td>
-              <td className="admin-overview-td small">{release.packageId || 'seeded'}</td>
-              <td className="admin-overview-td small">{formatTimestamp(release.publishedAt || release.createdAt)}</td>
-              <td className="admin-overview-td">
-                {release.proof ? <span className="chip good">Recorded</span> : <span className="chip warn">Missing</span>}
-              </td>
-            </tr>
-          ))}
+          {releases.map((release) => {
+            const fallback = release.audioFallback || null;
+            const audioWarnings = release.audioWarnings || null;
+            const warnings = Array.isArray(audioWarnings?.warnings) ? audioWarnings.warnings : [];
+            const affectedCount = Number(
+              audioWarnings?.affectedCount
+                ?? fallback?.affectedMatrix?.affectedCount
+                ?? 0,
+            ) || 0;
+            return (
+              <tr key={release.releaseId} className="admin-overview-tbody-row">
+                <td className="admin-overview-td-first">
+                  {release.releaseId}
+                  <div className="small muted">{release.snapshotHash || 'hash pending'}</div>
+                </td>
+                <td className="admin-overview-td">
+                  <span className={`chip ${release.status === 'published' ? 'good' : ''}`}>
+                    {release.status}
+                  </span>
+                </td>
+                <td className="admin-overview-td small">{release.packageId || 'seeded'}</td>
+                <td className="admin-overview-td small">{formatTimestamp(release.publishedAt || release.createdAt)}</td>
+                <td className="admin-overview-td">
+                  {fallback?.allowed ? (
+                    <div className="content-ops-release-audio">
+                      <span className="chip warn">Audio fallback</span>
+                      <div className="small muted">{String(affectedCount)} affected</div>
+                      {warnings.length ? (
+                        <div className="small muted">{warnings.slice(0, 3).join(', ')}</div>
+                      ) : null}
+                    </div>
+                  ) : (
+                    <span className="chip good">Ready</span>
+                  )}
+                </td>
+                <td className="admin-overview-td">
+                  {release.proof ? <span className="chip good">Recorded</span> : <span className="chip warn">Missing</span>}
+                </td>
+              </tr>
+            );
+          })}
         </tbody>
       </table>
     </div>
@@ -2888,6 +2964,7 @@ export function AdminContentOperationsSection({
     resolution = '',
     value = undefined,
     notes = '',
+    audioFallback = null,
   } = {}) => {
     if (!api || !packageId) return;
     setLifecycleState((current) => ({
@@ -2924,6 +3001,7 @@ export function AdminContentOperationsSection({
           packageId,
           candidateId,
           notes,
+          audioFallback,
           mutation: contentOperationMutation(action, packageId),
         });
       } else if (action === 'publish') {

--- a/styles/app.css
+++ b/styles/app.css
@@ -12536,10 +12536,23 @@ html { scroll-behavior: smooth; }
   resize: vertical;
 }
 
+.content-ops-checkbox-row {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+  font-size: 0.92rem;
+}
+
 .content-ops-lifecycle-actions {
   flex-wrap: wrap;
   justify-content: flex-end;
   margin-top: 18px;
+}
+
+.content-ops-release-audio {
+  display: grid;
+  gap: 4px;
+  min-width: 160px;
 }
 
 .content-ops-conflict-resolver {

--- a/tests/admin-content-operations-v2.test.js
+++ b/tests/admin-content-operations-v2.test.js
@@ -37,6 +37,7 @@ import {
   normaliseContentOperationsOverview,
   normaliseContentOperationsPackageDetail,
   normaliseContentOperationsPackageList,
+  normaliseContentOperationRelease,
   normaliseContentOperationsReleaseList,
   normaliseContentOperationsSpellingBrowse,
   normaliseContentOperationsSpellingItemDetail,
@@ -462,7 +463,20 @@ const CONTENT_OPS_OVERVIEW = {
       status: 'published',
       snapshotHash: 'hash-1',
       publishedAt: Date.UTC(2026, 5, 11, 9, 0, 0),
-      proof: { source: 'test' },
+      proof: {
+        source: 'test',
+        contentOperationsAudio: {
+          audioFallback: {
+            allowed: true,
+            reason: 'Temporary runtime TTS fallback while slow sentence audio is generated.',
+            affectedMatrix: { affectedCount: 1, lanes: { sentence: { affectedCount: 1 } } },
+          },
+          audioWarnings: {
+            status: 'warning',
+            warnings: ['audio_fallback_approved', 'sentence_audio_missing'],
+          },
+        },
+      },
     },
     packageCounts: { draft: 1, blocked: 1, approved: 1 },
     lanes: {
@@ -477,7 +491,20 @@ const CONTENT_OPS_OVERVIEW = {
           status: 'published',
           snapshotHash: 'hash-1',
           publishedAt: Date.UTC(2026, 5, 11, 9, 0, 0),
-          proof: { source: 'test' },
+          proof: {
+            source: 'test',
+            contentOperationsAudio: {
+              audioFallback: {
+                allowed: true,
+                reason: 'Temporary runtime TTS fallback while slow sentence audio is generated.',
+                affectedMatrix: { affectedCount: 1, lanes: { sentence: { affectedCount: 1 } } },
+              },
+              audioWarnings: {
+                status: 'warning',
+                warnings: ['audio_fallback_approved', 'sentence_audio_missing'],
+              },
+            },
+          },
         },
       ],
     },
@@ -646,7 +673,25 @@ describe('Content Operations Centre normalisers', () => {
     assert.equal(overview.lanes.drafts[0].blockers.warningCount, 1);
     assert.equal(overview.lanes.drafts[0].latestCandidate.candidateHash, 'candidate-hash-1');
     assert.equal(overview.recentReleases[0].proof.source, 'test');
+    assert.equal(overview.recentReleases[0].audioFallback.allowed, true);
+    assert.equal(overview.recentReleases[0].audioFallback.affectedMatrix.affectedCount, 1);
+    assert.equal(overview.recentReleases[0].audioWarnings.status, 'warning');
     assert.equal(overview.actor.capabilities['content_operations.approve'], true);
+  });
+
+  it('ignores caller-style fallback proof metadata that is not server canonical', () => {
+    const release = normaliseContentOperationRelease({
+      releaseId: 'rel-forged-proof',
+      proof: {
+        source: 'external-client',
+        audioFallback: { allowed: true, reason: 'Forged fallback proof.' },
+        audioWarnings: { status: 'warning', warnings: ['audio_fallback_approved'] },
+      },
+    });
+
+    assert.equal(release.audioFallback, null);
+    assert.equal(release.audioWarnings, null);
+    assert.equal(release.proof.audioFallback.allowed, true);
   });
 
   it('normalises package lists, release lists, and package detail array payloads', () => {
@@ -663,6 +708,8 @@ describe('Content Operations Centre normalisers', () => {
     assert.equal(packages[0].latestCandidate.candidateId, 'cand-draft-1');
     assert.equal(packages[0].blockers.blockingSections.includes('audio'), true);
     assert.equal(releases[0].releaseId, 'rel-global-1');
+    assert.equal(releases[0].audioFallback.allowed, true);
+    assert.equal(releases[0].audioWarnings.warnings[1], 'sentence_audio_missing');
     assert.equal(detail.package.operations[0].fieldPath, 'explanation');
     assert.equal(detail.package.latestCandidate.operationsHash, 'ops-hash-1');
     assert.equal(detail.events[0].eventType, 'package.created');
@@ -848,6 +895,9 @@ describe('Content Operations Centre hub API client', () => {
       packageId: 'pkg/with/slash',
       candidateId: 'cand/with/slash',
       notes: 'Reviewed candidate.',
+      audioFallback: {
+        reason: 'Temporary runtime TTS fallback while slow sentence audio is generated.',
+      },
       mutation: { requestId: 'approve-1' },
     });
     await api.publishContentOperationPackage({
@@ -871,6 +921,10 @@ describe('Content Operations Centre hub API client', () => {
     assert.equal(calls[0].body.includeSnapshot, true);
     assert.equal(calls[1].body.candidateId, 'cand/with/slash');
     assert.equal(calls[1].body.notes, 'Reviewed candidate.');
+    assert.equal(
+      calls[1].body.audioFallback.reason,
+      'Temporary runtime TTS fallback while slow sentence audio is generated.',
+    );
     assert.equal(calls[2].body.proof.source, 'test');
     assert.equal(calls[3].body.conflictId, 'conflict/with/slash');
     assert.equal(calls[3].body.resolution, 'edit');

--- a/tests/content-operations-api.test.js
+++ b/tests/content-operations-api.test.js
@@ -480,6 +480,112 @@ test('content operations generate-audio uses TTS, stores R2 audio, and records a
   assert.equal(batchOverrideRowCount, 1);
 });
 
+test('content operations audio override invalidates approval and records an audit event', async (t) => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => geminiAudioResponse();
+  const bucket = createMemoryR2Bucket();
+  const server = createWorkerRepositoryServer({
+    now: () => NOW,
+    env: {
+      GEMINI_API_KEY: 'test-gemini-key',
+      SPELLING_AUDIO_BUCKET: bucket,
+    },
+  });
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+    server.close();
+  });
+
+  seedAdultAccount(server.DB, { accountId: ADMIN_ID, platformRole: 'admin' });
+  const repository = createWorkerRepository({
+    env: server.env,
+    now: () => NOW,
+  });
+  await repository.seedFirstContentOperationRelease({
+    seededByAccountId: ADMIN_ID,
+    proof: { source: 'content-operations-api-override-invalidation-test' },
+  });
+
+  const seeded = await readSeededSpellingContentBundle();
+  const word = seeded.draft.words[0];
+  const created = await createPackage(server, { title: 'Override invalidates approval package' });
+  const packageId = created.package.packageId;
+  await appendContentOperation(server, packageId, {
+    entityType: 'spelling.word',
+    entityId: word.slug,
+    fieldPath: 'word',
+    action: 'set',
+    payload: word.word,
+  });
+
+  const validated = await validatePackage(server, packageId, { includeSnapshot: true });
+  seedUploadedAudioJobs(server.DB, {
+    packageId,
+    candidateId: validated.candidate.candidateId,
+    items: validated.candidate.audioScan.items,
+  });
+  const revalidated = await validatePackage(server, packageId, { includeSnapshot: true });
+  const approved = await approvePackage(server, packageId, revalidated.candidate.candidateId);
+  assert.equal(approved.approval.candidateId, revalidated.candidate.candidateId);
+
+  const target = revalidated.candidate.audioScan.items.find((item) => item.required !== false);
+  assert.ok(target, 'expected a required audio item');
+  const overrideResponse = await server.fetchAs(
+    ADMIN_ID,
+    `${BASE_URL}/api/admin/content-operations/packages/${packageId}/generate-audio`,
+    jsonInit('POST', {
+      candidateId: revalidated.candidate.candidateId,
+      itemIds: [target.itemId],
+      limit: 1,
+      override: true,
+      reason: 'Replace clipped word audio after editorial review.',
+    }),
+    adminHeaders(),
+  );
+  const overridePayload = await readPayload(overrideResponse);
+  assert.equal(overrideResponse.status, 200);
+  assert.equal(overridePayload.audio.summary.uploaded, 1);
+
+  const packageRow = server.DB.db.prepare(`
+    SELECT state, approved_at
+    FROM content_operation_packages
+    WHERE package_id = ?
+  `).get(packageId);
+  assert.equal(packageRow.state, 'draft');
+  assert.equal(packageRow.approved_at, null);
+  const approvalCount = server.DB.db.prepare(`
+    SELECT COUNT(*) AS count
+    FROM content_operation_package_approvals
+    WHERE package_id = ?
+  `).get(packageId).count;
+  assert.equal(approvalCount, 0);
+
+  const publishResponse = await server.fetchAs(
+    ADMIN_ID,
+    `${BASE_URL}/api/admin/content-operations/packages/${packageId}/publish`,
+    jsonInit('POST', {
+      proof: { source: 'content-operations-api-override-invalidation-test' },
+    }),
+    adminHeaders(),
+  );
+  const publishPayload = await readPayload(publishResponse);
+  assert.equal(publishResponse.status, 409);
+  assert.equal(publishPayload.code, 'content_operation_package_not_approved');
+
+  const eventRow = server.DB.db.prepare(`
+    SELECT event_type, event_json
+    FROM content_operation_events
+    WHERE package_id = ? AND event_type = 'audio.override'
+    ORDER BY created_at DESC
+    LIMIT 1
+  `).get(packageId);
+  assert.equal(eventRow.event_type, 'audio.override');
+  const event = JSON.parse(eventRow.event_json);
+  assert.equal(event.reason, 'Replace clipped word audio after editorial review.');
+  assert.equal(event.invalidatedApproval, true);
+  assert.equal(event.candidateId, revalidated.candidate.candidateId);
+});
+
 test('content operations reconcile operator-script audio jobs into readiness scan', async (t) => {
   const server = createWorkerRepositoryServer({
     now: () => NOW,
@@ -1362,6 +1468,14 @@ test('content operations API blocks approval when affected sentence audio is mis
   const server = createWorkerRepositoryServer({ now: () => NOW });
   try {
     seedAdultAccount(server.DB, { accountId: ADMIN_ID, platformRole: 'admin' });
+    const repository = createWorkerRepository({
+      env: server.env,
+      now: () => NOW,
+    });
+    await repository.seedFirstContentOperationRelease({
+      seededByAccountId: ADMIN_ID,
+      proof: { source: 'content-operations-api-audio-fallback-test' },
+    });
     const seeded = await readSeededSpellingContentBundle();
     const word = seeded.draft.words.find((entry) => entry.sentenceEntryIds?.length);
     const sentenceId = word.sentenceEntryIds[0];
@@ -1422,8 +1536,121 @@ test('content operations API blocks approval when affected sentence audio is mis
       adminHeaders(),
     );
     const fallbackPayload = await readPayload(fallbackResponse);
-    assert.equal(fallbackResponse.status, 400);
-    assert.equal(fallbackPayload.code, 'content_operation_audio_fallback_not_supported');
+    assert.equal(fallbackResponse.status, 200);
+    assert.equal(fallbackPayload.approval.audioFallback.allowed, true);
+    assert.equal(fallbackPayload.approval.audioFallback.reason, 'Operator override requested.');
+    assert.equal(fallbackPayload.approval.audioFallback.approvedByAccountId, ADMIN_ID);
+    assert.equal(fallbackPayload.approval.audioFallback.approvedAt, NOW);
+    assert.equal(fallbackPayload.approval.audioFallback.affectedMatrix.affectedCount, 4);
+    assert.equal(fallbackPayload.approval.audioFallback.affectedMatrix.lanes.sentence.affectedCount, 4);
+    assert.equal(fallbackPayload.approval.audioFallback.notes, 'Attempt a temporary audio fallback.');
+
+    const approvedScanRow = server.DB.db.prepare(`
+      SELECT audio_scan_json
+      FROM content_operation_package_candidates
+      WHERE candidate_id = ?
+    `).get(validated.candidate.candidateId);
+    const approvedScan = JSON.parse(approvedScanRow.audio_scan_json);
+    assert.equal(approvedScan.status, 'warning');
+    assert.deepEqual(approvedScan.blockers, []);
+    assert.ok(approvedScan.warnings.includes('audio_fallback_approved'));
+    assert.ok(approvedScan.warnings.includes('sentence_audio_missing'));
+    assert.equal(approvedScan.strictAudioReadiness.status, 'blocked');
+    assert.equal(approvedScan.strictAudioReadiness.affectedCount, 4);
+    assert.ok(approvedScan.strictAudioReadiness.blockers.includes('sentence_audio_missing'));
+
+    const blockedPublishResponse = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/packages/${packageId}/publish`,
+      jsonInit('POST', {
+        proof: {
+          source: 'content-operations-api-audio-fallback-test',
+          audioFallback: { allowed: true },
+        },
+      }),
+      adminHeaders(),
+    );
+    const blockedPublishPayload = await readPayload(blockedPublishResponse);
+    assert.equal(blockedPublishResponse.status, 400);
+    assert.equal(blockedPublishPayload.code, 'content_operation_release_proof_reserved_key');
+
+    const published = await publishPackage(server, packageId, {
+      proof: { source: 'content-operations-api-audio-fallback-test' },
+    });
+    assert.equal(published.release.audioFallback.allowed, true);
+    assert.equal(published.release.audioFallback.affectedMatrix.affectedCount, 4);
+    assert.equal(published.release.audioWarnings.status, 'warning');
+    assert.ok(published.release.audioWarnings.warnings.includes('audio_fallback_approved'));
+    assert.equal(published.release.proof.contentOperationsAudio.audioFallback.allowed, true);
+    assert.equal(published.release.proof.contentOperationsAudio.audioWarnings.status, 'warning');
+
+    const releaseDetailResponse = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/subjects/spelling/releases/${published.release.releaseId}`,
+      { method: 'GET', headers: { 'sec-fetch-site': 'same-origin' } },
+      adminHeaders(),
+    );
+    const releaseDetail = await readPayload(releaseDetailResponse);
+    assert.equal(releaseDetailResponse.status, 200);
+    assert.equal(releaseDetail.release.audioFallback.allowed, true);
+    assert.equal(releaseDetail.release.audioWarnings.status, 'warning');
+    assert.equal(releaseDetail.release.proof.contentOperationsAudio.audioFallback.allowed, true);
+  } finally {
+    server.close();
+  }
+});
+
+test('content operations API rejects client-supplied fallback proof metadata', async () => {
+  const server = createWorkerRepositoryServer({ now: () => NOW });
+  try {
+    seedAdultAccount(server.DB, { accountId: ADMIN_ID, platformRole: 'admin' });
+    const repository = createWorkerRepository({
+      env: server.env,
+      now: () => NOW,
+    });
+    await repository.seedFirstContentOperationRelease({
+      seededByAccountId: ADMIN_ID,
+      proof: { source: 'content-operations-api-proof-reserved-key-test' },
+    });
+    const seeded = await readSeededSpellingContentBundle();
+    const word = seeded.draft.words[0];
+    const created = await createPackage(server, { title: 'Proof reserved metadata package' });
+    const packageId = created.package.packageId;
+
+    await appendContentOperation(server, packageId, {
+      entityType: 'spelling.word',
+      entityId: word.slug,
+      fieldPath: 'explanation',
+      action: 'set',
+      payload: `${word.explanation || 'Proof metadata guard.'} Reviewed editorial note.`,
+    });
+
+    const validated = await validatePackage(server, packageId);
+    assert.equal(validated.candidate.validation.status, 'passed');
+    await approvePackage(server, packageId, validated.candidate.candidateId);
+
+    const publishResponse = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/packages/${packageId}/publish`,
+      jsonInit('POST', {
+        proof: {
+          source: 'content-operations-api-proof-reserved-key-test',
+          audioFallback: { allowed: true, reason: 'Forged fallback proof.' },
+        },
+      }),
+      adminHeaders(),
+    );
+    const publishPayload = await readPayload(publishResponse);
+    assert.equal(publishResponse.status, 400);
+    assert.equal(publishPayload.code, 'content_operation_release_proof_reserved_key');
+    assert.deepEqual(publishPayload.reservedKeys, ['audioFallback']);
+
+    const published = await publishPackage(server, packageId, {
+      proof: { source: 'content-operations-api-proof-reserved-key-test' },
+    });
+    assert.equal(published.release.audioFallback, null);
+    assert.equal(published.release.audioWarnings, null);
+    assert.equal(Object.prototype.hasOwnProperty.call(published.release.proof, 'audioFallback'), false);
   } finally {
     server.close();
   }

--- a/tests/react-admin-content-operations.test.js
+++ b/tests/react-admin-content-operations.test.js
@@ -126,7 +126,20 @@ const release = {
   status: 'published',
   snapshotHash: 'hash-1',
   publishedAt: Date.UTC(2026, 5, 11, 9, 0, 0),
-  proof: { source: 'test' },
+  proof: {
+    source: 'test',
+    contentOperationsAudio: {
+      audioFallback: {
+        allowed: true,
+        reason: 'Temporary runtime TTS fallback while slow sentence audio is generated.',
+        affectedMatrix: { affectedCount: 1, lanes: { sentence: { affectedCount: 1 } } },
+      },
+      audioWarnings: {
+        status: 'warning',
+        warnings: ['audio_fallback_approved', 'sentence_audio_missing'],
+      },
+    },
+  },
 };
 
 const overview = {
@@ -503,6 +516,17 @@ test('Content Operations Centre SSR renders home lanes and required top-level ar
   for (const label of ['Packages', 'Spelling', 'Audio', 'Pools &amp; Rewards', 'Monsters &amp; Assets', 'Hero / Codex', 'Approvals']) {
     assert.match(html, new RegExp(label));
   }
+});
+
+test('Content Operations Centre release history shows approved audio fallback warnings', async () => {
+  const html = await renderEntry(buildContentOpsEntry({
+    initialActiveTab: 'releases',
+  }));
+
+  assert.match(html, /Release history/);
+  assert.match(html, /Audio fallback/);
+  assert.match(html, /1 affected/);
+  assert.match(html, /sentence_audio_missing/);
 });
 
 test('Content Operations Centre SSR renders package-scoped domain tabs and audit state', async () => {

--- a/worker/src/content-operations/repository.js
+++ b/worker/src/content-operations/repository.js
@@ -58,6 +58,26 @@ function normaliseString(value, fallback = '') {
   return typeof value === 'string' ? value.trim() || fallback : fallback;
 }
 
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function uniqueStrings(values) {
+  const output = [];
+  const seen = new Set();
+  for (const value of values) {
+    const normalised = normaliseString(value);
+    if (!normalised || seen.has(normalised)) continue;
+    seen.add(normalised);
+    output.push(normalised);
+  }
+  return output;
+}
+
 function mutationChangeCount(result) {
   return Math.max(0, Number(result?.meta?.changes ?? result?.meta?.rows_written) || 0);
 }
@@ -183,6 +203,8 @@ async function attachLatestCandidatesToPackages(db, packages = []) {
 
 function releaseRowToRecord(row, { includeSnapshot = false } = {}) {
   if (!row) return null;
+  const proof = parseJson(row.proof_json, null);
+  const audioProof = audioReleaseProofFromProof(proof);
   return {
     releaseId: row.release_id,
     subjectId: row.subject_id,
@@ -194,7 +216,9 @@ function releaseRowToRecord(row, { includeSnapshot = false } = {}) {
     publishedAt: row.published_at == null ? null : Number(row.published_at),
     publishedByAccountId: row.published_by_account_id || null,
     rollbackOfReleaseId: row.rollback_of_release_id || null,
-    proof: parseJson(row.proof_json, null),
+    proof,
+    audioFallback: audioProof.audioFallback,
+    audioWarnings: audioProof.audioWarnings,
     createdAt: Number(row.created_at) || 0,
   };
 }
@@ -286,6 +310,225 @@ async function insertContentOperationEvent(db, {
     createdAt,
   ]);
   return eventId;
+}
+
+const AUDIO_FALLBACK_BLOCKING_STATUSES = new Set([
+  'missing',
+  'stale',
+  'generated',
+  'failed',
+  'skipped',
+  'override_requested',
+]);
+const RELEASE_AUDIO_PROOF_KEY = 'contentOperationsAudio';
+const RELEASE_PROOF_RESERVED_KEYS = new Set([
+  'audioFallback',
+  'audioWarnings',
+  RELEASE_AUDIO_PROOF_KEY,
+]);
+
+function audioFallbackBlockingItems(scan = null) {
+  return asArray(scan?.items).filter((item) => (
+    item?.required !== false
+    && AUDIO_FALLBACK_BLOCKING_STATUSES.has(normaliseString(item?.status))
+  ));
+}
+
+function audioFallbackItemIdentity(item = {}) {
+  return [
+    normaliseString(item.itemId),
+    normaliseString(item.lane),
+    normaliseString(item.profileVersion),
+    normaliseString(item.modelId),
+    normaliseString(item.voiceId),
+    normaliseString(item.paceId || item.speedId),
+    normaliseString(item.contentKey),
+  ].join('|');
+}
+
+function audioFallbackItemSummary(item = {}) {
+  return {
+    itemId: normaliseString(item.itemId),
+    lane: normaliseString(item.lane),
+    entityType: item.lane === 'sentence' ? 'spelling.sentenceEntry' : 'spelling.word',
+    entityId: item.lane === 'sentence'
+      ? normaliseString(item.sentenceId)
+      : normaliseString(item.slug),
+    slug: normaliseString(item.slug),
+    sentenceId: normaliseString(item.sentenceId),
+    voiceId: normaliseString(item.voiceId),
+    paceId: normaliseString(item.paceId || item.speedId),
+    speedId: normaliseString(item.speedId),
+    modelId: normaliseString(item.modelId),
+    profileVersion: normaliseString(item.profileVersion),
+    contentKey: normaliseString(item.contentKey),
+    status: normaliseString(item.status),
+    blocker: normaliseString(item.blocker),
+  };
+}
+
+function buildAudioFallbackAffectedMatrix(scan = null) {
+  const items = audioFallbackBlockingItems(scan).map(audioFallbackItemSummary);
+  const lanes = {};
+  for (const lane of ['word', 'sentence']) {
+    const laneItems = items.filter((item) => item.lane === lane);
+    lanes[lane] = {
+      affectedCount: laneItems.length,
+      statuses: uniqueStrings(laneItems.map((item) => item.status)),
+      voices: uniqueStrings(laneItems.map((item) => item.voiceId)),
+      paces: uniqueStrings(laneItems.map((item) => item.paceId || item.speedId)),
+    };
+  }
+  return {
+    profileVersion: normaliseString(scan?.profileVersion),
+    modelId: normaliseString(scan?.modelId),
+    affectedCount: items.length,
+    lanes,
+    items,
+  };
+}
+
+function normaliseAudioFallbackApproval(rawFallback, scan, {
+  approvedByAccountId,
+  approvedAt,
+  notes = '',
+} = {}) {
+  const raw = isPlainObject(rawFallback) ? rawFallback : {};
+  if (raw.allowed === false) return null;
+  const reason = normaliseString(raw.reason || raw.justification);
+  if (!reason) {
+    throw new BadRequestError('Content operation audio fallback approval requires a reason.', {
+      code: 'content_operation_audio_fallback_reason_required',
+    });
+  }
+  const affectedMatrix = buildAudioFallbackAffectedMatrix(scan);
+  if (affectedMatrix.affectedCount < 1) {
+    throw new BadRequestError('Content operation audio fallback approval has no affected audio blockers.', {
+      code: 'content_operation_audio_fallback_not_required',
+    });
+  }
+  return {
+    allowed: true,
+    reason,
+    notes: normaliseString(raw.notes || notes),
+    approvedByAccountId: normaliseString(approvedByAccountId),
+    approvedAt: Number(approvedAt) || 0,
+    affectedMatrix,
+  };
+}
+
+function applyAudioFallbackToScan(scan = null, fallbackApproval = null) {
+  if (!fallbackApproval?.allowed) return scan;
+  const next = cloneSerialisable(scan || {});
+  const fallbackWarning = 'audio_fallback_approved';
+  const topBlockers = asArray(next.blockers);
+  const strictItems = audioFallbackBlockingItems(next).map(audioFallbackItemSummary);
+  const strictBlockers = [...topBlockers];
+  next.status = topBlockers.length || audioFallbackBlockingItems(next).length ? 'warning' : (next.status || 'warning');
+  next.warnings = uniqueStrings([
+    fallbackWarning,
+    ...asArray(next.warnings),
+    ...topBlockers,
+  ]);
+  next.blockers = [];
+  if (isPlainObject(next.lanes)) {
+    for (const laneKey of Object.keys(next.lanes)) {
+      const lane = next.lanes[laneKey];
+      if (!isPlainObject(lane)) continue;
+      const laneBlockers = asArray(lane.blockers);
+      strictBlockers.push(...laneBlockers);
+      if (laneBlockers.length || lane.status === 'blocked') {
+        lane.status = 'warning';
+      }
+      lane.warnings = uniqueStrings([
+        ...asArray(lane.warnings),
+        ...laneBlockers,
+      ]);
+      lane.blockers = [];
+    }
+  }
+  if (isPlainObject(next.bySlug)) {
+    for (const entry of Object.values(next.bySlug)) {
+      if (!isPlainObject(entry)) continue;
+      const slugBlockers = asArray(entry.blockers);
+      strictBlockers.push(...slugBlockers);
+      if (slugBlockers.length || entry.status === 'blocked') {
+        entry.status = 'warning';
+      }
+      entry.warnings = uniqueStrings([
+        ...asArray(entry.warnings),
+        ...slugBlockers,
+      ]);
+      entry.blockers = [];
+    }
+  }
+  next.fallbackApproval = {
+    allowed: true,
+    approvedAt: fallbackApproval.approvedAt,
+    approvedByAccountId: fallbackApproval.approvedByAccountId,
+    affectedCount: Number(fallbackApproval.affectedMatrix?.affectedCount) || 0,
+  };
+  next.strictAudioReadiness = {
+    status: normaliseString(scan?.status, strictItems.length || strictBlockers.length ? 'blocked' : 'passed'),
+    blockers: uniqueStrings(strictBlockers),
+    affectedCount: strictItems.length,
+    items: strictItems,
+  };
+  return next;
+}
+
+function audioFallbackCoversCurrentScan(fallbackApproval = null, scan = null) {
+  const blockingItems = audioFallbackBlockingItems(scan);
+  if (!blockingItems.length) return true;
+  if (!fallbackApproval?.allowed) return false;
+  const approvedItems = asArray(fallbackApproval.affectedMatrix?.items);
+  const approvedIdentities = new Set(approvedItems.map(audioFallbackItemIdentity));
+  return blockingItems.every((item) => approvedIdentities.has(audioFallbackItemIdentity(item)));
+}
+
+function audioWarningProofForScan(scan = null, fallbackApproval = null) {
+  if (!fallbackApproval?.allowed) return null;
+  return {
+    status: normaliseString(scan?.status, 'warning'),
+    warnings: uniqueStrings(asArray(scan?.warnings)),
+    affectedCount: Number(fallbackApproval.affectedMatrix?.affectedCount) || 0,
+    affectedMatrix: fallbackApproval.affectedMatrix,
+  };
+}
+
+function audioReleaseProofFromProof(proof = null) {
+  const metadata = isPlainObject(proof?.[RELEASE_AUDIO_PROOF_KEY])
+    ? proof[RELEASE_AUDIO_PROOF_KEY]
+    : null;
+  return {
+    audioFallback: isPlainObject(metadata?.audioFallback) ? metadata.audioFallback : null,
+    audioWarnings: isPlainObject(metadata?.audioWarnings) ? metadata.audioWarnings : null,
+  };
+}
+
+function normaliseCallerReleaseProof(proof = null) {
+  if (proof == null) return null;
+  if (!isPlainObject(proof)) return { value: proof };
+  const reservedKeys = Object.keys(proof).filter((key) => RELEASE_PROOF_RESERVED_KEYS.has(key));
+  if (reservedKeys.length) {
+    throw new BadRequestError('Content operation release proof contains reserved audio metadata keys.', {
+      code: 'content_operation_release_proof_reserved_key',
+      reservedKeys,
+    });
+  }
+  return cloneSerialisable(proof);
+}
+
+function buildReleaseProof(proof = null, approval = null, audioScan = null) {
+  const baseProof = normaliseCallerReleaseProof(proof);
+  if (!approval?.audioFallback?.allowed) return baseProof;
+  return {
+    ...(baseProof || {}),
+    [RELEASE_AUDIO_PROOF_KEY]: {
+      audioFallback: approval.audioFallback,
+      audioWarnings: audioWarningProofForScan(audioScan, approval.audioFallback),
+    },
+  };
 }
 
 async function readLatestReleaseRow(db, subjectId, { includeSnapshot = false } = {}) {
@@ -1317,14 +1560,34 @@ export function createContentOperationsRepository({ db, now }) {
         candidate: candidate.candidate,
         operations,
       });
+      const nowTs = Number(nowFactory());
+      let approvedAudioScan = currentAudioScan;
+      let audioFallbackApproval = null;
       if (audioReadinessHasBlockingItems(currentAudioScan)) {
-        await persistCandidateAudioScan(db, candidateId, currentAudioScan);
-        throw new ConflictError('Content operation candidate has audio readiness blockers.', {
-          code: 'content_operation_candidate_audio_blocked',
-          packageId,
-          candidateId,
-          audioScan: currentAudioScan,
+        if (audioFallback == null) {
+          await persistCandidateAudioScan(db, candidateId, currentAudioScan);
+          throw new ConflictError('Content operation candidate has audio readiness blockers.', {
+            code: 'content_operation_candidate_audio_blocked',
+            packageId,
+            candidateId,
+            audioScan: currentAudioScan,
+          });
+        }
+        audioFallbackApproval = normaliseAudioFallbackApproval(audioFallback, currentAudioScan, {
+          approvedByAccountId: actor,
+          approvedAt: nowTs,
+          notes,
         });
+        if (!audioFallbackApproval) {
+          await persistCandidateAudioScan(db, candidateId, currentAudioScan);
+          throw new ConflictError('Content operation candidate has audio readiness blockers.', {
+            code: 'content_operation_candidate_audio_blocked',
+            packageId,
+            candidateId,
+            audioScan: currentAudioScan,
+          });
+        }
+        approvedAudioScan = applyAudioFallbackToScan(currentAudioScan, audioFallbackApproval);
       }
       if (Array.isArray(candidate.conflicts) && candidate.conflicts.length) {
         throw new ConflictError('Content operation candidate has unresolved conflicts.', {
@@ -1336,7 +1599,6 @@ export function createContentOperationsRepository({ db, now }) {
       }
 
       const approvalId = uid('coapp');
-      const nowTs = Number(nowFactory());
       await batch(db, [
         bindStatement(db, `
           DELETE FROM content_operation_package_approvals
@@ -1347,7 +1609,7 @@ export function createContentOperationsRepository({ db, now }) {
           SET audio_scan_json = ?
           WHERE candidate_id = ?
         `, [
-          JSON.stringify(currentAudioScan),
+          JSON.stringify(approvedAudioScan),
           candidateId,
         ]),
         bindStatement(db, `
@@ -1365,7 +1627,7 @@ export function createContentOperationsRepository({ db, now }) {
           actor,
           nowTs,
           normaliseString(notes),
-          audioFallback == null ? null : JSON.stringify(audioFallback),
+          audioFallbackApproval == null ? null : JSON.stringify(audioFallbackApproval),
           assetSummary == null ? null : JSON.stringify(assetSummary),
           JSON.stringify(candidate.validation),
         ]),
@@ -1399,11 +1661,12 @@ export function createContentOperationsRepository({ db, now }) {
             notes: normaliseString(notes),
             validationSummary: candidate.validation,
             audio: {
-              status: currentAudioScan.status,
-              blockers: currentAudioScan.blockers,
-              requiredCount: currentAudioScan.requiredCount,
+              status: approvedAudioScan.status,
+              blockers: approvedAudioScan.blockers,
+              warnings: approvedAudioScan.warnings,
+              requiredCount: approvedAudioScan.requiredCount,
             },
-            audioFallback,
+            audioFallback: audioFallbackApproval,
             assetSummary,
           }),
           nowTs,
@@ -1419,6 +1682,8 @@ export function createContentOperationsRepository({ db, now }) {
         approvedAt: nowTs,
         notes: normaliseString(notes),
         validationSummary: candidate.validation,
+        audioFallback: audioFallbackApproval,
+        assetSummary,
       };
     },
 
@@ -1506,19 +1771,26 @@ export function createContentOperationsRepository({ db, now }) {
         candidate: candidate.candidate,
         operations,
       });
+      let publishAudioScan = currentAudioScan;
       if (audioReadinessHasBlockingItems(currentAudioScan)) {
-        await persistCandidateAudioScan(db, candidate.candidateId, currentAudioScan);
-        throw new ConflictError('Approved candidate has audio readiness blockers.', {
-          code: 'content_operation_candidate_audio_blocked',
-          packageId,
-          candidateId: candidate.candidateId,
-          audioScan: currentAudioScan,
-        });
+        if (audioFallbackCoversCurrentScan(approval.audioFallback, currentAudioScan)) {
+          publishAudioScan = applyAudioFallbackToScan(currentAudioScan, approval.audioFallback);
+        } else {
+          await persistCandidateAudioScan(db, candidate.candidateId, currentAudioScan);
+          throw new ConflictError('Approved candidate has audio readiness blockers.', {
+            code: 'content_operation_candidate_audio_blocked',
+            packageId,
+            candidateId: candidate.candidateId,
+            audioScan: currentAudioScan,
+          });
+        }
       }
       const releaseId = uid('corel');
       const nowTs = Number(nowFactory());
       const snapshotHash = contentOperationHash(candidate.candidate, 'release');
       const encodedSnapshot = await encodeContentOperationSnapshot(candidate.candidate);
+      const releaseProof = buildReleaseProof(proof, approval, publishAudioScan);
+      const releaseAudioProof = audioReleaseProofFromProof(releaseProof);
 
       let publishResults = [];
       try {
@@ -1545,7 +1817,7 @@ export function createContentOperationsRepository({ db, now }) {
             packageId,
             nowTs,
             actor,
-            proof == null ? null : JSON.stringify(proof),
+            releaseProof == null ? null : JSON.stringify(releaseProof),
             nowTs,
             packageId,
             CONTENT_OPERATION_PACKAGE_STATES.APPROVED,
@@ -1557,7 +1829,7 @@ export function createContentOperationsRepository({ db, now }) {
             SET audio_scan_json = ?
             WHERE candidate_id = ?
           `, [
-            JSON.stringify(currentAudioScan),
+            JSON.stringify(publishAudioScan),
             candidate.candidateId,
           ]),
           bindStatement(db, `
@@ -1603,6 +1875,8 @@ export function createContentOperationsRepository({ db, now }) {
               candidateHash: candidate.candidateHash,
               snapshotHash,
               summary: buildSpellingContentSummary(candidate.candidate),
+              audioFallback: approval.audioFallback,
+              audioWarnings: audioWarningProofForScan(publishAudioScan, approval.audioFallback),
             }),
             nowTs,
             releaseId,
@@ -1652,7 +1926,9 @@ export function createContentOperationsRepository({ db, now }) {
         baseReleaseId: candidate.currentReleaseId || packageRow.base_release_id || null,
         publishedAt: nowTs,
         publishedByAccountId: actor,
-        proof,
+        proof: releaseProof,
+        audioFallback: releaseAudioProof.audioFallback,
+        audioWarnings: releaseAudioProof.audioWarnings,
       };
     },
 
@@ -1829,6 +2105,75 @@ export function createContentOperationsRepository({ db, now }) {
         LIMIT ?
       `, params);
       return rows.map(eventRowToRecord);
+    },
+
+    async invalidateContentOperationPackageApproval(packageId, {
+      actorAccountId,
+      reason = '',
+      event = {},
+      eventType = 'audio.override',
+    } = {}) {
+      const packageRow = await requirePackage(db, packageId);
+      assertPackageIsNotPublished(packageRow, packageId);
+      const actor = normaliseString(actorAccountId);
+      if (!actor) throw new BadRequestError('Content operation approval invalidation requires an actor account id.');
+      const approvalRow = await first(db, `
+        SELECT *
+        FROM content_operation_package_approvals
+        WHERE package_id = ?
+        ORDER BY approved_at DESC
+        LIMIT 1
+      `, [packageId]);
+      const nowTs = Number(nowFactory());
+      const invalidatedApproval = Boolean(approvalRow);
+      await batch(db, [
+        bindStatement(db, `
+          DELETE FROM content_operation_package_approvals
+          WHERE package_id = ?
+        `, [packageId]),
+        bindStatement(db, `
+          UPDATE content_operation_packages
+          SET state = CASE WHEN state = ? THEN ? ELSE state END,
+              approved_at = NULL,
+              updated_by_account_id = ?,
+              updated_at = ?
+          WHERE package_id = ?
+        `, [
+          CONTENT_OPERATION_PACKAGE_STATES.APPROVED,
+          CONTENT_OPERATION_PACKAGE_STATES.DRAFT,
+          actor,
+          nowTs,
+          packageId,
+        ]),
+        bindStatement(db, `
+          INSERT INTO content_operation_events (
+            event_id, package_id, release_id, subject_id, event_type,
+            actor_account_id, event_json, created_at
+          )
+          VALUES (?, ?, NULL, ?, ?, ?, ?, ?)
+        `, [
+          uid('coevt'),
+          packageId,
+          packageRow.subject_id,
+          normaliseString(eventType, 'audio.override'),
+          actor,
+          JSON.stringify({
+            ...(isPlainObject(event) ? event : {}),
+            reason: normaliseString(reason),
+            invalidatedApproval,
+            approvalId: approvalRow?.approval_id || null,
+            candidateId: event?.candidateId || approvalRow?.candidate_id || null,
+            invalidatedApprovalCandidateId: approvalRow?.candidate_id || null,
+          }),
+          nowTs,
+        ]),
+      ]);
+      return {
+        package: packageRowToRecord(await requirePackage(db, packageId)),
+        invalidatedApproval,
+        eventType: normaliseString(eventType, 'audio.override'),
+        createdAt: nowTs,
+      };
     },
 
     async recordContentOperationEvent(event) {

--- a/worker/src/content-operations/routes.js
+++ b/worker/src/content-operations/routes.js
@@ -578,18 +578,31 @@ export async function handleContentOperationsAdminRequest({
         } catch (error) {
           badContentOperation(error);
         }
+        const resolvedCandidateId = body.candidateId || body.candidate_id || candidate.candidateId;
+        const overrideReason = body.reason || body.overrideReason || body.override_reason || '';
         const audio = await generateContentOperationPackageAudio({
           db: requireDatabase(env),
           env,
           packageId,
           candidate,
-          candidateId: body.candidateId || body.candidate_id || candidate.candidateId,
+          candidateId: resolvedCandidateId,
           requestedByAccountId: actor.id,
           itemIds: body.itemIds || body.item_ids || [],
           limit: body.limit,
           override: body.override === true,
-          overrideReason: body.reason || body.overrideReason || body.override_reason || '',
+          overrideReason,
         });
+        const invalidation = body.override === true
+          ? await repository.invalidateContentOperationPackageApproval(packageId, {
+            actorAccountId: actor.id,
+            reason: overrideReason,
+            event: {
+              candidateId: resolvedCandidateId,
+              summary: audio.summary,
+              jobIds: Array.isArray(audio.jobs) ? audio.jobs.map((job) => job.jobId).filter(Boolean) : [],
+            },
+          })
+          : null;
         return json({
           ok: true,
           actor: serialiseContentOperationActor(actor),
@@ -597,6 +610,10 @@ export async function handleContentOperationsAdminRequest({
             includeSnapshot: includeSnapshot(url, body),
           }),
           audio,
+          package: invalidation?.package
+            ? serialiseContentOperationPackage(invalidation.package)
+            : undefined,
+          invalidation,
         });
       }
 
@@ -608,16 +625,10 @@ export async function handleContentOperationsAdminRequest({
             packageId,
           });
         }
-        if (body.audioFallback != null) {
-          throw new BadRequestError('Content operation audio fallback approvals are not supported.', {
-            code: 'content_operation_audio_fallback_not_supported',
-            packageId,
-            candidateId,
-          });
-        }
         const approval = await repository.approveContentOperationCandidate(packageId, candidateId, {
           approvedByAccountId: actor.id,
           notes: body.notes,
+          audioFallback: body.audioFallback ?? body.audio_fallback ?? null,
           assetSummary: body.assetSummary ?? null,
         });
         return json({

--- a/worker/src/content-operations/serialisers.js
+++ b/worker/src/content-operations/serialisers.js
@@ -81,11 +81,29 @@ function normaliseReadinessSection(value = null, fallbackStatus = 'not_scanned')
       warnings: [],
     };
   }
-  return {
+  const section = {
     status: typeof value.status === 'string' && value.status ? value.status : fallbackStatus,
     blockers: asArray(value.blockers),
     warnings: asArray(value.warnings),
   };
+  if (value.fallbackApproval && typeof value.fallbackApproval === 'object' && !Array.isArray(value.fallbackApproval)) {
+    section.fallbackApproval = value.fallbackApproval;
+  }
+  if (
+    value.strictAudioReadiness
+    && typeof value.strictAudioReadiness === 'object'
+    && !Array.isArray(value.strictAudioReadiness)
+  ) {
+    section.strictAudioReadiness = {
+      status: typeof value.strictAudioReadiness.status === 'string'
+        ? value.strictAudioReadiness.status
+        : 'not_scanned',
+      blockers: asArray(value.strictAudioReadiness.blockers),
+      affectedCount: Number(value.strictAudioReadiness.affectedCount) || 0,
+      items: asArray(value.strictAudioReadiness.items),
+    };
+  }
+  return section;
 }
 
 export function buildContentOperationBlockerEnvelope({
@@ -272,7 +290,26 @@ export function serialiseContentOperationApproval(approval = {}) {
   };
 }
 
+function releaseAudioProofFromProof(proof = null) {
+  const metadata = proof && typeof proof === 'object' && !Array.isArray(proof)
+    ? proof.contentOperationsAudio
+    : null;
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    return { audioFallback: null, audioWarnings: null };
+  }
+  return {
+    audioFallback: metadata.audioFallback && typeof metadata.audioFallback === 'object' && !Array.isArray(metadata.audioFallback)
+      ? metadata.audioFallback
+      : null,
+    audioWarnings: metadata.audioWarnings && typeof metadata.audioWarnings === 'object' && !Array.isArray(metadata.audioWarnings)
+      ? metadata.audioWarnings
+      : null,
+  };
+}
+
 export function serialiseContentOperationRelease(release = {}, { includeSnapshot = false } = {}) {
+  const proof = release.proof ?? null;
+  const proofAudio = releaseAudioProofFromProof(proof);
   return {
     releaseId: release.releaseId,
     subjectId: release.subjectId || CONTENT_OPERATION_SUBJECT_ID,
@@ -283,7 +320,9 @@ export function serialiseContentOperationRelease(release = {}, { includeSnapshot
     publishedAt: release.publishedAt ?? null,
     publishedByAccountId: release.publishedByAccountId || null,
     rollbackOfReleaseId: release.rollbackOfReleaseId || null,
-    proof: release.proof ?? null,
+    proof,
+    audioFallback: release.audioFallback ?? proofAudio.audioFallback,
+    audioWarnings: release.audioWarnings ?? proofAudio.audioWarnings,
     createdAt: Number(release.createdAt) || 0,
     ...(includeSnapshot ? { snapshot: release.snapshot || null } : {}),
   };


### PR DESCRIPTION
## Summary
- Add approval-time runtime TTS fallback for audio readiness blockers, with required operator reason and persisted fallback metadata.
- Invalidate existing package approval when audio is regenerated with override, and record an `audio.override` audit event.
- Expose fallback warnings in Content Operations release history while preserving strict audio readiness metadata for approved fallback scans.
- Reserve server-owned audio proof keys so caller-supplied publish proof cannot masquerade as an approved fallback.

## Verification
- `node --test tests/admin-content-operations-v2.test.js`
- `node --test tests/react-admin-content-operations.test.js`
- `node --test tests/content-operations-audio-readiness.test.js`
- `node --test tests/content-operations-api.test.js`
- `node --test --test-name-pattern "blocks approval when affected sentence audio is missing|rejects client-supplied fallback proof metadata" tests/content-operations-api.test.js`
- `git diff --check`
- `npm test` (111,778 pass, 0 fail, 12 skipped)
- `npm run check`
- Pre-push hook `npm test` (111,778 pass, 0 fail, 12 skipped)