### PR TITLE
Implement package-level content operation reverts

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2726,6 +2726,7 @@ function buildSurfaceActions() {
     generateAudio: hubApi.generateContentOperationAudio?.bind(hubApi),
     approvePackage: hubApi.approveContentOperationPackage?.bind(hubApi),
     publishPackage: hubApi.publishContentOperationPackage?.bind(hubApi),
+    createRevertPackage: hubApi.createContentOperationPackageRevert?.bind(hubApi),
     resolveConflict: hubApi.resolveContentOperationConflict?.bind(hubApi),
     readReleases: hubApi.readContentOperationReleases?.bind(hubApi),
     readRelease: hubApi.readContentOperationRelease?.bind(hubApi),

--- a/src/platform/hubs/api.js
+++ b/src/platform/hubs/api.js
@@ -432,6 +432,31 @@ export function createHubApi({
         }),
       }, authSession);
     },
+    async createContentOperationPackageRevert({
+      packageId,
+      reason = '',
+      title = '',
+      description = '',
+      includeSnapshot = false,
+      mutation,
+    } = {}) {
+      if (!packageId) throw new TypeError('Content operation package id is required.');
+      const safeReason = String(reason || '').trim();
+      if (!safeReason) throw new TypeError('Content operation package revert reason is required.');
+      const safePackageId = encodeURIComponent(String(packageId));
+      const url = buildRequestUrl(baseUrl, `/api/admin/content-operations/packages/${safePackageId}/create-revert`);
+      return fetchHubJson(fetch, url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          reason: safeReason,
+          title,
+          description,
+          includeSnapshot: Boolean(includeSnapshot),
+          mutation,
+        }),
+      }, authSession);
+    },
     async resolveContentOperationConflict({
       packageId,
       conflictId = '',

--- a/src/subjects/spelling/content/operations-model.js
+++ b/src/subjects/spelling/content/operations-model.js
@@ -439,6 +439,31 @@ export function readContentOperationField(bundle, operation) {
   return getAtPath(entity, splitFieldPath(normalised.fieldPath));
 }
 
+export function readContentOperationEntity(bundle, operation) {
+  const normalised = normaliseContentOperation(operation, { now: () => 0 });
+  const normalisedBundle = normaliseSpellingContentBundle(bundle);
+  if (normalised.entityType === CONTENT_OPERATION_MONSTER_ASSET_REFERENCE_ENTITY_TYPE) {
+    return undefined;
+  }
+  if (normalised.entityType === AUDIO_REQUIREMENT_PROFILE_ENTITY_TYPE) {
+    if (normalised.entityId !== AUDIO_REQUIREMENT_PROFILE_ENTITY_ID) return undefined;
+    return Object.prototype.hasOwnProperty.call(normalisedBundle.draft, 'audioRequirementProfile')
+      ? cloneSerialisable(normalisedBundle.draft.audioRequirementProfile)
+      : undefined;
+  }
+  if (normalised.entityType === HERO_EXPOSURE_ENTITY_TYPE) {
+    const descriptor = collectionFor(normalisedBundle, 'spelling.rewardTrack');
+    if (!descriptor) return undefined;
+    const { entity } = findEntity(descriptor.collection, descriptor.idField, normalised.entityId);
+    if (!entity || !isPlainObject(entity.heroExposure)) return undefined;
+    return cloneSerialisable(entity.heroExposure);
+  }
+  const descriptor = collectionFor(normalisedBundle, normalised.entityType);
+  if (!descriptor) return undefined;
+  const { entity } = findEntity(descriptor.collection, descriptor.idField, normalised.entityId);
+  return entity ? cloneSerialisable(entity) : undefined;
+}
+
 export function applyContentOperationsToSpellingContent(baseBundle, operations = []) {
   const candidate = normaliseSpellingContentBundle(baseBundle);
   const normalisedOperations = operations.map((operation) => normaliseContentOperation(operation, { now: () => 0 }));
@@ -460,5 +485,186 @@ export function buildSpellingContentOperationCandidate(baseBundle, operations = 
     candidate,
     validation,
     conflicts: [],
+  };
+}
+
+function valuesMatch(left, right) {
+  return contentOperationValueHash(left) === contentOperationValueHash(right);
+}
+
+function buildRevertRetirementPayload({
+  reason = '',
+  now = () => Date.now(),
+  sourcePackageId = '',
+  sourceReleaseId = '',
+  operation = null,
+} = {}) {
+  return {
+    reason: normaliseString(reason, 'Reverted through Content Operations Centre.'),
+    retiredAt: Number(now()),
+    source: 'content-operations-package-revert',
+    revertOfPackageId: normaliseString(sourcePackageId) || null,
+    revertOfReleaseId: normaliseString(sourceReleaseId) || null,
+    revertOfOperationId: normaliseString(operation?.operationId) || null,
+  };
+}
+
+function buildRetiredEntityForHash(operation, afterEntity, retirementPayload) {
+  if (operation.entityType === HERO_EXPOSURE_ENTITY_TYPE) {
+    return normaliseHeroExposure({ state: 'hidden' });
+  }
+  const normalisedRetirement = {
+    reason: normaliseString(retirementPayload?.reason),
+    source: normaliseString(retirementPayload?.source),
+    retiredAt: Number.isFinite(Number(retirementPayload?.retiredAt)) ? Number(retirementPayload.retiredAt) : 0,
+  };
+  return {
+    ...cloneSerialisable(afterEntity),
+    active: false,
+    retired: true,
+    retirement: normalisedRetirement,
+  };
+}
+
+function inverseStructuralAction(operation, beforeEntity, afterEntity, options) {
+  const beforeExists = beforeEntity !== undefined;
+  const afterExists = afterEntity !== undefined;
+  if (beforeExists && afterExists && valuesMatch(beforeEntity, afterEntity)) return null;
+
+  if (operation.entityType === CONTENT_OPERATION_MONSTER_ASSET_REFERENCE_ENTITY_TYPE) {
+    return null;
+  }
+
+  if (operation.action === 'remove') {
+    if (!beforeExists) return null;
+    return {
+      entityType: operation.entityType,
+      entityId: operation.entityId,
+      fieldPath: '',
+      action: 'upsert',
+      payload: beforeEntity,
+      beforeHash: contentOperationValueHash(afterEntity),
+      afterHash: contentOperationValueHash(beforeEntity),
+    };
+  }
+
+  if (operation.action === 'retire') {
+    if (!beforeExists) return null;
+    return {
+      entityType: operation.entityType,
+      entityId: operation.entityId,
+      fieldPath: '',
+      action: operation.entityType === AUDIO_REQUIREMENT_PROFILE_ENTITY_TYPE ? 'upsert' : 'replace',
+      payload: beforeEntity,
+      beforeHash: contentOperationValueHash(afterEntity),
+      afterHash: contentOperationValueHash(beforeEntity),
+    };
+  }
+
+  if (beforeExists) {
+    return {
+      entityType: operation.entityType,
+      entityId: operation.entityId,
+      fieldPath: '',
+      action: operation.entityType === AUDIO_REQUIREMENT_PROFILE_ENTITY_TYPE ? 'upsert' : 'replace',
+      payload: beforeEntity,
+      beforeHash: contentOperationValueHash(afterEntity),
+      afterHash: contentOperationValueHash(beforeEntity),
+    };
+  }
+
+  if (!afterExists) return null;
+
+  if (operation.entityType === AUDIO_REQUIREMENT_PROFILE_ENTITY_TYPE) {
+    return {
+      entityType: operation.entityType,
+      entityId: operation.entityId,
+      fieldPath: '',
+      action: 'remove',
+      payload: null,
+      beforeHash: contentOperationValueHash(afterEntity),
+      afterHash: contentOperationValueHash(null),
+    };
+  }
+
+  const retirementPayload = buildRevertRetirementPayload({ ...options, operation });
+  const retiredEntity = buildRetiredEntityForHash(operation, afterEntity, retirementPayload);
+  return {
+    entityType: operation.entityType,
+    entityId: operation.entityId,
+    fieldPath: '',
+    action: 'retire',
+    payload: retirementPayload,
+    beforeHash: contentOperationValueHash(afterEntity),
+    afterHash: contentOperationValueHash(retiredEntity),
+  };
+}
+
+function inverseSetAction(operation, beforeSnapshot, afterSnapshot, options) {
+  const beforeValue = readContentOperationField(beforeSnapshot, operation);
+  const afterValue = readContentOperationField(afterSnapshot, operation);
+  if (valuesMatch(beforeValue, afterValue)) return null;
+
+  if (beforeValue !== undefined) {
+    return {
+      entityType: operation.entityType,
+      entityId: operation.entityId,
+      fieldPath: operation.fieldPath,
+      action: 'set',
+      payload: beforeValue,
+      beforeHash: contentOperationValueHash(afterValue),
+      afterHash: contentOperationValueHash(beforeValue),
+    };
+  }
+
+  const beforeEntity = readContentOperationEntity(beforeSnapshot, operation);
+  const afterEntity = readContentOperationEntity(afterSnapshot, operation);
+  return inverseStructuralAction(operation, beforeEntity, afterEntity, options);
+}
+
+export function buildContentOperationRevertOperations({
+  sourceBaseSnapshot,
+  operations = [],
+  reason = '',
+  now = () => Date.now(),
+  sourcePackageId = '',
+  sourceReleaseId = '',
+} = {}) {
+  const normalisedOperations = operations.map((operation) => normaliseContentOperation(operation, { now: () => 0 }));
+  let cursor = normaliseSpellingContentBundle(sourceBaseSnapshot);
+  const timeline = [];
+  for (const operation of normalisedOperations) {
+    const beforeSnapshot = cursor;
+    const afterSnapshot = applyContentOperationsToSpellingContent(beforeSnapshot, [operation]);
+    timeline.push({ operation, beforeSnapshot, afterSnapshot });
+    cursor = afterSnapshot;
+  }
+
+  const inverseOperations = [];
+  const skippedOperations = [];
+  const options = { reason, now, sourcePackageId, sourceReleaseId };
+  for (const entry of [...timeline].reverse()) {
+    const beforeEntity = readContentOperationEntity(entry.beforeSnapshot, entry.operation);
+    const afterEntity = readContentOperationEntity(entry.afterSnapshot, entry.operation);
+    const inverse = entry.operation.action === 'set'
+      ? inverseSetAction(entry.operation, entry.beforeSnapshot, entry.afterSnapshot, options)
+      : inverseStructuralAction(entry.operation, beforeEntity, afterEntity, options);
+    if (inverse) {
+      inverseOperations.push(inverse);
+    } else {
+      skippedOperations.push({
+        operationId: entry.operation.operationId,
+        entityType: entry.operation.entityType,
+        entityId: entry.operation.entityId,
+        fieldPath: entry.operation.fieldPath,
+        action: entry.operation.action,
+      });
+    }
+  }
+
+  return {
+    operations: inverseOperations,
+    skippedOperations,
+    replayedSnapshot: cursor,
   };
 }

--- a/src/surfaces/hubs/AdminContentOperationsSection.jsx
+++ b/src/surfaces/hubs/AdminContentOperationsSection.jsx
@@ -3879,8 +3879,13 @@ function ReleaseTable({
   rollbackAvailable = false,
   rollbackState = null,
   onRollback = null,
+  canCreatePackageRevert = false,
+  packageRevertAvailable = false,
+  packageRevertState = null,
+  onCreatePackageRevert = null,
 }) {
   const [rollbackReasons, setRollbackReasons] = React.useState({});
+  const [packageRevertReasons, setPackageRevertReasons] = React.useState({});
   if (!releases.length) {
     return (
       <div className="feedback admin-note-spaced" data-content-ops-empty-releases="true">
@@ -3944,6 +3949,26 @@ function ReleaseTable({
             const rollbackHint = isLatestRelease
               ? 'Current release'
               : (!canRollback ? 'No rollback role' : (!rollbackAvailable ? 'Rollback unavailable' : 'Requires reason'));
+            const packageRevertReason = String(packageRevertReasons[release.packageId] ?? '');
+            const packageRevertRunning = packageRevertState?.running && packageRevertState.packageId === release.packageId;
+            const packageTerminal = ['reverted', 'superseded'].includes(history?.package?.state);
+            const packageRevertTargetable = Boolean(release.packageId)
+              && !release.rollbackOfReleaseId
+              && release.status === 'published'
+              && !packageTerminal;
+            const packageRevertDisabled = !packageRevertAvailable
+              || !canCreatePackageRevert
+              || !onCreatePackageRevert
+              || !packageRevertTargetable
+              || packageRevertRunning
+              || !packageRevertReason.trim();
+            const packageRevertHint = !release.packageId
+              ? 'No package'
+              : (packageTerminal
+                  ? 'Already reverted'
+                  : (!canCreatePackageRevert
+                      ? 'No rollback role'
+                      : (!packageRevertAvailable ? 'Package revert unavailable' : 'Requires reason')));
             return (
               <tr
                 key={release.releaseId}
@@ -4044,6 +4069,42 @@ function ReleaseTable({
                     <div className="small muted">
                       {rollbackRunning ? 'Rolling back...' : rollbackHint}
                     </div>
+                    {release.packageId && !release.rollbackOfReleaseId ? (
+                      <>
+                        <textarea
+                          rows={2}
+                          value={packageRevertReason}
+                          placeholder="Package revert reason"
+                          aria-label={`Package revert reason for ${release.packageId}`}
+                          data-content-ops-package-revert-reason={release.packageId}
+                          disabled={packageRevertRunning || !canCreatePackageRevert || !packageRevertAvailable || packageTerminal}
+                          onChange={(event) => {
+                            const value = event.target.value;
+                            setPackageRevertReasons((current) => ({
+                              ...current,
+                              [release.packageId]: value,
+                            }));
+                          }}
+                        />
+                        <button
+                          type="button"
+                          className="btn secondary compact"
+                          disabled={packageRevertDisabled}
+                          aria-busy={packageRevertRunning ? 'true' : undefined}
+                          data-content-ops-package-revert-action={release.packageId}
+                          onClick={() => onCreatePackageRevert?.({
+                            packageId: release.packageId,
+                            releaseId: release.releaseId,
+                            reason: packageRevertReason.trim(),
+                          })}
+                        >
+                          Create package revert
+                        </button>
+                        <div className="small muted">
+                          {packageRevertRunning ? 'Creating package revert...' : packageRevertHint}
+                        </div>
+                      </>
+                    ) : null}
                   </div>
                 </td>
               </tr>
@@ -4059,6 +4120,16 @@ function ReleaseTable({
       {rollbackState?.error ? (
         <div className="feedback warn admin-note-spaced" data-content-ops-rollback-error="true">
           {rollbackState.error.message}
+        </div>
+      ) : null}
+      {packageRevertState?.message ? (
+        <div className="feedback good admin-note-spaced" data-content-ops-package-revert-message="true">
+          {packageRevertState.message}
+        </div>
+      ) : null}
+      {packageRevertState?.error ? (
+        <div className="feedback warn admin-note-spaced" data-content-ops-package-revert-error="true">
+          {packageRevertState.error.message}
         </div>
       ) : null}
     </div>
@@ -4146,6 +4217,15 @@ export function AdminContentOperationsSection({
     message: '',
     error: null,
     release: null,
+  });
+  const [packageRevertState, setPackageRevertState] = React.useState({
+    packageId: '',
+    releaseId: '',
+    running: false,
+    message: '',
+    error: null,
+    package: null,
+    candidate: null,
   });
   const detailRequestRef = React.useRef({ id: '', seq: 0 });
   const spellingBrowseRequestRef = React.useRef(0);
@@ -4635,6 +4715,69 @@ export function AdminContentOperationsSection({
     }
   }, [api, invalidateSpellingBrowse, overview.actor?.accountId, refresh]);
 
+  const runCreatePackageRevert = React.useCallback(async ({ packageId, releaseId, reason }) => {
+    const safePackageId = String(packageId || '').trim();
+    const safeReleaseId = String(releaseId || '').trim();
+    const safeReason = String(reason || '').trim();
+    if (!api?.createRevertPackage || !safePackageId || !safeReason) return;
+    setPackageRevertState({
+      packageId: safePackageId,
+      releaseId: safeReleaseId,
+      running: true,
+      message: '',
+      error: null,
+      package: null,
+      candidate: null,
+    });
+    try {
+      const payload = await api.createRevertPackage({
+        packageId: safePackageId,
+        reason: safeReason,
+        title: `Revert package ${safePackageId}`,
+        mutation: contentOperationMutation('package-revert', safePackageId),
+      });
+      const nextPackage = normaliseContentOperationPackage(payload?.package || null);
+      const nextCandidate = payload?.candidate
+        ? normaliseContentOperationCandidate(payload.candidate)
+        : null;
+      setPackageRevertState({
+        packageId: safePackageId,
+        releaseId: safeReleaseId,
+        running: false,
+        message: `Created package revert ${nextPackage.packageId || ''}.`.trim(),
+        error: null,
+        package: nextPackage,
+        candidate: nextCandidate,
+      });
+      if (nextPackage.packageId) {
+        setSelectedPackageId(nextPackage.packageId);
+        setActiveTab('detail');
+        setDetailPayload({
+          package: nextPackage,
+          actor: payload?.actor || overview.actor || null,
+          events: [],
+        });
+        if (api.readPackage) {
+          await loadPackageDetail(nextPackage.packageId);
+        }
+      }
+      invalidateSpellingBrowse();
+      if (api.readOverview) {
+        await refresh();
+      }
+    } catch (error) {
+      setPackageRevertState({
+        packageId: safePackageId,
+        releaseId: safeReleaseId,
+        running: false,
+        message: '',
+        error: errorEnvelope(error, 'content_operations_package_revert_failed'),
+        package: null,
+        candidate: null,
+      });
+    }
+  }, [api, invalidateSpellingBrowse, loadPackageDetail, overview.actor, refresh]);
+
   const latestRelease = overview.latestRelease;
   const primaryData = overview.openPackageCount || packages.length || releases.length || latestRelease || spellingBrowse.words.length ? {
     overview,
@@ -4768,6 +4911,10 @@ export function AdminContentOperationsSection({
           rollbackAvailable={Boolean(api?.rollbackRelease)}
           rollbackState={rollbackState}
           onRollback={runRollbackRelease}
+          canCreatePackageRevert={canRollback}
+          packageRevertAvailable={Boolean(api?.createRevertPackage)}
+          packageRevertState={packageRevertState}
+          onCreatePackageRevert={runCreatePackageRevert}
         />
       ) : null}
     </AdminPanelFrame>

--- a/tests/button-label-consistency.test.js
+++ b/tests/button-label-consistency.test.js
@@ -354,6 +354,7 @@ test('button labels: every statically extractable label is classified', () => {
     'Edit',
     'Restore to v',
     'Rollback',
+    'Create package revert',
     'Confirm schedule',
     'Open Spelling',
     'Open settings tab',

--- a/tests/content-operations-revert.test.js
+++ b/tests/content-operations-revert.test.js
@@ -1,0 +1,427 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createWorkerRepository } from '../worker/src/repository.js';
+import {
+  readSeededSpellingContentBundle,
+} from '../worker/src/generated-spelling-content-seed.js';
+import { createMigratedSqliteD1Database } from './helpers/sqlite-d1.js';
+import { createWorkerRepositoryServer } from './helpers/worker-server.js';
+
+const BASE_URL = 'https://repo.test';
+const ADMIN_ID = 'admin-a';
+const NOW = Date.UTC(2026, 5, 12, 14, 0, 0);
+
+function seedAdultAccount(DB, {
+  accountId = ADMIN_ID,
+  platformRole = 'admin',
+} = {}) {
+  DB.db.prepare(`
+    INSERT INTO adult_accounts (id, email, display_name, platform_role, selected_learner_id, created_at, updated_at, repo_revision)
+    VALUES (?, ?, ?, ?, NULL, ?, ?, 0)
+    ON CONFLICT(id) DO UPDATE SET
+      platform_role = excluded.platform_role,
+      updated_at = excluded.updated_at
+  `).run(accountId, `${accountId}@example.test`, accountId, platformRole, NOW, NOW);
+}
+
+function jsonInit(method, body = {}) {
+  return {
+    method,
+    headers: {
+      'content-type': 'application/json',
+      'sec-fetch-site': 'same-origin',
+    },
+    body: JSON.stringify(body),
+  };
+}
+
+function adminHeaders() {
+  return {
+    'x-ks2-dev-platform-role': 'admin',
+    'sec-fetch-site': 'same-origin',
+  };
+}
+
+function createDeleteTrackingBucket() {
+  return {
+    deletes: [],
+    async get() {
+      return null;
+    },
+    async put() {},
+    async delete(key) {
+      this.deletes.push(key);
+    },
+  };
+}
+
+async function publishOperations(repository, {
+  title,
+  operations,
+  actorAccountId = ADMIN_ID,
+  templateId = 'test-package',
+} = {}) {
+  const contentPackage = await repository.createContentOperationPackage({
+    templateId,
+    title,
+    createdByAccountId: actorAccountId,
+  });
+  for (const operation of operations) {
+    // eslint-disable-next-line no-await-in-loop
+    await repository.appendContentOperation(contentPackage.packageId, operation, {
+      actorAccountId,
+    });
+  }
+  const candidate = await repository.buildContentOperationCandidate(contentPackage.packageId, {
+    actorAccountId,
+  });
+  await repository.approveContentOperationCandidate(contentPackage.packageId, candidate.candidateId, {
+    approvedByAccountId: actorAccountId,
+  });
+  const release = await repository.publishContentOperationPackage(contentPackage.packageId, {
+    publishedByAccountId: actorAccountId,
+    proof: { source: 'content-operations-revert-test' },
+  });
+  return { contentPackage, candidate, release };
+}
+
+test('package-level revert restores one package while preserving unrelated later releases', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const repository = createWorkerRepository({
+    env: { DB },
+    now: () => NOW,
+  });
+
+  try {
+    const seeded = await readSeededSpellingContentBundle();
+    await repository.seedFirstContentOperationRelease({
+      seededByAccountId: ADMIN_ID,
+      proof: { source: 'package-revert-seed' },
+    });
+    const firstWord = seeded.draft.words[0];
+    const secondWord = seeded.draft.words[1];
+    const firstExplanation = `Temporary package-level revert explanation for ${firstWord.word}.`;
+    const secondExplanation = `Unrelated later explanation for ${secondWord.word}.`;
+    const source = await publishOperations(repository, {
+      title: 'Package to revert',
+      operations: [{
+        entityType: 'spelling.word',
+        entityId: firstWord.slug,
+        fieldPath: 'explanation',
+        action: 'set',
+        payload: firstExplanation,
+      }],
+    });
+    await publishOperations(repository, {
+      title: 'Unrelated later package',
+      operations: [{
+        entityType: 'spelling.word',
+        entityId: secondWord.slug,
+        fieldPath: 'explanation',
+        action: 'set',
+        payload: secondExplanation,
+      }],
+    });
+
+    const revert = await repository.createContentOperationPackageRevert(source.contentPackage.packageId, {
+      createdByAccountId: ADMIN_ID,
+      reason: 'Undo the first package without touching the second package.',
+    });
+    assert.equal(revert.package.templateId, 'package-revert');
+    assert.equal(revert.package.baseReleaseId, source.release.releaseId);
+    assert.equal(revert.candidate.conflicts.length, 0);
+    assert.equal(revert.package.operations.length, 1);
+    assert.equal(revert.package.operations[0].action, 'set');
+    assert.equal(revert.package.operations[0].payload, firstWord.explanation);
+
+    await repository.approveContentOperationCandidate(revert.package.packageId, revert.candidate.candidateId, {
+      approvedByAccountId: ADMIN_ID,
+    });
+    await repository.publishContentOperationPackage(revert.package.packageId, {
+      publishedByAccountId: ADMIN_ID,
+      proof: { source: 'package-revert-publish-test' },
+    });
+    const latest = await repository.readLatestContentOperationRelease('spelling', {
+      includeSnapshot: true,
+    });
+    const latestFirst = latest.snapshot.draft.words.find((entry) => entry.slug === firstWord.slug);
+    const latestSecond = latest.snapshot.draft.words.find((entry) => entry.slug === secondWord.slug);
+    const sourceAfterRevert = await repository.readContentOperationPackage(source.contentPackage.packageId);
+
+    assert.equal(latestFirst.explanation, firstWord.explanation);
+    assert.equal(latestSecond.explanation, secondExplanation);
+    assert.equal(sourceAfterRevert.state, 'reverted');
+    assert.equal(sourceAfterRevert.supersededByPackageId, revert.package.packageId);
+
+    const sourceEvents = await repository.listContentOperationEvents({
+      packageId: source.contentPackage.packageId,
+      limit: 10,
+    });
+    assert.ok(sourceEvents.some((event) => event.eventType === 'package.revert_requested'));
+    assert.ok(sourceEvents.some((event) => event.eventType === 'package.reverted'));
+  } finally {
+    DB.close();
+  }
+});
+
+test('package-level revert surfaces same-field drift as a normal candidate conflict', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const repository = createWorkerRepository({
+    env: { DB },
+    now: () => NOW,
+  });
+
+  try {
+    const seeded = await readSeededSpellingContentBundle();
+    await repository.seedFirstContentOperationRelease({
+      seededByAccountId: ADMIN_ID,
+      proof: { source: 'package-revert-conflict-seed' },
+    });
+    const word = seeded.draft.words[0];
+    const sourceValue = `Source package explanation for ${word.word}.`;
+    const laterValue = `Later package explanation for ${word.word}.`;
+    const source = await publishOperations(repository, {
+      title: 'Source package with later conflict',
+      operations: [{
+        entityType: 'spelling.word',
+        entityId: word.slug,
+        fieldPath: 'explanation',
+        action: 'set',
+        payload: sourceValue,
+      }],
+    });
+    await publishOperations(repository, {
+      title: 'Later same-field package',
+      operations: [{
+        entityType: 'spelling.word',
+        entityId: word.slug,
+        fieldPath: 'explanation',
+        action: 'set',
+        payload: laterValue,
+      }],
+    });
+
+    const revert = await repository.createContentOperationPackageRevert(source.contentPackage.packageId, {
+      createdByAccountId: ADMIN_ID,
+      reason: 'Show the later same-field edit as a conflict.',
+    });
+
+    assert.equal(revert.candidate.conflicts.length, 1);
+    assert.equal(revert.candidate.conflicts[0].code, 'same_field_conflict');
+    assert.equal(revert.candidate.conflicts[0].packageValue, word.explanation);
+    assert.equal(revert.candidate.conflicts[0].currentValue, laterValue);
+
+    await assert.rejects(
+      () => repository.approveContentOperationCandidate(revert.package.packageId, revert.candidate.candidateId, {
+        approvedByAccountId: ADMIN_ID,
+      }),
+      (error) => {
+        assert.equal(error.extra?.code, 'content_operation_candidate_conflicted');
+        return true;
+      },
+    );
+  } finally {
+    DB.close();
+  }
+});
+
+test('package-level revert retires published content created by the source package', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const repository = createWorkerRepository({
+    env: { DB },
+    now: () => NOW,
+  });
+
+  try {
+    await repository.seedFirstContentOperationRelease({
+      seededByAccountId: ADMIN_ID,
+      proof: { source: 'package-revert-created-content-seed' },
+    });
+    const source = await publishOperations(repository, {
+      title: 'Create a temporary spelling pool',
+      templateId: 'pool-create',
+      operations: [{
+        entityType: 'spelling.pool',
+        entityId: 'temporary-revert-pool',
+        fieldPath: '',
+        action: 'create',
+        payload: {
+          id: 'temporary-revert-pool',
+          title: 'Temporary revert pool',
+          type: 'extension',
+          visibility: { state: 'hidden' },
+          sourceNote: 'Created by package revert test.',
+          provenance: { source: 'content-operations-revert-test' },
+        },
+      }],
+    });
+
+    const revert = await repository.createContentOperationPackageRevert(source.contentPackage.packageId, {
+      createdByAccountId: ADMIN_ID,
+      reason: 'Retire the published pool rather than hard deleting it.',
+    });
+    assert.equal(revert.package.operations[0].action, 'retire');
+
+    await repository.approveContentOperationCandidate(revert.package.packageId, revert.candidate.candidateId, {
+      approvedByAccountId: ADMIN_ID,
+    });
+    await repository.publishContentOperationPackage(revert.package.packageId, {
+      publishedByAccountId: ADMIN_ID,
+      proof: { source: 'package-revert-created-content-publish' },
+    });
+    const latest = await repository.readLatestContentOperationRelease('spelling', {
+      includeSnapshot: true,
+    });
+    const pool = latest.snapshot.draft.pools.find((entry) => entry.id === 'temporary-revert-pool');
+
+    assert.ok(pool, 'Published pool should remain as auditable retired content.');
+    assert.equal(pool.active, false);
+    assert.equal(pool.retired, true);
+    assert.equal(pool.retirement.source, 'content-operations-package-revert');
+  } finally {
+    DB.close();
+  }
+});
+
+test('package-level revert publish rejects a source package that was superseded after approval', async () => {
+  const DB = createMigratedSqliteD1Database();
+  const repository = createWorkerRepository({
+    env: { DB },
+    now: () => NOW,
+  });
+
+  try {
+    await repository.seedFirstContentOperationRelease({
+      seededByAccountId: ADMIN_ID,
+      proof: { source: 'package-revert-source-superseded-seed' },
+    });
+    const seeded = await readSeededSpellingContentBundle();
+    const word = seeded.draft.words[0];
+    const source = await publishOperations(repository, {
+      title: 'Package to supersede before revert publish',
+      operations: [{
+        entityType: 'spelling.word',
+        entityId: word.slug,
+        fieldPath: 'explanation',
+        action: 'set',
+        payload: `Superseded source package explanation for ${word.word}.`,
+      }],
+    });
+
+    const revert = await repository.createContentOperationPackageRevert(source.contentPackage.packageId, {
+      createdByAccountId: ADMIN_ID,
+      reason: 'Prepare a revert before another operator supersedes the source.',
+    });
+    await repository.approveContentOperationCandidate(revert.package.packageId, revert.candidate.candidateId, {
+      approvedByAccountId: ADMIN_ID,
+    });
+    DB.db.prepare(`
+      UPDATE content_operation_packages
+      SET state = 'reverted', superseded_by_package_id = ?
+      WHERE package_id = ?
+    `).run('copkg-other-revert', source.contentPackage.packageId);
+
+    await assert.rejects(
+      () => repository.publishContentOperationPackage(revert.package.packageId, {
+        publishedByAccountId: ADMIN_ID,
+        proof: { source: 'package-revert-source-superseded-publish' },
+      }),
+      (error) => {
+        assert.equal(error.extra?.code, 'content_operation_revert_source_superseded');
+        assert.equal(error.extra?.revertOfPackageId, source.contentPackage.packageId);
+        assert.equal(error.extra?.supersededByPackageId, 'copkg-other-revert');
+        return true;
+      },
+    );
+  } finally {
+    DB.close();
+  }
+});
+
+test('package-level revert API creates a draft inverse package and never deletes R2 audio objects', async () => {
+  const bucket = createDeleteTrackingBucket();
+  const server = createWorkerRepositoryServer({
+    env: { SPELLING_AUDIO_BUCKET: bucket },
+    now: () => NOW,
+  });
+
+  try {
+    seedAdultAccount(server.DB, { accountId: ADMIN_ID, platformRole: 'admin' });
+    const repository = createWorkerRepository({
+      env: server.env,
+      now: () => NOW,
+    });
+    const seeded = await readSeededSpellingContentBundle();
+    await repository.seedFirstContentOperationRelease({
+      seededByAccountId: ADMIN_ID,
+      proof: { source: 'package-revert-api-seed' },
+    });
+    const word = seeded.draft.words[0];
+    const source = await publishOperations(repository, {
+      title: 'API package to revert',
+      operations: [{
+        entityType: 'spelling.word',
+        entityId: word.slug,
+        fieldPath: 'explanation',
+        action: 'set',
+        payload: `API source package explanation for ${word.word}.`,
+      }],
+    });
+    const unpublished = await repository.createContentOperationPackage({
+      templateId: 'draft-only',
+      title: 'Unpublished revert target',
+      createdByAccountId: ADMIN_ID,
+    });
+
+    const missingReasonResponse = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/packages/${source.contentPackage.packageId}/create-revert`,
+      jsonInit('POST', {}),
+      adminHeaders(),
+    );
+    const missingReason = await missingReasonResponse.json();
+    assert.equal(missingReasonResponse.status, 400);
+    assert.equal(missingReason.code, 'content_operation_revert_reason_required');
+
+    const unpublishedResponse = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/packages/${unpublished.packageId}/create-revert`,
+      jsonInit('POST', { reason: 'This draft should not be revertable.' }),
+      adminHeaders(),
+    );
+    const unpublishedPayload = await unpublishedResponse.json();
+    assert.equal(unpublishedResponse.status, 409);
+    assert.equal(unpublishedPayload.code, 'content_operation_package_not_published');
+
+    const response = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/packages/${source.contentPackage.packageId}/create-revert`,
+      jsonInit('POST', {
+        reason: 'Create a package revert through the API.',
+      }),
+      adminHeaders(),
+    );
+    const payload = await response.json();
+
+    assert.equal(response.status, 201);
+    assert.equal(payload.ok, true);
+    assert.equal(payload.package.templateId, 'package-revert');
+    assert.equal(payload.package.baseReleaseId, source.release.releaseId);
+    assert.equal(payload.candidate.currentReleaseId, source.release.releaseId);
+    assert.equal(payload.source.packageId, source.contentPackage.packageId);
+    assert.equal(payload.release, undefined);
+    assert.deepEqual(bucket.deletes, []);
+
+    await repository.approveContentOperationCandidate(payload.package.packageId, payload.candidate.candidateId, {
+      approvedByAccountId: ADMIN_ID,
+    });
+    await repository.publishContentOperationPackage(payload.package.packageId, {
+      publishedByAccountId: ADMIN_ID,
+      proof: { source: 'package-revert-api-publish' },
+    });
+    assert.deepEqual(bucket.deletes, []);
+  } finally {
+    server.close();
+  }
+});

--- a/tests/react-admin-content-operations.test.js
+++ b/tests/react-admin-content-operations.test.js
@@ -1235,6 +1235,186 @@ test('Content Operations Centre mounted release history rolls back a prior relea
   assert.match(result.text, /Rollback of rel-global-1/);
 });
 
+test('Content Operations Centre mounted release history creates package-level revert drafts', async () => {
+  const packageRelease = {
+    ...release,
+    packageId: 'pkg-published-1',
+  };
+  const revertPackage = {
+    ...contentPackage,
+    packageId: 'pkg-revert-1',
+    templateId: 'package-revert',
+    title: 'Revert package pkg-published-1',
+    state: 'draft',
+    baseReleaseId: packageRelease.releaseId,
+    latestCandidate: lifecycleCandidate,
+    blockers: cleanLifecycleBlockers,
+  };
+  const revertOverview = {
+    ...overview,
+    latestRelease: packageRelease,
+    lanes: {
+      ...overview.lanes,
+      recentReleases: [packageRelease],
+      drafts: [revertPackage],
+    },
+    actor: {
+      ...overview.actor,
+      capabilities: {
+        ...overview.actor.capabilities,
+        'content_operations.rollback': true,
+      },
+    },
+  };
+  const modelWithPackageRevert = baseModel({
+    contentOperations: {
+      overview: revertOverview,
+      packages: { packages: [contentPackage] },
+      releases: { releases: [packageRelease] },
+      packageDetail: {
+        package: contentPackage,
+        events: [{ eventId: 'event-1', eventType: 'package.created', createdAt: Date.UTC(2026, 5, 11) }],
+      },
+    },
+  });
+  const output = await runClientEntry(`
+    const { JSDOM } = require('jsdom');
+
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+    const dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
+      url: 'https://ks2.eugnel.uk/admin',
+    });
+    globalThis.window = dom.window;
+    globalThis.document = dom.window.document;
+    globalThis.navigator = dom.window.navigator;
+    globalThis.HTMLElement = dom.window.HTMLElement;
+    globalThis.Event = dom.window.Event;
+
+    const React = require('react');
+    const { createRoot } = require('react-dom/client');
+    const { AdminContentOperationsSection } = require(${CONTENT_OPS_SECTION_PATH});
+    const { act } = React;
+
+    const model = ${JSON.stringify(modelWithPackageRevert)};
+    const packageRelease = ${JSON.stringify(packageRelease)};
+    const revertPackage = ${JSON.stringify(revertPackage)};
+    const candidate = ${JSON.stringify(lifecycleCandidate)};
+    const calls = [];
+    const actions = {
+      contentOperationsApi: {
+        async createRevertPackage(args) {
+          calls.push({ method: 'createRevertPackage', args });
+          return {
+            package: revertPackage,
+            candidate,
+            actor: model.contentOperations.overview.actor,
+          };
+        },
+        async readPackage({ packageId }) {
+          calls.push({ method: 'readPackage', packageId });
+          return {
+            package: revertPackage,
+            actor: model.contentOperations.overview.actor,
+            events: [{ eventId: 'event-revert', eventType: 'package.revert_created', createdAt: ${Date.UTC(2026, 5, 11, 10, 15, 0)}, event: {} }],
+          };
+        },
+        async readOverview(args) {
+          calls.push({ method: 'overview', args });
+          return {
+            ...model.contentOperations.overview,
+            lanes: {
+              ...model.contentOperations.overview.lanes,
+              drafts: [revertPackage],
+              recentReleases: [packageRelease],
+            },
+          };
+        },
+        async readPackages(args) {
+          calls.push({ method: 'packages', args });
+          return { packages: [revertPackage] };
+        },
+        async readReleases(args) {
+          calls.push({ method: 'releases', args });
+          return { releases: [packageRelease] };
+        },
+      },
+    };
+
+    async function flush() {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+    }
+
+    async function main() {
+      const root = createRoot(document.getElementById('root'));
+      await act(async () => {
+        root.render(React.createElement(AdminContentOperationsSection, {
+          model,
+          actions,
+          initialActiveTab: 'releases',
+        }));
+      });
+      await flush();
+
+      const button = document.querySelector('[data-content-ops-package-revert-action="pkg-published-1"]');
+      const buttonDisabledBeforeReason = button.disabled;
+      const reason = document.querySelector('[data-content-ops-package-revert-reason="pkg-published-1"]');
+      const valueSetter = Object.getOwnPropertyDescriptor(dom.window.HTMLTextAreaElement.prototype, 'value').set;
+      valueSetter.call(reason, 'Undo this package without rolling back later releases.');
+      await act(async () => {
+        reason.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
+        reason.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+      });
+      await flush();
+
+      const buttonDisabledAfterReason = button.disabled;
+      await act(async () => {
+        button.click();
+      });
+      await flush();
+      await flush();
+      await flush();
+
+      process.stdout.write(JSON.stringify({
+        calls,
+        text: document.body.textContent,
+        buttonDisabledBeforeReason,
+        buttonDisabledAfterReason,
+        selectedDetail: document.querySelector('[data-package-detail="pkg-revert-1"]') != null,
+      }));
+
+      await act(async () => {
+        root.unmount();
+      });
+      dom.window.close();
+      process.exit(0);
+    }
+
+    main().catch((error) => {
+      process.stderr.write(error.stack || error.message);
+      process.exitCode = 1;
+    });
+  `);
+  const result = JSON.parse(output);
+  const createCall = result.calls.find((entry) => entry.method === 'createRevertPackage');
+
+  assert.equal(result.buttonDisabledBeforeReason, true);
+  assert.equal(result.buttonDisabledAfterReason, false);
+  assert.equal(createCall.args.packageId, 'pkg-published-1');
+  assert.equal(createCall.args.reason, 'Undo this package without rolling back later releases.');
+  assert.ok(createCall.args.mutation.requestId.startsWith('content-ops-package-revert-pkg-published-1-'));
+  assert.equal(result.selectedDetail, true);
+  assert.match(result.text, /Revert package pkg-published-1/);
+  assert.deepEqual(result.calls.map((entry) => entry.method), [
+    'createRevertPackage',
+    'readPackage',
+    'overview',
+    'packages',
+    'releases',
+  ]);
+});
+
 test('Content Operations Centre spelling tab browses words and loads package draft detail', async () => {
   const output = await runClientEntry(`
     const { JSDOM } = require('jsdom');

--- a/tests/spelling-content-operations-model.test.js
+++ b/tests/spelling-content-operations-model.test.js
@@ -7,8 +7,10 @@ import {
   buildSpellingContentWordDetail,
 } from '../src/subjects/spelling/content/editor-read-model.js';
 import {
+  buildContentOperationRevertOperations,
   buildSpellingContentOperationCandidate,
   applyContentOperationsToSpellingContent,
+  contentOperationValueHash,
 } from '../src/subjects/spelling/content/operations-model.js';
 import {
   buildPublishedSnapshotFromDraft,
@@ -28,6 +30,9 @@ import {
   validateSpellingWordListEditorInput,
   validateSpellingWordEditorInput,
 } from '../src/subjects/spelling/content/package-operations.js';
+import {
+  readSeededSpellingContentBundle,
+} from '../worker/src/generated-spelling-content-seed.js';
 
 const NOW = Date.UTC(2026, 5, 11, 12, 0, 0);
 
@@ -756,6 +761,59 @@ test('spelling word editor builder keeps core word-family variants as separate r
     }),
     /Core word-family variants must stay as separate word rows/,
   );
+});
+
+test('content operation revert builder restores fields and retires created published entities', async () => {
+  const bundle = await readSeededSpellingContentBundle();
+  const word = bundle.draft.words[0];
+  const changedExplanation = `Temporary inverse-builder explanation for ${word.word}.`;
+  const operations = [{
+    operationId: 'source-set-word',
+    entityType: 'spelling.word',
+    entityId: word.slug,
+    fieldPath: 'explanation',
+    action: 'set',
+    payload: changedExplanation,
+  }, {
+    operationId: 'source-create-pool',
+    entityType: 'spelling.pool',
+    entityId: 'inverse-builder-pool',
+    fieldPath: '',
+    action: 'create',
+    payload: {
+      id: 'inverse-builder-pool',
+      title: 'Inverse builder pool',
+      type: 'extension',
+      visibility: { state: 'hidden' },
+      sourceNote: 'Created by inverse builder test.',
+      provenance: { source: 'content-operations-inverse-test' },
+    },
+  }];
+  const sourceSnapshot = applyContentOperationsToSpellingContent(bundle, operations);
+  const inverse = buildContentOperationRevertOperations({
+    sourceBaseSnapshot: bundle,
+    operations,
+    reason: 'Exercise inverse operation generation.',
+    now: () => NOW,
+    sourcePackageId: 'copkg-source',
+    sourceReleaseId: 'corel-source',
+  });
+
+  assert.equal(inverse.operations.length, 2);
+  assert.equal(inverse.operations[0].entityType, 'spelling.pool');
+  assert.equal(inverse.operations[0].action, 'retire');
+  assert.equal(inverse.operations[0].payload.source, 'content-operations-package-revert');
+  assert.equal(inverse.operations[1].entityType, 'spelling.word');
+  assert.equal(inverse.operations[1].action, 'set');
+  assert.equal(inverse.operations[1].payload, word.explanation);
+
+  const revertedSnapshot = applyContentOperationsToSpellingContent(sourceSnapshot, inverse.operations);
+  const revertedWord = revertedSnapshot.draft.words.find((entry) => entry.slug === word.slug);
+  const retiredPool = revertedSnapshot.draft.pools.find((entry) => entry.id === 'inverse-builder-pool');
+  assert.equal(revertedWord.explanation, word.explanation);
+  assert.equal(retiredPool.active, false);
+  assert.equal(retiredPool.retired, true);
+  assert.equal(inverse.operations[0].afterHash, contentOperationValueHash(retiredPool));
 });
 
 test('spelling word delete-or-retire operation hard deletes drafts and retires published words', () => {

--- a/worker/src/content-operations/assets.js
+++ b/worker/src/content-operations/assets.js
@@ -62,6 +62,11 @@ const SUPPORTED_IMAGE_TYPES = Object.freeze({
   'image/png': 'png',
   'image/webp': 'webp',
 });
+const TERMINAL_CONTENT_OPERATION_PACKAGE_STATES = new Set([
+  CONTENT_OPERATION_PACKAGE_STATES.PUBLISHED,
+  CONTENT_OPERATION_PACKAGE_STATES.REVERTED,
+  CONTENT_OPERATION_PACKAGE_STATES.SUPERSEDED,
+]);
 const MONSTER_ASSET_BODY_EXCEEDS_CAP = Symbol('monster-asset-body-exceeds-cap');
 
 function parseJson(value, fallback = null) {
@@ -209,6 +214,13 @@ async function requirePackage(db, packageId, { allowPublished = false } = {}) {
     throw new BadRequestError('Published content operation packages cannot accept draft asset uploads.', {
       code: 'content_operation_package_published',
       packageId,
+    });
+  }
+  if (!allowPublished && TERMINAL_CONTENT_OPERATION_PACKAGE_STATES.has(row.state)) {
+    throw new BadRequestError('Terminal content operation packages cannot accept draft asset uploads.', {
+      code: 'content_operation_package_terminal',
+      packageId,
+      state: row.state,
     });
   }
   return row;
@@ -1357,7 +1369,7 @@ export async function uploadContentOperationMonsterAsset({
         WHERE EXISTS (
           SELECT 1
           FROM content_operation_packages
-          WHERE package_id = ? AND state <> ?
+          WHERE package_id = ? AND state NOT IN (?, ?, ?)
         )
       `, [
         assetUploadId,
@@ -1378,6 +1390,8 @@ export async function uploadContentOperationMonsterAsset({
         nowTs,
         packageRow.package_id,
         CONTENT_OPERATION_PACKAGE_STATES.PUBLISHED,
+        CONTENT_OPERATION_PACKAGE_STATES.REVERTED,
+        CONTENT_OPERATION_PACKAGE_STATES.SUPERSEDED,
       ]),
       bindStatement(db, `
         DELETE FROM content_operation_asset_uploads
@@ -1462,7 +1476,7 @@ export async function uploadContentOperationMonsterAsset({
             updated_by_account_id = ?,
             updated_at = ?
         WHERE package_id = ?
-          AND state <> ?
+          AND state NOT IN (?, ?, ?)
           AND EXISTS (
             SELECT 1
             FROM content_operation_asset_uploads
@@ -1475,6 +1489,8 @@ export async function uploadContentOperationMonsterAsset({
         nowTs,
         packageRow.package_id,
         CONTENT_OPERATION_PACKAGE_STATES.PUBLISHED,
+        CONTENT_OPERATION_PACKAGE_STATES.REVERTED,
+        CONTENT_OPERATION_PACKAGE_STATES.SUPERSEDED,
         assetUploadId,
       ]),
       bindStatement(db, `

--- a/worker/src/content-operations/repository.js
+++ b/worker/src/content-operations/repository.js
@@ -1,6 +1,7 @@
 import { uid } from '../../../src/platform/core/utils.js';
 import { cloneSerialisable } from '../../../src/platform/core/repositories/helpers.js';
 import {
+  buildContentOperationRevertOperations,
   buildSpellingContentOperationCandidate,
   CONTENT_OPERATION_PACKAGE_STATES,
   CONTENT_OPERATION_SUBJECT_ID,
@@ -993,6 +994,21 @@ async function readReleaseRowById(db, subjectId, releaseId, { includeSnapshot = 
   `, [subjectId, releaseId]);
 }
 
+async function readReleaseRowByPackageId(db, subjectId, packageId, { includeSnapshot = false } = {}) {
+  if (!packageId) return null;
+  return first(db, `
+    SELECT
+      release_id, subject_id, status, snapshot_hash,
+      ${includeSnapshot ? 'snapshot_json' : 'NULL AS snapshot_json'},
+      base_release_id, package_id, published_at, published_by_account_id,
+      rollback_of_release_id, proof_json, created_at
+    FROM content_operation_releases
+    WHERE subject_id = ? AND package_id = ? AND status = 'published'
+    ORDER BY published_at DESC, created_at DESC, rowid DESC
+    LIMIT 1
+  `, [subjectId, packageId]);
+}
+
 async function readLegacySubjectContentBundle(db, subjectId) {
   const row = await first(db, `
     SELECT account_id, subject_id, content_json, updated_at, updated_by_account_id
@@ -1037,6 +1053,26 @@ async function listPackageOperations(db, packageId) {
     ORDER BY operation_order ASC
   `, [packageId]);
   return rows.map(operationRowToRecord);
+}
+
+async function readPackageRevertSource(db, packageId) {
+  const row = await first(db, `
+    SELECT event_json
+    FROM content_operation_events
+    WHERE package_id = ? AND event_type = 'package.revert_created'
+    ORDER BY created_at DESC, event_id DESC
+    LIMIT 1
+  `, [packageId]);
+  const event = parseJson(row?.event_json, null);
+  if (!isPlainObject(event)) return null;
+  const revertOfPackageId = normaliseString(event.revertOfPackageId);
+  const revertOfReleaseId = normaliseString(event.revertOfReleaseId);
+  if (!revertOfPackageId || !revertOfReleaseId) return null;
+  return {
+    revertOfPackageId,
+    revertOfReleaseId,
+    revertReason: normaliseString(event.revertReason),
+  };
 }
 
 async function attachReleaseHistorySummary(db, release = null) {
@@ -1262,11 +1298,24 @@ function packageOperationsHash(operations = []) {
   );
 }
 
+const TERMINAL_CONTENT_OPERATION_PACKAGE_STATES = new Set([
+  CONTENT_OPERATION_PACKAGE_STATES.PUBLISHED,
+  CONTENT_OPERATION_PACKAGE_STATES.REVERTED,
+  CONTENT_OPERATION_PACKAGE_STATES.SUPERSEDED,
+]);
+
 function assertPackageIsNotPublished(packageRow, packageId) {
   if (packageRow.state === CONTENT_OPERATION_PACKAGE_STATES.PUBLISHED) {
     throw new ConflictError('Published content operation packages cannot be mutated.', {
       code: 'content_operation_package_published',
       packageId,
+    });
+  }
+  if (TERMINAL_CONTENT_OPERATION_PACKAGE_STATES.has(packageRow.state)) {
+    throw new ConflictError('Terminal content operation packages cannot be mutated.', {
+      code: 'content_operation_package_terminal',
+      packageId,
+      state: packageRow.state,
     });
   }
 }
@@ -1471,6 +1520,230 @@ export function createContentOperationsRepository({ db, env = {}, now }) {
       ]);
 
       return record;
+    },
+
+    async createContentOperationPackageRevert(sourcePackageId, {
+      createdByAccountId,
+      reason = '',
+      title = '',
+      description = '',
+    } = {}) {
+      const sourcePackageRow = await requirePackage(db, sourcePackageId);
+      const actor = normaliseString(createdByAccountId);
+      if (!actor) throw new BadRequestError('Package revert creation requires an actor account id.');
+      const revertReason = normaliseString(reason);
+      if (!revertReason) {
+        throw new BadRequestError('Package revert creation requires a reason.', {
+          code: 'content_operation_revert_reason_required',
+          packageId: sourcePackageId,
+        });
+      }
+      if (sourcePackageRow.state !== CONTENT_OPERATION_PACKAGE_STATES.PUBLISHED) {
+        throw new ConflictError('Only published content operation packages can be reverted.', {
+          code: 'content_operation_package_not_published',
+          packageId: sourcePackageId,
+          state: sourcePackageRow.state,
+        });
+      }
+      if (normaliseString(sourcePackageRow.superseded_by_package_id)) {
+        throw new ConflictError('Content operation package already has a revert package.', {
+          code: 'content_operation_revert_already_created',
+          packageId: sourcePackageId,
+          revertPackageId: sourcePackageRow.superseded_by_package_id,
+        });
+      }
+
+      const sourceReleaseRow = await readReleaseRowByPackageId(
+        db,
+        sourcePackageRow.subject_id,
+        sourcePackageId,
+        { includeSnapshot: true },
+      );
+      const sourceRelease = await releaseRowToRecordAsync(sourceReleaseRow, { includeSnapshot: true });
+      if (!sourceRelease?.snapshot) {
+        throw new ConflictError('Published package release was not found for package revert.', {
+          code: 'content_operation_package_release_missing',
+          packageId: sourcePackageId,
+        });
+      }
+      const sourceBaseReleaseId = sourcePackageRow.base_release_id || sourceRelease.baseReleaseId || null;
+      const sourceBaseReleaseRow = sourceBaseReleaseId
+        ? await readReleaseRowById(db, sourcePackageRow.subject_id, sourceBaseReleaseId, { includeSnapshot: true })
+        : null;
+      if (sourceBaseReleaseId && !sourceBaseReleaseRow) {
+        throw new ConflictError('Published package base release was not found for package revert.', {
+          code: 'content_operation_package_base_release_missing',
+          packageId: sourcePackageId,
+          baseReleaseId: sourceBaseReleaseId,
+        });
+      }
+      const sourceBaseRelease = await releaseRowToRecordAsync(sourceBaseReleaseRow, { includeSnapshot: true });
+      const sourceBaseSnapshot = sourceBaseRelease?.snapshot || await readSeededSpellingContentBundle();
+      const sourceOperations = await listPackageOperations(db, sourcePackageId);
+      if (!sourceOperations.length) {
+        throw new ConflictError('Published package has no operations to revert.', {
+          code: 'content_operation_revert_no_operations',
+          packageId: sourcePackageId,
+        });
+      }
+
+      const nowTs = Number(nowFactory());
+      const inverse = buildContentOperationRevertOperations({
+        sourceBaseSnapshot,
+        operations: sourceOperations,
+        reason: revertReason,
+        now: () => nowTs,
+        sourcePackageId,
+        sourceReleaseId: sourceRelease.releaseId,
+      });
+      const replayedHash = contentOperationHash(inverse.replayedSnapshot, 'release');
+      if (replayedHash !== sourceRelease.snapshotHash) {
+        throw new ConflictError('Published package operations no longer replay to the source release.', {
+          code: 'content_operation_revert_source_replay_mismatch',
+          packageId: sourcePackageId,
+          releaseId: sourceRelease.releaseId,
+          expectedSnapshotHash: sourceRelease.snapshotHash,
+          replayedSnapshotHash: replayedHash,
+        });
+      }
+      if (!inverse.operations.length) {
+        throw new ConflictError('Published package has no snapshot-changing operations to revert.', {
+          code: 'content_operation_revert_no_operations',
+          packageId: sourcePackageId,
+          skippedOperations: inverse.skippedOperations,
+        });
+      }
+
+      const revertPackageId = uid('copkg');
+      const normalisedInverseOperations = inverse.operations.map((operation) => normaliseContentOperation(operation, {
+        actorAccountId: actor,
+        now: () => nowTs,
+        operationId: uid('coop'),
+      }));
+      const record = {
+        packageId: revertPackageId,
+        subjectId: sourcePackageRow.subject_id,
+        templateId: 'package-revert',
+        title: normaliseString(title, `Revert: ${sourcePackageRow.title || sourcePackageId}`),
+        description: normaliseString(
+          description,
+          `Package-level revert of ${sourcePackageId}. Reason: ${revertReason}`,
+        ),
+        baseReleaseId: sourceRelease.releaseId,
+        baseReleaseHash: sourceRelease.snapshotHash,
+        state: CONTENT_OPERATION_PACKAGE_STATES.DRAFT,
+        createdByAccountId: actor,
+        updatedByAccountId: actor,
+        createdAt: nowTs,
+        updatedAt: nowTs,
+      };
+      const lineage = {
+        revertOfPackageId: sourcePackageId,
+        revertOfReleaseId: sourceRelease.releaseId,
+        revertReason,
+        sourcePackageTitle: sourcePackageRow.title || '',
+        sourceReleaseSnapshotHash: sourceRelease.snapshotHash,
+        sourceBaseReleaseId,
+        sourceBaseReleaseHash: sourcePackageRow.base_release_hash || sourceBaseRelease?.snapshotHash || null,
+        inverseOperationIds: normalisedInverseOperations.map((operation) => operation.operationId),
+        skippedOperations: inverse.skippedOperations,
+      };
+
+      await batch(db, [
+        bindStatement(db, `
+          INSERT INTO content_operation_packages (
+            package_id, subject_id, template_id, title, description,
+            base_release_id, base_release_hash, state, created_by_account_id,
+            updated_by_account_id, created_at, updated_at
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `, [
+          record.packageId,
+          record.subjectId,
+          record.templateId,
+          record.title,
+          record.description,
+          record.baseReleaseId,
+          record.baseReleaseHash,
+          record.state,
+          record.createdByAccountId,
+          record.updatedByAccountId,
+          record.createdAt,
+          record.updatedAt,
+        ]),
+        ...normalisedInverseOperations.map((operation, index) => bindStatement(db, `
+          INSERT INTO content_operation_package_operations (
+            operation_id, package_id, operation_order, entity_type, entity_id,
+            field_path, action, before_hash, after_hash, payload_json,
+            created_by_account_id, created_at
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `, [
+          operation.operationId,
+          record.packageId,
+          index + 1,
+          operation.entityType,
+          operation.entityId,
+          operation.fieldPath,
+          operation.action,
+          operation.beforeHash || null,
+          operation.afterHash || null,
+          JSON.stringify(operation.payload),
+          operation.createdByAccountId,
+          operation.createdAt,
+        ])),
+        bindStatement(db, `
+          INSERT INTO content_operation_events (
+            event_id, package_id, release_id, subject_id, event_type,
+            actor_account_id, event_json, created_at
+          )
+          VALUES (?, ?, NULL, ?, ?, ?, ?, ?)
+        `, [
+          uid('coevt'),
+          record.packageId,
+          record.subjectId,
+          'package.revert_created',
+          actor,
+          JSON.stringify(lineage),
+          nowTs,
+        ]),
+        bindStatement(db, `
+          INSERT INTO content_operation_events (
+            event_id, package_id, release_id, subject_id, event_type,
+            actor_account_id, event_json, created_at
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        `, [
+          uid('coevt'),
+          sourcePackageId,
+          sourceRelease.releaseId,
+          record.subjectId,
+          'package.revert_requested',
+          actor,
+          JSON.stringify({
+            ...lineage,
+            revertPackageId: record.packageId,
+          }),
+          nowTs,
+        ]),
+      ]);
+
+      const candidate = await this.buildContentOperationCandidate(record.packageId, {
+        actorAccountId: actor,
+      });
+      const contentPackage = await this.readContentOperationPackage(record.packageId, {
+        includeOperations: true,
+      });
+      return {
+        package: contentPackage,
+        candidate,
+        source: {
+          packageId: sourcePackageId,
+          releaseId: sourceRelease.releaseId,
+          snapshotHash: sourceRelease.snapshotHash,
+        },
+        skippedOperations: inverse.skippedOperations,
+      };
     },
 
     async readContentOperationPackage(packageId, { includeOperations = true } = {}) {
@@ -2378,6 +2651,24 @@ export function createContentOperationsRepository({ db, env = {}, now }) {
       const releaseProof = buildReleaseProof(proof, approval, publishAudioScan, currentAssetScan);
       const releaseAudioProof = audioReleaseProofFromProof(releaseProof);
       const releaseAssetProof = releaseAssetProofFromProof(releaseProof);
+      const revertSource = await readPackageRevertSource(db, packageId);
+      if (revertSource) {
+        const sourcePackageRow = await requirePackage(db, revertSource.revertOfPackageId);
+        const sourceSupersededByPackageId = normaliseString(sourcePackageRow.superseded_by_package_id);
+        if (
+          sourcePackageRow.subject_id !== packageRow.subject_id
+          || sourcePackageRow.state !== CONTENT_OPERATION_PACKAGE_STATES.PUBLISHED
+          || sourceSupersededByPackageId
+        ) {
+          throw new ConflictError('Package revert source has already been superseded.', {
+            code: 'content_operation_revert_source_superseded',
+            packageId,
+            revertOfPackageId: revertSource.revertOfPackageId,
+            sourceState: sourcePackageRow.state,
+            supersededByPackageId: sourceSupersededByPackageId || null,
+          });
+        }
+      }
 
       let publishResults = [];
       try {
@@ -2471,6 +2762,84 @@ export function createContentOperationsRepository({ db, env = {}, now }) {
             nowTs,
             releaseId,
           ]),
+          ...(revertSource ? [
+            bindStatement(db, `
+              UPDATE content_operation_packages
+              SET state = ?, superseded_by_package_id = ?,
+                  updated_by_account_id = ?, updated_at = ?
+              WHERE package_id = ?
+                AND state = ?
+                AND EXISTS (
+                  SELECT 1
+                  FROM content_operation_releases
+                  WHERE release_id = ?
+                )
+            `, [
+              CONTENT_OPERATION_PACKAGE_STATES.REVERTED,
+              packageId,
+              actor,
+              nowTs,
+              revertSource.revertOfPackageId,
+              CONTENT_OPERATION_PACKAGE_STATES.PUBLISHED,
+              releaseId,
+            ]),
+            bindStatement(db, `
+              INSERT INTO content_operation_events (
+                event_id, package_id, release_id, subject_id, event_type,
+                actor_account_id, event_json, created_at
+              )
+              SELECT ?, ?, ?, ?, ?, ?, ?, ?
+              WHERE EXISTS (
+                SELECT 1
+                FROM content_operation_releases
+                WHERE release_id = ?
+              )
+            `, [
+              uid('coevt'),
+              revertSource.revertOfPackageId,
+              releaseId,
+              packageRow.subject_id,
+              'package.reverted',
+              actor,
+              JSON.stringify({
+                revertPackageId: packageId,
+                revertReleaseId: releaseId,
+                revertOfPackageId: revertSource.revertOfPackageId,
+                revertOfReleaseId: revertSource.revertOfReleaseId,
+                revertReason: revertSource.revertReason,
+              }),
+              nowTs,
+              releaseId,
+            ]),
+            bindStatement(db, `
+              INSERT INTO content_operation_events (
+                event_id, package_id, release_id, subject_id, event_type,
+                actor_account_id, event_json, created_at
+              )
+              SELECT ?, ?, ?, ?, ?, ?, ?, ?
+              WHERE EXISTS (
+                SELECT 1
+                FROM content_operation_releases
+                WHERE release_id = ?
+              )
+            `, [
+              uid('coevt'),
+              packageId,
+              releaseId,
+              packageRow.subject_id,
+              'package.revert_published',
+              actor,
+              JSON.stringify({
+                revertPackageId: packageId,
+                revertReleaseId: releaseId,
+                revertOfPackageId: revertSource.revertOfPackageId,
+                revertOfReleaseId: revertSource.revertOfReleaseId,
+                revertReason: revertSource.revertReason,
+              }),
+              nowTs,
+              releaseId,
+            ]),
+          ] : []),
         ]);
       } catch (error) {
         if (isUniqueConstraintError(error)) {

--- a/worker/src/content-operations/routes.js
+++ b/worker/src/content-operations/routes.js
@@ -41,7 +41,6 @@ const CONTENT_OPERATIONS_SUBJECT_ID = 'spelling';
 const STUBBED_CONTENT_OPERATION_ROUTES = Object.freeze({
   rebase: { ticket: 'T6', capability: CONTENT_OPERATION_CAPABILITIES.EDIT },
   'scan-audio': { ticket: 'T7', capability: CONTENT_OPERATION_CAPABILITIES.EDIT },
-  'create-revert': { ticket: 'T9', capability: CONTENT_OPERATION_CAPABILITIES.ROLLBACK },
 });
 
 function mutationFromRequest(body = {}, request) {
@@ -611,7 +610,11 @@ export async function handleContentOperationsAdminRequest({
       const stub = STUBBED_CONTENT_OPERATION_ROUTES[action];
       const capability = action === 'approve'
         ? CONTENT_OPERATION_CAPABILITIES.APPROVE
-        : (action === 'publish' ? CONTENT_OPERATION_CAPABILITIES.PUBLISH : (stub?.capability || CONTENT_OPERATION_CAPABILITIES.EDIT));
+        : (action === 'publish'
+            ? CONTENT_OPERATION_CAPABILITIES.PUBLISH
+            : (action === 'create-revert'
+                ? CONTENT_OPERATION_CAPABILITIES.ROLLBACK
+                : (stub?.capability || CONTENT_OPERATION_CAPABILITIES.EDIT)));
       const actor = await requireRouteActor({
         repository,
         session,
@@ -645,6 +648,25 @@ export async function handleContentOperationsAdminRequest({
       }
 
       const body = normaliseBody(await readJson(request));
+      if (action === 'create-revert') {
+        const result = await repository.createContentOperationPackageRevert(packageId, {
+          createdByAccountId: actor.id,
+          reason: body.reason || body.revertReason || body.revert_reason,
+          title: body.title,
+          description: body.description,
+        });
+        return json({
+          ok: true,
+          actor: serialiseContentOperationActor(actor),
+          package: serialiseContentOperationPackage(result.package),
+          candidate: serialiseContentOperationCandidate(result.candidate, {
+            includeSnapshot: includeSnapshot(url, body),
+          }),
+          source: result.source,
+          skippedOperations: result.skippedOperations || [],
+        }, 201);
+      }
+
       if (action === 'validate') {
         let candidate;
         try {

--- a/worker/src/content-operations/serialisers.js
+++ b/worker/src/content-operations/serialisers.js
@@ -167,6 +167,16 @@ function packagePublishReadiness(contentPackage = {}) {
       warnings: [],
     };
   }
+  if (
+    contentPackage.state === CONTENT_OPERATION_PACKAGE_STATES.REVERTED
+    || contentPackage.state === CONTENT_OPERATION_PACKAGE_STATES.SUPERSEDED
+  ) {
+    return {
+      status: contentPackage.state,
+      blockers: ['terminal_package_state'],
+      warnings: [],
+    };
+  }
   if (contentPackage.state === CONTENT_OPERATION_PACKAGE_STATES.APPROVED) {
     return {
       status: 'ready',


### PR DESCRIPTION
## Summary
- Add package-level content-operation revert creation that builds inverse operations from the source package release, returns a draft candidate, and publishes through the existing approval flow.
- Mark source packages as reverted/superseded only after the revert package publishes, with publish-time guards for stale or already-superseded sources.
- Wire the Release History UI and hub API for package revert drafts, and keep terminal package states immutable for asset/package edits.
- Add model, repository, route, and mounted React tests for conflict drift, created-content retirement, API contract shape, superseded guards, and R2 non-deletion.

## Validation
- `npm test` passed locally after the final server guard changes: 111,873 pass, 0 fail, 12 skipped.
- `npm run check` passed, including dry-run Worker deploy, public build, Worker build, and client bundle audit.
- `git diff --check` and `git diff --cached --check` passed.
- Pre-push hook reran `npm test` successfully before pushing: 111,873 pass, 0 fail, 12 skipped.

## Notes
- Package revert deliberately does not delete R2 audio objects.
- Monster asset reference operations remain snapshot no-ops for this ticket and are surfaced through `skippedOperations` rather than restored/deleted by the revert package.