### PR TITLE
Publish and fallback monster assets

### DIFF
--- a/src/platform/game/monster-visual-config.js
+++ b/src/platform/game/monster-visual-config.js
@@ -151,6 +151,10 @@ function isPlainObject(value) {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
 
+function normaliseString(value, fallback = '') {
+  return typeof value === 'string' ? value.trim() || fallback : fallback;
+}
+
 function numberOrDefault(value, fallback = 0) {
   const numeric = Number(value);
   return Number.isFinite(numeric) ? numeric : fallback;
@@ -286,6 +290,79 @@ export function buildBundledMonsterVisualConfig(manifest = MONSTER_ASSET_MANIFES
 }
 
 export const BUNDLED_MONSTER_VISUAL_CONFIG = Object.freeze(buildBundledMonsterVisualConfig());
+
+function normaliseRuntimeAssetUrl(value) {
+  const url = normaliseString(value);
+  if (!url.startsWith('/api/content-operations/assets/monster-image/')) return '';
+  if (/[\r\n]/.test(url)) return '';
+  return url;
+}
+
+function runtimeSourceSetForReference(src, width) {
+  const resolvedWidth = Math.max(1, Math.floor(Number(width) || 0));
+  return resolvedWidth ? `${src} ${resolvedWidth}w` : '';
+}
+
+function normaliseRuntimeAssetReferenceEntry(value = {}) {
+  if (!isPlainObject(value)) return null;
+  const target = isPlainObject(value.target) ? value.target : {};
+  const assetKey = normaliseString(value.assetKey)
+    || buildMonsterAssetKey(target.monsterId, target.branchId || target.branch, target.stageId ?? target.stage);
+  if (!assetKey || !assetByKey.has(assetKey)) return null;
+  const src = normaliseRuntimeAssetUrl(value.src);
+  if (!src) return null;
+  const width = Math.max(0, Math.floor(Number(value.width ?? value.content?.dimensions?.width) || 0));
+  const height = Math.max(0, Math.floor(Number(value.height ?? value.content?.dimensions?.height) || 0));
+  const sizes = width ? [width] : [];
+  return {
+    assetKey,
+    referenceId: normaliseString(value.referenceId),
+    releaseId: normaliseString(value.releaseId),
+    packageId: normaliseString(value.packageId),
+    assetUploadId: normaliseString(value.assetUploadId),
+    target: {
+      monsterId: normaliseString(target.monsterId),
+      branchId: normaliseString(target.branchId || target.branch),
+      stageId: normaliseString(target.stageId ?? target.stage),
+    },
+    contentType: normaliseString(value.contentType ?? value.content?.contentType),
+    byteSize: Math.max(0, Math.floor(Number(value.byteSize ?? value.content?.byteSize) || 0)),
+    width: width || null,
+    height: height || null,
+    src,
+    srcSet: runtimeSourceSetForReference(src, width),
+    sizes,
+  };
+}
+
+export function normaliseMonsterRuntimeAssetReferences(rawValue) {
+  if (!isPlainObject(rawValue)) return null;
+  const rawByAssetKey = isPlainObject(rawValue.byAssetKey) ? rawValue.byAssetKey : null;
+  const sourceEntries = rawByAssetKey
+    ? Object.values(rawByAssetKey)
+    : (Array.isArray(rawValue.references) ? rawValue.references : []);
+  const byAssetKey = {};
+  for (const entry of sourceEntries) {
+    const reference = normaliseRuntimeAssetReferenceEntry(entry);
+    if (!reference) continue;
+    byAssetKey[reference.assetKey] = reference;
+  }
+  const referenceCount = Object.keys(byAssetKey).length;
+  if (!referenceCount) return null;
+  return {
+    schemaVersion: Math.max(1, Math.floor(Number(rawValue.schemaVersion) || 1)),
+    source: normaliseString(rawValue.source, 'content-operation-release'),
+    releaseId: normaliseString(rawValue.releaseId),
+    hash: normaliseString(rawValue.hash),
+    referenceCount,
+    byAssetKey,
+  };
+}
+
+function runtimeReferenceForAssetKey(config, assetKey) {
+  const references = normaliseMonsterRuntimeAssetReferences(config?.runtimeAssetReferences);
+  return references?.byAssetKey?.[assetKey] || null;
+}
 
 function issue(code, message, details = {}) {
   return {
@@ -479,6 +556,11 @@ export function normaliseMonsterVisualRuntimeConfig(rawValue) {
     return null;
   }
 
+  const runtimeAssetReferences = normaliseMonsterRuntimeAssetReferences(
+    raw.runtimeAssetReferences || rawConfig.runtimeAssetReferences,
+  );
+  const assetReferenceHash = normaliseString(raw.assetReferenceHash || runtimeAssetReferences?.hash);
+
   // Pointer-only envelope (no bundled `config.assets`).
   if (raw.compact === true && !isPlainObject(rawConfig.assets)) {
     const manifestHash = typeof raw.manifestHash === 'string' && raw.manifestHash
@@ -490,8 +572,9 @@ export function normaliseMonsterVisualRuntimeConfig(rawValue) {
       manifestHashMismatch: Boolean(manifestHash && manifestHash !== MONSTER_ASSET_MANIFEST.manifestHash),
       publishedVersion: Math.max(0, numberOrDefault(raw.publishedVersion, 0)),
       publishedAt: Math.max(0, numberOrDefault(raw.publishedAt, 0)),
+      assetReferenceHash,
       compact: true,
-      config: null,
+      config: runtimeAssetReferences ? { runtimeAssetReferences } : null,
     };
   }
 
@@ -508,6 +591,7 @@ export function normaliseMonsterVisualRuntimeConfig(rawValue) {
     ...cloneSerialisable(rawConfig),
     schemaVersion,
     manifestHash: rawConfig.manifestHash || manifestHash,
+    ...(runtimeAssetReferences ? { runtimeAssetReferences } : {}),
   };
 
   return {
@@ -516,6 +600,7 @@ export function normaliseMonsterVisualRuntimeConfig(rawValue) {
     manifestHashMismatch: Boolean(manifestHash && manifestHash !== MONSTER_ASSET_MANIFEST.manifestHash),
     publishedVersion: Math.max(0, numberOrDefault(raw.publishedVersion ?? config.version, 0)),
     publishedAt: Math.max(0, numberOrDefault(raw.publishedAt, 0)),
+    assetReferenceHash,
     config,
   };
 }
@@ -545,7 +630,16 @@ export function resolveMonsterVisualConfigFromPointer(normalised, cachedConfig) 
     && !cachedConfig.compact
     && isPlainObject(cachedConfig.config)
     && isPlainObject(cachedConfig.config.assets);
-  if (hasCachedFull && cachedHash && cachedHash === normalised.manifestHash) {
+  const cachedAssetReferenceHash = normaliseString(
+    cachedConfig?.assetReferenceHash || cachedConfig?.config?.runtimeAssetReferences?.hash,
+  );
+  const normalisedAssetReferenceHash = normaliseString(normalised.assetReferenceHash);
+  if (
+    hasCachedFull
+    && cachedHash
+    && cachedHash === normalised.manifestHash
+    && cachedAssetReferenceHash === normalisedAssetReferenceHash
+  ) {
     return cachedConfig;
   }
   return normalised;
@@ -618,7 +712,15 @@ export function resolveMonsterVisual({
     branch,
     stage: normaliseStage(stage),
   }, resolvedContext);
-  const sources = monsterVisualAssetSources(assetKey, { preferredSize });
+  const bundledSources = monsterVisualAssetSources(assetKey, { preferredSize });
+  const runtimeReference = runtimeReferenceForAssetKey(config, assetKey);
+  const sources = runtimeReference
+    ? {
+        src: runtimeReference.src,
+        srcSet: runtimeReference.srcSet || runtimeSourceSetForReference(runtimeReference.src, runtimeReference.width),
+        sizes: runtimeReference.sizes.length ? runtimeReference.sizes : bundledSources.sizes,
+      }
+    : bundledSources;
   const facing = normaliseFacing(baseline.facing, 'left');
 
   return {
@@ -627,7 +729,8 @@ export function resolveMonsterVisual({
     branch: entry?.branch || branch,
     stage: normaliseStage(entry?.stage ?? stage),
     context: resolvedContext,
-    source: useCandidate ? 'config' : 'bundled',
+    source: runtimeReference ? (useCandidate ? 'config-runtime-asset' : 'runtime-asset') : (useCandidate ? 'config' : 'bundled'),
+    runtimeAssetReference: runtimeReference ? cloneSerialisable(runtimeReference) : null,
     ...cloneSerialisable(baseline),
     ...cloneSerialisable(contextValues),
     facing,
@@ -635,6 +738,9 @@ export function resolveMonsterVisual({
     src: sources.src,
     srcSet: sources.srcSet,
     sizes: sources.sizes,
+    fallbackSrc: runtimeReference ? bundledSources.src : '',
+    fallbackSrcSet: runtimeReference ? bundledSources.srcSet : '',
+    fallbackSizes: runtimeReference ? bundledSources.sizes : [],
   };
 }
 

--- a/src/platform/game/render/BaseSprite.jsx
+++ b/src/platform/game/render/BaseSprite.jsx
@@ -2,6 +2,8 @@
 // Kept thin so MonsterRender owns the layering decisions and BaseSprite
 // owns the visible shell tokens (className, src, srcSet, alt, sizes).
 //
+import { applyMonsterImageFallback, monsterImageFallbackDataset } from './image-fallback.js';
+
 // SH2-U10 CLS: declare an intrinsic aspect ratio via `width`/`height` so
 // the browser reserves the box before the .webp decodes. Monster sprites
 // are uniformly 1:1 across all branches (the assets pipeline in
@@ -21,6 +23,8 @@ export function BaseSprite({ monster, sizes, style }) {
       src={monster.img}
       srcSet={monster.srcSet}
       sizes={sizes != null ? sizes : monster.sizes}
+      {...monsterImageFallbackDataset(monster)}
+      onError={applyMonsterImageFallback}
       width={MONSTER_SPRITE_INTRINSIC_DIMENSION}
       height={MONSTER_SPRITE_INTRINSIC_DIMENSION}
       style={style}

--- a/src/platform/game/render/effects/celebration-shell.js
+++ b/src/platform/game/render/effects/celebration-shell.js
@@ -10,6 +10,7 @@
 import { useMonsterVisualConfig } from '../../MonsterVisualConfigContext.jsx';
 import { resolveMonsterVisual } from '../../monster-visual-config.js';
 import { monsterVisualCelebrationStyle } from '../../monster-visual-style.js';
+import { applyMonsterImageFallback, monsterImageFallbackDataset } from '../image-fallback.js';
 
 const PALETTE_DEFAULTS = Object.freeze({
   primary: '#3E6FA8',
@@ -52,6 +53,8 @@ function CelebrationVisual({ className, stage, visual }) {
         src={visual.src}
         srcSet={visual.srcSet}
         sizes="min(90vw, 540px)"
+        {...monsterImageFallbackDataset(visual)}
+        onError={applyMonsterImageFallback}
       />
     </span>
   );

--- a/src/platform/game/render/image-fallback.js
+++ b/src/platform/game/render/image-fallback.js
@@ -1,0 +1,19 @@
+export function monsterImageFallbackDataset(visual = {}) {
+  return {
+    'data-fallback-src': visual.fallbackSrc || '',
+    'data-fallback-srcset': visual.fallbackSrcSet || '',
+  };
+}
+
+export function applyMonsterImageFallback(event) {
+  const image = event?.currentTarget;
+  const fallbackSrc = image?.dataset?.fallbackSrc || '';
+  if (!fallbackSrc || image.dataset.fallbackApplied === 'true') return;
+  image.dataset.fallbackApplied = 'true';
+  image.src = fallbackSrc;
+  if (image.dataset.fallbackSrcset) {
+    image.srcset = image.dataset.fallbackSrcset;
+  } else {
+    image.removeAttribute('srcset');
+  }
+}

--- a/src/platform/ui/SubjectCompanionPanel.jsx
+++ b/src/platform/ui/SubjectCompanionPanel.jsx
@@ -7,6 +7,7 @@
  * nextFocus (string), emptyState (string). Stateless (R10): no store, no mastery writes.
  */
 import { SectionHeader } from './SectionHeader.jsx';
+import { applyMonsterImageFallback } from '../game/render/image-fallback.js';
 
 export function SubjectCompanionPanel({
   subjectId,
@@ -37,7 +38,7 @@ export function SubjectCompanionPanel({
             {monsterVisuals.map((m) => (
               <div className={`ss-meadow-cell${m.isEgg ? ' egg' : ''}`} key={m.id}>
                 <span className="ss-meadow-visual" style={m.visual.style}>
-                  <img className="ss-meadow-art" alt="" {...m.visual.imageProps} />
+                  <img className="ss-meadow-art" alt="" {...m.visual.imageProps} onError={applyMonsterImageFallback} />
                 </span>
               </div>
             ))}

--- a/src/subjects/grammar/components/grammar-view-model.js
+++ b/src/subjects/grammar/components/grammar-view-model.js
@@ -577,6 +577,8 @@ export function grammarMonsterImageVisual(monsterId, stage, visualConfig = null,
       src: visual.src,
       srcSet: visual.srcSet,
       sizes: 'min(30vw, 120px)',
+      'data-fallback-src': visual.fallbackSrc || '',
+      'data-fallback-srcset': visual.fallbackSrcSet || '',
     },
   };
 }

--- a/src/subjects/punctuation/components/punctuation-view-model.js
+++ b/src/subjects/punctuation/components/punctuation-view-model.js
@@ -90,6 +90,8 @@ export function punctuationMonsterAsset(monsterId = FALLBACK_MONSTER, stage = 0,
     stage: safeStage,
     src: visual.src,
     srcSet: visual.srcSet,
+    fallbackSrc: visual.fallbackSrc || '',
+    fallbackSrcSet: visual.fallbackSrcSet || '',
   };
 }
 
@@ -108,6 +110,8 @@ export function punctuationMonsterImageVisual(monsterId, stage, visualConfig = n
       src: visual.src,
       srcSet: visual.srcSet,
       sizes: 'min(30vw, 120px)',
+      'data-fallback-src': visual.fallbackSrc || '',
+      'data-fallback-srcset': visual.fallbackSrcSet || '',
     },
   };
 }

--- a/src/subjects/reading/components/ReadingPracticeSurface.jsx
+++ b/src/subjects/reading/components/ReadingPracticeSurface.jsx
@@ -232,6 +232,8 @@ export function readingMonsterImageVisual(monsterId, progress, config) {
       sizes: '(max-width: 720px) 96px, 120px',
       loading: 'lazy',
       decoding: 'async',
+      'data-fallback-src': visual.fallbackSrc || '',
+      'data-fallback-srcset': visual.fallbackSrcSet || '',
     },
   };
 }

--- a/src/subjects/reasoning/components/ReasoningPracticeSurface.jsx
+++ b/src/subjects/reasoning/components/ReasoningPracticeSurface.jsx
@@ -125,7 +125,15 @@ export function reasoningMonsterImageVisual(monsterId, progress, config) {
   const visual = resolveMonsterVisual({ monsterId: assetMonsterId, branch, stage, context: 'meadow', config, preferredSize: 320 });
   return {
     style: monsterVisualFrameStyle(visual),
-    imageProps: { src: visual.src, srcSet: visual.srcSet, sizes: '(max-width: 720px) 96px, 120px', loading: 'lazy', decoding: 'async' },
+    imageProps: {
+      src: visual.src,
+      srcSet: visual.srcSet,
+      sizes: '(max-width: 720px) 96px, 120px',
+      loading: 'lazy',
+      decoding: 'async',
+      'data-fallback-src': visual.fallbackSrc || '',
+      'data-fallback-srcset': visual.fallbackSrcSet || '',
+    },
   };
 }
 

--- a/src/subjects/spelling/components/SpellingSetupScene.jsx
+++ b/src/subjects/spelling/components/SpellingSetupScene.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useMonsterVisualConfig } from '../../../platform/game/MonsterVisualConfigContext.jsx';
+import { applyMonsterImageFallback } from '../../../platform/game/render/image-fallback.js';
 import { SpellingHeroBackdrop } from './SpellingHeroBackdrop.jsx';
 import { ArrowRightIcon, CheckIcon } from './spelling-icons.jsx';
 import { useSetupHeroContrast } from './useSetupHeroContrast.js';
@@ -238,7 +239,7 @@ export function SetupMeadow({ codex }) {
         return (
           <div className={`ss-meadow-cell${progress.stage === 0 ? ' egg' : ''}`} key={monster.id}>
             <span className="ss-meadow-visual" style={visual.style}>
-              <img className="ss-meadow-art" alt="" {...visual.imageProps} />
+              <img className="ss-meadow-art" alt="" {...visual.imageProps} onError={applyMonsterImageFallback} />
             </span>
           </div>
         );

--- a/src/subjects/spelling/components/spelling-view-model.js
+++ b/src/subjects/spelling/components/spelling-view-model.js
@@ -1100,6 +1100,8 @@ export function monsterImageVisual(monster, progress, visualConfig = null) {
       src: visual.src,
       srcSet: visual.srcSet,
       sizes: 'min(30vw, 120px)',
+      'data-fallback-src': visual.fallbackSrc || '',
+      'data-fallback-srcset': visual.fallbackSrcSet || '',
     },
   };
 }

--- a/src/surfaces/home/CodexCreature.jsx
+++ b/src/surfaces/home/CodexCreature.jsx
@@ -50,7 +50,13 @@ export function CodexCreatureVisual({ entry, sizes, context = 'card' }) {
   // asset than the entry default; fold it back into the monster object so
   // <BaseSprite> picks up src/srcSet without us forking its rendering.
   const monsterForRender = visual.src || visual.srcSet
-    ? { ...entry, img: visual.src || entry.img, srcSet: visual.srcSet || entry.srcSet }
+    ? {
+        ...entry,
+        img: visual.src || entry.img,
+        srcSet: visual.srcSet || entry.srcSet,
+        fallbackSrc: visual.fallbackSrc || '',
+        fallbackSrcSet: visual.fallbackSrcSet || '',
+      }
     : entry;
 
   return (

--- a/src/surfaces/home/MonsterMeadow.jsx
+++ b/src/surfaces/home/MonsterMeadow.jsx
@@ -1,5 +1,6 @@
 import { useMonsterVisualConfig } from '../../platform/game/MonsterVisualConfigContext.jsx';
 import { resolveMonsterVisual } from '../../platform/game/monster-visual-config.js';
+import { applyMonsterImageFallback, monsterImageFallbackDataset } from '../../platform/game/render/image-fallback.js';
 import { eggBreatheStyle } from './data.js';
 // SH2-U5: fresh learners land on the home hero with zero caught monsters.
 // Before the re-skin the meadow rendered `null`, which meant learners saw
@@ -98,6 +99,8 @@ export function MonsterMeadow({ monsters = [], maxSlots = 10 }) {
                 src={src}
                 srcSet={srcSet}
                 sizes={`${size}px`}
+                {...monsterImageFallbackDataset(visual)}
+                onError={applyMonsterImageFallback}
                 width={size}
                 height={size}
                 alt=""

--- a/src/surfaces/hubs/MonsterVisualPreviewGrid.jsx
+++ b/src/surfaces/hubs/MonsterVisualPreviewGrid.jsx
@@ -4,6 +4,7 @@ import {
   resolveMonsterVisual,
 } from '../../platform/game/monster-visual-config.js';
 import { MonsterRender } from '../../platform/game/render/MonsterRender.jsx';
+import { applyMonsterImageFallback, monsterImageFallbackDataset } from '../../platform/game/render/image-fallback.js';
 import { MonsterEffectConfigProvider } from '../../platform/game/MonsterEffectConfigContext.jsx';
 import { CELEBRATION_KINDS } from './monster-effect-celebration-helpers.js';
 
@@ -41,6 +42,8 @@ function buildMonsterPropForRender({ asset, visual }) {
     displayState: asset.stage === 0 ? 'egg' : 'monster',
     img: visual.src,
     srcSet: visual.srcSet,
+    fallbackSrc: visual.fallbackSrc || '',
+    fallbackSrcSet: visual.fallbackSrcSet || '',
     imageAlt: '',
   };
 }
@@ -99,6 +102,8 @@ export function MonsterVisualPreviewGrid({
               src={visual.src}
               srcSet={visual.srcSet}
               sizes="120px"
+              {...monsterImageFallbackDataset(visual)}
+              onError={applyMonsterImageFallback}
               style={previewStyle(visual)}
             />
           )}

--- a/src/surfaces/shell/MonsterCelebrationOverlay.jsx
+++ b/src/surfaces/shell/MonsterCelebrationOverlay.jsx
@@ -1,5 +1,6 @@
 import { useMonsterVisualConfig } from '../../platform/game/MonsterVisualConfigContext.jsx';
 import { resolveMonsterVisual } from '../../platform/game/monster-visual-config.js';
+import { applyMonsterImageFallback, monsterImageFallbackDataset } from '../../platform/game/render/image-fallback.js';
 import { monsterVisualCelebrationStyle } from '../../platform/game/monster-visual-style.js';
 
 function imageVisual(monsterId, stage, branch, config) {
@@ -60,6 +61,8 @@ function CelebrationVisual({ className, stage, visual }) {
         src={visual.src}
         srcSet={visual.srcSet}
         sizes="min(90vw, 540px)"
+        {...monsterImageFallbackDataset(visual)}
+        onError={applyMonsterImageFallback}
       />
     </span>
   );

--- a/src/surfaces/shell/ToastShelf.jsx
+++ b/src/surfaces/shell/ToastShelf.jsx
@@ -1,5 +1,6 @@
 import { useMonsterVisualConfig } from '../../platform/game/MonsterVisualConfigContext.jsx';
 import { resolveMonsterVisual } from '../../platform/game/monster-visual-config.js';
+import { applyMonsterImageFallback, monsterImageFallbackDataset } from '../../platform/game/render/image-fallback.js';
 
 function imageVisual(monsterId, stage, branch, config) {
   return resolveMonsterVisual({
@@ -53,6 +54,8 @@ function ToastContent({ toast }) {
             src={visual.src}
             srcSet={visual.srcSet}
             sizes="56px"
+            {...monsterImageFallbackDataset(visual)}
+            onError={applyMonsterImageFallback}
             width={56}
             height={56}
             style={portraitStyle(visual)}

--- a/tests/monster-asset-upload-validation.test.js
+++ b/tests/monster-asset-upload-validation.test.js
@@ -810,6 +810,115 @@ test('monster image uploads are bound to candidate approval and publish proof', 
   }
 });
 
+test('published monster image assets are runtime-readable with draft isolation and rollback retention', async () => {
+  const bucket = createMemoryR2Bucket();
+  const server = createWorkerRepositoryServer({
+    env: { SPELLING_AUDIO_BUCKET: bucket },
+    now: () => NOW,
+  });
+  try {
+    await seedFirstRelease(server);
+    const contentPackage = await createPackage(server);
+    const uploadResponse = await uploadMonsterAsset(server, contentPackage.packageId, monsterAssetForm());
+    assert.equal(uploadResponse.status, 201);
+
+    const draftBootstrapResponse = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/bootstrap`,
+      { headers: { 'x-ks2-public-read-models': '1' } },
+      adminHeaders(),
+    );
+    assert.equal(draftBootstrapResponse.status, 200);
+    const draftBootstrap = await draftBootstrapResponse.json();
+    assert.equal(draftBootstrap.monsterVisualConfig.runtimeAssetReferences, undefined);
+
+    const candidate = await validatePackage(server, contentPackage.packageId);
+    const approvalResponse = await approvePackage(server, contentPackage.packageId, candidate.candidate.candidateId);
+    assert.equal(approvalResponse.status, 200);
+    const publishResponse = await publishPackage(server, contentPackage.packageId);
+    assert.equal(publishResponse.status, 200);
+    const published = await publishResponse.json();
+    const reference = published.release.assetReferenceManifest.references[0];
+
+    const bootstrapResponse = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/bootstrap`,
+      { headers: { 'x-ks2-public-read-models': '1' } },
+      adminHeaders(),
+    );
+    assert.equal(bootstrapResponse.status, 200);
+    const bootstrap = await bootstrapResponse.json();
+    const runtimeReferences = bootstrap.monsterVisualConfig.runtimeAssetReferences;
+    assert.equal(bootstrap.monsterVisualConfig.compact, true);
+    assert.equal(runtimeReferences.releaseId, published.release.releaseId);
+    assert.equal(runtimeReferences.hash, published.release.assetReferenceManifest.hash);
+    assert.equal(runtimeReferences.byAssetKey['inklet-b1-0'].assetUploadId, reference.assetUploadId);
+    assert.match(
+      runtimeReferences.byAssetKey['inklet-b1-0'].src,
+      new RegExp(`^/api/content-operations/assets/monster-image/${published.release.releaseId}/monster-image%3Ainklet%3Ab1%3A0$`),
+    );
+    assert.equal(
+      runtimeReferences.byAssetKey['inklet-b1-0'].src.includes('/api/admin/content-operations/'),
+      false,
+    );
+    assert.equal(JSON.stringify(runtimeReferences).includes('r2Key'), false);
+
+    const imageResponse = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}${runtimeReferences.byAssetKey['inklet-b1-0'].src}`,
+      {},
+      adminHeaders(),
+    );
+    assert.equal(imageResponse.status, 200);
+    assert.equal(imageResponse.headers.get('content-type'), 'image/png');
+    assert.equal(imageResponse.headers.get('x-content-type-options'), 'nosniff');
+    assert.equal(imageResponse.headers.get('cache-control'), 'public, max-age=3600');
+    assert.equal((await imageResponse.arrayBuffer()).byteLength, validPngBytes().byteLength);
+
+    const repository = createWorkerRepository({
+      env: server.env,
+      now: () => NOW + 1000,
+    });
+    const rollback = await repository.rollbackContentOperationRelease('spelling', published.release.releaseId, {
+      rolledBackByAccountId: ADMIN_ID,
+      proof: { source: 'monster-asset-upload-validation-test' },
+    });
+    assert.equal(rollback.assetReferenceManifest.referenceCount, 1);
+    assert.equal(rollback.assetReferenceManifest.references[0].assetUploadId, reference.assetUploadId);
+
+    const rollbackBootstrapResponse = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/bootstrap`,
+      { headers: { 'x-ks2-public-read-models': '1' } },
+      adminHeaders(),
+    );
+    assert.equal(rollbackBootstrapResponse.status, 200);
+    const rollbackBootstrap = await rollbackBootstrapResponse.json();
+    const rollbackReferences = rollbackBootstrap.monsterVisualConfig.runtimeAssetReferences;
+    assert.equal(rollbackReferences.releaseId, rollback.releaseId);
+    assert.equal(rollbackReferences.byAssetKey['inklet-b1-0'].assetUploadId, reference.assetUploadId);
+
+    const rollbackImageResponse = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}${rollbackReferences.byAssetKey['inklet-b1-0'].src}`,
+      {},
+      adminHeaders(),
+    );
+    assert.equal(rollbackImageResponse.status, 200);
+
+    await bucket.delete(bucket.puts[0].key);
+    const missingImageResponse = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}${rollbackReferences.byAssetKey['inklet-b1-0'].src}`,
+      {},
+      adminHeaders(),
+    );
+    assert.equal(missingImageResponse.status, 404);
+  } finally {
+    server.close();
+  }
+});
+
 test('monster image release serialisation distinguishes caller proof from server asset proof', () => {
   const release = serialiseContentOperationRelease({
     releaseId: 'rel-server-asset-proof',

--- a/tests/monster-visual-config.test.js
+++ b/tests/monster-visual-config.test.js
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import { MONSTER_ASSET_MANIFEST } from '../src/platform/game/monster-asset-manifest.js';
+import { applyMonsterImageFallback } from '../src/platform/game/render/image-fallback.js';
 import {
   BUNDLED_MONSTER_VISUAL_CONFIG,
   MONSTER_VISUAL_CONTEXTS,
@@ -11,8 +12,10 @@ import {
   buildMonsterAssetKey,
   monsterVisualAssetSources,
   monsterVisualSourceMonsterId,
+  normaliseMonsterRuntimeAssetReferences,
   normaliseMonsterVisualRuntimeConfig,
   resolveMonsterVisual,
+  resolveMonsterVisualConfigFromPointer,
   validateMonsterVisualConfigForPublish,
 } from '../src/platform/game/monster-visual-config.js';
 
@@ -326,4 +329,155 @@ test('U7 adv-u7-r1-001: normaliser rejects pointer with incompatible schemaVersi
     publishedVersion: 1,
     compact: true,
   }), null, 'schema-mismatch pointer still rejected');
+});
+
+test('T23: runtime asset references are normalised to safe app URLs only', () => {
+  const references = normaliseMonsterRuntimeAssetReferences({
+    schemaVersion: 1,
+    releaseId: 'corel-published',
+    hash: 'asset-hash-1',
+    byAssetKey: {
+      'inklet-b1-0': {
+        assetKey: 'inklet-b1-0',
+        releaseId: 'corel-published',
+        referenceId: 'monster-image:inklet:b1:0',
+        target: { monsterId: 'inklet', branchId: 'b1', stageId: '0' },
+        contentType: 'image/png',
+        width: 320,
+        height: 320,
+        src: '/api/content-operations/assets/monster-image/corel-published/monster-image%3Ainklet%3Ab1%3A0',
+      },
+      'inklet-b1-1': {
+        assetKey: 'inklet-b1-1',
+        target: { monsterId: 'inklet', branchId: 'b1', stageId: '1' },
+        src: '/api/admin/content-operations/packages/pkg/monster-assets/coasset/preview',
+      },
+    },
+  });
+
+  assert.equal(references.referenceCount, 1);
+  assert.equal(references.byAssetKey['inklet-b1-0'].src, '/api/content-operations/assets/monster-image/corel-published/monster-image%3Ainklet%3Ab1%3A0');
+  assert.equal(references.byAssetKey['inklet-b1-0'].srcSet, '/api/content-operations/assets/monster-image/corel-published/monster-image%3Ainklet%3Ab1%3A0 320w');
+  assert.equal(references.byAssetKey['inklet-b1-1'], undefined, 'admin preview URLs are never runtime-readable');
+});
+
+test('T23: compact pointer can carry runtime asset references without a full config payload', () => {
+  const pointer = normaliseMonsterVisualRuntimeConfig({
+    schemaVersion: 1,
+    manifestHash: BUNDLED_MONSTER_VISUAL_CONFIG.manifestHash,
+    publishedVersion: 3,
+    publishedAt: 1740000000000,
+    compact: true,
+    assetReferenceHash: 'asset-hash-1',
+    runtimeAssetReferences: {
+      schemaVersion: 1,
+      releaseId: 'corel-published',
+      hash: 'asset-hash-1',
+      byAssetKey: {
+        'inklet-b1-0': {
+          assetKey: 'inklet-b1-0',
+          referenceId: 'monster-image:inklet:b1:0',
+          target: { monsterId: 'inklet', branchId: 'b1', stageId: '0' },
+          src: '/api/content-operations/assets/monster-image/corel-published/monster-image%3Ainklet%3Ab1%3A0',
+          width: 320,
+        },
+      },
+    },
+  });
+
+  assert.equal(pointer.compact, true);
+  assert.equal(pointer.assetReferenceHash, 'asset-hash-1');
+  assert.equal(pointer.config.runtimeAssetReferences.byAssetKey['inklet-b1-0'].src, '/api/content-operations/assets/monster-image/corel-published/monster-image%3Ainklet%3Ab1%3A0');
+});
+
+test('T23: pointer asset hash invalidates cached full config so new remote assets apply', () => {
+  const cached = normaliseMonsterVisualRuntimeConfig({
+    schemaVersion: 1,
+    manifestHash: BUNDLED_MONSTER_VISUAL_CONFIG.manifestHash,
+    publishedVersion: 2,
+    publishedAt: 1000,
+    assetReferenceHash: 'old-assets',
+    config: BUNDLED_MONSTER_VISUAL_CONFIG,
+  });
+  const pointer = normaliseMonsterVisualRuntimeConfig({
+    schemaVersion: 1,
+    manifestHash: BUNDLED_MONSTER_VISUAL_CONFIG.manifestHash,
+    publishedVersion: 3,
+    publishedAt: 2000,
+    compact: true,
+    assetReferenceHash: 'new-assets',
+    runtimeAssetReferences: {
+      schemaVersion: 1,
+      releaseId: 'corel-published',
+      hash: 'new-assets',
+      byAssetKey: {
+        'inklet-b1-0': {
+          assetKey: 'inklet-b1-0',
+          referenceId: 'monster-image:inklet:b1:0',
+          target: { monsterId: 'inklet', branchId: 'b1', stageId: '0' },
+          src: '/api/content-operations/assets/monster-image/corel-published/monster-image%3Ainklet%3Ab1%3A0',
+          width: 320,
+        },
+      },
+    },
+  });
+
+  const resolved = resolveMonsterVisualConfigFromPointer(pointer, cached);
+  assert.equal(resolved, pointer);
+});
+
+test('T23: visual resolver uses published runtime asset first with bundled fallback metadata', () => {
+  const visual = resolveMonsterVisual({
+    monsterId: 'inklet',
+    branch: 'b1',
+    stage: 0,
+    context: 'codexCard',
+    preferredSize: 640,
+    config: {
+      ...BUNDLED_MONSTER_VISUAL_CONFIG,
+      runtimeAssetReferences: {
+        schemaVersion: 1,
+        releaseId: 'corel-published',
+        hash: 'asset-hash-1',
+        byAssetKey: {
+          'inklet-b1-0': {
+            assetKey: 'inklet-b1-0',
+            referenceId: 'monster-image:inklet:b1:0',
+            target: { monsterId: 'inklet', branchId: 'b1', stageId: '0' },
+            src: '/api/content-operations/assets/monster-image/corel-published/monster-image%3Ainklet%3Ab1%3A0',
+            width: 320,
+          },
+        },
+      },
+    },
+  });
+
+  assert.equal(visual.source, 'config-runtime-asset');
+  assert.equal(visual.src, '/api/content-operations/assets/monster-image/corel-published/monster-image%3Ainklet%3Ab1%3A0');
+  assert.equal(visual.srcSet, '/api/content-operations/assets/monster-image/corel-published/monster-image%3Ainklet%3Ab1%3A0 320w');
+  assert.equal(visual.fallbackSrc, './assets/monsters/inklet/b1/inklet-b1-0.640.webp?v=20260514-subject-assets');
+  assert.match(visual.fallbackSrcSet, /inklet-b1-0\.1280\.webp\?v=20260514-subject-assets 1280w/);
+});
+
+test('T23: monster image error handler swaps remote failures to bundled fallback once', () => {
+  const image = {
+    dataset: {
+      fallbackSrc: './assets/monsters/inklet/b1/inklet-b1-0.640.webp?v=20260514-subject-assets',
+      fallbackSrcset: './assets/monsters/inklet/b1/inklet-b1-0.640.webp?v=20260514-subject-assets 640w',
+    },
+    src: '/api/content-operations/assets/monster-image/corel-published/monster-image%3Ainklet%3Ab1%3A0',
+    srcset: '/api/content-operations/assets/monster-image/corel-published/monster-image%3Ainklet%3Ab1%3A0 320w',
+    removeAttribute(name) {
+      this[name] = '';
+    },
+  };
+
+  applyMonsterImageFallback({ currentTarget: image });
+  assert.equal(image.dataset.fallbackApplied, 'true');
+  assert.equal(image.src, './assets/monsters/inklet/b1/inklet-b1-0.640.webp?v=20260514-subject-assets');
+  assert.equal(image.srcset, './assets/monsters/inklet/b1/inklet-b1-0.640.webp?v=20260514-subject-assets 640w');
+
+  image.src = '/api/content-operations/assets/monster-image/corel-published/retry';
+  applyMonsterImageFallback({ currentTarget: image });
+  assert.equal(image.src, '/api/content-operations/assets/monster-image/corel-published/retry');
 });

--- a/worker/src/app.js
+++ b/worker/src/app.js
@@ -36,6 +36,7 @@ import { createWorkerSubjectRuntime } from './subjects/runtime.js';
 import {
   ConflictError,
   ForbiddenError,
+  BadRequestError,
   NotFoundError,
   AccountSuspendedError,
   AccountPaymentHoldError,
@@ -47,6 +48,7 @@ import { getReadModelDerivedWriteBreaker } from './circuit-breaker-server.js';
 import { isResetableBreakerName } from '../../src/platform/core/circuit-breaker.js';
 import { handleHeroReadModel } from './hero/routes.js';
 import { handleContentOperationsAdminRequest } from './content-operations/routes.js';
+import { readPublishedContentOperationMonsterAssetObject } from './content-operations/assets.js';
 import { resolveHeroStartTaskCommand } from './hero/launch.js';
 import { resolveHeroClaimCommand } from './hero/claim.js';
 import { resolveHeroCampCommand } from './hero/camp.js';
@@ -777,6 +779,23 @@ function decorateResponse(response, { capacity, attachBody, requestId }) {
   });
 }
 
+function decodeRouteSegment(value, code) {
+  try {
+    return decodeURIComponent(value || '');
+  } catch {
+    throw new BadRequestError('Route segment is not valid URL encoding.', { code });
+  }
+}
+
+function publicMonsterAssetResponse({ object, upload }) {
+  const headers = new Headers();
+  const contentType = upload?.contentType || object?.httpMetadata?.contentType || 'application/octet-stream';
+  headers.set('content-type', contentType);
+  headers.set('cache-control', 'public, max-age=3600');
+  headers.set('x-content-type-options', 'nosniff');
+  return new Response(object.body, { headers });
+}
+
 export function createWorkerApp({
   now = Date.now,
   fetchFn = (...args) => fetch(...args),
@@ -1292,6 +1311,26 @@ export function createWorkerApp({
         const session = await auth.requireSession(request);
         const account = await repository.ensureAccount(session);
         resolvedPlatformRole = account?.platform_role || session.platformRole || 'parent';
+
+        const publicMonsterAssetMatch = /^\/api\/content-operations\/assets\/monster-image\/([^/]+)\/([^/]+)$/.exec(url.pathname);
+        if (publicMonsterAssetMatch && request.method === 'GET') {
+          const releaseId = decodeRouteSegment(
+            publicMonsterAssetMatch[1],
+            'content_operation_monster_asset_release_id_invalid',
+          );
+          const referenceId = decodeRouteSegment(
+            publicMonsterAssetMatch[2],
+            'content_operation_monster_asset_reference_id_invalid',
+          );
+          const result = await readPublishedContentOperationMonsterAssetObject({
+            db: requireDatabaseWithCapacity(env, capacity),
+            env,
+            subjectId: 'spelling',
+            releaseId,
+            referenceId,
+          });
+          return publicMonsterAssetResponse(result);
+        }
 
         const subjectCommandMatch = /^\/api\/subjects\/([^/]+)\/command$/.exec(url.pathname);
         if (subjectCommandMatch && request.method === 'POST') {

--- a/worker/src/content-operations/assets.js
+++ b/worker/src/content-operations/assets.js
@@ -1607,3 +1607,102 @@ export async function readContentOperationMonsterAssetObject({
   }
   return { upload, object };
 }
+
+function assetReferenceManifestFromReleaseProof(proof = null) {
+  const assets = proof && typeof proof === 'object' && !Array.isArray(proof)
+    ? proof.contentOperationsAssets
+    : null;
+  const manifest = assets && typeof assets === 'object' && !Array.isArray(assets)
+    ? assets.assetReferenceManifest
+    : null;
+  return manifest && typeof manifest === 'object' && !Array.isArray(manifest)
+    ? manifest
+    : null;
+}
+
+function assetReferenceTargetMatchesUpload(reference, upload) {
+  const target = reference?.target && typeof reference.target === 'object' && !Array.isArray(reference.target)
+    ? reference.target
+    : {};
+  return upload
+    && target.monsterId === upload.monsterId
+    && target.branchId === upload.branchId
+    && String(target.stageId) === String(upload.stageId)
+    && reference.assetKind === CONTENT_OPERATION_MONSTER_ASSET_KIND;
+}
+
+export async function readPublishedContentOperationMonsterAssetObject({
+  db,
+  env,
+  subjectId = CONTENT_OPERATION_SUBJECT_ID,
+  releaseId,
+  referenceId,
+}) {
+  const safeSubjectId = normaliseString(subjectId, CONTENT_OPERATION_SUBJECT_ID);
+  const safeReleaseId = normaliseString(releaseId);
+  const safeReferenceId = normaliseString(referenceId);
+  if (!safeReleaseId || !safeReferenceId) {
+    throw new BadRequestError('Published monster asset requests require a release id and reference id.', {
+      code: 'content_operation_monster_asset_runtime_target_required',
+    });
+  }
+
+  const releaseRow = await first(db, `
+    SELECT release_id, subject_id, status, proof_json
+    FROM content_operation_releases
+    WHERE subject_id = ? AND release_id = ? AND status = 'published'
+    LIMIT 1
+  `, [safeSubjectId, safeReleaseId]);
+  const manifest = assetReferenceManifestFromReleaseProof(parseJson(releaseRow?.proof_json, null));
+  const reference = Array.isArray(manifest?.references)
+    ? manifest.references.find((entry) => (
+        entry
+        && typeof entry === 'object'
+        && !Array.isArray(entry)
+        && entry.referenceId === safeReferenceId
+      ))
+    : null;
+  if (!reference) {
+    throw new NotFoundError('Published monster asset reference was not found.', {
+      code: 'content_operation_monster_asset_reference_not_found',
+      releaseId: safeReleaseId,
+      referenceId: safeReferenceId,
+    });
+  }
+
+  const packageId = normaliseString(reference.packageId);
+  const assetUploadId = normaliseString(reference.assetUploadId);
+  const row = await first(db, `
+    SELECT *
+    FROM content_operation_asset_uploads
+    WHERE package_id = ? AND asset_upload_id = ? AND asset_kind = ?
+    LIMIT 1
+  `, [packageId, assetUploadId, CONTENT_OPERATION_MONSTER_ASSET_KIND]);
+  const upload = assetUploadRowToRecord(row);
+  if (!assetReferenceTargetMatchesUpload(reference, upload)) {
+    throw new NotFoundError('Published monster asset upload no longer matches its release reference.', {
+      code: 'content_operation_monster_asset_reference_upload_mismatch',
+      releaseId: safeReleaseId,
+      referenceId: safeReferenceId,
+    });
+  }
+
+  const object = await assertContentOperationAssetBucket(env).get(upload.r2Key);
+  if (!object) {
+    throw new NotFoundError('Published monster asset object was not found.', {
+      code: 'content_operation_monster_asset_object_not_found',
+      releaseId: safeReleaseId,
+      referenceId: safeReferenceId,
+    });
+  }
+
+  return {
+    release: {
+      releaseId: safeReleaseId,
+      subjectId: safeSubjectId,
+    },
+    reference,
+    upload,
+    object,
+  };
+}

--- a/worker/src/content-operations/repository.js
+++ b/worker/src/content-operations/repository.js
@@ -2107,8 +2107,15 @@ export function createContentOperationsRepository({ db, env = {}, now }) {
       const rollbackReleaseId = uid('corel');
       const snapshotHash = contentOperationHash(validation.bundle, 'release');
       const encodedSnapshot = await encodeContentOperationSnapshot(validation.bundle);
+      const targetAssetProof = releaseAssetProofFromProof(target.proof);
       const rollbackProof = {
         ...(proof && typeof proof === 'object' && !Array.isArray(proof) ? proof : {}),
+        ...(targetAssetProof.assetSummary || targetAssetProof.assetReferenceManifest ? {
+          [RELEASE_ASSET_PROOF_KEY]: {
+            assetSummary: cloneSerialisable(targetAssetProof.assetSummary),
+            assetReferenceManifest: cloneSerialisable(targetAssetProof.assetReferenceManifest),
+          },
+        } : {}),
         rollback: {
           targetReleaseId: target.releaseId,
           targetSnapshotHash: target.snapshotHash,
@@ -2190,6 +2197,8 @@ export function createContentOperationsRepository({ db, env = {}, now }) {
         publishedByAccountId: actor,
         rollbackOfReleaseId: target.releaseId,
         proof: rollbackProof,
+        assetSummary: targetAssetProof.assetSummary,
+        assetReferenceManifest: targetAssetProof.assetReferenceManifest,
         createdAt: nowTs,
       };
     },

--- a/worker/src/repository.js
+++ b/worker/src/repository.js
@@ -182,6 +182,7 @@ import {
 } from '../../src/subjects/punctuation/service-contract.js';
 import {
   BUNDLED_MONSTER_VISUAL_CONFIG,
+  buildMonsterAssetKey,
   MONSTER_VISUAL_SCHEMA_VERSION,
   validateMonsterVisualConfigForPublish,
   validatePublishedConfigForPublish,
@@ -247,6 +248,8 @@ const MONSTER_VISUAL_CONFIG_POINTER_CACHE_TTL_MS = 5_000;
 const monsterVisualConfigPointerCache = new WeakMap();
 const MONSTER_VISUAL_SCOPE_TYPE = 'platform';
 const MONSTER_VISUAL_SCOPE_ID = 'monster-visual-config';
+const CONTENT_OPERATION_ASSET_PROOF_KEY = 'contentOperationsAssets';
+const CONTENT_OPERATION_MONSTER_ASSET_RUNTIME_ROUTE = '/api/content-operations/assets/monster-image';
 
 // safeJsonParse, asTs, isMissingTableError → repository-helpers.js
 
@@ -578,6 +581,7 @@ async function readPublishedContentOperationReleaseRow(db, subjectId = 'spelling
         status,
         snapshot_hash,
         ${includeSnapshot ? 'snapshot_json' : 'NULL AS snapshot_json'},
+        proof_json,
         published_at,
         created_at
       FROM content_operation_releases
@@ -602,6 +606,7 @@ async function readActiveContentOperationOverrideReleaseRow(db, accountId, subje
         r.status,
         r.snapshot_hash,
         ${includeSnapshot ? 'r.snapshot_json' : 'NULL'} AS snapshot_json,
+        r.proof_json,
         r.published_at,
         r.created_at
       FROM content_operation_account_overrides o
@@ -637,6 +642,7 @@ async function readResolvedContentOperationReleaseRow(db, accountId, subjectId =
         status,
         snapshot_hash,
         snapshot_json,
+        proof_json,
         published_at,
         created_at,
         release_source
@@ -647,6 +653,7 @@ async function readResolvedContentOperationReleaseRow(db, accountId, subjectId =
           r.status,
           r.snapshot_hash,
           ${includeSnapshot ? 'r.snapshot_json' : 'NULL'} AS snapshot_json,
+          r.proof_json,
           r.published_at,
           r.created_at,
           'override' AS release_source,
@@ -668,6 +675,7 @@ async function readResolvedContentOperationReleaseRow(db, accountId, subjectId =
           r.status,
           r.snapshot_hash,
           ${includeSnapshot ? 'r.snapshot_json' : 'NULL'} AS snapshot_json,
+          r.proof_json,
           r.published_at,
           r.created_at,
           'global' AS release_source,
@@ -700,6 +708,83 @@ function contentOperationReleaseRevisionToken(row) {
     row.snapshot_hash || '',
     Number(row.published_at) || 0,
   ].join(':');
+}
+
+function runtimeMonsterAssetReferenceUrl(releaseId, referenceId) {
+  return [
+    CONTENT_OPERATION_MONSTER_ASSET_RUNTIME_ROUTE,
+    encodeURIComponent(String(releaseId || '')),
+    encodeURIComponent(String(referenceId || '')),
+  ].join('/');
+}
+
+function runtimeMonsterAssetReferencesFromReleaseRow(row) {
+  const releaseId = typeof row?.release_id === 'string' ? row.release_id : '';
+  if (!releaseId) return null;
+  const proof = safeJsonParse(row?.proof_json, null);
+  const manifest = isPlainObject(proof?.[CONTENT_OPERATION_ASSET_PROOF_KEY]?.assetReferenceManifest)
+    ? proof[CONTENT_OPERATION_ASSET_PROOF_KEY].assetReferenceManifest
+    : null;
+  const references = Array.isArray(manifest?.references) ? manifest.references : [];
+  if (!references.length) return null;
+  const byAssetKey = {};
+
+  for (const reference of references) {
+    if (!isPlainObject(reference)) continue;
+    const target = isPlainObject(reference.target) ? reference.target : {};
+    const monsterId = typeof target.monsterId === 'string' ? target.monsterId.trim() : '';
+    const branchId = typeof target.branchId === 'string' ? target.branchId.trim() : '';
+    const stageId = String(target.stageId ?? '').trim();
+    const referenceId = typeof reference.referenceId === 'string' ? reference.referenceId.trim() : '';
+    if (!monsterId || !branchId || !stageId || !referenceId) continue;
+    const assetKey = buildMonsterAssetKey(monsterId, branchId, stageId);
+    const width = Math.max(0, Math.floor(Number(reference.content?.dimensions?.width) || 0));
+    const height = Math.max(0, Math.floor(Number(reference.content?.dimensions?.height) || 0));
+    const src = runtimeMonsterAssetReferenceUrl(releaseId, referenceId);
+    byAssetKey[assetKey] = {
+      assetKey,
+      releaseId,
+      referenceId,
+      packageId: typeof reference.packageId === 'string' ? reference.packageId : '',
+      assetUploadId: typeof reference.assetUploadId === 'string' ? reference.assetUploadId : '',
+      target: { monsterId, branchId, stageId },
+      contentType: typeof reference.content?.contentType === 'string' ? reference.content.contentType : '',
+      byteSize: Math.max(0, Math.floor(Number(reference.content?.byteSize) || 0)),
+      width: width || null,
+      height: height || null,
+      src,
+    };
+  }
+
+  const referenceCount = Object.keys(byAssetKey).length;
+  if (!referenceCount) return null;
+  const hash = typeof manifest.hash === 'string' && manifest.hash
+    ? manifest.hash
+    : stableHash(byAssetKey);
+  return {
+    schemaVersion: 1,
+    source: 'content-operation-release',
+    releaseId,
+    hash,
+    referenceCount,
+    byAssetKey,
+  };
+}
+
+function attachRuntimeMonsterAssetReferencesToVisualConfig(monsterVisualConfig, runtimeAssetReferences = null) {
+  if (!runtimeAssetReferences) return monsterVisualConfig;
+  const output = isPlainObject(monsterVisualConfig) ? cloneSerialisable(monsterVisualConfig) : {};
+  output.assetReferenceHash = runtimeAssetReferences.hash || '';
+  output.runtimeAssetReferences = runtimeAssetReferences;
+  if (isPlainObject(output.config)) {
+    output.config = {
+      ...output.config,
+      runtimeAssetReferences,
+    };
+  } else {
+    output.config = { runtimeAssetReferences };
+  }
+  return output;
 }
 
 async function readSpellingRuntimeContentBundle(db, accountId, subjectId = 'spelling', {
@@ -7474,7 +7559,7 @@ async function bootstrapBundle(db, accountId, {
         : null,
     }),
   );
-  const monsterVisualConfig = fullMonsterVisualConfig || monsterVisualConfigPointer;
+  const baseMonsterVisualConfig = fullMonsterVisualConfig || monsterVisualConfigPointer;
   const membershipRows = await measureBootstrapPhase(capacity, BOOTSTRAP_PHASE_TIMING.membership, () => (
     listMembershipRows(db, accountId, { writableOnly: true })
   ));
@@ -7536,6 +7621,10 @@ async function bootstrapBundle(db, accountId, {
       readResolvedContentOperationReleaseRow(db, accountId, 'spelling')
     ))
     : null;
+  const monsterVisualConfig = attachRuntimeMonsterAssetReferencesToVisualConfig(
+    baseMonsterVisualConfig,
+    runtimeMonsterAssetReferencesFromReleaseRow(spellingContentReleaseRow),
+  );
 
   // U7: precompute the revision-envelope ingredients so that both the
   // empty and non-empty branches can stamp them consistently. These


### PR DESCRIPTION
## Summary
- add authenticated runtime routing for published monster image asset references from content operation release proof
- attach published runtime asset references to bootstrap monster visual config while preserving bundled fallback metadata
- wire image fallback handling across monster render surfaces and retain rollback asset references in release rollback proof

## Contract coverage
- T23: published monster asset references resolve before bundled/generated fallback
- T23: draft uploads stay out of learner bootstrap until package publish
- T23: release rollback retains asset references and old R2 objects remain addressable
- T23: missing remote objects return 404 while client renderers fall back to bundled assets

## Validation
- node --test tests/monster-visual-config.test.js
- node --test tests/monster-asset-upload-validation.test.js
- npm test
- npm run check
- pre-push npm test: 111861 pass, 0 fail, 12 skipped

## Review notes
- No lockfile, report, generated build metadata, or monster manifest churn is included.
- Local review found no blocker findings after adding a direct fallback-handler unit test.