### PR TITLE
Add spelling reward track validators

### DIFF
--- a/src/platform/game/reward-track-config.js
+++ b/src/platform/game/reward-track-config.js
@@ -1,0 +1,346 @@
+import {
+  DIRECT_STAGE_THRESHOLDS,
+  MONSTERS,
+  MONSTERS_BY_SUBJECT,
+  PHAETON_STAGE_THRESHOLDS,
+} from './monsters.js';
+
+export const REWARD_TRACK_PROGRESS_MODES = Object.freeze(['parallel', 'sequentialAfter']);
+export const DEFAULT_REWARD_TRACK_PROGRESS_MODE = 'parallel';
+export const DEFAULT_REWARD_TRACK_THRESHOLD_TEMPLATE = 'direct';
+
+export const SPELLING_REWARD_TRACK_MONSTER_IDS = Object.freeze([...MONSTERS_BY_SUBJECT.spelling]);
+
+export const REWARD_TRACK_THRESHOLD_TEMPLATES = Object.freeze({
+  direct: Object.freeze({
+    id: 'direct',
+    label: 'Direct staged thresholds',
+    thresholds: Object.freeze([...DIRECT_STAGE_THRESHOLDS]),
+  }),
+  aggregate: Object.freeze({
+    id: 'aggregate',
+    label: 'Aggregate staged thresholds',
+    thresholds: Object.freeze([...PHAETON_STAGE_THRESHOLDS]),
+  }),
+});
+
+const REWARD_TRACK_PROGRESS_MODE_SET = new Set(REWARD_TRACK_PROGRESS_MODES);
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normaliseString(value, fallback = '') {
+  return typeof value === 'string' ? value.trim() || fallback : fallback;
+}
+
+function normaliseIdentifier(value, fallback = '') {
+  return normaliseString(value, fallback).toLowerCase();
+}
+
+function normaliseTimestamp(value, fallback = 0) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric >= 0 ? numeric : fallback;
+}
+
+function isValidStableId(value) {
+  return typeof value === 'string' && /^[a-z][a-z0-9-]{1,63}$/.test(value);
+}
+
+function uniqueStrings(values) {
+  const source = Array.isArray(values)
+    ? values
+    : String(values ?? '').split(/[\n,]+/);
+  const seen = new Set();
+  const output = [];
+  for (const value of source) {
+    const next = normaliseIdentifier(value);
+    if (!next || seen.has(next)) continue;
+    seen.add(next);
+    output.push(next);
+  }
+  return output;
+}
+
+function normaliseThresholdList(rawValue) {
+  if (Array.isArray(rawValue)) return rawValue.map((entry) => Number(entry));
+  if (!isPlainObject(rawValue)) return [];
+
+  return Object.entries(rawValue)
+    .map(([key, value]) => {
+      const match = String(key).match(/\d+/);
+      return {
+        order: match ? Number(match[0]) : Number.MAX_SAFE_INTEGER,
+        value: Number(value),
+      };
+    })
+    .sort((left, right) => left.order - right.order)
+    .map((entry) => entry.value);
+}
+
+function normaliseLabels(rawValue = {}, fallback = {}) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  const safeFallback = isPlainObject(fallback) ? fallback : {};
+  return {
+    title: normaliseString(raw.title, safeFallback.title),
+    shortLabel: normaliseString(raw.shortLabel, safeFallback.shortLabel),
+    description: normaliseString(raw.description, safeFallback.description),
+  };
+}
+
+function normaliseDependencyApproval(rawValue = {}, fallback = {}, approvedFallback = false) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  const safeFallback = isPlainObject(fallback) ? fallback : {};
+  const hasApprovedValue = Object.prototype.hasOwnProperty.call(raw, 'approved');
+  return {
+    approved: hasApprovedValue ? raw.approved === true : (safeFallback.approved === true || approvedFallback === true),
+    reason: normaliseString(raw.reason, safeFallback.reason),
+    approvedBy: normaliseString(raw.approvedBy, safeFallback.approvedBy),
+    approvedAt: normaliseTimestamp(raw.approvedAt ?? safeFallback.approvedAt, 0),
+  };
+}
+
+function issue(severity, code, path, message) {
+  return { severity, code, path, message };
+}
+
+function pathFor(index, field = '') {
+  const prefix = `rewardTracks[${index}]`;
+  return field ? `${prefix}.${field}` : prefix;
+}
+
+function valueFromPoolWordCounts(poolWordCounts, poolId) {
+  if (poolWordCounts instanceof Map) return poolWordCounts.get(poolId);
+  if (isPlainObject(poolWordCounts)) return poolWordCounts[poolId];
+  return undefined;
+}
+
+function learnerVisiblePoolIdsFrom(pools = []) {
+  return new Set((Array.isArray(pools) ? pools : [])
+    .filter((pool) => pool?.active !== false && !pool?.retired && pool?.visibility?.state === 'visible')
+    .map((pool) => pool.id)
+    .filter(Boolean));
+}
+
+export function isValidRewardTrackId(value) {
+  return isValidStableId(value);
+}
+
+export function isValidRewardTrackPoolId(value) {
+  return isValidStableId(value);
+}
+
+export function normaliseRewardTrackConfig(rawValue = {}, {
+  existingTrack = null,
+  defaultPoolId = '',
+} = {}) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  const existing = isPlainObject(existingTrack) ? existingTrack : {};
+  const activeProvided = Object.prototype.hasOwnProperty.call(raw, 'active');
+  const dependencyApproval = raw.dependencyApproval || existing.dependencyApproval || raw.crossPoolDependencyApproved === true
+    ? normaliseDependencyApproval(
+      raw.dependencyApproval,
+      existing.dependencyApproval,
+      raw.crossPoolDependencyApproved === true || existing.crossPoolDependencyApproved === true,
+    )
+    : null;
+
+  return {
+    id: normaliseIdentifier(raw.id || raw.rewardTrackId || raw.trackId, existing.id || existing.rewardTrackId || existing.trackId),
+    poolId: normaliseIdentifier(raw.poolId || raw.spellingPool, existing.poolId || existing.spellingPool || defaultPoolId),
+    monsterId: normaliseIdentifier(raw.monsterId, existing.monsterId),
+    progressionMode: normaliseString(
+      raw.progressionMode,
+      existing.progressionMode || DEFAULT_REWARD_TRACK_PROGRESS_MODE,
+    ),
+    thresholdTemplate: normaliseIdentifier(
+      raw.thresholdTemplate,
+      existing.thresholdTemplate || DEFAULT_REWARD_TRACK_THRESHOLD_TEMPLATE,
+    ),
+    thresholdOverrides: normaliseThresholdList(
+      Object.prototype.hasOwnProperty.call(raw, 'thresholdOverrides')
+        ? raw.thresholdOverrides
+        : (Object.prototype.hasOwnProperty.call(raw, 'thresholds') ? raw.thresholds : existing.thresholdOverrides),
+    ),
+    active: activeProvided ? raw.active !== false : existing.active !== false,
+    labels: normaliseLabels(raw.labels, existing.labels),
+    sequentialAfter: normaliseIdentifier(
+      raw.sequentialAfter || raw.afterTrackId,
+      existing.sequentialAfter || existing.afterTrackId,
+    ),
+    prerequisites: uniqueStrings(raw.prerequisites || existing.prerequisites),
+    ...(dependencyApproval ? { dependencyApproval } : {}),
+    sourceNote: normaliseString(raw.sourceNote, existing.sourceNote),
+    sortIndex: Number.isInteger(Number(raw.sortIndex)) && Number(raw.sortIndex) >= 0
+      ? Number(raw.sortIndex)
+      : (Number.isInteger(Number(existing.sortIndex)) ? Number(existing.sortIndex) : 0),
+  };
+}
+
+export function normaliseRewardTrackCollection(rawValue = []) {
+  return (Array.isArray(rawValue) ? rawValue : [])
+    .map((entry, index) => normaliseRewardTrackConfig(entry, { existingTrack: null, defaultPoolId: '' }))
+    .map((track, index) => ({
+      ...track,
+      sortIndex: Number.isInteger(Number(track.sortIndex)) && Number(track.sortIndex) >= 0 ? Number(track.sortIndex) : index,
+    }));
+}
+
+export function thresholdsForRewardTrack(track) {
+  if (Array.isArray(track?.thresholdOverrides) && track.thresholdOverrides.length) {
+    return [...track.thresholdOverrides];
+  }
+  const template = REWARD_TRACK_THRESHOLD_TEMPLATES[track?.thresholdTemplate || DEFAULT_REWARD_TRACK_THRESHOLD_TEMPLATE]
+    || REWARD_TRACK_THRESHOLD_TEMPLATES[DEFAULT_REWARD_TRACK_THRESHOLD_TEMPLATE];
+  return [...template.thresholds];
+}
+
+export function validateRewardTrackCollection(rawTracks = [], {
+  pools = [],
+  poolWordCounts = null,
+  learnerVisiblePoolIds = null,
+  allowedMonsterIds = Object.keys(MONSTERS),
+  enforceThresholdsForHiddenPools = false,
+} = {}) {
+  const tracks = normaliseRewardTrackCollection(rawTracks);
+  const errors = [];
+  const warnings = [];
+  const byId = new Map();
+  const poolsById = new Map((Array.isArray(pools) ? pools : []).map((pool) => [pool.id, pool]));
+  const allowedMonsterSet = new Set(Array.isArray(allowedMonsterIds) ? allowedMonsterIds : Object.keys(MONSTERS));
+  const visiblePools = learnerVisiblePoolIds instanceof Set
+    ? learnerVisiblePoolIds
+    : learnerVisiblePoolIdsFrom(pools);
+
+  tracks.forEach((track, index) => {
+    if (!track.id || !isValidRewardTrackId(track.id)) {
+      errors.push(issue('error', 'invalid_reward_track_id', pathFor(index, 'id'), 'Reward track id must be a stable lowercase id.'));
+    } else if (byId.has(track.id)) {
+      errors.push(issue('error', 'duplicate_reward_track', pathFor(index, 'id'), `Duplicate reward track id "${track.id}".`));
+    } else {
+      byId.set(track.id, track);
+    }
+
+    if (!track.poolId || !isValidRewardTrackPoolId(track.poolId)) {
+      errors.push(issue('error', 'invalid_reward_pool_id', pathFor(index, 'poolId'), `Reward track "${track.id || index + 1}" must target a stable pool id.`));
+    } else if (pools.length && !poolsById.has(track.poolId)) {
+      errors.push(issue('error', 'reward_pool_missing', pathFor(index, 'poolId'), `Reward track "${track.id}" points at missing pool "${track.poolId}".`));
+    }
+
+    if (!track.monsterId) {
+      errors.push(issue('error', 'reward_monster_required', pathFor(index, 'monsterId'), `Reward track "${track.id || index + 1}" must bind to a monster.`));
+    } else if (!MONSTERS[track.monsterId]) {
+      errors.push(issue('error', 'reward_monster_missing', pathFor(index, 'monsterId'), `Reward track "${track.id}" points at unknown monster "${track.monsterId}".`));
+    } else if (!allowedMonsterSet.has(track.monsterId)) {
+      errors.push(issue('error', 'reward_monster_not_allowed', pathFor(index, 'monsterId'), `Reward track "${track.id}" cannot bind monster "${track.monsterId}" for this subject.`));
+    }
+
+    if (!REWARD_TRACK_PROGRESS_MODE_SET.has(track.progressionMode)) {
+      errors.push(issue('error', 'invalid_reward_progression_mode', pathFor(index, 'progressionMode'), `Reward track "${track.id || index + 1}" has an invalid progression mode.`));
+    }
+
+    if (!REWARD_TRACK_THRESHOLD_TEMPLATES[track.thresholdTemplate]) {
+      errors.push(issue('error', 'invalid_reward_threshold_template', pathFor(index, 'thresholdTemplate'), `Reward track "${track.id || index + 1}" uses an unknown threshold template.`));
+    }
+
+    const thresholds = thresholdsForRewardTrack(track);
+    if (!thresholds.length) {
+      errors.push(issue('error', 'reward_threshold_required', pathFor(index, 'thresholdOverrides'), `Reward track "${track.id || index + 1}" must define at least one threshold.`));
+    }
+    thresholds.forEach((threshold, thresholdIndex) => {
+      if (!Number.isInteger(threshold) || threshold <= 0) {
+        errors.push(issue('error', 'invalid_reward_threshold', pathFor(index, `thresholdOverrides[${thresholdIndex}]`), `Reward track "${track.id || index + 1}" thresholds must be positive whole numbers.`));
+      }
+      if (thresholdIndex > 0 && Number.isFinite(threshold) && Number.isFinite(thresholds[thresholdIndex - 1]) && threshold <= thresholds[thresholdIndex - 1]) {
+        errors.push(issue('error', 'invalid_reward_threshold', pathFor(index, `thresholdOverrides[${thresholdIndex}]`), `Reward track "${track.id || index + 1}" thresholds must increase strictly.`));
+      }
+    });
+
+    const countShouldBlock = track.active !== false
+      && (enforceThresholdsForHiddenPools || visiblePools.has(track.poolId));
+    const poolWordCount = valueFromPoolWordCounts(poolWordCounts, track.poolId);
+    if (countShouldBlock && Number.isFinite(Number(poolWordCount)) && thresholds.length) {
+      const maxThreshold = Math.max(...thresholds.filter((entry) => Number.isFinite(entry)));
+      if (Number.isFinite(maxThreshold) && maxThreshold > Number(poolWordCount)) {
+        errors.push(issue(
+          'error',
+          'reward_threshold_exceeds_pool_count',
+          pathFor(index, 'thresholdOverrides'),
+          `Reward track "${track.id}" needs ${maxThreshold} active word(s), but pool "${track.poolId}" has ${Number(poolWordCount)}.`,
+        ));
+      }
+    }
+
+    if (track.progressionMode === 'sequentialAfter') {
+      if (!track.sequentialAfter) {
+        errors.push(issue('error', 'reward_dependency_required', pathFor(index, 'sequentialAfter'), `Reward track "${track.id || index + 1}" requires a sequential dependency.`));
+      } else if (track.sequentialAfter === track.id) {
+        errors.push(issue('error', 'reward_track_cycle', pathFor(index, 'sequentialAfter'), `Reward track "${track.id}" cannot depend on itself.`));
+      }
+    }
+
+    if (track.active === false && visiblePools.has(track.poolId)) {
+      warnings.push(issue('warn', 'inactive_visible_reward_track', pathFor(index, 'active'), `Reward track "${track.id}" is inactive for learner-visible pool "${track.poolId}".`));
+    }
+  });
+
+  tracks.forEach((track, index) => {
+    if (track.progressionMode !== 'sequentialAfter' || !track.sequentialAfter) return;
+    const dependency = byId.get(track.sequentialAfter);
+    if (!dependency) {
+      errors.push(issue('error', 'reward_dependency_missing', pathFor(index, 'sequentialAfter'), `Reward track "${track.id}" depends on missing track "${track.sequentialAfter}".`));
+      return;
+    }
+    if (dependency.active === false && track.active !== false) {
+      errors.push(issue('error', 'reward_dependency_inactive', pathFor(index, 'sequentialAfter'), `Reward track "${track.id}" depends on inactive track "${track.sequentialAfter}".`));
+    }
+    if (
+      track.active !== false
+      && dependency.poolId
+      && track.poolId
+      && dependency.poolId !== track.poolId
+      && track.dependencyApproval?.approved !== true
+    ) {
+      errors.push(issue(
+        'error',
+        'reward_cross_pool_dependency',
+        pathFor(index, 'dependencyApproval'),
+        `Reward track "${track.id}" depends on pool "${dependency.poolId}" from pool "${track.poolId}" without approval.`,
+      ));
+    }
+  });
+
+  const visiting = new Set();
+  const visited = new Set();
+  const cycleReported = new Set();
+  const visit = (track, stack = []) => {
+    if (!track || track.active === false || track.progressionMode !== 'sequentialAfter') return;
+    if (visiting.has(track.id)) {
+      const cycleStart = stack.indexOf(track.id);
+      const cycle = [...stack.slice(cycleStart >= 0 ? cycleStart : 0), track.id];
+      const key = [...cycle].sort().join('>');
+      if (!cycleReported.has(key)) {
+        cycleReported.add(key);
+        const index = tracks.findIndex((entry) => entry.id === track.id);
+        errors.push(issue('error', 'reward_track_cycle', pathFor(index, 'sequentialAfter'), `Reward track sequence contains a cycle: ${cycle.join(' -> ')}.`));
+      }
+      return;
+    }
+    if (visited.has(track.id)) return;
+    visiting.add(track.id);
+    const next = byId.get(track.sequentialAfter);
+    visit(next, [...stack, track.id]);
+    visiting.delete(track.id);
+    visited.add(track.id);
+  };
+
+  tracks.forEach((track) => visit(track));
+
+  return {
+    ok: errors.length === 0,
+    errors,
+    warnings,
+    tracks,
+    byId,
+  };
+}

