### PR TITLE
feat(content-ops): add monster asset upload validation

### DIFF
--- a/src/platform/hubs/admin-asset-registry.js
+++ b/src/platform/hubs/admin-asset-registry.js
@@ -208,6 +208,24 @@ const HANDLER_CAPABILITY_REGISTRY = Object.freeze({
     casFields: ['draftRevision'],
     auditBehaviour: 'log',
   }),
+  'content-operation-monster-asset-list': Object.freeze({
+    roleRequired: 'viewer',
+    mutationClass: 'read',
+    casFields: ['packageId'],
+    auditBehaviour: 'silent',
+  }),
+  'content-operation-monster-asset-preview': Object.freeze({
+    roleRequired: 'viewer',
+    mutationClass: 'read',
+    casFields: ['packageId', 'assetUploadId'],
+    auditBehaviour: 'silent',
+  }),
+  'content-operation-monster-asset-upload': Object.freeze({
+    roleRequired: 'editor',
+    mutationClass: 'draft-write',
+    casFields: ['packageId', 'monsterId', 'branchId', 'stageId'],
+    auditBehaviour: 'log',
+  }),
 });
 
 /**

--- a/src/platform/hubs/admin-asset-url-allowlist.js
+++ b/src/platform/hubs/admin-asset-url-allowlist.js
@@ -13,6 +13,9 @@
 const DEFAULT_ALLOWED_DOMAINS = Object.freeze([
   'ks2-mastery.pages.dev',
 ]);
+const CONTENT_OPERATION_MONSTER_ASSET_PREVIEW_HANDLE_RE = (
+  /^\/api\/admin\/content-operations\/packages\/[^/]+\/monster-assets\/[^/]+\/preview$/
+);
 
 /**
  * Validate whether a preview URL is safe to render as a clickable link.
@@ -46,6 +49,15 @@ export function isAllowedPreviewUrl(url, options) {
   // Reject protocol-relative URLs (//example.com/...)
   if (/^\/\//.test(trimmed)) {
     return { allowed: false, reason: 'Protocol-relative URLs are forbidden.' };
+  }
+
+  // Root-relative handles stay on the application origin, but only approved
+  // preview endpoints may bypass the external origin allowlist.
+  if (/^\//.test(trimmed)) {
+    if (CONTENT_OPERATION_MONSTER_ASSET_PREVIEW_HANDLE_RE.test(trimmed)) {
+      return { allowed: true };
+    }
+    return { allowed: false, reason: 'Root-relative URL is not an approved preview handle.' };
   }
 
   // Parse as URL — reject if unparseable

--- a/src/platform/hubs/admin-content-operations.js
+++ b/src/platform/hubs/admin-content-operations.js
@@ -183,6 +183,7 @@ export function normaliseContentOperationCandidate(entry = null) {
     candidateHash: asString(safe.candidateHash),
     validation,
     audioScan: isPlainObject(safe.audioScan) ? safe.audioScan : null,
+    assetScan: isPlainObject(safe.assetScan) ? safe.assetScan : null,
     blockers: normaliseContentOperationBlockers(safe.blockers),
     conflicts: asArray(safe.conflicts),
     createdAt: asTs(safe.createdAt),
@@ -239,6 +240,14 @@ function releaseAssetMetadataFromProof(proof = null) {
   };
 }
 
+function releaseHasCallerProof(proof = null) {
+  if (!isPlainObject(proof)) return false;
+  return Object.keys(proof).some((key) => (
+    key !== 'contentOperationsAudio'
+    && key !== 'contentOperationsAssets'
+  ));
+}
+
 export function normaliseContentOperationRelease(entry = null) {
   const safe = isPlainObject(entry) ? entry : {};
   const proof = safe.proof ?? null;
@@ -255,6 +264,9 @@ export function normaliseContentOperationRelease(entry = null) {
     publishedByAccountId: asNullableString(safe.publishedByAccountId),
     rollbackOfReleaseId: asNullableString(safe.rollbackOfReleaseId),
     proof,
+    hasCallerProof: typeof safe.hasCallerProof === 'boolean'
+      ? safe.hasCallerProof
+      : releaseHasCallerProof(proof),
     audioFallback: isPlainObject(safe.audioFallback)
       ? safe.audioFallback
       : proofAudio.audioFallback,

--- a/src/platform/hubs/admin-content-operations.js
+++ b/src/platform/hubs/admin-content-operations.js
@@ -232,10 +232,18 @@ function releaseAudioMetadataFromProof(proof = null) {
   };
 }
 
+function releaseAssetMetadataFromProof(proof = null) {
+  const metadata = isPlainObject(proof?.contentOperationsAssets) ? proof.contentOperationsAssets : null;
+  return {
+    assetSummary: isPlainObject(metadata?.assetSummary) ? metadata.assetSummary : null,
+  };
+}
+
 export function normaliseContentOperationRelease(entry = null) {
   const safe = isPlainObject(entry) ? entry : {};
   const proof = safe.proof ?? null;
   const proofAudio = releaseAudioMetadataFromProof(proof);
+  const proofAssets = releaseAssetMetadataFromProof(proof);
   return {
     releaseId: asString(safe.releaseId),
     subjectId: asString(safe.subjectId, 'spelling'),
@@ -253,6 +261,9 @@ export function normaliseContentOperationRelease(entry = null) {
     audioWarnings: isPlainObject(safe.audioWarnings)
       ? safe.audioWarnings
       : proofAudio.audioWarnings,
+    assetSummary: isPlainObject(safe.assetSummary)
+      ? safe.assetSummary
+      : proofAssets.assetSummary,
     createdAt: asTs(safe.createdAt),
   };
 }

--- a/src/platform/hubs/api.js
+++ b/src/platform/hubs/api.js
@@ -393,7 +393,6 @@ export function createHubApi({
       candidateId,
       notes = '',
       audioFallback = null,
-      assetSummary = null,
       mutation,
     } = {}) {
       if (!packageId) throw new TypeError('Content operation package id is required.');
@@ -407,7 +406,6 @@ export function createHubApi({
           candidateId,
           notes,
           audioFallback,
-          assetSummary,
           mutation,
         }),
       }, authSession);

--- a/src/surfaces/hubs/AdminContentOperationsSection.jsx
+++ b/src/surfaces/hubs/AdminContentOperationsSection.jsx
@@ -3751,7 +3751,7 @@ function ReleaseTable({ releases }) {
                   )}
                 </td>
                 <td className="admin-overview-td">
-                  {release.proof ? <span className="chip good">Recorded</span> : <span className="chip warn">Missing</span>}
+                  {release.hasCallerProof ? <span className="chip good">Recorded</span> : <span className="chip warn">Missing</span>}
                 </td>
               </tr>
             );

--- a/tests/admin-asset-preview-url-safety.test.js
+++ b/tests/admin-asset-preview-url-safety.test.js
@@ -84,6 +84,18 @@ describe('isAllowedPreviewUrl — allows safe URLs', () => {
     });
     assert.equal(result.allowed, true);
   });
+
+  it('allows root-relative admin preview handles', () => {
+    const result = isAllowedPreviewUrl('/api/admin/content-operations/packages/pkg-a/monster-assets/upload-a/preview');
+    assert.equal(result.allowed, true);
+    assert.equal(getSafePreviewUrl('  /api/admin/content-operations/packages/pkg-a/monster-assets/upload-a/preview  '),
+      '/api/admin/content-operations/packages/pkg-a/monster-assets/upload-a/preview');
+  });
+
+  it('rejects non-preview root-relative admin paths', () => {
+    assert.equal(isAllowedPreviewUrl('/api/auth/logout').allowed, false);
+    assert.equal(isAllowedPreviewUrl('/api/admin/assets/example/publish').allowed, false);
+  });
 });
 
 // ─── Null/undefined URL handling ──────────────────────────────────────────────

--- a/tests/admin-content-operations-v2.test.js
+++ b/tests/admin-content-operations-v2.test.js
@@ -439,6 +439,13 @@ const CONTENT_OPS_PACKAGE = {
     operationsHash: 'ops-hash-1',
     candidateHash: 'candidate-hash-1',
     validation: { ok: true, errorCount: 0, warningCount: 0, errors: [], warnings: [] },
+    assetScan: {
+      status: 'passed',
+      hash: 'asset-scan-hash-1',
+      uploadCount: 1,
+      blockers: [],
+      warnings: [],
+    },
     blockers: {
       validation: { status: 'passed', errorCount: 0, warningCount: 0, errors: [], warnings: [] },
       conflicts: { status: 'passed', count: 0, items: [] },
@@ -674,6 +681,7 @@ describe('Content Operations Centre normalisers', () => {
     assert.equal(overview.lanes.drafts[0].blockers.warningCount, 1);
     assert.equal(overview.lanes.drafts[0].latestCandidate.candidateHash, 'candidate-hash-1');
     assert.equal(overview.recentReleases[0].proof.source, 'test');
+    assert.equal(overview.recentReleases[0].hasCallerProof, true);
     assert.equal(overview.recentReleases[0].audioFallback.allowed, true);
     assert.equal(overview.recentReleases[0].audioFallback.affectedMatrix.affectedCount, 1);
     assert.equal(overview.recentReleases[0].audioWarnings.status, 'warning');
@@ -692,7 +700,22 @@ describe('Content Operations Centre normalisers', () => {
 
     assert.equal(release.audioFallback, null);
     assert.equal(release.audioWarnings, null);
+    assert.equal(release.hasCallerProof, true);
     assert.equal(release.proof.audioFallback.allowed, true);
+  });
+
+  it('does not treat server-only release proof metadata as caller proof', () => {
+    const release = normaliseContentOperationRelease({
+      releaseId: 'rel-server-proof-only',
+      proof: {
+        contentOperationsAssets: {
+          assetSummary: { hash: 'asset-scan-hash-1', uploadCount: 1 },
+        },
+      },
+    });
+
+    assert.equal(release.hasCallerProof, false);
+    assert.equal(release.assetSummary.hash, 'asset-scan-hash-1');
   });
 
   it('normalises package lists, release lists, and package detail array payloads', () => {
@@ -725,6 +748,8 @@ describe('Content Operations Centre normalisers', () => {
 
     assert.equal(candidate.candidateId, 'cand-draft-1');
     assert.equal(candidate.candidateHash, 'candidate-hash-1');
+    assert.equal(candidate.assetScan.hash, 'asset-scan-hash-1');
+    assert.equal(candidate.assetScan.uploadCount, 1);
     assert.equal(candidate.validation.status, 'passed');
     assert.deepEqual(candidate.blockers.blockingSections, ['publishReadiness']);
     assert.equal(candidate.blockers.publishReadiness.blockers[0], 'approval_required');
@@ -1033,6 +1058,7 @@ describe('Content Operations Centre hub API client', () => {
       calls[2].body.audioFallback.reason,
       'Temporary runtime TTS fallback while slow sentence audio is generated.',
     );
+    assert.equal(Object.prototype.hasOwnProperty.call(calls[2].body, 'assetSummary'), false);
     assert.equal(calls[3].body.proof.source, 'test');
     assert.equal(calls[4].body.conflictId, 'conflict/with/slash');
     assert.equal(calls[4].body.resolution, 'edit');

--- a/tests/content-operations-api.test.js
+++ b/tests/content-operations-api.test.js
@@ -1357,18 +1357,13 @@ test('content operations API supports admin package lifecycle through separate a
     assert.equal(validated.candidate.blockers.publishReadiness.status, 'not_ready');
     server.DB.db.prepare(`
       UPDATE content_operation_package_candidates
-      SET audio_scan_json = ?, asset_scan_json = ?
+      SET audio_scan_json = ?
       WHERE candidate_id = ?
     `).run(
       JSON.stringify({
         status: 'warning',
         blockers: [],
         warnings: ['slow_sentence_missing'],
-      }),
-      JSON.stringify({
-        status: 'warning',
-        blockers: [],
-        warnings: ['monster_asset_pending'],
       }),
       validated.candidate.candidateId,
     );
@@ -1384,7 +1379,6 @@ test('content operations API supports admin package lifecycle through separate a
     const packageSummary = packageList.packages.find((entry) => entry.packageId === packageId);
     assert.deepEqual(packageSummary.blockers.audio.blockers, []);
     assert.deepEqual(packageSummary.blockers.audio.warnings, ['slow_sentence_missing']);
-    assert.deepEqual(packageSummary.blockers.assets.warnings, ['monster_asset_pending']);
 
     const approved = await approvePackage(server, packageId, validated.candidate.candidateId);
     assert.equal(approved.approval.candidateId, validated.candidate.candidateId);
@@ -1402,7 +1396,6 @@ test('content operations API supports admin package lifecycle through separate a
       (entry) => entry.packageId === packageId,
     );
     assert.deepEqual(approvedSummary.blockers.audio.blockers, []);
-    assert.deepEqual(approvedSummary.blockers.assets.warnings, ['monster_asset_pending']);
 
     const publishResponse = await server.fetchAs(
       ADMIN_ID,

--- a/tests/monster-asset-upload-validation.test.js
+++ b/tests/monster-asset-upload-validation.test.js
@@ -8,6 +8,9 @@ import {
   CONTENT_OPERATION_MONSTER_ASSET_MAX_MULTIPART_BYTES,
   uploadContentOperationMonsterAsset,
 } from '../worker/src/content-operations/assets.js';
+import {
+  serialiseContentOperationRelease,
+} from '../worker/src/content-operations/serialisers.js';
 import { createWorkerRepositoryServer } from './helpers/worker-server.js';
 
 const BASE_URL = 'https://repo.test';
@@ -136,6 +139,23 @@ function pngHeaderBytes(width = 320, height = 320) {
   return bytes;
 }
 
+function invalidPngWithValidCrcBytes(width = 320, height = 320) {
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(width, 0);
+  ihdr.writeUInt32BE(height, 4);
+  ihdr[8] = 8;
+  ihdr[9] = 6;
+  ihdr[10] = 0;
+  ihdr[11] = 0;
+  ihdr[12] = 0;
+  return new Uint8Array(Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    pngChunk('IHDR', ihdr),
+    pngChunk('IDAT', Buffer.from([0x00])),
+    pngChunk('IEND'),
+  ]));
+}
+
 function jpegHeaderBytes(width = 320, height = 320) {
   const bytes = new Uint8Array(19);
   bytes.set([0xff, 0xd8], 0);
@@ -198,6 +218,40 @@ function webpHeaderBytes(width = 320, height = 320) {
   bytes[28] = (encodedHeight >> 8) & 0xff;
   bytes[29] = (encodedHeight >> 16) & 0xff;
   return bytes;
+}
+
+function webpVp8HeaderOnlyBytes(width = 320, height = 320) {
+  const chunk = Buffer.alloc(10);
+  chunk[3] = 0x9d;
+  chunk[4] = 0x01;
+  chunk[5] = 0x2a;
+  chunk.writeUInt16LE(width, 6);
+  chunk.writeUInt16LE(height, 8);
+  const header = Buffer.alloc(20);
+  header.write('RIFF', 0, 'ascii');
+  header.writeUInt32LE(4 + 8 + chunk.length, 4);
+  header.write('WEBP', 8, 'ascii');
+  header.write('VP8 ', 12, 'ascii');
+  header.writeUInt32LE(chunk.length, 16);
+  return new Uint8Array(Buffer.concat([header, chunk]));
+}
+
+function webpVp8lHeaderOnlyBytes(width = 320, height = 320) {
+  const encodedWidth = width - 1;
+  const encodedHeight = height - 1;
+  const chunk = Buffer.alloc(5);
+  chunk[0] = 0x2f;
+  chunk[1] = encodedWidth & 0xff;
+  chunk[2] = ((encodedWidth >> 8) & 0x3f) | ((encodedHeight & 0x03) << 6);
+  chunk[3] = (encodedHeight >> 2) & 0xff;
+  chunk[4] = (encodedHeight >> 10) & 0x0f;
+  const header = Buffer.alloc(20);
+  header.write('RIFF', 0, 'ascii');
+  header.writeUInt32LE(4 + 8 + chunk.length + 1, 4);
+  header.write('WEBP', 8, 'ascii');
+  header.write('VP8L', 12, 'ascii');
+  header.writeUInt32LE(chunk.length, 16);
+  return new Uint8Array(Buffer.concat([header, chunk, Buffer.from([0x00])]));
 }
 
 async function createPackage(server, body = {}) {
@@ -265,7 +319,6 @@ async function approvePackage(server, packageId, candidateId) {
     jsonInit('POST', {
       candidateId,
       notes: 'Approved in the monster asset upload validation test.',
-      assetSummary: { caller: 'must be ignored' },
     }),
     adminHeaders(),
   );
@@ -408,6 +461,12 @@ test('monster image upload rejects MIME spoofing and truncated image payloads', 
         filename: 'header-only.png',
       },
       {
+        name: 'valid CRC invalid IDAT PNG payload',
+        bytes: invalidPngWithValidCrcBytes(640, 640),
+        contentType: 'image/png',
+        filename: 'invalid-idat.png',
+      },
+      {
         name: 'header-only JPEG payload',
         bytes: jpegHeaderBytes(640, 640),
         contentType: 'image/jpeg',
@@ -424,6 +483,18 @@ test('monster image upload rejects MIME spoofing and truncated image payloads', 
         bytes: webpHeaderBytes(640, 640),
         contentType: 'image/webp',
         filename: 'header-only.webp',
+      },
+      {
+        name: 'VP8 header-only WebP payload',
+        bytes: webpVp8HeaderOnlyBytes(640, 640),
+        contentType: 'image/webp',
+        filename: 'vp8-header-only.webp',
+      },
+      {
+        name: 'VP8L header-only WebP payload',
+        bytes: webpVp8lHeaderOnlyBytes(640, 640),
+        contentType: 'image/webp',
+        filename: 'vp8l-header-only.webp',
       },
     ];
     for (const entry of cases) {
@@ -463,6 +534,41 @@ test('monster image upload rejects oversized multipart requests before form pars
         assert.fail('formData() must not be called for clearly oversized requests');
       },
     };
+    await assert.rejects(
+      () => uploadContentOperationMonsterAsset({
+        db: server.env.DB,
+        env: server.env,
+        packageId: contentPackage.packageId,
+        request,
+        actorAccountId: ADMIN_ID,
+        now: () => NOW,
+      }),
+      (error) => {
+        assert.equal(error.extra.code, 'content_operation_monster_asset_request_too_large');
+        return true;
+      },
+    );
+    assert.equal(rowCount(server, 'content_operation_asset_uploads'), 0);
+  } finally {
+    server.close();
+  }
+});
+
+test('monster image upload rejects multipart requests without Content-Length before form parsing', async () => {
+  const server = createWorkerRepositoryServer({
+    env: { SPELLING_AUDIO_BUCKET: createMemoryR2Bucket() },
+    now: () => NOW,
+  });
+  try {
+    const contentPackage = await createPackage(server);
+    const request = new Request(`${BASE_URL}/upload`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'multipart/form-data; boundary=test',
+      },
+      body: new Uint8Array(CONTENT_OPERATION_MONSTER_ASSET_MAX_MULTIPART_BYTES + 1),
+    });
+    assert.equal(request.headers.get('content-length'), null);
     await assert.rejects(
       () => uploadContentOperationMonsterAsset({
         db: server.env.DB,
@@ -656,11 +762,11 @@ test('monster image uploads are bound to candidate approval and publish proof', 
     const approved = await approvalResponse.json();
     assert.equal(approved.approval.assetSummary.hash, currentCandidate.candidate.assetScan.hash);
     assert.equal(approved.approval.assetSummary.uploadCount, 1);
-    assert.equal(approved.approval.assetSummary.caller, undefined);
 
     const publishResponse = await publishPackage(server, contentPackage.packageId);
     assert.equal(publishResponse.status, 200);
     const published = await publishResponse.json();
+    assert.equal(published.release.hasCallerProof, true);
     assert.equal(
       published.release.proof.contentOperationsAssets.assetSummary.hash,
       currentCandidate.candidate.assetScan.hash,
@@ -671,9 +777,126 @@ test('monster image uploads are bound to candidate approval and publish proof', 
   }
 });
 
-test('duplicate monster image target uploads block approval and publish', async () => {
+test('monster image release serialisation distinguishes caller proof from server asset proof', () => {
+  const release = serialiseContentOperationRelease({
+    releaseId: 'rel-server-asset-proof',
+    subjectId: 'spelling',
+    status: 'published',
+    proof: {
+      contentOperationsAssets: {
+        assetSummary: {
+          status: 'passed',
+          hash: 'asset-scan-hash-1',
+          uploadCount: 1,
+        },
+      },
+    },
+  });
+
+  assert.equal(release.hasCallerProof, false);
+  assert.equal(release.assetSummary.hash, 'asset-scan-hash-1');
+  assert.equal(release.assetSummary.uploadCount, 1);
+});
+
+test('content operation approval rejects caller-supplied monster asset summaries', async () => {
   const server = createWorkerRepositoryServer({
     env: { SPELLING_AUDIO_BUCKET: createMemoryR2Bucket() },
+    now: () => NOW,
+  });
+  try {
+    await seedFirstRelease(server);
+    const contentPackage = await createPackage(server);
+    const validated = await validatePackage(server, contentPackage.packageId);
+    const response = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/packages/${contentPackage.packageId}/approve`,
+      jsonInit('POST', {
+        candidateId: validated.candidate.candidateId,
+        notes: 'Attempt to pass caller asset summary.',
+        assetSummary: { hash: 'caller-controlled' },
+      }),
+      adminHeaders(),
+    );
+    assert.equal(response.status, 400);
+    const payload = await response.json();
+    assert.equal(payload.code, 'content_operation_approval_asset_summary_readonly');
+    assert.equal(rowCount(server, 'content_operation_package_approvals', 'WHERE package_id = ?', [contentPackage.packageId]), 0);
+  } finally {
+    server.close();
+  }
+});
+
+test('monster image approval blocks when the uploaded R2 object is missing', async () => {
+  const bucket = createMemoryR2Bucket();
+  const server = createWorkerRepositoryServer({
+    env: { SPELLING_AUDIO_BUCKET: bucket },
+    now: () => NOW,
+  });
+  try {
+    await seedFirstRelease(server);
+    const contentPackage = await createPackage(server);
+    const uploadResponse = await uploadMonsterAsset(server, contentPackage.packageId, monsterAssetForm());
+    assert.equal(uploadResponse.status, 201);
+    const candidate = await validatePackage(server, contentPackage.packageId);
+    assert.equal(candidate.candidate.assetScan.status, 'passed');
+    await bucket.delete(bucket.puts[0].key);
+
+    const approvalResponse = await approvePackage(
+      server,
+      contentPackage.packageId,
+      candidate.candidate.candidateId,
+    );
+    assert.equal(approvalResponse.status, 409);
+    const payload = await approvalResponse.json();
+    assert.equal(payload.code, 'content_operation_candidate_assets_stale');
+    assert.equal(payload.assetScan.status, 'blocked');
+    assert.equal(
+      payload.assetScan.blockers.some((entry) => (
+        entry.errorCodes.includes('content_operation_asset_object_missing')
+      )),
+      true,
+    );
+    assert.equal(rowCount(server, 'content_operation_package_approvals', 'WHERE package_id = ?', [contentPackage.packageId]), 0);
+  } finally {
+    server.close();
+  }
+});
+
+test('monster image publish blocks when an approved R2 object disappears', async () => {
+  const bucket = createMemoryR2Bucket();
+  const server = createWorkerRepositoryServer({
+    env: { SPELLING_AUDIO_BUCKET: bucket },
+    now: () => NOW,
+  });
+  try {
+    await seedFirstRelease(server);
+    const contentPackage = await createPackage(server);
+    const uploadResponse = await uploadMonsterAsset(server, contentPackage.packageId, monsterAssetForm());
+    assert.equal(uploadResponse.status, 201);
+    const candidate = await validatePackage(server, contentPackage.packageId);
+    const approvalResponse = await approvePackage(
+      server,
+      contentPackage.packageId,
+      candidate.candidate.candidateId,
+    );
+    assert.equal(approvalResponse.status, 200);
+    await bucket.delete(bucket.puts[0].key);
+
+    const publishResponse = await publishPackage(server, contentPackage.packageId);
+    assert.equal(publishResponse.status, 409);
+    const payload = await publishResponse.json();
+    assert.equal(payload.code, 'content_operation_candidate_assets_stale');
+    assert.equal(payload.assetScan.status, 'blocked');
+    assert.equal(rowCount(server, 'content_operation_releases', 'WHERE package_id = ?', [contentPackage.packageId]), 0);
+  } finally {
+    server.close();
+  }
+});
+
+test('duplicate monster image target uploads replace the previous draft target', async () => {
+  const bucket = createMemoryR2Bucket();
+  const server = createWorkerRepositoryServer({
+    env: { SPELLING_AUDIO_BUCKET: bucket },
     now: () => NOW,
   });
   try {
@@ -690,58 +913,25 @@ test('duplicate monster image target uploads block approval and publish', async 
       filename: 'inklet-b1-0-b.png',
     }));
     assert.equal(secondUpload.status, 201);
+    assert.equal(rowCount(server, 'content_operation_asset_uploads', 'WHERE package_id = ?', [contentPackage.packageId]), 1);
+    assert.equal(bucket.puts.length, 2);
+    assert.deepEqual(bucket.deletes, [bucket.puts[0].key]);
 
     const validated = await validatePackage(server, contentPackage.packageId);
-    assert.equal(validated.candidate.assetScan.status, 'blocked');
-    assert.equal(validated.candidate.assetScan.uploadCount, 2);
-    assert.equal(
-      validated.candidate.assetScan.blockers.some((entry) => (
-        entry.code === 'content_operation_asset_target_has_multiple_uploads'
-      )),
-      true,
-    );
+    assert.equal(validated.candidate.assetScan.status, 'passed');
+    assert.equal(validated.candidate.assetScan.uploadCount, 1);
+    assert.equal(validated.candidate.assetScan.blockers.length, 0);
 
     const approvalResponse = await approvePackage(
       server,
       contentPackage.packageId,
       validated.candidate.candidateId,
     );
-    assert.equal(approvalResponse.status, 409);
-    const approvalPayload = await approvalResponse.json();
-    assert.equal(approvalPayload.code, 'content_operation_candidate_assets_blocked');
-    assert.equal(rowCount(server, 'content_operation_package_approvals', 'WHERE package_id = ?', [contentPackage.packageId]), 0);
-
-    server.DB.db.prepare(`
-      INSERT INTO content_operation_package_approvals (
-        approval_id, package_id, candidate_id, candidate_hash,
-        approved_by_account_id, approved_at, notes, audio_fallback_json,
-        asset_summary_json, validation_summary_json
-      )
-      VALUES (?, ?, ?, ?, ?, ?, ?, NULL, ?, ?)
-    `).run(
-      'coapp-duplicate-publish-guard',
-      contentPackage.packageId,
-      validated.candidate.candidateId,
-      validated.candidate.candidateHash,
-      ADMIN_ID,
-      NOW,
-      'Direct approval fixture for publish guard coverage.',
-      JSON.stringify(validated.candidate.assetScan),
-      JSON.stringify(validated.candidate.validation),
-    );
-    server.DB.db.prepare(`
-      UPDATE content_operation_packages
-      SET state = 'approved',
-          approved_at = ?,
-          updated_at = ?
-      WHERE package_id = ?
-    `).run(NOW, NOW, contentPackage.packageId);
+    assert.equal(approvalResponse.status, 200);
 
     const publishResponse = await publishPackage(server, contentPackage.packageId);
-    assert.equal(publishResponse.status, 409);
-    const publishPayload = await publishResponse.json();
-    assert.equal(publishPayload.code, 'content_operation_candidate_assets_blocked');
-    assert.equal(rowCount(server, 'content_operation_releases', 'WHERE package_id = ?', [contentPackage.packageId]), 0);
+    assert.equal(publishResponse.status, 200);
+    assert.equal(rowCount(server, 'content_operation_releases', 'WHERE package_id = ?', [contentPackage.packageId]), 1);
   } finally {
     server.close();
   }

--- a/tests/monster-asset-upload-validation.test.js
+++ b/tests/monster-asset-upload-validation.test.js
@@ -1,0 +1,772 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { deflateSync } from 'node:zlib';
+
+import { createWorkerRepository } from '../worker/src/repository.js';
+import {
+  CONTENT_OPERATION_MONSTER_ASSET_MAX_BYTES,
+  CONTENT_OPERATION_MONSTER_ASSET_MAX_MULTIPART_BYTES,
+  uploadContentOperationMonsterAsset,
+} from '../worker/src/content-operations/assets.js';
+import { createWorkerRepositoryServer } from './helpers/worker-server.js';
+
+const BASE_URL = 'https://repo.test';
+const ADMIN_ID = 'admin-asset-admin';
+const NOW = Date.UTC(2026, 5, 12, 9, 30, 0);
+
+function jsonInit(method, body = {}) {
+  return {
+    method,
+    headers: {
+      'content-type': 'application/json',
+      'sec-fetch-site': 'same-origin',
+    },
+    body: JSON.stringify(body),
+  };
+}
+
+function adminHeaders() {
+  return {
+    'x-ks2-dev-platform-role': 'admin',
+    'sec-fetch-site': 'same-origin',
+  };
+}
+
+function createMemoryR2Bucket() {
+  const objects = new Map();
+  return {
+    puts: [],
+    gets: [],
+    deletes: [],
+    async get(key) {
+      this.gets.push(key);
+      const object = objects.get(key);
+      if (!object) return null;
+      return {
+        body: object.bytes,
+        httpMetadata: { contentType: object.contentType },
+        customMetadata: object.customMetadata,
+      };
+    },
+    async put(key, bytes, options = {}) {
+      const storedBytes = bytes instanceof Uint8Array
+        ? new Uint8Array(bytes)
+        : new Uint8Array(bytes);
+      this.puts.push({ key, bytes: storedBytes, options });
+      objects.set(key, {
+        bytes: storedBytes,
+        contentType: options.httpMetadata?.contentType || 'application/octet-stream',
+        customMetadata: options.customMetadata || {},
+      });
+    },
+    async delete(key) {
+      this.deletes.push(key);
+      objects.delete(key);
+    },
+  };
+}
+
+function buildCrc32Table() {
+  const table = new Uint32Array(256);
+  for (let index = 0; index < table.length; index += 1) {
+    let value = index;
+    for (let bit = 0; bit < 8; bit += 1) {
+      value = (value & 1) ? ((0xedb88320 ^ (value >>> 1)) >>> 0) : (value >>> 1);
+    }
+    table[index] = value >>> 0;
+  }
+  return table;
+}
+
+const CRC32_TABLE = buildCrc32Table();
+
+function crc32(bytes) {
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc = CRC32_TABLE[(crc ^ byte) & 0xff] ^ (crc >>> 8);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function pngChunk(type, data = Buffer.alloc(0)) {
+  const typeBytes = Buffer.from(type, 'ascii');
+  const length = Buffer.alloc(4);
+  length.writeUInt32BE(data.length, 0);
+  const crcInput = Buffer.concat([typeBytes, data]);
+  const crc = Buffer.alloc(4);
+  crc.writeUInt32BE(crc32(crcInput), 0);
+  return Buffer.concat([length, typeBytes, data, crc]);
+}
+
+function validPngBytes(width = 320, height = 320) {
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(width, 0);
+  ihdr.writeUInt32BE(height, 4);
+  ihdr[8] = 8;
+  ihdr[9] = 6;
+  ihdr[10] = 0;
+  ihdr[11] = 0;
+  ihdr[12] = 0;
+  const stride = 1 + (width * 4);
+  const pixels = Buffer.alloc(stride * height);
+  for (let row = 0; row < height; row += 1) {
+    pixels[row * stride] = 0;
+  }
+  return new Uint8Array(Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    pngChunk('IHDR', ihdr),
+    pngChunk('IDAT', deflateSync(pixels)),
+    pngChunk('IEND'),
+  ]));
+}
+
+function pngHeaderBytes(width = 320, height = 320) {
+  const bytes = new Uint8Array(33);
+  bytes.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+  bytes.set([0x00, 0x00, 0x00, 0x0d], 8);
+  bytes.set([0x49, 0x48, 0x44, 0x52], 12);
+  const view = new DataView(bytes.buffer);
+  view.setUint32(16, width);
+  view.setUint32(20, height);
+  bytes[24] = 8;
+  bytes[25] = 6;
+  bytes[26] = 0;
+  bytes[27] = 0;
+  bytes[28] = 0;
+  return bytes;
+}
+
+function jpegHeaderBytes(width = 320, height = 320) {
+  const bytes = new Uint8Array(19);
+  bytes.set([0xff, 0xd8], 0);
+  bytes.set([0xff, 0xc0], 2);
+  const view = new DataView(bytes.buffer);
+  view.setUint16(4, 15);
+  bytes[6] = 8;
+  view.setUint16(7, height);
+  view.setUint16(9, width);
+  bytes[11] = 3;
+  return bytes;
+}
+
+function jpegSegment(marker, data) {
+  const length = Buffer.alloc(2);
+  length.writeUInt16BE(data.length + 2, 0);
+  return Buffer.concat([Buffer.from([0xff, marker]), length, data]);
+}
+
+function fakeJpegWithEmptyScan(width = 320, height = 320) {
+  const dqt = Buffer.concat([Buffer.from([0x00]), Buffer.alloc(64, 1)]);
+  const dht = Buffer.concat([
+    Buffer.from([0x00]),
+    Buffer.from([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+    Buffer.from([0]),
+  ]);
+  const sof = Buffer.alloc(9);
+  sof[0] = 8;
+  sof.writeUInt16BE(height, 1);
+  sof.writeUInt16BE(width, 3);
+  sof[5] = 1;
+  sof[6] = 1;
+  sof[7] = 0x11;
+  sof[8] = 0;
+  const sos = Buffer.from([1, 1, 0, 0, 63, 0]);
+  return new Uint8Array(Buffer.concat([
+    Buffer.from([0xff, 0xd8]),
+    jpegSegment(0xdb, dqt),
+    jpegSegment(0xc4, dht),
+    jpegSegment(0xc0, sof),
+    jpegSegment(0xda, sos),
+    Buffer.from([0xff, 0xd9]),
+  ]));
+}
+
+function webpHeaderBytes(width = 320, height = 320) {
+  const bytes = new Uint8Array(30);
+  bytes.set(Buffer.from('RIFF', 'ascii'), 0);
+  const view = new DataView(bytes.buffer);
+  view.setUint32(4, bytes.length - 8, true);
+  bytes.set(Buffer.from('WEBP', 'ascii'), 8);
+  bytes.set(Buffer.from('VP8X', 'ascii'), 12);
+  view.setUint32(16, 10, true);
+  const encodedWidth = width - 1;
+  const encodedHeight = height - 1;
+  bytes[24] = encodedWidth & 0xff;
+  bytes[25] = (encodedWidth >> 8) & 0xff;
+  bytes[26] = (encodedWidth >> 16) & 0xff;
+  bytes[27] = encodedHeight & 0xff;
+  bytes[28] = (encodedHeight >> 8) & 0xff;
+  bytes[29] = (encodedHeight >> 16) & 0xff;
+  return bytes;
+}
+
+async function createPackage(server, body = {}) {
+  const response = await server.fetchAs(
+    ADMIN_ID,
+    `${BASE_URL}/api/admin/content-operations/subjects/spelling/packages`,
+    jsonInit('POST', {
+      title: 'Monster asset upload package',
+      templateId: 'monster-asset-upload',
+      ...body,
+    }),
+    adminHeaders(),
+  );
+  assert.equal(response.status, 201);
+  const payload = await response.json();
+  return payload.package;
+}
+
+function monsterAssetForm({
+  monsterId = 'inklet',
+  branchId = 'b1',
+  stageId = '0',
+  bytes = validPngBytes(),
+  contentType = 'image/png',
+  filename = 'inklet-b1-0.png',
+} = {}) {
+  const form = new FormData();
+  form.set('monsterId', monsterId);
+  form.set('branchId', branchId);
+  form.set('stageId', stageId);
+  form.set('asset', new Blob([bytes], { type: contentType }), filename);
+  return form;
+}
+
+async function uploadMonsterAsset(server, packageId, form) {
+  return server.fetchAs(
+    ADMIN_ID,
+    `${BASE_URL}/api/admin/content-operations/packages/${packageId}/upload-monster-asset`,
+    {
+      method: 'POST',
+      body: form,
+      headers: {
+        'sec-fetch-site': 'same-origin',
+      },
+    },
+    adminHeaders(),
+  );
+}
+
+async function validatePackage(server, packageId, body = {}) {
+  const response = await server.fetchAs(
+    ADMIN_ID,
+    `${BASE_URL}/api/admin/content-operations/packages/${packageId}/validate`,
+    jsonInit('POST', body),
+    adminHeaders(),
+  );
+  assert.equal(response.status, 200);
+  return response.json();
+}
+
+async function approvePackage(server, packageId, candidateId) {
+  const response = await server.fetchAs(
+    ADMIN_ID,
+    `${BASE_URL}/api/admin/content-operations/packages/${packageId}/approve`,
+    jsonInit('POST', {
+      candidateId,
+      notes: 'Approved in the monster asset upload validation test.',
+      assetSummary: { caller: 'must be ignored' },
+    }),
+    adminHeaders(),
+  );
+  return response;
+}
+
+async function publishPackage(server, packageId, body = {}) {
+  return server.fetchAs(
+    ADMIN_ID,
+    `${BASE_URL}/api/admin/content-operations/packages/${packageId}/publish`,
+    jsonInit('POST', {
+      proof: { source: 'monster-asset-upload-validation-test' },
+      ...body,
+    }),
+    adminHeaders(),
+  );
+}
+
+async function seedFirstRelease(server) {
+  const repository = createWorkerRepository({
+    env: server.env,
+    now: () => NOW,
+  });
+  await repository.seedFirstContentOperationRelease({
+    seededByAccountId: ADMIN_ID,
+    proof: { source: 'monster-asset-upload-validation-test' },
+  });
+}
+
+function rowCount(server, table, whereSql = '', params = []) {
+  const row = server.DB.db.prepare(`SELECT COUNT(*) AS count FROM ${table} ${whereSql}`).get(...params);
+  return Number(row.count) || 0;
+}
+
+test('monster image upload stores a package-scoped R2 draft and returns a safe preview handle', async () => {
+  const bucket = createMemoryR2Bucket();
+  const server = createWorkerRepositoryServer({
+    env: { SPELLING_AUDIO_BUCKET: bucket },
+    now: () => NOW,
+  });
+  try {
+    const contentPackage = await createPackage(server);
+    const bytes = validPngBytes(640, 640);
+    const response = await uploadMonsterAsset(server, contentPackage.packageId, monsterAssetForm({ bytes }));
+    assert.equal(response.status, 201);
+    const payload = await response.json();
+    assert.equal(payload.ok, true);
+    assert.equal(payload.assetUpload.monsterId, 'inklet');
+    assert.equal(payload.assetUpload.branchId, 'b1');
+    assert.equal(payload.assetUpload.stageId, '0');
+    assert.equal(payload.assetUpload.contentType, 'image/png');
+    assert.deepEqual(payload.assetUpload.dimensions, { width: 640, height: 640 });
+    assert.match(payload.assetUpload.previewUrl, /^\/api\/admin\/content-operations\/packages\/.+\/monster-assets\/.+\/preview$/);
+    assert.equal(payload.assetUpload.validation.ok, true);
+
+    assert.equal(bucket.puts.length, 1);
+    const stored = bucket.puts[0];
+    assert.match(stored.key, new RegExp(`^content-operations/packages/${contentPackage.packageId}/monster-assets/`));
+    assert.equal(stored.options.httpMetadata.contentType, 'image/png');
+    assert.equal(stored.options.customMetadata.contentOperationAssetKind, 'monster-image');
+
+    const responseText = JSON.stringify(payload);
+    assert.equal(responseText.includes(stored.key), false, 'API payload must not expose private R2 keys');
+
+    const listResponse = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/packages/${contentPackage.packageId}/monster-assets`,
+      {
+        method: 'GET',
+        headers: { 'sec-fetch-site': 'same-origin' },
+      },
+      adminHeaders(),
+    );
+    assert.equal(listResponse.status, 200);
+    const listPayload = await listResponse.json();
+    assert.equal(listPayload.uploads.length, 1);
+    assert.equal(JSON.stringify(listPayload).includes(stored.key), false);
+
+    const previewResponse = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}${payload.assetUpload.previewUrl}`,
+      {
+        method: 'GET',
+        headers: { 'sec-fetch-site': 'same-origin' },
+      },
+      adminHeaders(),
+    );
+    assert.equal(previewResponse.status, 200);
+    assert.equal(previewResponse.headers.get('content-type'), 'image/png');
+    assert.equal(previewResponse.headers.get('x-content-type-options'), 'nosniff');
+    assert.deepEqual(new Uint8Array(await previewResponse.arrayBuffer()), bytes);
+    assert.equal(bucket.gets.length, 1);
+  } finally {
+    server.close();
+  }
+});
+
+test('monster image upload rejects non-image content', async () => {
+  const server = createWorkerRepositoryServer({
+    env: { SPELLING_AUDIO_BUCKET: createMemoryR2Bucket() },
+    now: () => NOW,
+  });
+  try {
+    const contentPackage = await createPackage(server);
+    const response = await uploadMonsterAsset(
+      server,
+      contentPackage.packageId,
+      monsterAssetForm({
+        bytes: new TextEncoder().encode('not an image'),
+        contentType: 'text/plain',
+        filename: 'payload.txt',
+      }),
+    );
+    assert.equal(response.status, 400);
+    const payload = await response.json();
+    assert.equal(payload.code, 'content_operation_monster_asset_content_type_invalid');
+    assert.equal(rowCount(server, 'content_operation_asset_uploads'), 0);
+  } finally {
+    server.close();
+  }
+});
+
+test('monster image upload rejects MIME spoofing and truncated image payloads', async () => {
+  const bucket = createMemoryR2Bucket();
+  const server = createWorkerRepositoryServer({
+    env: { SPELLING_AUDIO_BUCKET: bucket },
+    now: () => NOW,
+  });
+  try {
+    const contentPackage = await createPackage(server);
+    const cases = [
+      {
+        name: 'image/png text payload',
+        bytes: new TextEncoder().encode('not an image'),
+      },
+      {
+        name: 'header-only PNG payload',
+        bytes: pngHeaderBytes(640, 640),
+        contentType: 'image/png',
+        filename: 'header-only.png',
+      },
+      {
+        name: 'header-only JPEG payload',
+        bytes: jpegHeaderBytes(640, 640),
+        contentType: 'image/jpeg',
+        filename: 'header-only.jpg',
+      },
+      {
+        name: 'empty-scan JPEG payload',
+        bytes: fakeJpegWithEmptyScan(640, 640),
+        contentType: 'image/jpeg',
+        filename: 'empty-scan.jpg',
+      },
+      {
+        name: 'VP8X-only WebP payload',
+        bytes: webpHeaderBytes(640, 640),
+        contentType: 'image/webp',
+        filename: 'header-only.webp',
+      },
+    ];
+    for (const entry of cases) {
+      const response = await uploadMonsterAsset(
+        server,
+        contentPackage.packageId,
+        monsterAssetForm({
+          bytes: entry.bytes,
+          contentType: entry.contentType || 'image/png',
+          filename: entry.filename || `${entry.name}.png`,
+        }),
+      );
+      assert.equal(response.status, 400, entry.name);
+      const payload = await response.json();
+      assert.equal(payload.code, 'content_operation_monster_asset_renderer_invalid');
+    }
+    assert.equal(bucket.puts.length, 0);
+    assert.equal(rowCount(server, 'content_operation_asset_uploads'), 0);
+  } finally {
+    server.close();
+  }
+});
+
+test('monster image upload rejects oversized multipart requests before form parsing', async () => {
+  const server = createWorkerRepositoryServer({
+    env: { SPELLING_AUDIO_BUCKET: createMemoryR2Bucket() },
+    now: () => NOW,
+  });
+  try {
+    const contentPackage = await createPackage(server);
+    const request = {
+      headers: new Headers({
+        'content-type': 'multipart/form-data; boundary=test',
+        'content-length': String(CONTENT_OPERATION_MONSTER_ASSET_MAX_MULTIPART_BYTES + 1),
+      }),
+      async formData() {
+        assert.fail('formData() must not be called for clearly oversized requests');
+      },
+    };
+    await assert.rejects(
+      () => uploadContentOperationMonsterAsset({
+        db: server.env.DB,
+        env: server.env,
+        packageId: contentPackage.packageId,
+        request,
+        actorAccountId: ADMIN_ID,
+        now: () => NOW,
+      }),
+      (error) => {
+        assert.equal(error.extra.code, 'content_operation_monster_asset_request_too_large');
+        return true;
+      },
+    );
+    assert.equal(rowCount(server, 'content_operation_asset_uploads'), 0);
+  } finally {
+    server.close();
+  }
+});
+
+test('monster image upload rejects oversized files before storage', async () => {
+  const bucket = createMemoryR2Bucket();
+  const server = createWorkerRepositoryServer({
+    env: { SPELLING_AUDIO_BUCKET: bucket },
+    now: () => NOW,
+  });
+  try {
+    const contentPackage = await createPackage(server);
+    const oversized = new Uint8Array(CONTENT_OPERATION_MONSTER_ASSET_MAX_BYTES + 1);
+    const response = await uploadMonsterAsset(
+      server,
+      contentPackage.packageId,
+      monsterAssetForm({ bytes: oversized }),
+    );
+    assert.equal(response.status, 400);
+    const payload = await response.json();
+    assert.equal(payload.code, 'content_operation_monster_asset_too_large');
+    assert.equal(bucket.puts.length, 0);
+    assert.equal(rowCount(server, 'content_operation_asset_uploads'), 0);
+  } finally {
+    server.close();
+  }
+});
+
+test('monster image upload removes the R2 object when D1 recording fails', async () => {
+  const bucket = createMemoryR2Bucket();
+  const server = createWorkerRepositoryServer({
+    env: { SPELLING_AUDIO_BUCKET: bucket },
+    now: () => NOW,
+  });
+  try {
+    const contentPackage = await createPackage(server);
+    const originalDb = server.env.DB;
+    server.env.DB = new Proxy(originalDb, {
+      get(target, property, receiver) {
+        if (property === 'batch') {
+          return async () => {
+            throw new Error('simulated D1 batch failure');
+          };
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    const response = await uploadMonsterAsset(server, contentPackage.packageId, monsterAssetForm());
+    assert.equal(response.status, 500);
+    assert.equal(bucket.puts.length, 1);
+    assert.deepEqual(bucket.deletes, [bucket.puts[0].key]);
+    assert.equal(rowCount(server, 'content_operation_asset_uploads'), 0);
+  } finally {
+    server.close();
+  }
+});
+
+test('monster image upload rejects and cleans up when publish wins the package-state race', async () => {
+  const bucket = createMemoryR2Bucket();
+  const server = createWorkerRepositoryServer({
+    env: { SPELLING_AUDIO_BUCKET: bucket },
+    now: () => NOW,
+  });
+  try {
+    const contentPackage = await createPackage(server);
+    const originalDb = server.env.DB;
+    let raced = false;
+    server.env.DB = new Proxy(originalDb, {
+      get(target, property, receiver) {
+        if (property === 'batch') {
+          return async (statements) => {
+            if (!raced) {
+              raced = true;
+              target.db.prepare(`
+                UPDATE content_operation_packages
+                SET state = 'published',
+                    published_at = ?,
+                    updated_at = ?
+                WHERE package_id = ?
+              `).run(NOW + 1, NOW + 1, contentPackage.packageId);
+            }
+            return target.batch(statements);
+          };
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+
+    const response = await uploadMonsterAsset(server, contentPackage.packageId, monsterAssetForm());
+    assert.equal(response.status, 409);
+    const payload = await response.json();
+    assert.equal(payload.code, 'content_operation_package_published');
+    assert.equal(bucket.puts.length, 1);
+    assert.deepEqual(bucket.deletes, [bucket.puts[0].key]);
+    assert.equal(rowCount(server, 'content_operation_asset_uploads'), 0);
+  } finally {
+    server.close();
+  }
+});
+
+test('monster image upload rejects unknown monster, branch and stage targets', async () => {
+  const cases = [
+    {
+      name: 'unknown monster',
+      form: monsterAssetForm({ monsterId: 'unknown-monster' }),
+      field: 'monsterId',
+    },
+    {
+      name: 'unknown branch',
+      form: monsterAssetForm({ branchId: 'b9' }),
+      field: 'branchId',
+    },
+    {
+      name: 'unknown stage',
+      form: monsterAssetForm({ stageId: '5' }),
+      field: 'stageId',
+    },
+  ];
+
+  for (const entry of cases) {
+    const server = createWorkerRepositoryServer({
+      env: { SPELLING_AUDIO_BUCKET: createMemoryR2Bucket() },
+      now: () => NOW,
+    });
+    try {
+      const contentPackage = await createPackage(server, { title: `Monster asset ${entry.name}` });
+      const response = await uploadMonsterAsset(server, contentPackage.packageId, entry.form);
+      assert.equal(response.status, 400, entry.name);
+      const payload = await response.json();
+      assert.equal(payload.code, 'content_operation_monster_asset_target_invalid');
+      assert.equal(payload.errors.some((error) => error.field === entry.field), true);
+      assert.equal(rowCount(server, 'content_operation_asset_uploads'), 0);
+    } finally {
+      server.close();
+    }
+  }
+});
+
+test('monster image uploads are bound to candidate approval and publish proof', async () => {
+  const bucket = createMemoryR2Bucket();
+  const server = createWorkerRepositoryServer({
+    env: { SPELLING_AUDIO_BUCKET: bucket },
+    now: () => NOW,
+  });
+  try {
+    await seedFirstRelease(server);
+    const contentPackage = await createPackage(server);
+
+    const firstCandidate = await validatePackage(server, contentPackage.packageId);
+    assert.equal(firstCandidate.candidate.assetScan.status, 'passed');
+    assert.equal(firstCandidate.candidate.assetScan.uploadCount, 0);
+
+    const uploadResponse = await uploadMonsterAsset(server, contentPackage.packageId, monsterAssetForm());
+    assert.equal(uploadResponse.status, 201);
+
+    const staleApprovalResponse = await approvePackage(
+      server,
+      contentPackage.packageId,
+      firstCandidate.candidate.candidateId,
+    );
+    assert.equal(staleApprovalResponse.status, 409);
+    const staleApproval = await staleApprovalResponse.json();
+    assert.equal(staleApproval.code, 'content_operation_candidate_assets_stale');
+
+    const currentCandidate = await validatePackage(server, contentPackage.packageId);
+    assert.equal(currentCandidate.candidate.assetScan.uploadCount, 1);
+    assert.notEqual(currentCandidate.candidate.assetScan.hash, firstCandidate.candidate.assetScan.hash);
+
+    const approvalResponse = await approvePackage(
+      server,
+      contentPackage.packageId,
+      currentCandidate.candidate.candidateId,
+    );
+    assert.equal(approvalResponse.status, 200);
+    const approved = await approvalResponse.json();
+    assert.equal(approved.approval.assetSummary.hash, currentCandidate.candidate.assetScan.hash);
+    assert.equal(approved.approval.assetSummary.uploadCount, 1);
+    assert.equal(approved.approval.assetSummary.caller, undefined);
+
+    const publishResponse = await publishPackage(server, contentPackage.packageId);
+    assert.equal(publishResponse.status, 200);
+    const published = await publishResponse.json();
+    assert.equal(
+      published.release.proof.contentOperationsAssets.assetSummary.hash,
+      currentCandidate.candidate.assetScan.hash,
+    );
+    assert.equal(published.release.assetSummary.hash, currentCandidate.candidate.assetScan.hash);
+  } finally {
+    server.close();
+  }
+});
+
+test('duplicate monster image target uploads block approval and publish', async () => {
+  const server = createWorkerRepositoryServer({
+    env: { SPELLING_AUDIO_BUCKET: createMemoryR2Bucket() },
+    now: () => NOW,
+  });
+  try {
+    await seedFirstRelease(server);
+    const contentPackage = await createPackage(server);
+
+    const firstUpload = await uploadMonsterAsset(server, contentPackage.packageId, monsterAssetForm({
+      bytes: validPngBytes(640, 640),
+      filename: 'inklet-b1-0-a.png',
+    }));
+    assert.equal(firstUpload.status, 201);
+    const secondUpload = await uploadMonsterAsset(server, contentPackage.packageId, monsterAssetForm({
+      bytes: validPngBytes(640, 640),
+      filename: 'inklet-b1-0-b.png',
+    }));
+    assert.equal(secondUpload.status, 201);
+
+    const validated = await validatePackage(server, contentPackage.packageId);
+    assert.equal(validated.candidate.assetScan.status, 'blocked');
+    assert.equal(validated.candidate.assetScan.uploadCount, 2);
+    assert.equal(
+      validated.candidate.assetScan.blockers.some((entry) => (
+        entry.code === 'content_operation_asset_target_has_multiple_uploads'
+      )),
+      true,
+    );
+
+    const approvalResponse = await approvePackage(
+      server,
+      contentPackage.packageId,
+      validated.candidate.candidateId,
+    );
+    assert.equal(approvalResponse.status, 409);
+    const approvalPayload = await approvalResponse.json();
+    assert.equal(approvalPayload.code, 'content_operation_candidate_assets_blocked');
+    assert.equal(rowCount(server, 'content_operation_package_approvals', 'WHERE package_id = ?', [contentPackage.packageId]), 0);
+
+    server.DB.db.prepare(`
+      INSERT INTO content_operation_package_approvals (
+        approval_id, package_id, candidate_id, candidate_hash,
+        approved_by_account_id, approved_at, notes, audio_fallback_json,
+        asset_summary_json, validation_summary_json
+      )
+      VALUES (?, ?, ?, ?, ?, ?, ?, NULL, ?, ?)
+    `).run(
+      'coapp-duplicate-publish-guard',
+      contentPackage.packageId,
+      validated.candidate.candidateId,
+      validated.candidate.candidateHash,
+      ADMIN_ID,
+      NOW,
+      'Direct approval fixture for publish guard coverage.',
+      JSON.stringify(validated.candidate.assetScan),
+      JSON.stringify(validated.candidate.validation),
+    );
+    server.DB.db.prepare(`
+      UPDATE content_operation_packages
+      SET state = 'approved',
+          approved_at = ?,
+          updated_at = ?
+      WHERE package_id = ?
+    `).run(NOW, NOW, contentPackage.packageId);
+
+    const publishResponse = await publishPackage(server, contentPackage.packageId);
+    assert.equal(publishResponse.status, 409);
+    const publishPayload = await publishResponse.json();
+    assert.equal(publishPayload.code, 'content_operation_candidate_assets_blocked');
+    assert.equal(rowCount(server, 'content_operation_releases', 'WHERE package_id = ?', [contentPackage.packageId]), 0);
+  } finally {
+    server.close();
+  }
+});
+
+test('monster image draft upload does not create runtime operations or releases', async () => {
+  const server = createWorkerRepositoryServer({
+    env: { SPELLING_AUDIO_BUCKET: createMemoryR2Bucket() },
+    now: () => NOW,
+  });
+  try {
+    const contentPackage = await createPackage(server);
+    const response = await uploadMonsterAsset(server, contentPackage.packageId, monsterAssetForm());
+    assert.equal(response.status, 201);
+    assert.equal(rowCount(server, 'content_operation_asset_uploads', 'WHERE package_id = ?', [contentPackage.packageId]), 1);
+    assert.equal(rowCount(server, 'content_operation_package_operations', 'WHERE package_id = ?', [contentPackage.packageId]), 0);
+    assert.equal(rowCount(server, 'content_operation_releases', 'WHERE package_id = ?', [contentPackage.packageId]), 0);
+    const packageRow = server.DB.db.prepare(`
+      SELECT state, published_at
+      FROM content_operation_packages
+      WHERE package_id = ?
+    `).get(contentPackage.packageId);
+    assert.equal(packageRow.state, 'draft');
+    assert.equal(packageRow.published_at, null);
+  } finally {
+    server.close();
+  }
+});

--- a/worker/src/app.js
+++ b/worker/src/app.js
@@ -2417,6 +2417,7 @@ export function createWorkerApp({
           env,
           session,
           repository,
+          capacity,
         });
         if (contentOperationsResponse) return contentOperationsResponse;
 

--- a/worker/src/content-operations/assets.js
+++ b/worker/src/content-operations/assets.js
@@ -39,6 +39,7 @@ const SUPPORTED_IMAGE_TYPES = Object.freeze({
   'image/png': 'png',
   'image/webp': 'webp',
 });
+const MONSTER_ASSET_BODY_EXCEEDS_CAP = Symbol('monster-asset-body-exceeds-cap');
 
 function parseJson(value, fallback = null) {
   if (value == null || value === '') return fallback;
@@ -91,6 +92,60 @@ function assertContentOperationAssetBucket(env = {}) {
     });
   }
   return bucket;
+}
+
+function overflowError() {
+  const error = new Error('monster-asset-body-exceeds-cap');
+  error.code = MONSTER_ASSET_BODY_EXCEEDS_CAP;
+  return error;
+}
+
+async function readRequestBodyWithCap(request, cap) {
+  const reader = request.body?.getReader?.();
+  if (!reader) {
+    if (typeof request.arrayBuffer !== 'function') return null;
+    const buffer = await request.arrayBuffer();
+    if (buffer.byteLength > cap) throw overflowError();
+    return new Uint8Array(buffer);
+  }
+
+  const chunks = [];
+  let read = 0;
+  try {
+    while (true) {
+      // eslint-disable-next-line no-await-in-loop
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+      read += value.byteLength;
+      if (read > cap) {
+        try { reader.cancel(); } catch { /* ignore */ }
+        throw overflowError();
+      }
+      chunks.push(value);
+    }
+  } finally {
+    try { reader.releaseLock(); } catch { /* ignore */ }
+  }
+
+  const output = new Uint8Array(read);
+  let offset = 0;
+  for (const chunk of chunks) {
+    output.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return output;
+}
+
+async function readMultipartFormWithCap(request, cap) {
+  const bytes = await readRequestBodyWithCap(request, cap);
+  if (!bytes) return request.formData().catch(() => null);
+  const formRequest = new Request('https://content-operations.local/monster-asset-upload', {
+    method: 'POST',
+    headers: request.headers,
+    body: bytes,
+  });
+  return formRequest.formData().catch(() => null);
 }
 
 function assetUploadRowToRecord(row) {
@@ -196,6 +251,80 @@ function crc32(bytes, start = 0, end = bytes.length) {
   return (crc ^ 0xffffffff) >>> 0;
 }
 
+function concatByteArrays(chunks) {
+  const length = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+  const output = new Uint8Array(length);
+  let offset = 0;
+  for (const chunk of chunks) {
+    output.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return output;
+}
+
+async function inflateDeflateBytes(bytes) {
+  if (typeof DecompressionStream !== 'function') return null;
+  try {
+    const stream = new Blob([bytes]).stream().pipeThrough(new DecompressionStream('deflate'));
+    return new Uint8Array(await new Response(stream).arrayBuffer());
+  } catch {
+    return null;
+  }
+}
+
+function pngBitsPerPixel(bitDepth, colourType) {
+  const samplesByColourType = {
+    0: 1,
+    2: 3,
+    3: 1,
+    4: 2,
+    6: 4,
+  };
+  const samples = samplesByColourType[colourType] || 0;
+  return samples * bitDepth;
+}
+
+function adam7PassSize(size, start, step) {
+  return size > start ? Math.floor((size - start + step - 1) / step) : 0;
+}
+
+function validatePngInflatedRows(inflated, {
+  width,
+  height,
+  bitDepth,
+  colourType,
+  interlace,
+}) {
+  const bitsPerPixel = pngBitsPerPixel(bitDepth, colourType);
+  if (!bitsPerPixel || width <= 0 || height <= 0) return false;
+  const passes = interlace === 1
+    ? [
+      [0, 0, 8, 8],
+      [4, 0, 8, 8],
+      [0, 4, 4, 8],
+      [2, 0, 4, 4],
+      [0, 2, 2, 4],
+      [1, 0, 2, 2],
+      [0, 1, 1, 2],
+    ]
+    : [[0, 0, 1, 1]];
+
+  let offset = 0;
+  for (const [startX, startY, stepX, stepY] of passes) {
+    const passWidth = adam7PassSize(width, startX, stepX);
+    const passHeight = adam7PassSize(height, startY, stepY);
+    if (!passWidth || !passHeight) continue;
+    const rowBytes = Math.ceil((passWidth * bitsPerPixel) / 8);
+    const stride = rowBytes + 1;
+    for (let row = 0; row < passHeight; row += 1) {
+      if (offset + stride > inflated.length) return false;
+      if (inflated[offset] > 4) return false;
+      offset += stride;
+    }
+  }
+  return offset === inflated.length;
+}
+
 function isValidPngIhdr(bytes, dataOffset) {
   const bitDepth = bytes[dataOffset + 8];
   const colourType = bytes[dataOffset + 9];
@@ -217,16 +346,20 @@ function isValidPngIhdr(bytes, dataOffset) {
   );
 }
 
-function parsePngDimensions(bytes) {
+async function parsePngDimensions(bytes) {
   if (bytes.length < 45) return null;
   const signature = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
   if (!signature.every((value, index) => bytes[index] === value)) return null;
 
   let offset = 8;
   let dimensions = null;
+  let bitDepth = 0;
+  let colourType = 0;
+  let interlace = 0;
   let sawIdat = false;
   let sawIend = false;
   let chunkIndex = 0;
+  const idatChunks = [];
 
   while (offset + 12 <= bytes.length) {
     const chunkLength = readUint32BE(bytes, offset);
@@ -247,13 +380,27 @@ function parsePngDimensions(bytes) {
         width: readUint32BE(bytes, dataOffset),
         height: readUint32BE(bytes, dataOffset + 4),
       };
+      bitDepth = bytes[dataOffset + 8];
+      colourType = bytes[dataOffset + 9];
+      interlace = bytes[dataOffset + 12];
     } else if (chunkType === 'IDAT') {
       if (!dimensions || chunkLength < 1) return null;
       sawIdat = true;
+      idatChunks.push(bytes.slice(dataOffset, dataEnd));
     } else if (chunkType === 'IEND') {
       if (chunkLength !== 0 || !dimensions || !sawIdat) return null;
       sawIend = true;
-      return nextOffset === bytes.length ? dimensions : null;
+      if (nextOffset !== bytes.length) return null;
+      const inflated = await inflateDeflateBytes(concatByteArrays(idatChunks));
+      if (!inflated || !validatePngInflatedRows(inflated, {
+        ...dimensions,
+        bitDepth,
+        colourType,
+        interlace,
+      })) {
+        return null;
+      }
+      return dimensions;
     }
 
     offset = nextOffset;
@@ -288,7 +435,7 @@ function parseWebpDimensions(bytes) {
         height: readUint24LE(bytes, dataOffset + 7) + 1,
       };
     } else if (chunk === 'VP8L') {
-      if (chunkLength < 5 || bytes[dataOffset] !== 0x2f) return null;
+      if (chunkLength <= 5 || bytes[dataOffset] !== 0x2f) return null;
       const b1 = bytes[dataOffset + 1];
       const b2 = bytes[dataOffset + 2];
       const b3 = bytes[dataOffset + 3];
@@ -299,7 +446,7 @@ function parseWebpDimensions(bytes) {
       };
     } else if (chunk === 'VP8 ') {
       if (
-        chunkLength < 10
+        chunkLength <= 10
         || bytes[dataOffset + 3] !== 0x9d
         || bytes[dataOffset + 4] !== 0x01
         || bytes[dataOffset + 5] !== 0x2a
@@ -437,6 +584,7 @@ function validateJpegEntropyScan(bytes, offset) {
       return {
         ok: entropyBytes > 0,
         eoiOffset: markerOffset,
+        entropyBytes,
       };
     }
     return { ok: false, eoiOffset: -1 };
@@ -490,7 +638,10 @@ function parseJpegDimensions(bytes) {
       if (!dimensions || !sawQuantisationTable || !sawHuffmanTable) return null;
       if (!validateJpegStartOfScan(bytes, dataOffset, dataLength)) return null;
       const scan = validateJpegEntropyScan(bytes, offset + segmentLength);
-      if (!scan.ok) return null;
+      const minEntropyBytes = dimensions
+        ? Math.max(16, Math.ceil((dimensions.width * dimensions.height) / 1024))
+        : 16;
+      if (!scan.ok || scan.entropyBytes < minEntropyBytes) return null;
       sawScan = true;
       offset = scan.eoiOffset + 2;
       break;
@@ -500,7 +651,7 @@ function parseJpegDimensions(bytes) {
   return dimensions && sawScan && offset === bytes.length ? dimensions : null;
 }
 
-function parseImageDimensions(bytes, contentType) {
+async function parseImageDimensions(bytes, contentType) {
   if (contentType === 'image/png') return parsePngDimensions(bytes);
   if (contentType === 'image/webp') return parseWebpDimensions(bytes);
   if (contentType === 'image/jpeg') return parseJpegDimensions(bytes);
@@ -610,10 +761,11 @@ function previewUrlForUpload({ packageId, assetUploadId }) {
   return `/api/admin/content-operations/packages/${encodeURIComponent(packageId)}/monster-assets/${encodeURIComponent(assetUploadId)}/preview`;
 }
 
-function assetUploadScanItem(upload) {
+function assetUploadScanItem(upload, storage = null) {
   const validation = upload.validation && typeof upload.validation === 'object' && !Array.isArray(upload.validation)
     ? upload.validation
     : { ok: false, status: 'blocked', errors: [], warnings: [] };
+  const storageErrors = Array.isArray(storage?.errors) ? storage.errors : [];
   return {
     assetUploadId: upload.assetUploadId,
     assetKind: upload.assetKind || CONTENT_OPERATION_MONSTER_ASSET_KIND,
@@ -625,7 +777,8 @@ function assetUploadScanItem(upload) {
     validationOk: Boolean(validation.ok),
     errorCodes: (Array.isArray(validation.errors) ? validation.errors : [])
       .map((entry) => normaliseString(entry?.code))
-      .filter(Boolean),
+      .filter(Boolean)
+      .concat(storageErrors.map((entry) => normaliseString(entry?.code)).filter(Boolean)),
     warningCodes: (Array.isArray(validation.warnings) ? validation.warnings : [])
       .map((entry) => normaliseString(entry?.code))
       .filter(Boolean),
@@ -636,11 +789,97 @@ function assetUploadScanItem(upload) {
       height: upload.height == null ? null : Number(upload.height),
     },
     createdAt: Number(upload.createdAt) || 0,
+    storage: storage ? {
+      status: storage.status,
+      byteSize: storage.byteSize,
+      contentType: storage.contentType,
+    } : {
+      status: 'not_checked',
+      byteSize: null,
+      contentType: '',
+    },
+  };
+}
+
+async function bytesFromR2Object(object) {
+  if (!object) return null;
+  if (object.body instanceof Uint8Array) return object.body;
+  if (object.body && typeof object.body.getReader === 'function') {
+    return new Uint8Array(await new Response(object.body).arrayBuffer());
+  }
+  if (typeof object.arrayBuffer === 'function') {
+    return new Uint8Array(await object.arrayBuffer());
+  }
+  return null;
+}
+
+async function verifyStoredAssetUpload(bucket, upload) {
+  const object = await bucket.get(upload.r2Key).catch(() => null);
+  if (!object) {
+    return {
+      status: 'missing',
+      byteSize: null,
+      contentType: '',
+      errors: [{
+        code: 'content_operation_asset_object_missing',
+        message: 'Monster image upload is missing from asset storage.',
+      }],
+    };
+  }
+
+  const bytes = await bytesFromR2Object(object);
+  const byteSize = bytes ? bytes.byteLength : Number(object.size) || null;
+  const contentType = normaliseString(object.httpMetadata?.contentType).toLowerCase();
+  const errors = [];
+  if (byteSize !== Number(upload.byteSize)) {
+    errors.push({
+      code: 'content_operation_asset_object_size_mismatch',
+      expected: Number(upload.byteSize),
+      actual: byteSize,
+    });
+  }
+  if (contentType && contentType !== upload.contentType) {
+    errors.push({
+      code: 'content_operation_asset_object_content_type_mismatch',
+      expected: upload.contentType,
+      actual: contentType,
+    });
+  }
+  if (!bytes) {
+    errors.push({
+      code: 'content_operation_asset_object_unreadable',
+      message: 'Monster image upload could not be read from asset storage.',
+    });
+  } else {
+    const dimensions = await parseImageDimensions(bytes, upload.contentType);
+    if (
+      !dimensions
+      || dimensions.width !== Number(upload.width)
+      || dimensions.height !== Number(upload.height)
+    ) {
+      errors.push({
+        code: 'content_operation_asset_object_image_mismatch',
+        expected: {
+          width: Number(upload.width) || null,
+          height: Number(upload.height) || null,
+        },
+        actual: dimensions,
+      });
+    }
+  }
+
+  return {
+    status: errors.length ? 'mismatch' : 'present',
+    byteSize,
+    contentType,
+    errors,
   };
 }
 
 export async function buildContentOperationAssetScan(db, {
   packageId,
+  env = null,
+  verifyStorage = false,
 } = {}) {
   const safePackageId = normaliseString(packageId);
   if (!safePackageId) {
@@ -655,13 +894,41 @@ export async function buildContentOperationAssetScan(db, {
     WHERE package_id = ?
     ORDER BY created_at ASC, asset_upload_id ASC
   `, [safePackageId]);
-  const items = rows.map(assetUploadRowToRecord).map(assetUploadScanItem);
+  const uploads = rows.map(assetUploadRowToRecord);
+  const bucket = verifyStorage && uploads.length ? contentOperationAssetBucket(env || {}) : null;
+  const storageByUploadId = new Map();
+  if (verifyStorage && uploads.length && !bucket) {
+    for (const upload of uploads) {
+      storageByUploadId.set(upload.assetUploadId, {
+        status: 'unavailable',
+        byteSize: null,
+        contentType: '',
+        errors: [{
+          code: 'content_operation_asset_storage_unavailable',
+          message: 'Content operation asset storage is not available for readiness verification.',
+        }],
+      });
+    }
+  } else if (verifyStorage && bucket) {
+    for (const upload of uploads) {
+      // eslint-disable-next-line no-await-in-loop
+      storageByUploadId.set(upload.assetUploadId, await verifyStoredAssetUpload(bucket, upload));
+    }
+  }
+  const items = uploads.map((upload) => assetUploadScanItem(
+    upload,
+    storageByUploadId.get(upload.assetUploadId) || null,
+  ));
   const blockers = [];
   const warnings = [];
   const targetCounts = new Map();
 
   for (const item of items) {
-    if (!item.validationOk || item.validationStatus === 'blocked') {
+    if (
+      !item.validationOk
+      || item.validationStatus === 'blocked'
+      || ['missing', 'mismatch', 'unavailable'].includes(item.storage?.status)
+    ) {
       blockers.push({
         code: 'content_operation_asset_upload_invalid',
         assetUploadId: item.assetUploadId,
@@ -748,7 +1015,18 @@ export async function uploadContentOperationMonsterAsset({
     });
   }
 
-  const form = await request.formData().catch(() => null);
+  let form;
+  try {
+    form = await readMultipartFormWithCap(request, CONTENT_OPERATION_MONSTER_ASSET_MAX_MULTIPART_BYTES);
+  } catch (error) {
+    if (error?.code === MONSTER_ASSET_BODY_EXCEEDS_CAP) {
+      throw new BadRequestError('Monster image upload request exceeds the maximum multipart size.', {
+        code: 'content_operation_monster_asset_request_too_large',
+        maxBytes: CONTENT_OPERATION_MONSTER_ASSET_MAX_MULTIPART_BYTES,
+      });
+    }
+    throw error;
+  }
   if (!form) {
     throw new BadRequestError('Monster image upload form data could not be read.', {
       code: 'content_operation_monster_asset_form_invalid',
@@ -795,7 +1073,7 @@ export async function uploadContentOperationMonsterAsset({
   }
 
   const bytes = new Uint8Array(await file.arrayBuffer());
-  const dimensions = parseImageDimensions(bytes, contentType);
+  const dimensions = await parseImageDimensions(bytes, contentType);
   const rendererValidation = validateRendererCompatibility(dimensions);
   if (!rendererValidation.ok) {
     throw new BadRequestError('Monster image upload is not compatible with the renderer.', {
@@ -803,6 +1081,22 @@ export async function uploadContentOperationMonsterAsset({
       validation: rendererValidation,
     });
   }
+
+  const replacedUploads = await all(db, `
+    SELECT *
+    FROM content_operation_asset_uploads
+    WHERE package_id = ?
+      AND asset_kind = ?
+      AND monster_id = ?
+      AND branch_id = ?
+      AND stage_id = ?
+  `, [
+    packageRow.package_id,
+    CONTENT_OPERATION_MONSTER_ASSET_KIND,
+    monsterId,
+    branchId,
+    stageId,
+  ]).then((rows) => rows.map(assetUploadRowToRecord));
 
   const assetUploadId = uid('coasset');
   const filename = filenameForUpload({ monsterId, branchId, stageId, extension });
@@ -877,6 +1171,28 @@ export async function uploadContentOperationMonsterAsset({
         CONTENT_OPERATION_PACKAGE_STATES.PUBLISHED,
       ]),
       bindStatement(db, `
+        DELETE FROM content_operation_asset_uploads
+        WHERE package_id = ?
+          AND asset_kind = ?
+          AND monster_id = ?
+          AND branch_id = ?
+          AND stage_id = ?
+          AND asset_upload_id <> ?
+          AND EXISTS (
+            SELECT 1
+            FROM content_operation_asset_uploads
+            WHERE asset_upload_id = ?
+          )
+      `, [
+        packageRow.package_id,
+        CONTENT_OPERATION_MONSTER_ASSET_KIND,
+        monsterId,
+        branchId,
+        stageId,
+        assetUploadId,
+        assetUploadId,
+      ]),
+      bindStatement(db, `
         DELETE FROM content_operation_package_approvals
         WHERE package_id = ?
           AND EXISTS (
@@ -887,7 +1203,7 @@ export async function uploadContentOperationMonsterAsset({
       `, [packageRow.package_id, assetUploadId]),
       bindStatement(db, `
         UPDATE content_operation_packages
-        SET state = CASE WHEN state = ? THEN ? ELSE state END,
+        SET state = CASE WHEN state <> ? THEN ? ELSE state END,
             approved_at = NULL,
             updated_by_account_id = ?,
             updated_at = ?
@@ -899,7 +1215,7 @@ export async function uploadContentOperationMonsterAsset({
             WHERE asset_upload_id = ?
           )
       `, [
-        CONTENT_OPERATION_PACKAGE_STATES.APPROVED,
+        CONTENT_OPERATION_PACKAGE_STATES.DRAFT,
         CONTENT_OPERATION_PACKAGE_STATES.DRAFT,
         actor,
         nowTs,
@@ -944,6 +1260,13 @@ export async function uploadContentOperationMonsterAsset({
         code: 'content_operation_package_published',
         packageId: packageRow.package_id,
       });
+    }
+    if (typeof bucket.delete === 'function') {
+      for (const replaced of replacedUploads) {
+        if (!replaced?.r2Key || replaced.r2Key === r2Key) continue;
+        // eslint-disable-next-line no-await-in-loop
+        await bucket.delete(replaced.r2Key).catch(() => {});
+      }
     }
   } catch (error) {
     if (r2Written && typeof bucket.delete === 'function') {

--- a/worker/src/content-operations/assets.js
+++ b/worker/src/content-operations/assets.js
@@ -1,0 +1,1029 @@
+import { uid } from '../../../src/platform/core/utils.js';
+import {
+  MONSTERS,
+  MONSTER_BRANCHES,
+} from '../../../src/platform/game/monsters.js';
+import {
+  CONTENT_OPERATION_PACKAGE_STATES,
+  CONTENT_OPERATION_SUBJECT_ID,
+  contentOperationHash,
+} from '../../../src/subjects/spelling/content/operations-model.js';
+import {
+  all,
+  batch,
+  bindStatement,
+  first,
+} from '../d1.js';
+import {
+  BackendUnavailableError,
+  BadRequestError,
+  ConflictError,
+  NotFoundError,
+} from '../errors.js';
+
+export const CONTENT_OPERATION_MONSTER_ASSET_KIND = 'monster-image';
+export const CONTENT_OPERATION_MONSTER_ASSET_MAX_BYTES = 4 * 1024 * 1024;
+export const CONTENT_OPERATION_MONSTER_ASSET_MAX_MULTIPART_BYTES = (
+  CONTENT_OPERATION_MONSTER_ASSET_MAX_BYTES + (256 * 1024)
+);
+
+const CONTENT_OPERATION_MONSTER_ASSET_PREFIX = 'content-operations/packages';
+const MIN_RENDERER_DIMENSION = 96;
+const MAX_RENDERER_DIMENSION = 4096;
+const MAX_RENDERER_ASPECT_RATIO = 4;
+const VALID_STAGE_IDS = new Set(['0', '1', '2', '3', '4']);
+const VALID_BRANCH_IDS = new Set(MONSTER_BRANCHES);
+const VALID_MONSTER_IDS = new Set(Object.keys(MONSTERS));
+const SUPPORTED_IMAGE_TYPES = Object.freeze({
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/webp': 'webp',
+});
+
+function parseJson(value, fallback = null) {
+  if (value == null || value === '') return fallback;
+  if (typeof value !== 'string') return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return fallback;
+  }
+}
+
+function normaliseString(value, fallback = '') {
+  return typeof value === 'string' ? value.trim() || fallback : fallback;
+}
+
+function mutationChangeCount(result) {
+  return Math.max(0, Number(result?.meta?.changes ?? result?.meta?.rows_written) || 0);
+}
+
+function normaliseStageId(value) {
+  const stage = String(value ?? '').trim();
+  if (!VALID_STAGE_IDS.has(stage)) return '';
+  return stage;
+}
+
+function normaliseBranchId(value) {
+  const branch = String(value ?? '').trim();
+  if (!VALID_BRANCH_IDS.has(branch)) return '';
+  return branch;
+}
+
+function normaliseMonsterId(value) {
+  const monsterId = String(value ?? '').trim();
+  if (!VALID_MONSTER_IDS.has(monsterId)) return '';
+  return monsterId;
+}
+
+function contentOperationAssetBucket(env = {}) {
+  const bucket = env.SPELLING_AUDIO_BUCKET;
+  return bucket && typeof bucket.get === 'function' && typeof bucket.put === 'function'
+    ? bucket
+    : null;
+}
+
+function assertContentOperationAssetBucket(env = {}) {
+  const bucket = contentOperationAssetBucket(env);
+  if (!bucket) {
+    throw new BackendUnavailableError('Content operation asset storage is not available.', {
+      code: 'content_operation_asset_storage_unavailable',
+    });
+  }
+  return bucket;
+}
+
+function assetUploadRowToRecord(row) {
+  if (!row) return null;
+  return {
+    assetUploadId: row.asset_upload_id,
+    packageId: row.package_id,
+    monsterId: row.monster_id,
+    branchId: row.branch_id,
+    stageId: row.stage_id,
+    assetKind: row.asset_kind,
+    r2Key: row.r2_key,
+    contentType: row.content_type,
+    byteSize: Number(row.byte_size) || 0,
+    width: row.width == null ? null : Number(row.width),
+    height: row.height == null ? null : Number(row.height),
+    validation: parseJson(row.validation_json, { ok: false, errors: [], warnings: [] }),
+    preview: parseJson(row.preview_json, null),
+    status: row.status,
+    createdByAccountId: row.created_by_account_id,
+    createdAt: Number(row.created_at) || 0,
+  };
+}
+
+async function requirePackage(db, packageId, { allowPublished = false } = {}) {
+  const row = await first(db, `
+    SELECT *
+    FROM content_operation_packages
+    WHERE package_id = ?
+  `, [packageId]);
+  if (!row) {
+    throw new NotFoundError('Content operation package was not found.', {
+      code: 'content_operation_package_not_found',
+      packageId,
+    });
+  }
+  if (!allowPublished && row.state === CONTENT_OPERATION_PACKAGE_STATES.PUBLISHED) {
+    throw new BadRequestError('Published content operation packages cannot accept draft asset uploads.', {
+      code: 'content_operation_package_published',
+      packageId,
+    });
+  }
+  return row;
+}
+
+function readUint24LE(bytes, offset) {
+  return bytes[offset] + (bytes[offset + 1] << 8) + (bytes[offset + 2] << 16);
+}
+
+function readUint16BE(bytes, offset) {
+  return (bytes[offset] << 8) + bytes[offset + 1];
+}
+
+function readUint16LE(bytes, offset) {
+  return bytes[offset] + (bytes[offset + 1] << 8);
+}
+
+function readUint32BE(bytes, offset) {
+  return (
+    (bytes[offset] << 24)
+    | (bytes[offset + 1] << 16)
+    | (bytes[offset + 2] << 8)
+    | bytes[offset + 3]
+  ) >>> 0;
+}
+
+function readUint32LE(bytes, offset) {
+  return (
+    bytes[offset]
+    | (bytes[offset + 1] << 8)
+    | (bytes[offset + 2] << 16)
+    | (bytes[offset + 3] << 24)
+  ) >>> 0;
+}
+
+function asciiAt(bytes, offset, length) {
+  let text = '';
+  for (let index = 0; index < length; index += 1) {
+    text += String.fromCharCode(bytes[offset + index] || 0);
+  }
+  return text;
+}
+
+function buildCrc32Table() {
+  const table = new Uint32Array(256);
+  for (let index = 0; index < table.length; index += 1) {
+    let value = index;
+    for (let bit = 0; bit < 8; bit += 1) {
+      value = (value & 1) ? ((0xedb88320 ^ (value >>> 1)) >>> 0) : (value >>> 1);
+    }
+    table[index] = value >>> 0;
+  }
+  return table;
+}
+
+const CRC32_TABLE = buildCrc32Table();
+
+function crc32(bytes, start = 0, end = bytes.length) {
+  let crc = 0xffffffff;
+  for (let index = start; index < end; index += 1) {
+    crc = CRC32_TABLE[(crc ^ bytes[index]) & 0xff] ^ (crc >>> 8);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function isValidPngIhdr(bytes, dataOffset) {
+  const bitDepth = bytes[dataOffset + 8];
+  const colourType = bytes[dataOffset + 9];
+  const compression = bytes[dataOffset + 10];
+  const filter = bytes[dataOffset + 11];
+  const interlace = bytes[dataOffset + 12];
+  const allowedBitDepths = {
+    0: new Set([1, 2, 4, 8, 16]),
+    2: new Set([8, 16]),
+    3: new Set([1, 2, 4, 8]),
+    4: new Set([8, 16]),
+    6: new Set([8, 16]),
+  };
+  return Boolean(
+    allowedBitDepths[colourType]?.has(bitDepth)
+      && compression === 0
+      && filter === 0
+      && (interlace === 0 || interlace === 1),
+  );
+}
+
+function parsePngDimensions(bytes) {
+  if (bytes.length < 45) return null;
+  const signature = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+  if (!signature.every((value, index) => bytes[index] === value)) return null;
+
+  let offset = 8;
+  let dimensions = null;
+  let sawIdat = false;
+  let sawIend = false;
+  let chunkIndex = 0;
+
+  while (offset + 12 <= bytes.length) {
+    const chunkLength = readUint32BE(bytes, offset);
+    const typeOffset = offset + 4;
+    const dataOffset = offset + 8;
+    const dataEnd = dataOffset + chunkLength;
+    const crcOffset = dataEnd;
+    const nextOffset = crcOffset + 4;
+    if (dataEnd > bytes.length || nextOffset > bytes.length) return null;
+
+    const chunkType = asciiAt(bytes, typeOffset, 4);
+    if (readUint32BE(bytes, crcOffset) !== crc32(bytes, typeOffset, dataEnd)) return null;
+    if (chunkIndex === 0 && chunkType !== 'IHDR') return null;
+
+    if (chunkType === 'IHDR') {
+      if (chunkIndex !== 0 || chunkLength !== 13 || !isValidPngIhdr(bytes, dataOffset)) return null;
+      dimensions = {
+        width: readUint32BE(bytes, dataOffset),
+        height: readUint32BE(bytes, dataOffset + 4),
+      };
+    } else if (chunkType === 'IDAT') {
+      if (!dimensions || chunkLength < 1) return null;
+      sawIdat = true;
+    } else if (chunkType === 'IEND') {
+      if (chunkLength !== 0 || !dimensions || !sawIdat) return null;
+      sawIend = true;
+      return nextOffset === bytes.length ? dimensions : null;
+    }
+
+    offset = nextOffset;
+    chunkIndex += 1;
+  }
+
+  return sawIend ? dimensions : null;
+}
+
+function parseWebpDimensions(bytes) {
+  if (bytes.length < 30 || asciiAt(bytes, 0, 4) !== 'RIFF' || asciiAt(bytes, 8, 4) !== 'WEBP') {
+    return null;
+  }
+
+  const declaredLength = readUint32LE(bytes, 4) + 8;
+  if (declaredLength !== bytes.length) return null;
+
+  let offset = 12;
+  let containerDimensions = null;
+  let imageDimensions = null;
+  while (offset + 8 <= bytes.length) {
+    const chunk = asciiAt(bytes, offset, 4);
+    const chunkLength = readUint32LE(bytes, offset + 4);
+    const dataOffset = offset + 8;
+    const dataEnd = dataOffset + chunkLength;
+    if (dataEnd > bytes.length) return null;
+
+    if (chunk === 'VP8X') {
+      if (chunkLength < 10) return null;
+      containerDimensions = {
+        width: readUint24LE(bytes, dataOffset + 4) + 1,
+        height: readUint24LE(bytes, dataOffset + 7) + 1,
+      };
+    } else if (chunk === 'VP8L') {
+      if (chunkLength < 5 || bytes[dataOffset] !== 0x2f) return null;
+      const b1 = bytes[dataOffset + 1];
+      const b2 = bytes[dataOffset + 2];
+      const b3 = bytes[dataOffset + 3];
+      const b4 = bytes[dataOffset + 4];
+      imageDimensions = {
+        width: 1 + (((b2 & 0x3f) << 8) | b1),
+        height: 1 + (((b4 & 0x0f) << 10) | (b3 << 2) | ((b2 & 0xc0) >> 6)),
+      };
+    } else if (chunk === 'VP8 ') {
+      if (
+        chunkLength < 10
+        || bytes[dataOffset + 3] !== 0x9d
+        || bytes[dataOffset + 4] !== 0x01
+        || bytes[dataOffset + 5] !== 0x2a
+      ) {
+        return null;
+      }
+      imageDimensions = {
+        width: readUint16LE(bytes, dataOffset + 6) & 0x3fff,
+        height: readUint16LE(bytes, dataOffset + 8) & 0x3fff,
+      };
+    }
+
+    offset = dataEnd + (chunkLength % 2);
+  }
+
+  if (offset !== bytes.length || !imageDimensions) return null;
+  if (
+    containerDimensions
+    && (
+      containerDimensions.width !== imageDimensions.width
+      || containerDimensions.height !== imageDimensions.height
+    )
+  ) {
+    return null;
+  }
+  return imageDimensions;
+}
+
+function validateJpegQuantisationTables(bytes, offset, length) {
+  const end = offset + length;
+  let cursor = offset;
+  let tableCount = 0;
+  while (cursor < end) {
+    const tableInfo = bytes[cursor];
+    cursor += 1;
+    const precision = tableInfo >> 4;
+    const tableId = tableInfo & 0x0f;
+    if (precision > 1 || tableId > 3) return false;
+    const tableBytes = 64 * (precision + 1);
+    if (cursor + tableBytes > end) return false;
+    cursor += tableBytes;
+    tableCount += 1;
+  }
+  return tableCount > 0 && cursor === end;
+}
+
+function validateJpegHuffmanTables(bytes, offset, length) {
+  const end = offset + length;
+  let cursor = offset;
+  let tableCount = 0;
+  while (cursor < end) {
+    if (cursor + 17 > end) return false;
+    const tableInfo = bytes[cursor];
+    cursor += 1;
+    const tableClass = tableInfo >> 4;
+    const tableId = tableInfo & 0x0f;
+    if (tableClass > 1 || tableId > 3) return false;
+    let symbolCount = 0;
+    for (let index = 0; index < 16; index += 1) {
+      symbolCount += bytes[cursor + index];
+    }
+    if (symbolCount > 256) return false;
+    cursor += 16;
+    if (cursor + symbolCount > end) return false;
+    cursor += symbolCount;
+    tableCount += 1;
+  }
+  return tableCount > 0 && cursor === end;
+}
+
+function parseJpegStartOfFrame(bytes, offset, length) {
+  if (length < 9) return null;
+  const precision = bytes[offset];
+  const height = readUint16BE(bytes, offset + 1);
+  const width = readUint16BE(bytes, offset + 3);
+  const componentCount = bytes[offset + 5];
+  if (![8, 12].includes(precision)) return null;
+  if (width <= 0 || height <= 0) return null;
+  if (componentCount < 1 || componentCount > 4) return null;
+  if (length !== 6 + (componentCount * 3)) return null;
+  const componentIds = new Set();
+  for (let index = 0; index < componentCount; index += 1) {
+    const componentOffset = offset + 6 + (index * 3);
+    const componentId = bytes[componentOffset];
+    const samplingFactors = bytes[componentOffset + 1];
+    const quantisationTableId = bytes[componentOffset + 2];
+    if (!componentId || componentIds.has(componentId)) return null;
+    if ((samplingFactors >> 4) === 0 || (samplingFactors & 0x0f) === 0) return null;
+    if (quantisationTableId > 3) return null;
+    componentIds.add(componentId);
+  }
+  return { width, height };
+}
+
+function validateJpegStartOfScan(bytes, offset, length) {
+  if (length < 6) return false;
+  const componentCount = bytes[offset];
+  if (componentCount < 1 || componentCount > 4) return false;
+  if (length !== 4 + (componentCount * 2)) return false;
+  const componentIds = new Set();
+  for (let index = 0; index < componentCount; index += 1) {
+    const componentOffset = offset + 1 + (index * 2);
+    const componentId = bytes[componentOffset];
+    const tableSelectors = bytes[componentOffset + 1];
+    if (!componentId || componentIds.has(componentId)) return false;
+    if ((tableSelectors >> 4) > 3 || (tableSelectors & 0x0f) > 3) return false;
+    componentIds.add(componentId);
+  }
+  const spectralStart = bytes[offset + 1 + (componentCount * 2)];
+  const spectralEnd = bytes[offset + 2 + (componentCount * 2)];
+  if (spectralStart > 63 || spectralEnd > 63 || spectralStart > spectralEnd) return false;
+  return true;
+}
+
+function validateJpegEntropyScan(bytes, offset) {
+  let cursor = offset;
+  let entropyBytes = 0;
+  while (cursor < bytes.length) {
+    if (bytes[cursor] !== 0xff) {
+      entropyBytes += 1;
+      cursor += 1;
+      continue;
+    }
+    const markerOffset = cursor;
+    while (cursor < bytes.length && bytes[cursor] === 0xff) cursor += 1;
+    if (cursor >= bytes.length) return { ok: false, eoiOffset: -1 };
+    const marker = bytes[cursor];
+    cursor += 1;
+    if (marker === 0x00) {
+      entropyBytes += 1;
+      continue;
+    }
+    if (marker >= 0xd0 && marker <= 0xd7) continue;
+    if (marker === 0xd9) {
+      return {
+        ok: entropyBytes > 0,
+        eoiOffset: markerOffset,
+      };
+    }
+    return { ok: false, eoiOffset: -1 };
+  }
+  return { ok: false, eoiOffset: -1 };
+}
+
+function parseJpegDimensions(bytes) {
+  if (bytes.length < 4 || bytes[0] !== 0xff || bytes[1] !== 0xd8) return null;
+  if (bytes[bytes.length - 2] !== 0xff || bytes[bytes.length - 1] !== 0xd9) return null;
+  let offset = 2;
+  let dimensions = null;
+  let sawScan = false;
+  let sawQuantisationTable = false;
+  let sawHuffmanTable = false;
+  while (offset + 4 < bytes.length) {
+    if (bytes[offset] !== 0xff) return null;
+    while (offset < bytes.length && bytes[offset] === 0xff) offset += 1;
+    if (offset >= bytes.length) return null;
+    const marker = bytes[offset];
+    offset += 1;
+    if (marker === 0x00) return null;
+    if (marker === 0xd9) return null;
+    if (marker === 0x01 || (marker >= 0xd0 && marker <= 0xd7)) continue;
+    if (offset + 2 > bytes.length) return null;
+    const segmentLength = readUint16BE(bytes, offset);
+    if (segmentLength < 2 || offset + segmentLength > bytes.length) return null;
+    const dataOffset = offset + 2;
+    const dataLength = segmentLength - 2;
+    const isStartOfFrame = (
+      (marker >= 0xc0 && marker <= 0xc3)
+      || (marker >= 0xc5 && marker <= 0xc7)
+      || (marker >= 0xc9 && marker <= 0xcb)
+      || (marker >= 0xcd && marker <= 0xcf)
+    );
+
+    if (marker === 0xdb) {
+      if (!validateJpegQuantisationTables(bytes, dataOffset, dataLength)) return null;
+      sawQuantisationTable = true;
+    } else if (marker === 0xc4) {
+      if (!validateJpegHuffmanTables(bytes, dataOffset, dataLength)) return null;
+      sawHuffmanTable = true;
+    } else if (isStartOfFrame) {
+      const frame = parseJpegStartOfFrame(bytes, dataOffset, dataLength);
+      if (!frame) return null;
+      dimensions = {
+        height: frame.height,
+        width: frame.width,
+      };
+    } else if (marker === 0xda) {
+      if (!dimensions || !sawQuantisationTable || !sawHuffmanTable) return null;
+      if (!validateJpegStartOfScan(bytes, dataOffset, dataLength)) return null;
+      const scan = validateJpegEntropyScan(bytes, offset + segmentLength);
+      if (!scan.ok) return null;
+      sawScan = true;
+      offset = scan.eoiOffset + 2;
+      break;
+    }
+    offset += segmentLength;
+  }
+  return dimensions && sawScan && offset === bytes.length ? dimensions : null;
+}
+
+function parseImageDimensions(bytes, contentType) {
+  if (contentType === 'image/png') return parsePngDimensions(bytes);
+  if (contentType === 'image/webp') return parseWebpDimensions(bytes);
+  if (contentType === 'image/jpeg') return parseJpegDimensions(bytes);
+  return null;
+}
+
+function validateRendererCompatibility(dimensions) {
+  const errors = [];
+  const warnings = [];
+  const width = Number(dimensions?.width) || 0;
+  const height = Number(dimensions?.height) || 0;
+  const aspectRatio = width && height ? Math.max(width / height, height / width) : 0;
+  if (!width || !height) {
+    errors.push({
+      code: 'content_operation_monster_asset_dimensions_missing',
+      message: 'Monster image dimensions could not be read.',
+    });
+  }
+  if (width > 0 && height > 0 && (width < MIN_RENDERER_DIMENSION || height < MIN_RENDERER_DIMENSION)) {
+    errors.push({
+      code: 'content_operation_monster_asset_dimensions_too_small',
+      message: `Monster image assets must be at least ${MIN_RENDERER_DIMENSION}px on both sides.`,
+      width,
+      height,
+    });
+  }
+  if (width > MAX_RENDERER_DIMENSION || height > MAX_RENDERER_DIMENSION) {
+    errors.push({
+      code: 'content_operation_monster_asset_dimensions_too_large',
+      message: `Monster image assets must be no larger than ${MAX_RENDERER_DIMENSION}px on either side.`,
+      width,
+      height,
+    });
+  }
+  if (aspectRatio > MAX_RENDERER_ASPECT_RATIO) {
+    errors.push({
+      code: 'content_operation_monster_asset_aspect_ratio_unsupported',
+      message: `Monster image assets must not exceed a ${MAX_RENDERER_ASPECT_RATIO}:1 aspect ratio.`,
+      width,
+      height,
+      aspectRatio,
+    });
+  }
+  if (width > 0 && height > 0 && (width < 320 || height < 320)) {
+    warnings.push({
+      code: 'content_operation_monster_asset_resolution_low',
+      message: 'Monster image assets below 320px may look soft in codex and camp surfaces.',
+      width,
+      height,
+    });
+  }
+  return {
+    ok: errors.length === 0,
+    status: errors.length ? 'blocked' : 'passed',
+    renderer: {
+      minDimension: MIN_RENDERER_DIMENSION,
+      maxDimension: MAX_RENDERER_DIMENSION,
+      maxAspectRatio: MAX_RENDERER_ASPECT_RATIO,
+      contexts: ['hero-camp', 'hero-codex', 'reward-track', 'subject-setup'],
+    },
+    errors,
+    warnings,
+  };
+}
+
+function validateTarget({ monsterId, branchId, stageId }) {
+  const errors = [];
+  if (!monsterId) {
+    errors.push({
+      code: 'content_operation_monster_asset_monster_unknown',
+      field: 'monsterId',
+      message: 'Monster image uploads must target a known monster.',
+    });
+  }
+  if (!branchId) {
+    errors.push({
+      code: 'content_operation_monster_asset_branch_unknown',
+      field: 'branchId',
+      message: 'Monster image uploads must target a known monster branch.',
+    });
+  }
+  if (!stageId) {
+    errors.push({
+      code: 'content_operation_monster_asset_stage_unknown',
+      field: 'stageId',
+      message: 'Monster image uploads must target stage 0, 1, 2, 3 or 4.',
+    });
+  }
+  if (errors.length) {
+    throw new BadRequestError('Monster image upload target is invalid.', {
+      code: 'content_operation_monster_asset_target_invalid',
+      errors,
+    });
+  }
+}
+
+function fileFromForm(form) {
+  const file = form.get('asset') || form.get('file') || form.get('image');
+  return file && typeof file.arrayBuffer === 'function' ? file : null;
+}
+
+function filenameForUpload({ monsterId, branchId, stageId, extension }) {
+  return `${monsterId}-${branchId}-${stageId}.${extension}`;
+}
+
+function previewUrlForUpload({ packageId, assetUploadId }) {
+  return `/api/admin/content-operations/packages/${encodeURIComponent(packageId)}/monster-assets/${encodeURIComponent(assetUploadId)}/preview`;
+}
+
+function assetUploadScanItem(upload) {
+  const validation = upload.validation && typeof upload.validation === 'object' && !Array.isArray(upload.validation)
+    ? upload.validation
+    : { ok: false, status: 'blocked', errors: [], warnings: [] };
+  return {
+    assetUploadId: upload.assetUploadId,
+    assetKind: upload.assetKind || CONTENT_OPERATION_MONSTER_ASSET_KIND,
+    monsterId: upload.monsterId,
+    branchId: upload.branchId,
+    stageId: upload.stageId,
+    status: upload.status || 'draft',
+    validationStatus: validation.status || (validation.ok ? 'passed' : 'blocked'),
+    validationOk: Boolean(validation.ok),
+    errorCodes: (Array.isArray(validation.errors) ? validation.errors : [])
+      .map((entry) => normaliseString(entry?.code))
+      .filter(Boolean),
+    warningCodes: (Array.isArray(validation.warnings) ? validation.warnings : [])
+      .map((entry) => normaliseString(entry?.code))
+      .filter(Boolean),
+    contentType: upload.contentType || '',
+    byteSize: Number(upload.byteSize) || 0,
+    dimensions: {
+      width: upload.width == null ? null : Number(upload.width),
+      height: upload.height == null ? null : Number(upload.height),
+    },
+    createdAt: Number(upload.createdAt) || 0,
+  };
+}
+
+export async function buildContentOperationAssetScan(db, {
+  packageId,
+} = {}) {
+  const safePackageId = normaliseString(packageId);
+  if (!safePackageId) {
+    throw new BadRequestError('Package id is required for content operation asset scan.', {
+      code: 'content_operation_package_id_required',
+    });
+  }
+  await requirePackage(db, safePackageId, { allowPublished: true });
+  const rows = await all(db, `
+    SELECT *
+    FROM content_operation_asset_uploads
+    WHERE package_id = ?
+    ORDER BY created_at ASC, asset_upload_id ASC
+  `, [safePackageId]);
+  const items = rows.map(assetUploadRowToRecord).map(assetUploadScanItem);
+  const blockers = [];
+  const warnings = [];
+  const targetCounts = new Map();
+
+  for (const item of items) {
+    if (!item.validationOk || item.validationStatus === 'blocked') {
+      blockers.push({
+        code: 'content_operation_asset_upload_invalid',
+        assetUploadId: item.assetUploadId,
+        target: {
+          monsterId: item.monsterId,
+          branchId: item.branchId,
+          stageId: item.stageId,
+        },
+        errorCodes: item.errorCodes,
+      });
+    }
+    for (const warningCode of item.warningCodes) {
+      warnings.push({
+        code: warningCode,
+        assetUploadId: item.assetUploadId,
+      });
+    }
+    const targetKey = `${item.monsterId}:${item.branchId}:${item.stageId}`;
+    targetCounts.set(targetKey, (targetCounts.get(targetKey) || 0) + 1);
+  }
+
+  for (const [targetKey, count] of targetCounts.entries()) {
+    if (count <= 1) continue;
+    const [monsterId, branchId, stageId] = targetKey.split(':');
+    blockers.push({
+      code: 'content_operation_asset_target_has_multiple_uploads',
+      count,
+      target: { monsterId, branchId, stageId },
+    });
+  }
+
+  const fingerprint = {
+    assetKind: CONTENT_OPERATION_MONSTER_ASSET_KIND,
+    packageId: safePackageId,
+    items,
+  };
+  const status = blockers.length ? 'blocked' : (warnings.length ? 'warning' : 'passed');
+  return {
+    status,
+    hash: contentOperationHash(fingerprint, 'coassets'),
+    blockers,
+    warnings,
+    uploadCount: items.length,
+    itemCount: items.length,
+    targetCount: targetCounts.size,
+    items,
+  };
+}
+
+export async function uploadContentOperationMonsterAsset({
+  db,
+  env,
+  packageId,
+  request,
+  actorAccountId,
+  now = Date.now,
+}) {
+  const packageRow = await requirePackage(db, packageId);
+  const actor = normaliseString(actorAccountId);
+  if (!actor) {
+    throw new BadRequestError('Monster image uploads require an actor account id.', {
+      code: 'content_operation_monster_asset_actor_required',
+      packageId,
+    });
+  }
+
+  const bucket = assertContentOperationAssetBucket(env);
+  const contentTypeHeader = request.headers.get('content-type') || '';
+  if (!contentTypeHeader.toLowerCase().includes('multipart/form-data')) {
+    throw new BadRequestError('Monster image uploads require multipart form data.', {
+      code: 'content_operation_monster_asset_multipart_required',
+      packageId,
+    });
+  }
+  const declaredContentLength = Number(request.headers.get('content-length'));
+  if (
+    Number.isFinite(declaredContentLength)
+    && declaredContentLength > CONTENT_OPERATION_MONSTER_ASSET_MAX_MULTIPART_BYTES
+  ) {
+    throw new BadRequestError('Monster image upload request exceeds the maximum multipart size.', {
+      code: 'content_operation_monster_asset_request_too_large',
+      byteSize: declaredContentLength,
+      maxBytes: CONTENT_OPERATION_MONSTER_ASSET_MAX_MULTIPART_BYTES,
+    });
+  }
+
+  const form = await request.formData().catch(() => null);
+  if (!form) {
+    throw new BadRequestError('Monster image upload form data could not be read.', {
+      code: 'content_operation_monster_asset_form_invalid',
+      packageId,
+    });
+  }
+
+  const monsterId = normaliseMonsterId(form.get('monsterId') || form.get('monster_id'));
+  const branchId = normaliseBranchId(form.get('branchId') || form.get('branch_id') || form.get('branch'));
+  const stageId = normaliseStageId(form.get('stageId') || form.get('stage_id') || form.get('stage'));
+  validateTarget({ monsterId, branchId, stageId });
+
+  const file = fileFromForm(form);
+  if (!file) {
+    throw new BadRequestError('Monster image upload requires an image file.', {
+      code: 'content_operation_monster_asset_file_required',
+      packageId,
+    });
+  }
+
+  const contentType = normaliseString(file.type).toLowerCase();
+  const extension = SUPPORTED_IMAGE_TYPES[contentType] || '';
+  if (!extension) {
+    throw new BadRequestError('Monster image upload content type is not supported.', {
+      code: 'content_operation_monster_asset_content_type_invalid',
+      contentType,
+      supportedContentTypes: Object.keys(SUPPORTED_IMAGE_TYPES),
+    });
+  }
+
+  const byteSize = Number(file.size) || 0;
+  if (byteSize <= 0) {
+    throw new BadRequestError('Monster image upload must not be empty.', {
+      code: 'content_operation_monster_asset_empty',
+      contentType,
+    });
+  }
+  if (byteSize > CONTENT_OPERATION_MONSTER_ASSET_MAX_BYTES) {
+    throw new BadRequestError('Monster image upload exceeds the maximum size.', {
+      code: 'content_operation_monster_asset_too_large',
+      byteSize,
+      maxBytes: CONTENT_OPERATION_MONSTER_ASSET_MAX_BYTES,
+    });
+  }
+
+  const bytes = new Uint8Array(await file.arrayBuffer());
+  const dimensions = parseImageDimensions(bytes, contentType);
+  const rendererValidation = validateRendererCompatibility(dimensions);
+  if (!rendererValidation.ok) {
+    throw new BadRequestError('Monster image upload is not compatible with the renderer.', {
+      code: 'content_operation_monster_asset_renderer_invalid',
+      validation: rendererValidation,
+    });
+  }
+
+  const assetUploadId = uid('coasset');
+  const filename = filenameForUpload({ monsterId, branchId, stageId, extension });
+  const r2Key = `${CONTENT_OPERATION_MONSTER_ASSET_PREFIX}/${packageRow.package_id}/monster-assets/${assetUploadId}/${filename}`;
+  const previewUrl = previewUrlForUpload({ packageId: packageRow.package_id, assetUploadId });
+  const nowTs = Number(now());
+  const validation = {
+    ok: true,
+    status: 'passed',
+    errors: [],
+    warnings: rendererValidation.warnings,
+    target: {
+      monsterId,
+      branchId,
+      stageId,
+    },
+    dimensions,
+    renderer: rendererValidation.renderer,
+  };
+  const preview = {
+    kind: 'admin-api-handle',
+    url: previewUrl,
+    contentType,
+  };
+
+  let r2Written = false;
+  try {
+    await bucket.put(r2Key, bytes, {
+      httpMetadata: { contentType },
+      customMetadata: {
+        contentOperationAssetUploadId: assetUploadId,
+        contentOperationPackageId: packageRow.package_id,
+        contentOperationAssetKind: CONTENT_OPERATION_MONSTER_ASSET_KIND,
+        monsterId,
+        branchId,
+        stageId,
+      },
+    });
+    r2Written = true;
+
+    const writeResults = await batch(db, [
+      bindStatement(db, `
+        INSERT INTO content_operation_asset_uploads (
+          asset_upload_id, package_id, monster_id, branch_id, stage_id,
+          asset_kind, r2_key, content_type, byte_size, width, height,
+          validation_json, preview_json, status, created_by_account_id, created_at
+        )
+        SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+        WHERE EXISTS (
+          SELECT 1
+          FROM content_operation_packages
+          WHERE package_id = ? AND state <> ?
+        )
+      `, [
+        assetUploadId,
+        packageRow.package_id,
+        monsterId,
+        branchId,
+        stageId,
+        CONTENT_OPERATION_MONSTER_ASSET_KIND,
+        r2Key,
+        contentType,
+        byteSize,
+        dimensions.width,
+        dimensions.height,
+        JSON.stringify(validation),
+        JSON.stringify(preview),
+        'draft',
+        actor,
+        nowTs,
+        packageRow.package_id,
+        CONTENT_OPERATION_PACKAGE_STATES.PUBLISHED,
+      ]),
+      bindStatement(db, `
+        DELETE FROM content_operation_package_approvals
+        WHERE package_id = ?
+          AND EXISTS (
+            SELECT 1
+            FROM content_operation_asset_uploads
+            WHERE asset_upload_id = ?
+          )
+      `, [packageRow.package_id, assetUploadId]),
+      bindStatement(db, `
+        UPDATE content_operation_packages
+        SET state = CASE WHEN state = ? THEN ? ELSE state END,
+            approved_at = NULL,
+            updated_by_account_id = ?,
+            updated_at = ?
+        WHERE package_id = ?
+          AND state <> ?
+          AND EXISTS (
+            SELECT 1
+            FROM content_operation_asset_uploads
+            WHERE asset_upload_id = ?
+          )
+      `, [
+        CONTENT_OPERATION_PACKAGE_STATES.APPROVED,
+        CONTENT_OPERATION_PACKAGE_STATES.DRAFT,
+        actor,
+        nowTs,
+        packageRow.package_id,
+        CONTENT_OPERATION_PACKAGE_STATES.PUBLISHED,
+        assetUploadId,
+      ]),
+      bindStatement(db, `
+        INSERT INTO content_operation_events (
+          event_id, package_id, release_id, subject_id, event_type,
+          actor_account_id, event_json, created_at
+        )
+        SELECT ?, ?, NULL, ?, ?, ?, ?, ?
+        WHERE EXISTS (
+          SELECT 1
+          FROM content_operation_asset_uploads
+          WHERE asset_upload_id = ?
+        )
+      `, [
+        uid('coevt'),
+        packageRow.package_id,
+        packageRow.subject_id || CONTENT_OPERATION_SUBJECT_ID,
+        'asset.monster_image_uploaded',
+        actor,
+        JSON.stringify({
+          assetUploadId,
+          assetKind: CONTENT_OPERATION_MONSTER_ASSET_KIND,
+          monsterId,
+          branchId,
+          stageId,
+          contentType,
+          byteSize,
+          dimensions,
+          preview: { kind: preview.kind, url: preview.url },
+        }),
+        nowTs,
+        assetUploadId,
+      ]),
+    ]);
+    if (mutationChangeCount(writeResults[0]) < 1) {
+      throw new ConflictError('Published content operation packages cannot accept draft asset uploads.', {
+        code: 'content_operation_package_published',
+        packageId: packageRow.package_id,
+      });
+    }
+  } catch (error) {
+    if (r2Written && typeof bucket.delete === 'function') {
+      await bucket.delete(r2Key).catch(() => {});
+    }
+    throw error;
+  }
+
+  const row = await first(db, `
+    SELECT *
+    FROM content_operation_asset_uploads
+    WHERE asset_upload_id = ?
+  `, [assetUploadId]);
+  return assetUploadRowToRecord(row);
+}
+
+export async function listContentOperationMonsterAssetUploads(db, {
+  packageId,
+  status = null,
+  limit = 100,
+} = {}) {
+  const safePackageId = normaliseString(packageId);
+  if (!safePackageId) {
+    throw new BadRequestError('Package id is required for monster image upload listing.', {
+      code: 'content_operation_package_id_required',
+    });
+  }
+  await requirePackage(db, safePackageId, { allowPublished: true });
+  const clauses = ['package_id = ?'];
+  const params = [safePackageId];
+  const safeStatus = normaliseString(status);
+  if (safeStatus && safeStatus !== 'all') {
+    clauses.push('status = ?');
+    params.push(safeStatus);
+  }
+  params.push(Math.min(250, Math.max(1, Math.floor(Number(limit) || 100))));
+  const rows = await all(db, `
+    SELECT *
+    FROM content_operation_asset_uploads
+    WHERE ${clauses.join(' AND ')}
+    ORDER BY created_at DESC, asset_upload_id DESC
+    LIMIT ?
+  `, params);
+  return rows.map(assetUploadRowToRecord);
+}
+
+export async function readContentOperationMonsterAssetObject({
+  db,
+  env,
+  packageId,
+  assetUploadId,
+}) {
+  const safePackageId = normaliseString(packageId);
+  const safeAssetUploadId = normaliseString(assetUploadId);
+  if (!safePackageId || !safeAssetUploadId) {
+    throw new BadRequestError('Monster image preview requires a package id and asset upload id.', {
+      code: 'content_operation_monster_asset_preview_target_required',
+    });
+  }
+  const row = await first(db, `
+    SELECT *
+    FROM content_operation_asset_uploads
+    WHERE package_id = ? AND asset_upload_id = ?
+    LIMIT 1
+  `, [safePackageId, safeAssetUploadId]);
+  const upload = assetUploadRowToRecord(row);
+  if (!upload) {
+    throw new NotFoundError('Monster image upload was not found.', {
+      code: 'content_operation_monster_asset_not_found',
+      packageId: safePackageId,
+      assetUploadId: safeAssetUploadId,
+    });
+  }
+  const object = await assertContentOperationAssetBucket(env).get(upload.r2Key);
+  if (!object) {
+    throw new NotFoundError('Monster image upload object was not found.', {
+      code: 'content_operation_monster_asset_object_not_found',
+      packageId: safePackageId,
+      assetUploadId: safeAssetUploadId,
+    });
+  }
+  return { upload, object };
+}

--- a/worker/src/content-operations/repository.js
+++ b/worker/src/content-operations/repository.js
@@ -39,6 +39,9 @@ import {
 import {
   buildContentOperationAudioScan,
 } from './audio.js';
+import {
+  buildContentOperationAssetScan,
+} from './assets.js';
 
 function parseJson(value, fallback = null) {
   if (value == null || value === '') return fallback;
@@ -205,6 +208,7 @@ function releaseRowToRecord(row, { includeSnapshot = false } = {}) {
   if (!row) return null;
   const proof = parseJson(row.proof_json, null);
   const audioProof = audioReleaseProofFromProof(proof);
+  const assetProof = releaseAssetProofFromProof(proof);
   return {
     releaseId: row.release_id,
     subjectId: row.subject_id,
@@ -219,6 +223,7 @@ function releaseRowToRecord(row, { includeSnapshot = false } = {}) {
     proof,
     audioFallback: audioProof.audioFallback,
     audioWarnings: audioProof.audioWarnings,
+    assetSummary: assetProof.assetSummary,
     createdAt: Number(row.created_at) || 0,
   };
 }
@@ -321,10 +326,14 @@ const AUDIO_FALLBACK_BLOCKING_STATUSES = new Set([
   'override_requested',
 ]);
 const RELEASE_AUDIO_PROOF_KEY = 'contentOperationsAudio';
+const RELEASE_ASSET_PROOF_KEY = 'contentOperationsAssets';
 const RELEASE_PROOF_RESERVED_KEYS = new Set([
   'audioFallback',
   'audioWarnings',
+  'assetSummary',
+  'assetWarnings',
   RELEASE_AUDIO_PROOF_KEY,
+  RELEASE_ASSET_PROOF_KEY,
 ]);
 
 function audioFallbackBlockingItems(scan = null) {
@@ -496,6 +505,16 @@ function audioWarningProofForScan(scan = null, fallbackApproval = null) {
   };
 }
 
+function assetScanHasBlockingItems(scan = null) {
+  return normaliseString(scan?.status) === 'blocked' || asArray(scan?.blockers).length > 0;
+}
+
+function assetScansMatch(left = null, right = null) {
+  const leftHash = normaliseString(left?.hash);
+  const rightHash = normaliseString(right?.hash);
+  return Boolean(leftHash && rightHash && leftHash === rightHash);
+}
+
 function audioReleaseProofFromProof(proof = null) {
   const metadata = isPlainObject(proof?.[RELEASE_AUDIO_PROOF_KEY])
     ? proof[RELEASE_AUDIO_PROOF_KEY]
@@ -519,15 +538,70 @@ function normaliseCallerReleaseProof(proof = null) {
   return cloneSerialisable(proof);
 }
 
-function buildReleaseProof(proof = null, approval = null, audioScan = null) {
-  const baseProof = normaliseCallerReleaseProof(proof);
-  if (!approval?.audioFallback?.allowed) return baseProof;
+function buildReleaseProof(proof = null, approval = null, audioScan = null, assetScan = null) {
+  let releaseProof = normaliseCallerReleaseProof(proof);
+  if (approval?.audioFallback?.allowed) {
+    releaseProof = {
+      ...(releaseProof || {}),
+      [RELEASE_AUDIO_PROOF_KEY]: {
+        audioFallback: approval.audioFallback,
+        audioWarnings: audioWarningProofForScan(audioScan, approval.audioFallback),
+      },
+    };
+  }
+  if (assetScan) {
+    releaseProof = {
+      ...(releaseProof || {}),
+      [RELEASE_ASSET_PROOF_KEY]: {
+        assetSummary: cloneSerialisable(assetScan),
+      },
+    };
+  }
+  return releaseProof;
+}
+
+function releaseAssetProofFromProof(proof = null) {
+  const metadata = isPlainObject(proof?.[RELEASE_ASSET_PROOF_KEY])
+    ? proof[RELEASE_ASSET_PROOF_KEY]
+    : null;
   return {
-    ...(baseProof || {}),
-    [RELEASE_AUDIO_PROOF_KEY]: {
-      audioFallback: approval.audioFallback,
-      audioWarnings: audioWarningProofForScan(audioScan, approval.audioFallback),
-    },
+    assetSummary: isPlainObject(metadata?.assetSummary) ? metadata.assetSummary : null,
+  };
+}
+
+function buildApprovalAssetSummary(assetScan = null) {
+  return assetScan ? cloneSerialisable(assetScan) : null;
+}
+
+function assetEventSummary(assetScan = null) {
+  if (!assetScan) return null;
+  return {
+    status: normaliseString(assetScan.status, 'not_scanned'),
+    hash: normaliseString(assetScan.hash),
+    blockers: asArray(assetScan.blockers),
+    warnings: asArray(assetScan.warnings),
+    uploadCount: Number(assetScan.uploadCount) || 0,
+    itemCount: Number(assetScan.itemCount) || 0,
+    targetCount: Number(assetScan.targetCount) || 0,
+  };
+}
+
+function approvedAssetSummaryMatches(approval = null, assetScan = null) {
+  if (!assetScan) return false;
+  return assetScansMatch(approval?.assetSummary, assetScan);
+}
+
+function candidateAssetScanMatches(candidate = null, assetScan = null) {
+  return assetScansMatch(candidate?.assetScan, assetScan);
+}
+
+function assetScanConflictExtra(packageId, candidateId, candidateAssetScan, currentAssetScan) {
+  return {
+    packageId,
+    candidateId,
+    candidateAssetHash: normaliseString(candidateAssetScan?.hash) || null,
+    currentAssetHash: normaliseString(currentAssetScan?.hash) || null,
+    assetScan: currentAssetScan,
   };
 }
 
@@ -1307,6 +1381,7 @@ export function createContentOperationsRepository({ db, now }) {
         candidate: candidate.candidate,
         operations,
       });
+      const assetScan = await buildContentOperationAssetScan(db, { packageId });
       const candidateId = uid('cocand');
       const nowTs = Number(nowFactory());
       const validationSummary = {
@@ -1326,7 +1401,7 @@ export function createContentOperationsRepository({ db, now }) {
             validation_json, audio_scan_json, asset_scan_json, reward_scan_json,
             visibility_scan_json, conflicts_json, created_at
           )
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, ?, ?)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, ?, ?)
         `, [
           candidateId,
           packageId,
@@ -1337,6 +1412,7 @@ export function createContentOperationsRepository({ db, now }) {
           encodedCandidateSnapshot,
           JSON.stringify(validationSummary),
           JSON.stringify(audioScan),
+          JSON.stringify(assetScan),
           JSON.stringify(conflicts),
           nowTs,
         ]),
@@ -1371,6 +1447,7 @@ export function createContentOperationsRepository({ db, now }) {
               blockers: audioScan.blockers,
               requiredCount: audioScan.requiredCount,
             },
+            assets: assetEventSummary(assetScan),
           }),
           nowTs,
         ]),
@@ -1386,6 +1463,7 @@ export function createContentOperationsRepository({ db, now }) {
         candidate: candidate.candidate,
         validation: validationSummary,
         audioScan,
+        assetScan,
         conflicts,
         createdAt: nowTs,
       };
@@ -1499,7 +1577,6 @@ export function createContentOperationsRepository({ db, now }) {
       approvedByAccountId,
       notes = '',
       audioFallback = null,
-      assetSummary = null,
     } = {}) {
       const packageRow = await requirePackage(db, packageId);
       assertPackageIsNotPublished(packageRow, packageId);
@@ -1560,6 +1637,7 @@ export function createContentOperationsRepository({ db, now }) {
         candidate: candidate.candidate,
         operations,
       });
+      const currentAssetScan = await buildContentOperationAssetScan(db, { packageId });
       const nowTs = Number(nowFactory());
       let approvedAudioScan = currentAudioScan;
       let audioFallbackApproval = null;
@@ -1589,6 +1667,20 @@ export function createContentOperationsRepository({ db, now }) {
         }
         approvedAudioScan = applyAudioFallbackToScan(currentAudioScan, audioFallbackApproval);
       }
+      if (!candidateAssetScanMatches(candidate, currentAssetScan)) {
+        throw new ConflictError('Content operation candidate was built from stale asset uploads.', {
+          code: 'content_operation_candidate_assets_stale',
+          ...assetScanConflictExtra(packageId, candidateId, candidate.assetScan, currentAssetScan),
+        });
+      }
+      if (assetScanHasBlockingItems(currentAssetScan)) {
+        throw new ConflictError('Content operation candidate has asset readiness blockers.', {
+          code: 'content_operation_candidate_assets_blocked',
+          packageId,
+          candidateId,
+          assetScan: currentAssetScan,
+        });
+      }
       if (Array.isArray(candidate.conflicts) && candidate.conflicts.length) {
         throw new ConflictError('Content operation candidate has unresolved conflicts.', {
           code: 'content_operation_candidate_conflicted',
@@ -1606,10 +1698,12 @@ export function createContentOperationsRepository({ db, now }) {
         `, [packageId]),
         bindStatement(db, `
           UPDATE content_operation_package_candidates
-          SET audio_scan_json = ?
+          SET audio_scan_json = ?,
+              asset_scan_json = ?
           WHERE candidate_id = ?
         `, [
           JSON.stringify(approvedAudioScan),
+          JSON.stringify(currentAssetScan),
           candidateId,
         ]),
         bindStatement(db, `
@@ -1628,7 +1722,7 @@ export function createContentOperationsRepository({ db, now }) {
           nowTs,
           normaliseString(notes),
           audioFallbackApproval == null ? null : JSON.stringify(audioFallbackApproval),
-          assetSummary == null ? null : JSON.stringify(assetSummary),
+          JSON.stringify(buildApprovalAssetSummary(currentAssetScan)),
           JSON.stringify(candidate.validation),
         ]),
         bindStatement(db, `
@@ -1667,7 +1761,7 @@ export function createContentOperationsRepository({ db, now }) {
               requiredCount: approvedAudioScan.requiredCount,
             },
             audioFallback: audioFallbackApproval,
-            assetSummary,
+            assetSummary: buildApprovalAssetSummary(currentAssetScan),
           }),
           nowTs,
         ]),
@@ -1683,7 +1777,7 @@ export function createContentOperationsRepository({ db, now }) {
         notes: normaliseString(notes),
         validationSummary: candidate.validation,
         audioFallback: audioFallbackApproval,
-        assetSummary,
+        assetSummary: buildApprovalAssetSummary(currentAssetScan),
       };
     },
 
@@ -1771,6 +1865,7 @@ export function createContentOperationsRepository({ db, now }) {
         candidate: candidate.candidate,
         operations,
       });
+      const currentAssetScan = await buildContentOperationAssetScan(db, { packageId });
       let publishAudioScan = currentAudioScan;
       if (audioReadinessHasBlockingItems(currentAudioScan)) {
         if (audioFallbackCoversCurrentScan(approval.audioFallback, currentAudioScan)) {
@@ -1785,12 +1880,38 @@ export function createContentOperationsRepository({ db, now }) {
           });
         }
       }
+      if (!candidateAssetScanMatches(candidate, currentAssetScan)) {
+        throw new ConflictError('Content operation candidate was built from stale asset uploads.', {
+          code: 'content_operation_candidate_assets_stale',
+          ...assetScanConflictExtra(packageId, candidate.candidateId, candidate.assetScan, currentAssetScan),
+        });
+      }
+      if (!approvedAssetSummaryMatches(approval, currentAssetScan)) {
+        throw new ConflictError('Content operation approval was built from stale asset uploads.', {
+          code: 'content_operation_approval_assets_stale',
+          packageId,
+          candidateId: candidate.candidateId,
+          approvalId: approval.approvalId,
+          approvalAssetHash: normaliseString(approval.assetSummary?.hash) || null,
+          currentAssetHash: normaliseString(currentAssetScan?.hash) || null,
+          assetScan: currentAssetScan,
+        });
+      }
+      if (assetScanHasBlockingItems(currentAssetScan)) {
+        throw new ConflictError('Approved candidate has asset readiness blockers.', {
+          code: 'content_operation_candidate_assets_blocked',
+          packageId,
+          candidateId: candidate.candidateId,
+          assetScan: currentAssetScan,
+        });
+      }
       const releaseId = uid('corel');
       const nowTs = Number(nowFactory());
       const snapshotHash = contentOperationHash(candidate.candidate, 'release');
       const encodedSnapshot = await encodeContentOperationSnapshot(candidate.candidate);
-      const releaseProof = buildReleaseProof(proof, approval, publishAudioScan);
+      const releaseProof = buildReleaseProof(proof, approval, publishAudioScan, currentAssetScan);
       const releaseAudioProof = audioReleaseProofFromProof(releaseProof);
+      const releaseAssetProof = releaseAssetProofFromProof(releaseProof);
 
       let publishResults = [];
       try {
@@ -1826,10 +1947,12 @@ export function createContentOperationsRepository({ db, now }) {
           ]),
           bindStatement(db, `
             UPDATE content_operation_package_candidates
-            SET audio_scan_json = ?
+            SET audio_scan_json = ?,
+                asset_scan_json = ?
             WHERE candidate_id = ?
           `, [
             JSON.stringify(publishAudioScan),
+            JSON.stringify(currentAssetScan),
             candidate.candidateId,
           ]),
           bindStatement(db, `
@@ -1877,6 +2000,7 @@ export function createContentOperationsRepository({ db, now }) {
               summary: buildSpellingContentSummary(candidate.candidate),
               audioFallback: approval.audioFallback,
               audioWarnings: audioWarningProofForScan(publishAudioScan, approval.audioFallback),
+              assets: assetEventSummary(currentAssetScan),
             }),
             nowTs,
             releaseId,
@@ -1929,6 +2053,7 @@ export function createContentOperationsRepository({ db, now }) {
         proof: releaseProof,
         audioFallback: releaseAudioProof.audioFallback,
         audioWarnings: releaseAudioProof.audioWarnings,
+        assetSummary: releaseAssetProof.assetSummary,
       };
     },
 

--- a/worker/src/content-operations/repository.js
+++ b/worker/src/content-operations/repository.js
@@ -817,7 +817,7 @@ function assertPackageIsNotPublished(packageRow, packageId) {
   }
 }
 
-export function createContentOperationsRepository({ db, now }) {
+export function createContentOperationsRepository({ db, env = {}, now }) {
   const nowFactory = typeof now === 'function' ? now : () => Date.now();
 
   return {
@@ -1381,7 +1381,11 @@ export function createContentOperationsRepository({ db, now }) {
         candidate: candidate.candidate,
         operations,
       });
-      const assetScan = await buildContentOperationAssetScan(db, { packageId });
+      const assetScan = await buildContentOperationAssetScan(db, {
+        packageId,
+        env,
+        verifyStorage: true,
+      });
       const candidateId = uid('cocand');
       const nowTs = Number(nowFactory());
       const validationSummary = {
@@ -1637,7 +1641,11 @@ export function createContentOperationsRepository({ db, now }) {
         candidate: candidate.candidate,
         operations,
       });
-      const currentAssetScan = await buildContentOperationAssetScan(db, { packageId });
+      const currentAssetScan = await buildContentOperationAssetScan(db, {
+        packageId,
+        env,
+        verifyStorage: true,
+      });
       const nowTs = Number(nowFactory());
       let approvedAudioScan = currentAudioScan;
       let audioFallbackApproval = null;
@@ -1865,7 +1873,11 @@ export function createContentOperationsRepository({ db, now }) {
         candidate: candidate.candidate,
         operations,
       });
-      const currentAssetScan = await buildContentOperationAssetScan(db, { packageId });
+      const currentAssetScan = await buildContentOperationAssetScan(db, {
+        packageId,
+        env,
+        verifyStorage: true,
+      });
       let publishAudioScan = currentAudioScan;
       if (audioReadinessHasBlockingItems(currentAudioScan)) {
         if (audioFallbackCoversCurrentScan(approval.audioFallback, currentAudioScan)) {

--- a/worker/src/content-operations/routes.js
+++ b/worker/src/content-operations/routes.js
@@ -710,6 +710,14 @@ export async function handleContentOperationsAdminRequest({
             packageId,
           });
         }
+        const callerAssetSummary = body.assetSummary ?? body.asset_summary ?? null;
+        if (callerAssetSummary != null) {
+          throw new BadRequestError('Content operation approval asset summaries are derived by the server.', {
+            code: 'content_operation_approval_asset_summary_readonly',
+            packageId,
+            candidateId,
+          });
+        }
         const approval = await repository.approveContentOperationCandidate(packageId, candidateId, {
           approvedByAccountId: actor.id,
           notes: body.notes,

--- a/worker/src/content-operations/routes.js
+++ b/worker/src/content-operations/routes.js
@@ -1,5 +1,8 @@
 import { requireMutationCapability } from '../auth.js';
-import { requireDatabase } from '../d1.js';
+import {
+  requireDatabase,
+  requireDatabaseWithCapacity,
+} from '../d1.js';
 import { requireSameOrigin } from '../demo/sessions.js';
 import {
   BadRequestError,
@@ -11,6 +14,7 @@ import {
   serialiseContentOperation,
   serialiseContentOperationActor,
   serialiseContentOperationApproval,
+  serialiseContentOperationAssetUpload,
   serialiseContentOperationCandidate,
   serialiseContentOperationEvent,
   serialiseContentOperationOverview,
@@ -26,13 +30,17 @@ import {
 import {
   generateContentOperationPackageAudio,
 } from './audio.js';
+import {
+  listContentOperationMonsterAssetUploads,
+  readContentOperationMonsterAssetObject,
+  uploadContentOperationMonsterAsset,
+} from './assets.js';
 
 const CONTENT_OPERATIONS_ROUTE_PREFIX = '/api/admin/content-operations';
 const CONTENT_OPERATIONS_SUBJECT_ID = 'spelling';
 const STUBBED_CONTENT_OPERATION_ROUTES = Object.freeze({
   rebase: { ticket: 'T6', capability: CONTENT_OPERATION_CAPABILITIES.EDIT },
   'scan-audio': { ticket: 'T7', capability: CONTENT_OPERATION_CAPABILITIES.EDIT },
-  'upload-monster-asset': { ticket: 'T8', capability: CONTENT_OPERATION_CAPABILITIES.EDIT },
   'create-revert': { ticket: 'T9', capability: CONTENT_OPERATION_CAPABILITIES.ROLLBACK },
 });
 
@@ -62,6 +70,10 @@ function includeSnapshot(url, body = {}) {
 function optionalQueryString(url, key) {
   const value = url.searchParams.get(key);
   return typeof value === 'string' && value.trim() ? value.trim() : '';
+}
+
+function routeDatabase(env, capacity = null) {
+  return capacity ? requireDatabaseWithCapacity(env, capacity) : requireDatabase(env);
 }
 
 function decodePathSegment(value, label) {
@@ -183,6 +195,7 @@ export async function handleContentOperationsAdminRequest({
   env,
   session,
   repository,
+  capacity = null,
 }) {
   if (!isContentOperationPath(url.pathname)) return null;
 
@@ -496,6 +509,63 @@ export async function handleContentOperationsAdminRequest({
   }
 
   {
+    const monsterAssetsMatch = /^\/packages\/([^/]+)\/monster-assets$/.exec(relativePath);
+    if (request.method === 'GET' && monsterAssetsMatch) {
+      const actor = await requireRouteActor({
+        repository,
+        session,
+        request,
+        env,
+        capability: CONTENT_OPERATION_CAPABILITIES.VIEW,
+      });
+      const packageId = decodePathSegment(monsterAssetsMatch[1], 'package_id');
+      const uploads = await listContentOperationMonsterAssetUploads(routeDatabase(env, capacity), {
+        packageId,
+        status: optionalQueryString(url, 'status') || null,
+        limit: normaliseLimit(url.searchParams.get('limit'), 100, 250),
+      });
+      return json({
+        ok: true,
+        actor: serialiseContentOperationActor(actor),
+        uploads: uploads.map(serialiseContentOperationAssetUpload),
+      });
+    }
+  }
+
+  {
+    const monsterAssetPreviewMatch = /^\/packages\/([^/]+)\/monster-assets\/([^/]+)\/preview$/.exec(relativePath);
+    if (request.method === 'GET' && monsterAssetPreviewMatch) {
+      await requireRouteActor({
+        repository,
+        session,
+        request,
+        env,
+        capability: CONTENT_OPERATION_CAPABILITIES.VIEW,
+      });
+      const packageId = decodePathSegment(monsterAssetPreviewMatch[1], 'package_id');
+      const assetUploadId = decodePathSegment(monsterAssetPreviewMatch[2], 'asset_upload_id');
+      const { upload, object } = await readContentOperationMonsterAssetObject({
+        db: routeDatabase(env, capacity),
+        env,
+        packageId,
+        assetUploadId,
+      });
+      const extension = upload.contentType === 'image/jpeg'
+        ? 'jpg'
+        : (upload.contentType.split('/')[1] || 'img');
+      return new Response(object.body, {
+        status: 200,
+        headers: {
+          'content-type': upload.contentType,
+          'cache-control': 'private, no-store',
+          'content-disposition': `inline; filename="${upload.monsterId}-${upload.branchId}-${upload.stageId}.${extension}"`,
+          'x-content-type-options': 'nosniff',
+        },
+      });
+    }
+  }
+
+  {
     const actionMatch = /^\/packages\/([^/]+)\/(validate|approve|publish|resolve-conflict|rebase|scan-audio|generate-audio|upload-monster-asset|create-revert)$/.exec(relativePath);
     if (request.method === 'POST' && actionMatch) {
       const packageId = decodePathSegment(actionMatch[1], 'package_id');
@@ -519,6 +589,21 @@ export async function handleContentOperationsAdminRequest({
           ticket: stub.ticket,
           capability,
         }), 501);
+      }
+
+      if (action === 'upload-monster-asset') {
+        const upload = await uploadContentOperationMonsterAsset({
+          db: routeDatabase(env, capacity),
+          env,
+          packageId,
+          request,
+          actorAccountId: actor.id,
+        });
+        return json({
+          ok: true,
+          actor: serialiseContentOperationActor(actor),
+          assetUpload: serialiseContentOperationAssetUpload(upload),
+        }, 201);
       }
 
       const body = normaliseBody(await readJson(request));
@@ -581,7 +666,7 @@ export async function handleContentOperationsAdminRequest({
         const resolvedCandidateId = body.candidateId || body.candidate_id || candidate.candidateId;
         const overrideReason = body.reason || body.overrideReason || body.override_reason || '';
         const audio = await generateContentOperationPackageAudio({
-          db: requireDatabase(env),
+          db: routeDatabase(env, capacity),
           env,
           packageId,
           candidate,
@@ -629,7 +714,6 @@ export async function handleContentOperationsAdminRequest({
           approvedByAccountId: actor.id,
           notes: body.notes,
           audioFallback: body.audioFallback ?? body.audio_fallback ?? null,
-          assetSummary: body.assetSummary ?? null,
         });
         return json({
           ok: true,

--- a/worker/src/content-operations/serialisers.js
+++ b/worker/src/content-operations/serialisers.js
@@ -350,6 +350,14 @@ function releaseAssetProofFromProof(proof = null) {
   };
 }
 
+function releaseHasCallerProof(proof = null) {
+  if (!proof || typeof proof !== 'object' || Array.isArray(proof)) return false;
+  return Object.keys(proof).some((key) => (
+    key !== 'contentOperationsAudio'
+    && key !== 'contentOperationsAssets'
+  ));
+}
+
 export function serialiseContentOperationRelease(release = {}, { includeSnapshot = false } = {}) {
   const proof = release.proof ?? null;
   const proofAudio = releaseAudioProofFromProof(proof);
@@ -365,6 +373,7 @@ export function serialiseContentOperationRelease(release = {}, { includeSnapshot
     publishedByAccountId: release.publishedByAccountId || null,
     rollbackOfReleaseId: release.rollbackOfReleaseId || null,
     proof,
+    hasCallerProof: releaseHasCallerProof(proof),
     audioFallback: release.audioFallback ?? proofAudio.audioFallback,
     audioWarnings: release.audioWarnings ?? proofAudio.audioWarnings,
     assetSummary: release.assetSummary ?? proofAssets.assetSummary,

--- a/worker/src/content-operations/serialisers.js
+++ b/worker/src/content-operations/serialisers.js
@@ -261,6 +261,7 @@ export function serialiseContentOperationCandidate(candidate = {}, { includeSnap
     candidateHash: candidate.candidateHash || '',
     validation: normaliseValidation(candidate.validation),
     audioScan: candidate.audioScan || null,
+    assetScan: candidate.assetScan || null,
     blockers: buildContentOperationBlockerEnvelope({
       validation: candidate.validation,
       conflicts: candidate.conflicts,
@@ -272,6 +273,36 @@ export function serialiseContentOperationCandidate(candidate = {}, { includeSnap
     conflicts: asArray(candidate.conflicts),
     createdAt: Number(candidate.createdAt) || 0,
     ...(includeSnapshot ? { candidate: candidate.candidate || null } : {}),
+  };
+}
+
+export function serialiseContentOperationAssetUpload(upload = {}) {
+  const preview = upload.preview && typeof upload.preview === 'object' && !Array.isArray(upload.preview)
+    ? upload.preview
+    : {};
+  return {
+    assetUploadId: upload.assetUploadId,
+    packageId: upload.packageId,
+    monsterId: upload.monsterId,
+    branchId: upload.branchId,
+    stageId: upload.stageId,
+    assetKind: upload.assetKind || 'monster-image',
+    contentType: upload.contentType || '',
+    byteSize: Number(upload.byteSize) || 0,
+    dimensions: {
+      width: upload.width == null ? null : Number(upload.width),
+      height: upload.height == null ? null : Number(upload.height),
+    },
+    validation: upload.validation || { ok: false, errors: [], warnings: [] },
+    preview: {
+      kind: preview.kind || 'admin-api-handle',
+      url: typeof preview.url === 'string' ? preview.url : null,
+      contentType: preview.contentType || upload.contentType || '',
+    },
+    previewUrl: typeof preview.url === 'string' ? preview.url : null,
+    status: upload.status || 'draft',
+    createdByAccountId: upload.createdByAccountId || null,
+    createdAt: Number(upload.createdAt) || 0,
   };
 }
 
@@ -307,9 +338,22 @@ function releaseAudioProofFromProof(proof = null) {
   };
 }
 
+function releaseAssetProofFromProof(proof = null) {
+  const metadata = proof && typeof proof === 'object' && !Array.isArray(proof)
+    ? proof.contentOperationsAssets
+    : null;
+  return {
+    assetSummary: metadata && typeof metadata === 'object' && !Array.isArray(metadata)
+      && metadata.assetSummary && typeof metadata.assetSummary === 'object' && !Array.isArray(metadata.assetSummary)
+      ? metadata.assetSummary
+      : null,
+  };
+}
+
 export function serialiseContentOperationRelease(release = {}, { includeSnapshot = false } = {}) {
   const proof = release.proof ?? null;
   const proofAudio = releaseAudioProofFromProof(proof);
+  const proofAssets = releaseAssetProofFromProof(proof);
   return {
     releaseId: release.releaseId,
     subjectId: release.subjectId || CONTENT_OPERATION_SUBJECT_ID,
@@ -323,6 +367,7 @@ export function serialiseContentOperationRelease(release = {}, { includeSnapshot
     proof,
     audioFallback: release.audioFallback ?? proofAudio.audioFallback,
     audioWarnings: release.audioWarnings ?? proofAudio.audioWarnings,
+    assetSummary: release.assetSummary ?? proofAssets.assetSummary,
     createdAt: Number(release.createdAt) || 0,
     ...(includeSnapshot ? { snapshot: release.snapshot || null } : {}),
   };

--- a/worker/src/repository.js
+++ b/worker/src/repository.js
@@ -9147,7 +9147,7 @@ export function createWorkerRepository({ env = {}, now = Date.now, capacity = nu
       // Structured logs are best-effort.
     }
   }
-  const contentOperations = createContentOperationsRepository({ db, now: nowFactory });
+  const contentOperations = createContentOperationsRepository({ db, env, now: nowFactory });
 
   return {
     ...contentOperations,


### PR DESCRIPTION
## Summary

- Add package-scoped monster image asset uploads for Content Operations packages, stored in R2 behind admin preview handles.
- Bind uploaded monster assets into candidate validation, approval, and publish proof so draft assets cannot reach learner runtime until package publish.
- Add server-side validation for monster/branch/stage targets, supported image MIME types, PNG/JPEG/WebP structure, renderer dimensions, duplicate same-target uploads, and upload-vs-publish races.
- Register the new admin asset handlers and tighten root-relative preview URL allowlisting to the monster asset preview route only.

## Review Closure

- Closed Lovelace P1 upload/publish race by making the asset insert conditional on package state during the D1 write and deleting the R2 object on a lost race.
- Closed malformed image findings with full PNG chunk/CRC checks and stricter JPEG/WebP structure checks, including empty-scan JPEG and VP8X-only WebP regressions.
- Closed duplicate target ambiguity by treating multiple uploads for the same monster/branch/stage target as asset blockers, not warnings.

## Verification

- `npm test -- tests/monster-asset-upload-validation.test.js tests/admin-asset-preview-url-safety.test.js tests/content-operations-api.test.js tests/worker-migration-0020.test.js` (98 pass, 0 fail)
- `npm test` (111845 pass, 0 fail, 12 skipped)
- `npm run check`
- Pre-push `npm test` (111845 pass, 0 fail, 12 skipped)

## Notes

- Residual upload-abuse hardening remains out of T21 scope: chunked/no-Content-Length multipart requests still reach `formData()` before file-size rejection, and per-admin upload rate limiting is not introduced here.