### PR TITLE
T19: Add pools and rewards editor

### DIFF
--- a/src/platform/game/reward-track-config.js
+++ b/src/platform/game/reward-track-config.js
@@ -227,6 +227,7 @@ export function normaliseRewardTrackConfig(rawValue = {}, {
   const raw = isPlainObject(rawValue) ? rawValue : {};
   const existing = isPlainObject(existingTrack) ? existingTrack : {};
   const activeProvided = Object.prototype.hasOwnProperty.call(raw, 'active');
+  const retired = Boolean(raw.retired || existing.retired);
   const dependencyApproval = raw.dependencyApproval || existing.dependencyApproval || raw.crossPoolDependencyApproved === true
     ? normaliseDependencyApproval(
       raw.dependencyApproval,
@@ -255,7 +256,9 @@ export function normaliseRewardTrackConfig(rawValue = {}, {
     compatibilityMode: normaliseIdentifier(raw.compatibilityMode, existing.compatibilityMode),
     progressKey: normaliseIdentifier(raw.progressKey || raw.legacyProgressKey, existing.progressKey || existing.legacyProgressKey),
     sourceMonsterIds: uniqueStrings(raw.sourceMonsterIds || raw.legacySourceMonsterIds || existing.sourceMonsterIds || existing.legacySourceMonsterIds),
-    active: activeProvided ? raw.active !== false : existing.active !== false,
+    active: retired ? false : (activeProvided ? raw.active !== false : existing.active !== false),
+    retired,
+    ...(raw.retirement || existing.retirement ? { retirement: raw.retirement || existing.retirement } : {}),
     labels: normaliseLabels(raw.labels, existing.labels),
     sequentialAfter: normaliseIdentifier(
       raw.sequentialAfter || raw.afterTrackId,

--- a/src/platform/hubs/admin-content-operations.js
+++ b/src/platform/hubs/admin-content-operations.js
@@ -509,13 +509,50 @@ function normaliseSpellingPoolSummary(row = null) {
     retired: Boolean(safe.retired),
     retirement: isPlainObject(safe.retirement) ? { ...safe.retirement } : null,
     noRewardException: isPlainObject(safe.noRewardException) ? { ...safe.noRewardException } : null,
+    rewardTrackIds: asArray(safe.rewardTrackIds),
     rewardTrack: isPlainObject(safe.rewardTrack) ? { ...safe.rewardTrack } : null,
     wordCount: Number(safe.wordCount) || 0,
+    activeWordCount: Number(safe.activeWordCount ?? safe.wordCount) || 0,
     totalWordCount: Number(safe.totalWordCount ?? safe.wordCount) || 0,
     sentenceCount: Number(safe.sentenceCount) || 0,
     variantCount: Number(safe.variantCount) || 0,
     draftStateCounts: isPlainObject(safe.draftStateCounts) ? { ...safe.draftStateCounts } : {},
     draftState: asString(safe.draftState, 'unchanged'),
+  };
+}
+
+function normaliseSpellingRewardTrackSummary(row = null) {
+  const safe = isPlainObject(row) ? row : {};
+  const labels = isPlainObject(safe.labels) ? safe.labels : {};
+  const dependencyApproval = isPlainObject(safe.dependencyApproval)
+    ? { ...safe.dependencyApproval }
+    : null;
+  return {
+    id: asString(safe.id),
+    poolId: asString(safe.poolId || safe.spellingPool),
+    monsterId: asString(safe.monsterId),
+    progressionMode: asString(safe.progressionMode, 'parallel'),
+    thresholdTemplate: asString(safe.thresholdTemplate, 'direct'),
+    thresholdOverrides: asArray(safe.thresholdOverrides).map((entry) => Number(entry)).filter(Number.isFinite),
+    compatibilityMode: asString(safe.compatibilityMode),
+    progressKey: asString(safe.progressKey),
+    sourceMonsterIds: asArray(safe.sourceMonsterIds),
+    active: safe.active === false ? false : true,
+    retired: Boolean(safe.retired),
+    retirement: isPlainObject(safe.retirement) ? { ...safe.retirement } : null,
+    labels: {
+      title: asString(labels.title),
+      shortLabel: asString(labels.shortLabel),
+      description: asString(labels.description),
+    },
+    sequentialAfter: asString(safe.sequentialAfter),
+    prerequisites: asArray(safe.prerequisites),
+    dependencyApproval,
+    sourceNote: asString(safe.sourceNote),
+    draftState: asString(safe.draftState, 'unchanged'),
+    hasCurrent: safe.hasCurrent !== false,
+    hasPackageDraft: Boolean(safe.hasPackageDraft),
+    sortIndex: Number.isInteger(Number(safe.sortIndex)) ? Number(safe.sortIndex) : 0,
   };
 }
 
@@ -569,6 +606,7 @@ export function normaliseContentOperationsSpellingBrowse(payload = null) {
     draftStateCounts: isPlainObject(safe.draftStateCounts) ? { ...safe.draftStateCounts } : {},
     pools: asArray(safe.pools).map(normaliseSpellingPoolSummary),
     wordLists: asArray(safe.wordLists).map(normaliseSpellingWordList),
+    rewardTracks: asArray(safe.rewardTracks).map(normaliseSpellingRewardTrackSummary),
     words: asArray(safe.words).map(normaliseSpellingBrowseWord),
     actor: normaliseContentOperationActor(payload?.actor),
   };

--- a/src/subjects/spelling/content/editor-read-model.js
+++ b/src/subjects/spelling/content/editor-read-model.js
@@ -211,6 +211,9 @@ function compactWordList(list, wordCount, draftState = 'unchanged', totalWordCou
 
 function compactPool(pool, rows, draftState = 'unchanged') {
   const poolRows = rows.filter((row) => row.spellingPool === pool.id);
+  const activeAnyVisibilityRows = pool.active !== false && !pool.retired
+    ? poolRows.filter((row) => row.active !== false && !row.retired)
+    : [];
   const activePoolRows = pool.active !== false && !pool.retired && pool.visibility?.state === 'visible'
     ? poolRows.filter((row) => row.active !== false && !row.retired)
     : [];
@@ -227,8 +230,10 @@ function compactPool(pool, rows, draftState = 'unchanged') {
     retired: Boolean(pool.retired),
     retirement: pool.retirement || null,
     noRewardException: pool.noRewardException || null,
+    rewardTrackIds: asArray(pool.rewardTrackIds),
     rewardTrack: pool.rewardTrack || null,
     wordCount: activePoolRows.length,
+    activeWordCount: activeAnyVisibilityRows.length,
     totalWordCount: poolRows.length,
     sentenceCount: activePoolRows.reduce((sum, row) => sum + row.sentenceCount + row.variantSentenceCount, 0),
     variantCount: activePoolRows.reduce((sum, row) => sum + row.variantCount, 0),
@@ -236,6 +241,57 @@ function compactPool(pool, rows, draftState = 'unchanged') {
     draftState,
     sortIndex: Number.isInteger(Number(pool.sortIndex)) ? Number(pool.sortIndex) : 0,
   };
+}
+
+function compactRewardTrack(track, draftState = 'unchanged', {
+  hasCurrent = true,
+  hasPackageDraft = false,
+} = {}) {
+  return {
+    id: track.id,
+    poolId: track.poolId,
+    monsterId: track.monsterId,
+    progressionMode: track.progressionMode || 'parallel',
+    thresholdTemplate: track.thresholdTemplate || 'direct',
+    thresholdOverrides: asArray(track.thresholdOverrides),
+    compatibilityMode: track.compatibilityMode || '',
+    progressKey: track.progressKey || '',
+    sourceMonsterIds: asArray(track.sourceMonsterIds),
+    active: track.active !== false,
+    retired: Boolean(track.retired),
+    retirement: track.retirement || null,
+    labels: track.labels || {},
+    sequentialAfter: track.sequentialAfter || '',
+    prerequisites: asArray(track.prerequisites),
+    dependencyApproval: track.dependencyApproval || null,
+    sourceNote: track.sourceNote || '',
+    draftState,
+    hasCurrent,
+    hasPackageDraft,
+    sortIndex: Number.isInteger(Number(track.sortIndex)) ? Number(track.sortIndex) : 0,
+  };
+}
+
+function rewardTrackSummaries({ currentBundle, packageBundle }) {
+  const trackIds = new Set([
+    ...asArray(currentBundle?.draft?.rewardTracks).map((entry) => entry.id),
+    ...asArray(packageBundle?.draft?.rewardTracks).map((entry) => entry.id),
+  ]);
+  const currentById = new Map(asArray(currentBundle?.draft?.rewardTracks).map((entry) => [entry.id, entry]));
+  const packageById = new Map(asArray(packageBundle?.draft?.rewardTracks).map((entry) => [entry.id, entry]));
+  return [...trackIds].map((id) => {
+    const currentTrack = currentById.get(id) || null;
+    const packageTrack = packageById.get(id) || null;
+    const display = packageTrack || currentTrack;
+    return compactRewardTrack(
+      display,
+      packageBundle ? packageDraftState(currentTrack, packageTrack) : 'unchanged',
+      {
+        hasCurrent: Boolean(currentTrack),
+        hasPackageDraft: Boolean(packageTrack),
+      },
+    );
+  }).sort((left, right) => left.sortIndex - right.sortIndex || left.id.localeCompare(right.id));
 }
 
 function comparablePool(pool) {
@@ -250,6 +306,7 @@ function comparablePool(pool) {
     active: pool.active !== false,
     retired: Boolean(pool.retired),
     noRewardException: pool.noRewardException || null,
+    rewardTrackIds: asArray(pool.rewardTrackIds),
     rewardTrack: pool.rewardTrack || null,
   };
 }
@@ -551,6 +608,10 @@ export function buildSpellingContentBrowseModel({
       packageBundle,
       currentMaps,
       packageMaps,
+    }),
+    rewardTracks: rewardTrackSummaries({
+      currentBundle,
+      packageBundle,
     }),
     words: limitedRows,
   };

--- a/src/subjects/spelling/content/package-operations.js
+++ b/src/subjects/spelling/content/package-operations.js
@@ -1,5 +1,6 @@
 import {
   SPELLING_REWARD_TRACK_MONSTER_IDS,
+  isValidRewardTrackId,
   normaliseRewardTrackConfig,
   validateRewardTrackCollection,
 } from '../../../platform/game/reward-track-config.js';
@@ -666,6 +667,41 @@ export function buildSpellingRewardTrackUpsertOperation(rawValue = {}, options =
     fieldPath: '',
     action: 'upsert',
     payload: validation.rewardTrack,
+  };
+}
+
+export function buildSpellingRewardTrackDeleteOrRetireOperation(rawValue = {}, {
+  publishedRewardTrackIds = [],
+  reason = '',
+  now = () => Date.now(),
+} = {}) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  const id = normaliseString(raw.id || raw.entityId || raw.rewardTrackId || raw.trackId).toLowerCase();
+  if (!id) throw new TypeError('Reward track id is required.');
+  if (!isValidRewardTrackId(id)) throw new TypeError('Reward track id must be a stable lowercase id.');
+  const publishedSet = publishedRewardTrackIds instanceof Set
+    ? publishedRewardTrackIds
+    : new Set((Array.isArray(publishedRewardTrackIds) ? publishedRewardTrackIds : []).map((entry) => String(entry)));
+  const published = Boolean(raw.published || raw.hasCurrent || publishedSet.has(id));
+  if (!published) {
+    return {
+      entityType: 'spelling.rewardTrack',
+      entityId: id,
+      fieldPath: '',
+      action: 'remove',
+      payload: null,
+    };
+  }
+  return {
+    entityType: 'spelling.rewardTrack',
+    entityId: id,
+    fieldPath: '',
+    action: 'retire',
+    payload: {
+      reason: normaliseString(reason, normaliseString(raw.reason, 'Retired through Content Operations Centre.')),
+      retiredAt: Number(now()),
+      source: 'content-operations-centre',
+    },
   };
 }
 

--- a/src/surfaces/hubs/AdminContentOperationsSection.jsx
+++ b/src/surfaces/hubs/AdminContentOperationsSection.jsx
@@ -17,6 +17,8 @@ import {
 import {
   buildSpellingPoolDeleteOrRetireOperation,
   buildSpellingPoolUpsertOperation,
+  buildSpellingRewardTrackDeleteOrRetireOperation,
+  buildSpellingRewardTrackUpsertOperation,
   buildSpellingSentenceDeleteOrRetireOperation,
   buildSpellingSentenceUpsertOperation,
   buildSpellingWordListDeleteOrRetireOperation,
@@ -24,6 +26,11 @@ import {
   buildSpellingWordDeleteOrRetireOperation,
   buildSpellingWordUpsertOperation,
 } from '../../subjects/spelling/content/package-operations.js';
+import {
+  REWARD_TRACK_PROGRESS_MODES,
+  REWARD_TRACK_THRESHOLD_TEMPLATES,
+  SPELLING_REWARD_TRACK_MONSTER_IDS,
+} from '../../platform/game/reward-track-config.js';
 
 const CENTRE_TABS = Object.freeze([
   { key: 'overview', label: 'Overview' },
@@ -65,6 +72,42 @@ function contentOperationMutation(action, packageId) {
 
 function csvValue(values) {
   return Array.isArray(values) ? values.filter(Boolean).join(', ') : '';
+}
+
+function csvNumberValue(values) {
+  return Array.isArray(values)
+    ? values.filter((entry) => Number.isFinite(Number(entry))).join(', ')
+    : '';
+}
+
+function csvNumberList(value) {
+  return thresholdOverrideParse(value).values;
+}
+
+function thresholdOverrideParse(value) {
+  const values = [];
+  const invalidTokens = [];
+  String(value || '')
+    .split(/[\n,]+/)
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .forEach((entry) => {
+      const numeric = Number(entry);
+      if (Number.isFinite(numeric)) {
+        values.push(numeric);
+      } else {
+        invalidTokens.push(entry);
+      }
+    });
+  return { values, invalidTokens };
+}
+
+function strictCsvNumberList(value) {
+  const parsed = thresholdOverrideParse(value);
+  if (parsed.invalidTokens.length) {
+    throw new TypeError(`Threshold overrides must be numbers; invalid value "${parsed.invalidTokens[0]}".`);
+  }
+  return parsed.values;
 }
 
 function provenanceField(provenance, key) {
@@ -304,6 +347,7 @@ function emptyPoolEditorForm(pools = [], selectedRow = null) {
     visibilityState: 'hidden',
     scheduledAt: '',
     rolloutFlag: '',
+    rewardTrackIds: '',
     tags: '',
     sourceNote: '',
     provenanceSource: '',
@@ -323,6 +367,7 @@ function poolEditorFormFromPool(pool, selectedRow = null, pools = []) {
     visibilityState: pool.visibility?.state || 'hidden',
     scheduledAt: pool.visibility?.scheduledAt ? String(pool.visibility.scheduledAt) : '',
     rolloutFlag: pool.visibility?.rolloutFlag || '',
+    rewardTrackIds: csvValue(pool.rewardTrackIds),
     tags: csvValue(pool.tags),
     sourceNote: pool.sourceNote || '',
     provenanceSource: provenanceField(pool.provenance, 'source'),
@@ -338,6 +383,7 @@ function operationInputFromPoolForm(form) {
     id: form.id,
     title: form.title,
     type: form.type,
+    rewardTrackIds: form.rewardTrackIds,
     visibility: {
       state: form.visibilityState,
       scheduledAt: form.scheduledAt,
@@ -353,6 +399,149 @@ function operationInputFromPoolForm(form) {
       approved: Boolean(form.noRewardExceptionApproved),
       reason: form.noRewardExceptionReason,
     },
+  };
+}
+
+function rewardTrackTemplateOptions() {
+  return Object.values(REWARD_TRACK_THRESHOLD_TEMPLATES);
+}
+
+function thresholdTemplateLabel(templateId) {
+  return REWARD_TRACK_THRESHOLD_TEMPLATES[templateId]?.label || templateId || 'Template';
+}
+
+function thresholdsForRewardTrackForm(form) {
+  const overrides = csvNumberList(form.thresholdOverrides);
+  if (overrides.length) return overrides;
+  const template = REWARD_TRACK_THRESHOLD_TEMPLATES[form.thresholdTemplate]
+    || REWARD_TRACK_THRESHOLD_TEMPLATES.direct;
+  return Array.isArray(template?.thresholds) ? [...template.thresholds] : [];
+}
+
+function poolWordCountValue(pool) {
+  return Number(pool?.activeWordCount ?? pool?.wordCount ?? pool?.totalWordCount) || 0;
+}
+
+function poolWordCountLookup(pools = []) {
+  return Object.fromEntries((Array.isArray(pools) ? pools : [])
+    .map((pool) => [spellingPoolOptionId(pool), poolWordCountValue(pool)])
+    .filter(([id]) => Boolean(id)));
+}
+
+function learnerVisiblePoolIds(pools = []) {
+  return new Set((Array.isArray(pools) ? pools : [])
+    .filter((pool) => pool?.active !== false && !pool?.retired && pool?.visibility?.state === 'visible')
+    .map(spellingPoolOptionId)
+    .filter(Boolean));
+}
+
+function rewardTrackOptionLabel(track) {
+  if (track?.labels?.title) return track.labels.title;
+  if (track?.id) return track.id;
+  return 'Reward track';
+}
+
+function nextRewardTrackId(poolId, monsterId, rewardTracks = []) {
+  const base = `${poolId || 'pool'}-${monsterId || 'reward-track'}`
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/^-+|-+$/g, '') || 'spelling-reward-track';
+  const existing = new Set((Array.isArray(rewardTracks) ? rewardTracks : [])
+    .map((track) => track?.id)
+    .filter(Boolean));
+  if (!existing.has(base)) return base;
+  for (let index = 2; index < 100; index += 1) {
+    const candidate = `${base}-${index}`;
+    if (!existing.has(candidate)) return candidate;
+  }
+  return `${base}-${Date.now()}`;
+}
+
+function firstAvailableMonsterId(poolId, rewardTracks = []) {
+  const used = new Set((Array.isArray(rewardTracks) ? rewardTracks : [])
+    .filter((track) => track?.poolId === poolId && track?.active !== false)
+    .map((track) => track.monsterId)
+    .filter(Boolean));
+  return SPELLING_REWARD_TRACK_MONSTER_IDS.find((monsterId) => !used.has(monsterId))
+    || SPELLING_REWARD_TRACK_MONSTER_IDS[0]
+    || '';
+}
+
+function emptyRewardTrackEditorForm(pools = [], selectedPool = null, rewardTracks = []) {
+  const poolId = spellingPoolOptionId(selectedPool) || spellingPoolOptionId(pools[0]) || 'extra';
+  const monsterId = firstAvailableMonsterId(poolId, rewardTracks);
+  return {
+    id: nextRewardTrackId(poolId, monsterId, rewardTracks),
+    poolId,
+    monsterId,
+    progressionMode: 'parallel',
+    thresholdTemplate: 'direct',
+    thresholdOverrides: '1',
+    active: true,
+    progressKey: monsterId,
+    sourceMonsterIds: monsterId,
+    sequentialAfter: '',
+    dependencyApprovalApproved: false,
+    dependencyApprovalReason: '',
+    labelsTitle: '',
+    labelsShortLabel: '',
+    labelsDescription: '',
+    sourceNote: '',
+    retirementReason: '',
+    sortIndex: String(Array.isArray(rewardTracks) ? rewardTracks.length : 0),
+  };
+}
+
+function rewardTrackEditorFormFromTrack(track, selectedPool = null, pools = [], rewardTracks = []) {
+  if (!track) return emptyRewardTrackEditorForm(pools, selectedPool, rewardTracks);
+  return {
+    id: track.id || '',
+    poolId: track.poolId || spellingPoolOptionId(selectedPool) || '',
+    monsterId: track.monsterId || '',
+    progressionMode: track.progressionMode || 'parallel',
+    thresholdTemplate: track.thresholdTemplate || 'direct',
+    thresholdOverrides: csvNumberValue(track.thresholdOverrides),
+    active: track.active !== false,
+    progressKey: track.progressKey || track.monsterId || '',
+    sourceMonsterIds: csvValue(track.sourceMonsterIds),
+    sequentialAfter: track.sequentialAfter || '',
+    dependencyApprovalApproved: track.dependencyApproval?.approved === true,
+    dependencyApprovalReason: track.dependencyApproval?.reason || '',
+    labelsTitle: track.labels?.title || '',
+    labelsShortLabel: track.labels?.shortLabel || '',
+    labelsDescription: track.labels?.description || '',
+    sourceNote: track.sourceNote || '',
+    retirementReason: '',
+    sortIndex: Number.isInteger(Number(track.sortIndex)) ? String(track.sortIndex) : '0',
+  };
+}
+
+function operationInputFromRewardTrackForm(form) {
+  const dependencyApproval = form.dependencyApprovalApproved || form.dependencyApprovalReason
+    ? {
+        approved: Boolean(form.dependencyApprovalApproved),
+        reason: form.dependencyApprovalReason,
+      }
+    : undefined;
+  return {
+    id: form.id,
+    poolId: form.poolId,
+    monsterId: form.monsterId,
+    progressionMode: form.progressionMode,
+    thresholdTemplate: form.thresholdTemplate,
+    thresholdOverrides: strictCsvNumberList(form.thresholdOverrides),
+    active: Boolean(form.active),
+    progressKey: form.progressKey,
+    sourceMonsterIds: form.sourceMonsterIds,
+    sequentialAfter: form.sequentialAfter,
+    labels: {
+      title: form.labelsTitle,
+      shortLabel: form.labelsShortLabel,
+      description: form.labelsDescription,
+    },
+    ...(dependencyApproval ? { dependencyApproval } : {}),
+    sourceNote: form.sourceNote,
+    sortIndex: form.sortIndex,
   };
 }
 
@@ -1127,6 +1316,7 @@ function PublishedAreaPanel({
 }
 
 function SpellingBrowsePanel({
+  areaKey = 'spelling',
   browse,
   itemDetail,
   filters,
@@ -1159,6 +1349,13 @@ function SpellingBrowsePanel({
   const selectedPool = browse.pools.find((pool) => pool.id === selectedRow?.spellingPool || pool.pool === selectedRow?.spellingPool)
     || browse.pools[0]
     || null;
+  const rewardTracks = React.useMemo(() => (
+    Array.isArray(browse.rewardTracks) ? browse.rewardTracks : []
+  ), [browse.rewardTracks]);
+  const selectedPoolId = spellingPoolOptionId(selectedPool);
+  const rewardTracksForSelectedPool = React.useMemo(() => (
+    rewardTracks.filter((track) => track.poolId === selectedPoolId)
+  ), [rewardTracks, selectedPoolId]);
   const poolOptions = React.useMemo(() => spellingPoolOptions(browse.pools), [browse.pools]);
   const sentenceOptions = React.useMemo(() => {
     const seen = new Set();
@@ -1184,6 +1381,11 @@ function SpellingBrowsePanel({
   const [wordListForm, setWordListForm] = React.useState(() => emptyWordListEditorForm(browse.wordLists, selectedRow));
   const [poolMode, setPoolMode] = React.useState('edit');
   const [poolForm, setPoolForm] = React.useState(() => emptyPoolEditorForm(browse.pools, selectedRow));
+  const [rewardTrackMode, setRewardTrackMode] = React.useState('edit');
+  const [selectedRewardTrackId, setSelectedRewardTrackId] = React.useState('');
+  const [rewardTrackForm, setRewardTrackForm] = React.useState(() => (
+    emptyRewardTrackEditorForm(browse.pools, selectedPool, rewardTracks)
+  ));
   const [formError, setFormError] = React.useState('');
   const formDisabled = !selectedPackageId
     || !canEdit
@@ -1196,6 +1398,18 @@ function SpellingBrowsePanel({
   const selectedSentence = sentenceOptions.find((sentence) => sentence.id === selectedSentenceId)
     || sentenceOptions[0]
     || null;
+  const selectedRewardTrack = rewardTracks.find((track) => track.id === selectedRewardTrackId)
+    || rewardTracksForSelectedPool[0]
+    || rewardTracks[0]
+    || null;
+  const selectedRewardThresholds = React.useMemo(
+    () => thresholdsForRewardTrackForm(rewardTrackForm),
+    [rewardTrackForm],
+  );
+  const selectedRewardPool = browse.pools.find((pool) => spellingPoolOptionId(pool) === rewardTrackForm.poolId)
+    || selectedPool
+    || null;
+  const selectedRewardPoolWordCount = poolWordCountValue(selectedRewardPool);
 
   React.useEffect(() => {
     if (editorMode === 'create') return;
@@ -1247,6 +1461,24 @@ function SpellingBrowsePanel({
     selectedRow?.spellingPool,
   ]);
 
+  React.useEffect(() => {
+    if (rewardTrackMode === 'create') return;
+    setFormError('');
+    setSelectedRewardTrackId(selectedRewardTrack?.id || '');
+    setRewardTrackForm(rewardTrackEditorFormFromTrack(
+      selectedRewardTrack,
+      selectedPool,
+      browse.pools,
+      rewardTracks,
+    ));
+  }, [
+    browse.pools,
+    rewardTrackMode,
+    rewardTracks,
+    selectedPool,
+    selectedRewardTrack,
+  ]);
+
   const updateWordForm = React.useCallback((patch) => {
     setFormError('');
     setWordForm((current) => {
@@ -1286,6 +1518,22 @@ function SpellingBrowsePanel({
       if (Object.prototype.hasOwnProperty.call(patch, 'type')) {
         if (patch.type === 'statutory') next.visibilityState = next.id === 'core' ? next.visibilityState : 'hidden';
         if (patch.type === 'enrichment' && !next.id) next.id = 'extra';
+      }
+      return next;
+    });
+  }, []);
+
+  const updateRewardTrackForm = React.useCallback((patch) => {
+    setFormError('');
+    setRewardTrackForm((current) => {
+      const next = { ...current, ...patch };
+      if (Object.prototype.hasOwnProperty.call(patch, 'monsterId')) {
+        if (!next.progressKey || next.progressKey === current.monsterId) {
+          next.progressKey = patch.monsterId;
+        }
+        if (!next.sourceMonsterIds || next.sourceMonsterIds === current.monsterId) {
+          next.sourceMonsterIds = patch.monsterId;
+        }
       }
       return next;
     });
@@ -1382,6 +1630,26 @@ function SpellingBrowsePanel({
     setFormError('');
     setPoolForm(poolEditorFormFromPool(nextPool, selectedRow, browse.pools));
   }, [browse.pools, selectedPool, selectedRow]);
+
+  const startCreateRewardTrack = React.useCallback(() => {
+    setRewardTrackMode('create');
+    setSelectedRewardTrackId('');
+    setFormError('');
+    setRewardTrackForm(emptyRewardTrackEditorForm(browse.pools, selectedPool, rewardTracks));
+  }, [browse.pools, rewardTracks, selectedPool]);
+
+  const startEditRewardTrack = React.useCallback((trackId = '') => {
+    const nextTrack = rewardTracks.find((track) => track.id === trackId) || selectedRewardTrack;
+    setRewardTrackMode('edit');
+    setSelectedRewardTrackId(nextTrack?.id || '');
+    setFormError('');
+    setRewardTrackForm(rewardTrackEditorFormFromTrack(
+      nextTrack,
+      selectedPool,
+      browse.pools,
+      rewardTracks,
+    ));
+  }, [browse.pools, rewardTracks, selectedPool, selectedRewardTrack]);
 
   const submitWordForm = React.useCallback((event) => {
     event?.preventDefault?.();
@@ -1503,12 +1771,56 @@ function SpellingBrowsePanel({
     }
   }, [onSubmitSpellingOperation, poolForm.id, poolForm.retirementReason, selectedPool, selectedRow?.slug]);
 
+  const submitRewardTrackForm = React.useCallback((event) => {
+    event?.preventDefault?.();
+    if (!onSubmitSpellingOperation) return;
+    try {
+      const operation = buildSpellingRewardTrackUpsertOperation(operationInputFromRewardTrackForm(rewardTrackForm), {
+        existingTrack: rewardTrackMode === 'edit' ? selectedRewardTrack : null,
+        rewardTracks,
+        pools: browse.pools,
+        poolWordCounts: poolWordCountLookup(browse.pools),
+        learnerVisiblePoolIds: learnerVisiblePoolIds(browse.pools),
+        enforceThresholdsForHiddenPools: true,
+      });
+      onSubmitSpellingOperation(operation, { slug: selectedRow?.slug, action: 'reward-track-upsert' });
+    } catch (submitError) {
+      setFormError(submitError?.validation?.errors?.[0]?.message || submitError?.message || 'Reward-track operation is invalid.');
+    }
+  }, [
+    browse.pools,
+    onSubmitSpellingOperation,
+    rewardTrackForm,
+    rewardTrackMode,
+    rewardTracks,
+    selectedRewardTrack,
+    selectedRow?.slug,
+  ]);
+
+  const submitRewardTrackRemoval = React.useCallback(() => {
+    if (!onSubmitSpellingOperation || !selectedRewardTrack) return;
+    try {
+      const operation = buildSpellingRewardTrackDeleteOrRetireOperation({
+        id: rewardTrackForm.id || selectedRewardTrack.id,
+        hasCurrent: selectedRewardTrack.hasCurrent !== false && selectedRewardTrack.draftState !== 'added',
+        reason: rewardTrackForm.retirementReason,
+      }, {
+        reason: rewardTrackForm.retirementReason,
+      });
+      onSubmitSpellingOperation(operation, { slug: selectedRow?.slug, action: `reward-track-${operation.action}` });
+    } catch (submitError) {
+      setFormError(submitError?.message || 'Reward-track operation is invalid.');
+    }
+  }, [onSubmitSpellingOperation, rewardTrackForm.id, rewardTrackForm.retirementReason, selectedRewardTrack, selectedRow?.slug]);
+
   return (
-    <div className="content-ops-area-panel" data-content-ops-area="spelling" data-content-ops-spelling-browse="true">
+    <div className="content-ops-area-panel" data-content-ops-area={areaKey} data-content-ops-spelling-browse="true">
       <div className="content-ops-detail-header">
         <div>
           <div className="eyebrow">Published state</div>
-          <h4 className="section-title admin-section-title">Spelling browse</h4>
+          <h4 className="section-title admin-section-title">
+            {areaKey === 'poolsRewards' ? 'Pools & Rewards' : 'Spelling browse'}
+          </h4>
           <p className="small muted admin-note-spaced">
             Latest release {releaseLabel}
           </p>
@@ -1569,6 +1881,7 @@ function SpellingBrowsePanel({
                 <th className="small admin-overview-th">Type</th>
                 <th className="small admin-overview-th">Visibility</th>
                 <th className="small admin-overview-th-right">Words</th>
+                <th className="small admin-overview-th-right">Tracks</th>
                 <th className="small admin-overview-th">Draft</th>
               </tr>
             </thead>
@@ -1592,7 +1905,8 @@ function SpellingBrowsePanel({
                       {pool.retired ? 'retired' : (pool.visibility?.state || 'hidden')}
                     </span>
                   </td>
-                  <td className="admin-overview-td-right small">{String(pool.wordCount)} / {String(pool.totalWordCount)}</td>
+                  <td className="admin-overview-td-right small">{String(pool.activeWordCount ?? pool.wordCount)} / {String(pool.totalWordCount)}</td>
+                  <td className="admin-overview-td-right small">{String((pool.rewardTrackIds || []).length)}</td>
                   <td className="admin-overview-td">
                     <span className={`chip ${draftStateChipClass(pool.draftState)}`}>
                       {draftStateLabel(pool.draftState)}
@@ -1662,6 +1976,14 @@ function SpellingBrowsePanel({
               data-content-ops-pool-field="rolloutFlag"
             />
           </label>
+          <label className="content-ops-editor-wide">
+            <span className="small muted">Reward track ids</span>
+            <textarea
+              value={poolForm.rewardTrackIds}
+              onChange={(event) => updatePoolForm({ rewardTrackIds: event.target.value })}
+              data-content-ops-pool-field="rewardTrackIds"
+            />
+          </label>
           <label>
             <span className="small muted">Tags</span>
             <input
@@ -1717,6 +2039,269 @@ function SpellingBrowsePanel({
             </button>
             <button type="button" className="btn secondary" onClick={submitPoolRemoval} disabled={formDisabled || !selectedPool}>
               {selectedPool?.draftState === 'added' ? 'Delete draft pool' : 'Retire pool'}
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <section className="content-ops-editor-panel" data-content-ops-reward-editor="true">
+        <div className="content-ops-word-editor-header">
+          <div>
+            <div className="eyebrow">Reward tracks</div>
+            <strong>{rewardTrackMode === 'create' ? 'New reward track' : rewardTrackOptionLabel(selectedRewardTrack)}</strong>
+          </div>
+          <div className="chip-row content-ops-chip-wrap">
+            <button type="button" className="btn secondary compact" onClick={() => startEditRewardTrack(selectedRewardTrack?.id)} disabled={!selectedRewardTrack}>
+              Edit track
+            </button>
+            <button type="button" className="btn secondary compact" onClick={startCreateRewardTrack}>
+              New track
+            </button>
+          </div>
+        </div>
+        <div className="content-ops-reward-impact" data-content-ops-reward-impact="true">
+          <MetricTile
+            label="Selected pool words"
+            value={String(selectedRewardPoolWordCount)}
+            detail={selectedRewardPool?.title || selectedRewardPool?.id || 'No pool'}
+          />
+          <MetricTile
+            label="Thresholds"
+            value={String(selectedRewardThresholds.length)}
+            detail={selectedRewardThresholds.length ? `Highest ${String(Math.max(...selectedRewardThresholds))}` : 'Template required'}
+          />
+          <MetricTile
+            label="Progression"
+            value={rewardTrackForm.progressionMode}
+            detail={thresholdTemplateLabel(rewardTrackForm.thresholdTemplate)}
+          />
+        </div>
+        <div className="feedback warn content-ops-reward-safety" data-content-ops-reward-safety="true">
+          Existing learner history stays keyed by the published progress key. Changing thresholds, source monsters, or sequence changes future reward projection after approval.
+        </div>
+        <div className="content-ops-table-scroll">
+          <table className="admin-overview-table content-ops-table" aria-label="Spelling reward tracks">
+            <thead>
+              <tr className="admin-overview-thead-row">
+                <th className="small admin-overview-th-first">Track</th>
+                <th className="small admin-overview-th">Pool</th>
+                <th className="small admin-overview-th">Monster</th>
+                <th className="small admin-overview-th">Mode</th>
+                <th className="small admin-overview-th-right">Thresholds</th>
+                <th className="small admin-overview-th">State</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rewardTracks.length ? rewardTracks.map((track) => (
+                <tr key={track.id} className="admin-overview-tbody-row" data-selected={track.id === selectedRewardTrack?.id ? 'true' : undefined}>
+                  <td className="admin-overview-td-first">
+                    <button
+                      type="button"
+                      className="content-ops-row-button"
+                      onClick={() => startEditRewardTrack(track.id)}
+                      data-content-ops-reward-row={track.id}
+                    >
+                      {rewardTrackOptionLabel(track)}
+                    </button>
+                    <div className="small muted">{track.id}</div>
+                  </td>
+                  <td className="admin-overview-td small">{track.poolId || 'No pool'}</td>
+                  <td className="admin-overview-td small">{track.monsterId || 'No monster'}</td>
+                  <td className="admin-overview-td small">{track.progressionMode || 'parallel'}</td>
+                  <td className="admin-overview-td-right small">
+                    {String((track.thresholdOverrides || []).length || (REWARD_TRACK_THRESHOLD_TEMPLATES[track.thresholdTemplate]?.thresholds || []).length)}
+                  </td>
+                  <td className="admin-overview-td">
+                    <span className={`chip ${track.retired ? 'bad' : (track.active === false ? 'warn' : 'good')}`}>
+                      {track.retired ? 'retired' : (track.active === false ? 'inactive' : 'active')}
+                    </span>
+                  </td>
+                </tr>
+              )) : (
+                <tr className="admin-overview-tbody-row">
+                  <td className="admin-overview-td-first small muted" colSpan={6}>
+                    No reward tracks in this package view.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+        <form className="content-ops-word-editor-grid" onSubmit={submitRewardTrackForm}>
+          <label>
+            <span className="small muted">Track id</span>
+            <input
+              value={rewardTrackForm.id}
+              onChange={(event) => updateRewardTrackForm({ id: event.target.value })}
+              data-content-ops-reward-field="id"
+              disabled={rewardTrackMode === 'edit'}
+            />
+          </label>
+          <label>
+            <span className="small muted">Pool</span>
+            <select
+              value={rewardTrackForm.poolId}
+              onChange={(event) => updateRewardTrackForm({ poolId: event.target.value })}
+              data-content-ops-reward-field="poolId"
+            >
+              {poolOptions.map((pool) => (
+                <option key={pool.id} value={pool.id}>{pool.label}</option>
+              ))}
+            </select>
+          </label>
+          <label>
+            <span className="small muted">Monster</span>
+            <select
+              value={rewardTrackForm.monsterId}
+              onChange={(event) => updateRewardTrackForm({ monsterId: event.target.value })}
+              data-content-ops-reward-field="monsterId"
+            >
+              {SPELLING_REWARD_TRACK_MONSTER_IDS.map((monsterId) => (
+                <option key={monsterId} value={monsterId}>{monsterId}</option>
+              ))}
+            </select>
+          </label>
+          <label>
+            <span className="small muted">Progression mode</span>
+            <select
+              value={rewardTrackForm.progressionMode}
+              onChange={(event) => updateRewardTrackForm({ progressionMode: event.target.value })}
+              data-content-ops-reward-field="progressionMode"
+            >
+              {REWARD_TRACK_PROGRESS_MODES.map((mode) => (
+                <option key={mode} value={mode}>{mode}</option>
+              ))}
+            </select>
+          </label>
+          <label>
+            <span className="small muted">Threshold template</span>
+            <select
+              value={rewardTrackForm.thresholdTemplate}
+              onChange={(event) => updateRewardTrackForm({ thresholdTemplate: event.target.value })}
+              data-content-ops-reward-field="thresholdTemplate"
+            >
+              {rewardTrackTemplateOptions().map((template) => (
+                <option key={template.id} value={template.id}>{template.label}</option>
+              ))}
+            </select>
+          </label>
+          <label>
+            <span className="small muted">Threshold overrides</span>
+            <input
+              value={rewardTrackForm.thresholdOverrides}
+              onChange={(event) => updateRewardTrackForm({ thresholdOverrides: event.target.value })}
+              data-content-ops-reward-field="thresholdOverrides"
+            />
+          </label>
+          <label>
+            <span className="small muted">Progress key</span>
+            <input
+              value={rewardTrackForm.progressKey}
+              onChange={(event) => updateRewardTrackForm({ progressKey: event.target.value })}
+              data-content-ops-reward-field="progressKey"
+            />
+          </label>
+          <label>
+            <span className="small muted">Source monsters</span>
+            <input
+              value={rewardTrackForm.sourceMonsterIds}
+              onChange={(event) => updateRewardTrackForm({ sourceMonsterIds: event.target.value })}
+              data-content-ops-reward-field="sourceMonsterIds"
+            />
+          </label>
+          <label>
+            <span className="small muted">Sequential after</span>
+            <select
+              value={rewardTrackForm.sequentialAfter}
+              onChange={(event) => updateRewardTrackForm({ sequentialAfter: event.target.value })}
+              data-content-ops-reward-field="sequentialAfter"
+            >
+              <option value="">No dependency</option>
+              {rewardTracks.filter((track) => track.id !== rewardTrackForm.id).map((track) => (
+                <option key={track.id} value={track.id}>{rewardTrackOptionLabel(track)}</option>
+              ))}
+            </select>
+          </label>
+          <label>
+            <span className="small muted">Active</span>
+            <input
+              type="checkbox"
+              checked={rewardTrackForm.active}
+              onChange={(event) => updateRewardTrackForm({ active: event.target.checked })}
+              data-content-ops-reward-field="active"
+            />
+          </label>
+          <label>
+            <span className="small muted">Order</span>
+            <input
+              value={rewardTrackForm.sortIndex}
+              onChange={(event) => updateRewardTrackForm({ sortIndex: event.target.value })}
+              data-content-ops-reward-field="sortIndex"
+            />
+          </label>
+          <label>
+            <span className="small muted">Dependency approved</span>
+            <input
+              type="checkbox"
+              checked={rewardTrackForm.dependencyApprovalApproved}
+              onChange={(event) => updateRewardTrackForm({ dependencyApprovalApproved: event.target.checked })}
+              data-content-ops-reward-field="dependencyApprovalApproved"
+            />
+          </label>
+          <label>
+            <span className="small muted">Track title</span>
+            <input
+              value={rewardTrackForm.labelsTitle}
+              onChange={(event) => updateRewardTrackForm({ labelsTitle: event.target.value })}
+              data-content-ops-reward-field="labelsTitle"
+            />
+          </label>
+          <label>
+            <span className="small muted">Short label</span>
+            <input
+              value={rewardTrackForm.labelsShortLabel}
+              onChange={(event) => updateRewardTrackForm({ labelsShortLabel: event.target.value })}
+              data-content-ops-reward-field="labelsShortLabel"
+            />
+          </label>
+          <label className="content-ops-editor-wide">
+            <span className="small muted">Track description</span>
+            <textarea
+              value={rewardTrackForm.labelsDescription}
+              onChange={(event) => updateRewardTrackForm({ labelsDescription: event.target.value })}
+              data-content-ops-reward-field="labelsDescription"
+            />
+          </label>
+          <label className="content-ops-editor-wide">
+            <span className="small muted">Dependency approval reason</span>
+            <textarea
+              value={rewardTrackForm.dependencyApprovalReason}
+              onChange={(event) => updateRewardTrackForm({ dependencyApprovalReason: event.target.value })}
+              data-content-ops-reward-field="dependencyApprovalReason"
+            />
+          </label>
+          <label className="content-ops-editor-wide">
+            <span className="small muted">Source notes</span>
+            <textarea
+              value={rewardTrackForm.sourceNote}
+              onChange={(event) => updateRewardTrackForm({ sourceNote: event.target.value })}
+              data-content-ops-reward-field="sourceNote"
+            />
+          </label>
+          <label className="content-ops-editor-wide">
+            <span className="small muted">Retirement reason</span>
+            <input
+              value={rewardTrackForm.retirementReason}
+              onChange={(event) => updateRewardTrackForm({ retirementReason: event.target.value })}
+              data-content-ops-reward-field="retirementReason"
+            />
+          </label>
+          <div className="content-ops-editor-actions content-ops-editor-wide">
+            <button type="submit" className="btn primary" disabled={formDisabled}>
+              Save reward track
+            </button>
+            <button type="button" className="btn secondary" onClick={submitRewardTrackRemoval} disabled={formDisabled || !selectedRewardTrack}>
+              {selectedRewardTrack?.draftState === 'added' || selectedRewardTrack?.hasCurrent === false ? 'Delete draft track' : 'Retire track'}
             </button>
           </div>
         </form>
@@ -3261,7 +3846,9 @@ export function AdminContentOperationsSection({
         ? 'Sentence'
         : (operation.entityType === 'spelling.wordList'
             ? 'Word list'
-            : (operation.entityType === 'spelling.pool' ? 'Pool' : 'Word'));
+            : (operation.entityType === 'spelling.pool'
+                ? 'Pool'
+                : (operation.entityType === 'spelling.rewardTrack' ? 'Reward track' : 'Word')));
       setSpellingOperationState({
         packageId: selectedPackageId,
         action,
@@ -3326,7 +3913,7 @@ export function AdminContentOperationsSection({
   }, [api, overviewPayload, packageListPayload, refresh, releaseListPayload]);
 
   React.useEffect(() => {
-    if (activeTab !== 'spelling') return;
+    if (!['spelling', 'poolsRewards'].includes(activeTab)) return;
     if (!api?.readSpellingBrowse) return;
     if (spellingBrowsePayload) return;
     loadSpellingBrowse();
@@ -3600,8 +4187,9 @@ export function AdminContentOperationsSection({
         />
       ) : null}
 
-      {activeTab === 'spelling' ? (
+      {['spelling', 'poolsRewards'].includes(activeTab) ? (
         <SpellingBrowsePanel
+          areaKey={activeTab}
           browse={spellingBrowse}
           itemDetail={spellingItemDetail}
           filters={spellingFilters}
@@ -3620,7 +4208,7 @@ export function AdminContentOperationsSection({
         />
       ) : null}
 
-      {['audio', 'poolsRewards', 'monstersAssets', 'heroCodex', 'approvals'].includes(activeTab) ? (
+      {['audio', 'monstersAssets', 'heroCodex', 'approvals'].includes(activeTab) ? (
         <PublishedAreaPanel
           activeTab={activeTab}
           latestRelease={latestRelease}

--- a/styles/app.css
+++ b/styles/app.css
@@ -12449,6 +12449,16 @@ html { scroll-behavior: smooth; }
   padding-top: 12px;
 }
 
+.content-ops-reward-impact {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.content-ops-reward-safety {
+  margin: 0;
+}
+
 .content-ops-word-editor-header,
 .content-ops-word-editor-actions,
 .content-ops-editor-actions {
@@ -12708,7 +12718,8 @@ html { scroll-behavior: smooth; }
   }
 
   .content-ops-word-editor-grid,
-  .content-ops-word-variant-row {
+  .content-ops-word-variant-row,
+  .content-ops-reward-impact {
     grid-template-columns: 1fr;
   }
 

--- a/tests/admin-content-operations-v2.test.js
+++ b/tests/admin-content-operations-v2.test.js
@@ -828,9 +828,26 @@ describe('Content Operations Centre normalisers', () => {
             title: 'Secure vocabulary',
             type: 'extension',
             visibility: { state: 'hidden' },
+            rewardTrackIds: ['secure-track', 'secure-vellhorn'],
             rewardTrack: { id: 'secure-track', approved: true },
+            wordCount: 0,
+            activeWordCount: 12,
+            totalWordCount: 15,
           },
         ],
+        rewardTracks: [{
+          id: 'secure-track',
+          poolId: 'secure-vocabulary',
+          monsterId: 'inklet',
+          progressionMode: 'parallel',
+          thresholdTemplate: 'direct',
+          thresholdOverrides: [1, 2, 3],
+          active: true,
+          labels: { title: 'Secure Inklet', shortLabel: 'Inklet' },
+          sourceMonsterIds: ['inklet'],
+          progressKey: 'inklet',
+          sourceNote: 'Normaliser fixture.',
+        }],
       },
       actor: CONTENT_OPS_SPELLING_BROWSE.actor,
     });
@@ -842,7 +859,14 @@ describe('Content Operations Centre normalisers', () => {
     assert.equal(browse.pools[0].draftStateCounts.modified, 1);
     assert.equal(browse.pools[1].id, 'secure-vocabulary');
     assert.equal(browse.pools[1].pool, 'secure-vocabulary');
+    assert.deepEqual(browse.pools[1].rewardTrackIds, ['secure-track', 'secure-vellhorn']);
     assert.equal(browse.pools[1].rewardTrack.approved, true);
+    assert.equal(browse.pools[1].activeWordCount, 12);
+    assert.equal(browse.pools[1].totalWordCount, 15);
+    assert.equal(browse.rewardTracks[0].id, 'secure-track');
+    assert.equal(browse.rewardTracks[0].poolId, 'secure-vocabulary');
+    assert.equal(browse.rewardTracks[0].labels.title, 'Secure Inklet');
+    assert.deepEqual(browse.rewardTracks[0].thresholdOverrides, [1, 2, 3]);
     assert.equal(browse.wordLists[0].title, 'Extra Greek roots');
     assert.equal(browse.words[0].draftState, 'modified');
     assert.deepEqual(browse.words[0].audioReadiness.wordProfiles, ['male.natural', 'female.natural']);

--- a/tests/button-label-consistency.test.js
+++ b/tests/button-label-consistency.test.js
@@ -554,6 +554,14 @@ test('button labels: every statically extractable label is classified', () => {
     'Edit pool',
     'New pool',
     'Save pool',
+    // Content Operations Centre T19: reward-track editor controls are
+    // package-scoped and intentionally track-specific so operators can
+    // distinguish pool metadata edits from reward configuration edits.
+    'Edit track',
+    'New track',
+    'Save reward track',
+    'Retire track',
+    'Delete draft track',
     // Content Operations Centre T16: audio operations controls are
     // package-scoped and need explicit scan/generate/regenerate wording so
     // operators can distinguish missing-audio generation from override.

--- a/tests/react-admin-content-operations.test.js
+++ b/tests/react-admin-content-operations.test.js
@@ -271,7 +271,20 @@ const spellingBrowse = {
     filters: { query: '', pool: 'all', listId: '', limit: 75 },
     totals: { words: 1, displayedWords: 1, matchedWords: 1, wordLists: 1, sentences: 2, variants: 1, families: 1 },
     draftStateCounts: { added: 0, modified: 1, removed: 0, unchanged: 0 },
-    pools: [{ pool: 'extra', wordCount: 1, sentenceCount: 2, variantCount: 1, draftStateCounts: { modified: 1 } }],
+    pools: [{
+      id: 'extra',
+      pool: 'extra',
+      title: 'Extra',
+      type: 'enrichment',
+      visibility: { state: 'hidden', learnerVisible: false },
+      rewardTrackIds: ['extra-vellhorn'],
+      wordCount: 1,
+      totalWordCount: 1,
+      sentenceCount: 2,
+      variantCount: 1,
+      draftStateCounts: { modified: 1 },
+      draftState: 'unchanged',
+    }],
     wordLists: [{
       id: 'extra-greek',
       title: 'Extra Greek roots',
@@ -317,6 +330,24 @@ const spellingBrowse = {
         wordListId: 'extra-greek',
         monsterBinding: { mode: 'pool', poolId: 'extra', assignment: 'unresolved' },
       },
+    }],
+    rewardTracks: [{
+      id: 'extra-vellhorn',
+      poolId: 'extra',
+      monsterId: 'vellhorn',
+      progressionMode: 'parallel',
+      thresholdTemplate: 'direct',
+      thresholdOverrides: [1],
+      active: true,
+      progressKey: 'vellhorn',
+      sourceMonsterIds: ['vellhorn'],
+      labels: {
+        title: 'Extra Vellhorn',
+        shortLabel: 'Vellhorn',
+        description: 'Existing Extra spelling reward track.',
+      },
+      sourceNote: 'Seed fixture.',
+      sortIndex: 0,
     }],
   },
 };
@@ -1393,6 +1424,7 @@ test('Content Operations Centre spelling pool editor appends pool upsert operati
       await setControl('[data-content-ops-pool-field="title"]', 'Extra spelling revised');
       await setControl('[data-content-ops-pool-field="type"]', 'enrichment');
       await setControl('[data-content-ops-pool-field="visibilityState"]', 'hidden');
+      await setControl('[data-content-ops-pool-field="rewardTrackIds"]', 'extra-vellhorn, extra-inklet');
       await setControl('[data-content-ops-pool-field="sourceNote"]', 'Edited in Content Operations Centre.');
       await setControl('[data-content-ops-pool-field="provenanceSource"]', 'admin-editor');
       const saveButton = Array.from(document.querySelectorAll('button'))
@@ -1432,12 +1464,475 @@ test('Content Operations Centre spelling pool editor appends pool upsert operati
   assert.equal(appendCall.args.operation.payload.title, 'Extra spelling revised');
   assert.equal(appendCall.args.operation.payload.type, 'enrichment');
   assert.equal(appendCall.args.operation.payload.visibility.state, 'hidden');
+  assert.deepEqual(appendCall.args.operation.payload.rewardTrackIds, ['extra-vellhorn', 'extra-inklet']);
   assert.equal(appendCall.args.mutation.requestId.startsWith('content-ops-pool-upsert-pkg-draft-1-'), true);
   assert.match(result.text, /Pool operation saved/);
   assert.match(result.text, /Secure vocabulary/);
   assert.ok(result.optionValues.browse.includes('secure-vocabulary'));
   assert.ok(result.optionValues.word.includes('secure-vocabulary'));
   assert.ok(result.optionValues.wordList.includes('secure-vocabulary'));
+});
+
+test('Content Operations Centre pools and rewards tab appends reward-track upsert operations', async () => {
+  const spellingBrowseWithRewardCapacity = {
+    browse: {
+      ...spellingBrowse.browse,
+      pools: spellingBrowse.browse.pools.map((pool) => ({
+        ...pool,
+        wordCount: 250,
+        totalWordCount: 250,
+      })),
+    },
+  };
+  const output = await runClientEntry(`
+    const { JSDOM } = require('jsdom');
+
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+    const dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
+      url: 'https://ks2.eugnel.uk/admin',
+    });
+    globalThis.window = dom.window;
+    globalThis.document = dom.window.document;
+    globalThis.navigator = dom.window.navigator;
+    globalThis.HTMLElement = dom.window.HTMLElement;
+    globalThis.Event = dom.window.Event;
+
+    const React = require('react');
+    const { createRoot } = require('react-dom/client');
+    const { AdminContentOperationsSection } = require(${CONTENT_OPS_SECTION_PATH});
+    const { act } = React;
+
+    const calls = [];
+    const model = ${JSON.stringify(baseModel({
+      contentOperations: {
+        overview,
+        packages: { packages: [contentPackage] },
+        releases: { releases: [release] },
+        spellingBrowse: spellingBrowseWithRewardCapacity,
+        spellingItemDetail: spellingWordDetail,
+      },
+    }))};
+    const actions = {
+      contentOperationsApi: {
+        async readSpellingWord(args) {
+          calls.push({ method: 'readSpellingWord', args });
+          return ${JSON.stringify(spellingWordDetail)};
+        },
+        async appendOperation(args) {
+          calls.push({ method: 'appendOperation', args });
+          return { ok: true, operation: { operationId: 'op-reward-save-1', ...args.operation } };
+        },
+      },
+    };
+
+    async function flush() {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+    }
+
+    async function setControl(selector, value) {
+      const control = document.querySelector(selector);
+      const prototype = control.tagName === 'TEXTAREA'
+        ? dom.window.HTMLTextAreaElement.prototype
+        : (control.tagName === 'SELECT'
+            ? dom.window.HTMLSelectElement.prototype
+            : dom.window.HTMLInputElement.prototype);
+      const valueSetter = Object.getOwnPropertyDescriptor(prototype, 'value').set;
+      valueSetter.call(control, value);
+      await act(async () => {
+        control.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
+        control.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+      });
+    }
+
+    async function main() {
+      const root = createRoot(document.getElementById('root'));
+      await act(async () => {
+        root.render(React.createElement(AdminContentOperationsSection, {
+          model,
+          actions,
+          initialActiveTab: 'poolsRewards',
+          initialSelectedPackageId: 'pkg-draft-1',
+        }));
+      });
+      await flush();
+
+      const newTrackButton = Array.from(document.querySelectorAll('button'))
+        .find((button) => button.textContent === 'New track');
+      await act(async () => {
+        newTrackButton.click();
+      });
+
+      await setControl('[data-content-ops-reward-field="id"]', 'extra-inklet');
+      await setControl('[data-content-ops-reward-field="poolId"]', 'extra');
+      await setControl('[data-content-ops-reward-field="monsterId"]', 'inklet');
+      await setControl('[data-content-ops-reward-field="progressionMode"]', 'parallel');
+      await setControl('[data-content-ops-reward-field="thresholdTemplate"]', 'direct');
+      await setControl('[data-content-ops-reward-field="thresholdOverrides"]', '');
+      await setControl('[data-content-ops-reward-field="progressKey"]', 'inklet');
+      await setControl('[data-content-ops-reward-field="sourceMonsterIds"]', 'inklet');
+      await setControl('[data-content-ops-reward-field="labelsTitle"]', 'Extra Inklet');
+      await setControl('[data-content-ops-reward-field="labelsShortLabel"]', 'Inklet');
+      await setControl('[data-content-ops-reward-field="sourceNote"]', 'Edited in Content Operations Centre.');
+
+      const saveButton = Array.from(document.querySelectorAll('button'))
+        .find((button) => button.textContent === 'Save reward track');
+      await act(async () => {
+        saveButton.click();
+      });
+      await flush();
+      await flush();
+
+      process.stdout.write(JSON.stringify({
+        calls,
+        text: document.body.textContent,
+        area: document.querySelector('[data-content-ops-area]')?.getAttribute('data-content-ops-area'),
+      }));
+
+      await act(async () => {
+        root.unmount();
+      });
+      dom.window.close();
+      process.exit(0);
+    }
+
+    main().catch((error) => {
+      process.stderr.write(error.stack || error.message);
+      process.exitCode = 1;
+    });
+  `);
+  const result = JSON.parse(output);
+  const appendCall = result.calls.find((entry) => entry.method === 'appendOperation');
+
+  assert.equal(result.area, 'poolsRewards');
+  assert.ok(appendCall, 'reward-track editor should append an operation');
+  assert.equal(appendCall.args.packageId, 'pkg-draft-1');
+  assert.equal(appendCall.args.operation.entityType, 'spelling.rewardTrack');
+  assert.equal(appendCall.args.operation.action, 'upsert');
+  assert.equal(appendCall.args.operation.entityId, 'extra-inklet');
+  assert.equal(appendCall.args.operation.payload.poolId, 'extra');
+  assert.equal(appendCall.args.operation.payload.monsterId, 'inklet');
+  assert.deepEqual(appendCall.args.operation.payload.thresholdOverrides, []);
+  assert.equal(appendCall.args.operation.payload.labels.title, 'Extra Inklet');
+  assert.equal(appendCall.args.mutation.requestId.startsWith('content-ops-reward-track-upsert-pkg-draft-1-'), true);
+  assert.match(result.text, /Reward track operation saved/);
+});
+
+test('Content Operations Centre pools and rewards tab cold-loads spelling browse data', async () => {
+  const output = await runClientEntry(`
+    const { JSDOM } = require('jsdom');
+
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+    const dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
+      url: 'https://ks2.eugnel.uk/admin',
+    });
+    globalThis.window = dom.window;
+    globalThis.document = dom.window.document;
+    globalThis.navigator = dom.window.navigator;
+    globalThis.HTMLElement = dom.window.HTMLElement;
+    globalThis.Event = dom.window.Event;
+
+    const React = require('react');
+    const { createRoot } = require('react-dom/client');
+    const { AdminContentOperationsSection } = require(${CONTENT_OPS_SECTION_PATH});
+    const { act } = React;
+
+    const calls = [];
+    const model = ${JSON.stringify(baseModel({
+      contentOperations: {
+        overview,
+        packages: { packages: [contentPackage] },
+        releases: { releases: [release] },
+        spellingBrowse: null,
+        spellingItemDetail: null,
+      },
+    }))};
+    const actions = {
+      contentOperationsApi: {
+        async readSpellingBrowse(args) {
+          calls.push({ method: 'readSpellingBrowse', args });
+          return ${JSON.stringify(spellingBrowse)};
+        },
+      },
+    };
+
+    async function flush() {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+    }
+
+    async function main() {
+      const root = createRoot(document.getElementById('root'));
+      await act(async () => {
+        root.render(React.createElement(AdminContentOperationsSection, {
+          model,
+          actions,
+          initialActiveTab: 'poolsRewards',
+          initialSelectedPackageId: 'pkg-draft-1',
+        }));
+      });
+      await flush();
+      await flush();
+
+      process.stdout.write(JSON.stringify({ calls, text: document.body.textContent }));
+
+      await act(async () => {
+        root.unmount();
+      });
+      dom.window.close();
+      process.exit(0);
+    }
+
+    main().catch((error) => {
+      process.stderr.write(error.stack || error.message);
+      process.exitCode = 1;
+    });
+  `);
+  const result = JSON.parse(output);
+  assert.deepEqual(result.calls, [{
+    method: 'readSpellingBrowse',
+    args: { packageId: 'pkg-draft-1', query: '', pool: null, listId: null, limit: 75 },
+  }]);
+  assert.match(result.text, /Extra Vellhorn/);
+});
+
+test('Content Operations Centre reward editor rejects invalid or impossible threshold overrides before append', async () => {
+  const spellingBrowseWithLowActiveCount = {
+    browse: {
+      ...spellingBrowse.browse,
+      pools: spellingBrowse.browse.pools.map((pool) => ({
+        ...pool,
+        activeWordCount: 1,
+        wordCount: 0,
+        totalWordCount: 250,
+      })),
+    },
+  };
+  const output = await runClientEntry(`
+    const { JSDOM } = require('jsdom');
+
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+    const dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
+      url: 'https://ks2.eugnel.uk/admin',
+    });
+    globalThis.window = dom.window;
+    globalThis.document = dom.window.document;
+    globalThis.navigator = dom.window.navigator;
+    globalThis.HTMLElement = dom.window.HTMLElement;
+    globalThis.Event = dom.window.Event;
+
+    const React = require('react');
+    const { createRoot } = require('react-dom/client');
+    const { AdminContentOperationsSection } = require(${CONTENT_OPS_SECTION_PATH});
+    const { act } = React;
+
+    const calls = [];
+    const model = ${JSON.stringify(baseModel({
+      contentOperations: {
+        overview,
+        packages: { packages: [contentPackage] },
+        releases: { releases: [release] },
+        spellingBrowse: spellingBrowseWithLowActiveCount,
+        spellingItemDetail: spellingWordDetail,
+      },
+    }))};
+    const actions = {
+      contentOperationsApi: {
+        async appendOperation(args) {
+          calls.push({ method: 'appendOperation', args });
+          return { ok: true, operation: { operationId: 'op-reward-save-1', ...args.operation } };
+        },
+      },
+    };
+
+    async function flush() {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+    }
+
+    async function setControl(selector, value) {
+      const control = document.querySelector(selector);
+      const prototype = control.tagName === 'TEXTAREA'
+        ? dom.window.HTMLTextAreaElement.prototype
+        : (control.tagName === 'SELECT'
+            ? dom.window.HTMLSelectElement.prototype
+            : dom.window.HTMLInputElement.prototype);
+      const valueSetter = Object.getOwnPropertyDescriptor(prototype, 'value').set;
+      valueSetter.call(control, value);
+      await act(async () => {
+        control.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
+        control.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+      });
+    }
+
+    async function saveNewTrack(thresholdOverrides) {
+      const newTrackButton = Array.from(document.querySelectorAll('button'))
+        .find((button) => button.textContent === 'New track');
+      await act(async () => {
+        newTrackButton.click();
+      });
+      await setControl('[data-content-ops-reward-field="id"]', 'extra-inklet');
+      await setControl('[data-content-ops-reward-field="poolId"]', 'extra');
+      await setControl('[data-content-ops-reward-field="monsterId"]', 'inklet');
+      await setControl('[data-content-ops-reward-field="thresholdOverrides"]', thresholdOverrides);
+      const saveButton = Array.from(document.querySelectorAll('button'))
+        .find((button) => button.textContent === 'Save reward track');
+      await act(async () => {
+        saveButton.click();
+      });
+      await flush();
+    }
+
+    async function main() {
+      const root = createRoot(document.getElementById('root'));
+      await act(async () => {
+        root.render(React.createElement(AdminContentOperationsSection, {
+          model,
+          actions,
+          initialActiveTab: 'poolsRewards',
+          initialSelectedPackageId: 'pkg-draft-1',
+        }));
+      });
+      await flush();
+
+      await saveNewTrack('1, nope, 3');
+      const invalidText = document.body.textContent;
+      await setControl('[data-content-ops-reward-field="thresholdOverrides"]', '2');
+      const saveButton = Array.from(document.querySelectorAll('button'))
+        .find((button) => button.textContent === 'Save reward track');
+      await act(async () => {
+        saveButton.click();
+      });
+      await flush();
+      const impossibleText = document.body.textContent;
+
+      process.stdout.write(JSON.stringify({ calls, invalidText, impossibleText }));
+
+      await act(async () => {
+        root.unmount();
+      });
+      dom.window.close();
+      process.exit(0);
+    }
+
+    main().catch((error) => {
+      process.stderr.write(error.stack || error.message);
+      process.exitCode = 1;
+    });
+  `);
+  const result = JSON.parse(output);
+  assert.deepEqual(result.calls, []);
+  assert.match(result.invalidText, /invalid value "nope"/);
+  assert.match(result.impossibleText, /needs 2 active word\(s\), but pool "extra" has 1/);
+});
+
+test('Content Operations Centre reward editor retires existing reward tracks', async () => {
+  const output = await runClientEntry(`
+    const { JSDOM } = require('jsdom');
+
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+    const dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
+      url: 'https://ks2.eugnel.uk/admin',
+    });
+    globalThis.window = dom.window;
+    globalThis.document = dom.window.document;
+    globalThis.navigator = dom.window.navigator;
+    globalThis.HTMLElement = dom.window.HTMLElement;
+    globalThis.Event = dom.window.Event;
+
+    const React = require('react');
+    const { createRoot } = require('react-dom/client');
+    const { AdminContentOperationsSection } = require(${CONTENT_OPS_SECTION_PATH});
+    const { act } = React;
+
+    const calls = [];
+    const model = ${JSON.stringify(baseModel({
+      contentOperations: {
+        overview,
+        packages: { packages: [contentPackage] },
+        releases: { releases: [release] },
+        spellingBrowse,
+        spellingItemDetail: spellingWordDetail,
+      },
+    }))};
+    const actions = {
+      contentOperationsApi: {
+        async appendOperation(args) {
+          calls.push({ method: 'appendOperation', args });
+          return { ok: true, operation: { operationId: 'op-reward-retire-1', ...args.operation } };
+        },
+      },
+    };
+
+    async function flush() {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+    }
+
+    async function setControl(selector, value) {
+      const control = document.querySelector(selector);
+      const prototype = control.tagName === 'TEXTAREA'
+        ? dom.window.HTMLTextAreaElement.prototype
+        : (control.tagName === 'SELECT'
+            ? dom.window.HTMLSelectElement.prototype
+            : dom.window.HTMLInputElement.prototype);
+      const valueSetter = Object.getOwnPropertyDescriptor(prototype, 'value').set;
+      valueSetter.call(control, value);
+      await act(async () => {
+        control.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
+        control.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+      });
+    }
+
+    async function main() {
+      const root = createRoot(document.getElementById('root'));
+      await act(async () => {
+        root.render(React.createElement(AdminContentOperationsSection, {
+          model,
+          actions,
+          initialActiveTab: 'poolsRewards',
+          initialSelectedPackageId: 'pkg-draft-1',
+        }));
+      });
+      await flush();
+
+      await setControl('[data-content-ops-reward-field="retirementReason"]', 'Replacing the reward route.');
+      const retireButton = Array.from(document.querySelectorAll('button'))
+        .find((button) => button.textContent === 'Retire track');
+      await act(async () => {
+        retireButton.click();
+      });
+      await flush();
+      await flush();
+
+      process.stdout.write(JSON.stringify({ calls, text: document.body.textContent }));
+
+      await act(async () => {
+        root.unmount();
+      });
+      dom.window.close();
+      process.exit(0);
+    }
+
+    main().catch((error) => {
+      process.stderr.write(error.stack || error.message);
+      process.exitCode = 1;
+    });
+  `);
+  const result = JSON.parse(output);
+  const appendCall = result.calls.find((entry) => entry.method === 'appendOperation');
+
+  assert.ok(appendCall, 'reward-track editor should append a retire operation');
+  assert.equal(appendCall.args.operation.entityType, 'spelling.rewardTrack');
+  assert.equal(appendCall.args.operation.entityId, 'extra-vellhorn');
+  assert.equal(appendCall.args.operation.action, 'retire');
+  assert.equal(appendCall.args.operation.payload.reason, 'Replacing the reward route.');
+  assert.equal(appendCall.args.mutation.requestId.startsWith('content-ops-reward-track-retire-pkg-draft-1-'), true);
+  assert.match(result.text, /Reward track retired/);
 });
 
 test('Content Operations Centre spelling tab reloads browse data after package selection changes', async () => {

--- a/tests/spelling-content-operations-model.test.js
+++ b/tests/spelling-content-operations-model.test.js
@@ -330,8 +330,30 @@ test('spelling content operations browse exposes pool metadata and future hidden
   assert.equal(securePool.type, 'extension');
   assert.equal(securePool.visibility.state, 'hidden');
   assert.equal(securePool.wordCount, 0);
+  assert.equal(securePool.activeWordCount, 0);
   assert.equal(secureList.spellingPool, 'secure-vocabulary');
   assert.equal(secureList.coverageTier, 'secure-extension');
+});
+
+test('spelling content operations browse exposes active word counts for hidden reward validation', () => {
+  const bundle = contentBundle();
+  addFuturePoolWord(bundle, {
+    poolId: 'secure-hidden',
+    title: 'Secure hidden',
+    visibilityState: 'hidden',
+    slug: 'hiddenword',
+    word: 'hiddenword',
+  });
+
+  const browse = buildSpellingContentBrowseModel({
+    publishedContent: bundle,
+    filters: { pool: 'secure-hidden', limit: 20 },
+  });
+  const securePool = browse.pools.find((pool) => pool.id === 'secure-hidden');
+
+  assert.equal(securePool.wordCount, 0);
+  assert.equal(securePool.activeWordCount, 1);
+  assert.equal(securePool.totalWordCount, 1);
 });
 
 test('spelling published snapshot filters hidden and staged pool words but keeps visible approved pool words', () => {

--- a/tests/spelling-reward-tracks.test.js
+++ b/tests/spelling-reward-tracks.test.js
@@ -15,6 +15,7 @@ import {
 } from '../src/subjects/spelling/content/operations-model.js';
 import {
   buildSpellingPoolUpsertOperation,
+  buildSpellingRewardTrackDeleteOrRetireOperation,
   buildSpellingRewardTrackUpsertOperation,
   normaliseSpellingPoolEditorInput,
   validateSpellingRewardTrackEditorInput,
@@ -395,6 +396,65 @@ test('reward-track editor validator catches duplicate ids in context', () => {
 
   assert.equal(validation.ok, false);
   assert.ok(validation.errors.some((entry) => entry.code === 'duplicate_reward_track'));
+});
+
+test('reward-track editor operation normalises UI-submitted source monsters and inactive state', () => {
+  const operation = buildSpellingRewardTrackUpsertOperation({
+    id: 'secure-vellhorn',
+    poolId: 'secure-vocabulary',
+    monsterId: 'vellhorn',
+    thresholdOverrides: [1, 2],
+    sourceMonsterIds: 'vellhorn, inklet',
+    active: false,
+    labels: { title: 'Secure Vellhorn' },
+  }, {
+    pools: [poolFixture('secure-vocabulary', { visibilityState: 'hidden' })],
+    poolWordCounts: { 'secure-vocabulary': 2 },
+    enforceThresholdsForHiddenPools: true,
+  });
+
+  assert.equal(operation.entityType, 'spelling.rewardTrack');
+  assert.equal(operation.payload.active, false);
+  assert.deepEqual(operation.payload.sourceMonsterIds, ['vellhorn', 'inklet']);
+  assert.deepEqual(operation.payload.thresholdOverrides, [1, 2]);
+});
+
+test('reward-track editor can remove draft tracks or retire published tracks', () => {
+  const removeDraft = buildSpellingRewardTrackDeleteOrRetireOperation({
+    id: 'secure-inklet',
+    hasCurrent: false,
+  });
+  const retirePublished = buildSpellingRewardTrackDeleteOrRetireOperation({
+    id: 'secure-inklet',
+    hasCurrent: true,
+    reason: 'Replacing the track with a new monster route.',
+  }, {
+    now: () => NOW,
+  });
+  const base = rewardBundle({
+    pools: [poolFixture('secure-vocabulary', {
+      visibilityState: 'hidden',
+      rewardTrackIds: ['secure-inklet'],
+    })],
+    rewardTracks: [{
+      id: 'secure-inklet',
+      poolId: 'secure-vocabulary',
+      monsterId: 'inklet',
+      thresholdOverrides: [1],
+    }],
+    wordCounts: { 'secure-vocabulary': 1 },
+  });
+  const candidate = buildSpellingContentOperationCandidate(base, [retirePublished]);
+  const retiredTrack = candidate.validation.bundle.draft.rewardTracks.find((track) => track.id === 'secure-inklet');
+
+  assert.equal(removeDraft.action, 'remove');
+  assert.equal(removeDraft.payload, null);
+  assert.equal(retirePublished.action, 'retire');
+  assert.equal(retirePublished.payload.reason, 'Replacing the track with a new monster route.');
+  assert.equal(retirePublished.payload.retiredAt, NOW);
+  assert.equal(retiredTrack.active, false);
+  assert.equal(retiredTrack.retired, true);
+  assert.equal(retiredTrack.retirement.reason, 'Replacing the track with a new monster route.');
 });
 
 test('pool editor can clear existing formal reward-track bindings', () => {


### PR DESCRIPTION
## Summary
- Add the Content Operations Centre Pools & Rewards editor for pool reward-track bindings, reward-track metadata, thresholds, ordering, dependency approvals, and retirement/removal operations.
- Surface reward-track state in the spelling browse read model and admin normalisers, including active word counts for threshold validation.
- Add regression coverage for Pools & Rewards cold loading, invalid thresholds, active-word threshold caps, reward-track retirement, and button-label policy.

## Validation
- npm test -- tests/react-admin-content-operations.test.js
- npm test -- tests/spelling-reward-tracks.test.js
- npm test -- tests/spelling-content-operations-model.test.js
- npm test -- tests/admin-content-operations-v2.test.js
- npm test -- tests/button-label-consistency.test.js
- npm run check
- npm test
- pre-push npm test

## Notes
- The worktree still has unstaged generated/report noise from build and test commands; the commit stages only the intended T19 source, style, and test files.