### PR TITLE
Add content operations release rollback

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2729,6 +2729,7 @@ function buildSurfaceActions() {
     resolveConflict: hubApi.resolveContentOperationConflict?.bind(hubApi),
     readReleases: hubApi.readContentOperationReleases?.bind(hubApi),
     readRelease: hubApi.readContentOperationRelease?.bind(hubApi),
+    rollbackRelease: hubApi.rollbackContentOperationRelease?.bind(hubApi),
   } : null;
   return {
     dispatch: dispatchAction,

--- a/src/platform/hubs/api.js
+++ b/src/platform/hubs/api.js
@@ -499,6 +499,29 @@ export function createHubApi({
         body: JSON.stringify({ proof }),
       }, authSession);
     },
+    async rollbackContentOperationRelease({
+      releaseId,
+      reason = '',
+      proof = null,
+      includeSnapshot = false,
+      mutation,
+    } = {}) {
+      if (!releaseId) throw new TypeError('Content operation release id is required.');
+      const safeReason = String(reason || '').trim();
+      if (!safeReason) throw new TypeError('Content operation rollback reason is required.');
+      const safeReleaseId = encodeURIComponent(String(releaseId));
+      const url = buildRequestUrl(baseUrl, `/api/admin/content-operations/releases/${safeReleaseId}/rollback`);
+      return fetchHubJson(fetch, url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          reason: safeReason,
+          proof,
+          includeSnapshot: Boolean(includeSnapshot),
+          mutation,
+        }),
+      }, authSession);
+    },
     async readAdminOpsKpi() {
       const url = buildRequestUrl(baseUrl, '/api/admin/ops/kpi');
       return fetchHubJson(fetch, url, { method: 'GET' }, authSession);

--- a/src/surfaces/hubs/AdminContentOperationsSection.jsx
+++ b/src/surfaces/hubs/AdminContentOperationsSection.jsx
@@ -60,6 +60,7 @@ const CONTENT_OPERATION_CAPABILITIES = Object.freeze({
   EDIT: 'content_operations.edit',
   APPROVE: 'content_operations.approve',
   PUBLISH: 'content_operations.publish',
+  ROLLBACK: 'content_operations.rollback',
 });
 
 const SPELLING_OPERATION_NOUNS = Object.freeze({
@@ -3871,7 +3872,15 @@ function releaseAssetChangeLines(assetChanges = null) {
   return lines;
 }
 
-function ReleaseTable({ releases }) {
+function ReleaseTable({
+  releases,
+  latestReleaseId = '',
+  canRollback = false,
+  rollbackAvailable = false,
+  rollbackState = null,
+  onRollback = null,
+}) {
+  const [rollbackReasons, setRollbackReasons] = React.useState({});
   if (!releases.length) {
     return (
       <div className="feedback admin-note-spaced" data-content-ops-empty-releases="true">
@@ -3891,6 +3900,7 @@ function ReleaseTable({ releases }) {
             <th className="small admin-overview-th">Changed</th>
             <th className="small admin-overview-th">Audio</th>
             <th className="small admin-overview-th">Proof</th>
+            <th className="small admin-overview-th">Recovery</th>
           </tr>
         </thead>
         <tbody>
@@ -3918,6 +3928,22 @@ function ReleaseTable({ releases }) {
               .join(', ');
             const changedLines = releaseChangedEntityLines(changedEntities);
             const assetLines = releaseAssetChangeLines(history?.assetChanges);
+            const rollbackMetadata = release.proof?.rollback && typeof release.proof.rollback === 'object'
+              ? release.proof.rollback
+              : null;
+            const rollbackReason = String(rollbackReasons[release.releaseId] ?? '');
+            const isLatestRelease = Boolean(latestReleaseId && release.releaseId === latestReleaseId);
+            const rollbackRunning = rollbackState?.running && rollbackState.releaseId === release.releaseId;
+            const rollbackDisabled = !rollbackAvailable
+              || !canRollback
+              || !onRollback
+              || isLatestRelease
+              || release.status !== 'published'
+              || rollbackRunning
+              || !rollbackReason.trim();
+            const rollbackHint = isLatestRelease
+              ? 'Current release'
+              : (!canRollback ? 'No rollback role' : (!rollbackAvailable ? 'Rollback unavailable' : 'Requires reason'));
             return (
               <tr
                 key={release.releaseId}
@@ -3934,8 +3960,16 @@ function ReleaseTable({ releases }) {
                   </span>
                 </td>
                 <td className="admin-overview-td small">
-                  {history?.package?.title || release.packageId || 'seeded'}
-                  <div className="small muted">{release.packageId || 'first release'}</div>
+                  {history?.package?.title || (release.rollbackOfReleaseId ? 'Rollback release' : (release.packageId || 'seeded'))}
+                  <div className="small muted">{release.packageId || (release.rollbackOfReleaseId ? 'recovery action' : 'first release')}</div>
+                  {release.rollbackOfReleaseId ? (
+                    <div className="small muted" data-content-ops-rollback-lineage={release.rollbackOfReleaseId}>
+                      Rollback of {release.rollbackOfReleaseId}
+                    </div>
+                  ) : null}
+                  {rollbackMetadata?.reason ? (
+                    <div className="small muted">Reason: {rollbackMetadata.reason}</div>
+                  ) : null}
                 </td>
                 <td className="admin-overview-td small">
                   <div>Published by {history?.publishedByAccountId || release.publishedByAccountId || 'unknown'}</div>
@@ -3977,11 +4011,56 @@ function ReleaseTable({ releases }) {
                   {!missingSurfaces && linkedSurfaces ? <div className="small muted">{linkedSurfaces}</div> : null}
                   {capture ? <div className="small muted">{capture}</div> : null}
                 </td>
+                <td className="admin-overview-td">
+                  <div className="content-ops-release-recovery">
+                    <textarea
+                      rows={2}
+                      value={rollbackReason}
+                      placeholder="Rollback reason"
+                      aria-label={`Rollback reason for ${release.releaseId}`}
+                      data-content-ops-rollback-reason={release.releaseId}
+                      disabled={isLatestRelease || rollbackRunning || !canRollback || !rollbackAvailable}
+                      onChange={(event) => {
+                        const value = event.target.value;
+                        setRollbackReasons((current) => ({
+                          ...current,
+                          [release.releaseId]: value,
+                        }));
+                      }}
+                    />
+                    <button
+                      type="button"
+                      className="btn secondary compact"
+                      disabled={rollbackDisabled}
+                      aria-busy={rollbackRunning ? 'true' : undefined}
+                      data-content-ops-rollback-action={release.releaseId}
+                      onClick={() => onRollback?.({
+                        releaseId: release.releaseId,
+                        reason: rollbackReason.trim(),
+                      })}
+                    >
+                      Rollback
+                    </button>
+                    <div className="small muted">
+                      {rollbackRunning ? 'Rolling back...' : rollbackHint}
+                    </div>
+                  </div>
+                </td>
               </tr>
             );
           })}
         </tbody>
       </table>
+      {rollbackState?.message ? (
+        <div className="feedback good admin-note-spaced" data-content-ops-rollback-message="true">
+          {rollbackState.message}
+        </div>
+      ) : null}
+      {rollbackState?.error ? (
+        <div className="feedback warn admin-note-spaced" data-content-ops-rollback-error="true">
+          {rollbackState.error.message}
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -4060,6 +4139,13 @@ export function AdminContentOperationsSection({
     running: false,
     message: '',
     error: null,
+  });
+  const [rollbackState, setRollbackState] = React.useState({
+    releaseId: '',
+    running: false,
+    message: '',
+    error: null,
+    release: null,
   });
   const detailRequestRef = React.useRef({ id: '', seq: 0 });
   const spellingBrowseRequestRef = React.useRef(0);
@@ -4498,6 +4584,57 @@ export function AdminContentOperationsSection({
     }
   }, [api, invalidateSpellingBrowse, loadPackageDetail, refresh]);
 
+  const runRollbackRelease = React.useCallback(async ({ releaseId, reason }) => {
+    const safeReleaseId = String(releaseId || '').trim();
+    const safeReason = String(reason || '').trim();
+    if (!api?.rollbackRelease || !safeReleaseId || !safeReason) return;
+    setRollbackState({
+      releaseId: safeReleaseId,
+      running: true,
+      message: '',
+      error: null,
+      release: null,
+    });
+    try {
+      const payload = await api.rollbackRelease({
+        releaseId: safeReleaseId,
+        reason: safeReason,
+        proof: {
+          source: 'content-operations-centre',
+          reason: safeReason,
+          rollback: {
+            targetReleaseId: safeReleaseId,
+            reason: safeReason,
+            approvedByAccountId: overview.actor?.accountId || null,
+            publishedByAccountId: overview.actor?.accountId || null,
+            approvalMode: 'same-role-placeholder',
+            proofRequirement: 'production-proof-after-rollback',
+          },
+        },
+        mutation: contentOperationMutation('rollback', safeReleaseId),
+      });
+      setRollbackState({
+        releaseId: safeReleaseId,
+        running: false,
+        message: `Rolled back to ${safeReleaseId}.`,
+        error: null,
+        release: payload?.release || null,
+      });
+      invalidateSpellingBrowse();
+      if (api.readOverview) {
+        await refresh();
+      }
+    } catch (error) {
+      setRollbackState({
+        releaseId: safeReleaseId,
+        running: false,
+        message: '',
+        error: errorEnvelope(error, 'content_operations_rollback_failed'),
+        release: null,
+      });
+    }
+  }, [api, invalidateSpellingBrowse, overview.actor?.accountId, refresh]);
+
   const latestRelease = overview.latestRelease;
   const primaryData = overview.openPackageCount || packages.length || releases.length || latestRelease || spellingBrowse.words.length ? {
     overview,
@@ -4524,6 +4661,7 @@ export function AdminContentOperationsSection({
     approve: Boolean(api?.approvePackage),
     publish: Boolean(api?.publishPackage),
   };
+  const canRollback = actorCan(overview.actor, CONTENT_OPERATION_CAPABILITIES.ROLLBACK);
   const audioActionAvailability = {
     scan: Boolean(api?.validatePackage),
     generate: Boolean(api?.generateAudio),
@@ -4622,7 +4760,16 @@ export function AdminContentOperationsSection({
         />
       ) : null}
 
-      {activeTab === 'releases' ? <ReleaseTable releases={releases} /> : null}
+      {activeTab === 'releases' ? (
+        <ReleaseTable
+          releases={releases}
+          latestReleaseId={latestRelease?.releaseId || ''}
+          canRollback={canRollback}
+          rollbackAvailable={Boolean(api?.rollbackRelease)}
+          rollbackState={rollbackState}
+          onRollback={runRollbackRelease}
+        />
+      ) : null}
     </AdminPanelFrame>
   );
 }

--- a/tests/admin-content-operations-v2.test.js
+++ b/tests/admin-content-operations-v2.test.js
@@ -1211,6 +1211,12 @@ describe('Content Operations Centre hub API client', () => {
       proof: { surfaces: { spellingSetup: { evidence: 'setup' } } },
       includeSnapshot: true,
     });
+    await api.rollbackContentOperationRelease({
+      releaseId: 'rel/with/slash',
+      reason: 'Restore the previous global spelling release.',
+      proof: { source: 'test', reason: 'Restore the previous global spelling release.' },
+      mutation: { requestId: 'rollback-1' },
+    });
     await api.resolveContentOperationConflict({
       packageId: 'pkg/with/slash',
       conflictId: 'conflict/with/slash',
@@ -1225,8 +1231,9 @@ describe('Content Operations Centre hub API client', () => {
     assert.equal(new URL(calls[3].url).pathname, '/api/admin/content-operations/packages/pkg%2Fwith%2Fslash/publish');
     assert.equal(new URL(calls[4].url).pathname, '/api/admin/content-operations/subjects/spelling/releases/rel%2Fwith%2Fslash/proof');
     assert.equal(new URL(calls[4].url).searchParams.get('includeSnapshot'), 'true');
-    assert.equal(new URL(calls[5].url).pathname, '/api/admin/content-operations/packages/pkg%2Fwith%2Fslash/resolve-conflict');
-    assert.deepEqual(calls.map((call) => call.method), ['POST', 'POST', 'POST', 'POST', 'POST', 'POST']);
+    assert.equal(new URL(calls[5].url).pathname, '/api/admin/content-operations/releases/rel%2Fwith%2Fslash/rollback');
+    assert.equal(new URL(calls[6].url).pathname, '/api/admin/content-operations/packages/pkg%2Fwith%2Fslash/resolve-conflict');
+    assert.deepEqual(calls.map((call) => call.method), ['POST', 'POST', 'POST', 'POST', 'POST', 'POST', 'POST']);
     assert.equal(calls[0].body.includeSnapshot, true);
     assert.equal(calls[1].body.candidateId, 'cand/with/slash');
     assert.deepEqual(calls[1].body.itemIds, ['word:meta:base:male.natural']);
@@ -1242,9 +1249,12 @@ describe('Content Operations Centre hub API client', () => {
     assert.equal(Object.prototype.hasOwnProperty.call(calls[2].body, 'assetSummary'), false);
     assert.equal(calls[3].body.proof.source, 'test');
     assert.equal(calls[4].body.proof.surfaces.spellingSetup.evidence, 'setup');
-    assert.equal(calls[5].body.conflictId, 'conflict/with/slash');
-    assert.equal(calls[5].body.resolution, 'edit');
-    assert.equal(calls[5].body.value, 'Merged value.');
+    assert.equal(calls[5].body.reason, 'Restore the previous global spelling release.');
+    assert.equal(calls[5].body.proof.reason, 'Restore the previous global spelling release.');
+    assert.equal(calls[5].body.mutation.requestId, 'rollback-1');
+    assert.equal(calls[6].body.conflictId, 'conflict/with/slash');
+    assert.equal(calls[6].body.resolution, 'edit');
+    assert.equal(calls[6].body.value, 'Merged value.');
   });
 
   it('calls content operation append and delete endpoints', async () => {
@@ -1299,6 +1309,14 @@ describe('Content Operations Centre hub API client', () => {
     await assert.rejects(
       () => api.readContentOperationRelease({ releaseId: '' }),
       /Content operation release id is required/,
+    );
+    await assert.rejects(
+      () => api.rollbackContentOperationRelease({ releaseId: '' }),
+      /Content operation release id is required/,
+    );
+    await assert.rejects(
+      () => api.rollbackContentOperationRelease({ releaseId: 'rel-1', reason: '' }),
+      /Content operation rollback reason is required/,
     );
     await assert.rejects(
       () => api.readContentOperationSpellingWord({ slug: '' }),

--- a/tests/button-label-consistency.test.js
+++ b/tests/button-label-consistency.test.js
@@ -353,6 +353,7 @@ test('button labels: every statically extractable label is classified', () => {
     'Refresh now',
     'Edit',
     'Restore to v',
+    'Rollback',
     'Confirm schedule',
     'Open Spelling',
     'Open settings tab',

--- a/tests/content-operations-repository.test.js
+++ b/tests/content-operations-repository.test.js
@@ -153,6 +153,7 @@ test('content operations repository rollback writes a new latest release pointin
 
     const rollback = await repository.rollbackContentOperationRelease('spelling', seedRelease.releaseId, {
       rolledBackByAccountId: 'admin-a',
+      reason: 'Restore the seeded content after a test edit.',
       proof: { source: 'rollback-test' },
     });
     const latest = await repository.readLatestContentOperationRelease('spelling', {
@@ -161,6 +162,9 @@ test('content operations repository rollback writes a new latest release pointin
 
     assert.equal(rollback.rollbackOfReleaseId, seedRelease.releaseId);
     assert.equal(rollback.baseReleaseId, changed.release.releaseId);
+    assert.equal(rollback.proof.rollback.reason, 'Restore the seeded content after a test edit.');
+    assert.equal(rollback.proof.rollback.approvedByAccountId, 'admin-a');
+    assert.equal(rollback.proof.rollback.publishedByAccountId, 'admin-a');
     assert.equal(rollback.snapshotHash, seedRelease.snapshotHash);
     assert.deepEqual(rollback.snapshot, seedRelease.snapshot);
     assert.equal(latest.releaseId, rollback.releaseId);

--- a/tests/content-operations-rollback.test.js
+++ b/tests/content-operations-rollback.test.js
@@ -1,0 +1,180 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createWorkerRepository } from '../worker/src/repository.js';
+import {
+  readSeededSpellingContentBundle,
+} from '../worker/src/generated-spelling-content-seed.js';
+import { createWorkerRepositoryServer } from './helpers/worker-server.js';
+
+const BASE_URL = 'https://repo.test';
+const ADMIN_ID = 'admin-a';
+const NOW = Date.UTC(2026, 5, 12, 10, 0, 0);
+
+function seedAdultAccount(DB, {
+  accountId = ADMIN_ID,
+  platformRole = 'admin',
+} = {}) {
+  DB.db.prepare(`
+    INSERT INTO adult_accounts (id, email, display_name, platform_role, selected_learner_id, created_at, updated_at, repo_revision)
+    VALUES (?, ?, ?, ?, NULL, ?, ?, 0)
+    ON CONFLICT(id) DO UPDATE SET
+      platform_role = excluded.platform_role,
+      updated_at = excluded.updated_at
+  `).run(accountId, `${accountId}@example.test`, accountId, platformRole, NOW, NOW);
+}
+
+function jsonInit(method, body = {}) {
+  return {
+    method,
+    headers: {
+      'content-type': 'application/json',
+      'sec-fetch-site': 'same-origin',
+    },
+    body: JSON.stringify(body),
+  };
+}
+
+function adminHeaders() {
+  return {
+    'x-ks2-dev-platform-role': 'admin',
+    'sec-fetch-site': 'same-origin',
+  };
+}
+
+function createDeleteTrackingBucket() {
+  return {
+    deletes: [],
+    async get() {
+      return null;
+    },
+    async put() {},
+    async delete(key) {
+      this.deletes.push(key);
+    },
+  };
+}
+
+async function publishTemporaryWordEdit(repository, seedRelease) {
+  const seeded = await readSeededSpellingContentBundle();
+  const word = seeded.draft.words[0];
+  const contentPackage = await repository.createContentOperationPackage({
+    templateId: 'edit-spelling-word',
+    title: 'Rollback route temporary spelling edit',
+    createdByAccountId: ADMIN_ID,
+  });
+  await repository.appendContentOperation(contentPackage.packageId, {
+    entityType: 'spelling.word',
+    entityId: word.slug,
+    fieldPath: 'explanation',
+    action: 'set',
+    payload: `Temporary rollback route explanation for ${word.word}.`,
+  }, {
+    actorAccountId: ADMIN_ID,
+  });
+  const candidate = await repository.buildContentOperationCandidate(contentPackage.packageId, {
+    actorAccountId: ADMIN_ID,
+  });
+  assert.equal(candidate.currentReleaseId, seedRelease.releaseId);
+  await repository.approveContentOperationCandidate(contentPackage.packageId, candidate.candidateId, {
+    approvedByAccountId: ADMIN_ID,
+  });
+  return repository.publishContentOperationPackage(contentPackage.packageId, {
+    publishedByAccountId: ADMIN_ID,
+    proof: {
+      source: 'content-operations-rollback-test',
+      surfaces: {
+        spellingSetup: { evidence: 'setup-smoke-before-rollback' },
+        wordBank: { evidence: 'word-bank-smoke-before-rollback' },
+      },
+    },
+  });
+}
+
+test('content operations rollback route publishes a new latest release with lineage and reason', async () => {
+  const bucket = createDeleteTrackingBucket();
+  const server = createWorkerRepositoryServer({
+    env: { SPELLING_AUDIO_BUCKET: bucket },
+    now: () => NOW,
+  });
+  try {
+    seedAdultAccount(server.DB, { accountId: ADMIN_ID, platformRole: 'admin' });
+    const repository = createWorkerRepository({
+      env: server.env,
+      now: () => NOW,
+    });
+    const seedRelease = await repository.seedFirstContentOperationRelease({
+      seededByAccountId: ADMIN_ID,
+      proof: { source: 'content-operations-rollback-seed' },
+    });
+    const changedRelease = await publishTemporaryWordEdit(repository, seedRelease);
+    assert.notEqual(changedRelease.snapshotHash, seedRelease.snapshotHash);
+
+    const missingReasonResponse = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/releases/${seedRelease.releaseId}/rollback`,
+      jsonInit('POST', {
+        proof: { source: 'content-operations-rollback-test' },
+      }),
+      adminHeaders(),
+    );
+    assert.equal(missingReasonResponse.status, 400);
+
+    const rollbackResponse = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/releases/${seedRelease.releaseId}/rollback`,
+      jsonInit('POST', {
+        reason: 'Restore the seeded release after a temporary content edit.',
+        proof: {
+          source: 'content-operations-rollback-test',
+          rollback: {
+            reason: 'Restore the seeded release after a temporary content edit.',
+            approvedByAccountId: ADMIN_ID,
+            publishedByAccountId: ADMIN_ID,
+            approvalMode: 'same-role-placeholder',
+            proofRequirement: 'production-proof-after-rollback',
+          },
+        },
+      }),
+      adminHeaders(),
+    );
+    const rollbackPayload = await rollbackResponse.json();
+    assert.equal(rollbackResponse.status, 200);
+    assert.equal(rollbackPayload.release.rollbackOfReleaseId, seedRelease.releaseId);
+    assert.equal(rollbackPayload.release.baseReleaseId, changedRelease.releaseId);
+    assert.equal(rollbackPayload.release.snapshotHash, seedRelease.snapshotHash);
+    assert.equal(rollbackPayload.release.proof.rollback.reason, 'Restore the seeded release after a temporary content edit.');
+    assert.equal(rollbackPayload.release.proof.rollback.approvedByAccountId, ADMIN_ID);
+    assert.equal(rollbackPayload.release.proof.rollback.publishedByAccountId, ADMIN_ID);
+    assert.equal(rollbackPayload.release.proof.rollback.proofRequirement, 'production-proof-after-rollback');
+
+    const latest = await repository.readLatestContentOperationRelease('spelling', {
+      includeSnapshot: true,
+    });
+    assert.equal(latest.releaseId, rollbackPayload.release.releaseId);
+    assert.equal(latest.rollbackOfReleaseId, seedRelease.releaseId);
+    assert.deepEqual(latest.snapshot, seedRelease.snapshot);
+
+    const releaseListResponse = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/subjects/spelling/releases?includeHistory=true`,
+      { method: 'GET', headers: { 'sec-fetch-site': 'same-origin' } },
+      adminHeaders(),
+    );
+    const releaseList = await releaseListResponse.json();
+    assert.equal(releaseListResponse.status, 200);
+    assert.equal(releaseList.releases[0].releaseId, rollbackPayload.release.releaseId);
+    assert.equal(releaseList.releases[0].rollbackOfReleaseId, seedRelease.releaseId);
+    assert.equal(releaseList.releases[0].history.package, null);
+
+    const events = await repository.listContentOperationEvents({
+      releaseId: rollbackPayload.release.releaseId,
+    });
+    const rollbackEvent = events.find((event) => event.eventType === 'release.rollback');
+    assert.ok(rollbackEvent);
+    assert.equal(rollbackEvent.event.reason, 'Restore the seeded release after a temporary content edit.');
+    assert.deepEqual(bucket.deletes, []);
+  } finally {
+    server.close();
+  }
+});

--- a/tests/monster-asset-upload-validation.test.js
+++ b/tests/monster-asset-upload-validation.test.js
@@ -881,6 +881,7 @@ test('published monster image assets are runtime-readable with draft isolation a
     });
     const rollback = await repository.rollbackContentOperationRelease('spelling', published.release.releaseId, {
       rolledBackByAccountId: ADMIN_ID,
+      reason: 'Restore the published monster image release for rollback retention coverage.',
       proof: { source: 'monster-asset-upload-validation-test' },
     });
     assert.equal(rollback.assetReferenceManifest.referenceCount, 1);

--- a/tests/react-admin-content-operations.test.js
+++ b/tests/react-admin-content-operations.test.js
@@ -317,6 +317,59 @@ const release = {
   },
 };
 
+const rollbackRelease = {
+  ...release,
+  releaseId: 'rel-rollback-1',
+  snapshotHash: 'hash-rollback-1',
+  baseReleaseId: 'rel-global-2',
+  packageId: null,
+  publishedAt: Date.UTC(2026, 5, 11, 9, 30, 0),
+  publishedByAccountId: 'admin-a',
+  rollbackOfReleaseId: 'rel-global-1',
+  proof: {
+    source: 'test',
+    reason: 'Restore the previous global spelling release.',
+    rollback: {
+      targetReleaseId: 'rel-global-1',
+      targetSnapshotHash: 'hash-1',
+      previousLatestReleaseId: 'rel-global-2',
+      reason: 'Restore the previous global spelling release.',
+      approvedByAccountId: 'admin-a',
+      publishedByAccountId: 'admin-a',
+      approvalMode: 'same-role-placeholder',
+      proofRequirement: 'production-proof-after-rollback',
+    },
+  },
+  history: {
+    releaseId: 'rel-rollback-1',
+    package: null,
+    approvedByAccountId: null,
+    approvedAt: null,
+    publishedByAccountId: 'admin-a',
+    publishedAt: Date.UTC(2026, 5, 11, 9, 30, 0),
+    changedEntities: {
+      operationCount: 0,
+      entityCount: 0,
+      entityTypes: [],
+      actionCounts: {},
+      fieldPaths: [],
+      preview: [],
+    },
+    assetChanges: {
+      uploadCount: 0,
+      referenceCount: 0,
+      preview: [],
+    },
+    productionProof: {
+      status: 'missing',
+      hasCallerProof: false,
+      requiredSurfaces: [{ key: 'spellingSetup', label: 'Spelling setup' }, { key: 'wordBank', label: 'Word Bank' }],
+      linkedSurfaces: [],
+      missingSurfaces: [{ key: 'spellingSetup', label: 'Spelling setup' }, { key: 'wordBank', label: 'Word Bank' }],
+    },
+  },
+};
+
 const overview = {
   subjectId: 'spelling',
   latestRelease: release,
@@ -745,6 +798,43 @@ test('Content Operations Centre release history shows approved audio fallback wa
   assert.match(html, /Captured by admin-publisher/);
 });
 
+test('Content Operations Centre release history shows rollback lineage', async () => {
+  const rollbackOverview = {
+    ...overview,
+    latestRelease: rollbackRelease,
+    lanes: {
+      ...overview.lanes,
+      recentReleases: [rollbackRelease, release],
+    },
+    actor: {
+      ...overview.actor,
+      capabilities: {
+        ...overview.actor.capabilities,
+        'content_operations.rollback': true,
+      },
+    },
+  };
+  const html = await renderEntry(buildContentOpsEntry({
+    model: baseModel({
+      contentOperations: {
+        overview: rollbackOverview,
+        packages: { packages: [contentPackage] },
+        releases: { releases: [rollbackRelease, release] },
+        packageDetail: {
+          package: contentPackage,
+          events: [{ eventId: 'event-1', eventType: 'package.created', createdAt: Date.UTC(2026, 5, 11) }],
+        },
+      },
+    }),
+    initialActiveTab: 'releases',
+  }));
+
+  assert.match(html, /Rollback release/);
+  assert.match(html, /Rollback of rel-global-1/);
+  assert.match(html, /Reason: Restore the previous global spelling release\./);
+  assert.match(html, /data-content-ops-rollback-lineage="rel-global-1"/);
+});
+
 test('Content Operations Centre SSR renders package-scoped domain tabs and audit state', async () => {
   const html = await renderEntry(buildContentOpsEntry({
     initialActiveTab: 'detail',
@@ -988,6 +1078,161 @@ test('Content Operations Centre mounted shell loads API data without implicit pa
   assert.match(result.overviewText, /rel-global-1/);
   assert.match(result.packageTableText, /Pending/);
   assert.equal(result.selectedRows, 0);
+});
+
+test('Content Operations Centre mounted release history rolls back a prior release with reason', async () => {
+  const currentRelease = {
+    ...release,
+    releaseId: 'rel-global-2',
+    snapshotHash: 'hash-2',
+    baseReleaseId: 'rel-global-1',
+    publishedAt: Date.UTC(2026, 5, 11, 9, 20, 0),
+  };
+  const rollbackEnabledOverview = {
+    ...overview,
+    latestRelease: currentRelease,
+    lanes: {
+      ...overview.lanes,
+      recentReleases: [currentRelease, release],
+    },
+    actor: {
+      ...overview.actor,
+      capabilities: {
+        ...overview.actor.capabilities,
+        'content_operations.rollback': true,
+      },
+    },
+  };
+  const modelWithRollback = baseModel({
+    contentOperations: {
+      overview: rollbackEnabledOverview,
+      packages: { packages: [contentPackage] },
+      releases: { releases: [currentRelease, release] },
+      packageDetail: {
+        package: contentPackage,
+        events: [{ eventId: 'event-1', eventType: 'package.created', createdAt: Date.UTC(2026, 5, 11) }],
+      },
+    },
+  });
+  const output = await runClientEntry(`
+    const { JSDOM } = require('jsdom');
+
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+    const dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
+      url: 'https://ks2.eugnel.uk/admin',
+    });
+    globalThis.window = dom.window;
+    globalThis.document = dom.window.document;
+    globalThis.navigator = dom.window.navigator;
+    globalThis.HTMLElement = dom.window.HTMLElement;
+    globalThis.Event = dom.window.Event;
+
+    const React = require('react');
+    const { createRoot } = require('react-dom/client');
+    const { AdminContentOperationsSection } = require(${CONTENT_OPS_SECTION_PATH});
+    const { act } = React;
+
+    const model = ${JSON.stringify(modelWithRollback)};
+    const rollbackRelease = ${JSON.stringify(rollbackRelease)};
+    const currentRelease = ${JSON.stringify(currentRelease)};
+    const oldRelease = ${JSON.stringify(release)};
+    const calls = [];
+    const actions = {
+      contentOperationsApi: {
+        async rollbackRelease(args) {
+          calls.push({ method: 'rollback', args });
+          return { release: rollbackRelease };
+        },
+        async readOverview(args) {
+          calls.push({ method: 'overview', args });
+          return {
+            ...model.contentOperations.overview,
+            latestRelease: rollbackRelease,
+            lanes: {
+              ...model.contentOperations.overview.lanes,
+              recentReleases: [rollbackRelease, currentRelease, oldRelease],
+            },
+          };
+        },
+        async readPackages(args) {
+          calls.push({ method: 'packages', args });
+          return model.contentOperations.packages;
+        },
+        async readReleases(args) {
+          calls.push({ method: 'releases', args });
+          return { releases: [rollbackRelease, currentRelease, oldRelease] };
+        },
+      },
+    };
+
+    async function flush() {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+    }
+
+    async function main() {
+      const root = createRoot(document.getElementById('root'));
+      await act(async () => {
+        root.render(React.createElement(AdminContentOperationsSection, {
+          model,
+          actions,
+          initialActiveTab: 'releases',
+        }));
+      });
+      await flush();
+
+      const button = document.querySelector('[data-content-ops-rollback-action="rel-global-1"]');
+      const buttonDisabledBeforeReason = button.disabled;
+      const reason = document.querySelector('[data-content-ops-rollback-reason="rel-global-1"]');
+      const valueSetter = Object.getOwnPropertyDescriptor(dom.window.HTMLTextAreaElement.prototype, 'value').set;
+      valueSetter.call(reason, 'Restore the previous global spelling release.');
+      await act(async () => {
+        reason.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
+        reason.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+      });
+      await flush();
+
+      const buttonDisabledAfterReason = button.disabled;
+      await act(async () => {
+        button.click();
+      });
+      await flush();
+      await flush();
+      await flush();
+
+      process.stdout.write(JSON.stringify({
+        calls,
+        text: document.body.textContent,
+        buttonDisabledBeforeReason,
+        buttonDisabledAfterReason,
+      }));
+
+      await act(async () => {
+        root.unmount();
+      });
+      dom.window.close();
+      process.exit(0);
+    }
+
+    main().catch((error) => {
+      process.stderr.write(error.stack || error.message);
+      process.exitCode = 1;
+    });
+  `);
+  const result = JSON.parse(output);
+  const rollbackCall = result.calls.find((entry) => entry.method === 'rollback');
+
+  assert.equal(result.buttonDisabledBeforeReason, true);
+  assert.equal(result.buttonDisabledAfterReason, false);
+  assert.equal(rollbackCall.args.releaseId, 'rel-global-1');
+  assert.equal(rollbackCall.args.reason, 'Restore the previous global spelling release.');
+  assert.equal(rollbackCall.args.proof.rollback.approvalMode, 'same-role-placeholder');
+  assert.equal(rollbackCall.args.proof.rollback.proofRequirement, 'production-proof-after-rollback');
+  assert.ok(rollbackCall.args.mutation.requestId.startsWith('content-ops-rollback-rel-global-1-'));
+  assert.deepEqual(result.calls.map((entry) => entry.method), ['rollback', 'overview', 'packages', 'releases']);
+  assert.match(result.text, /Rolled back to rel-global-1\./);
+  assert.match(result.text, /Rollback of rel-global-1/);
 });
 
 test('Content Operations Centre spelling tab browses words and loads package draft detail', async () => {

--- a/worker/src/content-operations/repository.js
+++ b/worker/src/content-operations/repository.js
@@ -2540,11 +2540,23 @@ export function createContentOperationsRepository({ db, env = {}, now }) {
 
     async rollbackContentOperationRelease(subjectId = CONTENT_OPERATION_SUBJECT_ID, releaseId, {
       rolledBackByAccountId,
+      reason = '',
       proof = null,
     } = {}) {
       const resolvedSubjectId = normaliseSubjectId(subjectId);
       const actor = normaliseString(rolledBackByAccountId);
       if (!actor) throw new BadRequestError('Content operation rollback requires an actor account id.');
+      const suppliedRollbackProof = isPlainObject(proof?.rollback) ? proof.rollback : {};
+      const rollbackReason = normaliseString(reason)
+        || normaliseString(proof?.reason)
+        || normaliseString(suppliedRollbackProof.reason);
+      if (!rollbackReason) {
+        throw new BadRequestError('Content operation rollback requires a reason.', {
+          code: 'content_operation_rollback_reason_required',
+          subjectId: resolvedSubjectId,
+          releaseId,
+        });
+      }
       const targetRow = await readReleaseRowById(db, resolvedSubjectId, normaliseString(releaseId), {
         includeSnapshot: true,
       });
@@ -2581,9 +2593,15 @@ export function createContentOperationsRepository({ db, env = {}, now }) {
           },
         } : {}),
         rollback: {
+          ...cloneSerialisable(suppliedRollbackProof),
           targetReleaseId: target.releaseId,
           targetSnapshotHash: target.snapshotHash,
           previousLatestReleaseId: currentRow?.release_id || null,
+          reason: rollbackReason,
+          approvedByAccountId: normaliseString(suppliedRollbackProof.approvedByAccountId, actor),
+          publishedByAccountId: normaliseString(suppliedRollbackProof.publishedByAccountId, actor),
+          approvalMode: normaliseString(suppliedRollbackProof.approvalMode, 'same-role-placeholder'),
+          proofRequirement: normaliseString(suppliedRollbackProof.proofRequirement, 'production-proof-after-rollback'),
         },
       };
 
@@ -2632,6 +2650,7 @@ export function createContentOperationsRepository({ db, env = {}, now }) {
             rollbackOfReleaseId: target.releaseId,
             previousLatestReleaseId: currentRow?.release_id || null,
             snapshotHash,
+            reason: rollbackReason,
           }),
           nowTs,
           rollbackReleaseId,

--- a/worker/src/content-operations/routes.js
+++ b/worker/src/content-operations/routes.js
@@ -797,6 +797,7 @@ export async function handleContentOperationsAdminRequest({
       const body = normaliseBody(await readJson(request));
       const release = await repository.rollbackContentOperationRelease(CONTENT_OPERATIONS_SUBJECT_ID, releaseId, {
         rolledBackByAccountId: actor.id,
+        reason: body.reason,
         proof: proofFromRequest(body, request, 'rollback'),
       });
       return json({


### PR DESCRIPTION
## Summary
- add a Content Operations release rollback API client action and admin UI recovery control gated by rollback capability and a required reason
- make server-side rollback reason mandatory, preserving same-role approval placeholder proof and rollback lineage metadata
- cover rollback route, repository, API client, and React release-history behaviour with focused tests

## Verification
- node --test tests/button-label-consistency.test.js tests/content-operations-rollback.test.js tests/content-operations-repository.test.js tests/admin-content-operations-v2.test.js tests/react-admin-content-operations.test.js tests/content-operations-api.test.js tests/monster-asset-upload-validation.test.js
- npm run check
- npm test (pre-push hook): 111866 pass, 0 fail, 12 skipped