### PR TITLE
Add content operations release history proof

### DIFF
--- a/src/platform/hubs/admin-content-operations.js
+++ b/src/platform/hubs/admin-content-operations.js
@@ -345,6 +345,104 @@ function releaseHasCallerProof(proof = null) {
   ));
 }
 
+function normaliseProofSurfaces(value = null) {
+  return asArray(value).map((entry) => {
+    const safe = isPlainObject(entry) ? entry : {};
+    return {
+      key: asString(safe.key),
+      label: asString(safe.label || safe.key),
+    };
+  }).filter((entry) => entry.key || entry.label);
+}
+
+function normaliseReleaseProductionProof(value = null) {
+  const safe = isPlainObject(value) ? value : {};
+  return {
+    status: asString(safe.status, 'unknown'),
+    hasCallerProof: Boolean(safe.hasCallerProof),
+    capturedAt: asTs(safe.capturedAt),
+    capturedByAccountId: asNullableString(safe.capturedByAccountId),
+    requiredSurfaces: normaliseProofSurfaces(safe.requiredSurfaces),
+    linkedSurfaces: normaliseProofSurfaces(safe.linkedSurfaces),
+    missingSurfaces: normaliseProofSurfaces(safe.missingSurfaces),
+  };
+}
+
+function normaliseReleaseChangedEntityPreview(value = null) {
+  const safe = isPlainObject(value) ? value : {};
+  return {
+    entityType: asString(safe.entityType, 'unknown'),
+    entityId: asString(safe.entityId, 'unknown'),
+    actionCount: Number(safe.actionCount) || 0,
+    actions: asArray(safe.actions).map((entry) => asString(entry)).filter(Boolean),
+    fields: asArray(safe.fields).map((entry) => asString(entry)).filter(Boolean),
+  };
+}
+
+function normaliseReleaseChangedEntities(value = null) {
+  const safe = isPlainObject(value) ? value : {};
+  return {
+    operationCount: Number(safe.operationCount) || 0,
+    entityCount: Number(safe.entityCount) || 0,
+    entityTypes: asArray(safe.entityTypes).map((entry) => {
+      const type = isPlainObject(entry) ? entry : {};
+      return {
+        entityType: asString(type.entityType, 'unknown'),
+        operationCount: Number(type.operationCount) || 0,
+        entityCount: Number(type.entityCount) || 0,
+      };
+    }),
+    actionCounts: isPlainObject(safe.actionCounts) ? { ...safe.actionCounts } : {},
+    fieldPaths: asArray(safe.fieldPaths).map((entry) => asString(entry)).filter(Boolean),
+    preview: asArray(safe.preview).map(normaliseReleaseChangedEntityPreview),
+  };
+}
+
+function normaliseReleaseAssetChanges(value = null) {
+  const safe = isPlainObject(value) ? value : {};
+  return {
+    uploadCount: Number(safe.uploadCount) || 0,
+    referenceCount: Number(safe.referenceCount) || 0,
+    hash: asString(safe.hash),
+    preview: asArray(safe.preview).map((entry) => {
+      const safeEntry = isPlainObject(entry) ? entry : {};
+      return {
+        assetUploadId: asString(safeEntry.assetUploadId),
+        referenceId: asString(safeEntry.referenceId),
+        assetKind: asString(safeEntry.assetKind),
+        monsterId: asString(safeEntry.monsterId),
+        branchId: asString(safeEntry.branchId),
+        stageId: asString(safeEntry.stageId),
+        validationStatus: asString(safeEntry.validationStatus),
+      };
+    }),
+  };
+}
+
+function normaliseContentOperationReleaseHistory(value = null) {
+  const safe = isPlainObject(value) ? value : {};
+  const contentPackage = isPlainObject(safe.package) ? safe.package : null;
+  return {
+    releaseId: asString(safe.releaseId),
+    package: contentPackage ? {
+      packageId: asString(contentPackage.packageId),
+      title: asString(contentPackage.title),
+      templateId: asString(contentPackage.templateId),
+      state: asString(contentPackage.state),
+    } : null,
+    approvedByAccountId: asNullableString(safe.approvedByAccountId),
+    approvedAt: asTs(safe.approvedAt),
+    approvalId: asNullableString(safe.approvalId),
+    candidateId: asNullableString(safe.candidateId),
+    candidateHash: asString(safe.candidateHash),
+    publishedByAccountId: asNullableString(safe.publishedByAccountId),
+    publishedAt: asTs(safe.publishedAt),
+    changedEntities: normaliseReleaseChangedEntities(safe.changedEntities),
+    assetChanges: normaliseReleaseAssetChanges(safe.assetChanges),
+    productionProof: normaliseReleaseProductionProof(safe.productionProof),
+  };
+}
+
 export function normaliseContentOperationRelease(entry = null) {
   const safe = isPlainObject(entry) ? entry : {};
   const proof = safe.proof ?? null;
@@ -380,6 +478,7 @@ export function normaliseContentOperationRelease(entry = null) {
         ? safe.assetReferenceManifest
         : proofAssets.assetReferenceManifest,
     ),
+    history: safe.history ? normaliseContentOperationReleaseHistory(safe.history) : null,
     createdAt: asTs(safe.createdAt),
   };
 }

--- a/src/platform/hubs/api.js
+++ b/src/platform/hubs/api.js
@@ -262,11 +262,14 @@ export function createHubApi({
         body: JSON.stringify({ version, expectedPublishedVersion, mutation }),
       }, authSession);
     },
-    async readContentOperationsOverview({ limit = 30 } = {}) {
+    async readContentOperationsOverview({ limit = 30, includeHistory = false } = {}) {
       const url = buildRequestUrl(
         baseUrl,
         '/api/admin/content-operations/subjects/spelling/overview',
-        { limit },
+        {
+          limit,
+          includeHistory: includeHistory ? 'true' : null,
+        },
       );
       return fetchHubJson(fetch, url, { method: 'GET' }, authSession);
     },
@@ -455,18 +458,19 @@ export function createHubApi({
         }),
       }, authSession);
     },