--- a/src/subjects/spelling/content/model.js
+++ b/src/subjects/spelling/content/model.js
@@ -1,4 +1,9 @@
 import { cloneSerialisable } from '../../../platform/core/repositories/helpers.js';
+import {
+  SPELLING_REWARD_TRACK_MONSTER_IDS,
+  normaliseRewardTrackCollection,
+  validateRewardTrackCollection,
+} from '../../../platform/game/reward-track-config.js';
 import { PATTERN_LAUNCH_THRESHOLD, SPELLING_PATTERN_IDS, SPELLING_PATTERNS } from './patterns.js';
 import {
   coverageTierForWord,
@@ -17,7 +22,7 @@ export const SPELLING_CONTENT_SUBJECT_ID = 'spelling';
  * a cached bundle — runtime consumers treat `modelVersion < MODEL_VERSION`
  * as "normalise and rewrite" on next save.
  */
-export const SPELLING_CONTENT_MODEL_VERSION = 8;
+export const SPELLING_CONTENT_MODEL_VERSION = 10;
 export const SPELLING_CONTENT_EXPORT_KIND = 'ks2-spelling-content';
 export const SPELLING_CONTENT_EXPORT_VERSION = 1;
 export const SPELLING_CONTENT_POOLS = Object.freeze(['core', 'extra']);
@@ -199,7 +204,7 @@ function normaliseNoRewardException(rawValue = null) {
   };
 }
 
