### PR TITLE
Add monster asset package reference previews

### DIFF
--- a/src/platform/hubs/admin-asset-registry.js
+++ b/src/platform/hubs/admin-asset-registry.js
@@ -43,6 +43,16 @@ function isPlainObject(value) {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
 
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function packageArrayFromValue(value) {
+  if (Array.isArray(value)) return value;
+  if (isPlainObject(value)) return asArray(value.packages);
+  return [];
+}
+
 function safeString(value, fallback) {
   return typeof value === 'string' ? value : (fallback || '');
 }
@@ -145,11 +155,102 @@ export function buildMonsterVisualRegistryEntry(monsterVisualConfig) {
   };
 }
 
+function contentOperationPackagesFromModel(model) {
+  const hub = isPlainObject(model) ? model : {};
+  const contentOperations = isPlainObject(hub.contentOperations) ? hub.contentOperations : hub;
+  const directPackages = packageArrayFromValue(contentOperations.packages);
+  const lanes = isPlainObject(contentOperations.lanes) ? contentOperations.lanes : {};
+  const lanePackages = Object.values(lanes).flatMap((lane) => asArray(lane));
+  const selectedPackage = isPlainObject(contentOperations.package) ? [contentOperations.package] : [];
+  const byId = new Map();
+  for (const contentPackage of [...directPackages, ...lanePackages, ...selectedPackage]) {
+    const packageId = safeString(contentPackage?.packageId, '');
+    if (!packageId || byId.has(packageId)) continue;
+    byId.set(packageId, contentPackage);
+  }
+  return [...byId.values()];
+}
+
+function monsterAssetReferenceTargetLabel(target = {}) {
+  const monsterId = safeString(target.monsterId, 'monster');
+  const branchId = safeString(target.branchId, 'branch');
+  const stageId = safeString(target.stageId, 'stage');
+  return `${monsterId} / ${branchId} / stage ${stageId}`;
+}
+
+function publishBlockersForMonsterAssetReference(reference = {}) {
+  const blockers = [
+    'Publish this monster image through the content operation package workflow.',
+  ];
+  const validation = isPlainObject(reference.validation) ? reference.validation : {};
+  const storage = isPlainObject(reference.storage) ? reference.storage : {};
+  if (validation.ok === false || safeString(validation.status, '') === 'blocked') {
+    blockers.push('Renderer validation must pass before publish.');
+  }
+  if (['missing', 'mismatch', 'unavailable'].includes(safeString(storage.status, ''))) {
+    blockers.push('Stored image object must be present and match the approved upload.');
+  }
+  return blockers;
+}
+
+function buildMonsterAssetReferenceRegistryEntry(reference, contentPackage) {
+  const safeReference = isPlainObject(reference) ? reference : {};
+  const target = isPlainObject(safeReference.target) ? safeReference.target : {};
+  const preview = isPlainObject(safeReference.preview) ? safeReference.preview : {};
+  const validation = isPlainObject(safeReference.validation) ? safeReference.validation : {};
+  const blockers = publishBlockersForMonsterAssetReference(safeReference);
+  const rawPreviewUrl = safeString(preview.url, '');
+  const previewUrl = getSafePreviewUrl(rawPreviewUrl);
+  return {
+    assetId: `content-operation-monster-asset:${safeString(contentPackage?.packageId, 'package')}:${safeString(safeReference.referenceId, safeString(safeReference.assetUploadId, 'upload'))}`,
+    category: 'visual',
+    displayName: `Monster Image - ${monsterAssetReferenceTargetLabel(target)}`,
+    draftVersion: safeNonNegativeInt(contentPackage?.latestCandidate?.createdAt),
+    publishedVersion: 0,
+    manifestHash: safeString(contentPackage?.latestCandidate?.assetScan?.hash, safeString(safeReference.assetUploadId, '')),
+    reviewStatus: blockers.length ? 'has-blockers' : 'publishable',
+    validationState: {
+      ok: validation.ok === true,
+      errorCount: asArray(validation.errors).length + asArray(validation.errorCodes).length,
+      warningCount: asArray(validation.warnings).length + asArray(validation.warningCodes).length,
+      errors: asArray(validation.errors),
+      warnings: asArray(validation.warnings),
+    },
+    lastPublishedAt: 0,
+    lastPublishedBy: '',
+    canManage: true,
+    hasDraft: true,
+    hasPublished: false,
+    versions: [],
+    publishBlockers: blockers,
+    previewUrl,
+    previewBlockedReason: getPreviewBlockedReason(rawPreviewUrl),
+    reducedMotionStatus: null,
+    fallbackStatus: 'bundled-manifest-unchanged',
+    packageId: safeString(contentPackage?.packageId, ''),
+    assetUploadId: safeString(safeReference.assetUploadId, ''),
+    target: {
+      monsterId: safeString(target.monsterId, ''),
+      branchId: safeString(target.branchId, ''),
+      stageId: safeString(target.stageId, ''),
+    },
+    rendererContexts: asArray(safeReference.renderer?.contexts),
+  };
+}
+
+export function buildContentOperationMonsterAssetRegistryEntries(model) {
+  return contentOperationPackagesFromModel(model).flatMap((contentPackage) => {
+    const manifest = contentPackage?.latestCandidate?.assetScan?.assetReferenceManifest;
+    const references = asArray(manifest?.references);
+    return references.map((reference) => buildMonsterAssetReferenceRegistryEntry(reference, contentPackage));
+  });
+}
+
 /**
  * Build the full asset registry from the admin hub read-model.
  *
- * Returns an array of registry entries. Currently contains one entry
- * (monster-visual-config). Future asset categories append to this array.
+ * Returns an array of registry entries. The global monster visual config stays
+ * first; package-scoped monster image references append as draft entries.
  *
  * @param {object} model — the full admin hub read-model
  * @returns {RegistryEntry[]}
@@ -158,6 +259,7 @@ export function buildAssetRegistry(model) {
   const hub = isPlainObject(model) ? model : {};
   return [
     buildMonsterVisualRegistryEntry(hub.monsterVisualConfig),
+    ...buildContentOperationMonsterAssetRegistryEntries(hub),
   ];
 }
 

--- a/src/platform/hubs/admin-content-operations.js
+++ b/src/platform/hubs/admin-content-operations.js
@@ -1,6 +1,10 @@
 import {
   normaliseHeroExposure,
 } from '../game/reward-track-config.js';
+import {
+  getPreviewBlockedReason,
+  getSafePreviewUrl,
+} from './admin-asset-url-allowlist.js';
 
 const PACKAGE_STATE_LABELS = Object.freeze({
   draft: 'Draft',
@@ -168,6 +172,98 @@ export function normaliseContentOperationActor(actor = null) {
   };
 }
 
+function normaliseContentOperationAssetReference(reference = null) {
+  const safe = isPlainObject(reference) ? reference : {};
+  const target = isPlainObject(safe.target) ? safe.target : {};
+  const preview = isPlainObject(safe.preview) ? safe.preview : {};
+  const content = isPlainObject(safe.content) ? safe.content : {};
+  const dimensions = isPlainObject(content.dimensions) ? content.dimensions : {};
+  const storage = isPlainObject(safe.storage) ? safe.storage : {};
+  const validation = isPlainObject(safe.validation) ? safe.validation : {};
+  const renderer = isPlainObject(safe.renderer) ? safe.renderer : {};
+  const previewUrl = getSafePreviewUrl(preview.url);
+  return {
+    schemaVersion: Number(safe.schemaVersion) || 1,
+    referenceId: asString(safe.referenceId),
+    assetKind: asString(safe.assetKind, 'monster-image'),
+    assetUploadId: asString(safe.assetUploadId),
+    packageId: asNullableString(safe.packageId),
+    target: {
+      monsterId: asString(target.monsterId),
+      branchId: asString(target.branchId),
+      stageId: asString(target.stageId),
+    },
+    preview: {
+      kind: asString(preview.kind, 'admin-api-handle'),
+      url: previewUrl,
+      blockedReason: getPreviewBlockedReason(preview.url),
+      contentType: asString(preview.contentType, content.contentType || ''),
+    },
+    content: {
+      contentType: asString(content.contentType),
+      byteSize: Number(content.byteSize) || 0,
+      dimensions: {
+        width: dimensions.width == null ? null : Number(dimensions.width),
+        height: dimensions.height == null ? null : Number(dimensions.height),
+      },
+    },
+    validation: {
+      status: asString(validation.status, validation.ok === false ? 'blocked' : 'passed'),
+      ok: validation.ok === true,
+      errorCodes: asArray(validation.errorCodes),
+      warningCodes: asArray(validation.warningCodes),
+      errors: asArray(validation.errors),
+      warnings: asArray(validation.warnings),
+    },
+    storage: {
+      status: asString(storage.status, 'not_checked'),
+      byteSize: storage.byteSize == null ? null : Number(storage.byteSize),
+      contentType: asString(storage.contentType),
+    },
+    renderer: {
+      contexts: asArray(renderer.contexts),
+      minDimension: Number(renderer.minDimension) || 0,
+      maxDimension: Number(renderer.maxDimension) || 0,
+      maxAspectRatio: Number(renderer.maxAspectRatio) || 0,
+    },
+    policy: isPlainObject(safe.policy) ? safe.policy : {},
+    createdAt: asTs(safe.createdAt),
+  };
+}
+
+export function normaliseContentOperationAssetReferenceManifest(manifest = null) {
+  const safe = isPlainObject(manifest) ? manifest : {};
+  const references = asArray(safe.references)
+    .map(normaliseContentOperationAssetReference)
+    .filter((reference) => reference.referenceId || reference.assetUploadId);
+  return {
+    schemaVersion: Number(safe.schemaVersion) || 1,
+    assetKind: asString(safe.assetKind, 'monster-image'),
+    packageId: asNullableString(safe.packageId),
+    status: asString(safe.status, references.length ? 'passed' : 'not_scanned'),
+    hash: asString(safe.hash),
+    referenceCount: Number(safe.referenceCount ?? references.length) || 0,
+    references,
+    policy: isPlainObject(safe.policy) ? safe.policy : {},
+  };
+}
+
+export function normaliseContentOperationAssetScan(scan = null) {
+  if (!isPlainObject(scan)) return null;
+  return {
+    ...scan,
+    status: asString(scan.status, 'not_scanned'),
+    hash: asString(scan.hash),
+    blockers: asArray(scan.blockers),
+    warnings: asArray(scan.warnings),
+    uploadCount: Number(scan.uploadCount) || 0,
+    itemCount: Number(scan.itemCount) || 0,
+    targetCount: Number(scan.targetCount) || 0,
+    items: asArray(scan.items),
+    assetReferenceManifest: normaliseContentOperationAssetReferenceManifest(scan.assetReferenceManifest),
+  };
+}
+
 export function normaliseContentOperationCandidate(entry = null) {
   const safe = isPlainObject(entry) ? entry : {};
   const validation = normaliseBlockerSection(safe.validation);
@@ -183,7 +279,7 @@ export function normaliseContentOperationCandidate(entry = null) {
     candidateHash: asString(safe.candidateHash),
     validation,
     audioScan: isPlainObject(safe.audioScan) ? safe.audioScan : null,
-    assetScan: isPlainObject(safe.assetScan) ? safe.assetScan : null,
+    assetScan: normaliseContentOperationAssetScan(safe.assetScan),
     blockers: normaliseContentOperationBlockers(safe.blockers),
     conflicts: asArray(safe.conflicts),
     createdAt: asTs(safe.createdAt),
@@ -237,6 +333,7 @@ function releaseAssetMetadataFromProof(proof = null) {
   const metadata = isPlainObject(proof?.contentOperationsAssets) ? proof.contentOperationsAssets : null;
   return {
     assetSummary: isPlainObject(metadata?.assetSummary) ? metadata.assetSummary : null,
+    assetReferenceManifest: isPlainObject(metadata?.assetReferenceManifest) ? metadata.assetReferenceManifest : null,
   };
 }
 
@@ -273,9 +370,16 @@ export function normaliseContentOperationRelease(entry = null) {
     audioWarnings: isPlainObject(safe.audioWarnings)
       ? safe.audioWarnings
       : proofAudio.audioWarnings,
-    assetSummary: isPlainObject(safe.assetSummary)
-      ? safe.assetSummary
-      : proofAssets.assetSummary,
+    assetSummary: normaliseContentOperationAssetScan(
+      isPlainObject(safe.assetSummary)
+        ? safe.assetSummary
+        : proofAssets.assetSummary,
+    ),
+    assetReferenceManifest: normaliseContentOperationAssetReferenceManifest(
+      isPlainObject(safe.assetReferenceManifest)
+        ? safe.assetReferenceManifest
+        : proofAssets.assetReferenceManifest,
+    ),
     createdAt: asTs(safe.createdAt),
   };
 }

--- a/src/subjects/spelling/content/operations-model.js
+++ b/src/subjects/spelling/content/operations-model.js
@@ -21,9 +21,12 @@ export const CONTENT_OPERATION_PACKAGE_STATES = Object.freeze({
   SUPERSEDED: 'superseded',
 });
 
+export const CONTENT_OPERATION_MONSTER_ASSET_REFERENCE_ENTITY_TYPE = 'spelling.monsterAssetReference';
+
 export const CONTENT_OPERATION_ENTITY_TYPES = Object.freeze([
   'spelling.audioRequirementProfile',
   'spelling.heroExposure',
+  CONTENT_OPERATION_MONSTER_ASSET_REFERENCE_ENTITY_TYPE,
   'spelling.pool',
   'spelling.rewardTrack',
   'spelling.word',
@@ -152,6 +155,10 @@ function applyCollectionOperation(bundle, operation) {
       bundle.draft.audioRequirementProfile = next;
       return;
     }
+  }
+
+  if (operation.entityType === CONTENT_OPERATION_MONSTER_ASSET_REFERENCE_ENTITY_TYPE) {
+    return;
   }
 
   if (operation.entityType === HERO_EXPOSURE_ENTITY_TYPE) {
@@ -408,6 +415,9 @@ export function detectContentOperationConflicts(leftOperations = [], rightOperat
 
 export function readContentOperationField(bundle, operation) {
   const normalised = normaliseContentOperation(operation, { now: () => 0 });
+  if (normalised.entityType === CONTENT_OPERATION_MONSTER_ASSET_REFERENCE_ENTITY_TYPE) {
+    return undefined;
+  }
   if (normalised.entityType === AUDIO_REQUIREMENT_PROFILE_ENTITY_TYPE) {
     if (normalised.entityId !== AUDIO_REQUIREMENT_PROFILE_ENTITY_ID) return undefined;
     return getAtPath(

--- a/src/surfaces/hubs/AdminContentOperationsSection.jsx
+++ b/src/surfaces/hubs/AdminContentOperationsSection.jsx
@@ -783,8 +783,8 @@ function draftStateLabel(state) {
 }
 
 function statusChipClass(status) {
-  if (['available', 'passed', 'published'].includes(status)) return 'good';
-  if (['blocked', 'stale_candidate'].includes(status)) return 'bad';
+  if (['available', 'passed', 'published', 'present'].includes(status)) return 'good';
+  if (['blocked', 'stale_candidate', 'missing', 'mismatch', 'unavailable'].includes(status)) return 'bad';
   if (['candidate_required', 'not_ready', 'warning', 'warnings_only'].includes(status)) return 'warn';
   return '';
 }
@@ -843,6 +843,126 @@ function audioGenerationMessage(action, payload) {
 
 function audioItemSelectable(item) {
   return Boolean(item?.canGenerate || item?.canOverride);
+}
+
+function assetScanForPackage(contentPackage) {
+  return contentPackage?.latestCandidate?.assetScan || null;
+}
+
+function assetManifestForPackage(contentPackage, latestRelease = null) {
+  const scanManifest = assetScanForPackage(contentPackage)?.assetReferenceManifest || null;
+  if (scanManifest?.references?.length) return scanManifest;
+  if (latestRelease?.assetReferenceManifest?.references?.length) return latestRelease.assetReferenceManifest;
+  return scanManifest || latestRelease?.assetReferenceManifest || null;
+}
+
+function assetReferenceTargetLabel(reference) {
+  const target = reference?.target || {};
+  return [
+    target.monsterId || 'monster',
+    target.branchId || 'branch',
+    target.stageId ? `stage ${target.stageId}` : 'stage',
+  ].join(' / ');
+}
+
+function byteSizeLabel(bytes) {
+  const numeric = Number(bytes) || 0;
+  if (numeric >= 1024 * 1024) return `${(numeric / (1024 * 1024)).toFixed(1)} MB`;
+  if (numeric >= 1024) return `${Math.round(numeric / 1024)} KB`;
+  return `${String(numeric)} B`;
+}
+
+function rendererContextLabel(context) {
+  return String(context || '').replace(/-/g, ' ');
+}
+
+function AssetReferencePreviewCards({ manifest }) {
+  const references = Array.isArray(manifest?.references) ? manifest.references : [];
+  if (!references.length) {
+    return (
+      <div className="feedback admin-note-spaced" data-content-ops-asset-preview-empty="true">
+        No package monster image references.
+      </div>
+    );
+  }
+  return (
+    <div className="content-ops-asset-preview-grid" data-content-ops-asset-preview-grid="true">
+      {references.map((reference) => {
+        const dimensions = reference.content?.dimensions || {};
+        const contexts = Array.isArray(reference.renderer?.contexts) ? reference.renderer.contexts : [];
+        const previewUrl = reference.preview?.url || '';
+        const key = reference.referenceId || reference.assetUploadId || assetReferenceTargetLabel(reference);
+        return (
+          <article className="content-ops-package-summary content-ops-asset-preview-card" key={key} data-content-ops-asset-reference={key}>
+            <span className="content-ops-package-summary-main">
+              <strong>{assetReferenceTargetLabel(reference)}</strong>
+              <span className="small muted">{reference.assetUploadId || 'Upload pending'}</span>
+            </span>
+            {previewUrl ? (
+              <img
+                src={previewUrl}
+                alt={`${assetReferenceTargetLabel(reference)} monster asset preview`}
+                loading="lazy"
+                className="content-ops-asset-preview-image"
+              />
+            ) : (
+              <div className="feedback warn admin-note-spaced" data-content-ops-asset-preview-blocked="true">
+                {reference.preview?.blockedReason || 'Preview unavailable'}
+              </div>
+            )}
+            <span className="chip-row content-ops-package-summary-meta">
+              <span className={`chip ${statusChipClass(reference.validation?.status)}`}>{statusLabel(reference.validation?.status)}</span>
+              <span className={`chip ${statusChipClass(reference.storage?.status)}`}>{statusLabel(reference.storage?.status)}</span>
+              <span className="chip">{dimensions.width || '?'} x {dimensions.height || '?'}</span>
+              <span className="chip">{byteSizeLabel(reference.content?.byteSize)}</span>
+            </span>
+            {contexts.length ? (
+              <span className="chip-row content-ops-chip-wrap">
+                {contexts.map((context) => (
+                  <span className="chip" key={context}>{rendererContextLabel(context)}</span>
+                ))}
+              </span>
+            ) : null}
+          </article>
+        );
+      })}
+    </div>
+  );
+}
+
+function MonsterAssetsPanel({ contentPackage, latestRelease = null, blockerSection = null }) {
+  const scan = assetScanForPackage(contentPackage);
+  const manifest = assetManifestForPackage(contentPackage, latestRelease);
+  const status = scan?.status || manifest?.status || 'not_scanned';
+  const references = Array.isArray(manifest?.references) ? manifest.references : [];
+  return (
+    <section className="content-ops-area-panel" data-content-ops-monster-assets-panel="true">
+      <div className="content-ops-detail-header">
+        <div>
+          <div className="eyebrow">Monster assets</div>
+          <h5>Package image references</h5>
+          <p className="small muted admin-note-spaced">
+            {contentPackage?.packageId ? `Package ${contentPackage.packageId}` : `Latest release ${latestRelease?.releaseId || 'bundled fallback'}`}
+          </p>
+        </div>
+        <div className="chip-row content-ops-chip-wrap">
+          <span className={`chip ${statusChipClass(status)}`}>{statusLabel(status)}</span>
+          <span className="chip">{String(references.length)} references</span>
+          {manifest?.policy?.runtimeReadable === false ? <span className="chip warn">Runtime T23</span> : null}
+        </div>
+      </div>
+      <div className="content-ops-metric-grid">
+        <MetricTile label="Uploads" value={String(scan?.uploadCount || 0)} detail={`${String(scan?.targetCount || references.length)} targets`} />
+        <MetricTile label="Manifest" value={manifest?.hash || scan?.hash || 'Pending'} detail={`Schema ${String(manifest?.schemaVersion || 1)}`} />
+        <MetricTile label="Rollback" value={manifest?.policy?.retention?.rollbackAvailability || 'retained'} detail="Release reference policy" />
+        <MetricTile label="Derivatives" value={manifest?.policy?.responsiveDerivatives?.mode || 'source'} detail="Responsive policy" />
+      </div>
+      {blockerSection && contentPackage ? (
+        <BlockerSummary blockers={contentPackage.blockers} sectionKey={blockerSection} />
+      ) : null}
+      <AssetReferencePreviewCards manifest={manifest} />
+    </section>
+  );
 }
 
 function CentreTabNav({ activeTab, onSelect }) {
@@ -1360,6 +1480,15 @@ function PublishedAreaPanel({
         audioState={audioState}
         actionAvailability={audioActionAvailability}
         onRunAction={onRunAudioAction}
+      />
+    );
+  }
+  if (activeTab === 'monstersAssets') {
+    return (
+      <MonsterAssetsPanel
+        contentPackage={selectedSummary}
+        latestRelease={latestRelease}
+        blockerSection={blockerSection}
       />
     );
   }
@@ -3596,6 +3725,15 @@ function PackageDetailBody({
         audioState={audioState}
         actionAvailability={audioActionAvailability}
         onRunAction={onRunAudioAction}
+      />
+    );
+  }
+
+  if (activeTab === 'monstersAssets') {
+    return (
+      <MonsterAssetsPanel
+        contentPackage={contentPackage}
+        blockerSection={DETAIL_TAB_BLOCKER_SECTIONS.monstersAssets}
       />
     );
   }

--- a/styles/app.css
+++ b/styles/app.css
@@ -12348,6 +12348,28 @@ html { scroll-behavior: smooth; }
   flex-shrink: 0;
 }
 
+.content-ops-asset-preview-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.content-ops-asset-preview-card {
+  display: grid;
+  gap: 8px;
+  cursor: default;
+}
+
+.content-ops-asset-preview-image {
+  width: 100%;
+  aspect-ratio: 1;
+  object-fit: contain;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--panel);
+}
+
 .content-ops-row-button {
   padding: 0;
   border: 0;

--- a/tests/admin-asset-registry-v1.test.js
+++ b/tests/admin-asset-registry-v1.test.js
@@ -9,6 +9,7 @@ import assert from 'node:assert/strict';
 
 import {
   buildAssetRegistry,
+  buildContentOperationMonsterAssetRegistryEntries,
   buildMonsterVisualRegistryEntry,
 } from '../src/platform/hubs/admin-asset-registry.js';
 
@@ -80,6 +81,37 @@ const NO_DRAFT_CONFIG = {
   draft: null,
   published: { monsters: [] },
   versions: [{ version: 1, publishedAt: 1714000000000 }],
+};
+
+const CONTENT_OPERATION_PACKAGE_WITH_ASSET = {
+  packageId: 'pkg-draft-1',
+  latestCandidate: {
+    createdAt: 1714300800000,
+    assetScan: {
+      status: 'passed',
+      hash: 'asset-scan-hash-1',
+      assetReferenceManifest: {
+        schemaVersion: 1,
+        assetKind: 'monster-image',
+        packageId: 'pkg-draft-1',
+        status: 'passed',
+        hash: 'asset-scan-hash-1',
+        referenceCount: 1,
+        references: [{
+          referenceId: 'monster-image:inklet:b1:0',
+          assetUploadId: 'coasset-1',
+          target: { monsterId: 'inklet', branchId: 'b1', stageId: '0' },
+          preview: {
+            kind: 'admin-api-handle',
+            url: '/api/admin/content-operations/packages/pkg-draft-1/monster-assets/coasset-1/preview',
+          },
+          validation: { status: 'passed', ok: true, errors: [], warnings: [] },
+          storage: { status: 'present', byteSize: 1024, contentType: 'image/png' },
+          renderer: { contexts: ['hero-camp', 'hero-codex'] },
+        }],
+      },
+    },
+  },
 };
 
 const NO_PERMISSION_CONFIG = {
@@ -213,6 +245,50 @@ describe('buildAssetRegistry — v1 extended shape', () => {
     const registry = buildAssetRegistry(null);
     // Null model => no permission, no draft => at least 2 blockers
     assert.ok(registry[0].publishBlockers.length >= 2);
+  });
+
+  it('appends package monster image asset references after the global visual config entry', () => {
+    const model = {
+      monsterVisualConfig: PUBLISHABLE_CONFIG,
+      contentOperations: {
+        packages: [CONTENT_OPERATION_PACKAGE_WITH_ASSET],
+      },
+    };
+    const registry = buildAssetRegistry(model);
+
+    assert.equal(registry[0].assetId, 'monster-visual-config');
+    assert.equal(registry[1].assetId, 'content-operation-monster-asset:pkg-draft-1:monster-image:inklet:b1:0');
+    assert.equal(registry[1].assetUploadId, 'coasset-1');
+    assert.equal(registry[1].previewUrl, '/api/admin/content-operations/packages/pkg-draft-1/monster-assets/coasset-1/preview');
+    assert.deepEqual(registry[1].rendererContexts, ['hero-camp', 'hero-codex']);
+    assert.equal(registry[1].reviewStatus, 'has-blockers');
+    assert.ok(registry[1].publishBlockers.some((blocker) => blocker.includes('package workflow')));
+  });
+
+  it('discovers package monster image references from wrapped content operation package lists', () => {
+    const registry = buildAssetRegistry({
+      monsterVisualConfig: PUBLISHABLE_CONFIG,
+      contentOperations: {
+        packages: {
+          packages: [CONTENT_OPERATION_PACKAGE_WITH_ASSET],
+        },
+      },
+    });
+
+    assert.equal(registry.length, 2);
+    assert.equal(registry[1].assetUploadId, 'coasset-1');
+    assert.ok(registry[1].publishBlockers.some((blocker) => blocker.includes('package workflow')));
+  });
+
+  it('builds package monster image entries directly from content operation packages', () => {
+    const entries = buildContentOperationMonsterAssetRegistryEntries({
+      packages: [CONTENT_OPERATION_PACKAGE_WITH_ASSET],
+    });
+
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].displayName, 'Monster Image - inklet / b1 / stage 0');
+    assert.equal(entries[0].fallbackStatus, 'bundled-manifest-unchanged');
+    assert.ok(entries[0].publishBlockers.some((blocker) => blocker.includes('package workflow')));
   });
 });
 

--- a/tests/admin-content-operations-v2.test.js
+++ b/tests/admin-content-operations-v2.test.js
@@ -33,6 +33,7 @@ import {
   CONTENT_OPERATION_DETAIL_TABS,
   CONTENT_OPERATION_LANES,
   normaliseContentOperationAudioScan,
+  normaliseContentOperationAssetReferenceManifest,
   normaliseContentOperationCandidate,
   normaliseContentOperationPackage,
   normaliseContentOperationsOverview,
@@ -710,12 +711,78 @@ describe('Content Operations Centre normalisers', () => {
       proof: {
         contentOperationsAssets: {
           assetSummary: { hash: 'asset-scan-hash-1', uploadCount: 1 },
+          assetReferenceManifest: {
+            schemaVersion: 1,
+            assetKind: 'monster-image',
+            packageId: 'pkg-draft-1',
+            status: 'passed',
+            hash: 'asset-scan-hash-1',
+            referenceCount: 1,
+            references: [{
+              referenceId: 'monster-image:inklet:b1:0',
+              assetUploadId: 'coasset-1',
+              target: { monsterId: 'inklet', branchId: 'b1', stageId: '0' },
+              preview: {
+                kind: 'admin-api-handle',
+                url: '/api/admin/content-operations/packages/pkg-draft-1/monster-assets/coasset-1/preview',
+              },
+              content: {
+                contentType: 'image/png',
+                byteSize: 1024,
+                dimensions: { width: 640, height: 640 },
+              },
+              storage: { status: 'present', byteSize: 1024, contentType: 'image/png' },
+            }],
+          },
         },
       },
     });
 
     assert.equal(release.hasCallerProof, false);
     assert.equal(release.assetSummary.hash, 'asset-scan-hash-1');
+    assert.equal(release.assetReferenceManifest.referenceCount, 1);
+    assert.equal(
+      release.assetReferenceManifest.references[0].preview.url,
+      '/api/admin/content-operations/packages/pkg-draft-1/monster-assets/coasset-1/preview',
+    );
+  });
+
+  it('normalises package monster asset manifests without rendering unsafe preview URLs', () => {
+    const manifest = normaliseContentOperationAssetReferenceManifest({
+      schemaVersion: 1,
+      assetKind: 'monster-image',
+      packageId: 'pkg-draft-1',
+      status: 'passed',
+      hash: 'asset-hash',
+      referenceCount: 2,
+      references: [
+        {
+          referenceId: 'monster-image:inklet:b1:0',
+          assetUploadId: 'coasset-safe',
+          target: { monsterId: 'inklet', branchId: 'b1', stageId: '0' },
+          preview: { url: '/api/admin/content-operations/packages/pkg-draft-1/monster-assets/coasset-safe/preview' },
+          validation: { status: 'passed', ok: true },
+          storage: { status: 'present' },
+        },
+        {
+          referenceId: 'monster-image:inklet:b1:1',
+          assetUploadId: 'coasset-unsafe',
+          target: { monsterId: 'inklet', branchId: 'b1', stageId: '1' },
+          preview: { url: 'javascript:alert(1)' },
+          validation: { status: 'passed', ok: true },
+          storage: { status: 'present' },
+        },
+      ],
+    });
+
+    assert.equal(manifest.referenceCount, 2);
+    assert.equal(
+      manifest.references[0].preview.url,
+      '/api/admin/content-operations/packages/pkg-draft-1/monster-assets/coasset-safe/preview',
+    );
+    assert.equal(manifest.references[0].storage.status, 'present');
+    assert.equal(manifest.references[1].preview.url, null);
+    assert.match(manifest.references[1].preview.blockedReason, /javascript:/);
   });
 
   it('normalises package lists, release lists, and package detail array payloads', () => {

--- a/tests/monster-asset-upload-validation.test.js
+++ b/tests/monster-asset-upload-validation.test.js
@@ -747,11 +747,34 @@ test('monster image uploads are bound to candidate approval and publish proof', 
     );
     assert.equal(staleApprovalResponse.status, 409);
     const staleApproval = await staleApprovalResponse.json();
-    assert.equal(staleApproval.code, 'content_operation_candidate_assets_stale');
+    assert.equal(staleApproval.code, 'content_operation_candidate_operations_stale');
 
     const currentCandidate = await validatePackage(server, contentPackage.packageId);
     assert.equal(currentCandidate.candidate.assetScan.uploadCount, 1);
     assert.notEqual(currentCandidate.candidate.assetScan.hash, firstCandidate.candidate.assetScan.hash);
+    assert.equal(currentCandidate.candidate.assetScan.assetReferenceManifest.referenceCount, 1);
+    assert.equal(currentCandidate.candidate.assetScan.assetReferenceManifest.references[0].assetUploadId, currentCandidate.candidate.assetScan.items[0].assetUploadId);
+    assert.match(
+      currentCandidate.candidate.assetScan.assetReferenceManifest.references[0].preview.url,
+      /^\/api\/admin\/content-operations\/packages\/.+\/monster-assets\/.+\/preview$/,
+    );
+    assert.equal(
+      JSON.stringify(currentCandidate.candidate.assetScan.assetReferenceManifest).includes('r2Key'),
+      false,
+    );
+
+    const operationRow = server.DB.db.prepare(`
+      SELECT entity_type, entity_id, action, payload_json
+      FROM content_operation_package_operations
+      WHERE package_id = ?
+    `).get(contentPackage.packageId);
+    assert.equal(operationRow.entity_type, 'spelling.monsterAssetReference');
+    assert.equal(operationRow.entity_id, 'inklet:b1:0');
+    assert.equal(operationRow.action, 'replace');
+    const operationPayload = JSON.parse(operationRow.payload_json);
+    assert.equal(operationPayload.assetUploadId, currentCandidate.candidate.assetScan.items[0].assetUploadId);
+    assert.equal(operationPayload.preview.url, currentCandidate.candidate.assetScan.assetReferenceManifest.references[0].preview.url);
+    assert.equal(JSON.stringify(operationPayload).includes('r2Key'), false);
 
     const approvalResponse = await approvePackage(
       server,
@@ -771,7 +794,17 @@ test('monster image uploads are bound to candidate approval and publish proof', 
       published.release.proof.contentOperationsAssets.assetSummary.hash,
       currentCandidate.candidate.assetScan.hash,
     );
+    assert.equal(
+      published.release.proof.contentOperationsAssets.assetReferenceManifest.referenceCount,
+      1,
+    );
+    assert.equal(
+      published.release.proof.contentOperationsAssets.assetReferenceManifest.references[0].assetUploadId,
+      operationPayload.assetUploadId,
+    );
+    assert.equal(JSON.stringify(published.release.proof.contentOperationsAssets.assetReferenceManifest).includes('r2Key'), false);
     assert.equal(published.release.assetSummary.hash, currentCandidate.candidate.assetScan.hash);
+    assert.equal(published.release.assetReferenceManifest.referenceCount, 1);
   } finally {
     server.close();
   }
@@ -789,6 +822,20 @@ test('monster image release serialisation distinguishes caller proof from server
           hash: 'asset-scan-hash-1',
           uploadCount: 1,
         },
+        assetReferenceManifest: {
+          schemaVersion: 1,
+          assetKind: 'monster-image',
+          packageId: 'pkg-asset',
+          status: 'passed',
+          hash: 'asset-scan-hash-1',
+          referenceCount: 1,
+          references: [{
+            referenceId: 'monster-image:inklet:b1:0',
+            assetUploadId: 'coasset-1',
+            target: { monsterId: 'inklet', branchId: 'b1', stageId: '0' },
+            preview: { kind: 'admin-api-handle', url: '/api/admin/content-operations/packages/pkg-asset/monster-assets/coasset-1/preview' },
+          }],
+        },
       },
     },
   });
@@ -796,6 +843,8 @@ test('monster image release serialisation distinguishes caller proof from server
   assert.equal(release.hasCallerProof, false);
   assert.equal(release.assetSummary.hash, 'asset-scan-hash-1');
   assert.equal(release.assetSummary.uploadCount, 1);
+  assert.equal(release.assetReferenceManifest.referenceCount, 1);
+  assert.equal(release.assetReferenceManifest.references[0].assetUploadId, 'coasset-1');
 });
 
 test('content operation approval rejects caller-supplied monster asset summaries', async () => {
@@ -921,6 +970,13 @@ test('duplicate monster image target uploads replace the previous draft target',
     assert.equal(validated.candidate.assetScan.status, 'passed');
     assert.equal(validated.candidate.assetScan.uploadCount, 1);
     assert.equal(validated.candidate.assetScan.blockers.length, 0);
+    assert.equal(rowCount(server, 'content_operation_package_operations', 'WHERE package_id = ?', [contentPackage.packageId]), 1);
+    const operationPayload = JSON.parse(server.DB.db.prepare(`
+      SELECT payload_json
+      FROM content_operation_package_operations
+      WHERE package_id = ?
+    `).get(contentPackage.packageId).payload_json);
+    assert.equal(operationPayload.assetUploadId, (await secondUpload.json()).assetUpload.assetUploadId);
 
     const approvalResponse = await approvePackage(
       server,
@@ -937,7 +993,7 @@ test('duplicate monster image target uploads replace the previous draft target',
   }
 });
 
-test('monster image draft upload does not create runtime operations or releases', async () => {
+test('monster image draft upload creates a package reference operation but no release', async () => {
   const server = createWorkerRepositoryServer({
     env: { SPELLING_AUDIO_BUCKET: createMemoryR2Bucket() },
     now: () => NOW,
@@ -947,8 +1003,16 @@ test('monster image draft upload does not create runtime operations or releases'
     const response = await uploadMonsterAsset(server, contentPackage.packageId, monsterAssetForm());
     assert.equal(response.status, 201);
     assert.equal(rowCount(server, 'content_operation_asset_uploads', 'WHERE package_id = ?', [contentPackage.packageId]), 1);
-    assert.equal(rowCount(server, 'content_operation_package_operations', 'WHERE package_id = ?', [contentPackage.packageId]), 0);
+    assert.equal(rowCount(server, 'content_operation_package_operations', 'WHERE package_id = ?', [contentPackage.packageId]), 1);
     assert.equal(rowCount(server, 'content_operation_releases', 'WHERE package_id = ?', [contentPackage.packageId]), 0);
+    const operationRow = server.DB.db.prepare(`
+      SELECT entity_type, entity_id, payload_json
+      FROM content_operation_package_operations
+      WHERE package_id = ?
+    `).get(contentPackage.packageId);
+    assert.equal(operationRow.entity_type, 'spelling.monsterAssetReference');
+    assert.equal(operationRow.entity_id, 'inklet:b1:0');
+    assert.match(JSON.parse(operationRow.payload_json).preview.url, /\/monster-assets\/.+\/preview$/);
     const packageRow = server.DB.db.prepare(`
       SELECT state, published_at
       FROM content_operation_packages

--- a/tests/react-admin-content-operations.test.js
+++ b/tests/react-admin-content-operations.test.js
@@ -105,6 +105,51 @@ const audioScan = {
   ],
 };
 
+const monsterAssetScan = {
+  status: 'passed',
+  hash: 'asset-scan-hash-1',
+  blockers: [],
+  warnings: [],
+  uploadCount: 1,
+  itemCount: 1,
+  targetCount: 1,
+  assetReferenceManifest: {
+    schemaVersion: 1,
+    assetKind: 'monster-image',
+    packageId: 'pkg-draft-1',
+    status: 'passed',
+    hash: 'asset-scan-hash-1',
+    referenceCount: 1,
+    references: [{
+      referenceId: 'monster-image:inklet:b1:0',
+      assetUploadId: 'coasset-1',
+      target: { monsterId: 'inklet', branchId: 'b1', stageId: '0' },
+      preview: {
+        kind: 'admin-api-handle',
+        url: '/api/admin/content-operations/packages/pkg-draft-1/monster-assets/coasset-1/preview',
+        contentType: 'image/png',
+      },
+      content: {
+        contentType: 'image/png',
+        byteSize: 1024,
+        dimensions: { width: 640, height: 640 },
+      },
+      validation: { status: 'passed', ok: true },
+      storage: { status: 'present', byteSize: 1024, contentType: 'image/png' },
+      renderer: { contexts: ['hero-camp', 'hero-codex', 'reward-track'] },
+      policy: {
+        retention: { rollbackAvailability: 'release-reference-retained' },
+        responsiveDerivatives: { mode: 'source_image_until_runtime_derivatives' },
+      },
+    }],
+    policy: {
+      runtimeReadable: false,
+      retention: { rollbackAvailability: 'release-reference-retained' },
+      responsiveDerivatives: { mode: 'source_image_until_runtime_derivatives' },
+    },
+  },
+};
+
 const contentPackage = {
   packageId: 'pkg-draft-1',
   subjectId: 'spelling',
@@ -725,13 +770,49 @@ test('Content Operations Centre area pages show selected package audio operation
   assert.match(audioHtml, /word_audio_missing/);
   assert.doesNotMatch(audioHtml, /No mutation controls/);
 
+  const assetPackage = {
+    ...contentPackage,
+    latestCandidate: {
+      ...contentPackage.latestCandidate,
+      assetScan: monsterAssetScan,
+      blockers: {
+        ...contentPackage.latestCandidate.blockers,
+        assets: { status: 'passed', blockers: [], warnings: [] },
+      },
+    },
+    blockers: {
+      ...contentPackage.blockers,
+      assets: { status: 'passed', blockers: [], warnings: [] },
+    },
+  };
   const assetHtml = await renderEntry(buildContentOpsEntry({
+    model: baseModel({
+      contentOperations: {
+        overview: {
+          ...overview,
+          lanes: {
+            ...overview.lanes,
+            drafts: [assetPackage],
+          },
+        },
+        packages: { packages: [assetPackage] },
+        releases: { releases: [release] },
+        packageDetail: {
+          package: assetPackage,
+          events: [],
+        },
+      },
+    }),
     initialActiveTab: 'monstersAssets',
     initialSelectedPackageId: 'pkg-draft-1',
   }));
-  assert.match(assetHtml, /Monsters &amp; Assets/);
-  assert.match(assetHtml, /1 warnings/);
-  assert.match(assetHtml, /No mutation controls/);
+  assert.match(assetHtml, /Monster assets/);
+  assert.match(assetHtml, /Package image references/);
+  assert.match(assetHtml, /coasset-1/);
+  assert.match(assetHtml, /inklet \/ b1 \/ stage 0/);
+  assert.match(assetHtml, /src="\/api\/admin\/content-operations\/packages\/pkg-draft-1\/monster-assets\/coasset-1\/preview"/);
+  assert.match(assetHtml, /hero camp/);
+  assert.doesNotMatch(assetHtml, /No mutation controls/);
 });
 
 test('Content Operations Centre SSR handles missing local data without breaking the panel', async () => {

--- a/worker/src/content-operations/assets.js
+++ b/worker/src/content-operations/assets.js
@@ -5,8 +5,10 @@ import {
 } from '../../../src/platform/game/monsters.js';
 import {
   CONTENT_OPERATION_PACKAGE_STATES,
+  CONTENT_OPERATION_MONSTER_ASSET_REFERENCE_ENTITY_TYPE,
   CONTENT_OPERATION_SUBJECT_ID,
   contentOperationHash,
+  contentOperationValueHash,
 } from '../../../src/subjects/spelling/content/operations-model.js';
 import {
   all,
@@ -34,6 +36,27 @@ const MAX_RENDERER_ASPECT_RATIO = 4;
 const VALID_STAGE_IDS = new Set(['0', '1', '2', '3', '4']);
 const VALID_BRANCH_IDS = new Set(MONSTER_BRANCHES);
 const VALID_MONSTER_IDS = new Set(Object.keys(MONSTERS));
+const ASSET_REFERENCE_MANIFEST_SCHEMA_VERSION = 1;
+const ASSET_REFERENCE_RENDERER_CONTEXTS = Object.freeze([
+  'hero-camp',
+  'hero-codex',
+  'reward-track',
+  'subject-setup',
+]);
+const ASSET_REFERENCE_RESPONSIVE_DERIVATIVE_POLICY = Object.freeze({
+  mode: 'source_image_until_runtime_derivatives',
+  sourceRequired: true,
+  generatedDerivatives: [],
+  plannedWidths: [320, 640, 960, 1280],
+  owner: 'content-operations',
+});
+const ASSET_REFERENCE_RETENTION_POLICY = Object.freeze({
+  draftRetentionDays: 30,
+  publishedRetentionDays: 180,
+  rollbackAvailability: 'release-reference-retained',
+  cleanupOwner: 'content-operations',
+  runtimeCleanupBlockedUntil: 'remote-monster-asset-runtime-reader',
+});
 const SUPPORTED_IMAGE_TYPES = Object.freeze({
   'image/jpeg': 'jpg',
   'image/png': 'png',
@@ -761,10 +784,162 @@ function previewUrlForUpload({ packageId, assetUploadId }) {
   return `/api/admin/content-operations/packages/${encodeURIComponent(packageId)}/monster-assets/${encodeURIComponent(assetUploadId)}/preview`;
 }
 
+export function contentOperationMonsterAssetReferenceEntityId({
+  monsterId,
+  branchId,
+  stageId,
+} = {}) {
+  return [
+    normaliseString(monsterId),
+    normaliseString(branchId),
+    normaliseString(stageId),
+  ].filter(Boolean).join(':');
+}
+
+function assetReferenceId(item = {}) {
+  return `monster-image:${contentOperationMonsterAssetReferenceEntityId(item)}`;
+}
+
+function safePreviewForReference(preview = {}, contentType = '') {
+  return {
+    kind: normaliseString(preview.kind, 'admin-api-handle'),
+    url: normaliseString(preview.url) || null,
+    contentType: normaliseString(preview.contentType, contentType),
+  };
+}
+
+function monsterAssetReferencePayloadFromUpload({
+  packageId,
+  assetUploadId,
+  monsterId,
+  branchId,
+  stageId,
+  contentType,
+  byteSize,
+  dimensions,
+  preview,
+  validation,
+  createdAt,
+}) {
+  const target = { monsterId, branchId, stageId };
+  const renderer = validation?.renderer && typeof validation.renderer === 'object'
+    ? validation.renderer
+    : { contexts: ASSET_REFERENCE_RENDERER_CONTEXTS };
+  return {
+    schemaVersion: ASSET_REFERENCE_MANIFEST_SCHEMA_VERSION,
+    referenceId: assetReferenceId(target),
+    assetKind: CONTENT_OPERATION_MONSTER_ASSET_KIND,
+    assetUploadId,
+    packageId,
+    target,
+    preview: safePreviewForReference(preview, contentType),
+    content: {
+      contentType,
+      byteSize: Number(byteSize) || 0,
+      dimensions: {
+        width: Number(dimensions?.width) || null,
+        height: Number(dimensions?.height) || null,
+      },
+    },
+    validation: {
+      status: normaliseString(validation?.status, validation?.ok ? 'passed' : 'blocked'),
+      ok: validation?.ok === true,
+      warnings: Array.isArray(validation?.warnings) ? validation.warnings : [],
+      errors: Array.isArray(validation?.errors) ? validation.errors : [],
+    },
+    renderer: {
+      contexts: Array.isArray(renderer.contexts) && renderer.contexts.length
+        ? renderer.contexts
+        : ASSET_REFERENCE_RENDERER_CONTEXTS,
+      minDimension: Number(renderer.minDimension) || MIN_RENDERER_DIMENSION,
+      maxDimension: Number(renderer.maxDimension) || MAX_RENDERER_DIMENSION,
+      maxAspectRatio: Number(renderer.maxAspectRatio) || MAX_RENDERER_ASPECT_RATIO,
+    },
+    policy: {
+      responsiveDerivatives: ASSET_REFERENCE_RESPONSIVE_DERIVATIVE_POLICY,
+      retention: ASSET_REFERENCE_RETENTION_POLICY,
+    },
+    createdAt: Number(createdAt) || 0,
+  };
+}
+
+function assetReferenceFromScanItem(item = {}) {
+  return {
+    schemaVersion: ASSET_REFERENCE_MANIFEST_SCHEMA_VERSION,
+    referenceId: assetReferenceId(item),
+    assetKind: item.assetKind || CONTENT_OPERATION_MONSTER_ASSET_KIND,
+    assetUploadId: item.assetUploadId,
+    packageId: item.packageId || null,
+    target: {
+      monsterId: item.monsterId,
+      branchId: item.branchId,
+      stageId: item.stageId,
+    },
+    preview: safePreviewForReference(item.preview, item.contentType),
+    content: {
+      contentType: item.contentType || '',
+      byteSize: Number(item.byteSize) || 0,
+      dimensions: item.dimensions || { width: null, height: null },
+    },
+    validation: {
+      status: item.validationStatus || (item.validationOk ? 'passed' : 'blocked'),
+      ok: item.validationOk === true,
+      errorCodes: Array.isArray(item.errorCodes) ? item.errorCodes : [],
+      warningCodes: Array.isArray(item.warningCodes) ? item.warningCodes : [],
+    },
+    storage: item.storage || { status: 'not_checked', byteSize: null, contentType: '' },
+    renderer: item.renderer || {
+      contexts: ASSET_REFERENCE_RENDERER_CONTEXTS,
+      minDimension: MIN_RENDERER_DIMENSION,
+      maxDimension: MAX_RENDERER_DIMENSION,
+      maxAspectRatio: MAX_RENDERER_ASPECT_RATIO,
+    },
+    policy: {
+      responsiveDerivatives: ASSET_REFERENCE_RESPONSIVE_DERIVATIVE_POLICY,
+      retention: ASSET_REFERENCE_RETENTION_POLICY,
+    },
+    createdAt: Number(item.createdAt) || 0,
+  };
+}
+
+export function buildContentOperationAssetReferenceManifest({
+  packageId,
+  status = 'not_scanned',
+  hash = '',
+  items = [],
+} = {}) {
+  const references = items.map((item) => assetReferenceFromScanItem({
+    ...item,
+    packageId,
+  }));
+  return {
+    schemaVersion: ASSET_REFERENCE_MANIFEST_SCHEMA_VERSION,
+    assetKind: CONTENT_OPERATION_MONSTER_ASSET_KIND,
+    packageId: normaliseString(packageId),
+    status: normaliseString(status, 'not_scanned'),
+    hash: normaliseString(hash),
+    referenceCount: references.length,
+    references,
+    policy: {
+      responsiveDerivatives: ASSET_REFERENCE_RESPONSIVE_DERIVATIVE_POLICY,
+      retention: ASSET_REFERENCE_RETENTION_POLICY,
+      runtimeReadable: false,
+      runtimeReadableFromTicket: 'T23',
+      bundledManifestWriteBack: false,
+    },
+  };
+}
+
 function assetUploadScanItem(upload, storage = null) {
   const validation = upload.validation && typeof upload.validation === 'object' && !Array.isArray(upload.validation)
     ? upload.validation
     : { ok: false, status: 'blocked', errors: [], warnings: [] };
+  const preview = upload.preview && typeof upload.preview === 'object' && !Array.isArray(upload.preview)
+    ? upload.preview
+    : {};
+  const renderer = validation.renderer && typeof validation.renderer === 'object' && !Array.isArray(validation.renderer)
+    ? validation.renderer
+    : null;
   const storageErrors = Array.isArray(storage?.errors) ? storage.errors : [];
   return {
     assetUploadId: upload.assetUploadId,
@@ -787,6 +962,18 @@ function assetUploadScanItem(upload, storage = null) {
     dimensions: {
       width: upload.width == null ? null : Number(upload.width),
       height: upload.height == null ? null : Number(upload.height),
+    },
+    preview: safePreviewForReference(preview, upload.contentType),
+    renderer: renderer ? {
+      contexts: Array.isArray(renderer.contexts) ? renderer.contexts : ASSET_REFERENCE_RENDERER_CONTEXTS,
+      minDimension: Number(renderer.minDimension) || MIN_RENDERER_DIMENSION,
+      maxDimension: Number(renderer.maxDimension) || MAX_RENDERER_DIMENSION,
+      maxAspectRatio: Number(renderer.maxAspectRatio) || MAX_RENDERER_ASPECT_RATIO,
+    } : {
+      contexts: ASSET_REFERENCE_RENDERER_CONTEXTS,
+      minDimension: MIN_RENDERER_DIMENSION,
+      maxDimension: MAX_RENDERER_DIMENSION,
+      maxAspectRatio: MAX_RENDERER_ASPECT_RATIO,
     },
     createdAt: Number(upload.createdAt) || 0,
     storage: storage ? {
@@ -966,15 +1153,22 @@ export async function buildContentOperationAssetScan(db, {
     items,
   };
   const status = blockers.length ? 'blocked' : (warnings.length ? 'warning' : 'passed');
+  const hash = contentOperationHash(fingerprint, 'coassets');
   return {
     status,
-    hash: contentOperationHash(fingerprint, 'coassets'),
+    hash,
     blockers,
     warnings,
     uploadCount: items.length,
     itemCount: items.length,
     targetCount: targetCounts.size,
     items,
+    assetReferenceManifest: buildContentOperationAssetReferenceManifest({
+      packageId: safePackageId,
+      status,
+      hash,
+      items,
+    }),
   };
 }
 
@@ -1121,6 +1315,21 @@ export async function uploadContentOperationMonsterAsset({
     url: previewUrl,
     contentType,
   };
+  const assetReferencePayload = monsterAssetReferencePayloadFromUpload({
+    packageId: packageRow.package_id,
+    assetUploadId,
+    monsterId,
+    branchId,
+    stageId,
+    contentType,
+    byteSize,
+    dimensions,
+    preview,
+    validation,
+    createdAt: nowTs,
+  });
+  const assetReferenceOperationId = uid('coop');
+  const assetReferenceEntityId = contentOperationMonsterAssetReferenceEntityId({ monsterId, branchId, stageId });
 
   let r2Written = false;
   try {
@@ -1193,6 +1402,51 @@ export async function uploadContentOperationMonsterAsset({
         assetUploadId,
       ]),
       bindStatement(db, `
+        DELETE FROM content_operation_package_operations
+        WHERE package_id = ?
+          AND entity_type = ?
+          AND entity_id = ?
+          AND EXISTS (
+            SELECT 1
+            FROM content_operation_asset_uploads
+            WHERE asset_upload_id = ?
+          )
+      `, [
+        packageRow.package_id,
+        CONTENT_OPERATION_MONSTER_ASSET_REFERENCE_ENTITY_TYPE,
+        assetReferenceEntityId,
+        assetUploadId,
+      ]),
+      bindStatement(db, `
+        INSERT INTO content_operation_package_operations (
+          operation_id, package_id, operation_order, entity_type, entity_id,
+          field_path, action, before_hash, after_hash, payload_json,
+          created_by_account_id, created_at
+        )
+        SELECT ?, ?, (
+          SELECT COALESCE(MAX(operation_order), 0) + 1
+          FROM content_operation_package_operations
+          WHERE package_id = ?
+        ), ?, ?, '', ?, NULL, ?, ?, ?, ?
+        WHERE EXISTS (
+          SELECT 1
+          FROM content_operation_asset_uploads
+          WHERE asset_upload_id = ?
+        )
+      `, [
+        assetReferenceOperationId,
+        packageRow.package_id,
+        packageRow.package_id,
+        CONTENT_OPERATION_MONSTER_ASSET_REFERENCE_ENTITY_TYPE,
+        assetReferenceEntityId,
+        'replace',
+        contentOperationValueHash(assetReferencePayload),
+        JSON.stringify(assetReferencePayload),
+        actor,
+        nowTs,
+        assetUploadId,
+      ]),
+      bindStatement(db, `
         DELETE FROM content_operation_package_approvals
         WHERE package_id = ?
           AND EXISTS (
@@ -1243,6 +1497,9 @@ export async function uploadContentOperationMonsterAsset({
         JSON.stringify({
           assetUploadId,
           assetKind: CONTENT_OPERATION_MONSTER_ASSET_KIND,
+          operationId: assetReferenceOperationId,
+          entityType: CONTENT_OPERATION_MONSTER_ASSET_REFERENCE_ENTITY_TYPE,
+          entityId: assetReferenceEntityId,
           monsterId,
           branchId,
           stageId,

--- a/worker/src/content-operations/repository.js
+++ b/worker/src/content-operations/repository.js
@@ -224,6 +224,7 @@ function releaseRowToRecord(row, { includeSnapshot = false } = {}) {
     audioFallback: audioProof.audioFallback,
     audioWarnings: audioProof.audioWarnings,
     assetSummary: assetProof.assetSummary,
+    assetReferenceManifest: assetProof.assetReferenceManifest,
     createdAt: Number(row.created_at) || 0,
   };
 }
@@ -554,6 +555,7 @@ function buildReleaseProof(proof = null, approval = null, audioScan = null, asse
       ...(releaseProof || {}),
       [RELEASE_ASSET_PROOF_KEY]: {
         assetSummary: cloneSerialisable(assetScan),
+        assetReferenceManifest: cloneSerialisable(assetScan.assetReferenceManifest || null),
       },
     };
   }
@@ -566,6 +568,7 @@ function releaseAssetProofFromProof(proof = null) {
     : null;
   return {
     assetSummary: isPlainObject(metadata?.assetSummary) ? metadata.assetSummary : null,
+    assetReferenceManifest: isPlainObject(metadata?.assetReferenceManifest) ? metadata.assetReferenceManifest : null,
   };
 }
 
@@ -583,6 +586,7 @@ function assetEventSummary(assetScan = null) {
     uploadCount: Number(assetScan.uploadCount) || 0,
     itemCount: Number(assetScan.itemCount) || 0,
     targetCount: Number(assetScan.targetCount) || 0,
+    referenceCount: Number(assetScan.assetReferenceManifest?.referenceCount) || 0,
   };
 }
 
@@ -2066,6 +2070,7 @@ export function createContentOperationsRepository({ db, env = {}, now }) {
         audioFallback: releaseAudioProof.audioFallback,
         audioWarnings: releaseAudioProof.audioWarnings,
         assetSummary: releaseAssetProof.assetSummary,
+        assetReferenceManifest: releaseAssetProof.assetReferenceManifest,
       };
     },
 

--- a/worker/src/content-operations/serialisers.js
+++ b/worker/src/content-operations/serialisers.js
@@ -347,6 +347,10 @@ function releaseAssetProofFromProof(proof = null) {
       && metadata.assetSummary && typeof metadata.assetSummary === 'object' && !Array.isArray(metadata.assetSummary)
       ? metadata.assetSummary
       : null,
+    assetReferenceManifest: metadata && typeof metadata === 'object' && !Array.isArray(metadata)
+      && metadata.assetReferenceManifest && typeof metadata.assetReferenceManifest === 'object' && !Array.isArray(metadata.assetReferenceManifest)
+      ? metadata.assetReferenceManifest
+      : null,
   };
 }
 
@@ -377,6 +381,7 @@ export function serialiseContentOperationRelease(release = {}, { includeSnapshot
     audioFallback: release.audioFallback ?? proofAudio.audioFallback,
     audioWarnings: release.audioWarnings ?? proofAudio.audioWarnings,
     assetSummary: release.assetSummary ?? proofAssets.assetSummary,
+    assetReferenceManifest: release.assetReferenceManifest ?? proofAssets.assetReferenceManifest,
     createdAt: Number(release.createdAt) || 0,
     ...(includeSnapshot ? { snapshot: release.snapshot || null } : {}),
   };


### PR DESCRIPTION
## Summary
- add package-level monster asset reference operations for uploaded spelling monster images
- expose release/candidate asset reference manifests with safe preview URL normalisation
- render monster asset reference previews in the Content Operations Centre and list them in the admin asset registry with package-workflow blockers

## Validation
- npm test -- tests/monster-asset-upload-validation.test.js tests/admin-content-operations-v2.test.js tests/admin-asset-registry-v1.test.js tests/react-admin-content-operations.test.js
- npm test -- tests/build-public.test.js
- npm test -- tests/content-operations-api.test.js
- npm run check
- pre-push npm test: 111855 passed, 0 failed, 12 skipped

## Notes
- Uploads create content operation package reference records; image assets are still published through the content operations package workflow rather than the generic asset registry publish action.
- Release proof now carries the asset reference manifest so rollback and audit paths can account for package-uploaded monster images.