-    async readContentOperationReleases({ limit = 20, includeSnapshot = false } = {}) {
+    async readContentOperationReleases({ limit = 20, includeSnapshot = false, includeHistory = false } = {}) {
       const url = buildRequestUrl(
         baseUrl,
         '/api/admin/content-operations/subjects/spelling/releases',
         {
           limit,
           includeSnapshot: includeSnapshot ? 'true' : null,
+          includeHistory: includeHistory ? 'true' : null,
         },
       );
       return fetchHubJson(fetch, url, { method: 'GET' }, authSession);
     },
-    async readContentOperationRelease({ releaseId, includeSnapshot = false } = {}) {
+    async readContentOperationRelease({ releaseId, includeSnapshot = false, includeHistory = false } = {}) {
       if (!releaseId) throw new TypeError('Content operation release id is required.');
       const safeReleaseId = encodeURIComponent(String(releaseId));
       const url = buildRequestUrl(
@@ -474,9 +478,26 @@ export function createHubApi({
         `/api/admin/content-operations/subjects/spelling/releases/${safeReleaseId}`,
         {
           includeSnapshot: includeSnapshot ? 'true' : null,
+          includeHistory: includeHistory ? 'true' : null,
         },
       );
       return fetchHubJson(fetch, url, { method: 'GET' }, authSession);
+    },
+    async captureContentOperationReleaseProof({ releaseId, proof, includeSnapshot = false } = {}) {
+      if (!releaseId) throw new TypeError('Content operation release id is required.');
+      const safeReleaseId = encodeURIComponent(String(releaseId));
+      const url = buildRequestUrl(
+        baseUrl,
+        `/api/admin/content-operations/subjects/spelling/releases/${safeReleaseId}/proof`,
+        {
+          includeSnapshot: includeSnapshot ? 'true' : null,
+        },
+      );
+      return fetchHubJson(fetch, url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ proof }),
+      }, authSession);
     },
     async readAdminOpsKpi() {
       const url = buildRequestUrl(baseUrl, '/api/admin/ops/kpi');

--- a/src/surfaces/hubs/AdminContentOperationsSection.jsx
+++ b/src/surfaces/hubs/AdminContentOperationsSection.jsx
@@ -3831,6 +3831,46 @@ function PackageDetail({
   );
 }
 
+function releaseProofChipClass(status) {
+  if (status === 'recorded' || status === 'not_required') return 'good';
+  if (status === 'partial') return 'warn';
+  return 'warn';
+}
+
+function releaseProofLabel(status) {
+  if (status === 'recorded') return 'Recorded';
+  if (status === 'partial') return 'Partial';
+  if (status === 'missing') return 'Missing';
+  if (status === 'not_required') return 'Not required';
+  return 'Unknown';
+}
+
+function releaseSurfaceLabels(surfaces = []) {
+  return surfaces.map((surface) => surface.label || surface.key).filter(Boolean).join(', ');
+}
+
+function releaseChangedEntityLines(changedEntities = null) {
+  return (changedEntities?.preview || [])
+    .slice(0, 3)
+    .map((entry) => {
+      const actions = Array.isArray(entry.actions) && entry.actions.length ? entry.actions.join('/') : 'changed';
+      const fields = Array.isArray(entry.fields) && entry.fields.length ? entry.fields.join(', ') : '$';
+      return `${entry.entityType}:${entry.entityId} ${actions} ${fields}`;
+    });
+}
+
+function releaseAssetChangeLines(assetChanges = null) {
+  const uploadCount = Number(assetChanges?.uploadCount) || 0;
+  const referenceCount = Number(assetChanges?.referenceCount) || 0;
+  if (!uploadCount && !referenceCount) return [];
+  const lines = [`Assets ${uploadCount} uploads / ${referenceCount} references`];
+  for (const reference of (assetChanges?.preview || []).slice(0, 2)) {
+    const target = [reference.monsterId, reference.branchId, reference.stageId].filter(Boolean).join('/');
+    lines.push(target || reference.assetUploadId || reference.referenceId || 'asset reference');
+  }
+  return lines;
+}
+
 function ReleaseTable({ releases }) {
   if (!releases.length) {
     return (
@@ -3847,7 +3887,8 @@ function ReleaseTable({ releases }) {
             <th className="small admin-overview-th-first">Release</th>
             <th className="small admin-overview-th">Status</th>
             <th className="small admin-overview-th">Package</th>
-            <th className="small admin-overview-th">Published</th>
+            <th className="small admin-overview-th">Actors</th>
+            <th className="small admin-overview-th">Changed</th>
             <th className="small admin-overview-th">Audio</th>
             <th className="small admin-overview-th">Proof</th>
           </tr>
@@ -3862,8 +3903,27 @@ function ReleaseTable({ releases }) {
                 ?? fallback?.affectedMatrix?.affectedCount
                 ?? 0,
             ) || 0;
+            const history = release.history || null;
+            const changedEntities = history?.changedEntities || null;
+            const productionProof = history?.productionProof || null;
+            const proofStatus = productionProof?.status || (release.hasCallerProof ? 'recorded' : 'missing');
+            const missingSurfaces = releaseSurfaceLabels(productionProof?.missingSurfaces || []);
+            const linkedSurfaces = releaseSurfaceLabels(productionProof?.linkedSurfaces || []);
+            const capture = productionProof?.capturedAt
+              ? `Captured by ${productionProof.capturedByAccountId || 'unknown'} ${formatTimestamp(productionProof.capturedAt)}`
+              : '';
+            const entityTypeSummary = (changedEntities?.entityTypes || [])
+              .slice(0, 3)
+              .map((entry) => `${entry.entityType} ${entry.entityCount}`)
+              .join(', ');
+            const changedLines = releaseChangedEntityLines(changedEntities);
+            const assetLines = releaseAssetChangeLines(history?.assetChanges);
             return (
-              <tr key={release.releaseId} className="admin-overview-tbody-row">
+              <tr
+                key={release.releaseId}
+                className="admin-overview-tbody-row"
+                data-content-ops-release-history-row={release.releaseId}
+              >
                 <td className="admin-overview-td-first">
                   {release.releaseId}
                   <div className="small muted">{release.snapshotHash || 'hash pending'}</div>
@@ -3873,8 +3933,26 @@ function ReleaseTable({ releases }) {
                     {release.status}
                   </span>
                 </td>
-                <td className="admin-overview-td small">{release.packageId || 'seeded'}</td>
-                <td className="admin-overview-td small">{formatTimestamp(release.publishedAt || release.createdAt)}</td>
+                <td className="admin-overview-td small">
+                  {history?.package?.title || release.packageId || 'seeded'}
+                  <div className="small muted">{release.packageId || 'first release'}</div>
+                </td>
+                <td className="admin-overview-td small">
+                  <div>Published by {history?.publishedByAccountId || release.publishedByAccountId || 'unknown'}</div>
+                  <div className="small muted">{formatTimestamp(history?.publishedAt || release.publishedAt || release.createdAt)}</div>
+                  <div className="small muted">Approved by {history?.approvedByAccountId || 'n/a'}</div>
+                </td>
+                <td className="admin-overview-td small">
+                  <strong>{String(changedEntities?.entityCount || 0)} entities</strong>
+                  <div className="small muted">{String(changedEntities?.operationCount || 0)} operations</div>
+                  {entityTypeSummary ? <div className="small muted">{entityTypeSummary}</div> : null}
+                  {changedLines.map((line) => (
+                    <div className="small muted" key={line}>{line}</div>
+                  ))}
+                  {assetLines.map((line) => (
+                    <div className="small muted" key={line}>{line}</div>
+                  ))}
+                </td>
                 <td className="admin-overview-td">
                   {fallback?.allowed ? (
                     <div className="content-ops-release-audio">
@@ -3889,7 +3967,15 @@ function ReleaseTable({ releases }) {
                   )}
                 </td>
                 <td className="admin-overview-td">
-                  {release.hasCallerProof ? <span className="chip good">Recorded</span> : <span className="chip warn">Missing</span>}
+                  <span
+                    className={`chip ${releaseProofChipClass(proofStatus)}`}
+                    data-content-ops-release-proof-status={proofStatus}
+                  >
+                  {releaseProofLabel(proofStatus)}
+                  </span>
+                  {missingSurfaces ? <div className="small muted">Missing {missingSurfaces}</div> : null}
+                  {!missingSurfaces && linkedSurfaces ? <div className="small muted">{linkedSurfaces}</div> : null}
+                  {capture ? <div className="small muted">{capture}</div> : null}
                 </td>
               </tr>
             );
@@ -4181,9 +4267,9 @@ export function AdminContentOperationsSection({
     setRefreshError(null);
     try {
       const [nextOverview, nextPackages, nextReleases] = await Promise.all([
-        api.readOverview({ limit: 30 }),
+        api.readOverview({ limit: 30, includeHistory: true }),
         api.readPackages?.({ limit: 50 }),
-        api.readReleases?.({ limit: 20 }),
+        api.readReleases?.({ limit: 20, includeHistory: true }),
       ]);
       if (refreshRequestRef.current !== seq) return;
       setOverviewPayload(nextOverview);

--- a/tests/admin-content-operations-v2.test.js
+++ b/tests/admin-content-operations-v2.test.js
@@ -474,6 +474,7 @@ const CONTENT_OPS_OVERVIEW = {
       publishedAt: Date.UTC(2026, 5, 11, 9, 0, 0),
       proof: {
         source: 'test',
+        surfaces: { spellingSetup: {}, wordBank: {} },
         contentOperationsAudio: {
           audioFallback: {
             allowed: true,
@@ -484,6 +485,45 @@ const CONTENT_OPS_OVERVIEW = {
             status: 'warning',
             warnings: ['audio_fallback_approved', 'sentence_audio_missing'],
           },
+        },
+      },
+      history: {
+        releaseId: 'rel-global-1',
+        package: { packageId: 'pkg-published-1', title: 'Published word edit', templateId: 'edit-spelling-word', state: 'published' },
+        approvedByAccountId: 'admin-reviewer',
+        approvedAt: Date.UTC(2026, 5, 11, 8, 55, 0),
+        publishedByAccountId: 'admin-publisher',
+        publishedAt: Date.UTC(2026, 5, 11, 9, 0, 0),
+        changedEntities: {
+          operationCount: 1,
+          entityCount: 1,
+          entityTypes: [{ entityType: 'spelling.word', operationCount: 1, entityCount: 1 }],
+          actionCounts: { set: 1 },
+          fieldPaths: ['explanation'],
+          preview: [{ entityType: 'spelling.word', entityId: 'accident', actionCount: 1, actions: ['set'], fields: ['explanation'] }],
+        },
+        assetChanges: {
+          uploadCount: 1,
+          referenceCount: 1,
+          hash: 'asset-reference-proof-hash',
+          preview: [{
+            assetUploadId: 'coasset-proof-1',
+            referenceId: 'coref-proof-1',
+            assetKind: 'monster-image',
+            monsterId: 'inklet',
+            branchId: 'default',
+            stageId: 'base',
+            validationStatus: 'passed',
+          }],
+        },
+        productionProof: {
+          status: 'recorded',
+          hasCallerProof: true,
+          capturedAt: Date.UTC(2026, 5, 11, 9, 1, 0),
+          capturedByAccountId: 'admin-publisher',
+          requiredSurfaces: [{ key: 'spellingSetup', label: 'Spelling setup' }, { key: 'wordBank', label: 'Word Bank' }],
+          linkedSurfaces: [{ key: 'spellingSetup', label: 'Spelling setup' }, { key: 'wordBank', label: 'Word Bank' }],
+          missingSurfaces: [],
         },
       },
     },
@@ -502,6 +542,7 @@ const CONTENT_OPS_OVERVIEW = {
           publishedAt: Date.UTC(2026, 5, 11, 9, 0, 0),
           proof: {
             source: 'test',
+            surfaces: { spellingSetup: {}, wordBank: {} },
             contentOperationsAudio: {
               audioFallback: {
                 allowed: true,
@@ -512,6 +553,45 @@ const CONTENT_OPS_OVERVIEW = {
                 status: 'warning',
                 warnings: ['audio_fallback_approved', 'sentence_audio_missing'],
               },
+            },
+          },
+          history: {
+            releaseId: 'rel-global-1',
+            package: { packageId: 'pkg-published-1', title: 'Published word edit', templateId: 'edit-spelling-word', state: 'published' },
+            approvedByAccountId: 'admin-reviewer',
+            approvedAt: Date.UTC(2026, 5, 11, 8, 55, 0),
+            publishedByAccountId: 'admin-publisher',
+            publishedAt: Date.UTC(2026, 5, 11, 9, 0, 0),
+            changedEntities: {
+              operationCount: 1,
+              entityCount: 1,
+              entityTypes: [{ entityType: 'spelling.word', operationCount: 1, entityCount: 1 }],
+              actionCounts: { set: 1 },
+              fieldPaths: ['explanation'],
+              preview: [{ entityType: 'spelling.word', entityId: 'accident', actionCount: 1, actions: ['set'], fields: ['explanation'] }],
+            },
+            assetChanges: {
+              uploadCount: 1,
+              referenceCount: 1,
+              hash: 'asset-reference-proof-hash',
+              preview: [{
+                assetUploadId: 'coasset-proof-1',
+                referenceId: 'coref-proof-1',
+                assetKind: 'monster-image',
+                monsterId: 'inklet',
+                branchId: 'default',
+                stageId: 'base',
+                validationStatus: 'passed',
+              }],
+            },
+            productionProof: {
+              status: 'recorded',
+              hasCallerProof: true,
+              capturedAt: Date.UTC(2026, 5, 11, 9, 1, 0),
+              capturedByAccountId: 'admin-publisher',
+              requiredSurfaces: [{ key: 'spellingSetup', label: 'Spelling setup' }, { key: 'wordBank', label: 'Word Bank' }],
+              linkedSurfaces: [{ key: 'spellingSetup', label: 'Spelling setup' }, { key: 'wordBank', label: 'Word Bank' }],
+              missingSurfaces: [],
             },
           },
         },
@@ -686,6 +766,19 @@ describe('Content Operations Centre normalisers', () => {
     assert.equal(overview.recentReleases[0].audioFallback.allowed, true);
     assert.equal(overview.recentReleases[0].audioFallback.affectedMatrix.affectedCount, 1);
     assert.equal(overview.recentReleases[0].audioWarnings.status, 'warning');
+    assert.equal(overview.recentReleases[0].history.approvedByAccountId, 'admin-reviewer');
+    assert.equal(overview.recentReleases[0].history.publishedByAccountId, 'admin-publisher');
+    assert.equal(overview.recentReleases[0].history.changedEntities.entityCount, 1);
+    assert.equal(overview.recentReleases[0].history.changedEntities.preview[0].entityId, 'accident');
+    assert.equal(overview.recentReleases[0].history.assetChanges.uploadCount, 1);
+    assert.equal(overview.recentReleases[0].history.assetChanges.referenceCount, 1);
+    assert.equal(overview.recentReleases[0].history.assetChanges.preview[0].monsterId, 'inklet');
+    assert.equal(overview.recentReleases[0].history.productionProof.status, 'recorded');
+    assert.equal(overview.recentReleases[0].history.productionProof.capturedByAccountId, 'admin-publisher');
+    assert.deepEqual(
+      overview.recentReleases[0].history.productionProof.linkedSurfaces.map((entry) => entry.key),
+      ['spellingSetup', 'wordBank'],
+    );
     assert.equal(overview.actor.capabilities['content_operations.approve'], true);
   });
 
@@ -1023,6 +1116,7 @@ describe('Content Operations Centre hub API client', () => {
     });
 
     await api.readContentOperationsOverview({ limit: 7 });
+    await api.readContentOperationsOverview({ limit: 8, includeHistory: true });
     await api.readContentOperationPackages({ state: 'draft', limit: 11 });
     await api.readContentOperationPackage({ packageId: 'pkg/with/slash' });
     await api.readContentOperationSpellingBrowse({
@@ -1036,25 +1130,38 @@ describe('Content Operations Centre hub API client', () => {
     await api.readContentOperationSpellingSentence({ sentenceId: 'sentence/1', packageId: 'pkg/with/slash' });
     await api.readContentOperationReleases({ limit: 5, includeSnapshot: true });
     await api.readContentOperationRelease({ releaseId: 'rel/with/slash', includeSnapshot: true });
+    await api.readContentOperationReleases({ limit: 6, includeHistory: true });
+    await api.readContentOperationRelease({ releaseId: 'rel/with/slash', includeHistory: true });
 
     assert.equal(new URL(calls[0].url).pathname, '/api/admin/content-operations/subjects/spelling/overview');
     assert.equal(new URL(calls[0].url).searchParams.get('limit'), '7');
-    assert.equal(new URL(calls[1].url).pathname, '/api/admin/content-operations/packages');
-    assert.equal(new URL(calls[1].url).searchParams.get('state'), 'draft');
-    assert.equal(new URL(calls[2].url).pathname, '/api/admin/content-operations/packages/pkg%2Fwith%2Fslash');
-    assert.equal(new URL(calls[3].url).pathname, '/api/admin/content-operations/subjects/spelling/browse');
-    assert.equal(new URL(calls[3].url).searchParams.get('packageId'), 'pkg/with/slash');
-    assert.equal(new URL(calls[3].url).searchParams.get('query'), 'meta');
-    assert.equal(new URL(calls[3].url).searchParams.get('pool'), 'extra');
-    assert.equal(new URL(calls[3].url).searchParams.get('listId'), 'extra-greek');
-    assert.equal(new URL(calls[4].url).pathname, '/api/admin/content-operations/subjects/spelling/words/meta%2Fmorphosis');
+    assert.equal(new URL(calls[0].url).searchParams.get('includeHistory'), null);
+    assert.equal(new URL(calls[1].url).pathname, '/api/admin/content-operations/subjects/spelling/overview');
+    assert.equal(new URL(calls[1].url).searchParams.get('limit'), '8');
+    assert.equal(new URL(calls[1].url).searchParams.get('includeHistory'), 'true');
+    assert.equal(new URL(calls[2].url).pathname, '/api/admin/content-operations/packages');
+    assert.equal(new URL(calls[2].url).searchParams.get('state'), 'draft');
+    assert.equal(new URL(calls[3].url).pathname, '/api/admin/content-operations/packages/pkg%2Fwith%2Fslash');
+    assert.equal(new URL(calls[4].url).pathname, '/api/admin/content-operations/subjects/spelling/browse');
     assert.equal(new URL(calls[4].url).searchParams.get('packageId'), 'pkg/with/slash');
-    assert.equal(new URL(calls[5].url).pathname, '/api/admin/content-operations/subjects/spelling/sentences/sentence%2F1');
-    assert.equal(new URL(calls[6].url).pathname, '/api/admin/content-operations/subjects/spelling/releases');
-    assert.equal(new URL(calls[6].url).searchParams.get('includeSnapshot'), 'true');
-    assert.equal(new URL(calls[7].url).pathname, '/api/admin/content-operations/subjects/spelling/releases/rel%2Fwith%2Fslash');
+    assert.equal(new URL(calls[4].url).searchParams.get('query'), 'meta');
+    assert.equal(new URL(calls[4].url).searchParams.get('pool'), 'extra');
+    assert.equal(new URL(calls[4].url).searchParams.get('listId'), 'extra-greek');
+    assert.equal(new URL(calls[5].url).pathname, '/api/admin/content-operations/subjects/spelling/words/meta%2Fmorphosis');
+    assert.equal(new URL(calls[5].url).searchParams.get('packageId'), 'pkg/with/slash');
+    assert.equal(new URL(calls[6].url).pathname, '/api/admin/content-operations/subjects/spelling/sentences/sentence%2F1');
+    assert.equal(new URL(calls[7].url).pathname, '/api/admin/content-operations/subjects/spelling/releases');
     assert.equal(new URL(calls[7].url).searchParams.get('includeSnapshot'), 'true');
-    assert.deepEqual(calls.map((call) => call.method), ['GET', 'GET', 'GET', 'GET', 'GET', 'GET', 'GET', 'GET']);
+    assert.equal(new URL(calls[7].url).searchParams.get('includeHistory'), null);
+    assert.equal(new URL(calls[8].url).pathname, '/api/admin/content-operations/subjects/spelling/releases/rel%2Fwith%2Fslash');
+    assert.equal(new URL(calls[8].url).searchParams.get('includeSnapshot'), 'true');
+    assert.equal(new URL(calls[8].url).searchParams.get('includeHistory'), null);
+    assert.equal(new URL(calls[9].url).pathname, '/api/admin/content-operations/subjects/spelling/releases');
+    assert.equal(new URL(calls[9].url).searchParams.get('limit'), '6');
+    assert.equal(new URL(calls[9].url).searchParams.get('includeHistory'), 'true');
+    assert.equal(new URL(calls[10].url).pathname, '/api/admin/content-operations/subjects/spelling/releases/rel%2Fwith%2Fslash');
+    assert.equal(new URL(calls[10].url).searchParams.get('includeHistory'), 'true');
+    assert.deepEqual(calls.map((call) => call.method), ['GET', 'GET', 'GET', 'GET', 'GET', 'GET', 'GET', 'GET', 'GET', 'GET', 'GET']);
   });
 
   it('calls lifecycle mutation endpoints with package, candidate, and proof payloads', async () => {
@@ -1099,6 +1206,11 @@ describe('Content Operations Centre hub API client', () => {
       proof: { source: 'test' },
       mutation: { requestId: 'publish-1' },
     });
+    await api.captureContentOperationReleaseProof({
+      releaseId: 'rel/with/slash',
+      proof: { surfaces: { spellingSetup: { evidence: 'setup' } } },
+      includeSnapshot: true,
+    });
     await api.resolveContentOperationConflict({
       packageId: 'pkg/with/slash',
       conflictId: 'conflict/with/slash',
@@ -1111,8 +1223,10 @@ describe('Content Operations Centre hub API client', () => {
     assert.equal(new URL(calls[1].url).pathname, '/api/admin/content-operations/packages/pkg%2Fwith%2Fslash/generate-audio');
     assert.equal(new URL(calls[2].url).pathname, '/api/admin/content-operations/packages/pkg%2Fwith%2Fslash/approve');
     assert.equal(new URL(calls[3].url).pathname, '/api/admin/content-operations/packages/pkg%2Fwith%2Fslash/publish');
-    assert.equal(new URL(calls[4].url).pathname, '/api/admin/content-operations/packages/pkg%2Fwith%2Fslash/resolve-conflict');
-    assert.deepEqual(calls.map((call) => call.method), ['POST', 'POST', 'POST', 'POST', 'POST']);
+    assert.equal(new URL(calls[4].url).pathname, '/api/admin/content-operations/subjects/spelling/releases/rel%2Fwith%2Fslash/proof');
+    assert.equal(new URL(calls[4].url).searchParams.get('includeSnapshot'), 'true');
+    assert.equal(new URL(calls[5].url).pathname, '/api/admin/content-operations/packages/pkg%2Fwith%2Fslash/resolve-conflict');
+    assert.deepEqual(calls.map((call) => call.method), ['POST', 'POST', 'POST', 'POST', 'POST', 'POST']);
     assert.equal(calls[0].body.includeSnapshot, true);
     assert.equal(calls[1].body.candidateId, 'cand/with/slash');
     assert.deepEqual(calls[1].body.itemIds, ['word:meta:base:male.natural']);
@@ -1127,9 +1241,10 @@ describe('Content Operations Centre hub API client', () => {
     );
     assert.equal(Object.prototype.hasOwnProperty.call(calls[2].body, 'assetSummary'), false);
     assert.equal(calls[3].body.proof.source, 'test');
-    assert.equal(calls[4].body.conflictId, 'conflict/with/slash');
-    assert.equal(calls[4].body.resolution, 'edit');
-    assert.equal(calls[4].body.value, 'Merged value.');
+    assert.equal(calls[4].body.proof.surfaces.spellingSetup.evidence, 'setup');
+    assert.equal(calls[5].body.conflictId, 'conflict/with/slash');
+    assert.equal(calls[5].body.resolution, 'edit');
+    assert.equal(calls[5].body.value, 'Merged value.');
   });
 
   it('calls content operation append and delete endpoints', async () => {

--- a/tests/content-operations-api.test.js
+++ b/tests/content-operations-api.test.js
@@ -1401,7 +1401,14 @@ test('content operations API supports admin package lifecycle through separate a
       ADMIN_ID,
       `${BASE_URL}/api/admin/content-operations/packages/${packageId}/publish`,
       jsonInit('POST', {
-        proof: { source: 'content-operations-api-test', reviewer: ADMIN_ID },
+        proof: {
+          source: 'content-operations-api-test',
+          reviewer: ADMIN_ID,
+          surfaces: {
+            spellingSetup: { evidence: 'setup-smoke' },
+            wordBank: { evidence: 'word-bank-smoke' },
+          },
+        },
       }),
       adminHeaders(),
     );
@@ -1409,10 +1416,99 @@ test('content operations API supports admin package lifecycle through separate a
     assert.equal(publishResponse.status, 200);
     assert.equal(published.release.packageId, packageId);
     assert.equal(published.release.publishedByAccountId, ADMIN_ID);
+    assert.equal(published.release.history.approvedByAccountId, ADMIN_ID);
+    assert.equal(published.release.history.publishedByAccountId, ADMIN_ID);
+    assert.equal(published.release.history.changedEntities.operationCount, 1);
+    assert.equal(published.release.history.changedEntities.entityCount, 1);
+    assert.equal(published.release.history.changedEntities.entityTypes[0].entityType, 'spelling.word');
+    assert.equal(published.release.history.changedEntities.preview[0].entityId, word.slug);
+    assert.equal(published.release.history.changedEntities.preview[0].actions[0], 'set');
+    assert.equal(published.release.history.changedEntities.preview[0].fields[0], 'explanation');
+    assert.equal(published.release.history.productionProof.status, 'partial');
+    assert.deepEqual(
+      published.release.history.productionProof.missingSurfaces.map((entry) => entry.key).sort(),
+      ['spellingSetup', 'wordBank'].sort(),
+    );
+
+    const capturedResponse = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/subjects/spelling/releases/${published.release.releaseId}/proof`,
+      jsonInit('POST', {
+        proof: {
+          source: 'content-operations-api-test',
+          surfaces: {
+            spellingSetup: { evidence: 'setup-smoke' },
+            wordBank: { evidence: 'word-bank-smoke' },
+          },
+        },
+      }),
+      adminHeaders(),
+    );
+    const captured = await readPayload(capturedResponse);
+    assert.equal(capturedResponse.status, 200);
+    assert.equal(captured.release.history.productionProof.status, 'recorded');
+    assert.equal(captured.release.history.productionProof.capturedByAccountId, ADMIN_ID);
+    assert.deepEqual(
+      captured.release.history.productionProof.linkedSurfaces.map((entry) => entry.key).sort(),
+      ['spellingSetup', 'wordBank'].sort(),
+    );
+
+    const proofWithAssetChanges = {
+      ...captured.release.proof,
+      contentOperationsAssets: {
+        assetSummary: {
+          uploadCount: 1,
+          hash: 'asset-proof-hash',
+        },
+        assetReferenceManifest: {
+          referenceCount: 1,
+          hash: 'asset-reference-proof-hash',
+          references: [{
+            assetUploadId: 'coasset-proof-1',
+            referenceId: 'coref-proof-1',
+            assetKind: 'monster-image',
+            target: {
+              monsterId: 'inklet',
+              branchId: 'default',
+              stageId: 'base',
+            },
+            validation: { status: 'passed' },
+          }],
+        },
+      },
+    };
+    server.DB.db.prepare(`
+      UPDATE content_operation_releases
+      SET proof_json = ?
+      WHERE release_id = ?
+    `).run(JSON.stringify(proofWithAssetChanges), captured.release.releaseId);
+
+    const capturedAssetProofResponse = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/subjects/spelling/releases/${published.release.releaseId}/proof`,
+      jsonInit('POST', {
+        proof: {
+          source: 'content-operations-api-test',
+          surfaces: {
+            spellingSetup: { evidence: 'setup-smoke' },
+            wordBank: { evidence: 'word-bank-smoke' },
+            monsterRendering: { evidence: 'monster-rendering-smoke' },
+          },
+        },
+      }),
+      adminHeaders(),
+    );
+    const capturedAssetProof = await readPayload(capturedAssetProofResponse);
+    assert.equal(capturedAssetProofResponse.status, 200);
+    assert.equal(capturedAssetProof.release.history.productionProof.status, 'recorded');
+    assert.deepEqual(
+      capturedAssetProof.release.history.productionProof.linkedSurfaces.map((entry) => entry.key).sort(),
+      ['monsterRendering', 'spellingSetup', 'wordBank'].sort(),
+    );
 
     const releaseDetailResponse = await server.fetchAs(
       ADMIN_ID,
-      `${BASE_URL}/api/admin/content-operations/subjects/spelling/releases/${published.release.releaseId}?includeSnapshot=true`,
+      `${BASE_URL}/api/admin/content-operations/subjects/spelling/releases/${published.release.releaseId}?includeSnapshot=true&includeHistory=true`,
       { method: 'GET', headers: { 'sec-fetch-site': 'same-origin' } },
       adminHeaders(),
     );
@@ -1422,6 +1518,23 @@ test('content operations API supports admin package lifecycle through separate a
       releaseDetail.release.snapshot.draft.words.find((entry) => entry.slug === word.slug).explanation,
       explanation,
     );
+    assert.equal(releaseDetail.release.history.package.title, 'API spelling edit package renamed');
+    assert.equal(releaseDetail.release.history.approvedByAccountId, ADMIN_ID);
+    assert.equal(releaseDetail.release.history.productionProof.status, 'recorded');
+    assert.equal(releaseDetail.release.history.assetChanges.uploadCount, 1);
+    assert.equal(releaseDetail.release.history.assetChanges.referenceCount, 1);
+    assert.equal(releaseDetail.release.history.assetChanges.preview[0].monsterId, 'inklet');
+    assert.equal(releaseDetail.release.history.assetChanges.preview[0].validationStatus, 'passed');
+
+    const defaultReleaseDetailResponse = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/subjects/spelling/releases/${published.release.releaseId}`,
+      { method: 'GET', headers: { 'sec-fetch-site': 'same-origin' } },
+      adminHeaders(),
+    );
+    const defaultReleaseDetail = await readPayload(defaultReleaseDetailResponse);
+    assert.equal(defaultReleaseDetailResponse.status, 200);
+    assert.equal(defaultReleaseDetail.release.history, null);
 
     const detailResponse = await server.fetchAs(
       ADMIN_ID,
@@ -1443,15 +1556,131 @@ test('content operations API supports admin package lifecycle through separate a
 
     const overviewResponse = await server.fetchAs(
       ADMIN_ID,
-      `${BASE_URL}/api/admin/content-operations/subjects/spelling/overview`,
+      `${BASE_URL}/api/admin/content-operations/subjects/spelling/overview?includeHistory=true`,
       { method: 'GET', headers: { 'sec-fetch-site': 'same-origin' } },
       adminHeaders(),
     );
     const overview = await readPayload(overviewResponse);
     assert.equal(overviewResponse.status, 200);
     assert.equal(overview.overview.latestRelease.releaseId, published.release.releaseId);
+    assert.equal(overview.overview.latestRelease.history.productionProof.status, 'recorded');
+    assert.equal(overview.overview.lanes.recentReleases[0].history.changedEntities.preview[0].entityId, word.slug);
     assert.equal(overview.overview.actor.capabilities['content_operations.approve'], true);
     assert.equal(overview.overview.actor.capabilities['content_operations.publish'], true);
+
+    const releaseListResponse = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/subjects/spelling/releases?includeHistory=true`,
+      { method: 'GET', headers: { 'sec-fetch-site': 'same-origin' } },
+      adminHeaders(),
+    );
+    const releaseList = await readPayload(releaseListResponse);
+    assert.equal(releaseListResponse.status, 200);
+    assert.equal(releaseList.releases[0].history.releaseId, captured.release.releaseId);
+    assert.equal(releaseList.releases[0].history.productionProof.status, 'recorded');
+    assert.equal(releaseList.releases[0].history.assetChanges.preview[0].monsterId, 'inklet');
+
+    const defaultReleaseListResponse = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/subjects/spelling/releases`,
+      { method: 'GET', headers: { 'sec-fetch-site': 'same-origin' } },
+      adminHeaders(),
+    );
+    const defaultReleaseList = await readPayload(defaultReleaseListResponse);
+    assert.equal(defaultReleaseListResponse.status, 200);
+    assert.equal(defaultReleaseList.releases[0].history, null);
+
+    const defaultOverviewResponse = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/subjects/spelling/overview`,
+      { method: 'GET', headers: { 'sec-fetch-site': 'same-origin' } },
+      adminHeaders(),
+    );
+    const defaultOverview = await readPayload(defaultOverviewResponse);
+    assert.equal(defaultOverviewResponse.status, 200);
+    assert.equal(defaultOverview.overview.latestRelease.history, null);
+  } finally {
+    server.close();
+  }
+});
+
+test('content operations API requires Hero / Codex proof for hero exposure releases', async () => {
+  const server = createWorkerRepositoryServer({ now: () => NOW });
+  try {
+    seedAdultAccount(server.DB, { accountId: ADMIN_ID, platformRole: 'admin' });
+    const repository = createWorkerRepository({
+      env: server.env,
+      now: () => NOW,
+    });
+    await repository.seedFirstContentOperationRelease({
+      seededByAccountId: ADMIN_ID,
+      proof: { source: 'content-operations-api-hero-proof-test' },
+    });
+    const seeded = await readSeededSpellingContentBundle();
+    const rewardTrack = seeded.draft.rewardTracks[0];
+    assert.ok(rewardTrack, 'seeded spelling content should include a reward track');
+
+    const created = await createPackage(server, { title: 'Hero exposure proof package' });
+    await appendContentOperation(server, created.package.packageId, {
+      entityType: 'spelling.heroExposure',
+      entityId: rewardTrack.id,
+      fieldPath: '',
+      action: 'upsert',
+      payload: {
+        state: 'scheduled',
+        surfaces: ['heroCamp', 'codex'],
+        scheduledAt: NOW + 60_000,
+        rolloutFlag: 'content-operations-api-hero-proof',
+        previewAllowed: true,
+      },
+    });
+
+    const validated = await validatePackage(server, created.package.packageId);
+    assert.equal(validated.candidate.validation.status, 'passed');
+    const approved = await approvePackage(server, created.package.packageId, validated.candidate.candidateId);
+    assert.equal(approved.approval.approvedByAccountId, ADMIN_ID);
+
+    const published = await publishPackage(server, created.package.packageId, {
+      proof: {
+        surfaces: {
+          spellingSetup: { evidence: 'setup-smoke' },
+          wordBank: { evidence: 'word-bank-smoke' },
+        },
+      },
+    });
+    assert.equal(published.release.history.productionProof.status, 'partial');
+    assert.deepEqual(
+      published.release.history.productionProof.missingSurfaces.map((entry) => entry.key).sort(),
+      ['heroCodex', 'spellingSetup', 'wordBank'].sort(),
+    );
+    assert.ok(
+      published.release.history.changedEntities.preview.some((entry) => (
+        entry.entityType === 'spelling.heroExposure'
+          && entry.entityId === rewardTrack.id
+      )),
+    );
+
+    const capturedResponse = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/subjects/spelling/releases/${published.release.releaseId}/proof`,
+      jsonInit('POST', {
+        proof: {
+          surfaces: {
+            spellingSetup: { evidence: 'setup-smoke' },
+            wordBank: { evidence: 'word-bank-smoke' },
+            heroCodex: { evidence: 'codex-and-hero-smoke' },
+          },
+        },
+      }),
+      adminHeaders(),
+    );
+    const captured = await readPayload(capturedResponse);
+    assert.equal(capturedResponse.status, 200);
+    assert.equal(captured.release.history.productionProof.status, 'recorded');
+    assert.deepEqual(
+      captured.release.history.productionProof.linkedSurfaces.map((entry) => entry.key).sort(),
+      ['heroCodex', 'spellingSetup', 'wordBank'].sort(),
+    );
   } finally {
     server.close();
   }

--- a/tests/content-operations-repository.test.js
+++ b/tests/content-operations-repository.test.js
@@ -1044,3 +1044,49 @@ test('content operations repository orders latest releases deterministically on 
     DB.close();
   }
 });
+
+test('content operations repository batches release history enrichment', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const repository = createWorkerRepository({
+    env: { DB },
+    now: () => 1_777_000_000_000,
+  });
+
+  try {
+    const seeded = await readSeededSpellingContentBundle();
+    const words = seeded.draft.words.slice(0, 4);
+    assert.equal(words.length, 4);
+
+    for (const [index, word] of words.entries()) {
+      await publishWordEdit(repository, word, {
+        actorAccountId: `admin-${index}`,
+        title: `Batch history package ${index + 1}`,
+        payload: `Batch history explanation ${index + 1} for ${word.word}.`,
+      });
+    }
+
+    DB.clearQueryLog();
+    const releases = await repository.listContentOperationReleases({
+      subjectId: 'spelling',
+      includeHistory: true,
+      limit: 10,
+    });
+    const queryLog = DB.takeQueryLog();
+
+    assert.ok(releases.length >= 4);
+    assert.equal(releases[0].history.package.title, 'Batch history package 4');
+    assert.equal(releases[0].history.changedEntities.preview[0].entityType, 'spelling.word');
+    assert.ok(releases.every((release) => release.history));
+
+    const historyReads = queryLog.filter((entry) => (
+      entry.operation === 'all'
+        && /FROM content_operation_(releases|packages|package_approvals|package_operations)\b/i.test(entry.sql)
+    ));
+    assert.equal(historyReads.length, 4);
+    assert.equal(historyReads.filter((entry) => /FROM content_operation_packages\b/i.test(entry.sql)).length, 1);
+    assert.equal(historyReads.filter((entry) => /FROM content_operation_package_approvals\b/i.test(entry.sql)).length, 1);
+    assert.equal(historyReads.filter((entry) => /FROM content_operation_package_operations\b/i.test(entry.sql)).length, 1);
+  } finally {
+    DB.close();
+  }
+});

--- a/tests/monster-asset-upload-validation.test.js
+++ b/tests/monster-asset-upload-validation.test.js
@@ -919,7 +919,7 @@ test('published monster image assets are runtime-readable with draft isolation a
   }
 });
 
-test('monster image release serialisation distinguishes caller proof from server asset proof', () => {
+test('monster image release serialisation distinguishes caller proof from server proof metadata', () => {
   const release = serialiseContentOperationRelease({
     releaseId: 'rel-server-asset-proof',
     subjectId: 'spelling',
@@ -945,6 +945,12 @@ test('monster image release serialisation distinguishes caller proof from server
             preview: { kind: 'admin-api-handle', url: '/api/admin/content-operations/packages/pkg-asset/monster-assets/coasset-1/preview' },
           }],
         },
+      },
+      productionProof: {
+        releaseId: 'rel-server-asset-proof',
+        capturedAt: NOW + 1,
+        capturedByAccountId: ADMIN_ID,
+        surfaces: ['monsterRendering'],
       },
     },
   });

--- a/tests/react-admin-content-operations.test.js
+++ b/tests/react-admin-content-operations.test.js
@@ -263,6 +263,7 @@ const release = {
   publishedAt: Date.UTC(2026, 5, 11, 9, 0, 0),
   proof: {
     source: 'test',
+    surfaces: { spellingSetup: {}, wordBank: {} },
     contentOperationsAudio: {
       audioFallback: {
         allowed: true,
@@ -273,6 +274,45 @@ const release = {
         status: 'warning',
         warnings: ['audio_fallback_approved', 'sentence_audio_missing'],
       },
+    },
+  },
+  history: {
+    releaseId: 'rel-global-1',
+    package: { packageId: 'pkg-published-1', title: 'Published word edit', templateId: 'edit-spelling-word', state: 'published' },
+    approvedByAccountId: 'admin-reviewer',
+    approvedAt: Date.UTC(2026, 5, 11, 8, 55, 0),
+    publishedByAccountId: 'admin-publisher',
+    publishedAt: Date.UTC(2026, 5, 11, 9, 0, 0),
+    changedEntities: {
+      operationCount: 1,
+      entityCount: 1,
+      entityTypes: [{ entityType: 'spelling.word', operationCount: 1, entityCount: 1 }],
+      actionCounts: { set: 1 },
+      fieldPaths: ['explanation'],
+      preview: [{ entityType: 'spelling.word', entityId: 'accident', actionCount: 1, actions: ['set'], fields: ['explanation'] }],
+    },
+    assetChanges: {
+      uploadCount: 1,
+      referenceCount: 1,
+      hash: 'asset-reference-proof-hash',
+      preview: [{
+        assetUploadId: 'coasset-proof-1',
+        referenceId: 'coref-proof-1',
+        assetKind: 'monster-image',
+        monsterId: 'inklet',
+        branchId: 'default',
+        stageId: 'base',
+        validationStatus: 'passed',
+      }],
+    },
+    productionProof: {
+      status: 'recorded',
+      hasCallerProof: true,
+      capturedAt: Date.UTC(2026, 5, 11, 9, 1, 0),
+      capturedByAccountId: 'admin-publisher',
+      requiredSurfaces: [{ key: 'spellingSetup', label: 'Spelling setup' }, { key: 'wordBank', label: 'Word Bank' }],
+      linkedSurfaces: [{ key: 'spellingSetup', label: 'Spelling setup' }, { key: 'wordBank', label: 'Word Bank' }],
+      missingSurfaces: [],
     },
   },
 };
@@ -693,6 +733,16 @@ test('Content Operations Centre release history shows approved audio fallback wa
   assert.match(html, /Audio fallback/);
   assert.match(html, /1 affected/);
   assert.match(html, /sentence_audio_missing/);
+  assert.match(html, /Published by admin-publisher/);
+  assert.match(html, /Approved by admin-reviewer/);
+  assert.match(html, /1 entities/);
+  assert.match(html, /1 operations/);
+  assert.match(html, /spelling\.word:accident set explanation/);
+  assert.match(html, /Assets 1 uploads \/ 1 references/);
+  assert.match(html, /inklet\/default\/base/);
+  assert.match(html, /data-content-ops-release-proof-status="recorded"/);
+  assert.match(html, /Spelling setup, Word Bank/);
+  assert.match(html, /Captured by admin-publisher/);
 });
 
 test('Content Operations Centre SSR renders package-scoped domain tabs and audit state', async () => {
@@ -929,9 +979,9 @@ test('Content Operations Centre mounted shell loads API data without implicit pa
   const result = JSON.parse(output);
 
   assert.deepEqual(result.calls, [
-    { method: 'overview', args: { limit: 30 } },
+    { method: 'overview', args: { limit: 30, includeHistory: true } },
     { method: 'packages', args: { limit: 50 } },
-    { method: 'releases', args: { limit: 20 } },
+    { method: 'releases', args: { limit: 20, includeHistory: true } },
   ]);
   assert.match(result.overviewText, /Word family update/);
   assert.match(result.overviewText, /Audio \/ asset warnings/);

--- a/worker/src/content-operations/repository.js
+++ b/worker/src/content-operations/repository.js
@@ -328,6 +328,7 @@ const AUDIO_FALLBACK_BLOCKING_STATUSES = new Set([
 ]);
 const RELEASE_AUDIO_PROOF_KEY = 'contentOperationsAudio';
 const RELEASE_ASSET_PROOF_KEY = 'contentOperationsAssets';
+const RELEASE_PRODUCTION_PROOF_KEY = 'productionProof';
 const RELEASE_PROOF_RESERVED_KEYS = new Set([
   'audioFallback',
   'audioWarnings',
@@ -335,6 +336,18 @@ const RELEASE_PROOF_RESERVED_KEYS = new Set([
   'assetWarnings',
   RELEASE_AUDIO_PROOF_KEY,
   RELEASE_ASSET_PROOF_KEY,
+  RELEASE_PRODUCTION_PROOF_KEY,
+]);
+const PRODUCTION_PROOF_SURFACES = Object.freeze([
+  { key: 'spellingSetup', label: 'Spelling setup', aliases: ['spellingSetup', 'spelling-setup', 'setup'] },
+  { key: 'wordBank', label: 'Word Bank', aliases: ['wordBank', 'word-bank', 'wordbank'] },
+  { key: 'heroCodex', label: 'Hero / Codex', aliases: ['heroCodex', 'hero-codex', 'codex', 'hero'] },
+  { key: 'monsterRendering', label: 'Monster rendering', aliases: ['monsterRendering', 'monster-rendering', 'monster', 'monsters'] },
+]);
+const PRODUCTION_PROOF_RESERVED_KEYS = new Set([
+  RELEASE_AUDIO_PROOF_KEY,
+  RELEASE_ASSET_PROOF_KEY,
+  RELEASE_PRODUCTION_PROOF_KEY,
 ]);
 
 function audioFallbackBlockingItems(scan = null) {
@@ -531,7 +544,7 @@ function normaliseCallerReleaseProof(proof = null) {
   if (!isPlainObject(proof)) return { value: proof };
   const reservedKeys = Object.keys(proof).filter((key) => RELEASE_PROOF_RESERVED_KEYS.has(key));
   if (reservedKeys.length) {
-    throw new BadRequestError('Content operation release proof contains reserved audio metadata keys.', {
+    throw new BadRequestError('Content operation release proof contains reserved metadata keys.', {
       code: 'content_operation_release_proof_reserved_key',
       reservedKeys,
     });
@@ -569,6 +582,348 @@ function releaseAssetProofFromProof(proof = null) {
   return {
     assetSummary: isPlainObject(metadata?.assetSummary) ? metadata.assetSummary : null,
     assetReferenceManifest: isPlainObject(metadata?.assetReferenceManifest) ? metadata.assetReferenceManifest : null,
+  };
+}
+
+function proofHasCallerMetadata(proof = null) {
+  if (!isPlainObject(proof)) return false;
+  return Object.keys(proof).some((key) => !PRODUCTION_PROOF_RESERVED_KEYS.has(key));
+}
+
+function normaliseProofSurfaceKey(value) {
+  const raw = normaliseString(value);
+  if (!raw) return '';
+  const comparable = raw.toLowerCase().replace(/[^a-z0-9]/g, '');
+  for (const surface of PRODUCTION_PROOF_SURFACES) {
+    const candidates = [surface.key, ...surface.aliases];
+    if (candidates.some((candidate) => candidate.toLowerCase().replace(/[^a-z0-9]/g, '') === comparable)) {
+      return surface.key;
+    }
+  }
+  return '';
+}
+
+function proofSurfaceKeysFromValue(value, keys = new Set()) {
+  if (typeof value === 'string') {
+    const key = normaliseProofSurfaceKey(value);
+    if (key) keys.add(key);
+    return keys;
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      if (typeof entry === 'string') {
+        proofSurfaceKeysFromValue(entry, keys);
+      } else if (isPlainObject(entry)) {
+        proofSurfaceKeysFromValue(entry.key || entry.id || entry.surface || entry.name, keys);
+      }
+    }
+    return keys;
+  }
+  if (isPlainObject(value)) {
+    for (const [rawKey, entry] of Object.entries(value)) {
+      if (entry === false || entry == null) continue;
+      const key = normaliseProofSurfaceKey(rawKey);
+      if (key) keys.add(key);
+      if (isPlainObject(entry)) {
+        proofSurfaceKeysFromValue(entry.key || entry.id || entry.surface || entry.name, keys);
+      }
+    }
+  }
+  return keys;
+}
+
+function proofSurfaceEvidenceEntriesFromValue(value, entries = new Map()) {
+  if (typeof value === 'string') {
+    const key = normaliseProofSurfaceKey(value);
+    if (key && !entries.has(key)) entries.set(key, {});
+    return entries;
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      if (typeof entry === 'string') {
+        proofSurfaceEvidenceEntriesFromValue(entry, entries);
+      } else if (isPlainObject(entry)) {
+        const key = normaliseProofSurfaceKey(entry.key || entry.id || entry.surface || entry.name);
+        if (key && !entries.has(key)) entries.set(key, cloneSerialisable(entry));
+      }
+    }
+    return entries;
+  }
+  if (isPlainObject(value)) {
+    for (const [rawKey, entry] of Object.entries(value)) {
+      if (entry === false || entry == null) continue;
+      const key = normaliseProofSurfaceKey(rawKey);
+      if (key && !entries.has(key)) {
+        entries.set(key, isPlainObject(entry) ? cloneSerialisable(entry) : {});
+      }
+      if (isPlainObject(entry)) {
+        const nestedKey = normaliseProofSurfaceKey(entry.key || entry.id || entry.surface || entry.name);
+        if (nestedKey && !entries.has(nestedKey)) entries.set(nestedKey, cloneSerialisable(entry));
+      }
+    }
+  }
+  return entries;
+}
+
+function productionProofCaptureForRelease(proof = null, release = {}) {
+  if (!isPlainObject(proof)) return null;
+  const capture = isPlainObject(proof[RELEASE_PRODUCTION_PROOF_KEY])
+    ? proof[RELEASE_PRODUCTION_PROOF_KEY]
+    : null;
+  if (!capture) return null;
+  const releaseId = normaliseString(capture.releaseId);
+  if (!releaseId || releaseId !== release.releaseId) return null;
+  const capturedAt = Number(capture.capturedAt) || 0;
+  const publishedAt = Number(release.publishedAt) || 0;
+  if (!capturedAt || (publishedAt && capturedAt < publishedAt)) return null;
+  return {
+    ...capture,
+    capturedAt,
+    capturedByAccountId: normaliseString(capture.capturedByAccountId) || null,
+  };
+}
+
+function productionProofSurfaceKeys(proof = null, release = {}) {
+  const capture = productionProofCaptureForRelease(proof, release);
+  if (!capture) return [];
+  const keys = new Set();
+  proofSurfaceKeysFromValue(capture.surfaces, keys);
+  proofSurfaceKeysFromValue(capture.surfaceProof, keys);
+  return [...keys];
+}
+
+function surfaceDescriptor(key) {
+  const surface = PRODUCTION_PROOF_SURFACES.find((entry) => entry.key === key);
+  return surface || { key, label: key };
+}
+
+function surfaceCaptureDescriptor(key, capture = null) {
+  return {
+    ...surfaceDescriptor(key),
+    capturedAt: Number(capture?.capturedAt) || null,
+    capturedByAccountId: capture?.capturedByAccountId || null,
+  };
+}
+
+function isPoolVisibilityChange(operation = {}) {
+  if (operation.entityType !== 'spelling.pool') return false;
+  if (operation.fieldPath === 'visibility' || operation.fieldPath === 'rewardTrack' || operation.fieldPath === 'noRewardException') return true;
+  return isPlainObject(operation.payload)
+    && (
+      isPlainObject(operation.payload.visibility)
+      || isPlainObject(operation.payload.rewardTrack)
+      || isPlainObject(operation.payload.noRewardException)
+    );
+}
+
+function isHeroCodexVisibilityChange(operation = {}) {
+  const entityType = normaliseString(operation.entityType);
+  const fieldPath = normaliseString(operation.fieldPath);
+  if (entityType === 'spelling.heroExposure' || entityType === 'spelling.visibilityRule') return true;
+  if (isPoolVisibilityChange(operation)) return true;
+  if (entityType !== 'spelling.rewardTrack') return false;
+  if (fieldPath === 'heroExposure' || fieldPath.startsWith('heroExposure.')) return true;
+  return isPlainObject(operation.payload) && isPlainObject(operation.payload.heroExposure);
+}
+
+function requiredProductionProofSurfaceKeys(operations = [], release = {}) {
+  const required = new Set();
+  if (operations.some((operation) => normaliseString(operation.entityType).startsWith('spelling.'))) {
+    required.add('spellingSetup');
+    required.add('wordBank');
+  }
+  if (operations.some(isHeroCodexVisibilityChange)) {
+    required.add('heroCodex');
+  }
+  const assetReferenceCount = Number(release.assetReferenceManifest?.referenceCount) || 0;
+  const assetUploadCount = Number(release.assetSummary?.uploadCount) || 0;
+  if (assetReferenceCount > 0 || assetUploadCount > 0) {
+    required.add('monsterRendering');
+  }
+  return [...required];
+}
+
+function summariseContentOperationChanges(operations = []) {
+  const entities = new Map();
+  const entityTypeCounts = new Map();
+  const actionCounts = {};
+  const fieldPaths = new Set();
+  for (const operation of operations) {
+    const entityType = normaliseString(operation.entityType, 'unknown');
+    const entityId = normaliseString(operation.entityId, 'unknown');
+    const key = `${entityType}:${entityId}`;
+    if (!entities.has(key)) {
+      entities.set(key, {
+        entityType,
+        entityId,
+        actionCount: 0,
+        actions: [],
+        fields: [],
+      });
+    }
+    const entry = entities.get(key);
+    const action = normaliseString(operation.action, 'unknown');
+    const fieldPath = normaliseString(operation.fieldPath || '$', '$');
+    entry.actionCount += 1;
+    if (!entry.actions.includes(action)) entry.actions.push(action);
+    if (!entry.fields.includes(fieldPath)) entry.fields.push(fieldPath);
+    entityTypeCounts.set(entityType, (entityTypeCounts.get(entityType) || 0) + 1);
+    actionCounts[action] = (actionCounts[action] || 0) + 1;
+    fieldPaths.add(fieldPath);
+  }
+  return {
+    operationCount: operations.length,
+    entityCount: entities.size,
+    entityTypes: [...entityTypeCounts.entries()].map(([entityType, operationCount]) => ({
+      entityType,
+      operationCount,
+      entityCount: [...entities.values()].filter((entry) => entry.entityType === entityType).length,
+    })),
+    actionCounts,
+    fieldPaths: [...fieldPaths],
+    preview: [...entities.values()].slice(0, 12),
+  };
+}
+
+function summariseReleaseAssetChanges(release = {}) {
+  const assetSummary = isPlainObject(release.assetSummary) ? release.assetSummary : null;
+  const assetReferenceManifest = isPlainObject(release.assetReferenceManifest) ? release.assetReferenceManifest : null;
+  const references = asArray(assetReferenceManifest?.references).map((reference) => {
+    const target = isPlainObject(reference?.target) ? reference.target : {};
+    return {
+      assetUploadId: normaliseString(reference?.assetUploadId),
+      referenceId: normaliseString(reference?.referenceId),
+      assetKind: normaliseString(reference?.assetKind),
+      monsterId: normaliseString(target.monsterId),
+      branchId: normaliseString(target.branchId),
+      stageId: normaliseString(target.stageId),
+      validationStatus: normaliseString(reference?.validation?.status),
+    };
+  }).filter((reference) => reference.assetUploadId || reference.referenceId || reference.monsterId);
+  return {
+    uploadCount: Number(assetSummary?.uploadCount) || 0,
+    referenceCount: Number(assetReferenceManifest?.referenceCount ?? references.length) || 0,
+    hash: normaliseString(assetReferenceManifest?.hash || assetSummary?.hash),
+    preview: references.slice(0, 12),
+  };
+}
+
+function buildProductionProofSummary(release = {}, operations = []) {
+  const requiredKeys = requiredProductionProofSurfaceKeys(operations, release);
+  const capture = productionProofCaptureForRelease(release.proof, release);
+  const linkedKeys = productionProofSurfaceKeys(release.proof, release);
+  const missingKeys = requiredKeys.filter((key) => !linkedKeys.includes(key));
+  const hasCallerProof = proofHasCallerMetadata(release.proof);
+  let status = 'not_required';
+  if (requiredKeys.length) {
+    if (!missingKeys.length) {
+      status = 'recorded';
+    } else if (linkedKeys.length || hasCallerProof) {
+      status = 'partial';
+    } else {
+      status = 'missing';
+    }
+  } else if (hasCallerProof) {
+    status = 'recorded';
+  }
+  return {
+    status,
+    hasCallerProof,
+    capturedAt: Number(capture?.capturedAt) || null,
+    capturedByAccountId: capture?.capturedByAccountId || null,
+    requiredSurfaces: requiredKeys.map(surfaceDescriptor),
+    linkedSurfaces: linkedKeys.map((key) => surfaceCaptureDescriptor(key, capture)),
+    missingSurfaces: missingKeys.map(surfaceDescriptor),
+  };
+}
+
+function buildProductionProofCapture(proof = null, {
+  releaseId,
+  capturedByAccountId,
+  capturedAt,
+} = {}) {
+  if (!isPlainObject(proof)) {
+    throw new BadRequestError('Production proof capture requires a proof object.', {
+      code: 'content_operation_release_proof_required',
+      releaseId,
+    });
+  }
+  const reservedKeys = Object.keys(proof).filter((key) => (
+    key !== RELEASE_PRODUCTION_PROOF_KEY && RELEASE_PROOF_RESERVED_KEYS.has(key)
+  ));
+  if (reservedKeys.length) {
+    throw new BadRequestError('Production proof capture contains reserved metadata keys.', {
+      code: 'content_operation_release_proof_reserved_key',
+      releaseId,
+      reservedKeys,
+    });
+  }
+  const source = isPlainObject(proof[RELEASE_PRODUCTION_PROOF_KEY])
+    ? proof[RELEASE_PRODUCTION_PROOF_KEY]
+    : proof;
+  const entries = new Map();
+  proofSurfaceEvidenceEntriesFromValue(proof.surfaces, entries);
+  proofSurfaceEvidenceEntriesFromValue(proof.surfaceProof, entries);
+  proofSurfaceEvidenceEntriesFromValue(source.surfaces, entries);
+  proofSurfaceEvidenceEntriesFromValue(source.surfaceProof, entries);
+  for (const surface of PRODUCTION_PROOF_SURFACES) {
+    if (proof[surface.key] != null) {
+      entries.set(surface.key, isPlainObject(proof[surface.key]) ? cloneSerialisable(proof[surface.key]) : {});
+    }
+  }
+  if (!entries.size) {
+    throw new BadRequestError('Production proof capture requires at least one recognised surface.', {
+      code: 'content_operation_release_proof_surfaces_required',
+      releaseId,
+    });
+  }
+  const surfaces = {};
+  for (const [key, evidence] of entries.entries()) {
+    surfaces[key] = {
+      ...surfaceDescriptor(key),
+      ...(isPlainObject(evidence) ? evidence : {}),
+      key,
+      label: surfaceDescriptor(key).label,
+      releaseId,
+      capturedAt,
+      capturedByAccountId,
+    };
+  }
+  return {
+    releaseId,
+    capturedAt,
+    capturedByAccountId,
+    source: normaliseString(proof.source || source.source, 'content-operations-admin'),
+    notes: normaliseString(proof.notes || source.notes),
+    surfaces,
+  };
+}
+
+function buildReleaseHistorySummary({
+  release = null,
+  contentPackage = null,
+  approval = null,
+  operations = [],
+} = {}) {
+  if (!release) return null;
+  return {
+    releaseId: release.releaseId,
+    package: contentPackage ? {
+      packageId: contentPackage.packageId,
+      title: contentPackage.title,
+      templateId: contentPackage.templateId,
+      state: contentPackage.state,
+    } : null,
+    approvedByAccountId: approval?.approvedByAccountId || null,
+    approvedAt: approval?.approvedAt ?? null,
+    approvalId: approval?.approvalId || null,
+    candidateId: approval?.candidateId || null,
+    candidateHash: approval?.candidateHash || '',
+    publishedByAccountId: release.publishedByAccountId || null,
+    publishedAt: release.publishedAt ?? null,
+    changedEntities: summariseContentOperationChanges(operations),
+    assetChanges: summariseReleaseAssetChanges(release),
+    productionProof: buildProductionProofSummary(release, operations),
   };
 }
 
@@ -682,6 +1037,101 @@ async function listPackageOperations(db, packageId) {
     ORDER BY operation_order ASC
   `, [packageId]);
   return rows.map(operationRowToRecord);
+}
+
+async function attachReleaseHistorySummary(db, release = null) {
+  if (!release) return null;
+  if (!release.packageId) {
+    return {
+      ...release,
+      history: buildReleaseHistorySummary({ release }),
+    };
+  }
+  const [packageRow, approvalRow, operations] = await Promise.all([
+    first(db, `
+      SELECT *
+      FROM content_operation_packages
+      WHERE package_id = ?
+    `, [release.packageId]),
+    first(db, `
+      SELECT *
+      FROM content_operation_package_approvals
+      WHERE package_id = ?
+      ORDER BY approved_at DESC
+      LIMIT 1
+    `, [release.packageId]),
+    listPackageOperations(db, release.packageId),
+  ]);
+  return {
+    ...release,
+    history: buildReleaseHistorySummary({
+      release,
+      contentPackage: packageRow ? packageRowToRecord(packageRow) : null,
+      approval: approvalRowToRecord(approvalRow),
+      operations,
+    }),
+  };
+}
+
+async function attachReleaseHistorySummaries(db, releases = []) {
+  if (!releases.length) return releases;
+  const packageIds = uniqueStrings(releases.map((release) => release?.packageId).filter(Boolean));
+  if (!packageIds.length) {
+    return releases.map((release) => ({
+      ...release,
+      history: buildReleaseHistorySummary({ release }),
+    }));
+  }
+  const placeholders = packageIds.map(() => '?').join(', ');
+  const [packageRows, approvalRows, operationRows] = await Promise.all([
+    all(db, `
+      SELECT *
+      FROM content_operation_packages
+      WHERE package_id IN (${placeholders})
+    `, packageIds),
+    all(db, `
+      SELECT *
+      FROM content_operation_package_approvals
+      WHERE package_id IN (${placeholders})
+      ORDER BY package_id ASC, approved_at DESC
+    `, packageIds),
+    all(db, `
+      SELECT *
+      FROM content_operation_package_operations
+      WHERE package_id IN (${placeholders})
+      ORDER BY package_id ASC, operation_order ASC
+    `, packageIds),
+  ]);
+  const packagesById = new Map(packageRows.map((row) => [row.package_id, packageRowToRecord(row)]));
+  const approvalsByPackageId = new Map();
+  for (const row of approvalRows) {
+    if (!approvalsByPackageId.has(row.package_id)) {
+      approvalsByPackageId.set(row.package_id, approvalRowToRecord(row));
+    }
+  }
+  const operationsByPackageId = new Map();
+  for (const row of operationRows) {
+    const operation = operationRowToRecord(row);
+    if (!operationsByPackageId.has(row.package_id)) operationsByPackageId.set(row.package_id, []);
+    operationsByPackageId.get(row.package_id).push(operation);
+  }
+  return releases.map((release) => {
+    if (!release?.packageId) {
+      return {
+        ...release,
+        history: buildReleaseHistorySummary({ release }),
+      };
+    }
+    return {
+      ...release,
+      history: buildReleaseHistorySummary({
+        release,
+        contentPackage: packagesById.get(release.packageId) || null,
+        approval: approvalsByPackageId.get(release.packageId) || null,
+        operations: operationsByPackageId.get(release.packageId) || [],
+      }),
+    };
+  });
 }
 
 function releaseDriftConflict(packageRow, currentReleaseRow, baseReleaseRow) {
@@ -2056,7 +2506,7 @@ export function createContentOperationsRepository({ db, env = {}, now }) {
         });
       }
 
-      return {
+      const releaseRecord = {
         releaseId,
         packageId,
         subjectId: packageRow.subject_id,
@@ -2071,6 +2521,20 @@ export function createContentOperationsRepository({ db, env = {}, now }) {
         audioWarnings: releaseAudioProof.audioWarnings,
         assetSummary: releaseAssetProof.assetSummary,
         assetReferenceManifest: releaseAssetProof.assetReferenceManifest,
+      };
+      return {
+        ...releaseRecord,
+        history: buildReleaseHistorySummary({
+          release: releaseRecord,
+          contentPackage: {
+            packageId,
+            title: packageRow.title,
+            templateId: packageRow.template_id,
+            state: CONTENT_OPERATION_PACKAGE_STATES.PUBLISHED,
+          },
+          approval,
+          operations,
+        }),
       };
     },
 
@@ -2203,19 +2667,99 @@ export function createContentOperationsRepository({ db, env = {}, now }) {
       };
     },
 
-    async readLatestContentOperationRelease(subjectId = CONTENT_OPERATION_SUBJECT_ID, { includeSnapshot = false } = {}) {
-      const row = await readLatestReleaseRow(db, normaliseSubjectId(subjectId), { includeSnapshot });
-      return releaseRowToRecordAsync(row, { includeSnapshot });
+    async captureContentOperationReleaseProof(subjectId = CONTENT_OPERATION_SUBJECT_ID, releaseId, {
+      capturedByAccountId,
+      proof = null,
+    } = {}) {
+      const actor = normaliseString(capturedByAccountId);
+      const safeSubjectId = normaliseSubjectId(subjectId);
+      const safeReleaseId = normaliseString(releaseId);
+      if (!actor) throw new BadRequestError('Content operation release proof capture requires an account id.', {
+        code: 'content_operation_release_proof_actor_required',
+        releaseId: safeReleaseId,
+      });
+      const row = await readReleaseRowById(db, safeSubjectId, safeReleaseId, { includeSnapshot: false });
+      if (!row) {
+        throw new NotFoundError('Content operation release was not found.', {
+          code: 'content_operation_release_not_found',
+          releaseId: safeReleaseId,
+        });
+      }
+      const release = await releaseRowToRecordAsync(row, { includeSnapshot: false });
+      if (release.status !== 'published') {
+        throw new ConflictError('Production proof can only be captured for published releases.', {
+          code: 'content_operation_release_not_published',
+          releaseId: safeReleaseId,
+          status: release.status,
+        });
+      }
+      const nowTs = Number(nowFactory());
+      const capture = buildProductionProofCapture(proof, {
+        releaseId: release.releaseId,
+        capturedByAccountId: actor,
+        capturedAt: nowTs,
+      });
+      const nextProof = {
+        ...(isPlainObject(release.proof) ? release.proof : {}),
+        [RELEASE_PRODUCTION_PROOF_KEY]: capture,
+      };
+      await batch(db, [
+        bindStatement(db, `
+          UPDATE content_operation_releases
+          SET proof_json = ?
+          WHERE subject_id = ? AND release_id = ?
+        `, [
+          JSON.stringify(nextProof),
+          safeSubjectId,
+          safeReleaseId,
+        ]),
+        bindStatement(db, `
+          INSERT INTO content_operation_events (
+            event_id, package_id, release_id, subject_id, event_type,
+            actor_account_id, event_json, created_at
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        `, [
+          uid('coevt'),
+          release.packageId || null,
+          release.releaseId,
+          safeSubjectId,
+          'release.production_proof_captured',
+          actor,
+          JSON.stringify({
+            releaseId: release.releaseId,
+            capturedAt: nowTs,
+            surfaces: Object.keys(capture.surfaces || {}),
+          }),
+          nowTs,
+        ]),
+      ]);
+      return attachReleaseHistorySummary(db, {
+        ...release,
+        proof: nextProof,
+      });
     },
 
-    async readContentOperationRelease(subjectId = CONTENT_OPERATION_SUBJECT_ID, releaseId, { includeSnapshot = false } = {}) {
+    async readLatestContentOperationRelease(subjectId = CONTENT_OPERATION_SUBJECT_ID, { includeSnapshot = false, includeHistory = false } = {}) {
+      const row = await readLatestReleaseRow(db, normaliseSubjectId(subjectId), { includeSnapshot });
+      const release = await releaseRowToRecordAsync(row, { includeSnapshot });
+      return includeHistory ? attachReleaseHistorySummary(db, release) : release;
+    },
+
+    async readContentOperationRelease(subjectId = CONTENT_OPERATION_SUBJECT_ID, releaseId, { includeSnapshot = false, includeHistory = false } = {}) {
       const row = await readReleaseRowById(db, normaliseSubjectId(subjectId), normaliseString(releaseId), {
         includeSnapshot,
       });
-      return releaseRowToRecordAsync(row, { includeSnapshot });
+      const release = await releaseRowToRecordAsync(row, { includeSnapshot });
+      return includeHistory ? attachReleaseHistorySummary(db, release) : release;
     },
 
-    async listContentOperationReleases({ subjectId = CONTENT_OPERATION_SUBJECT_ID, includeSnapshot = false, limit = 20 } = {}) {
+    async listContentOperationReleases({
+      subjectId = CONTENT_OPERATION_SUBJECT_ID,
+      includeSnapshot = false,
+      includeHistory = false,
+      limit = 20,
+    } = {}) {
       const safeLimit = Math.max(1, Math.min(100, Number(limit) || 20));
       const rows = await all(db, `
         SELECT
@@ -2228,7 +2772,8 @@ export function createContentOperationsRepository({ db, env = {}, now }) {
         ORDER BY published_at DESC, created_at DESC, rowid DESC
         LIMIT ?
       `, [normaliseSubjectId(subjectId), safeLimit]);
-      return Promise.all(rows.map((row) => releaseRowToRecordAsync(row, { includeSnapshot })));
+      const releases = await Promise.all(rows.map((row) => releaseRowToRecordAsync(row, { includeSnapshot })));
+      return includeHistory ? attachReleaseHistorySummaries(db, releases) : releases;
     },
 
     async listContentOperationEvents({ packageId = null, releaseId = null, subjectId = CONTENT_OPERATION_SUBJECT_ID, limit = 50 } = {}) {

--- a/worker/src/content-operations/routes.js
+++ b/worker/src/content-operations/routes.js
@@ -67,6 +67,11 @@ function includeSnapshot(url, body = {}) {
   return value === true || value === 'true' || value === '1';
 }
 
+function includeHistory(url, body = {}) {
+  const value = url.searchParams.get('includeHistory') ?? body.includeHistory;
+  return value === true || value === 'true' || value === '1';
+}
+
 function optionalQueryString(url, key) {
   const value = url.searchParams.get(key);
   return typeof value === 'string' && value.trim() ? value.trim() : '';
@@ -211,11 +216,15 @@ export async function handleContentOperationsAdminRequest({
       capability: CONTENT_OPERATION_CAPABILITIES.VIEW,
     });
     const limit = normaliseLimit(url.searchParams.get('limit'), 30, 100);
-    const [latestRelease, packages, releases] = await Promise.all([
-      repository.readLatestContentOperationRelease(CONTENT_OPERATIONS_SUBJECT_ID, { includeSnapshot: false }),
+    const history = includeHistory(url);
+    const [packages, releases] = await Promise.all([
       repository.listContentOperationPackages({ subjectId: CONTENT_OPERATIONS_SUBJECT_ID, limit }),
-      repository.listContentOperationReleases({ subjectId: CONTENT_OPERATIONS_SUBJECT_ID, limit: 10 }),
+      repository.listContentOperationReleases({ subjectId: CONTENT_OPERATIONS_SUBJECT_ID, includeHistory: history, limit: 10 }),
     ]);
+    const latestRelease = releases[0] || await repository.readLatestContentOperationRelease(CONTENT_OPERATIONS_SUBJECT_ID, {
+      includeSnapshot: false,
+      includeHistory: history,
+    });
     return json({
       ok: true,
       overview: serialiseContentOperationOverview({
@@ -331,6 +340,7 @@ export async function handleContentOperationsAdminRequest({
     const releases = await repository.listContentOperationReleases({
       subjectId: CONTENT_OPERATIONS_SUBJECT_ID,
       includeSnapshot: includeSnapshot(url),
+      includeHistory: includeHistory(url),
       limit: normaliseLimit(url.searchParams.get('limit'), 20, 100),
     });
     return json({
@@ -355,12 +365,40 @@ export async function handleContentOperationsAdminRequest({
       const releaseId = decodePathSegment(releaseMatch[1], 'release_id');
       const release = await repository.readContentOperationRelease(CONTENT_OPERATIONS_SUBJECT_ID, releaseId, {
         includeSnapshot: includeSnapshot(url),
+        includeHistory: includeHistory(url),
       });
       if (!release) return notFoundRoute();
       return json({
         ok: true,
         actor: serialiseContentOperationActor(actor),
         release: serialiseContentOperationRelease(release, { includeSnapshot: includeSnapshot(url) }),
+      });
+    }
+  }
+
+  {
+    const releaseProofMatch = /^\/subjects\/spelling\/releases\/([^/]+)\/proof$/.exec(relativePath);
+    if (request.method === 'POST' && releaseProofMatch) {
+      const actor = await requireRouteActor({
+        repository,
+        session,
+        request,
+        env,
+        capability: CONTENT_OPERATION_CAPABILITIES.PUBLISH,
+        mutation: true,
+      });
+      const releaseId = decodePathSegment(releaseProofMatch[1], 'release_id');
+      const body = normaliseBody(await readJson(request));
+      const release = await repository.captureContentOperationReleaseProof(CONTENT_OPERATIONS_SUBJECT_ID, releaseId, {
+        capturedByAccountId: actor.id,
+        proof: proofFromRequest(body, request, 'capture-production-proof'),
+      });
+      return json({
+        ok: true,
+        actor: serialiseContentOperationActor(actor),
+        release: serialiseContentOperationRelease(release, {
+          includeSnapshot: includeSnapshot(url, body),
+        }),
       });
     }
   }

--- a/worker/src/content-operations/serialisers.js
+++ b/worker/src/content-operations/serialisers.js
@@ -359,7 +359,65 @@ function releaseHasCallerProof(proof = null) {
   return Object.keys(proof).some((key) => (
     key !== 'contentOperationsAudio'
     && key !== 'contentOperationsAssets'
+    && key !== 'productionProof'
   ));
+}
+
+function serialiseReleaseHistory(history = null) {
+  if (!history || typeof history !== 'object' || Array.isArray(history)) return null;
+  const productionProof = history.productionProof && typeof history.productionProof === 'object' && !Array.isArray(history.productionProof)
+    ? history.productionProof
+    : null;
+  const changedEntities = history.changedEntities && typeof history.changedEntities === 'object' && !Array.isArray(history.changedEntities)
+    ? history.changedEntities
+    : null;
+  const assetChanges = history.assetChanges && typeof history.assetChanges === 'object' && !Array.isArray(history.assetChanges)
+    ? history.assetChanges
+    : null;
+  const contentPackage = history.package && typeof history.package === 'object' && !Array.isArray(history.package)
+    ? history.package
+    : null;
+  return {
+    releaseId: history.releaseId || '',
+    package: contentPackage ? {
+      packageId: contentPackage.packageId || '',
+      title: contentPackage.title || '',
+      templateId: contentPackage.templateId || '',
+      state: contentPackage.state || '',
+    } : null,
+    approvedByAccountId: history.approvedByAccountId || null,
+    approvedAt: history.approvedAt ?? null,
+    approvalId: history.approvalId || null,
+    candidateId: history.candidateId || null,
+    candidateHash: history.candidateHash || '',
+    publishedByAccountId: history.publishedByAccountId || null,
+    publishedAt: history.publishedAt ?? null,
+    changedEntities: changedEntities ? {
+      operationCount: Number(changedEntities.operationCount) || 0,
+      entityCount: Number(changedEntities.entityCount) || 0,
+      entityTypes: Array.isArray(changedEntities.entityTypes) ? changedEntities.entityTypes : [],
+      actionCounts: changedEntities.actionCounts && typeof changedEntities.actionCounts === 'object' && !Array.isArray(changedEntities.actionCounts)
+        ? changedEntities.actionCounts
+        : {},
+      fieldPaths: Array.isArray(changedEntities.fieldPaths) ? changedEntities.fieldPaths : [],
+      preview: Array.isArray(changedEntities.preview) ? changedEntities.preview : [],
+    } : null,
+    assetChanges: assetChanges ? {
+      uploadCount: Number(assetChanges.uploadCount) || 0,
+      referenceCount: Number(assetChanges.referenceCount) || 0,
+      hash: assetChanges.hash || '',
+      preview: Array.isArray(assetChanges.preview) ? assetChanges.preview : [],
+    } : null,
+    productionProof: productionProof ? {
+      status: productionProof.status || 'unknown',
+      hasCallerProof: Boolean(productionProof.hasCallerProof),
+      capturedAt: Number(productionProof.capturedAt) || null,
+      capturedByAccountId: productionProof.capturedByAccountId || null,
+      requiredSurfaces: Array.isArray(productionProof.requiredSurfaces) ? productionProof.requiredSurfaces : [],
+      linkedSurfaces: Array.isArray(productionProof.linkedSurfaces) ? productionProof.linkedSurfaces : [],
+      missingSurfaces: Array.isArray(productionProof.missingSurfaces) ? productionProof.missingSurfaces : [],
+    } : null,
+  };
 }
 
 export function serialiseContentOperationRelease(release = {}, { includeSnapshot = false } = {}) {
@@ -382,6 +440,7 @@ export function serialiseContentOperationRelease(release = {}, { includeSnapshot
     audioWarnings: release.audioWarnings ?? proofAudio.audioWarnings,
     assetSummary: release.assetSummary ?? proofAssets.assetSummary,
     assetReferenceManifest: release.assetReferenceManifest ?? proofAssets.assetReferenceManifest,
+    history: serialiseReleaseHistory(release.history),
     createdAt: Number(release.createdAt) || 0,
     ...(includeSnapshot ? { snapshot: release.snapshot || null } : {}),
   };


### PR DESCRIPTION
## Summary
- Batch-enrich Content Operations release history with package, approval, changed entity, asset change, and production proof summaries.
- Add opt-in `includeHistory` reads plus a post-publish production proof capture endpoint for spelling, Word Bank, Hero / Codex, and monster rendering evidence.
- Surface release actors, changed entities, asset changes, and proof status in the Content Operations Centre UI.

## Verification
- `node --test tests/monster-asset-upload-validation.test.js tests/content-operations-api.test.js tests/admin-content-operations-v2.test.js tests/react-admin-content-operations.test.js tests/content-operations-repository.test.js`
- `npm run check`
- `npm test` via pre-push hook: 111,863 pass / 0 fail / 12 skipped