-function normaliseRewardTrack(rawValue = null) {
+function normalisePoolRewardTrackApproval(rawValue = null) {
   const raw = isPlainObject(rawValue) ? rawValue : {};
   return {
     id: normaliseString(raw.id || raw.rewardTrackId || raw.trackId),
@@ -211,12 +216,20 @@ function normaliseRewardTrack(rawValue = null) {
   };
 }
 
+function normaliseRewardTrackIds(rawValue, fallback = []) {
+  const source = Array.isArray(rawValue)
+    ? rawValue
+    : (typeof rawValue === 'string' ? rawValue.split(/[\n,]+/) : fallback);
+  return uniqueStrings(source, { lowerCase: true });
+}
+
 function normaliseSpellingPoolMetadata(rawValue, index = 0) {
   const raw = isPlainObject(rawValue) ? rawValue : {};
   const id = normalisePoolIdCandidate(raw.id || raw.pool || raw.spellingPool, index === 0 ? 'core' : `pool-${index + 1}`);
   const defaults = DEFAULT_POOL_METADATA[id] || {};
   const typeCandidate = normaliseString(raw.type || raw.poolType, defaults.type || 'custom').toLowerCase();
   const type = VALID_POOL_TYPES.has(typeCandidate) ? typeCandidate : 'custom';
+  const rewardTrackIds = normaliseRewardTrackIds(raw.rewardTrackIds);
   return {
     id,
     title: normaliseString(raw.title, defaults.title || `Pool ${index + 1}`),
@@ -229,7 +242,8 @@ function normaliseSpellingPoolMetadata(rawValue, index = 0) {
     retired: Boolean(raw.retired),
     ...(raw.retired || raw.active === false || raw.retirement ? { retirement: normaliseRetirement(raw.retirement) } : {}),
     ...(raw.noRewardException ? { noRewardException: normaliseNoRewardException(raw.noRewardException) } : {}),
-    ...(raw.rewardTrack ? { rewardTrack: normaliseRewardTrack(raw.rewardTrack) } : {}),
+    ...(rewardTrackIds.length ? { rewardTrackIds } : {}),
+    ...(raw.rewardTrack ? { rewardTrack: normalisePoolRewardTrackApproval(raw.rewardTrack) } : {}),
     sortIndex: Number.isInteger(Number(raw.sortIndex)) && Number(raw.sortIndex) >= 0 ? Number(raw.sortIndex) : index,
   };
 }
@@ -462,6 +476,7 @@ function normaliseDraft(rawValue) {
       ? { audioRequirementProfile: cloneSerialisable(raw.audioRequirementProfile) }
       : {}),
     pools,
+    rewardTracks: normaliseRewardTrackCollection(raw.rewardTracks),
     wordLists,
     words: (Array.isArray(raw.words) ? raw.words : []).map((entry, index) => normaliseWordEntry(entry, index, wordListsById)),
     sentences: (Array.isArray(raw.sentences) ? raw.sentences : []).map((entry, index) => normaliseSentenceEntry(entry, index)),
@@ -558,6 +573,26 @@ function issue(severity, code, path, message) {
   return { severity, code, path, message };
 }
 
+function buildLearnerVisiblePoolIds(pools = []) {
+  return new Set((Array.isArray(pools) ? pools : [])
+    .filter((pool) => pool.active !== false && !pool.retired && pool.visibility?.state === 'visible')
+    .map((pool) => pool.id));
+}
+
+function buildActivePoolWordCounts(words = [], wordListsById = new Map(), poolsById = new Map()) {
+  const counts = new Map();
+  for (const poolId of poolsById.keys()) counts.set(poolId, 0);
+  for (const word of Array.isArray(words) ? words : []) {
+    if (word.active === false || word.retired) continue;
+    const pool = poolsById.get(word.spellingPool);
+    if (!pool || pool.active === false || pool.retired) continue;
+    const wordList = word.listId ? wordListsById.get(word.listId) : null;
+    if (!wordList || wordList.active === false || wordList.retired) continue;
+    counts.set(word.spellingPool, (counts.get(word.spellingPool) || 0) + 1);
+  }
+  return counts;
+}
+
 export function validateSpellingContentBundle(rawBundle) {
   const bundle = normaliseSpellingContentBundle(rawBundle);
   const errors = [];
@@ -598,12 +633,6 @@ export function validateSpellingContentBundle(rawBundle) {
     }
     if (pool.retired && pool.visibility?.state === 'visible') {
       warnings.push(issue('warn', 'retired_pool_visible', `draft.pools[${index}].visibility.state`, `Retired pool "${pool.id}" keeps visible metadata for history but is hidden from new sessions.`));
-    }
-    const learnerVisible = pool.active !== false && !pool.retired && pool.visibility?.state === 'visible';
-    const noRewardApproved = pool.noRewardException?.approved === true;
-    const rewardTrackApproved = pool.rewardTrack?.approved === true;
-    if (learnerVisible && !LEGACY_SPELLING_POOLS.has(pool.id) && !noRewardApproved && !rewardTrackApproved) {
-      errors.push(issue('error', 'pool_reward_required', `draft.pools[${index}].visibility.state`, `Learner-visible pool "${pool.id}" requires a reward track or approved no-reward exception before publish.`));
     }
   });
 
@@ -704,6 +733,61 @@ export function validateSpellingContentBundle(rawBundle) {
         errors.push(issue('error', 'broken_sentence_reference', `draft.words[${index}].variants[${variantIndex}].sentenceEntryIds`, `Variant "${variant.word || variantIndex + 1}" for word "${word.slug}" must reference at least one sentence entry.`));
       }
     });
