### PR TITLE
feat(content-ops): add hero codex exposure controls

### DIFF
--- a/shared/spelling/service.js
+++ b/shared/spelling/service.js
@@ -1332,6 +1332,11 @@ export function createSpellingService({ repository, storage, tts, now, random, c
   const runtimeWordBySlug = contentSnapshot?.wordBySlug && typeof contentSnapshot.wordBySlug === 'object' && !Array.isArray(contentSnapshot.wordBySlug)
     ? cloneSerialisable(contentSnapshot.wordBySlug)
     : Object.fromEntries(runtimeWords.map((word) => [word.slug, cloneSerialisable(word)]));
+  const runtimeContentSnapshot = contentSnapshot && typeof contentSnapshot === 'object' && !Array.isArray(contentSnapshot)
+    ? cloneSerialisable(contentSnapshot)
+    : {};
+  runtimeContentSnapshot.words = cloneSerialisable(runtimeWords);
+  runtimeContentSnapshot.wordBySlug = cloneSerialisable(runtimeWordBySlug);
   const isRuntimeKnownSlug = (slug) => isKnownSlug(slug, runtimeWordBySlug);
   const engine = createLegacySpellingEngine({
     words: runtimeWords,
@@ -4129,6 +4134,13 @@ export function createSpellingService({ repository, storage, tts, now, random, c
 
   return {
     initState,
+    getRuntimeContentSnapshot() {
+      return cloneSerialisable(runtimeContentSnapshot);
+    },
+    getRuntimeRewardTracks() {
+      const rewardTracks = runtimeContentSnapshot?.rewardTracks;
+      return Array.isArray(rewardTracks) ? cloneSerialisable(rewardTracks) : null;
+    },
     getPrefs,
     savePrefs,
     getStats,

--- a/src/platform/game/mastery/spelling.js
+++ b/src/platform/game/mastery/spelling.js
@@ -4,6 +4,8 @@ import {
   stageFor,
 } from '../monsters.js';
 import {
+  LEGACY_SPELLING_REWARD_TRACKS,
+  rewardTracksVisibleForHeroSurface,
   spellingRewardTrackForMonster,
   thresholdsForRewardTrack,
 } from '../reward-track-config.js';
@@ -85,11 +87,40 @@ function secureWordsFromAnalytics(analytics, branchState = {}) {
   return state;
 }
 
-export function progressForMonster(state, monsterId) {
-  if (monsterId === 'phaeton') return derivePhaeton(state);
+function visibleSpellingMonsterIdsForHeroSurface(rewardTracks, {
+  surface = 'codex',
+  now = Date.now(),
+  env = {},
+} = {}) {
+  if (!Array.isArray(rewardTracks)) return null;
+  const visibleTrackSet = new Set(
+    rewardTracksVisibleForHeroSurface(
+      rewardTracks.length ? rewardTracks : [],
+      { surface, now, env },
+    ).map((track) => track.monsterId),
+  );
+  return SPELLING_MONSTER_IDS.filter((monsterId) => visibleTrackSet.has(monsterId));
+}
+
+function spellingMonsterIdsForSummary(state = {}, options = {}) {
+  const byRewardTrack = visibleSpellingMonsterIdsForHeroSurface(options.rewardTracks, options);
+  if (byRewardTrack) return byRewardTrack;
+
+  const exposedSpellingMonsterIds = SPELLING_MONSTER_IDS
+    .filter((monsterId) => state?.[monsterId]?.visibleInCodex === true);
+  return exposedSpellingMonsterIds.length ? exposedSpellingMonsterIds : SPELLING_MONSTER_IDS;
+}
+
+export function progressForMonster(state, monsterId, { rewardTracks = LEGACY_SPELLING_REWARD_TRACKS } = {}) {
+  if (monsterId === 'phaeton') {
+    const progress = derivePhaeton(state);
+    return state?.phaeton?.visibleInCodex === true
+      ? { ...progress, visibleInCodex: true }
+      : progress;
+  }
   const entry = isPlainObject(state?.[monsterId]) ? state[monsterId] : { mastered: [], caught: false };
   const mastered = masteredCount(entry);
-  const rewardTrack = spellingRewardTrackForMonster(monsterId);
+  const rewardTrack = spellingRewardTrackForMonster(monsterId, rewardTracks);
   return {
     mastered,
     stage: stageFor(mastered, rewardTrack ? thresholdsForRewardTrack(rewardTrack) : undefined),
@@ -97,6 +128,7 @@ export function progressForMonster(state, monsterId) {
     caught: mastered >= 1,
     branch: branchForMonster(state, monsterId),
     masteredList: masteredList(entry),
+    ...(entry.visibleInCodex === true ? { visibleInCodex: true } : {}),
     ...(rewardTrack ? {
       rewardTrackId: rewardTrack.id,
       progressKey: rewardTrack.progressKey || monsterId,
@@ -148,11 +180,20 @@ export function monsterSummary(learnerId, gameStateRepository, { punctuationStar
   return monsterSummaryFromState(state, { punctuationStarView });
 }
 
-export function monsterSummaryFromState(state = {}, { punctuationStarView = null } = {}) {
-  const spelling = SPELLING_MONSTER_IDS.map((monsterId) => ({
+export function monsterSummaryFromState(state = {}, {
+  punctuationStarView = null,
+  rewardTracks = null,
+  surface = 'codex',
+  now = Date.now(),
+  env = {},
+} = {}) {
+  const spellingMonsterIds = spellingMonsterIdsForSummary(state, { rewardTracks, surface, now, env });
+  const spelling = spellingMonsterIds.map((monsterId) => ({
     subjectId: 'spelling',
     monster: MONSTERS[monsterId],
-    progress: progressForMonster(state, monsterId),
+    progress: progressForMonster(state, monsterId, {
+      rewardTracks: Array.isArray(rewardTracks) ? rewardTracks : LEGACY_SPELLING_REWARD_TRACKS,
+    }),
   }));
   // Route Grammar through `normaliseGrammarRewardState` so pre-flip learners
   // whose only evidence is under a retired direct id (Glossbloom / Loomrill /
@@ -174,6 +215,10 @@ export function monsterSummaryFromSpellingAnalytics(analytics, {
   learnerId = null,
   gameStateRepository = null,
   punctuationStarView = null,
+  rewardTracks = null,
+  surface = 'codex',
+  now = Date.now(),
+  env = {},
   random = Math.random,
   persistBranches = true,
 } = {}) {
@@ -192,7 +237,13 @@ export function monsterSummaryFromSpellingAnalytics(analytics, {
   }
 
   if (!analyticsHasWordRows(analytics) && hasMonsterMasteryProgress(branchState)) {
-    return monsterSummaryFromState(branchState, { punctuationStarView });
+    return monsterSummaryFromState(branchState, {
+      punctuationStarView,
+      rewardTracks,
+      surface,
+      now,
+      env,
+    });
   }
 
   const state = secureWordsFromAnalytics(analytics, branchState);
@@ -201,7 +252,12 @@ export function monsterSummaryFromSpellingAnalytics(analytics, {
   // pre-flip retired-id progress still surfaces Concordium on the meadow.
   const normalisedBranchState = normaliseGrammarRewardState(branchState);
   return [
-    ...monsterSummaryFromState(state),
+    ...monsterSummaryFromState(state, {
+      rewardTracks,
+      surface,
+      now,
+      env,
+    }),
     ...activePunctuationMonsterSummaryFromState(branchState, { starView: punctuationStarView }),
     ...activeGrammarMonsterSummaryFromState(normalisedBranchState),
     ...activeReadingMonsterSummaryFromState(branchState),

--- a/src/platform/game/reward-track-config.js
+++ b/src/platform/game/reward-track-config.js
@@ -9,6 +9,39 @@ export const REWARD_TRACK_PROGRESS_MODES = Object.freeze(['parallel', 'sequentia
 export const DEFAULT_REWARD_TRACK_PROGRESS_MODE = 'parallel';
 export const DEFAULT_REWARD_TRACK_THRESHOLD_TEMPLATE = 'direct';
 
+const HERO_EXPOSURE_STATE_ALIASES = Object.freeze({
+  rolloutFlagged: 'rollout-flagged',
+  rollout_flagged: 'rollout-flagged',
+  rollout: 'rollout-flagged',
+  flagged: 'rollout-flagged',
+  staged: 'scheduled',
+});
+
+export const HERO_EXPOSURE_STATES = Object.freeze([
+  'visible',
+  'hidden',
+  'scheduled',
+  'rollout-flagged',
+]);
+
+export const HERO_EXPOSURE_SURFACES = Object.freeze([
+  'heroCamp',
+  'heroQuest',
+  'codex',
+  'subjectSetup',
+]);
+
+export const DEFAULT_HERO_EXPOSURE = Object.freeze({
+  state: 'visible',
+  surfaces: HERO_EXPOSURE_SURFACES,
+  scheduledAt: 0,
+  rolloutFlag: '',
+  previewAllowed: true,
+});
+
+const HERO_EXPOSURE_STATE_SET = new Set(HERO_EXPOSURE_STATES);
+const HERO_EXPOSURE_SURFACE_SET = new Set(HERO_EXPOSURE_SURFACES);
+
 export const SPELLING_REWARD_TRACK_MONSTER_IDS = Object.freeze([...MONSTERS_BY_SUBJECT.spelling]);
 
 export const REWARD_TRACK_THRESHOLD_TEMPLATES = Object.freeze({
@@ -25,10 +58,15 @@ export const REWARD_TRACK_THRESHOLD_TEMPLATES = Object.freeze({
 });
 
 function freezeLegacyTrack(track) {
+  const heroExposure = normaliseHeroExposure(track.heroExposure);
   return Object.freeze({
     ...track,
     labels: Object.freeze({ ...(track.labels || {}) }),
     sourceMonsterIds: Object.freeze([...(track.sourceMonsterIds || [])]),
+    heroExposure: Object.freeze({
+      ...heroExposure,
+      surfaces: Object.freeze([...heroExposure.surfaces]),
+    }),
   });
 }
 
@@ -131,6 +169,89 @@ function normaliseIdentifier(value, fallback = '') {
 function normaliseTimestamp(value, fallback = 0) {
   const numeric = Number(value);
   return Number.isFinite(numeric) && numeric >= 0 ? numeric : fallback;
+}
+
+function normaliseHeroExposureState(value, fallback = DEFAULT_HERO_EXPOSURE.state) {
+  const raw = normaliseString(value, fallback);
+  const aliased = HERO_EXPOSURE_STATE_ALIASES[raw] || raw;
+  return HERO_EXPOSURE_STATE_SET.has(aliased) ? aliased : fallback;
+}
+
+function normaliseHeroExposureSurfaces(value, fallback = DEFAULT_HERO_EXPOSURE.surfaces) {
+  const hasExplicitValue = Array.isArray(value) || typeof value === 'string';
+  const source = Array.isArray(value)
+    ? value
+    : (typeof value === 'string' ? value.split(/[\n,]+/) : fallback);
+  const seen = new Set();
+  const output = [];
+  for (const entry of source) {
+    const surface = normaliseString(entry);
+    if (!HERO_EXPOSURE_SURFACE_SET.has(surface) || seen.has(surface)) continue;
+    seen.add(surface);
+    output.push(surface);
+  }
+  if (output.length) return output;
+  return hasExplicitValue ? [] : [...DEFAULT_HERO_EXPOSURE.surfaces];
+}
+
+function heroExposureEnvFlagEnabled(env, flagName) {
+  const name = normaliseString(flagName);
+  if (!name) return false;
+  const value = isPlainObject(env) ? env[name] : undefined;
+  return ['1', 'true', 'yes', 'on'].includes(String(value || '').trim().toLowerCase());
+}
+
+export function isKnownHeroExposureState(value) {
+  const raw = normaliseString(value);
+  const aliased = HERO_EXPOSURE_STATE_ALIASES[raw] || raw;
+  return HERO_EXPOSURE_STATE_SET.has(aliased);
+}
+
+export function isKnownHeroExposureSurface(value) {
+  return HERO_EXPOSURE_SURFACE_SET.has(normaliseString(value));
+}
+
+export function normaliseHeroExposure(rawValue = null, fallback = null) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  const safeFallback = isPlainObject(fallback) ? fallback : DEFAULT_HERO_EXPOSURE;
+  return {
+    state: normaliseHeroExposureState(raw.state, normaliseHeroExposureState(safeFallback.state)),
+    surfaces: normaliseHeroExposureSurfaces(raw.surfaces, safeFallback.surfaces),
+    scheduledAt: normaliseTimestamp(raw.scheduledAt ?? safeFallback.scheduledAt, 0),
+    rolloutFlag: normaliseString(raw.rolloutFlag, safeFallback.rolloutFlag || ''),
+    previewAllowed: raw.previewAllowed === false ? false : safeFallback.previewAllowed !== false,
+  };
+}
+
+export function heroExposureSurfaceEnabled(exposure, surface) {
+  const safe = normaliseHeroExposure(exposure);
+  return safe.surfaces.includes(surface);
+}
+
+export function isHeroExposureVisible(exposure, {
+  surface = 'codex',
+  now = Date.now(),
+  env = {},
+} = {}) {
+  const safe = normaliseHeroExposure(exposure);
+  if (!heroExposureSurfaceEnabled(safe, surface)) return false;
+  if (safe.state === 'hidden') return false;
+  if (safe.state === 'visible') return true;
+  if (safe.state === 'scheduled') {
+    return safe.scheduledAt > 0 && safe.scheduledAt <= normaliseTimestamp(now, Date.now());
+  }
+  if (safe.state === 'rollout-flagged') {
+    return heroExposureEnvFlagEnabled(env, safe.rolloutFlag);
+  }
+  return false;
+}
+
+export function heroExposureStatus(exposure, options = {}) {
+  const safe = normaliseHeroExposure(exposure);
+  return {
+    ...safe,
+    learnerVisible: isHeroExposureVisible(safe, options),
+  };
 }
 
 function isValidStableId(value) {
@@ -259,6 +380,7 @@ export function normaliseRewardTrackConfig(rawValue = {}, {
     active: retired ? false : (activeProvided ? raw.active !== false : existing.active !== false),
     retired,
     ...(raw.retirement || existing.retirement ? { retirement: raw.retirement || existing.retirement } : {}),
+    heroExposure: normaliseHeroExposure(raw.heroExposure || raw.exposure, existing.heroExposure || existing.exposure),
     labels: normaliseLabels(raw.labels, existing.labels),
     sequentialAfter: normaliseIdentifier(
       raw.sequentialAfter || raw.afterTrackId,
@@ -296,6 +418,10 @@ function cloneRewardTrack(track) {
     ...track,
     labels: { ...(track.labels || {}) },
     sourceMonsterIds: [...(track.sourceMonsterIds || [])],
+    heroExposure: {
+      ...(track.heroExposure || DEFAULT_HERO_EXPOSURE),
+      surfaces: [...(track.heroExposure?.surfaces || DEFAULT_HERO_EXPOSURE.surfaces)],
+    },
     ...(Array.isArray(track.thresholdOverrides) ? { thresholdOverrides: [...track.thresholdOverrides] } : {}),
   };
 }
@@ -332,6 +458,25 @@ export function sourceMonsterIdsForRewardTrack(track) {
   return sourceIds.length ? sourceIds : [progressKeyForRewardTrack(normalised)].filter(Boolean);
 }
 
+export function rewardTracksVisibleForHeroSurface(rewardTracks = LEGACY_SPELLING_REWARD_TRACKS, {
+  surface = 'codex',
+  now = Date.now(),
+  env = {},
+  includeAdminPreview = false,
+} = {}) {
+  return normaliseRewardTrackCollection(rewardTracks)
+    .filter((track) => {
+      if (track.active === false || track.retired) return false;
+      const status = heroExposureStatus(track.heroExposure, { surface, now, env });
+      return status.learnerVisible
+        || (
+          includeAdminPreview === true
+          && status.previewAllowed !== false
+          && status.surfaces.includes(surface)
+        );
+    });
+}
+
 export function validateRewardTrackCollection(rawTracks = [], {
   pools = [],
   poolWordCounts = null,
@@ -340,6 +485,7 @@ export function validateRewardTrackCollection(rawTracks = [], {
   enforceThresholdsForHiddenPools = false,
 } = {}) {
   const tracks = normaliseRewardTrackCollection(rawTracks);
+  const rawTrackValues = Array.isArray(rawTracks) ? rawTracks : [];
   const errors = [];
   const warnings = [];
   const byId = new Map();
@@ -350,6 +496,15 @@ export function validateRewardTrackCollection(rawTracks = [], {
     : learnerVisiblePoolIdsFrom(pools);
 
   tracks.forEach((track, index) => {
+    const rawTrack = isPlainObject(rawTrackValues[index]) ? rawTrackValues[index] : {};
+    const rawHeroExposure = isPlainObject(rawTrack.heroExposure)
+      ? rawTrack.heroExposure
+      : (isPlainObject(rawTrack.exposure) ? rawTrack.exposure : null);
+    const rawHeroExposureSurfaces = Array.isArray(rawHeroExposure?.surfaces)
+      ? rawHeroExposure.surfaces.map((surface) => String(surface || '').trim()).filter(Boolean)
+      : (typeof rawHeroExposure?.surfaces === 'string'
+          ? rawHeroExposure.surfaces.split(/[\n,]+/).map((surface) => surface.trim()).filter(Boolean)
+          : []);
     if (!track.id || !isValidRewardTrackId(track.id)) {
       errors.push(issue('error', 'invalid_reward_track_id', pathFor(index, 'id'), 'Reward track id must be a stable lowercase id.'));
     } else if (byId.has(track.id)) {
@@ -438,6 +593,24 @@ export function validateRewardTrackCollection(rawTracks = [], {
 
     if (track.active === false && visiblePools.has(track.poolId)) {
       warnings.push(issue('warn', 'inactive_visible_reward_track', pathFor(index, 'active'), `Reward track "${track.id}" is inactive for learner-visible pool "${track.poolId}".`));
+    }
+
+    if (rawHeroExposure?.state && !isKnownHeroExposureState(rawHeroExposure.state)) {
+      errors.push(issue('error', 'invalid_hero_exposure_state', pathFor(index, 'heroExposure.state'), `Reward track "${track.id || index + 1}" has an unknown Hero / Codex exposure state.`));
+    }
+    if (!Array.isArray(track.heroExposure?.surfaces) || track.heroExposure.surfaces.length === 0) {
+      errors.push(issue('error', 'hero_exposure_surface_required', pathFor(index, 'heroExposure.surfaces'), `Reward track "${track.id || index + 1}" needs at least one Hero / Codex exposure surface.`));
+    }
+    rawHeroExposureSurfaces.forEach((surface, surfaceIndex) => {
+      if (!isKnownHeroExposureSurface(surface)) {
+        errors.push(issue('error', 'invalid_hero_exposure_surface', pathFor(index, `heroExposure.surfaces[${surfaceIndex}]`), `Reward track "${track.id || index + 1}" has an unknown Hero / Codex exposure surface.`));
+      }
+    });
+    if (track.heroExposure?.state === 'scheduled' && !track.heroExposure.scheduledAt) {
+      errors.push(issue('error', 'hero_exposure_schedule_required', pathFor(index, 'heroExposure.scheduledAt'), `Reward track "${track.id || index + 1}" requires a schedule timestamp for scheduled exposure.`));
+    }
+    if (track.heroExposure?.state === 'rollout-flagged' && !track.heroExposure.rolloutFlag) {
+      errors.push(issue('error', 'hero_exposure_flag_required', pathFor(index, 'heroExposure.rolloutFlag'), `Reward track "${track.id || index + 1}" requires a rollout flag for flagged exposure.`));
     }
   });
 

--- a/src/platform/hubs/admin-content-operations.js
+++ b/src/platform/hubs/admin-content-operations.js
@@ -1,3 +1,7 @@
+import {
+  normaliseHeroExposure,
+} from '../game/reward-track-config.js';
+
 const PACKAGE_STATE_LABELS = Object.freeze({
   draft: 'Draft',
   ready_for_approval: 'Ready for approval',
@@ -524,6 +528,7 @@ function normaliseSpellingPoolSummary(row = null) {
 function normaliseSpellingRewardTrackSummary(row = null) {
   const safe = isPlainObject(row) ? row : {};
   const labels = isPlainObject(safe.labels) ? safe.labels : {};
+  const heroExposure = normaliseHeroExposure(safe.heroExposure);
   const dependencyApproval = isPlainObject(safe.dependencyApproval)
     ? { ...safe.dependencyApproval }
     : null;
@@ -540,6 +545,7 @@ function normaliseSpellingRewardTrackSummary(row = null) {
     active: safe.active === false ? false : true,
     retired: Boolean(safe.retired),
     retirement: isPlainObject(safe.retirement) ? { ...safe.retirement } : null,
+    heroExposure,
     labels: {
       title: asString(labels.title),
       shortLabel: asString(labels.shortLabel),

--- a/src/subjects/spelling/components/spelling-view-model.js
+++ b/src/subjects/spelling/components/spelling-view-model.js
@@ -1030,6 +1030,9 @@ export function buildSpellingContext({ appState, service, repositories, subject 
   };
   const needsAnalytics = ui.phase === 'dashboard' || ui.phase === 'word-bank';
   const analytics = needsAnalytics ? service.getAnalyticsSnapshot(learner.id) : null;
+  const runtimeRewardTracks = typeof service.getRuntimeRewardTracks === 'function'
+    ? service.getRuntimeRewardTracks()
+    : null;
   // Post-mastery aggregates are needed on the dashboard (mode selection,
   // Alt+4 gate), the summary scene (to render "Next check" in Guardian
   // mode), and the Word Bank (to gate the four Guardian filter chips and
@@ -1070,6 +1073,8 @@ export function buildSpellingContext({ appState, service, repositories, subject 
       ? monsterSummaryFromSpellingAnalytics(analytics, {
           learnerId: learner.id,
           gameStateRepository: repositories?.gameState,
+          rewardTracks: Array.isArray(runtimeRewardTracks) ? runtimeRewardTracks : null,
+          surface: 'subjectSetup',
           persistBranches: false,
         })
       : [],

--- a/src/subjects/spelling/content/editor-read-model.js
+++ b/src/subjects/spelling/content/editor-read-model.js
@@ -7,6 +7,9 @@ import {
 import {
   audioReadinessSummaryForWord,
 } from './audio-readiness.js';
+import {
+  normaliseHeroExposure,
+} from '../../../platform/game/reward-track-config.js';
 
 const DEFAULT_BROWSE_LIMIT = 75;
 const MAX_BROWSE_LIMIT = 250;
@@ -247,6 +250,7 @@ function compactRewardTrack(track, draftState = 'unchanged', {
   hasCurrent = true,
   hasPackageDraft = false,
 } = {}) {
+  const heroExposure = normaliseHeroExposure(track.heroExposure);
   return {
     id: track.id,
     poolId: track.poolId,
@@ -260,6 +264,7 @@ function compactRewardTrack(track, draftState = 'unchanged', {
     active: track.active !== false,
     retired: Boolean(track.retired),
     retirement: track.retirement || null,
+    heroExposure,
     labels: track.labels || {},
     sequentialAfter: track.sequentialAfter || '',
     prerequisites: asArray(track.prerequisites),

--- a/src/subjects/spelling/content/operations-model.js
+++ b/src/subjects/spelling/content/operations-model.js
@@ -4,6 +4,9 @@ import {
   normaliseSpellingContentBundle,
   validateSpellingContentBundle,
 } from './model.js';
+import {
+  normaliseHeroExposure,
+} from '../../../platform/game/reward-track-config.js';
 
 export const CONTENT_OPERATION_SUBJECT_ID = 'spelling';
 
@@ -20,6 +23,7 @@ export const CONTENT_OPERATION_PACKAGE_STATES = Object.freeze({
 
 export const CONTENT_OPERATION_ENTITY_TYPES = Object.freeze([
   'spelling.audioRequirementProfile',
+  'spelling.heroExposure',
   'spelling.pool',
   'spelling.rewardTrack',
   'spelling.word',
@@ -41,6 +45,7 @@ const ACTION_SET = new Set(CONTENT_OPERATION_ACTIONS);
 const STRUCTURAL_ACTIONS = new Set(['create', 'upsert', 'replace', 'remove', 'retire']);
 const AUDIO_REQUIREMENT_PROFILE_ENTITY_TYPE = 'spelling.audioRequirementProfile';
 const AUDIO_REQUIREMENT_PROFILE_ENTITY_ID = 'default';
+const HERO_EXPOSURE_ENTITY_TYPE = 'spelling.heroExposure';
 
 const EDITABLE_COLLECTIONS = Object.freeze({
   'spelling.pool': Object.freeze({ collectionPath: ['draft', 'pools'], idField: 'id' }),
@@ -149,6 +154,45 @@ function applyCollectionOperation(bundle, operation) {
     }
   }
 
+  if (operation.entityType === HERO_EXPOSURE_ENTITY_TYPE) {
+    const descriptor = collectionFor(bundle, 'spelling.rewardTrack');
+    if (!descriptor) {
+      throw new Error('Reward-track collection is unavailable.');
+    }
+    const { collection, idField } = descriptor;
+    const { index, entity } = findEntity(collection, idField, operation.entityId);
+    if (index < 0 || !entity) {
+      throw new Error(`Hero / Codex exposure target "${operation.entityId}" does not exist.`);
+    }
+
+    if (operation.action === 'remove' || operation.action === 'retire') {
+      collection[index] = {
+        ...cloneSerialisable(entity),
+        heroExposure: normaliseHeroExposure({ state: 'hidden' }),
+      };
+      return;
+    }
+
+    if (operation.action === 'set') {
+      const pathParts = splitFieldPath(operation.fieldPath);
+      if (!pathParts.length) {
+        throw new Error('Set operations require a fieldPath.');
+      }
+      const nextExposure = isPlainObject(entity.heroExposure)
+        ? cloneSerialisable(entity.heroExposure)
+        : {};
+      setAtPath(nextExposure, pathParts, operation.payload);
+      collection[index] = { ...cloneSerialisable(entity), heroExposure: nextExposure };
+      return;
+    }
+
+    collection[index] = {
+      ...cloneSerialisable(entity),
+      heroExposure: cloneSerialisable(operation.payload) || {},
+    };
+    return;
+  }
+
   const descriptor = collectionFor(bundle, operation.entityType);
   if (!descriptor) {
     throw new Error(`Unsupported content operation entity type "${operation.entityType}".`);
@@ -207,6 +251,7 @@ function applyCollectionOperation(bundle, operation) {
 }
 
 function isStructuralOperation(operation) {
+  if (operation?.entityType === HERO_EXPOSURE_ENTITY_TYPE) return false;
   return STRUCTURAL_ACTIONS.has(operation.action) || !operation.fieldPath || operation.fieldPath === '$';
 }
 
@@ -280,7 +325,26 @@ export function normaliseContentOperation(rawValue = {}, {
 
 export function operationConflictKey(operation) {
   const normalised = normaliseContentOperation(operation, { now: () => 0 });
-  return `${normalised.entityType}::${normalised.entityId}::${normalised.fieldPath || '$'}`;
+  const target = operationConflictTarget(normalised);
+  return `${target.entityType}::${target.entityId}::${target.fieldPath || '$'}`;
+}
+
+function operationConflictTarget(operation) {
+  if (operation?.entityType === HERO_EXPOSURE_ENTITY_TYPE) {
+    const fieldPath = operation.action === 'set' && operation.fieldPath
+      ? `heroExposure.${operation.fieldPath}`
+      : 'heroExposure';
+    return {
+      entityType: 'spelling.rewardTrack',
+      entityId: operation.entityId,
+      fieldPath,
+    };
+  }
+  return {
+    entityType: operation.entityType,
+    entityId: operation.entityId,
+    fieldPath: operation.fieldPath || '$',
+  };
 }
 
 export function effectiveContentOperations(operations = []) {
@@ -302,13 +366,15 @@ export function detectContentOperationConflicts(leftOperations = [], rightOperat
 
   for (const leftOperation of left) {
     for (const rightOperation of right) {
+      const leftTarget = operationConflictTarget(leftOperation);
+      const rightTarget = operationConflictTarget(rightOperation);
       if (
-        leftOperation.entityType !== rightOperation.entityType
-        || leftOperation.entityId !== rightOperation.entityId
+        leftTarget.entityType !== rightTarget.entityType
+        || leftTarget.entityId !== rightTarget.entityId
       ) {
         continue;
       }
-      const sameField = (leftOperation.fieldPath || '$') === (rightOperation.fieldPath || '$');
+      const sameField = (leftTarget.fieldPath || '$') === (rightTarget.fieldPath || '$');
       const structural = isStructuralOperation(leftOperation) || isStructuralOperation(rightOperation);
       if (!sameField && !structural) continue;
       if (contentOperationHash(leftOperation) === contentOperationHash(rightOperation)) continue;
@@ -319,18 +385,18 @@ export function detectContentOperationConflicts(leftOperations = [], rightOperat
       conflicts.push({
         conflictId: contentOperationHash({
           code: conflictCodeFor(leftOperation, rightOperation),
-          entityType: leftOperation.entityType,
-          entityId: leftOperation.entityId,
-          fieldPath: sameField ? (leftOperation.fieldPath || rightOperation.fieldPath || '$') : '$',
+          entityType: leftTarget.entityType,
+          entityId: leftTarget.entityId,
+          fieldPath: sameField ? (leftTarget.fieldPath || rightTarget.fieldPath || '$') : '$',
           leftOperationId: leftOperation.operationId,
           rightOperationId: rightOperation.operationId,
           leftValueHash,
           rightValueHash,
         }, 'conflict'),
         code: conflictCodeFor(leftOperation, rightOperation),
-        entityType: leftOperation.entityType,
-        entityId: leftOperation.entityId,
-        fieldPath: sameField ? (leftOperation.fieldPath || rightOperation.fieldPath || '$') : '$',
+        entityType: leftTarget.entityType,
+        entityId: leftTarget.entityId,
+        fieldPath: sameField ? (leftTarget.fieldPath || rightTarget.fieldPath || '$') : '$',
         leftOperationId: leftOperation.operationId,
         rightOperationId: rightOperation.operationId,
       });
@@ -348,6 +414,13 @@ export function readContentOperationField(bundle, operation) {
       normaliseSpellingContentBundle(bundle).draft.audioRequirementProfile || {},
       splitFieldPath(normalised.fieldPath),
     );
+  }
+  if (normalised.entityType === HERO_EXPOSURE_ENTITY_TYPE) {
+    const descriptor = collectionFor(normaliseSpellingContentBundle(bundle), 'spelling.rewardTrack');
+    if (!descriptor) return undefined;
+    const { entity } = findEntity(descriptor.collection, descriptor.idField, normalised.entityId);
+    if (!entity) return undefined;
+    return getAtPath(entity, ['heroExposure', ...splitFieldPath(normalised.fieldPath)]);
   }
   const descriptor = collectionFor(normaliseSpellingContentBundle(bundle), normalised.entityType);
   if (!descriptor) return undefined;

--- a/src/subjects/spelling/content/package-operations.js
+++ b/src/subjects/spelling/content/package-operations.js
@@ -1,6 +1,10 @@
 import {
+  HERO_EXPOSURE_SURFACES,
   SPELLING_REWARD_TRACK_MONSTER_IDS,
+  isKnownHeroExposureState,
+  isKnownHeroExposureSurface,
   isValidRewardTrackId,
+  normaliseHeroExposure,
   normaliseRewardTrackConfig,
   validateRewardTrackCollection,
 } from '../../../platform/game/reward-track-config.js';
@@ -151,6 +155,15 @@ function rewardTrackValidationResult(errors, warnings, rewardTrack = null) {
     errors,
     warnings,
     rewardTrack,
+  };
+}
+
+function heroExposureValidationResult(errors, warnings, heroExposure = null) {
+  return {
+    ok: errors.length === 0,
+    errors,
+    warnings,
+    heroExposure,
   };
 }
 
@@ -585,10 +598,16 @@ export function validateSpellingRewardTrackEditorInput(rawValue = {}, options = 
   const raw = isPlainObject(rawValue) ? rawValue : {};
   const existing = isPlainObject(options.existingTrack) ? options.existingTrack : null;
   const rewardTrack = normaliseSpellingRewardTrackEditorInput(raw, options);
+  const rawHeroExposure = isPlainObject(raw.heroExposure)
+    ? raw.heroExposure
+    : (isPlainObject(raw.exposure) ? raw.exposure : null);
+  const validationTrack = rawHeroExposure
+    ? { ...rewardTrack, heroExposure: rawHeroExposure }
+    : rewardTrack;
   const existingId = normaliseString(existing?.id);
   const peers = (Array.isArray(options.rewardTracks) ? options.rewardTracks : [])
     .filter((entry) => !existingId || entry?.id !== existingId);
-  const validation = validateRewardTrackCollection([...peers, rewardTrack], {
+  const validation = validateRewardTrackCollection([...peers, validationTrack], {
     pools: options.pools || [],
     poolWordCounts: options.poolWordCounts || null,
     learnerVisiblePoolIds: options.learnerVisiblePoolIds || null,
@@ -601,6 +620,51 @@ export function validateSpellingRewardTrackEditorInput(rawValue = {}, options = 
     validation.warnings.map(rewardTrackIssueToEditorIssue),
     rewardTrack,
   );
+}
+
+export function normaliseSpellingHeroExposureEditorInput(rawValue = {}, {
+  existingTrack = null,
+} = {}) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  return normaliseHeroExposure(raw.heroExposure || raw.exposure || raw, existingTrack?.heroExposure);
+}
+
+export function validateSpellingHeroExposureEditorInput(rawValue = {}, options = {}) {
+  const errors = [];
+  const warnings = [];
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  const exposureRaw = isPlainObject(raw.heroExposure)
+    ? raw.heroExposure
+    : (isPlainObject(raw.exposure) ? raw.exposure : raw);
+  const heroExposure = normaliseSpellingHeroExposureEditorInput(exposureRaw, options);
+
+  if (exposureRaw.state && !isKnownHeroExposureState(exposureRaw.state)) {
+    errors.push(issue('heroExposure.state', 'Hero / Codex exposure state is invalid.', 'invalid_hero_exposure_state'));
+  }
+  const rawSurfaces = Array.isArray(exposureRaw.surfaces)
+    ? exposureRaw.surfaces.map((surface) => String(surface || '').trim()).filter(Boolean)
+    : (typeof exposureRaw.surfaces === 'string'
+        ? exposureRaw.surfaces.split(/[\n,]+/).map((surface) => surface.trim()).filter(Boolean)
+        : []);
+  rawSurfaces.forEach((surface) => {
+    if (!isKnownHeroExposureSurface(surface)) {
+      errors.push(issue('heroExposure.surfaces', `Hero / Codex exposure surface "${surface}" is invalid.`, 'invalid_hero_exposure_surface'));
+    }
+  });
+  if (!heroExposure.surfaces.length) {
+    errors.push(issue('heroExposure.surfaces', 'At least one Hero / Codex surface is required.', 'hero_exposure_surface_required'));
+  }
+  if (heroExposure.state === 'scheduled' && !heroExposure.scheduledAt) {
+    errors.push(issue('heroExposure.scheduledAt', 'Scheduled exposure requires a visibility timestamp.', 'hero_exposure_schedule_required'));
+  }
+  if (heroExposure.state === 'rollout-flagged' && !heroExposure.rolloutFlag) {
+    errors.push(issue('heroExposure.rolloutFlag', 'Rollout-flagged exposure requires a rollout flag.', 'hero_exposure_flag_required'));
+  }
+  if (heroExposure.state === 'hidden' && heroExposure.surfaces.length === HERO_EXPOSURE_SURFACES.length) {
+    warnings.push(issue('heroExposure.state', 'Hidden exposure keeps admin preview available but hides this track from learner Hero / Codex surfaces.', 'hero_exposure_hidden'));
+  }
+
+  return heroExposureValidationResult(errors, warnings, heroExposure);
 }
 
 function throwIfInvalid(validation) {
@@ -667,6 +731,22 @@ export function buildSpellingRewardTrackUpsertOperation(rawValue = {}, options =
     fieldPath: '',
     action: 'upsert',
     payload: validation.rewardTrack,
+  };
+}
+
+export function buildSpellingHeroExposureUpsertOperation(rawValue = {}, options = {}) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  const id = normaliseString(raw.id || raw.entityId || raw.rewardTrackId || raw.trackId || options.existingTrack?.id).toLowerCase();
+  if (!id) throw new TypeError('Reward track id is required.');
+  if (!isValidRewardTrackId(id)) throw new TypeError('Reward track id must be a stable lowercase id.');
+  const validation = validateSpellingHeroExposureEditorInput(raw.heroExposure || raw.exposure || raw, options);
+  throwIfInvalid(validation);
+  return {
+    entityType: 'spelling.heroExposure',
+    entityId: id,
+    fieldPath: '',
+    action: 'upsert',
+    payload: validation.heroExposure,
   };
 }
 

--- a/src/subjects/spelling/module.js
+++ b/src/subjects/spelling/module.js
@@ -168,7 +168,13 @@ export const spellingModule = {
   getDashboardStats(appState, { service, repositories }) {
     const learner = appState.learners.byId[appState.learners.selectedId];
     const stats = getOverallSpellingStats(service, learner.id);
-    const codex = monsterSummaryFromSpellingAnalytics(service.getAnalyticsSnapshot(learner.id));
+    const runtimeRewardTracks = typeof service.getRuntimeRewardTracks === 'function'
+      ? service.getRuntimeRewardTracks()
+      : null;
+    const codex = monsterSummaryFromSpellingAnalytics(service.getAnalyticsSnapshot(learner.id), {
+      rewardTracks: Array.isArray(runtimeRewardTracks) ? runtimeRewardTracks : null,
+      surface: 'subjectSetup',
+    });
     // Post-Mega banner branch — graduated learners see the
     // `cover-post-mega-{branch}` banner on the home subject card so the
     // tile matches the Guardian / Boss / Pattern Quest vista they will

--- a/src/surfaces/home/data.js
+++ b/src/surfaces/home/data.js
@@ -758,17 +758,30 @@ export function buildCodexEntries(summary = []) {
   });
 }
 
+function visibleMonsterRosterFromSummary(summary = []) {
+  const bySubject = new Map();
+  for (const entry of Array.isArray(summary) ? summary : []) {
+    if (entry?.progress?.visibleInCodex !== true || !entry?.monster?.id) continue;
+    const subjectId = entry.subjectId || entry.progress?.subjectId || 'spelling';
+    const existing = bySubject.get(subjectId) || [];
+    if (!existing.includes(entry.monster.id)) existing.push(entry.monster.id);
+    bySubject.set(subjectId, existing);
+  }
+  return bySubject;
+}
+
 function withSynthesisedUncaughtMonsters(summary = []) {
   const presentIds = new Set(
     summary.map(({ monster }) => monster?.id).filter(Boolean),
   );
+  const exposedRosterBySubject = visibleMonsterRosterFromSummary(summary);
   const synthesised = [];
   // Scope iteration to active learner-facing subject groups only. Reserved
   // buckets (`punctuationReserve`, `grammarReserve`) never enter the Codex
   // pipeline; without this guard, every uncaught reserve monster would surface
   // as a "not caught" Codex card, leaking the retired Hero Camp roster.
   for (const subjectId of CODEX_SUBJECT_GROUP_IDS) {
-    const monsterIds = MONSTERS_BY_SUBJECT[subjectId] || [];
+    const monsterIds = exposedRosterBySubject.get(subjectId) || MONSTERS_BY_SUBJECT[subjectId] || [];
     for (const monsterId of monsterIds) {
       if (presentIds.has(monsterId)) continue;
       const monster = MONSTERS[monsterId];

--- a/src/surfaces/hubs/AdminContentOperationsSection.jsx
+++ b/src/surfaces/hubs/AdminContentOperationsSection.jsx
@@ -17,6 +17,7 @@ import {
 import {
   buildSpellingPoolDeleteOrRetireOperation,
   buildSpellingPoolUpsertOperation,
+  buildSpellingHeroExposureUpsertOperation,
   buildSpellingRewardTrackDeleteOrRetireOperation,
   buildSpellingRewardTrackUpsertOperation,
   buildSpellingSentenceDeleteOrRetireOperation,
@@ -27,9 +28,12 @@ import {
   buildSpellingWordUpsertOperation,
 } from '../../subjects/spelling/content/package-operations.js';
 import {
+  HERO_EXPOSURE_STATES,
+  HERO_EXPOSURE_SURFACES,
   REWARD_TRACK_PROGRESS_MODES,
   REWARD_TRACK_THRESHOLD_TEMPLATES,
   SPELLING_REWARD_TRACK_MONSTER_IDS,
+  heroExposureStatus,
 } from '../../platform/game/reward-track-config.js';
 
 const CENTRE_TABS = Object.freeze([
@@ -58,6 +62,14 @@ const CONTENT_OPERATION_CAPABILITIES = Object.freeze({
   PUBLISH: 'content_operations.publish',
 });
 
+const SPELLING_OPERATION_NOUNS = Object.freeze({
+  'spelling.sentenceEntry': 'Sentence',
+  'spelling.wordList': 'Word list',
+  'spelling.pool': 'Pool',
+  'spelling.rewardTrack': 'Reward track',
+  'spelling.heroExposure': 'Hero / Codex',
+});
+
 function actorCan(actor, capability) {
   return Boolean(actor?.capabilities?.[capability]);
 }
@@ -82,6 +94,14 @@ function csvNumberValue(values) {
 
 function csvNumberList(value) {
   return thresholdOverrideParse(value).values;
+}
+
+function csvList(value) {
+  if (Array.isArray(value)) return value.filter(Boolean);
+  return String(value || '')
+    .split(/[\n,]+/)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
 }
 
 function thresholdOverrideParse(value) {
@@ -410,6 +430,28 @@ function thresholdTemplateLabel(templateId) {
   return REWARD_TRACK_THRESHOLD_TEMPLATES[templateId]?.label || templateId || 'Template';
 }
 
+function heroExposureStateLabel(state) {
+  if (state === 'rollout-flagged') return 'Rollout flagged';
+  if (state === 'scheduled') return 'Scheduled';
+  if (state === 'hidden') return 'Hidden';
+  return 'Visible';
+}
+
+function heroExposureSurfaceLabel(surface) {
+  if (surface === 'heroCamp') return 'Hero Camp';
+  if (surface === 'heroQuest') return 'Hero Quest';
+  if (surface === 'subjectSetup') return 'Subject setup';
+  if (surface === 'codex') return 'Codex';
+  return surface;
+}
+
+function heroExposureChipClass(exposure) {
+  const state = exposure?.state || 'visible';
+  if (state === 'hidden') return 'warn';
+  if (state === 'scheduled' || state === 'rollout-flagged') return '';
+  return 'good';
+}
+
 function thresholdsForRewardTrackForm(form) {
   const overrides = csvNumberList(form.thresholdOverrides);
   if (overrides.length) return overrides;
@@ -483,6 +525,11 @@ function emptyRewardTrackEditorForm(pools = [], selectedPool = null, rewardTrack
     sequentialAfter: '',
     dependencyApprovalApproved: false,
     dependencyApprovalReason: '',
+    heroExposureState: 'visible',
+    heroExposureSurfaces: csvValue(HERO_EXPOSURE_SURFACES),
+    heroExposureScheduledAt: '',
+    heroExposureRolloutFlag: '',
+    heroExposurePreviewAllowed: true,
     labelsTitle: '',
     labelsShortLabel: '',
     labelsDescription: '',
@@ -494,6 +541,10 @@ function emptyRewardTrackEditorForm(pools = [], selectedPool = null, rewardTrack
 
 function rewardTrackEditorFormFromTrack(track, selectedPool = null, pools = [], rewardTracks = []) {
   if (!track) return emptyRewardTrackEditorForm(pools, selectedPool, rewardTracks);
+  const exposure = track.heroExposure || {};
+  const exposureSurfaces = Array.isArray(exposure.surfaces) && exposure.surfaces.length
+    ? exposure.surfaces
+    : HERO_EXPOSURE_SURFACES;
   return {
     id: track.id || '',
     poolId: track.poolId || spellingPoolOptionId(selectedPool) || '',
@@ -507,12 +558,27 @@ function rewardTrackEditorFormFromTrack(track, selectedPool = null, pools = [], 
     sequentialAfter: track.sequentialAfter || '',
     dependencyApprovalApproved: track.dependencyApproval?.approved === true,
     dependencyApprovalReason: track.dependencyApproval?.reason || '',
+    heroExposureState: exposure.state || 'visible',
+    heroExposureSurfaces: csvValue(exposureSurfaces),
+    heroExposureScheduledAt: exposure.scheduledAt ? String(exposure.scheduledAt) : '',
+    heroExposureRolloutFlag: exposure.rolloutFlag || '',
+    heroExposurePreviewAllowed: exposure.previewAllowed !== false,
     labelsTitle: track.labels?.title || '',
     labelsShortLabel: track.labels?.shortLabel || '',
     labelsDescription: track.labels?.description || '',
     sourceNote: track.sourceNote || '',
     retirementReason: '',
     sortIndex: Number.isInteger(Number(track.sortIndex)) ? String(track.sortIndex) : '0',
+  };
+}
+
+function heroExposureInputFromForm(form) {
+  return {
+    state: form.heroExposureState,
+    surfaces: csvList(form.heroExposureSurfaces),
+    scheduledAt: form.heroExposureScheduledAt,
+    rolloutFlag: form.heroExposureRolloutFlag,
+    previewAllowed: Boolean(form.heroExposurePreviewAllowed),
   };
 }
 
@@ -539,9 +605,17 @@ function operationInputFromRewardTrackForm(form) {
       shortLabel: form.labelsShortLabel,
       description: form.labelsDescription,
     },
+    heroExposure: heroExposureInputFromForm(form),
     ...(dependencyApproval ? { dependencyApproval } : {}),
     sourceNote: form.sourceNote,
     sortIndex: form.sortIndex,
+  };
+}
+
+function operationInputFromHeroExposureForm(form) {
+  return {
+    id: form.id,
+    heroExposure: heroExposureInputFromForm(form),
   };
 }
 
@@ -1402,6 +1476,9 @@ function SpellingBrowsePanel({
     || rewardTracksForSelectedPool[0]
     || rewardTracks[0]
     || null;
+  const canSaveRewardExposure = rewardTrackMode === 'edit'
+    && Boolean(selectedRewardTrack)
+    && rewardTrackForm.id === selectedRewardTrack?.id;
   const selectedRewardThresholds = React.useMemo(
     () => thresholdsForRewardTrackForm(rewardTrackForm),
     [rewardTrackForm],
@@ -1410,6 +1487,10 @@ function SpellingBrowsePanel({
     || selectedPool
     || null;
   const selectedRewardPoolWordCount = poolWordCountValue(selectedRewardPool);
+  const selectedRewardExposureStatus = heroExposureStatus(
+    heroExposureInputFromForm(rewardTrackForm),
+    { surface: 'codex', now: Date.now() },
+  );
 
   React.useEffect(() => {
     if (editorMode === 'create') return;
@@ -1797,6 +1878,24 @@ function SpellingBrowsePanel({
     selectedRow?.slug,
   ]);
 
+  const submitHeroExposureForm = React.useCallback(() => {
+    if (!onSubmitSpellingOperation || !canSaveRewardExposure) return;
+    try {
+      const operation = buildSpellingHeroExposureUpsertOperation(operationInputFromHeroExposureForm(rewardTrackForm), {
+        existingTrack: selectedRewardTrack,
+      });
+      onSubmitSpellingOperation(operation, { slug: selectedRow?.slug, action: 'hero-exposure-upsert' });
+    } catch (submitError) {
+      setFormError(submitError?.validation?.errors?.[0]?.message || submitError?.message || 'Hero / Codex exposure operation is invalid.');
+    }
+  }, [
+    onSubmitSpellingOperation,
+    canSaveRewardExposure,
+    rewardTrackForm,
+    selectedRewardTrack,
+    selectedRow?.slug,
+  ]);
+
   const submitRewardTrackRemoval = React.useCallback(() => {
     if (!onSubmitSpellingOperation || !selectedRewardTrack) return;
     try {
@@ -1819,7 +1918,7 @@ function SpellingBrowsePanel({
         <div>
           <div className="eyebrow">Published state</div>
           <h4 className="section-title admin-section-title">
-            {areaKey === 'poolsRewards' ? 'Pools & Rewards' : 'Spelling browse'}
+            {areaKey === 'heroCodex' ? 'Hero / Codex' : (areaKey === 'poolsRewards' ? 'Pools & Rewards' : 'Spelling browse')}
           </h4>
           <p className="small muted admin-note-spaced">
             Latest release {releaseLabel}
@@ -2075,6 +2174,13 @@ function SpellingBrowsePanel({
             value={rewardTrackForm.progressionMode}
             detail={thresholdTemplateLabel(rewardTrackForm.thresholdTemplate)}
           />
+          <MetricTile
+            label="Codex exposure"
+            value={heroExposureStateLabel(selectedRewardExposureStatus.state)}
+            detail={selectedRewardExposureStatus.learnerVisible
+              ? 'Learner visible now'
+              : (selectedRewardExposureStatus.previewAllowed === false ? 'Hidden from preview' : 'Admin preview only')}
+          />
         </div>
         <div className="feedback warn content-ops-reward-safety" data-content-ops-reward-safety="true">
           Existing learner history stays keyed by the published progress key. Changing thresholds, source monsters, or sequence changes future reward projection after approval.
@@ -2087,6 +2193,7 @@ function SpellingBrowsePanel({
                 <th className="small admin-overview-th">Pool</th>
                 <th className="small admin-overview-th">Monster</th>
                 <th className="small admin-overview-th">Mode</th>
+                <th className="small admin-overview-th">Exposure</th>
                 <th className="small admin-overview-th-right">Thresholds</th>
                 <th className="small admin-overview-th">State</th>
               </tr>
@@ -2108,6 +2215,16 @@ function SpellingBrowsePanel({
                   <td className="admin-overview-td small">{track.poolId || 'No pool'}</td>
                   <td className="admin-overview-td small">{track.monsterId || 'No monster'}</td>
                   <td className="admin-overview-td small">{track.progressionMode || 'parallel'}</td>
+                  <td className="admin-overview-td">
+                    <span className={`chip ${heroExposureChipClass(track.heroExposure)}`}>
+                      {heroExposureStateLabel(track.heroExposure?.state || 'visible')}
+                    </span>
+                    <div className="small muted">
+                      {((Array.isArray(track.heroExposure?.surfaces) && track.heroExposure.surfaces.length)
+                        ? track.heroExposure.surfaces
+                        : HERO_EXPOSURE_SURFACES).map(heroExposureSurfaceLabel).join(', ')}
+                    </div>
+                  </td>
                   <td className="admin-overview-td-right small">
                     {String((track.thresholdOverrides || []).length || (REWARD_TRACK_THRESHOLD_TEMPLATES[track.thresholdTemplate]?.thresholds || []).length)}
                   </td>
@@ -2119,7 +2236,7 @@ function SpellingBrowsePanel({
                 </tr>
               )) : (
                 <tr className="admin-overview-tbody-row">
-                  <td className="admin-overview-td-first small muted" colSpan={6}>
+                  <td className="admin-overview-td-first small muted" colSpan={7}>
                     No reward tracks in this package view.
                   </td>
                 </tr>
@@ -2232,6 +2349,51 @@ function SpellingBrowsePanel({
             />
           </label>
           <label>
+            <span className="small muted">Hero / Codex exposure</span>
+            <select
+              value={rewardTrackForm.heroExposureState}
+              onChange={(event) => updateRewardTrackForm({ heroExposureState: event.target.value })}
+              data-content-ops-reward-field="heroExposureState"
+            >
+              {HERO_EXPOSURE_STATES.map((state) => (
+                <option key={state} value={state}>{heroExposureStateLabel(state)}</option>
+              ))}
+            </select>
+          </label>
+          <label>
+            <span className="small muted">Exposure surfaces</span>
+            <input
+              value={rewardTrackForm.heroExposureSurfaces}
+              onChange={(event) => updateRewardTrackForm({ heroExposureSurfaces: event.target.value })}
+              data-content-ops-reward-field="heroExposureSurfaces"
+            />
+          </label>
+          <label>
+            <span className="small muted">Exposure scheduled at</span>
+            <input
+              value={rewardTrackForm.heroExposureScheduledAt}
+              onChange={(event) => updateRewardTrackForm({ heroExposureScheduledAt: event.target.value })}
+              data-content-ops-reward-field="heroExposureScheduledAt"
+            />
+          </label>
+          <label>
+            <span className="small muted">Exposure rollout flag</span>
+            <input
+              value={rewardTrackForm.heroExposureRolloutFlag}
+              onChange={(event) => updateRewardTrackForm({ heroExposureRolloutFlag: event.target.value })}
+              data-content-ops-reward-field="heroExposureRolloutFlag"
+            />
+          </label>
+          <label>
+            <span className="small muted">Admin preview</span>
+            <input
+              type="checkbox"
+              checked={rewardTrackForm.heroExposurePreviewAllowed}
+              onChange={(event) => updateRewardTrackForm({ heroExposurePreviewAllowed: event.target.checked })}
+              data-content-ops-reward-field="heroExposurePreviewAllowed"
+            />
+          </label>
+          <label>
             <span className="small muted">Order</span>
             <input
               value={rewardTrackForm.sortIndex}
@@ -2299,6 +2461,9 @@ function SpellingBrowsePanel({
           <div className="content-ops-editor-actions content-ops-editor-wide">
             <button type="submit" className="btn primary" disabled={formDisabled}>
               Save reward track
+            </button>
+            <button type="button" className="btn secondary" onClick={submitHeroExposureForm} disabled={formDisabled || !canSaveRewardExposure}>
+              Save exposure
             </button>
             <button type="button" className="btn secondary" onClick={submitRewardTrackRemoval} disabled={formDisabled || !selectedRewardTrack}>
               {selectedRewardTrack?.draftState === 'added' || selectedRewardTrack?.hasCurrent === false ? 'Delete draft track' : 'Retire track'}
@@ -3842,13 +4007,7 @@ export function AdminContentOperationsSection({
         operation,
         mutation: contentOperationMutation(action, selectedPackageId),
       });
-      const noun = operation.entityType === 'spelling.sentenceEntry'
-        ? 'Sentence'
-        : (operation.entityType === 'spelling.wordList'
-            ? 'Word list'
-            : (operation.entityType === 'spelling.pool'
-                ? 'Pool'
-                : (operation.entityType === 'spelling.rewardTrack' ? 'Reward track' : 'Word')));
+      const noun = SPELLING_OPERATION_NOUNS[operation.entityType] || 'Word';
       setSpellingOperationState({
         packageId: selectedPackageId,
         action,
@@ -3913,7 +4072,7 @@ export function AdminContentOperationsSection({
   }, [api, overviewPayload, packageListPayload, refresh, releaseListPayload]);
 
   React.useEffect(() => {
-    if (!['spelling', 'poolsRewards'].includes(activeTab)) return;
+    if (!['spelling', 'poolsRewards', 'heroCodex'].includes(activeTab)) return;
     if (!api?.readSpellingBrowse) return;
     if (spellingBrowsePayload) return;
     loadSpellingBrowse();
@@ -4187,7 +4346,7 @@ export function AdminContentOperationsSection({
         />
       ) : null}
 
-      {['spelling', 'poolsRewards'].includes(activeTab) ? (
+      {['spelling', 'poolsRewards', 'heroCodex'].includes(activeTab) ? (
         <SpellingBrowsePanel
           areaKey={activeTab}
           browse={spellingBrowse}
@@ -4208,7 +4367,7 @@ export function AdminContentOperationsSection({
         />
       ) : null}
 
-      {['audio', 'monstersAssets', 'heroCodex', 'approvals'].includes(activeTab) ? (
+      {['audio', 'monstersAssets', 'approvals'].includes(activeTab) ? (
         <PublishedAreaPanel
           activeTab={activeTab}
           latestRelease={latestRelease}

--- a/tests/button-label-consistency.test.js
+++ b/tests/button-label-consistency.test.js
@@ -560,6 +560,7 @@ test('button labels: every statically extractable label is classified', () => {
     'Edit track',
     'New track',
     'Save reward track',
+    'Save exposure',
     'Retire track',
     'Delete draft track',
     // Content Operations Centre T16: audio operations controls are

--- a/tests/content-operations-merge.test.js
+++ b/tests/content-operations-merge.test.js
@@ -6,6 +6,7 @@ import {
   contentOperationHash,
   detectContentOperationConflicts,
   normaliseContentOperation,
+  operationConflictKey,
   readContentOperationField,
 } from '../src/subjects/spelling/content/operations-model.js';
 import {
@@ -135,6 +136,59 @@ test('structural operations conflict with child-field edits on the same entity',
   assert.equal(conflicts[0].code, 'structural_conflict');
   assert.equal(conflicts[0].fieldPath, '$');
 });
+
+test('Hero / Codex exposure operations conflict with reward-track edits on the same track', async () => {
+  const structuralRewardTrackEdit = [{
+    operationId: 'reward-track-op',
+    entityType: 'spelling.rewardTrack',
+    entityId: 'spelling-core-inklet',
+    action: 'upsert',
+    payload: {
+      id: 'spelling-core-inklet',
+      poolId: 'core',
+      monsterId: 'inklet',
+      thresholdOverrides: [1],
+      heroExposure: { state: 'visible', surfaces: ['codex'] },
+    },
+  }];
+  const exposureOnlyEdit = [{
+    operationId: 'exposure-op',
+    entityType: 'spelling.heroExposure',
+    entityId: 'spelling-core-inklet',
+    action: 'upsert',
+    payload: {
+      state: 'hidden',
+      surfaces: ['codex'],
+      scheduledAt: 0,
+      rolloutFlag: '',
+      previewAllowed: true,
+    },
+  }];
+  const unrelatedRewardTrackLabelEdit = [{
+    operationId: 'reward-track-labels-op',
+    entityType: 'spelling.rewardTrack',
+    entityId: 'spelling-core-inklet',
+    fieldPath: 'labels.title',
+    action: 'set',
+    payload: 'Core Inklet',
+  }];
+  const bundle = await readSeededSpellingContentBundle();
+
+  const conflicts = detectContentOperationConflicts(exposureOnlyEdit, structuralRewardTrackEdit);
+
+  assert.equal(operationConflictKey(exposureOnlyEdit[0]), 'spelling.rewardTrack::spelling-core-inklet::heroExposure');
+  assert.equal(conflicts.length, 1);
+  assert.equal(conflicts[0].code, 'structural_conflict');
+  assert.equal(conflicts[0].entityType, 'spelling.rewardTrack');
+  assert.equal(conflicts[0].entityId, 'spelling-core-inklet');
+  assert.equal(conflicts[0].fieldPath, '$');
+  assert.deepEqual(detectContentOperationConflicts(exposureOnlyEdit, unrelatedRewardTrackLabelEdit), []);
+  assert.equal(
+    readContentOperationField(bundle, exposureOnlyEdit[0]).state,
+    'visible',
+  );
+}
+);
 
 test('spelling package candidate applies word edits against the existing bundle', async () => {
   const bundle = await readSeededSpellingContentBundle();

--- a/tests/hero-contracts.test.js
+++ b/tests/hero-contracts.test.js
@@ -22,6 +22,13 @@ import {
 } from '../shared/hero/contracts.js';
 
 import {
+  HERO_EXPOSURE_SURFACES,
+  heroExposureStatus,
+  isHeroExposureVisible,
+  normaliseHeroExposure,
+} from '../src/platform/game/reward-track-config.js';
+
+import {
   generateHeroSeed,
   deriveDateKey,
   createSeededRandom,
@@ -167,6 +174,76 @@ test('legacy spelling reward-track monsters have bundled visual coverage', () =>
       }
     }
   }
+});
+
+test('Hero / Codex exposure normalises scheduled and rollout-flagged states', () => {
+  const scheduled = normaliseHeroExposure({
+    state: 'staged',
+    surfaces: 'codex, heroQuest',
+    scheduledAt: Date.UTC(2026, 5, 12, 9, 0, 0),
+  });
+  const flagged = normaliseHeroExposure({
+    state: 'rolloutFlagged',
+    rolloutFlag: 'HERO_CODEX_REWARD_TRACKS_ENABLED',
+  });
+  const emptySurfaces = normaliseHeroExposure({
+    state: 'visible',
+    surfaces: [],
+  });
+
+  assert.equal(scheduled.state, 'scheduled');
+  assert.deepEqual(scheduled.surfaces, ['codex', 'heroQuest']);
+  assert.equal(flagged.state, 'rollout-flagged');
+  assert.deepEqual(flagged.surfaces, HERO_EXPOSURE_SURFACES);
+  assert.deepEqual(emptySurfaces.surfaces, []);
+});
+
+test('Hero / Codex exposure resolves learner visibility by surface, schedule, and rollout flag', () => {
+  const scheduled = {
+    state: 'scheduled',
+    surfaces: ['codex'],
+    scheduledAt: Date.UTC(2026, 5, 12, 9, 0, 0),
+  };
+  const flagged = {
+    state: 'rollout-flagged',
+    surfaces: ['codex'],
+    rolloutFlag: 'HERO_CODEX_REWARD_TRACKS_ENABLED',
+  };
+
+  assert.equal(isHeroExposureVisible(scheduled, {
+    surface: 'codex',
+    now: Date.UTC(2026, 5, 12, 8, 59, 59),
+  }), false);
+  assert.equal(isHeroExposureVisible(scheduled, {
+    surface: 'codex',
+    now: Date.UTC(2026, 5, 12, 9, 0, 0),
+  }), true);
+  assert.equal(isHeroExposureVisible(scheduled, {
+    surface: 'heroCamp',
+    now: Date.UTC(2026, 5, 12, 10, 0, 0),
+  }), false);
+  assert.equal(isHeroExposureVisible(flagged, {
+    surface: 'codex',
+    env: { HERO_CODEX_REWARD_TRACKS_ENABLED: 'false' },
+  }), false);
+  assert.equal(heroExposureStatus(flagged, {
+    surface: 'codex',
+    env: { HERO_CODEX_REWARD_TRACKS_ENABLED: 'true' },
+  }).learnerVisible, true);
+  assert.deepEqual(heroExposureStatus({
+    state: 'hidden',
+    surfaces: ['codex'],
+    previewAllowed: false,
+  }, {
+    surface: 'codex',
+  }), {
+    state: 'hidden',
+    surfaces: ['codex'],
+    scheduledAt: 0,
+    rolloutFlag: '',
+    previewAllowed: false,
+    learnerVisible: false,
+  });
 });
 
 // ── Intent / launcher validation ───────────────────────────────────

--- a/tests/hero-p5-camp-resolver.test.js
+++ b/tests/hero-p5-camp-resolver.test.js
@@ -75,6 +75,7 @@ function invoke(command, body, opts = {}) {
     learnerId: opts.learnerId || LEARNER,
     rosterVersion: opts.rosterVersion || ROSTER_V,
     nowTs: opts.nowTs || NOW,
+    allowedMonsterIds: opts.allowedMonsterIds,
   });
 }
 
@@ -182,6 +183,17 @@ test('unknown monsterId returns hero_monster_unknown', () => {
   assert.equal(result.ok, false);
   assert.equal(result.code, 'hero_monster_unknown');
   assert.equal(result.httpStatus, 400);
+});
+
+test('hidden Hero Camp monster returns hero_monster_hidden before spending checks', () => {
+  const result = invoke('unlock-monster', { monsterId: 'loomrill', branch: 'b1' }, {
+    balance: 500,
+    allowedMonsterIds: ['glossbloom'],
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.code, 'hero_monster_hidden');
+  assert.equal(result.httpStatus, 404);
 });
 
 // ── Error: invalid branch ───────────────────────────────────────────

--- a/tests/hero-p5-read-model.test.js
+++ b/tests/hero-p5-read-model.test.js
@@ -151,6 +151,16 @@ test('camp enabled + economy enabled → v6 with camp block and 6 monsters', () 
   );
 });
 
+test('camp read model honours explicit exposure monster roster', () => {
+  const model = buildV6({ campMonsterIds: ['glossbloom', 'colisk'] });
+
+  assert.equal(model.version, 6);
+  assert.deepEqual(
+    model.camp.monsters.map(m => m.monsterId),
+    ['glossbloom', 'colisk'],
+  );
+});
+
 test('owned monster shows correct stage, branch, and costs', () => {
   const state = makeProgressStateWithPool({
     monsters: {

--- a/tests/react-admin-content-operations.test.js
+++ b/tests/react-admin-content-operations.test.js
@@ -1619,6 +1619,219 @@ test('Content Operations Centre pools and rewards tab appends reward-track upser
   assert.match(result.text, /Reward track operation saved/);
 });
 
+test('Content Operations Centre Hero / Codex tab appends exposure-only operations', async () => {
+  const output = await runClientEntry(`
+    const { JSDOM } = require('jsdom');
+
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+    const dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
+      url: 'https://ks2.eugnel.uk/admin',
+    });
+    globalThis.window = dom.window;
+    globalThis.document = dom.window.document;
+    globalThis.navigator = dom.window.navigator;
+    globalThis.HTMLElement = dom.window.HTMLElement;
+    globalThis.Event = dom.window.Event;
+
+    const React = require('react');
+    const { createRoot } = require('react-dom/client');
+    const { AdminContentOperationsSection } = require(${CONTENT_OPS_SECTION_PATH});
+    const { act } = React;
+
+    const calls = [];
+    const model = ${JSON.stringify(baseModel({
+      contentOperations: {
+        overview,
+        packages: { packages: [contentPackage] },
+        releases: { releases: [release] },
+        spellingBrowse,
+        spellingItemDetail: spellingWordDetail,
+      },
+    }))};
+    const actions = {
+      contentOperationsApi: {
+        async readSpellingWord(args) {
+          calls.push({ method: 'readSpellingWord', args });
+          return ${JSON.stringify(spellingWordDetail)};
+        },
+        async appendOperation(args) {
+          calls.push({ method: 'appendOperation', args });
+          return { ok: true, operation: { operationId: 'op-exposure-save-1', ...args.operation } };
+        },
+      },
+    };
+
+    async function flush() {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+    }
+
+    async function setControl(selector, value) {
+      const control = document.querySelector(selector);
+      const prototype = control.tagName === 'TEXTAREA'
+        ? dom.window.HTMLTextAreaElement.prototype
+        : (control.tagName === 'SELECT'
+            ? dom.window.HTMLSelectElement.prototype
+            : dom.window.HTMLInputElement.prototype);
+      const valueSetter = Object.getOwnPropertyDescriptor(prototype, 'value').set;
+      valueSetter.call(control, value);
+      await act(async () => {
+        control.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
+        control.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+      });
+    }
+
+    async function main() {
+      const root = createRoot(document.getElementById('root'));
+      await act(async () => {
+        root.render(React.createElement(AdminContentOperationsSection, {
+          model,
+          actions,
+          initialActiveTab: 'heroCodex',
+          initialSelectedPackageId: 'pkg-draft-1',
+        }));
+      });
+      await flush();
+
+      await setControl('[data-content-ops-reward-field="heroExposureState"]', 'scheduled');
+      await setControl('[data-content-ops-reward-field="heroExposureSurfaces"]', 'heroCamp, heroQuest, codex, subjectSetup');
+      await setControl('[data-content-ops-reward-field="heroExposureScheduledAt"]', '1781254800000');
+
+      const saveButton = Array.from(document.querySelectorAll('button'))
+        .find((button) => button.textContent === 'Save exposure');
+      await act(async () => {
+        saveButton.click();
+      });
+      await flush();
+      await flush();
+
+      process.stdout.write(JSON.stringify({
+        calls,
+        text: document.body.textContent,
+        area: document.querySelector('[data-content-ops-area]')?.getAttribute('data-content-ops-area'),
+      }));
+
+      await act(async () => {
+        root.unmount();
+      });
+      dom.window.close();
+      process.exit(0);
+    }
+
+    main().catch((error) => {
+      process.stderr.write(error.stack || error.message);
+      process.exitCode = 1;
+    });
+  `);
+  const result = JSON.parse(output);
+  const appendCall = result.calls.find((entry) => entry.method === 'appendOperation');
+
+  assert.equal(result.area, 'heroCodex');
+  assert.ok(appendCall, 'Hero / Codex editor should append an operation');
+  assert.equal(appendCall.args.packageId, 'pkg-draft-1');
+  assert.equal(appendCall.args.operation.entityType, 'spelling.heroExposure');
+  assert.equal(appendCall.args.operation.action, 'upsert');
+  assert.equal(appendCall.args.operation.entityId, 'extra-vellhorn');
+  assert.equal(appendCall.args.operation.payload.state, 'scheduled');
+  assert.equal(appendCall.args.operation.payload.scheduledAt, 1781254800000);
+  assert.deepEqual(appendCall.args.operation.payload.surfaces, ['heroCamp', 'heroQuest', 'codex', 'subjectSetup']);
+  assert.equal(appendCall.args.mutation.requestId.startsWith('content-ops-hero-exposure-upsert-pkg-draft-1-'), true);
+  assert.match(result.text, /Hero \/ Codex operation saved/);
+});
+
+test('Content Operations Centre disables exposure-only save while creating a new reward track', async () => {
+  const output = await runClientEntry(`
+    const { JSDOM } = require('jsdom');
+
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+    const dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
+      url: 'https://ks2.eugnel.uk/admin',
+    });
+    globalThis.window = dom.window;
+    globalThis.document = dom.window.document;
+    globalThis.navigator = dom.window.navigator;
+    globalThis.HTMLElement = dom.window.HTMLElement;
+    globalThis.Event = dom.window.Event;
+
+    const React = require('react');
+    const { createRoot } = require('react-dom/client');
+    const { AdminContentOperationsSection } = require(${CONTENT_OPS_SECTION_PATH});
+    const { act } = React;
+
+    const calls = [];
+    const model = ${JSON.stringify(baseModel({
+      contentOperations: {
+        overview,
+        packages: { packages: [contentPackage] },
+        releases: { releases: [release] },
+        spellingBrowse,
+        spellingItemDetail: spellingWordDetail,
+      },
+    }))};
+    const actions = {
+      contentOperationsApi: {
+        async appendOperation(args) {
+          calls.push({ method: 'appendOperation', args });
+          return { ok: true, operation: { operationId: 'op-exposure-create-leak', ...args.operation } };
+        },
+      },
+    };
+
+    async function flush() {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+    }
+
+    async function main() {
+      const root = createRoot(document.getElementById('root'));
+      await act(async () => {
+        root.render(React.createElement(AdminContentOperationsSection, {
+          model,
+          actions,
+          initialActiveTab: 'heroCodex',
+          initialSelectedPackageId: 'pkg-draft-1',
+        }));
+      });
+      await flush();
+
+      const newTrackButton = Array.from(document.querySelectorAll('button'))
+        .find((button) => button.textContent === 'New track');
+      await act(async () => {
+        newTrackButton.click();
+      });
+
+      const saveExposureButton = Array.from(document.querySelectorAll('button'))
+        .find((button) => button.textContent === 'Save exposure');
+      await act(async () => {
+        saveExposureButton.click();
+      });
+      await flush();
+
+      process.stdout.write(JSON.stringify({
+        calls,
+        disabled: saveExposureButton.disabled,
+      }));
+
+      await act(async () => {
+        root.unmount();
+      });
+      dom.window.close();
+      process.exit(0);
+    }
+
+    main().catch((error) => {
+      process.stderr.write(error.stack || error.message);
+      process.exitCode = 1;
+    });
+  `);
+  const result = JSON.parse(output);
+
+  assert.equal(result.disabled, true);
+  assert.deepEqual(result.calls, []);
+});
+
 test('Content Operations Centre pools and rewards tab cold-loads spelling browse data', async () => {
   const output = await runClientEntry(`
     const { JSDOM } = require('jsdom');

--- a/tests/render.test.js
+++ b/tests/render.test.js
@@ -535,6 +535,29 @@ test('codex synthesises uncaught entries for every registered subject monster', 
   assert.equal(readingEgg.nextGoal, 'Find this egg with a reading round');
 });
 
+test('codex synthesis respects exposure-filtered spelling rosters', async () => {
+  const { buildCodexEntries } = await import('../src/surfaces/home/data.js');
+  const entries = buildCodexEntries([
+    {
+      subjectId: 'spelling',
+      monster: MONSTERS.glimmerbug,
+      progress: { caught: false, mastered: 0, stage: 0, level: 0, branch: 'b1', visibleInCodex: true },
+    },
+    {
+      subjectId: 'spelling',
+      monster: MONSTERS.phaeton,
+      progress: { caught: false, mastered: 0, stage: 0, level: 0, branch: 'b1', visibleInCodex: true },
+    },
+  ]);
+  const spellingIds = entries
+    .filter((entry) => entry.subjectId === 'spelling')
+    .map((entry) => entry.id)
+    .sort();
+
+  assert.deepEqual(spellingIds, ['glimmerbug', 'phaeton']);
+  assert.ok(entries.some((entry) => entry.id === 'bracehart'), 'non-spelling subjects still use their default roster');
+});
+
 test('codex entries use grammar displayState for first-Star Egg Found', async () => {
   const { buildCodexEntries } = await import('../src/surfaces/home/data.js');
   const [entry] = buildCodexEntries([

--- a/tests/spelling-reward-tracks.test.js
+++ b/tests/spelling-reward-tracks.test.js
@@ -5,8 +5,12 @@ import {
   LEGACY_SPELLING_REWARD_TRACKS,
   legacySpellingRewardTrackIdsForPool,
   normaliseRewardTrackConfig,
+  rewardTracksVisibleForHeroSurface,
   thresholdsForRewardTrack,
 } from '../src/platform/game/reward-track-config.js';
+import {
+  monsterSummaryFromSpellingAnalytics,
+} from '../src/platform/game/monster-system.js';
 import {
   validateSpellingContentBundle,
 } from '../src/subjects/spelling/content/model.js';
@@ -14,6 +18,7 @@ import {
   buildSpellingContentOperationCandidate,
 } from '../src/subjects/spelling/content/operations-model.js';
 import {
+  buildSpellingHeroExposureUpsertOperation,
   buildSpellingPoolUpsertOperation,
   buildSpellingRewardTrackDeleteOrRetireOperation,
   buildSpellingRewardTrackUpsertOperation,
@@ -145,7 +150,103 @@ test('reward track config defaults to parallel direct progression', () => {
   assert.equal(track.monsterId, 'inklet');
   assert.equal(track.progressionMode, 'parallel');
   assert.equal(track.thresholdTemplate, 'direct');
+  assert.equal(track.heroExposure.state, 'visible');
   assert.deepEqual(thresholdsForRewardTrack(track), [1, 10, 30, 60, 100]);
+});
+
+test('reward track Hero / Codex exposure filters learner surfaces without removing admin preview', () => {
+  const now = Date.UTC(2026, 5, 12, 9, 0, 0);
+  const tracks = [
+    normaliseRewardTrackConfig({
+      id: 'secure-hidden',
+      poolId: 'secure-vocabulary',
+      monsterId: 'inklet',
+      thresholdOverrides: [1],
+      heroExposure: { state: 'hidden' },
+    }),
+    normaliseRewardTrackConfig({
+      id: 'secure-scheduled',
+      poolId: 'secure-vocabulary',
+      monsterId: 'glimmerbug',
+      thresholdOverrides: [1],
+      heroExposure: { state: 'scheduled', scheduledAt: now + 60_000 },
+    }),
+    normaliseRewardTrackConfig({
+      id: 'secure-visible',
+      poolId: 'secure-vocabulary',
+      monsterId: 'vellhorn',
+      thresholdOverrides: [1],
+      heroExposure: { state: 'visible', surfaces: ['codex'] },
+    }),
+    normaliseRewardTrackConfig({
+      id: 'secure-preview-blocked',
+      poolId: 'secure-vocabulary',
+      monsterId: 'inklet',
+      thresholdOverrides: [1],
+      heroExposure: { state: 'hidden', previewAllowed: false },
+    }),
+    normaliseRewardTrackConfig({
+      id: 'secure-hero-camp-only',
+      poolId: 'secure-vocabulary',
+      monsterId: 'vellhorn',
+      thresholdOverrides: [1],
+      heroExposure: { state: 'hidden', surfaces: ['heroCamp'] },
+    }),
+  ];
+
+  assert.deepEqual(
+    rewardTracksVisibleForHeroSurface(tracks, { surface: 'codex', now }).map((track) => track.id),
+    ['secure-visible'],
+  );
+  assert.deepEqual(
+    rewardTracksVisibleForHeroSurface(tracks, { surface: 'codex', now, includeAdminPreview: true }).map((track) => track.id),
+    ['secure-hidden', 'secure-scheduled', 'secure-visible'],
+  );
+});
+
+test('spelling setup monster summary reads subjectSetup exposure rules', () => {
+  const tracks = LEGACY_SPELLING_REWARD_TRACKS.map((track) => {
+    if (track.monsterId === 'inklet') {
+      return normaliseRewardTrackConfig({
+        ...track,
+        heroExposure: { state: 'visible', surfaces: ['codex'] },
+      });
+    }
+    if (track.monsterId === 'vellhorn') {
+      return normaliseRewardTrackConfig({
+        ...track,
+        heroExposure: { state: 'visible', surfaces: ['subjectSetup'] },
+      });
+    }
+    return normaliseRewardTrackConfig({
+      ...track,
+      heroExposure: { state: 'hidden', surfaces: ['codex', 'subjectSetup'] },
+    });
+  });
+  const analytics = {
+    wordGroups: [{
+      words: [
+        { slug: 'core-secure', word: 'core', year: '3-4', spellingPool: 'core', status: 'secure' },
+        { slug: 'extra-secure', word: 'extra', year: 'extra', spellingPool: 'extra', status: 'secure' },
+      ],
+    }],
+  };
+
+  const setupIds = monsterSummaryFromSpellingAnalytics(analytics, {
+    rewardTracks: tracks,
+    surface: 'subjectSetup',
+  })
+    .filter((entry) => entry.subjectId === 'spelling')
+    .map((entry) => entry.monster.id);
+  const codexIds = monsterSummaryFromSpellingAnalytics(analytics, {
+    rewardTracks: tracks,
+    surface: 'codex',
+  })
+    .filter((entry) => entry.subjectId === 'spelling')
+    .map((entry) => entry.monster.id);
+
+  assert.deepEqual(setupIds, ['vellhorn']);
+  assert.deepEqual(codexIds, ['inklet']);
 });
 
 test('seeded spelling content binds legacy pools to formal reward tracks', () => {
@@ -396,6 +497,99 @@ test('reward-track editor validator catches duplicate ids in context', () => {
 
   assert.equal(validation.ok, false);
   assert.ok(validation.errors.some((entry) => entry.code === 'duplicate_reward_track'));
+});
+
+test('reward-track editor validates scheduled and rollout-flagged Hero / Codex exposure', () => {
+  const scheduled = validateSpellingRewardTrackEditorInput({
+    id: 'secure-inklet',
+    poolId: 'secure-vocabulary',
+    monsterId: 'inklet',
+    thresholdOverrides: [1],
+    heroExposure: { state: 'scheduled' },
+  }, {
+    pools: [poolFixture('secure-vocabulary')],
+  });
+  const flagged = validateSpellingRewardTrackEditorInput({
+    id: 'secure-vellhorn',
+    poolId: 'secure-vocabulary',
+    monsterId: 'vellhorn',
+    thresholdOverrides: [1],
+    heroExposure: { state: 'rollout-flagged' },
+  }, {
+    pools: [poolFixture('secure-vocabulary')],
+  });
+
+  assert.equal(scheduled.ok, false);
+  assert.equal(flagged.ok, false);
+  assert.ok(scheduled.errors.some((entry) => entry.code === 'hero_exposure_schedule_required'));
+  assert.ok(flagged.errors.some((entry) => entry.code === 'hero_exposure_flag_required'));
+});
+
+test('reward-track editor validates empty and invalid Hero / Codex exposure surfaces', () => {
+  const empty = validateSpellingRewardTrackEditorInput({
+    id: 'secure-inklet',
+    poolId: 'secure-vocabulary',
+    monsterId: 'inklet',
+    thresholdOverrides: [1],
+    heroExposure: { state: 'visible', surfaces: [] },
+  }, {
+    pools: [poolFixture('secure-vocabulary')],
+  });
+  const invalid = validateSpellingRewardTrackEditorInput({
+    id: 'secure-vellhorn',
+    poolId: 'secure-vocabulary',
+    monsterId: 'vellhorn',
+    thresholdOverrides: [1],
+    heroExposure: { state: 'visible', surfaces: 'codex, archive' },
+  }, {
+    pools: [poolFixture('secure-vocabulary')],
+  });
+
+  assert.equal(empty.ok, false);
+  assert.equal(invalid.ok, false);
+  assert.ok(empty.errors.some((entry) => entry.code === 'hero_exposure_surface_required'));
+  assert.ok(invalid.errors.some((entry) => entry.code === 'invalid_hero_exposure_surface'));
+});
+
+test('Hero / Codex exposure operation updates reward-track exposure without replacing the track', () => {
+  const base = rewardBundle({
+    pools: [poolFixture('secure-vocabulary', {
+      visibilityState: 'hidden',
+      rewardTrackIds: ['secure-inklet'],
+    })],
+    rewardTracks: [{
+      id: 'secure-inklet',
+      poolId: 'secure-vocabulary',
+      monsterId: 'inklet',
+      thresholdOverrides: [1],
+      labels: { title: 'Secure Inklet' },
+      heroExposure: { state: 'visible', surfaces: ['codex'] },
+    }],
+    wordCounts: { 'secure-vocabulary': 1 },
+  });
+  const operation = buildSpellingHeroExposureUpsertOperation({
+    id: 'secure-inklet',
+    heroExposure: {
+      state: 'scheduled',
+      surfaces: 'heroCamp, codex',
+      scheduledAt: NOW,
+      previewAllowed: false,
+    },
+  }, {
+    existingTrack: base.draft.rewardTracks[0],
+  });
+  const candidate = buildSpellingContentOperationCandidate(base, [operation]);
+  const updatedTrack = candidate.validation.bundle.draft.rewardTracks.find((track) => track.id === 'secure-inklet');
+
+  assert.equal(operation.entityType, 'spelling.heroExposure');
+  assert.equal(updatedTrack.monsterId, 'inklet');
+  assert.deepEqual(updatedTrack.heroExposure, {
+    state: 'scheduled',
+    surfaces: ['heroCamp', 'codex'],
+    scheduledAt: NOW,
+    rolloutFlag: '',
+    previewAllowed: false,
+  });
 });
 
 test('reward-track editor operation normalises UI-submitted source monsters and inactive state', () => {

--- a/tests/worker-subject-runtime.test.js
+++ b/tests/worker-subject-runtime.test.js
@@ -4,9 +4,12 @@ import { readFile } from 'node:fs/promises';
 
 import { createWorkerApp } from '../worker/src/app.js';
 import {
+  PUBLIC_SPELLING_MONSTER_IDS,
   PUBLIC_SPELLING_REWARD_TRACK_IDS,
   createWorkerRepository,
+  publicMonsterCodexState,
   publicMonsterCodexStateFromSpellingProgress,
+  publicMonsterCodexStateWithoutSpellingEntries,
 } from '../worker/src/repository.js';
 import { createSubjectRuntime, createWorkerSubjectRuntime } from '../worker/src/subjects/runtime.js';
 import { normaliseSubjectCommandRequest } from '../worker/src/subjects/command-contract.js';
@@ -71,6 +74,99 @@ test('Worker spelling codex projection follows legacy reward-track mapping witho
   assert.equal(derived.state.phaeton.masteredCount, 2);
   assert.equal(derived.state.vellhorn.masteredCount, 1);
   assert.equal(derived.state.inklet.rewardTrackId, undefined);
+});
+
+test('Worker spelling codex projection respects reward-track Hero / Codex exposure', () => {
+  const now = Date.UTC(2026, 5, 12, 9, 0, 0);
+  const exposedTracks = LEGACY_SPELLING_REWARD_TRACKS.map((track) => {
+    if (track.id === 'spelling-core-inklet') {
+      return { ...track, heroExposure: { state: 'hidden' } };
+    }
+    if (track.id === 'spelling-core-glimmerbug') {
+      return { ...track, heroExposure: { state: 'scheduled', scheduledAt: now + 60_000 } };
+    }
+    return { ...track, heroExposure: { state: 'visible' } };
+  });
+  const snapshot = {
+    rewardTracks: exposedTracks,
+    words: [
+      { slug: 'alpha', spellingPool: 'core', yearBand: '3-4' },
+      { slug: 'bravo', spellingPool: 'core', yearBand: '5-6' },
+    ],
+  };
+  const progress = {
+    alpha: { stage: 4 },
+    bravo: { stage: 4 },
+  };
+
+  const learnerRuntime = publicMonsterCodexStateFromSpellingProgress(progress, snapshot, {}, {
+    learnerId: 'learner-exposure',
+    now,
+  });
+  const afterSchedule = publicMonsterCodexStateFromSpellingProgress(progress, {
+    ...snapshot,
+    rewardTracks: exposedTracks.map((track) => (
+      track.id === 'spelling-core-glimmerbug'
+        ? { ...track, heroExposure: { state: 'scheduled', scheduledAt: now } }
+        : track
+    )),
+  }, {}, {
+    learnerId: 'learner-exposure',
+    now,
+  });
+  const adminPreview = publicMonsterCodexStateFromSpellingProgress(progress, snapshot, {}, {
+    learnerId: 'learner-exposure',
+    now,
+    includeAdminPreview: true,
+  });
+
+  assert.equal(learnerRuntime.knownWordCount, 2);
+  assert.equal(learnerRuntime.state.inklet, undefined);
+  assert.equal(learnerRuntime.state.glimmerbug, undefined);
+  assert.equal(learnerRuntime.state.phaeton.masteredCount, 0);
+  assert.equal(afterSchedule.state.glimmerbug.masteredCount, 1);
+  assert.equal(afterSchedule.state.phaeton.masteredCount, 1);
+  assert.equal(adminPreview.state.inklet.masteredCount, 1);
+  assert.equal(adminPreview.state.glimmerbug.masteredCount, 1);
+});
+
+test('Worker spelling codex projection drops stale hidden entries while preserving other subjects', () => {
+  const now = Date.UTC(2026, 5, 12, 9, 0, 0);
+  const learnerId = 'learner-stale-exposure';
+  const rewardTracks = LEGACY_SPELLING_REWARD_TRACKS.map((track) => {
+    if (track.id === 'spelling-core-inklet') {
+      return { ...track, heroExposure: { state: 'hidden' } };
+    }
+    return { ...track, heroExposure: { state: 'visible' } };
+  });
+  const existingState = publicMonsterCodexState({
+    inklet: { masteredCount: 12, caught: true, branch: 'b1' },
+    quoral: { masteredCount: 3, caught: true, branch: 'b2' },
+  }, { learnerId });
+  const derived = publicMonsterCodexStateFromSpellingProgress(
+    { alpha: { stage: 4 }, bravo: { stage: 4 } },
+    {
+      rewardTracks,
+      words: [
+        { slug: 'alpha', spellingPool: 'core', yearBand: '3-4' },
+        { slug: 'bravo', spellingPool: 'core', yearBand: '5-6' },
+      ],
+    },
+    existingState,
+    { learnerId, now },
+  );
+  const merged = publicMonsterCodexState({
+    ...publicMonsterCodexStateWithoutSpellingEntries(existingState, { learnerId }),
+    ...derived.state,
+  }, { learnerId });
+
+  assert.equal(PUBLIC_SPELLING_MONSTER_IDS.includes('inklet'), true);
+  assert.equal(derived.state.inklet, undefined);
+  assert.equal(merged.inklet, undefined);
+  assert.equal(merged.glimmerbug.visibleInCodex, true);
+  assert.equal(merged.phaeton.visibleInCodex, true);
+  assert.equal(merged.quoral.masteredCount, 3);
+  assert.equal(merged.quoral.branch, 'b2');
 });
 
 async function postJson(server, path, body = {}, headers = {}) {

--- a/worker/src/app.js
+++ b/worker/src/app.js
@@ -50,6 +50,7 @@ import { handleContentOperationsAdminRequest } from './content-operations/routes
 import { resolveHeroStartTaskCommand } from './hero/launch.js';
 import { resolveHeroClaimCommand } from './hero/claim.js';
 import { resolveHeroCampCommand } from './hero/camp.js';
+import { heroCampMonsterIdsFromRewardTracks } from './hero/exposure.js';
 import { probeHeroTelemetry, buildExpandedProbeResponse, stripPrivacyFields } from './hero/telemetry-probe.js';
 import { resolveHeroFlagsWithOverride, resolveHeroFlagsForAccount, HERO_FLAG_KEYS } from '../../shared/hero/account-override.js';
 import {
@@ -476,6 +477,27 @@ function shouldUsePublicReadModels(request, env = {}) {
 
 function envFlagEnabled(value) {
   return ['1', 'true', 'yes', 'on'].includes(String(value || '').trim().toLowerCase());
+}
+
+async function visibleHeroCampMonsterIdsFromSpellingExposure(repository, accountId, {
+  now = Date.now(),
+  env = {},
+} = {}) {
+  if (!accountId || typeof repository?.readSpellingRuntimeContent !== 'function') return null;
+  try {
+    const runtimeContent = await repository.readSpellingRuntimeContent(accountId, 'spelling', {
+      includeAccountContent: false,
+      includeGlobalContent: true,
+    });
+    const rewardTracks = runtimeContent?.snapshot?.rewardTracks;
+    if (!Array.isArray(rewardTracks)) return null;
+    return heroCampMonsterIdsFromRewardTracks(rewardTracks, {
+      now,
+      env,
+    });
+  } catch {
+    return null;
+  }
 }
 
 export function subjectExposureGatesFromEnv(env = {}) {
@@ -1885,6 +1907,11 @@ export function createWorkerApp({
 
             const nowTs = now();
             const heroProgressState = await repository.readHeroProgress(heroLearnerId);
+            const allowedCampMonsterIds = await visibleHeroCampMonsterIdsFromSpellingExposure(
+              repository,
+              session.accountId,
+              { now: nowTs, env: heroCommandEnv },
+            );
 
             // Resolve the camp command (pure function)
             const campResult = resolveHeroCampCommand({
@@ -1894,6 +1921,7 @@ export function createWorkerApp({
               learnerId: heroLearnerId,
               rosterVersion: heroProgressState.heroPool?.rosterVersion || HERO_POOL_ROSTER_VERSION,
               nowTs,
+              allowedMonsterIds: allowedCampMonsterIds,
             });
 
             // Handle rejection

--- a/worker/src/hero/camp.js
+++ b/worker/src/hero/camp.js
@@ -19,13 +19,18 @@ export const FORBIDDEN_CAMP_FIELDS = Object.freeze([
 
 const CAMP_COMMANDS = new Set(['unlock-monster', 'evolve-monster']);
 
+function allowedMonsterSet(allowedMonsterIds) {
+  if (!Array.isArray(allowedMonsterIds)) return null;
+  return new Set(allowedMonsterIds.map((entry) => String(entry || '').trim()).filter(Boolean));
+}
+
 // ── Main resolver ──────────────────────────────────────────────────
 
 /**
  * Pure camp command resolver — receives pre-loaded state, returns intent.
  * Does NOT perform DB reads or writes.
  */
-export function resolveHeroCampCommand({ command, body, heroState, learnerId, rosterVersion, nowTs }) {
+export function resolveHeroCampCommand({ command, body, heroState, learnerId, rosterVersion, nowTs, allowedMonsterIds = null }) {
   // 1. Validate command
   if (!CAMP_COMMANDS.has(command)) {
     return { ok: false, code: 'hero_camp_disabled', httpStatus: 400, reason: `Unknown camp command: ${command}` };
@@ -39,6 +44,17 @@ export function resolveHeroCampCommand({ command, body, heroState, learnerId, ro
       code: 'hero_client_field_rejected',
       httpStatus: 400,
       reason: `Client must not send: ${rejectedFields.join(', ')}`,
+    };
+  }
+
+  const monsterId = String(body?.monsterId || '').trim();
+  const allowList = allowedMonsterSet(allowedMonsterIds);
+  if (allowList && !allowList.has(monsterId)) {
+    return {
+      ok: false,
+      code: 'hero_monster_hidden',
+      httpStatus: 404,
+      reason: 'This Hero Camp monster is not currently available.',
     };
   }
 

--- a/worker/src/hero/exposure.js
+++ b/worker/src/hero/exposure.js
@@ -1,0 +1,22 @@
+import { HERO_POOL_INITIAL_MONSTER_IDS } from '../../../shared/hero/hero-pool.js';
+import { rewardTracksVisibleForHeroSurface } from '../../../src/platform/game/reward-track-config.js';
+
+export function heroCampMonsterIdsFromRewardTracks(rewardTracks = [], {
+  now = Date.now(),
+  env = {},
+} = {}) {
+  const tracks = Array.isArray(rewardTracks) ? rewardTracks : [];
+  const heroCampRoster = new Set(HERO_POOL_INITIAL_MONSTER_IDS);
+  const hasConfiguredHeroCampTrack = tracks.some((track) => (
+    heroCampRoster.has(String(track?.monsterId || '').trim())
+  ));
+  if (!hasConfiguredHeroCampTrack) return null;
+
+  const visible = new Set(rewardTracksVisibleForHeroSurface(tracks, {
+    surface: 'heroCamp',
+    now,
+    env,
+  }).map((track) => String(track?.monsterId || '').trim()));
+
+  return HERO_POOL_INITIAL_MONSTER_IDS.filter((monsterId) => visible.has(monsterId));
+}

--- a/worker/src/hero/read-model.js
+++ b/worker/src/hero/read-model.js
@@ -192,6 +192,7 @@ export function buildHeroShadowReadModel({
   progressEnabled = false,
   economyEnabled = false,
   campEnabled = false,
+  campMonsterIds = null,
 } = {}) {
   const dateKey = deriveDateKey(now, HERO_DEFAULT_TIMEZONE);
 
@@ -539,7 +540,9 @@ export function buildHeroShadowReadModel({
   // 18. If camp enabled → evolve to v6 with child-safe Camp block
   if (!campEnabled) return v5Result;
 
-  const campBlock = buildChildSafeCampBlock(heroProgressState, economyBlock?.balance ?? 0);
+  const campBlock = buildChildSafeCampBlock(heroProgressState, economyBlock?.balance ?? 0, {
+    monsterIds: campMonsterIds,
+  });
 
   return {
     ...v5Result,
@@ -550,14 +553,21 @@ export function buildHeroShadowReadModel({
 
 // ── Camp block helpers ────────────────────────────────────────────────
 
-function buildChildSafeCampBlock(heroProgressState, balance) {
+function visibleHeroPoolMonsterIds(monsterIds = null) {
+  if (!Array.isArray(monsterIds)) return HERO_POOL_INITIAL_MONSTER_IDS;
+  const allowed = new Set(monsterIds.map((entry) => String(entry || '').trim()).filter(Boolean));
+  return HERO_POOL_INITIAL_MONSTER_IDS.filter((monsterId) => allowed.has(monsterId));
+}
+
+function buildChildSafeCampBlock(heroProgressState, balance, { monsterIds = null } = {}) {
   const heroPool = heroProgressState?.heroPool;
+  const visibleMonsterIds = visibleHeroPoolMonsterIds(monsterIds);
 
   if (!heroPool || typeof heroPool !== 'object') {
-    return buildEmptyCampBlock(balance);
+    return buildEmptyCampBlock(balance, { monsterIds: visibleMonsterIds });
   }
 
-  const monsters = HERO_POOL_INITIAL_MONSTER_IDS.map(monsterId => {
+  const monsters = visibleMonsterIds.map(monsterId => {
     const def = HERO_POOL_REGISTRY[monsterId];
     const owned = heroPool.monsters?.[monsterId];
 
@@ -588,7 +598,7 @@ function buildChildSafeCampBlock(heroProgressState, balance) {
   });
 
   const recentActions = Array.isArray(heroPool.recentActions)
-    ? heroPool.recentActions.slice(-5).map(a => ({
+    ? heroPool.recentActions.filter((action) => visibleMonsterIds.includes(action?.monsterId)).slice(-5).map(a => ({
         type: a.type,
         monsterId: a.monsterId,
         stageAfter: a.stageAfter,
@@ -607,13 +617,13 @@ function buildChildSafeCampBlock(heroProgressState, balance) {
     },
     rosterVersion: HERO_POOL_ROSTER_VERSION,
     balance,
-    selectedMonsterId: heroPool.selectedMonsterId || null,
+    selectedMonsterId: visibleMonsterIds.includes(heroPool.selectedMonsterId) ? heroPool.selectedMonsterId : null,
     monsters,
     recentActions,
   };
 }
 
-function buildEmptyCampBlock(balance) {
+function buildEmptyCampBlock(balance, { monsterIds = HERO_POOL_INITIAL_MONSTER_IDS } = {}) {
   return {
     enabled: true,
     version: 1,
@@ -625,7 +635,7 @@ function buildEmptyCampBlock(balance) {
     rosterVersion: HERO_POOL_ROSTER_VERSION,
     balance: balance || 0,
     selectedMonsterId: null,
-    monsters: HERO_POOL_INITIAL_MONSTER_IDS.map(monsterId => {
+    monsters: monsterIds.map(monsterId => {
       const def = HERO_POOL_REGISTRY[monsterId];
       return {
         monsterId: def.monsterId,

--- a/worker/src/hero/routes.js
+++ b/worker/src/hero/routes.js
@@ -8,9 +8,15 @@ import { json } from '../http.js';
 import { NotFoundError } from '../errors.js';
 import { buildHeroShadowReadModel } from './read-model.js';
 import { resolveHeroFlagsForAccount } from '../../../shared/hero/account-override.js';
+import { heroCampMonsterIdsFromRewardTracks } from './exposure.js';
 
 function envFlagEnabled(value) {
   return ['1', 'true', 'yes', 'on'].includes(String(value || '').trim().toLowerCase());
+}
+
+function campMonsterIdsFromSubjectExposure(subjectReadModels, { now, env } = {}) {
+  const rewardTracks = subjectReadModels?.spelling?.content?.rewardTracks;
+  return heroCampMonsterIdsFromRewardTracks(rewardTracks, { now, env });
 }
 
 /**
@@ -101,6 +107,10 @@ export async function handleHeroReadModel({
   const progressFlagEnabled = envFlagEnabled(resolvedEnv.HERO_MODE_PROGRESS_ENABLED);
   const economyFlagEnabled = envFlagEnabled(resolvedEnv.HERO_MODE_ECONOMY_ENABLED);
   const campFlagEnabled = envFlagEnabled(resolvedEnv.HERO_MODE_CAMP_ENABLED);
+  const campMonsterIds = campMonsterIdsFromSubjectExposure(subjectReadModels, {
+    now: nowTs,
+    env: resolvedEnv,
+  });
   const heroProgressData = progressFlagEnabled
     ? await repository.readHeroProgressData(learnerId)
     : { heroProgressState: null, recentCompletedSessions: [] };
@@ -118,6 +128,7 @@ export async function handleHeroReadModel({
     progressEnabled: progressFlagEnabled,
     economyEnabled: progressFlagEnabled && economyFlagEnabled,
     campEnabled: progressFlagEnabled && economyFlagEnabled && campFlagEnabled,
+    campMonsterIds,
   });
 
   // U10: structured observability — fire-and-forget, never blocks the response.

--- a/worker/src/repository.js
+++ b/worker/src/repository.js
@@ -104,10 +104,12 @@ import {
   publicMonsterCodexHasMastery,
   publicMonsterCodexState,
   publicMonsterCodexStateFromSpellingProgress,
+  publicMonsterCodexStateWithoutSpellingEntries,
   PUBLIC_MONSTER_BRANCHES,
   PUBLIC_MONSTER_CODEX_SYSTEM_ID,
   PUBLIC_DIRECT_SPELLING_MONSTER_IDS,
   PUBLIC_MONSTER_IDS,
+  PUBLIC_SPELLING_MONSTER_IDS,
   PUBLIC_SPELLING_REWARD_TRACK_IDS,
   PUBLIC_PRACTICE_CARD_LABELS,
   publicPracticeLabel,
@@ -481,7 +483,11 @@ async function publicSubjectStateRowToRecord(row, { spellingContentSnapshot = nu
 // spellingProgressFromSubjectRow, publicMonsterCodexStateFromSpellingProgress,
 // publicMonsterCodexHasMastery → row-transforms.js
 
-async function mergePublicSpellingCodexState(db, accountId, subjectRows, gameState, { runtimeSnapshot = null } = {}) {
+async function mergePublicSpellingCodexState(db, accountId, subjectRows, gameState, {
+  runtimeSnapshot = null,
+  now = Date.now(),
+  env = {},
+} = {}) {
   const spellingRows = subjectRows.filter((row) => row.subject_id === 'spelling');
   if (!spellingRows.length) return gameState;
 
@@ -492,11 +498,19 @@ async function mergePublicSpellingCodexState(db, accountId, subjectRows, gameSta
     if (!progress) continue;
     const key = gameStateKey(row.learner_id, PUBLIC_MONSTER_CODEX_SYSTEM_ID);
     const existingState = publicMonsterCodexState(gameState[key] || {}, { learnerId: row.learner_id });
-    const derived = publicMonsterCodexStateFromSpellingProgress(progress, snapshot, existingState, { learnerId: row.learner_id });
+    const hasExistingSpellingState = PUBLIC_SPELLING_MONSTER_IDS.some((monsterId) => (
+      Object.prototype.hasOwnProperty.call(existingState, monsterId)
+    ));
+    const derived = publicMonsterCodexStateFromSpellingProgress(progress, snapshot, existingState, {
+      learnerId: row.learner_id,
+      now,
+      env,
+    });
     if (!derived) continue;
-    if (derived.knownWordCount > 0 || !publicMonsterCodexHasMastery(existingState)) {
+    if (derived.knownWordCount > 0 || hasExistingSpellingState || !publicMonsterCodexHasMastery(existingState)) {
+      const existingNonSpellingState = publicMonsterCodexStateWithoutSpellingEntries(existingState);
       gameState[key] = publicMonsterCodexState({
-        ...existingState,
+        ...existingNonSpellingState,
         ...derived.state,
       }, { learnerId: row.learner_id });
     }
@@ -7435,6 +7449,7 @@ async function bootstrapBundle(db, accountId, {
   // server-side snapshot to avoid a duplicate adult account point read.
   accountSnapshot = null,
   capacity = null,
+  env = {},
 } = {}) {
   const snapshot = accountSnapshotForBootstrap(accountSnapshot, accountId);
   const account = snapshot
@@ -7740,6 +7755,8 @@ async function bootstrapBundle(db, accountId, {
     if (publicReadModels) {
       await mergePublicSpellingCodexState(db, accountId, subjectRows, gameState, {
         runtimeSnapshot: publicSpellingContent?.snapshot || null,
+        now: publicReadModelNow,
+        env,
       });
     }
   });
@@ -9146,7 +9163,7 @@ export function createWorkerRepository({ env = {}, now = Date.now, capacity = nu
       return first(db, 'SELECT * FROM adult_accounts WHERE id = ?', [accountId]);
     },
     async bootstrap(accountId, options = {}) {
-      const bundle = await bootstrapBundle(db, accountId, { ...options, capacity });
+      const bundle = await bootstrapBundle(db, accountId, { env, ...options, capacity });
       // U3: stamp `bootstrapCapacity` on the collector when the bundle
       // emitted one. The collector is mutated rather than returned —
       // keeps repository call signatures stable across all callers.
@@ -9203,6 +9220,7 @@ export function createWorkerRepository({ env = {}, now = Date.now, capacity = nu
         }
       }
       const bundle = await bootstrapBundle(db, accountId, {
+        env,
         publicReadModels,
         selectedLearnerBounded: true,
         preferredLearnerId,
@@ -9227,6 +9245,7 @@ export function createWorkerRepository({ env = {}, now = Date.now, capacity = nu
       accountSnapshot = null,
     } = {}) {
       const bundle = await bootstrapBundle(db, accountId, {
+        env,
         publicReadModels,
         selectedLearnerBounded: true,
         preferredLearnerId,
@@ -10257,7 +10276,7 @@ export function createWorkerRepository({ env = {}, now = Date.now, capacity = nu
           if (rows.length > 0) {
             await bumpAccountLearnerListRevision(db, accountId, nowTs);
           }
-          const bundle = await bootstrapBundle(db, accountId);
+          const bundle = await bootstrapBundle(db, accountId, { env });
           return {
             reset: true,
             learners: bundle.learners,
@@ -10332,7 +10351,13 @@ export function createWorkerRepository({ env = {}, now = Date.now, capacity = nu
           }
           : rawUi;
         if (data || ui) {
-          result[row.subject_id] = { data, ui };
+          result[row.subject_id] = {
+            data,
+            ui,
+            ...(row.subject_id === 'spelling' && spellingContent?.snapshot
+              ? { content: spellingContent.snapshot }
+              : {}),
+          };
         }
       }
       return result;
@@ -10395,10 +10420,12 @@ export {
   publicMonsterCodexHasMastery,
   publicMonsterCodexState,
   publicMonsterCodexStateFromSpellingProgress,
+  publicMonsterCodexStateWithoutSpellingEntries,
   PUBLIC_MONSTER_BRANCHES,
   PUBLIC_MONSTER_CODEX_SYSTEM_ID,
   PUBLIC_DIRECT_SPELLING_MONSTER_IDS,
   PUBLIC_MONSTER_IDS,
+  PUBLIC_SPELLING_MONSTER_IDS,
   PUBLIC_SPELLING_REWARD_TRACK_IDS,
   PUBLIC_PRACTICE_CARD_LABELS,
   publicPracticeLabel,

--- a/worker/src/row-transforms.js
+++ b/worker/src/row-transforms.js
@@ -25,8 +25,8 @@ import { monsterBranchOverrideForLearner } from '../../src/platform/game/learner
 import { monsterIdForSpellingWord } from '../../src/platform/game/monster-system.js';
 import {
   LEGACY_SPELLING_REWARD_TRACKS,
+  rewardTracksVisibleForHeroSurface,
   sourceMonsterIdsForRewardTrack,
-  spellingRewardTrackForMonster,
 } from '../../src/platform/game/reward-track-config.js';
 import {
   asTs,
@@ -199,6 +199,7 @@ export function publicMonsterCodexEntry(entry, branchOverride = null) {
     masteredCount: mastered,
     caught: Boolean(entry.caught) || mastered > 0,
   };
+  if (entry.visibleInCodex === true) output.visibleInCodex = true;
   if (PUBLIC_MONSTER_BRANCHES.has(branchOverride)) output.branch = branchOverride;
   else if (PUBLIC_MONSTER_BRANCHES.has(entry.branch)) output.branch = entry.branch;
   const starHighWater = safePublicNonNegativeInt(entry.starHighWater);
@@ -221,6 +222,14 @@ export function publicMonsterCodexState(rawState, { learnerId = '' } = {}) {
   return output;
 }
 
+export function publicMonsterCodexStateWithoutSpellingEntries(rawState, { learnerId = '' } = {}) {
+  const output = publicMonsterCodexState(rawState, { learnerId });
+  for (const monsterId of PUBLIC_SPELLING_MONSTER_IDS) {
+    delete output[monsterId];
+  }
+  return output;
+}
+
 export function publicGameStateRowToRecord(row) {
   if (row.system_id !== PUBLIC_MONSTER_CODEX_SYSTEM_ID) return null;
   return publicMonsterCodexState(gameStateRowToRecord(row), { learnerId: row.learner_id });
@@ -238,7 +247,28 @@ export function spellingProgressFromSubjectRow(row) {
   return isPlainObject(data?.progress) ? data.progress : null;
 }
 
-export function publicMonsterCodexStateFromSpellingProgress(progress, snapshot, existingState = {}, { learnerId = '' } = {}) {
+function rewardTrackCountsWord(track, word, sourceMonsterIds = sourceMonsterIdsForRewardTrack(track)) {
+  if (!track?.poolId || !word?.spellingPool || track.poolId !== word.spellingPool) return false;
+  if (!['core', 'extra'].includes(track.poolId)) return true;
+  const sourceMonsterId = monsterIdForSpellingWord(word);
+  return sourceMonsterIds.includes(sourceMonsterId);
+}
+
+function rewardTrackProjection(track) {
+  const sourceMonsterIds = sourceMonsterIdsForRewardTrack(track);
+  return {
+    track,
+    sourceMonsterIds,
+    aggregate: track?.thresholdTemplate === 'aggregate' || sourceMonsterIds.length > 1,
+  };
+}
+
+export function publicMonsterCodexStateFromSpellingProgress(progress, snapshot, existingState = {}, {
+  learnerId = '',
+  now = Date.now(),
+  env = {},
+  includeAdminPreview = false,
+} = {}) {
   if (!isPlainObject(progress)) return null;
   const branchOverride = monsterBranchOverrideForLearner(learnerId);
   const branchForOutput = (existing) => (
@@ -246,9 +276,17 @@ export function publicMonsterCodexStateFromSpellingProgress(progress, snapshot, 
       ? { branch: branchOverride }
       : (PUBLIC_MONSTER_BRANCHES.has(existing.branch) ? { branch: existing.branch } : {})
   );
-  const directRewardTracks = LEGACY_SPELLING_REWARD_TRACKS
-    .filter((track) => PUBLIC_DIRECT_SPELLING_MONSTER_IDS.includes(track.monsterId));
-  const counts = Object.fromEntries(directRewardTracks.map((track) => [track.monsterId, 0]));
+  const rewardTracks = rewardTracksVisibleForHeroSurface(
+    Array.isArray(snapshot?.rewardTracks) && snapshot.rewardTracks.length
+      ? snapshot.rewardTracks
+      : LEGACY_SPELLING_REWARD_TRACKS,
+    { surface: 'codex', now, env, includeAdminPreview },
+  );
+  const rewardTrackProjections = rewardTracks.map((track) => rewardTrackProjection(track));
+  const directRewardTrackProjections = rewardTrackProjections
+    .filter((projection) => !projection.aggregate)
+    .filter(({ track }) => PUBLIC_DIRECT_SPELLING_MONSTER_IDS.includes(track.monsterId));
+  const counts = Object.fromEntries(directRewardTrackProjections.map(({ track }) => [track.monsterId, 0]));
   const words = Array.isArray(snapshot?.words) ? snapshot.words : [];
   let knownWordCount = 0;
 
@@ -256,32 +294,45 @@ export function publicMonsterCodexStateFromSpellingProgress(progress, snapshot, 
     if (!word?.slug || !isPlainObject(progress[word.slug])) continue;
     knownWordCount += 1;
     if (!secureSpellingProgress(progress[word.slug])) continue;
-    const monsterId = monsterIdForSpellingWord(word);
-    const rewardTrack = spellingRewardTrackForMonster(monsterId);
-    if (rewardTrack?.monsterId && Object.prototype.hasOwnProperty.call(counts, rewardTrack.monsterId)) {
-      counts[rewardTrack.monsterId] += 1;
+    for (const { track: rewardTrack, sourceMonsterIds } of directRewardTrackProjections) {
+      if (rewardTrackCountsWord(rewardTrack, word, sourceMonsterIds) && Object.prototype.hasOwnProperty.call(counts, rewardTrack.monsterId)) {
+        counts[rewardTrack.monsterId] += 1;
+      }
     }
   }
 
   const nextState = {};
-  for (const { monsterId } of directRewardTracks) {
-    const existing = isPlainObject(existingState?.[monsterId]) ? existingState[monsterId] : {};
-    nextState[monsterId] = {
-      masteredCount: counts[monsterId],
-      caught: counts[monsterId] > 0,
+  for (const { track } of directRewardTrackProjections) {
+    const existing = isPlainObject(existingState?.[track.monsterId]) ? existingState[track.monsterId] : {};
+    const masteredCount = Math.max(
+      counts[track.monsterId] || 0,
+      safePublicNonNegativeInt(existing.masteredCount),
+    );
+    counts[track.monsterId] = masteredCount;
+    nextState[track.monsterId] = {
+      masteredCount,
+      caught: existing.caught === true || masteredCount > 0,
+      visibleInCodex: true,
       ...branchForOutput(existing),
     };
   }
 
-  const phaetonTrack = spellingRewardTrackForMonster('phaeton');
-  const phaetonCount = sourceMonsterIdsForRewardTrack(phaetonTrack)
-    .reduce((sum, monsterId) => sum + (counts[monsterId] || 0), 0);
-  const existingPhaeton = isPlainObject(existingState?.phaeton) ? existingState.phaeton : {};
-  nextState.phaeton = {
-    masteredCount: phaetonCount,
-    caught: phaetonCount >= 3,
-    ...branchForOutput(existingPhaeton),
-  };
+  const aggregateRewardTrackProjections = rewardTrackProjections
+    .filter((projection) => projection.aggregate)
+    .filter(({ track }) => PUBLIC_SPELLING_MONSTER_IDS.includes(track.monsterId));
+  for (const { track, sourceMonsterIds } of aggregateRewardTrackProjections) {
+    const existing = isPlainObject(existingState?.[track.monsterId]) ? existingState[track.monsterId] : {};
+    const masteredCount = Math.max(
+      sourceMonsterIds.reduce((sum, monsterId) => sum + (counts[monsterId] || 0), 0),
+      safePublicNonNegativeInt(existing.masteredCount),
+    );
+    nextState[track.monsterId] = {
+      masteredCount,
+      caught: existing.caught === true || masteredCount >= 3,
+      visibleInCodex: true,
+      ...branchForOutput(existing),
+    };
+  }
 
   return {
     state: publicMonsterCodexState(nextState, { learnerId }),


### PR DESCRIPTION
## Summary

Content operators can now configure where spelling reward-track monsters appear across Hero Camp, Codex, and subject setup without creating a second creature model. Hidden, scheduled, and rollout-flagged exposure rules are applied to learner runtime projections while remaining previewable to operators.

## What changed

| Area | Outcome |
| --- | --- |
| Exposure contract | Reward tracks carry `heroExposure` with visible, hidden, scheduled, and rollout-flagged states across Hero Camp, Hero Quest, Codex, and subject setup surfaces. |
| Runtime visibility | Public Codex and Hero Camp now filter spelling monsters through published exposure rules and remove stale spelling Codex entries before merging learner state. |
| Operations UI | The Content Operations Centre exposes Hero / Codex controls, shows exposure status, and supports exposure-only package operations with publish conflict protection. |
| Compatibility | Legacy reward-track progress keys and non-spelling Codex state remain intact; no duplicate creature model is introduced. |

## Validation

- `npm test -- tests/hero-no-write-boundary.test.js tests/worker-auth.test.js tests/hero-contracts.test.js tests/spelling-reward-tracks.test.js tests/worker-subject-runtime.test.js tests/react-admin-content-operations.test.js tests/render.test.js tests/hero-p5-read-model.test.js tests/hero-p5-camp-resolver.test.js tests/content-operations-merge.test.js` - 209 passed.
- `npm test` - 111,820 passed, 0 failed, 12 skipped.
- `npm run check` - Worker dry-run deploy, public build assertion, and client bundle audit passed.

## Post-Deploy Monitoring & Validation

- Log queries/search terms: `hero_monster_hidden`, `hero_read_model_loaded`, `hero_camp_disabled_attempt`, `content_operations`, `bootstrap`, `monster-codex`.
- Metrics or dashboards to watch: `/api/bootstrap`, `/api/hero/read-model`, `/api/hero/command`, and Content Operations append/validate/publish route status and latency.
- Expected healthy signals: hidden or future-dated spelling monsters are absent from learner Codex/Hero Camp responses, exposure-only operations validate without conflicts unless a reward track changed concurrently, and bootstrap continues returning non-spelling Codex state.
- Failure signals and rollback trigger: unexpected 5xx/409 spikes on Hero or Content Operations routes, hidden spelling monsters visible to learners, or bootstrap response-size/latency regression after publish. Roll back the content package or revert this branch if runtime filtering is the cause.
- Validation window and owner: first production smoke after merge plus 24 hours of route/error monitoring, owner James/operator on duty.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
