### PR TITLE
Add content operations audio controls

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2723,6 +2723,7 @@ function buildSurfaceActions() {
     appendOperation: hubApi.appendContentOperation?.bind(hubApi),
     deleteOperation: hubApi.deleteContentOperation?.bind(hubApi),
     validatePackage: hubApi.validateContentOperationPackage?.bind(hubApi),
+    generateAudio: hubApi.generateContentOperationAudio?.bind(hubApi),
     approvePackage: hubApi.approveContentOperationPackage?.bind(hubApi),
     publishPackage: hubApi.publishContentOperationPackage?.bind(hubApi),
     resolveConflict: hubApi.resolveContentOperationConflict?.bind(hubApi),

--- a/src/platform/hubs/admin-content-operations.js
+++ b/src/platform/hubs/admin-content-operations.js
@@ -68,6 +68,15 @@ const BLOCKER_SECTION_KEYS = Object.freeze([
   'publishReadiness',
 ]);
 
+const GENERATABLE_AUDIO_STATUSES = new Set([
+  'missing',
+  'stale',
+  'generated',
+  'failed',
+  'skipped',
+  'override_requested',
+]);
+
 function isPlainObject(value) {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
@@ -306,6 +315,110 @@ function normaliseAudioReadiness(value = null) {
     wordAudioRequired: Number(safe.wordAudioRequired) || 0,
     sentenceAudioRequired: Number(safe.sentenceAudioRequired) || 0,
     totalRequired: Number(safe.totalRequired) || 0,
+  };
+}
+
+function normaliseAudioLaneSummary(value = null) {
+  const safe = isPlainObject(value) ? value : {};
+  return {
+    status: asString(safe.status, 'not_scanned'),
+    blockers: asArray(safe.blockers),
+    warnings: asArray(safe.warnings),
+    requiredCount: Number(safe.requiredCount ?? safe.totalRequired) || 0,
+    totalRequired: Number(safe.totalRequired ?? safe.requiredCount) || 0,
+    presentCount: Number(safe.presentCount) || 0,
+    missingCount: Number(safe.missingCount) || 0,
+    staleCount: Number(safe.staleCount) || 0,
+    generatedCount: Number(safe.generatedCount) || 0,
+    failedCount: Number(safe.failedCount) || 0,
+    skippedCount: Number(safe.skippedCount) || 0,
+    overrideRequestedCount: Number(safe.overrideRequestedCount) || 0,
+    statusCounts: isPlainObject(safe.statusCounts) ? { ...safe.statusCounts } : {},
+  };
+}
+
+function audioItemLabel(item) {
+  if (item.lane === 'sentence') {
+    return item.sentenceId
+      ? `${item.slug} / ${item.sentenceId}`
+      : `${item.slug} / sentence`;
+  }
+  if (item.surface && item.surface !== 'base') return `${item.slug} / ${item.surface}`;
+  return item.slug || 'word';
+}
+
+function normaliseAudioScanItem(item = null) {
+  const safe = isPlainObject(item) ? item : {};
+  const status = asString(safe.status, 'unknown');
+  const lane = safe.lane === 'sentence' ? 'sentence' : 'word';
+  const itemId = asString(safe.itemId);
+  const required = safe.required === false ? false : true;
+  return {
+    itemId,
+    lane,
+    status,
+    statusLabel: status.replace(/_/g, ' '),
+    required,
+    canGenerate: required && GENERATABLE_AUDIO_STATUSES.has(status),
+    canOverride: required,
+    blocker: asString(safe.blocker),
+    slug: asString(safe.slug),
+    word: asString(safe.word),
+    sentenceId: asString(safe.sentenceId),
+    sentence: asString(safe.sentence),
+    profileId: asString(safe.profileId),
+    voiceId: asString(safe.voiceId),
+    voiceRole: asString(safe.voiceRole, 'unknown'),
+    paceId: asString(safe.paceId),
+    speedId: asString(safe.speedId),
+    slow: Boolean(safe.slow),
+    surface: asString(safe.surface, 'base'),
+    variantIndex: safe.variantIndex === null || safe.variantIndex === undefined ? null : Number(safe.variantIndex),
+    variantWord: asString(safe.variantWord),
+    modelId: asString(safe.modelId),
+    profileVersion: asString(safe.profileVersion),
+    contentKey: asString(safe.contentKey),
+    r2Key: asString(safe.r2Key),
+    error: isPlainObject(safe.error) ? { ...safe.error } : null,
+    label: audioItemLabel({
+      lane,
+      slug: asString(safe.slug),
+      sentenceId: asString(safe.sentenceId),
+      surface: asString(safe.surface, 'base'),
+    }),
+  };
+}
+
+export function normaliseContentOperationAudioScan(value = null) {
+  const safe = isPlainObject(value) ? value : {};
+  const items = asArray(safe.items).map(normaliseAudioScanItem).filter((item) => item.itemId);
+  const lanes = isPlainObject(safe.lanes) ? safe.lanes : {};
+  const summary = normaliseAudioLaneSummary(safe);
+  const actionableItems = items.filter((item) => item.canGenerate);
+  const presentItems = items.filter((item) => item.required && item.status === 'present');
+  const failedItems = items.filter((item) => item.required && item.status === 'failed');
+  return {
+    status: asString(safe.status, summary.status),
+    profileVersion: asString(safe.profileVersion),
+    modelId: asString(safe.modelId),
+    scope: asString(safe.scope, 'unknown'),
+    operationCount: Number(safe.operationCount) || 0,
+    scannedWordCount: Number(safe.scannedWordCount) || 0,
+    profile: isPlainObject(safe.profile) ? safe.profile : null,
+    summary,
+    lanes: {
+      word: normaliseAudioLaneSummary(lanes.word),
+      sentence: normaliseAudioLaneSummary(lanes.sentence),
+    },
+    items,
+    actionableItems,
+    actionableItemIds: actionableItems.map((item) => item.itemId),
+    presentItems,
+    failedItems,
+    blockers: asArray(safe.blockers),
+    warnings: asArray(safe.warnings),
+    bySlug: isPlainObject(safe.bySlug) ? { ...safe.bySlug } : {},
+    hasScan: Boolean(safe.status || items.length),
   };
 }
 

--- a/src/platform/hubs/api.js
+++ b/src/platform/hubs/api.js
@@ -363,6 +363,31 @@ export function createHubApi({
         }),
       }, authSession);
     },