+  });
+
+  const learnerVisiblePoolIds = buildLearnerVisiblePoolIds(bundle.draft.pools);
+  const poolWordCounts = buildActivePoolWordCounts(bundle.draft.words, wordListsById, poolsById);
+  const rewardValidation = validateRewardTrackCollection(bundle.draft.rewardTracks, {
+    pools: bundle.draft.pools,
+    poolWordCounts,
+    learnerVisiblePoolIds,
+    allowedMonsterIds: SPELLING_REWARD_TRACK_MONSTER_IDS,
+    enforceThresholdsForHiddenPools: true,
+  });
+  rewardValidation.errors.forEach((entry) => {
+    errors.push(issue(entry.severity, entry.code, `draft.${entry.path}`, entry.message));
+  });
+  rewardValidation.warnings.forEach((entry) => {
+    warnings.push(issue(entry.severity, entry.code, `draft.${entry.path}`, entry.message));
+  });
+
+  const activeRewardTracksByPool = new Map();
+  for (const track of rewardValidation.tracks) {
+    if (track.active === false || !track.poolId) continue;
+    if (!activeRewardTracksByPool.has(track.poolId)) activeRewardTracksByPool.set(track.poolId, []);
+    activeRewardTracksByPool.get(track.poolId).push(track);
+  }
+
+  bundle.draft.pools.forEach((pool, index) => {
+    const rewardTrackIds = Array.isArray(pool.rewardTrackIds) ? pool.rewardTrackIds : [];
+    rewardTrackIds.forEach((trackId, position) => {
+      const track = rewardValidation.byId.get(trackId);
+      if (!track) {
+        errors.push(issue('error', 'reward_track_missing', `draft.pools[${index}].rewardTrackIds[${position}]`, `Pool "${pool.id}" points at missing reward track "${trackId}".`));
+        return;
+      }
+      if (track.poolId !== pool.id) {
+        errors.push(issue('error', 'reward_pool_mismatch', `draft.pools[${index}].rewardTrackIds[${position}]`, `Pool "${pool.id}" cannot bind reward track "${trackId}" for pool "${track.poolId}".`));
+      }
+    });
+
+    const learnerVisible = learnerVisiblePoolIds.has(pool.id);
+    const noRewardApproved = pool.noRewardException?.approved === true;
+    const legacyRewardTrackApproved = pool.rewardTrack?.approved === true;
+    const formalRewardTracks = rewardTrackIds.length
+      ? rewardTrackIds
+        .map((trackId) => rewardValidation.byId.get(trackId))
+        .filter((track) => track && track.active !== false && track.poolId === pool.id)
+      : (activeRewardTracksByPool.get(pool.id) || []);
+    if (
+      learnerVisible
+      && !LEGACY_SPELLING_POOLS.has(pool.id)
+      && !noRewardApproved
+      && !legacyRewardTrackApproved
+      && formalRewardTracks.length === 0
+    ) {
+      errors.push(issue('error', 'pool_reward_required', `draft.pools[${index}].visibility.state`, `Learner-visible pool "${pool.id}" requires a reward track or approved no-reward exception before publish.`));
+    }
   });
 
   bundle.draft.sentences.forEach((sentence, index) => {

--- a/src/subjects/spelling/content/operations-model.js
+++ b/src/subjects/spelling/content/operations-model.js
@@ -21,6 +21,7 @@ export const CONTENT_OPERATION_PACKAGE_STATES = Object.freeze({
 export const CONTENT_OPERATION_ENTITY_TYPES = Object.freeze([
   'spelling.audioRequirementProfile',
   'spelling.pool',
+  'spelling.rewardTrack',
   'spelling.word',
   'spelling.sentenceEntry',
   'spelling.wordList',
@@ -43,6 +44,7 @@ const AUDIO_REQUIREMENT_PROFILE_ENTITY_ID = 'default';
 
 const EDITABLE_COLLECTIONS = Object.freeze({
   'spelling.pool': Object.freeze({ collectionPath: ['draft', 'pools'], idField: 'id' }),
+  'spelling.rewardTrack': Object.freeze({ collectionPath: ['draft', 'rewardTracks'], idField: 'id' }),
   'spelling.word': Object.freeze({ collectionPath: ['draft', 'words'], idField: 'slug' }),
   'spelling.sentenceEntry': Object.freeze({ collectionPath: ['draft', 'sentences'], idField: 'id' }),
   'spelling.wordList': Object.freeze({ collectionPath: ['draft', 'wordLists'], idField: 'id' }),

--- a/src/subjects/spelling/content/package-operations.js
+++ b/src/subjects/spelling/content/package-operations.js
@@ -1,3 +1,9 @@
+import {
+  SPELLING_REWARD_TRACK_MONSTER_IDS,
+  normaliseRewardTrackConfig,
+  validateRewardTrackCollection,
+} from '../../../platform/game/reward-track-config.js';
+
 const LEGACY_SPELLING_POOLS = new Set(['core', 'extra']);
 const RESERVED_POOL_IDS = new Set(['all']);
 const VALID_POOL_TYPES = new Set(['statutory', 'enrichment', 'extension', 'custom']);
@@ -135,6 +141,15 @@ function poolValidationResult(errors, warnings, pool = null) {
     errors,
     warnings,
     pool,
+  };
+}
+
+function rewardTrackValidationResult(errors, warnings, rewardTrack = null) {
+  return {
+    ok: errors.length === 0,
+    errors,
+    warnings,
+    rewardTrack,
   };
 }
 
@@ -454,7 +469,7 @@ function normaliseNoRewardException(rawValue = {}, existingException = null) {
   };
 }
 
-function normaliseRewardTrack(rawValue = {}, existingTrack = null) {
+function normalisePoolRewardTrackApproval(rawValue = {}, existingTrack = null) {
   const raw = isPlainObject(rawValue) ? rawValue : {};
   const existing = isPlainObject(existingTrack) ? existingTrack : {};
   const hasApprovedValue = Object.prototype.hasOwnProperty.call(raw, 'approved');
@@ -468,6 +483,10 @@ function normaliseRewardTrack(rawValue = {}, existingTrack = null) {
       ? Number(raw.approvedAt ?? existing.approvedAt)
       : 0,
   };
+}
+
+function normaliseRewardTrackIds(rawValue, existingValue = [], { explicit = false } = {}) {
+  return uniqueStrings(explicit ? rawValue : (hasExplicitList(rawValue) ? rawValue : existingValue), { lowerCase: true });
 }
 
 export function normaliseSpellingPoolEditorInput(rawValue = {}, {
@@ -484,8 +503,12 @@ export function normaliseSpellingPoolEditorInput(rawValue = {}, {
   const noRewardException = raw.noRewardException || existing.noRewardException
     ? normaliseNoRewardException(raw.noRewardException, existing.noRewardException)
     : null;
+  const hasRewardTrackIds = Object.prototype.hasOwnProperty.call(raw, 'rewardTrackIds');
+  const rewardTrackIds = normaliseRewardTrackIds(raw.rewardTrackIds, existing.rewardTrackIds, {
+    explicit: hasRewardTrackIds,
+  });
   const rewardTrack = raw.rewardTrack || existing.rewardTrack
-    ? normaliseRewardTrack(raw.rewardTrack, existing.rewardTrack)
+    ? normalisePoolRewardTrackApproval(raw.rewardTrack, existing.rewardTrack)
     : null;
   return {
     id,
@@ -499,6 +522,7 @@ export function normaliseSpellingPoolEditorInput(rawValue = {}, {
     retired: Boolean(raw.retired || existing.retired),
     ...(raw.retirement || existing.retirement ? { retirement: raw.retirement || existing.retirement } : {}),
     ...(noRewardException ? { noRewardException } : {}),
+    ...(rewardTrackIds.length ? { rewardTrackIds } : {}),
     ...(rewardTrack ? { rewardTrack } : {}),
     sortIndex: Number.isInteger(Number(raw.sortIndex)) && Number(raw.sortIndex) >= 0
       ? Number(raw.sortIndex)
@@ -532,6 +556,7 @@ export function validateSpellingPoolEditorInput(rawValue = {}, options = {}) {
     pool.visibility.state === 'visible'
     && !LEGACY_SPELLING_POOLS.has(pool.id)
     && pool.noRewardException?.approved !== true
+    && !(Array.isArray(pool.rewardTrackIds) && pool.rewardTrackIds.length > 0)
     && pool.rewardTrack?.approved !== true
   ) {
     errors.push(issue('visibility.state', 'Learner-visible future pools require a reward track or approved no-reward exception.', 'pool_reward_required'));
@@ -541,6 +566,40 @@ export function validateSpellingPoolEditorInput(rawValue = {}, options = {}) {
   }
 
   return poolValidationResult(errors, warnings, pool);
+}
+
+function rewardTrackIssueToEditorIssue(entry) {
+  const field = normaliseString(entry.path).replace(/^rewardTracks\[\d+\]\.?/, '') || 'id';
+  return issue(field, entry.message, entry.code);
+}
+
+export function normaliseSpellingRewardTrackEditorInput(rawValue = {}, {
+  existingTrack = null,
+  defaultPoolId = '',
+} = {}) {
+  return normaliseRewardTrackConfig(rawValue, { existingTrack, defaultPoolId });
+}
+
+export function validateSpellingRewardTrackEditorInput(rawValue = {}, options = {}) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  const existing = isPlainObject(options.existingTrack) ? options.existingTrack : null;
+  const rewardTrack = normaliseSpellingRewardTrackEditorInput(raw, options);
+  const existingId = normaliseString(existing?.id);
+  const peers = (Array.isArray(options.rewardTracks) ? options.rewardTracks : [])
+    .filter((entry) => !existingId || entry?.id !== existingId);
+  const validation = validateRewardTrackCollection([...peers, rewardTrack], {
+    pools: options.pools || [],
+    poolWordCounts: options.poolWordCounts || null,
+    learnerVisiblePoolIds: options.learnerVisiblePoolIds || null,
+    allowedMonsterIds: options.allowedMonsterIds || SPELLING_REWARD_TRACK_MONSTER_IDS,
+    enforceThresholdsForHiddenPools: options.enforceThresholdsForHiddenPools === true,
+  });
+
+  return rewardTrackValidationResult(
+    validation.errors.map(rewardTrackIssueToEditorIssue),
+    validation.warnings.map(rewardTrackIssueToEditorIssue),
+    rewardTrack,
+  );
 }
 
 function throwIfInvalid(validation) {
@@ -595,6 +654,18 @@ export function buildSpellingPoolUpsertOperation(rawValue = {}, options = {}) {
     fieldPath: '',
     action: 'upsert',
     payload: validation.pool,
+  };
+}
+
+export function buildSpellingRewardTrackUpsertOperation(rawValue = {}, options = {}) {
+  const validation = validateSpellingRewardTrackEditorInput(rawValue, options);
+  throwIfInvalid(validation);
+  return {
+    entityType: 'spelling.rewardTrack',
+    entityId: validation.rewardTrack.id,
+    fieldPath: '',
+    action: 'upsert',
+    payload: validation.rewardTrack,
   };
 }
 

--- a/tests/hero-contracts.test.js
+++ b/tests/hero-contracts.test.js
@@ -31,6 +31,14 @@ import {
   buildTaskEnvelope,
   validateTaskEnvelope,
 } from '../shared/hero/task-envelope.js';
+import {
+  MONSTERS,
+  MONSTERS_BY_SUBJECT,
+} from '../src/platform/game/monsters.js';
+import {
+  REWARD_TRACK_THRESHOLD_TEMPLATES,
+  SPELLING_REWARD_TRACK_MONSTER_IDS,
+} from '../src/platform/game/reward-track-config.js';
 
 // ── Constants ──────────────────────────────────────────────────────
 
@@ -91,6 +99,26 @@ test('HERO_SCHEDULER_VERSION is a non-empty string', () => {
 
 test('HERO_DEFAULT_TIMEZONE is Europe/London', () => {
   assert.equal(HERO_DEFAULT_TIMEZONE, 'Europe/London');
+});
+
+test('spelling reward-track monsters match the active spelling roster', () => {
+  assert.deepEqual(
+    [...SPELLING_REWARD_TRACK_MONSTER_IDS].sort(),
+    [...MONSTERS_BY_SUBJECT.spelling].sort(),
+  );
+  for (const monsterId of SPELLING_REWARD_TRACK_MONSTER_IDS) {
+    assert.ok(MONSTERS[monsterId], `${monsterId} should exist in the monster registry`);
+  }
+});
+
+test('spelling reward-track thresholds fit current monster mastered maxima', () => {
+  const directMax = Math.max(...REWARD_TRACK_THRESHOLD_TEMPLATES.direct.thresholds);
+  const aggregateMax = Math.max(...REWARD_TRACK_THRESHOLD_TEMPLATES.aggregate.thresholds);
+
+  for (const monsterId of ['inklet', 'glimmerbug', 'vellhorn']) {
+    assert.ok(directMax <= MONSTERS[monsterId].masteredMax);
+  }
+  assert.ok(aggregateMax <= MONSTERS.phaeton.masteredMax);
 });
 
 // ── Intent / launcher validation ───────────────────────────────────

--- a/tests/spelling-content-patterns.test.js
+++ b/tests/spelling-content-patterns.test.js
@@ -306,7 +306,7 @@ test('H7 convention: content model even, service state odd', () => {
 });
 
 test('SPELLING_CONTENT_MODEL_VERSION keeps the even content-model lane', () => {
-  assert.equal(SPELLING_CONTENT_MODEL_VERSION, 8);
+  assert.equal(SPELLING_CONTENT_MODEL_VERSION, 10);
 });
 
 test('normaliser drops unknown patternIds without crashing', () => {

--- a/tests/spelling-content.test.js
+++ b/tests/spelling-content.test.js
@@ -201,7 +201,7 @@ test('seeded spelling content validates and round-trips through the portable exp
   const validation = content.validate();
   assert.equal(validation.ok, true);
   assert.equal(validation.bundle.modelVersion, SPELLING_CONTENT_MODEL_VERSION);
-  assert.equal(SPELLING_CONTENT_MODEL_VERSION, 8, 'Spelling content model keeps the even-version convention.');
+  assert.equal(SPELLING_CONTENT_MODEL_VERSION, 10, 'Spelling content model keeps the even-version convention.');
   assert.equal(validation.errors.length, 0);
   assert.equal(validation.bundle.releases.length, 7);
   assert.equal(validation.bundle.publication.publishedVersion, 7);

--- a/tests/spelling-reward-tracks.test.js
+++ b/tests/spelling-reward-tracks.test.js
@@ -1,0 +1,363 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  normaliseRewardTrackConfig,
+  thresholdsForRewardTrack,
+} from '../src/platform/game/reward-track-config.js';
+import {
+  validateSpellingContentBundle,
+} from '../src/subjects/spelling/content/model.js';
+import {
+  buildSpellingContentOperationCandidate,
+} from '../src/subjects/spelling/content/operations-model.js';
+import {
+  buildSpellingPoolUpsertOperation,
+  buildSpellingRewardTrackUpsertOperation,
+  normaliseSpellingPoolEditorInput,
+  validateSpellingRewardTrackEditorInput,
+} from '../src/subjects/spelling/content/package-operations.js';
+
+const NOW = Date.UTC(2026, 5, 12, 9, 0, 0);
+
+function poolFixture(poolId, {
+  title = poolId,
+  visibilityState = 'visible',
+  rewardTrackIds = [],
+  sortIndex = 0,
+} = {}) {
+  return {
+    id: poolId,
+    title,
+    type: 'extension',
+    sourceNote: 'Reward-track test fixture.',
+    provenance: { source: 'spelling-reward-tracks-test' },
+    visibility: { state: visibilityState },
+    ...(rewardTrackIds.length ? { rewardTrackIds } : {}),
+    sortIndex,
+  };
+}
+
+function addWordsForPool(target, poolId, count) {
+  const listId = `${poolId}-list`;
+  const wordSlugs = [];
+  target.wordLists.push({
+    id: listId,
+    title: `${poolId} list`,
+    spellingPool: poolId,
+    coverageTier: 'secure-extension',
+    yearGroups: [],
+    wordSlugs,
+    sourceNote: 'Reward-track test word list.',
+    provenance: { source: 'spelling-reward-tracks-test' },
+    sortIndex: target.wordLists.length,
+  });
+
+  for (let index = 0; index < count; index += 1) {
+    const slug = `${poolId}-word-${index + 1}`;
+    const word = `${poolId.replace(/-/g, '')}word${index + 1}`;
+    const sentenceId = `${slug}-s1`;
+    wordSlugs.push(slug);
+    target.words.push({
+      slug,
+      word,
+      family: `${poolId}-family`,
+      listId,
+      spellingPool: poolId,
+      coverageTier: 'secure-extension',
+      yearGroups: [],
+      accepted: [word],
+      explanation: `${word} has a clear learner-facing explanation for reward validation.`,
+      sentenceEntryIds: [sentenceId],
+      sourceNote: 'Reward-track test word.',
+      provenance: { source: 'spelling-reward-tracks-test' },
+      sortIndex: target.words.length,
+    });
+    target.sentences.push({
+      id: sentenceId,
+      wordSlug: slug,
+      text: `The ${word} example supports reward-track validation.`,
+      variantLabel: 'default',
+      sourceNote: 'Reward-track test sentence.',
+      provenance: { source: 'spelling-reward-tracks-test' },
+      sortIndex: target.sentences.length,
+    });
+  }
+}
+
+function rewardBundle({
+  pools = [poolFixture('secure-vocabulary', { rewardTrackIds: ['secure-inklet'] })],
+  rewardTracks = [{
+    id: 'secure-inklet',
+    poolId: 'secure-vocabulary',
+    monsterId: 'inklet',
+    thresholdOverrides: [1],
+  }],
+  wordCounts = { 'secure-vocabulary': 1 },
+} = {}) {
+  const draftCollections = {
+    wordLists: [],
+    words: [],
+    sentences: [],
+  };
+  for (const [poolId, count] of Object.entries(wordCounts)) {
+    addWordsForPool(draftCollections, poolId, count);
+  }
+
+  return {
+    modelVersion: 10,
+    subjectId: 'spelling',
+    draft: {
+      id: 'main',
+      state: 'draft',
+      version: 1,
+      title: 'Reward-track test draft',
+      createdAt: NOW,
+      updatedAt: NOW,
+      pools,
+      rewardTracks,
+      ...draftCollections,
+    },
+    releases: [],
+    publication: { currentReleaseId: '', publishedVersion: 0, updatedAt: 0 },
+  };
+}
+
+function errorCodes(validation) {
+  return validation.errors.map((entry) => entry.code);
+}
+
+test('reward track config defaults to parallel direct progression', () => {
+  const track = normaliseRewardTrackConfig({
+    id: 'Secure-Inklet',
+    poolId: 'Secure-Vocabulary',
+    monsterId: 'Inklet',
+  });
+
+  assert.equal(track.id, 'secure-inklet');
+  assert.equal(track.poolId, 'secure-vocabulary');
+  assert.equal(track.monsterId, 'inklet');
+  assert.equal(track.progressionMode, 'parallel');
+  assert.equal(track.thresholdTemplate, 'direct');
+  assert.deepEqual(thresholdsForRewardTrack(track), [1, 10, 30, 60, 100]);
+});
+
+test('pool can bind to multiple formal reward tracks through content operations', () => {
+  const base = rewardBundle({
+    pools: [poolFixture('secure-vocabulary', { visibilityState: 'hidden' })],
+    rewardTracks: [],
+    wordCounts: { 'secure-vocabulary': 3 },
+  });
+  const poolWordCounts = new Map([['secure-vocabulary', 3]]);
+  const learnerVisiblePoolIds = new Set(['secure-vocabulary']);
+  const rewardTrackOptions = {
+    pools: base.draft.pools,
+    poolWordCounts,
+    learnerVisiblePoolIds,
+  };
+
+  const firstTrack = buildSpellingRewardTrackUpsertOperation({
+    id: 'secure-inklet',
+    poolId: 'secure-vocabulary',
+    monsterId: 'inklet',
+    thresholdOverrides: [1, 2, 3],
+    labels: { title: 'Secure Inklet' },
+  }, rewardTrackOptions);
+  const secondTrack = buildSpellingRewardTrackUpsertOperation({
+    id: 'secure-vellhorn',
+    poolId: 'secure-vocabulary',
+    monsterId: 'vellhorn',
+    thresholdOverrides: [1, 2, 3],
+    labels: { title: 'Secure Vellhorn' },
+  }, rewardTrackOptions);
+  const poolUpdate = buildSpellingPoolUpsertOperation({
+    ...base.draft.pools[0],
+    visibility: { state: 'visible' },
+    rewardTrackIds: ['secure-inklet', 'secure-vellhorn'],
+  }, { existingPool: base.draft.pools[0] });
+  const candidate = buildSpellingContentOperationCandidate(base, [firstTrack, secondTrack, poolUpdate]);
+
+  assert.equal(firstTrack.entityType, 'spelling.rewardTrack');
+  assert.equal(secondTrack.payload.progressionMode, 'parallel');
+  assert.equal(candidate.validation.ok, true, JSON.stringify(candidate.validation.errors, null, 2));
+  assert.deepEqual(
+    candidate.validation.bundle.draft.pools.find((pool) => pool.id === 'secure-vocabulary').rewardTrackIds,
+    ['secure-inklet', 'secure-vellhorn'],
+  );
+  assert.equal(candidate.validation.bundle.draft.rewardTracks.length, 2);
+});
+
+test('impossible reward thresholds block learner-visible publish', () => {
+  const validation = validateSpellingContentBundle(rewardBundle({
+    pools: [poolFixture('secure-vocabulary', { rewardTrackIds: ['secure-inklet'] })],
+    rewardTracks: [{
+      id: 'secure-inklet',
+      poolId: 'secure-vocabulary',
+      monsterId: 'inklet',
+      thresholdOverrides: [1, 2],
+    }],
+    wordCounts: { 'secure-vocabulary': 1 },
+  }));
+
+  assert.equal(validation.ok, false);
+  assert.ok(errorCodes(validation).includes('reward_threshold_exceeds_pool_count'));
+});
+
+test('impossible reward thresholds block active hidden and staged pools', () => {
+  const hidden = validateSpellingContentBundle(rewardBundle({
+    pools: [poolFixture('secure-vocabulary', {
+      visibilityState: 'hidden',
+      rewardTrackIds: ['secure-inklet'],
+    })],
+    rewardTracks: [{
+      id: 'secure-inklet',
+      poolId: 'secure-vocabulary',
+      monsterId: 'inklet',
+      thresholdOverrides: [1, 2],
+    }],
+    wordCounts: { 'secure-vocabulary': 1 },
+  }));
+  const staged = validateSpellingContentBundle(rewardBundle({
+    pools: [poolFixture('secure-vocabulary', {
+      visibilityState: 'staged',
+      rewardTrackIds: ['secure-inklet'],
+    })],
+    rewardTracks: [{
+      id: 'secure-inklet',
+      poolId: 'secure-vocabulary',
+      monsterId: 'inklet',
+      thresholdOverrides: [1, 2],
+    }],
+    wordCounts: { 'secure-vocabulary': 1 },
+  }));
+
+  assert.equal(hidden.ok, false);
+  assert.equal(staged.ok, false);
+  assert.ok(errorCodes(hidden).includes('reward_threshold_exceeds_pool_count'));
+  assert.ok(errorCodes(staged).includes('reward_threshold_exceeds_pool_count'));
+});
+
+test('dangling pool rewardTrackIds return validation errors instead of throwing', () => {
+  const validation = validateSpellingContentBundle(rewardBundle({
+    pools: [poolFixture('secure-vocabulary', { rewardTrackIds: ['missing-track'] })],
+    rewardTracks: [],
+    wordCounts: { 'secure-vocabulary': 1 },
+  }));
+
+  assert.equal(validation.ok, false);
+  assert.ok(errorCodes(validation).includes('reward_track_missing'));
+});
+
+test('sequential reward-track cycles block publish', () => {
+  const validation = validateSpellingContentBundle(rewardBundle({
+    pools: [poolFixture('secure-vocabulary', { rewardTrackIds: ['secure-inklet', 'secure-vellhorn'] })],
+    rewardTracks: [
+      {
+        id: 'secure-inklet',
+        poolId: 'secure-vocabulary',
+        monsterId: 'inklet',
+        progressionMode: 'sequentialAfter',
+        sequentialAfter: 'secure-vellhorn',
+        thresholdOverrides: [1],
+      },
+      {
+        id: 'secure-vellhorn',
+        poolId: 'secure-vocabulary',
+        monsterId: 'vellhorn',
+        progressionMode: 'sequentialAfter',
+        sequentialAfter: 'secure-inklet',
+        thresholdOverrides: [1],
+      },
+    ],
+    wordCounts: { 'secure-vocabulary': 2 },
+  }));
+
+  assert.equal(validation.ok, false);
+  assert.ok(errorCodes(validation).includes('reward_track_cycle'));
+});
+
+test('cross-pool sequential dependencies require explicit approval', () => {
+  const pools = [
+    poolFixture('secure-vocabulary', { rewardTrackIds: ['secure-inklet'], sortIndex: 0 }),
+    poolFixture('challenge-vocabulary', { rewardTrackIds: ['challenge-vellhorn'], sortIndex: 1 }),
+  ];
+  const rewardTracks = [
+    {
+      id: 'secure-inklet',
+      poolId: 'secure-vocabulary',
+      monsterId: 'inklet',
+      thresholdOverrides: [1],
+    },
+    {
+      id: 'challenge-vellhorn',
+      poolId: 'challenge-vocabulary',
+      monsterId: 'vellhorn',
+      progressionMode: 'sequentialAfter',
+      sequentialAfter: 'secure-inklet',
+      thresholdOverrides: [1],
+    },
+  ];
+  const blocked = validateSpellingContentBundle(rewardBundle({
+    pools,
+    rewardTracks,
+    wordCounts: { 'secure-vocabulary': 1, 'challenge-vocabulary': 1 },
+  }));
+  const approved = validateSpellingContentBundle(rewardBundle({
+    pools,
+    rewardTracks: rewardTracks.map((track) => (track.id === 'challenge-vellhorn'
+      ? {
+          ...track,
+          dependencyApproval: {
+            approved: true,
+            reason: 'Approved as an editorial bridge between pools.',
+            approvedBy: 'content-admin',
+            approvedAt: NOW,
+          },
+        }
+      : track)),
+    wordCounts: { 'secure-vocabulary': 1, 'challenge-vocabulary': 1 },
+  }));
+
+  assert.equal(blocked.ok, false);
+  assert.ok(errorCodes(blocked).includes('reward_cross_pool_dependency'));
+  assert.equal(approved.ok, true, JSON.stringify(approved.errors, null, 2));
+});
+
+test('reward-track editor validator catches duplicate ids in context', () => {
+  const validation = validateSpellingRewardTrackEditorInput({
+    id: 'secure-inklet',
+    poolId: 'secure-vocabulary',
+    monsterId: 'vellhorn',
+    thresholdOverrides: [1],
+  }, {
+    rewardTracks: [{
+      id: 'secure-inklet',
+      poolId: 'secure-vocabulary',
+      monsterId: 'inklet',
+      thresholdOverrides: [1],
+    }],
+    pools: [poolFixture('secure-vocabulary')],
+  });
+
+  assert.equal(validation.ok, false);
+  assert.ok(validation.errors.some((entry) => entry.code === 'duplicate_reward_track'));
+});
+
+test('pool editor can clear existing formal reward-track bindings', () => {
+  const pool = normaliseSpellingPoolEditorInput({
+    id: 'secure-vocabulary',
+    title: 'Secure vocabulary',
+    type: 'extension',
+    visibility: { state: 'hidden' },
+    sourceNote: 'Reward-track test fixture.',
+    provenance: { source: 'spelling-reward-tracks-test' },
+    rewardTrackIds: [],
+  }, {
+    existingPool: poolFixture('secure-vocabulary', {
+      visibilityState: 'hidden',
+      rewardTrackIds: ['secure-inklet'],
+    }),
+  });
+
+  assert.equal(pool.rewardTrackIds, undefined);
+});


### PR DESCRIPTION
## Summary
- add formal spelling reward-track configuration with parallel and sequential progression validation
- let spelling pools bind to multiple reward tracks while preserving the legacy approval placeholder
- add publish blockers for impossible thresholds, missing tracks, pool mismatches, sequential cycles, and unapproved cross-pool dependencies
- pin hero contract coverage for the spelling monster roster and threshold templates

## Validation
- `node --test tests/spelling-reward-tracks.test.js`
- `node --test tests/hero-contracts.test.js`
- `node --test tests/spelling-content.test.js tests/spelling-content-patterns.test.js`
- `node --test tests/spelling-content-operations-model.test.js`
- `node --test tests/content-operations-api.test.js`
- `node --test tests/admin-content-operations-v2.test.js`
- `npm run check`
- `npm test` (111,804 tests, 111,792 pass, 0 fail, 12 skipped)
- pre-push `npm test` (111,804 tests, 111,792 pass, 0 fail, 12 skipped)

## Independent review
- API/contract reviewer found hidden/staged pool threshold enforcement gap; fixed with `enforceThresholdsForHiddenPools` coverage.
- Correctness reviewer found dangling pool track crash and empty binding clear issue; both fixed with regression tests.