+    async generateContentOperationAudio({
+      packageId,
+      candidateId = '',
+      itemIds = [],
+      limit = null,
+      override = false,
+      reason = '',
+      mutation,
+    } = {}) {
+      if (!packageId) throw new TypeError('Content operation package id is required.');
+      const safePackageId = encodeURIComponent(String(packageId));
+      const url = buildRequestUrl(baseUrl, `/api/admin/content-operations/packages/${safePackageId}/generate-audio`);
+      return fetchHubJson(fetch, url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          candidateId,
+          itemIds: Array.isArray(itemIds) ? itemIds : [],
+          limit,
+          override: Boolean(override),
+          reason,
+          mutation,
+        }),
+      }, authSession);
+    },
     async approveContentOperationPackage({
       packageId,
       candidateId,

--- a/src/surfaces/hubs/AdminContentOperationsSection.jsx
+++ b/src/surfaces/hubs/AdminContentOperationsSection.jsx
@@ -4,6 +4,7 @@ import { formatTimestamp } from './hub-utils.js';
 import {
   CONTENT_OPERATION_DETAIL_TABS,
   CONTENT_OPERATION_LANES,
+  normaliseContentOperationAudioScan,
   normaliseContentOperationCandidate,
   normaliseContentOperationPackage,
   normaliseContentOperationsOverview,
@@ -529,6 +530,58 @@ function statusLabel(status) {
   return String(status || 'unknown').replace(/_/g, ' ');
 }
 
+const AUDIO_STATUS_FILTERS = Object.freeze([
+  { value: 'actionable', label: 'Actionable gaps' },
+  { value: 'all', label: 'All states' },
+  { value: 'missing', label: 'Missing' },
+  { value: 'failed', label: 'Failed' },
+  { value: 'stale', label: 'Stale' },
+  { value: 'generated', label: 'Generated' },
+  { value: 'skipped', label: 'Skipped' },
+  { value: 'override_requested', label: 'Override requested' },
+  { value: 'present', label: 'Present' },
+]);
+
+function audioStatusChipClass(status) {
+  if (status === 'present' || status === 'passed') return 'good';
+  if (status === 'missing' || status === 'failed' || status === 'blocked') return 'bad';
+  if (['stale', 'generated', 'skipped', 'override_requested', 'warning'].includes(status)) return 'warn';
+  return '';
+}
+
+function filterAudioItems(items, { laneFilter, statusFilter }) {
+  return items.filter((item) => {
+    if (laneFilter !== 'all' && item.lane !== laneFilter) return false;
+    if (statusFilter === 'actionable') return item.canGenerate;
+    if (statusFilter !== 'all' && item.status !== statusFilter) return false;
+    return true;
+  });
+}
+
+function audioItemDetail(item) {
+  const parts = [
+    item.voiceRole ? `${item.voiceRole} voice` : '',
+    item.paceId || item.speedId || '',
+    item.profileId || '',
+  ].filter(Boolean);
+  return parts.join(' / ');
+}
+
+function audioGenerationMessage(action, payload) {
+  if (action === 'scan') return 'Audio scan refreshed.';
+  const summary = payload?.audio?.summary || {};
+  const uploaded = Number(summary.uploaded) || 0;
+  const failed = Number(summary.failed) || 0;
+  const skipped = (Number(summary.skippedExisting) || 0)
+    + (Number(summary.skippedPresent) || 0)
+    + (Number(summary.skippedDueLimit) || 0);
+  return `Audio generation finished: ${String(uploaded)} uploaded, ${String(failed)} failed, ${String(skipped)} skipped.`;
+}
+
+function audioItemSelectable(item) {
+  return Boolean(item?.canGenerate || item?.canOverride);
+}
+
 function CentreTabNav({ activeTab, onSelect }) {
   return (
     <div className="content-ops-tabs" role="tablist" aria-label="Content operations views">
@@ -681,6 +734,291 @@ function BlockerSummary({ blockers, sectionKey }) {
   );
 }
 
+function AudioOperationsPanel({
+  contentPackage,
+  actor,
+  audioState,
+  actionAvailability = {},
+  onRunAction,
+}) {
+  const candidate = latestCandidateForPackage(contentPackage, audioState);
+  const scan = normaliseContentOperationAudioScan(candidate?.audioScan);
+  const audioSection = candidate?.blockers?.audio || contentPackage.blockers.audio;
+  const strictReadiness = audioSection?.strictAudioReadiness || null;
+  const fallbackApproval = audioSection?.fallbackApproval || null;
+  const canEdit = actorCan(actor, CONTENT_OPERATION_CAPABILITIES.EDIT);
+  const isRunning = Boolean(
+    audioState?.running
+      && audioState.packageId === contentPackage.packageId
+  );
+  const activeAction = isRunning ? audioState.action : '';
+  const actionError = audioState?.packageId === contentPackage.packageId ? audioState.error : null;
+  const actionMessageText = audioState?.packageId === contentPackage.packageId ? audioState.message : '';
+  const [laneFilter, setLaneFilter] = React.useState('all');
+  const [statusFilter, setStatusFilter] = React.useState('actionable');
+  const [selectedItemIds, setSelectedItemIds] = React.useState([]);
+  const [overrideReason, setOverrideReason] = React.useState('');
+
+  React.useEffect(() => {
+    setSelectedItemIds([]);
+    setOverrideReason('');
+  }, [contentPackage.packageId, candidate?.candidateId]);
+
+  const filteredItems = React.useMemo(
+    () => filterAudioItems(scan.items, { laneFilter, statusFilter }),
+    [laneFilter, scan.items, statusFilter],
+  );
+  const selectedSet = React.useMemo(() => new Set(selectedItemIds), [selectedItemIds]);
+  const selectedItems = scan.items.filter((item) => selectedSet.has(item.itemId));
+  const selectedGeneratableIds = selectedItems
+    .filter((item) => item.canGenerate)
+    .map((item) => item.itemId);
+  const selectedOverrideIds = selectedItems
+    .filter((item) => item.canOverride)
+    .map((item) => item.itemId);
+  const visibleSelectableIds = filteredItems
+    .filter(audioItemSelectable)
+    .map((item) => item.itemId)
+    .filter(Boolean);
+  const allVisibleSelected = visibleSelectableIds.length > 0
+    && visibleSelectableIds.every((itemId) => selectedSet.has(itemId));
+  const batchCount = scan.actionableItems.length;
+  const overrideReady = overrideReason.trim().length > 0;
+  const run = (action, extra = {}) => {
+    if (!onRunAction) return;
+    onRunAction(action, {
+      packageId: contentPackage.packageId,
+      candidateId: candidate?.candidateId || '',
+      ...extra,
+    });
+  };
+  const toggleVisibleSelection = () => {
+    setSelectedItemIds((current) => {
+      if (allVisibleSelected) {
+        const visible = new Set(visibleSelectableIds);
+        return current.filter((itemId) => !visible.has(itemId));
+      }
+      return [...new Set([...current, ...visibleSelectableIds])];
+    });
+  };
+  const toggleItem = (itemId) => {
+    setSelectedItemIds((current) => (
+      current.includes(itemId)
+        ? current.filter((entry) => entry !== itemId)
+        : [...current, itemId]
+    ));
+  };
+  const scanDisabled = !canEdit || !actionAvailability.scan || isRunning || contentPackage.state === 'published';
+  const generateSelectedDisabled = !canEdit
+    || !actionAvailability.generate
+    || isRunning
+    || selectedGeneratableIds.length === 0
+    || contentPackage.state === 'published';
+  const batchDisabled = !canEdit
+    || !actionAvailability.generate
+    || isRunning
+    || batchCount === 0
+    || contentPackage.state === 'published';
+  const overrideDisabled = !canEdit
+    || !actionAvailability.generate
+    || isRunning
+    || !candidate?.candidateId
+    || !overrideReady
+    || contentPackage.state === 'published';
+
+  return (
+    <section className="content-ops-audio-panel" data-content-ops-audio-panel="true">
+      <div className="content-ops-detail-header">
+        <div>
+          <div className="eyebrow">Audio operations</div>
+          <h5>Scan, generate, override</h5>
+          <p className="small muted admin-note-spaced">
+            {candidate?.candidateId ? `Candidate ${candidate.candidateId}` : 'Run validation to build an audio scan'}
+          </p>
+        </div>
+        <div className="chip-row content-ops-chip-wrap">
+          <span className={`chip ${audioStatusChipClass(scan.status)}`}>{statusLabel(scan.status)}</span>
+          <span className="chip">{String(scan.summary.totalRequired)} required</span>
+          {fallbackApproval?.allowed ? <span className="chip warn">Fallback approved</span> : null}
+        </div>
+      </div>
+
+      <div className="content-ops-metric-grid">
+        <MetricTile label="Word audio" value={String(scan.lanes.word.totalRequired)} detail={`${String(scan.lanes.word.missingCount)} missing`} />
+        <MetricTile label="Sentence audio" value={String(scan.lanes.sentence.totalRequired)} detail={`${String(scan.lanes.sentence.missingCount)} missing`} />
+        <MetricTile label="Present" value={String(scan.summary.presentCount)} detail={`${String(scan.actionableItems.length)} actionable`} />
+        <MetricTile label="Failures" value={String(scan.summary.failedCount)} detail={`${String(scan.summary.staleCount)} stale`} />
+      </div>
+
+      <div className="content-ops-audio-controls">
+        <div className="content-ops-audio-filter-row">
+          <label>
+            <span className="small muted">Lane</span>
+            <select
+              value={laneFilter}
+              onChange={(event) => setLaneFilter(event.target.value)}
+              data-content-ops-audio-lane-filter="true"
+            >
+              <option value="all">All lanes</option>
+              <option value="word">Word</option>
+              <option value="sentence">Sentence</option>
+            </select>
+          </label>
+          <label>
+            <span className="small muted">State</span>
+            <select
+              value={statusFilter}
+              onChange={(event) => setStatusFilter(event.target.value)}
+              data-content-ops-audio-status-filter="true"
+            >
+              {AUDIO_STATUS_FILTERS.map((entry) => (
+                <option key={entry.value} value={entry.value}>{entry.label}</option>
+              ))}
+            </select>
+          </label>
+          <button
+            type="button"
+            className="btn secondary compact"
+            onClick={toggleVisibleSelection}
+            disabled={!visibleSelectableIds.length}
+            data-content-ops-audio-select-visible="true"
+          >
+            {allVisibleSelected ? 'Clear visible' : 'Select visible'}
+          </button>
+        </div>
+        <div className="actions content-ops-lifecycle-actions">
+          <button
+            type="button"
+            className="btn secondary"
+            disabled={scanDisabled}
+            aria-busy={activeAction === 'scan' ? 'true' : undefined}
+            data-content-ops-audio-action="scan"
+            onClick={() => run('scan')}
+          >
+            Refresh scan
+          </button>
+          <button
+            type="button"
+            className="btn secondary"
+            disabled={generateSelectedDisabled}
+            aria-busy={activeAction === 'generate-selected' ? 'true' : undefined}
+            data-content-ops-audio-action="generate-selected"
+            onClick={() => run('generate-selected', {
+              itemIds: selectedGeneratableIds,
+              limit: Math.max(1, selectedGeneratableIds.length),
+            })}
+          >
+            Generate selected
+          </button>
+          <button
+            type="button"
+            className="btn primary"
+            disabled={batchDisabled}
+            aria-busy={activeAction === 'generate-batch' ? 'true' : undefined}
+            data-content-ops-audio-action="generate-batch"
+            onClick={() => run('generate-batch', { itemIds: [], limit: 25 })}
+          >
+            Batch generate gaps
+          </button>
+        </div>
+      </div>
+
+      <div className="content-ops-audio-override">
+        <label className="content-ops-notes-field">
+          <span className="small muted">Override reason</span>
+          <textarea
+            value={overrideReason}
+            onChange={(event) => setOverrideReason(event.target.value)}
+            rows={2}
+            data-content-ops-audio-override-reason="true"
+          />
+        </label>
+        <button
+          type="button"
+          className="btn secondary"
+          disabled={overrideDisabled}
+          aria-busy={activeAction === 'override' ? 'true' : undefined}
+          data-content-ops-audio-action="override"
+          onClick={() => run('override', {
+            itemIds: selectedOverrideIds,
+            limit: selectedOverrideIds.length ? selectedOverrideIds.length : 25,
+            override: true,
+            reason: overrideReason.trim(),
+          })}
+        >
+          Regenerate selected or package
+        </button>
+      </div>
+
+      {strictReadiness ? (
+        <div className="feedback warn admin-note-spaced" data-content-ops-audio-strict-readiness="true">
+          Strict audio readiness: {statusLabel(strictReadiness.status)} - {String(strictReadiness.affectedCount)} affected
+        </div>
+      ) : null}
+      <BlockerSummary blockers={{ audio: audioSection }} sectionKey="audio" />
+
+      <div className="content-ops-table-scroll">
+        <table className="admin-overview-table content-ops-table content-ops-audio-table" aria-label="Content operation audio matrix">
+          <thead>
+            <tr className="admin-overview-thead-row">
+              <th className="small admin-overview-th-first">Item</th>
+              <th className="small admin-overview-th">Lane</th>
+              <th className="small admin-overview-th">State</th>
+              <th className="small admin-overview-th">Voice</th>
+              <th className="small admin-overview-th">Storage</th>
+              <th className="small admin-overview-th">Select</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filteredItems.length ? filteredItems.slice(0, 80).map((item) => (
+              <tr key={item.itemId} className="admin-overview-tbody-row" data-audio-status={item.status}>
+                <td className="admin-overview-td-first">
+                  <strong>{item.label}</strong>
+                  <div className="small muted">{item.lane === 'sentence' ? (item.sentence || 'Sentence') : (item.word || 'Word')}</div>
+                </td>
+                <td className="admin-overview-td small">{item.lane}</td>
+                <td className="admin-overview-td">
+                  <span className={`chip ${audioStatusChipClass(item.status)}`}>{item.statusLabel}</span>
+                  {item.blocker ? <div className="small muted">{item.blocker}</div> : null}
+                </td>
+                <td className="admin-overview-td small">{audioItemDetail(item) || 'Profile pending'}</td>
+                <td className="admin-overview-td small">{item.r2Key || 'No R2 key'}</td>
+                <td className="admin-overview-td">
+                  <input
+                    type="checkbox"
+                    checked={selectedSet.has(item.itemId)}
+                    disabled={!audioItemSelectable(item)}
+                    onChange={() => toggleItem(item.itemId)}
+                    aria-label={`Select ${item.itemId}`}
+                    data-content-ops-audio-item={item.itemId}
+                  />
+                </td>
+              </tr>
+            )) : (
+              <tr className="admin-overview-tbody-row">
+                <td className="admin-overview-td-first" colSpan={6}>
+                  <span className="small muted">No audio items match the current filters.</span>
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {actionError ? (
+        <div className="feedback warn admin-note-spaced" data-content-ops-audio-error="true">
+          <strong>{actionError.code}</strong>
+          <div>{actionError.message}</div>
+        </div>
+      ) : actionMessageText ? (
+        <div className="feedback good admin-note-spaced" data-content-ops-audio-message="true">
+          {actionMessageText}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
 function PackageTable({ packages, selectedPackageId, onSelectPackage }) {
   if (!packages.length) {
     return (
@@ -739,9 +1077,29 @@ function PackageTable({ packages, selectedPackageId, onSelectPackage }) {
   );
 }
 
-function PublishedAreaPanel({ activeTab, latestRelease, selectedPackageId, selectedSummary }) {
+function PublishedAreaPanel({
+  activeTab,
+  latestRelease,
+  selectedPackageId,
+  selectedSummary,
+  actor,
+  audioState,
+  audioActionAvailability,
+  onRunAudioAction,
+}) {
   const tab = CENTRE_TABS.find((entry) => entry.key === activeTab);
   const blockerSection = DETAIL_TAB_BLOCKER_SECTIONS[activeTab] || null;
+  if (activeTab === 'audio' && selectedSummary) {
+    return (
+      <AudioOperationsPanel
+        contentPackage={selectedSummary}
+        actor={actor}
+        audioState={audioState}
+        actionAvailability={audioActionAvailability}
+        onRunAction={onRunAudioAction}
+      />
+    );
+  }
   return (
     <div className="content-ops-area-panel" data-content-ops-area={activeTab}>
       <div className="content-ops-detail-header">
@@ -2415,7 +2773,15 @@ function PackageLifecyclePanel({
   );
 }
 
-function PackageDetailBody({ contentPackage, activeTab, events }) {
+function PackageDetailBody({
+  contentPackage,
+  activeTab,
+  events,
+  actor,
+  audioState,
+  audioActionAvailability,
+  onRunAudioAction,
+}) {
   if (activeTab === 'spelling') {
     return (
       <div>
@@ -2472,6 +2838,18 @@ function PackageDetailBody({ contentPackage, activeTab, events }) {
     );
   }
 
+  if (activeTab === 'audio') {
+    return (
+      <AudioOperationsPanel
+        contentPackage={contentPackage}
+        actor={actor}
+        audioState={audioState}
+        actionAvailability={audioActionAvailability}
+        onRunAction={onRunAudioAction}
+      />
+    );
+  }
+
   const tab = CONTENT_OPERATION_DETAIL_TABS.find((entry) => entry.key === activeTab);
   const blockerSection = DETAIL_TAB_BLOCKER_SECTIONS[activeTab];
   return (
@@ -2496,6 +2874,9 @@ function PackageDetail({
   lifecycleState,
   lifecycleActionAvailability,
   onRunLifecycleAction,
+  audioState,
+  audioActionAvailability,
+  onRunAudioAction,
 }) {
   const contentPackage = detail?.package || null;
   if (!selectedPackageId) {
@@ -2552,6 +2933,10 @@ function PackageDetail({
           contentPackage={contentPackage}
           activeTab={activeTab}
           events={events}
+          actor={actor}
+          audioState={audioState}
+          audioActionAvailability={audioActionAvailability}
+          onRunAudioAction={onRunAudioAction}
         />
       </div>
     </div>
@@ -2686,6 +3071,14 @@ export function AdminContentOperationsSection({
     candidate: null,
     approval: null,
     release: null,
+  });
+  const [audioOperationState, setAudioOperationState] = React.useState({
+    packageId: '',
+    action: '',
+    running: false,
+    message: '',
+    error: null,
+    candidate: null,
   });
   const [spellingOperationState, setSpellingOperationState] = React.useState({
     packageId: '',
@@ -2955,6 +3348,22 @@ export function AdminContentOperationsSection({
     selectedPackageId,
   ]);
 
+  React.useEffect(() => {
+    if (activeTab !== 'audio') return;
+    if (!selectedPackageId || !api?.readPackage) return;
+    if (loadingDetailId === selectedPackageId || detailErrorId === selectedPackageId) return;
+    if (detail.package?.packageId === selectedPackageId) return;
+    loadPackageDetail(selectedPackageId);
+  }, [
+    activeTab,
+    api,
+    detail.package?.packageId,
+    detailErrorId,
+    loadPackageDetail,
+    loadingDetailId,
+    selectedPackageId,
+  ]);
+
   const runLifecycleAction = React.useCallback(async (action, {
     packageId,
     candidateId = '',
@@ -3051,6 +3460,74 @@ export function AdminContentOperationsSection({
     }
   }, [api, invalidateSpellingBrowse, loadPackageDetail, refresh]);
 
+  const runAudioOperation = React.useCallback(async (action, {
+    packageId,
+    candidateId = '',
+    itemIds = [],
+    limit = null,
+    override = false,
+    reason = '',
+  } = {}) => {
+    if (!api || !packageId) return;
+    setAudioOperationState({
+      packageId,
+      action,
+      running: true,
+      message: '',
+      error: null,
+      candidate: null,
+    });
+    try {
+      let payload = null;
+      if (action === 'scan') {
+        if (!api.validatePackage) throw new Error('Audio scan action is not available.');
+        payload = await api.validatePackage({
+          packageId,
+          includeSnapshot: false,
+          mutation: contentOperationMutation('audio-scan', packageId),
+        });
+      } else {
+        if (!api.generateAudio) throw new Error('Audio generation action is not available.');
+        payload = await api.generateAudio({
+          packageId,
+          candidateId,
+          itemIds,
+          limit,
+          override,
+          reason,
+          mutation: contentOperationMutation(`audio-${action}`, packageId),
+        });
+      }
+      const nextCandidate = payload?.candidate
+        ? normaliseContentOperationCandidate(payload.candidate)
+        : null;
+      setAudioOperationState({
+        packageId,
+        action,
+        running: false,
+        message: audioGenerationMessage(action, payload),
+        error: null,
+        candidate: nextCandidate,
+      });
+      invalidateSpellingBrowse();
+      if (api.readPackage) {
+        await loadPackageDetail(packageId);
+      }
+      if (api.readOverview) {
+        await refresh();
+      }
+    } catch (error) {
+      setAudioOperationState({
+        packageId,
+        action,
+        running: false,
+        message: '',
+        error: errorEnvelope(error, `content_operations_audio_${action}_failed`),
+        candidate: null,
+      });
+    }
+  }, [api, invalidateSpellingBrowse, loadPackageDetail, refresh]);
+
   const latestRelease = overview.latestRelease;
   const primaryData = overview.openPackageCount || packages.length || releases.length || latestRelease || spellingBrowse.words.length ? {
     overview,
@@ -3066,14 +3543,20 @@ export function AdminContentOperationsSection({
     : (!api?.readPackage && selectedSummary
       ? { package: normaliseContentOperationPackage(selectedSummary), events: [] }
       : { package: null, events: [] });
+  const selectedPackageForAudio = safeDetail.package || selectedSummary;
   const warningSectionCount = packages.reduce((sum, entry) => sum + entry.blockers.warningCount, 0);
   const detailActor = safeDetail.actor?.accountId ? safeDetail.actor : overview.actor;
   const spellingActor = spellingBrowse.actor?.accountId ? spellingBrowse.actor : overview.actor;
+  const audioActor = safeDetail.actor?.accountId ? safeDetail.actor : overview.actor;
   const lifecycleActionAvailability = {
     validate: Boolean(api?.validatePackage),
     resolveConflict: Boolean(api?.resolveConflict),
     approve: Boolean(api?.approvePackage),
     publish: Boolean(api?.publishPackage),
+  };
+  const audioActionAvailability = {
+    scan: Boolean(api?.validatePackage),
+    generate: Boolean(api?.generateAudio),
   };
 
   return (
@@ -3142,7 +3625,11 @@ export function AdminContentOperationsSection({
           activeTab={activeTab}
           latestRelease={latestRelease}
           selectedPackageId={selectedPackageId}
-          selectedSummary={selectedSummary}
+          selectedSummary={selectedPackageForAudio}
+          actor={audioActor}
+          audioState={audioOperationState}
+          audioActionAvailability={audioActionAvailability}
+          onRunAudioAction={runAudioOperation}
         />
       ) : null}
 
@@ -3158,6 +3645,9 @@ export function AdminContentOperationsSection({
           lifecycleState={lifecycleState}
           lifecycleActionAvailability={lifecycleActionAvailability}
           onRunLifecycleAction={runLifecycleAction}
+          audioState={audioOperationState}
+          audioActionAvailability={audioActionAvailability}
+          onRunAudioAction={runAudioOperation}
         />
       ) : null}
 

--- a/styles/app.css
+++ b/styles/app.css
@@ -12549,6 +12549,52 @@ html { scroll-behavior: smooth; }
   margin-top: 18px;
 }
 
+.content-ops-audio-panel {
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+}
+
+.content-ops-audio-controls,
+.content-ops-audio-override {
+  display: flex;
+  gap: 12px;
+  align-items: flex-end;
+  justify-content: space-between;
+}
+
+.content-ops-audio-filter-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: flex-end;
+}
+
+.content-ops-audio-filter-row label {
+  display: grid;
+  gap: 4px;
+  min-width: 150px;
+}
+
+.content-ops-audio-filter-row select {
+  width: 100%;
+}
+
+.content-ops-audio-override {
+  align-items: flex-start;
+  border-top: 1px solid var(--line);
+  padding-top: 10px;
+}
+
+.content-ops-audio-table {
+  min-width: 960px;
+}
+
+.content-ops-audio-table input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+}
+
 .content-ops-release-audio {
   display: grid;
   gap: 4px;
@@ -12651,6 +12697,8 @@ html { scroll-behavior: smooth; }
   .content-ops-detail-header,
   .content-ops-lifecycle-header,
   .content-ops-lifecycle-controls,
+  .content-ops-audio-controls,
+  .content-ops-audio-override,
   .content-ops-word-editor-header,
   .content-ops-word-editor-actions,
   .content-ops-spelling-detail-header,

--- a/tests/admin-content-operations-v2.test.js
+++ b/tests/admin-content-operations-v2.test.js
@@ -32,6 +32,7 @@ import { createHubApi } from '../src/platform/hubs/api.js';
 import {
   CONTENT_OPERATION_DETAIL_TABS,
   CONTENT_OPERATION_LANES,
+  normaliseContentOperationAudioScan,
   normaliseContentOperationCandidate,
   normaliseContentOperationPackage,
   normaliseContentOperationsOverview,
@@ -731,6 +732,74 @@ describe('Content Operations Centre normalisers', () => {
     assert.deepEqual(snapshotCandidate.candidate, { draft: { words: [{ slug: 'accident' }] } });
   });
 
+  it('normalises audio scans into filterable item matrices', () => {
+    const scan = normaliseContentOperationAudioScan({
+      status: 'blocked',
+      profileVersion: 'spelling-audio-profile-v1',
+      modelId: 'gemini-tts',
+      scope: 'affected',
+      totalRequired: 3,
+      presentCount: 1,
+      missingCount: 1,
+      failedCount: 1,
+      blockers: ['word_audio_missing', 'sentence_audio_failed'],
+      lanes: {
+        word: { status: 'blocked', totalRequired: 1, missingCount: 1, blockers: ['word_audio_missing'] },
+        sentence: { status: 'blocked', totalRequired: 2, presentCount: 1, failedCount: 1, blockers: ['sentence_audio_failed'] },
+      },
+      items: [
+        {
+          itemId: 'word:metamorphosis:base:male.natural',
+          lane: 'word',
+          status: 'missing',
+          required: true,
+          slug: 'metamorphosis',
+          word: 'metamorphosis',
+          voiceRole: 'male',
+          paceId: 'natural',
+          profileId: 'male.natural',
+          blocker: 'word_audio_missing',
+        },
+        {
+          itemId: 'sentence:metamorphosis:meta-s1:base:female.slow',
+          lane: 'sentence',
+          status: 'failed',
+          required: true,
+          slug: 'metamorphosis',
+          sentenceId: 'meta-s1',
+          sentence: 'A tadpole changes completely.',
+          voiceRole: 'female',
+          paceId: 'slow',
+          profileId: 'female.slow',
+          blocker: 'sentence_audio_failed',
+        },
+        {
+          itemId: 'sentence:metamorphosis:meta-s1:base:male.normal',
+          lane: 'sentence',
+          status: 'present',
+          required: true,
+          slug: 'metamorphosis',
+          sentenceId: 'meta-s1',
+          voiceRole: 'male',
+          paceId: 'standard',
+          profileId: 'male.normal',
+          r2Key: 'spelling-audio/metamorphosis.wav',
+        },
+      ],
+    });
+
+    assert.equal(scan.status, 'blocked');
+    assert.equal(scan.summary.totalRequired, 3);
+    assert.equal(scan.lanes.word.missingCount, 1);
+    assert.equal(scan.lanes.sentence.failedCount, 1);
+    assert.deepEqual(scan.actionableItemIds, [
+      'word:metamorphosis:base:male.natural',
+      'sentence:metamorphosis:meta-s1:base:female.slow',
+    ]);
+    assert.equal(scan.presentItems[0].canGenerate, false);
+    assert.equal(scan.items[1].label, 'metamorphosis / meta-s1');
+  });
+
   it('keeps compact package operation counts unknown instead of inventing zero', () => {
     const missingCountPackage = normaliseContentOperationPackage({
       packageId: 'pkg-summary-only',
@@ -891,6 +960,15 @@ describe('Content Operations Centre hub API client', () => {
       includeSnapshot: true,
       mutation: { requestId: 'validate-1' },
     });
+    await api.generateContentOperationAudio({
+      packageId: 'pkg/with/slash',
+      candidateId: 'cand/with/slash',
+      itemIds: ['word:meta:base:male.natural'],
+      limit: 1,
+      override: true,
+      reason: 'Replace clipped word audio.',
+      mutation: { requestId: 'generate-1' },
+    });
     await api.approveContentOperationPackage({
       packageId: 'pkg/with/slash',
       candidateId: 'cand/with/slash',
@@ -914,21 +992,27 @@ describe('Content Operations Centre hub API client', () => {
     });
 
     assert.equal(new URL(calls[0].url).pathname, '/api/admin/content-operations/packages/pkg%2Fwith%2Fslash/validate');
-    assert.equal(new URL(calls[1].url).pathname, '/api/admin/content-operations/packages/pkg%2Fwith%2Fslash/approve');
-    assert.equal(new URL(calls[2].url).pathname, '/api/admin/content-operations/packages/pkg%2Fwith%2Fslash/publish');
-    assert.equal(new URL(calls[3].url).pathname, '/api/admin/content-operations/packages/pkg%2Fwith%2Fslash/resolve-conflict');
-    assert.deepEqual(calls.map((call) => call.method), ['POST', 'POST', 'POST', 'POST']);
+    assert.equal(new URL(calls[1].url).pathname, '/api/admin/content-operations/packages/pkg%2Fwith%2Fslash/generate-audio');
+    assert.equal(new URL(calls[2].url).pathname, '/api/admin/content-operations/packages/pkg%2Fwith%2Fslash/approve');
+    assert.equal(new URL(calls[3].url).pathname, '/api/admin/content-operations/packages/pkg%2Fwith%2Fslash/publish');
+    assert.equal(new URL(calls[4].url).pathname, '/api/admin/content-operations/packages/pkg%2Fwith%2Fslash/resolve-conflict');
+    assert.deepEqual(calls.map((call) => call.method), ['POST', 'POST', 'POST', 'POST', 'POST']);
     assert.equal(calls[0].body.includeSnapshot, true);
     assert.equal(calls[1].body.candidateId, 'cand/with/slash');
-    assert.equal(calls[1].body.notes, 'Reviewed candidate.');
+    assert.deepEqual(calls[1].body.itemIds, ['word:meta:base:male.natural']);
+    assert.equal(calls[1].body.limit, 1);
+    assert.equal(calls[1].body.override, true);
+    assert.equal(calls[1].body.reason, 'Replace clipped word audio.');
+    assert.equal(calls[2].body.candidateId, 'cand/with/slash');
+    assert.equal(calls[2].body.notes, 'Reviewed candidate.');
     assert.equal(
-      calls[1].body.audioFallback.reason,
+      calls[2].body.audioFallback.reason,
       'Temporary runtime TTS fallback while slow sentence audio is generated.',
     );
-    assert.equal(calls[2].body.proof.source, 'test');
-    assert.equal(calls[3].body.conflictId, 'conflict/with/slash');
-    assert.equal(calls[3].body.resolution, 'edit');
-    assert.equal(calls[3].body.value, 'Merged value.');
+    assert.equal(calls[3].body.proof.source, 'test');
+    assert.equal(calls[4].body.conflictId, 'conflict/with/slash');
+    assert.equal(calls[4].body.resolution, 'edit');
+    assert.equal(calls[4].body.value, 'Merged value.');
   });
 
   it('calls content operation append and delete endpoints', async () => {
@@ -994,6 +1078,10 @@ describe('Content Operations Centre hub API client', () => {
     );
     await assert.rejects(
       () => api.validateContentOperationPackage({ packageId: '' }),
+      /Content operation package id is required/,
+    );
+    await assert.rejects(
+      () => api.generateContentOperationAudio({ packageId: '' }),
       /Content operation package id is required/,
     );
     await assert.rejects(

--- a/tests/button-label-consistency.test.js
+++ b/tests/button-label-consistency.test.js
@@ -554,6 +554,13 @@ test('button labels: every statically extractable label is classified', () => {
     'Edit pool',
     'New pool',
     'Save pool',
+    // Content Operations Centre T16: audio operations controls are
+    // package-scoped and need explicit scan/generate/regenerate wording so
+    // operators can distinguish missing-audio generation from override.
+    'Refresh scan',
+    'Generate selected',
+    'Batch generate gaps',
+    'Regenerate selected or package',
     // Reasoning launch: delayed SATs-style sets use "Mark set" and "Save
     // answers" to distinguish full-set marking from single-question submit.
     // "Partly worked support" is the child-facing scaffold request, matching

--- a/tests/react-admin-content-operations.test.js
+++ b/tests/react-admin-content-operations.test.js
@@ -37,6 +37,74 @@ function normaliseLineEndings(value) {
   return String(value).replace(/\r\n/g, '\n').replace(/\r/g, '\n');
 }
 
+const audioScan = {
+  status: 'blocked',
+  profileVersion: 'spelling-audio-profile-v1',
+  modelId: 'gemini-tts',
+  scope: 'affected',
+  totalRequired: 3,
+  presentCount: 1,
+  missingCount: 1,
+  failedCount: 1,
+  blockers: ['word_audio_missing', 'sentence_audio_failed'],
+  lanes: {
+    word: { status: 'blocked', totalRequired: 1, missingCount: 1, blockers: ['word_audio_missing'] },
+    sentence: { status: 'blocked', totalRequired: 2, presentCount: 1, failedCount: 1, blockers: ['sentence_audio_failed'] },
+  },
+  items: [
+    {
+      itemId: 'word:metamorphosis:base:male.natural',
+      lane: 'word',
+      status: 'missing',
+      required: true,
+      slug: 'metamorphosis',
+      word: 'metamorphosis',
+      voiceRole: 'male',
+      paceId: 'natural',
+      profileId: 'male.natural',
+      blocker: 'word_audio_missing',
+    },
+    {
+      itemId: 'sentence:metamorphosis:meta-s1:base:female.slow',
+      lane: 'sentence',
+      status: 'failed',
+      required: true,
+      slug: 'metamorphosis',
+      sentenceId: 'meta-s1',
+      sentence: 'The tadpole changes completely.',
+      voiceRole: 'female',
+      paceId: 'slow',
+      profileId: 'female.slow',
+      blocker: 'sentence_audio_failed',
+    },
+    {
+      itemId: 'sentence:metamorphosis:meta-s1:base:male.normal',
+      lane: 'sentence',
+      status: 'present',
+      required: true,
+      slug: 'metamorphosis',
+      sentenceId: 'meta-s1',
+      sentence: 'The tadpole changes completely.',
+      voiceRole: 'male',
+      paceId: 'standard',
+      profileId: 'male.normal',
+      r2Key: 'spelling-audio/metamorphosis.wav',
+    },
+    {
+      itemId: 'sentence:metamorphosis:meta-s2:optional:female.slow',
+      lane: 'sentence',
+      status: 'skipped',
+      required: false,
+      slug: 'metamorphosis',
+      sentenceId: 'meta-s2',
+      sentence: 'Optional practice copy.',
+      voiceRole: 'female',
+      paceId: 'slow',
+      profileId: 'female.slow',
+    },
+  ],
+};
+
 const contentPackage = {
   packageId: 'pkg-draft-1',
   subjectId: 'spelling',
@@ -62,6 +130,28 @@ const contentPackage = {
     visibility: { status: 'passed', blockers: [], warnings: [] },
     exposure: { status: 'passed', blockers: [], warnings: [] },
     publishReadiness: { status: 'not_ready', blockers: ['approval_required'], warnings: [] },
+  },
+  latestCandidate: {
+    candidateId: 'cand-draft-1',
+    packageId: 'pkg-draft-1',
+    baseReleaseId: 'rel-global-1',
+    currentReleaseId: 'rel-global-1',
+    operationsHash: 'ops-hash-1',
+    candidateHash: 'candidate-hash-1',
+    validation: { ok: true, errorCount: 0, warningCount: 0, errors: [], warnings: [] },
+    blockers: {
+      validation: { status: 'passed', errorCount: 0, warningCount: 0, errors: [], warnings: [] },
+      conflicts: { status: 'passed', count: 0, items: [] },
+      audio: { status: 'blocked', blockers: ['word_audio_missing'], warnings: [] },
+      assets: { status: 'passed', blockers: [], warnings: [] },
+      rewards: { status: 'passed', blockers: [], warnings: [] },
+      visibility: { status: 'passed', blockers: [], warnings: [] },
+      exposure: { status: 'passed', blockers: [], warnings: [] },
+      publishReadiness: { status: 'not_ready', blockers: ['approval_required'], warnings: [] },
+    },
+    audioScan,
+    conflicts: [],
+    createdAt: Date.UTC(2026, 5, 11, 10, 5, 0),
   },
 };
 
@@ -545,6 +635,21 @@ test('Content Operations Centre SSR renders package-scoped domain tabs and audit
   }
 });
 
+test('Content Operations Centre SSR renders package audio operations matrix', async () => {
+  const html = await renderEntry(buildContentOpsEntry({
+    initialActiveTab: 'detail',
+    initialDetailTab: 'audio',
+  }));
+
+  assert.match(html, /data-content-ops-audio-panel="true"/);
+  assert.match(html, /Audio operations/);
+  assert.match(html, /Refresh scan/);
+  assert.match(html, /Generate selected/);
+  assert.match(html, /Regenerate selected or package/);
+  assert.match(html, /sentence:metamorphosis:meta-s1:base:female\.slow/);
+  assert.match(html, /sentence_audio_failed/);
+});
+
 test('Content Operations Centre area pages browse without package mutation controls', async () => {
   const html = await renderEntry(buildContentOpsEntry({
     model: baseModel({
@@ -575,17 +680,19 @@ test('Content Operations Centre area pages browse without package mutation contr
   assert.doesNotMatch(html, /generate-audio/);
 });
 
-test('Content Operations Centre area pages show selected package readiness without mutation controls', async () => {
+test('Content Operations Centre area pages show selected package audio operations and non-audio readiness', async () => {
   const audioHtml = await renderEntry(buildContentOpsEntry({
     initialActiveTab: 'audio',
     initialSelectedPackageId: 'pkg-draft-1',
   }));
-  assert.match(audioHtml, /Published state/);
-  assert.match(audioHtml, /Package pkg-draft-1/);
+  assert.match(audioHtml, /Audio operations/);
+  assert.match(audioHtml, /Scan, generate, override/);
+  assert.match(audioHtml, /word:metamorphosis:base:male\.natural/);
+  assert.match(audioHtml, /Batch generate gaps/);
   assert.match(audioHtml, /blocked/);
   assert.match(audioHtml, /1 blockers/);
   assert.match(audioHtml, /word_audio_missing/);
-  assert.match(audioHtml, /No mutation controls/);
+  assert.doesNotMatch(audioHtml, /No mutation controls/);
 
   const assetHtml = await renderEntry(buildContentOpsEntry({
     initialActiveTab: 'monstersAssets',
@@ -1730,6 +1837,173 @@ test('Content Operations Centre mounted package detail runs validate, approve, a
   assert.equal(result.publishDisabledAfterApprove, false);
   assert.match(result.textAfterPublish, /Package published/);
   assert.match(result.textAfterPublish, /rel-published-1/);
+});
+
+test('Content Operations Centre mounted audio panel scans, generates selected items, and requires override reason', async () => {
+  const output = await runClientEntry(`
+    const { JSDOM } = require('jsdom');
+
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+    const dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
+      url: 'https://ks2.eugnel.uk/admin',
+    });
+    globalThis.window = dom.window;
+    globalThis.document = dom.window.document;
+    globalThis.navigator = dom.window.navigator;
+    globalThis.HTMLElement = dom.window.HTMLElement;
+    globalThis.Event = dom.window.Event;
+
+    const React = require('react');
+    const { createRoot } = require('react-dom/client');
+    const { AdminContentOperationsSection } = require(${CONTENT_OPS_SECTION_PATH});
+    const { act } = React;
+
+    const model = ${JSON.stringify(baseModel())};
+    const basePackage = ${JSON.stringify(contentPackage)};
+    const candidate = basePackage.latestCandidate;
+    const calls = [];
+    const actions = {
+      contentOperationsApi: {
+        async validatePackage(args) {
+          calls.push({ method: 'validate', args });
+          return { candidate: { ...candidate, candidateId: 'cand-audio-scan-1' } };
+        },
+        async generateAudio(args) {
+          calls.push({ method: 'generateAudio', args });
+          return {
+            candidate,
+            audio: {
+              summary: {
+                requested: args.itemIds && args.itemIds.length ? args.itemIds.length : 3,
+                uploaded: 1,
+                failed: 0,
+                queued: 0,
+                skippedExisting: 0,
+                skippedPresent: 0,
+                skippedDueLimit: 0,
+              },
+              jobs: [{ jobId: 'audio-job-1', status: 'uploaded' }],
+            },
+          };
+        },
+        async readPackage({ packageId }) {
+          calls.push({ method: 'readPackage', packageId });
+          return {
+            package: basePackage,
+            actor: model.contentOperations.overview.actor,
+            events: [],
+          };
+        },
+        async readOverview(args) {
+          calls.push({ method: 'overview', args });
+          return model.contentOperations.overview;
+        },
+        async readPackages(args) {
+          calls.push({ method: 'packages', args });
+          return model.contentOperations.packages;
+        },
+        async readReleases(args) {
+          calls.push({ method: 'releases', args });
+          return model.contentOperations.releases;
+        },
+      },
+    };
+
+    async function flush() {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+    }
+
+    async function click(selector) {
+      const element = document.querySelector(selector);
+      await act(async () => {
+        element.click();
+      });
+      await flush();
+      await flush();
+      await flush();
+    }
+
+    async function selectValue(selector, value) {
+      const element = document.querySelector(selector);
+      const valueSetter = Object.getOwnPropertyDescriptor(dom.window.HTMLSelectElement.prototype, 'value').set;
+      valueSetter.call(element, value);
+      await act(async () => {
+        element.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
+        element.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+      });
+      await flush();
+    }
+
+    async function main() {
+      const root = createRoot(document.getElementById('root'));
+      await act(async () => {
+        root.render(React.createElement(AdminContentOperationsSection, {
+          model,
+          actions,
+          initialActiveTab: 'audio',
+          initialSelectedPackageId: 'pkg-draft-1',
+        }));
+      });
+      await flush();
+
+      const overrideButtonBeforeReason = document.querySelector('[data-content-ops-audio-action="override"]').disabled;
+      await click('[data-content-ops-audio-action="scan"]');
+      await selectValue('[data-content-ops-audio-status-filter="true"]', 'all');
+      await click('[data-content-ops-audio-select-visible="true"]');
+      await click('[data-content-ops-audio-action="generate-selected"]');
+
+      const reason = document.querySelector('[data-content-ops-audio-override-reason="true"]');
+      const valueSetter = Object.getOwnPropertyDescriptor(dom.window.HTMLTextAreaElement.prototype, 'value').set;
+      valueSetter.call(reason, 'Replace clipped generated audio.');
+      await act(async () => {
+        reason.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
+        reason.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+      });
+      const overrideButtonAfterReason = document.querySelector('[data-content-ops-audio-action="override"]').disabled;
+      await click('[data-content-ops-audio-select-visible="true"]');
+      await click('[data-content-ops-audio-action="override"]');
+
+      process.stdout.write(JSON.stringify({
+        calls,
+        text: document.body.textContent,
+        overrideButtonBeforeReason,
+        overrideButtonAfterReason,
+      }));
+
+      await act(async () => {
+        root.unmount();
+      });
+      dom.window.close();
+      process.exit(0);
+    }
+
+    main().catch((error) => {
+      process.stderr.write(error.stack || error.message);
+      process.exitCode = 1;
+    });
+  `);
+  const result = JSON.parse(output);
+  const audioCalls = result.calls.filter((entry) => ['validate', 'generateAudio'].includes(entry.method));
+
+  assert.deepEqual(audioCalls.map((entry) => entry.method), ['validate', 'generateAudio', 'generateAudio']);
+  assert.equal(audioCalls[0].args.packageId, 'pkg-draft-1');
+  assert.deepEqual(audioCalls[1].args.itemIds, [
+    'word:metamorphosis:base:male.natural',
+    'sentence:metamorphosis:meta-s1:base:female.slow',
+  ]);
+  assert.equal(audioCalls[1].args.override, false);
+  assert.equal(audioCalls[2].args.override, true);
+  assert.deepEqual(audioCalls[2].args.itemIds, [
+    'word:metamorphosis:base:male.natural',
+    'sentence:metamorphosis:meta-s1:base:female.slow',
+    'sentence:metamorphosis:meta-s1:base:male.normal',
+  ]);
+  assert.equal(audioCalls[2].args.reason, 'Replace clipped generated audio.');
+  assert.equal(result.overrideButtonBeforeReason, true);
+  assert.equal(result.overrideButtonAfterReason, false);
+  assert.match(result.text, /Audio generation finished: 1 uploaded, 0 failed, 0 skipped/);
 });
 
 test('Content Operations Centre mounted package detail resolves same-field conflicts', async () => {


### PR DESCRIPTION
## Summary
- Add Content Operations audio scan normalisation and API client support for selected/batch generation.
- Add the Audio Operations UI for package-level scans, item selection, batch gap generation, and explicit override generation with a reason.
- Cover the UI, normalisers, API payloads, and button label audit with focused tests.

## Validation
- node --test tests/react-admin-content-operations.test.js
- node --test tests/admin-content-operations-v2.test.js
- node --test tests/content-operations-api.test.js
- node --test tests/button-label-consistency.test.js
- npm test
- npm run check