### PR TITLE
Add content operations visibility proof workflow

### DIFF
--- a/src/subjects/spelling/content/audio-readiness.js
+++ b/src/subjects/spelling/content/audio-readiness.js
@@ -12,6 +12,9 @@ import {
 import {
   normaliseSpellingContentBundle,
 } from './model.js';
+import {
+  isSpellingPoolPotentiallyLearnerVisible,
+} from './pool-visibility.js';
 
 export const SPELLING_AUDIO_REQUIREMENT_PROFILE_VERSION = 'spelling-audio-profile-v1';
 
@@ -309,7 +312,11 @@ function activeVisibleWord(word, maps) {
   const list = maps.wordListsById.get(word.listId);
   if (list && (list.active === false || list.retired)) return false;
   const pool = maps.poolsById.get(word.spellingPool);
-  if (pool && (pool.active === false || pool.retired || pool.visibility?.state !== 'visible')) return false;
+  if (pool && (
+    pool.active === false
+      || pool.retired
+      || !isSpellingPoolPotentiallyLearnerVisible(pool.visibility)
+  )) return false;
   return true;
 }
 

--- a/src/subjects/spelling/content/model.js
+++ b/src/subjects/spelling/content/model.js
@@ -6,11 +6,26 @@ import {
 } from '../../../platform/game/reward-track-config.js';
 import { PATTERN_LAUNCH_THRESHOLD, SPELLING_PATTERN_IDS, SPELLING_PATTERNS } from './patterns.js';
 import {
+  SPELLING_POOL_VISIBILITY_STATES,
+  isKnownSpellingPoolVisibilityState,
+  isSpellingPoolLearnerVisible,
+  isSpellingPoolPotentiallyLearnerVisible,
+  normalisePoolVisibility,
+} from './pool-visibility.js';
+import {
   coverageTierForWord,
   coverageTierCounts,
   isStatutoryCoreWord,
   normaliseCoverageTier,
 } from './taxonomy.js';
+
+export {
+  SPELLING_POOL_VISIBILITY_STATES,
+  isKnownSpellingPoolVisibilityState,
+  isSpellingPoolLearnerVisible,
+  isSpellingPoolPotentiallyLearnerVisible,
+  normalisePoolVisibility,
+};
 
 export const SPELLING_CONTENT_SUBJECT_ID = 'spelling';
 /**
@@ -32,7 +47,6 @@ const LEGACY_SPELLING_POOLS = new Set(SPELLING_CONTENT_POOLS);
 const VALID_DRAFT_STATES = new Set(['draft']);
 const VALID_RELEASE_STATES = new Set(['published']);
 const VALID_POOL_TYPES = new Set(['statutory', 'enrichment', 'extension', 'custom']);
-const VALID_POOL_VISIBILITY_STATES = new Set(['visible', 'hidden', 'staged']);
 const RESERVED_POOL_IDS = new Set(['all']);
 const MIN_WORD_EXPLANATION_LENGTH = 12;
 
@@ -176,22 +190,6 @@ function defaultCoverageTierForPool(poolId, pool = null) {
   if (poolId === 'core') return 'statutory-core';
   if (poolId === 'extra' || pool?.type === 'enrichment') return 'enrichment-extra';
   return 'secure-extension';
-}
-
-function normalisePoolVisibility(rawValue = null, fallback = null) {
-  const raw = isPlainObject(rawValue) ? rawValue : {};
-  const safeFallback = isPlainObject(fallback) ? fallback : {};
-  const state = VALID_POOL_VISIBILITY_STATES.has(normaliseString(raw.state).toLowerCase())
-    ? normaliseString(raw.state).toLowerCase()
-    : (VALID_POOL_VISIBILITY_STATES.has(normaliseString(safeFallback.state).toLowerCase())
-        ? normaliseString(safeFallback.state).toLowerCase()
-        : 'hidden');
-  return {
-    state,
-    learnerVisible: state === 'visible',
-    scheduledAt: normaliseTimestamp(raw.scheduledAt ?? safeFallback.scheduledAt, 0),
-    rolloutFlag: normaliseString(raw.rolloutFlag, safeFallback.rolloutFlag || ''),
-  };
 }
 
 function normaliseNoRewardException(rawValue = null) {
@@ -464,6 +462,34 @@ function normalisePublishedSnapshot(rawValue, {
   };
 }
 
+export function resolveLearnerVisibleSpellingSnapshot(rawSnapshot, {
+  now = Date.now(),
+  env = {},
+} = {}) {
+  const snapshot = normalisePublishedSnapshot(rawSnapshot);
+  const visiblePoolIds = new Set(snapshot.pools
+    .filter((pool) => (
+      pool.active !== false
+        && !pool.retired
+        && isSpellingPoolLearnerVisible(pool.visibility, { now, env })
+    ))
+    .map((pool) => pool.id));
+  const pools = snapshot.pools.filter((pool) => visiblePoolIds.has(pool.id));
+  const rewardTracks = snapshot.rewardTracks.filter((track) => (
+    track.active !== false
+      && !track.retired
+      && visiblePoolIds.has(track.poolId)
+  ));
+  const words = snapshot.words.filter((word) => visiblePoolIds.has(word.spellingPool));
+  return {
+    ...snapshot,
+    pools,
+    rewardTracks,
+    words,
+    wordBySlug: Object.fromEntries(words.map((word) => [word.slug, word])),
+  };
+}
+
 function normaliseDraft(rawValue) {
   const raw = isPlainObject(rawValue) ? rawValue : {};
   const updatedAt = normaliseTimestamp(raw.updatedAt, 0);
@@ -600,7 +626,7 @@ function issue(severity, code, path, message) {
 
 function buildLearnerVisiblePoolIds(pools = []) {
   return new Set((Array.isArray(pools) ? pools : [])
-    .filter((pool) => pool.active !== false && !pool.retired && pool.visibility?.state === 'visible')
+    .filter((pool) => pool.active !== false && !pool.retired && isSpellingPoolPotentiallyLearnerVisible(pool.visibility))
     .map((pool) => pool.id));
 }
 
@@ -656,8 +682,14 @@ export function validateSpellingContentBundle(rawBundle) {
     if (pool.id !== 'core' && pool.type === 'statutory') {
       errors.push(issue('error', 'pool_type_mismatch', `draft.pools[${index}].type`, `Only the core pool can use statutory type.`));
     }
-    if (pool.retired && pool.visibility?.state === 'visible') {
+    if (pool.retired && isSpellingPoolPotentiallyLearnerVisible(pool.visibility)) {
       warnings.push(issue('warn', 'retired_pool_visible', `draft.pools[${index}].visibility.state`, `Retired pool "${pool.id}" keeps visible metadata for history but is hidden from new sessions.`));
+    }
+    if (pool.visibility?.state === 'scheduled' && !pool.visibility.scheduledAt) {
+      errors.push(issue('error', 'pool_visibility_schedule_required', `draft.pools[${index}].visibility.scheduledAt`, `Pool "${pool.id}" requires a schedule timestamp for scheduled visibility.`));
+    }
+    if (pool.visibility?.state === 'rollout-flagged' && !pool.visibility.rolloutFlag) {
+      errors.push(issue('error', 'pool_visibility_flag_required', `draft.pools[${index}].visibility.rolloutFlag`, `Pool "${pool.id}" requires a rollout flag for flagged visibility.`));
     }
   });
 
@@ -996,7 +1028,10 @@ function orderedDraftWords(draft) {
   return ordered;
 }
 
-export function buildPublishedSnapshotFromDraft(rawDraft, { generatedAt = Date.now() } = {}) {
+export function buildPublishedSnapshotFromDraft(rawDraft, {
+  generatedAt = Date.now(),
+  includeDeferredVisibility = false,
+} = {}) {
   const draft = normaliseDraft(rawDraft);
   const poolById = new Map(draft.pools.map((entry) => [entry.id, entry]));
   const listById = new Map(draft.wordLists.map((entry) => [entry.id, entry]));
@@ -1006,7 +1041,12 @@ export function buildPublishedSnapshotFromDraft(rawDraft, { generatedAt = Date.n
     .filter((word) => {
       if (word.active === false || word.retired) return false;
       const pool = poolById.get(word.spellingPool);
-      if (pool && (pool.active === false || pool.retired || pool.visibility?.state !== 'visible')) return false;
+      if (pool && (pool.active === false || pool.retired)) return false;
+      if (pool && includeDeferredVisibility) {
+        if (!isSpellingPoolPotentiallyLearnerVisible(pool.visibility)) return false;
+      } else if (pool && !isSpellingPoolLearnerVisible(pool.visibility, { now: generatedAt })) {
+        return false;
+      }
       const list = listById.get(word.listId);
       if (list && (list.active === false || list.retired)) return false;
       return true;

--- a/src/subjects/spelling/content/package-operations.js
+++ b/src/subjects/spelling/content/package-operations.js
@@ -8,11 +8,15 @@ import {
   normaliseRewardTrackConfig,
   validateRewardTrackCollection,
 } from '../../../platform/game/reward-track-config.js';
+import {
+  isKnownSpellingPoolVisibilityState,
+  isSpellingPoolPotentiallyLearnerVisible,
+  normalisePoolVisibility as normaliseContentPoolVisibility,
+} from './pool-visibility.js';
 
 const LEGACY_SPELLING_POOLS = new Set(['core', 'extra']);
 const RESERVED_POOL_IDS = new Set(['all']);
 const VALID_POOL_TYPES = new Set(['statutory', 'enrichment', 'extension', 'custom']);
-const VALID_POOL_VISIBILITY_STATES = new Set(['visible', 'hidden', 'staged']);
 const DEFAULT_COVERAGE_BY_POOL = Object.freeze({
   core: 'statutory-core',
   extra: 'enrichment-extra',
@@ -454,19 +458,7 @@ export function validateSpellingWordListEditorInput(rawValue = {}, options = {})
 }
 
 function normalisePoolVisibility(rawValue = {}, existingVisibility = null) {
-  const raw = isPlainObject(rawValue) ? rawValue : {};
-  const existing = isPlainObject(existingVisibility) ? existingVisibility : {};
-  const state = VALID_POOL_VISIBILITY_STATES.has(normaliseString(raw.state, existing.state).toLowerCase())
-    ? normaliseString(raw.state, existing.state).toLowerCase()
-    : 'hidden';
-  return {
-    state,
-    learnerVisible: state === 'visible',
-    scheduledAt: Number.isFinite(Number(raw.scheduledAt ?? existing.scheduledAt)) && Number(raw.scheduledAt ?? existing.scheduledAt) >= 0
-      ? Number(raw.scheduledAt ?? existing.scheduledAt)
-      : 0,
-    rolloutFlag: normaliseString(raw.rolloutFlag, existing.rolloutFlag),
-  };
+  return normaliseContentPoolVisibility(rawValue, existingVisibility);
 }
 
 function normaliseNoRewardException(rawValue = {}, existingException = null) {
@@ -560,14 +552,17 @@ export function validateSpellingPoolEditorInput(rawValue = {}, options = {}) {
   if (!hasExplicitProvenance(raw, existing)) {
     errors.push(issue('provenance', 'Pool provenance or source notes are required.', 'invalid_pool_operation'));
   }
-  if (pool.retired && pool.visibility.state === 'visible') {
+  if (raw.visibility?.state && !isKnownSpellingPoolVisibilityState(raw.visibility.state)) {
+    errors.push(issue('visibility.state', 'Pool visibility state is invalid.', 'invalid_pool_operation'));
+  }
+  if (pool.retired && isSpellingPoolPotentiallyLearnerVisible(pool.visibility)) {
     errors.push(issue('visibility.state', 'Retired pools cannot be learner-visible.', 'invalid_pool_operation'));
   }
   if (pool.id !== 'core' && pool.type === 'statutory') {
     errors.push(issue('type', 'Only the core pool can use statutory type.', 'invalid_pool_operation'));
   }
   if (
-    pool.visibility.state === 'visible'
+    isSpellingPoolPotentiallyLearnerVisible(pool.visibility)
     && !LEGACY_SPELLING_POOLS.has(pool.id)
     && pool.noRewardException?.approved !== true
     && !(Array.isArray(pool.rewardTrackIds) && pool.rewardTrackIds.length > 0)
@@ -575,8 +570,11 @@ export function validateSpellingPoolEditorInput(rawValue = {}, options = {}) {
   ) {
     errors.push(issue('visibility.state', 'Learner-visible future pools require a reward track or approved no-reward exception.', 'pool_reward_required'));
   }
-  if (pool.visibility.state === 'staged' && !pool.visibility.scheduledAt && !pool.visibility.rolloutFlag) {
-    warnings.push(issue('visibility.state', 'Staged pools should include a schedule or rollout flag before publish.', 'invalid_pool_operation'));
+  if (pool.visibility.state === 'scheduled' && !pool.visibility.scheduledAt) {
+    errors.push(issue('visibility.scheduledAt', 'Scheduled pool visibility requires a timestamp.', 'pool_visibility_schedule_required'));
+  }
+  if (pool.visibility.state === 'rollout-flagged' && !pool.visibility.rolloutFlag) {
+    errors.push(issue('visibility.rolloutFlag', 'Rollout-flagged pool visibility requires a rollout flag.', 'pool_visibility_flag_required'));
   }
 
   return poolValidationResult(errors, warnings, pool);

--- a/src/subjects/spelling/content/pool-visibility.js
+++ b/src/subjects/spelling/content/pool-visibility.js
@@ -1,0 +1,96 @@
+const POOL_VISIBILITY_STATE_ALIASES = Object.freeze({
+  rolloutFlagged: 'rollout-flagged',
+  rolloutflagged: 'rollout-flagged',
+  rollout_flagged: 'rollout-flagged',
+  rollout: 'rollout-flagged',
+  flagged: 'rollout-flagged',
+});
+
+export const SPELLING_POOL_VISIBILITY_STATES = Object.freeze([
+  'visible',
+  'hidden',
+  'scheduled',
+  'rollout-flagged',
+]);
+
+const VALID_POOL_VISIBILITY_STATES = new Set(SPELLING_POOL_VISIBILITY_STATES);
+const LEARNER_ACTIVATABLE_POOL_VISIBILITY_STATES = new Set(['visible', 'scheduled', 'rollout-flagged']);
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normaliseString(value, fallback = '') {
+  return typeof value === 'string' ? value.trim() || fallback : fallback;
+}
+
+function normaliseTimestamp(value, fallback = 0) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric >= 0 ? numeric : fallback;
+}
+
+function poolVisibilityEnvFlagEnabled(env, flagName) {
+  const name = normaliseString(flagName);
+  if (!name) return false;
+  const value = isPlainObject(env) ? env[name] : undefined;
+  return ['1', 'true', 'yes', 'on'].includes(String(value || '').trim().toLowerCase());
+}
+
+function normalisePoolVisibilityState(value, fallback = 'hidden', context = {}) {
+  const raw = normaliseString(value, fallback);
+  const lookup = raw.toLowerCase();
+  if (lookup === 'staged') {
+    const scheduledAt = normaliseTimestamp(context?.scheduledAt, 0);
+    const rolloutFlag = normaliseString(context?.rolloutFlag);
+    return !scheduledAt && rolloutFlag ? 'rollout-flagged' : 'scheduled';
+  }
+  const aliased = POOL_VISIBILITY_STATE_ALIASES[raw] || POOL_VISIBILITY_STATE_ALIASES[lookup] || lookup;
+  return VALID_POOL_VISIBILITY_STATES.has(aliased) ? aliased : fallback;
+}
+
+export function isKnownSpellingPoolVisibilityState(value) {
+  const raw = normaliseString(value);
+  const lookup = raw.toLowerCase();
+  return lookup === 'staged' || VALID_POOL_VISIBILITY_STATES.has(
+    POOL_VISIBILITY_STATE_ALIASES[raw] || POOL_VISIBILITY_STATE_ALIASES[lookup] || lookup,
+  );
+}
+
+export function normalisePoolVisibility(rawValue = null, fallback = null) {
+  const raw = isPlainObject(rawValue) ? rawValue : {};
+  const safeFallback = isPlainObject(fallback) ? fallback : {};
+  const rawState = normaliseString(raw.state).toLowerCase();
+  const fallbackState = normaliseString(safeFallback.state).toLowerCase();
+  const state = normalisePoolVisibilityState(
+    rawState || fallbackState,
+    'hidden',
+    rawState ? raw : safeFallback,
+  );
+  return {
+    state,
+    learnerVisible: state === 'visible',
+    scheduledAt: normaliseTimestamp(raw.scheduledAt ?? safeFallback.scheduledAt, 0),
+    rolloutFlag: normaliseString(raw.rolloutFlag, safeFallback.rolloutFlag || ''),
+  };
+}
+
+export function isSpellingPoolPotentiallyLearnerVisible(visibility = null) {
+  const safe = normalisePoolVisibility(visibility);
+  return LEARNER_ACTIVATABLE_POOL_VISIBILITY_STATES.has(safe.state);
+}
+
+export function isSpellingPoolLearnerVisible(visibility = null, {
+  now = Date.now(),
+  env = {},
+} = {}) {
+  const safe = normalisePoolVisibility(visibility);
+  if (safe.state === 'hidden') return false;
+  if (safe.state === 'visible') return true;
+  if (safe.state === 'scheduled') {
+    return safe.scheduledAt > 0 && safe.scheduledAt <= normaliseTimestamp(now, Date.now());
+  }
+  if (safe.state === 'rollout-flagged') {
+    return poolVisibilityEnvFlagEnabled(env, safe.rolloutFlag);
+  }
+  return false;
+}

--- a/src/surfaces/hubs/AdminContentOperationsSection.jsx
+++ b/src/surfaces/hubs/AdminContentOperationsSection.jsx
@@ -472,8 +472,9 @@ function poolWordCountLookup(pools = []) {
 }
 
 function learnerVisiblePoolIds(pools = []) {
+  const learnerVisibilityStates = new Set(['visible', 'scheduled', 'rollout-flagged']);
   return new Set((Array.isArray(pools) ? pools : [])
-    .filter((pool) => pool?.active !== false && !pool?.retired && pool?.visibility?.state === 'visible')
+    .filter((pool) => pool?.active !== false && !pool?.retired && learnerVisibilityStates.has(pool?.visibility?.state))
     .map(spellingPoolOptionId)
     .filter(Boolean));
 }
@@ -2185,7 +2186,8 @@ function SpellingBrowsePanel({
               data-content-ops-pool-field="visibilityState"
             >
               <option value="hidden">Hidden</option>
-              <option value="staged">Staged</option>
+              <option value="scheduled">Scheduled</option>
+              <option value="rollout-flagged">Rollout flagged</option>
               <option value="visible">Visible</option>
             </select>
           </label>
@@ -3924,6 +3926,7 @@ function ReleaseTable({
             const proofStatus = productionProof?.status || (release.hasCallerProof ? 'recorded' : 'missing');
             const missingSurfaces = releaseSurfaceLabels(productionProof?.missingSurfaces || []);
             const linkedSurfaces = releaseSurfaceLabels(productionProof?.linkedSurfaces || []);
+            const proofWarnings = Array.isArray(productionProof?.warnings) ? productionProof.warnings : [];
             const capture = productionProof?.capturedAt
               ? `Captured by ${productionProof.capturedByAccountId || 'unknown'} ${formatTimestamp(productionProof.capturedAt)}`
               : '';
@@ -4034,6 +4037,15 @@ function ReleaseTable({
                   </span>
                   {missingSurfaces ? <div className="small muted">Missing {missingSurfaces}</div> : null}
                   {!missingSurfaces && linkedSurfaces ? <div className="small muted">{linkedSurfaces}</div> : null}
+                  {proofWarnings.slice(0, 2).map((warning) => (
+                    <div
+                      className="small muted"
+                      key={warning.code || warning.message}
+                      data-content-ops-release-proof-warning={warning.code || 'proof_warning'}
+                    >
+                      {warning.message || warning.code}
+                    </div>
+                  ))}
                   {capture ? <div className="small muted">{capture}</div> : null}
                 </td>
                 <td className="admin-overview-td">

--- a/tests/content-operations-api.test.js
+++ b/tests/content-operations-api.test.js
@@ -1605,7 +1605,8 @@ test('content operations API supports admin package lifecycle through separate a
 });
 
 test('content operations API requires Hero / Codex proof for hero exposure releases', async () => {
-  const server = createWorkerRepositoryServer({ now: () => NOW });
+  let currentNow = NOW;
+  const server = createWorkerRepositoryServer({ now: () => currentNow });
   try {
     seedAdultAccount(server.DB, { accountId: ADMIN_ID, platformRole: 'admin' });
     const repository = createWorkerRepository({
@@ -1628,7 +1629,7 @@ test('content operations API requires Hero / Codex proof for hero exposure relea
       action: 'upsert',
       payload: {
         state: 'scheduled',
-        surfaces: ['heroCamp', 'codex'],
+        surfaces: ['heroQuest'],
         scheduledAt: NOW + 60_000,
         rolloutFlag: 'content-operations-api-hero-proof',
         previewAllowed: true,
@@ -1653,10 +1654,28 @@ test('content operations API requires Hero / Codex proof for hero exposure relea
       published.release.history.productionProof.missingSurfaces.map((entry) => entry.key).sort(),
       ['heroCodex', 'spellingSetup', 'wordBank'].sort(),
     );
+    assert.equal(published.release.history.productionProof.activation.status, 'scheduled');
+    assert.equal(published.release.history.productionProof.warnings.length, 0);
     assert.ok(
       published.release.history.changedEntities.preview.some((entry) => (
         entry.entityType === 'spelling.heroExposure'
           && entry.entityId === rewardTrack.id
+      )),
+    );
+
+    currentNow = NOW + 60_000;
+    const activatedDetailResponse = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/subjects/spelling/releases/${published.release.releaseId}?includeHistory=true`,
+      { method: 'GET', headers: { 'sec-fetch-site': 'same-origin' } },
+      adminHeaders(),
+    );
+    const activatedDetail = await readPayload(activatedDetailResponse);
+    assert.equal(activatedDetailResponse.status, 200);
+    assert.equal(activatedDetail.release.history.productionProof.activation.status, 'active');
+    assert.ok(
+      activatedDetail.release.history.productionProof.warnings.some((entry) => (
+        entry.code === 'production_proof_missing_after_visibility_activation'
       )),
     );
 
@@ -1681,6 +1700,80 @@ test('content operations API requires Hero / Codex proof for hero exposure relea
       captured.release.history.productionProof.linkedSurfaces.map((entry) => entry.key).sort(),
       ['heroCodex', 'spellingSetup', 'wordBank'].sort(),
     );
+    assert.equal(captured.release.history.productionProof.warnings.length, 0);
+  } finally {
+    server.close();
+  }
+});
+
+test('content operations API requires Hero / Codex proof for field-level pool visibility releases', async () => {
+  const server = createWorkerRepositoryServer({ now: () => NOW });
+  try {
+    seedAdultAccount(server.DB, { accountId: ADMIN_ID, platformRole: 'admin' });
+    const repository = createWorkerRepository({
+      env: server.env,
+      now: () => NOW,
+    });
+    await repository.seedFirstContentOperationRelease({
+      seededByAccountId: ADMIN_ID,
+      proof: { source: 'content-operations-api-pool-visibility-proof-test' },
+    });
+
+    const created = await createPackage(server, { title: 'Pool field visibility proof package' });
+    await appendContentOperation(server, created.package.packageId, {
+      entityType: 'spelling.pool',
+      entityId: 'field-visibility-proof',
+      fieldPath: '',
+      action: 'upsert',
+      payload: {
+        id: 'field-visibility-proof',
+        title: 'Field visibility proof',
+        type: 'extension',
+        sourceNote: 'Field-level visibility proof regression fixture.',
+        provenance: { source: 'content-operations-api-test' },
+      },
+    });
+    await appendContentOperation(server, created.package.packageId, {
+      entityType: 'spelling.pool',
+      entityId: 'field-visibility-proof',
+      fieldPath: 'noRewardException.approved',
+      action: 'set',
+      payload: true,
+    });
+    await appendContentOperation(server, created.package.packageId, {
+      entityType: 'spelling.pool',
+      entityId: 'field-visibility-proof',
+      fieldPath: 'noRewardException.reason',
+      action: 'set',
+      payload: 'Pool intentionally has no reward track while visibility proof is tested.',
+    });
+    await appendContentOperation(server, created.package.packageId, {
+      entityType: 'spelling.pool',
+      entityId: 'field-visibility-proof',
+      fieldPath: 'visibility.state',
+      action: 'set',
+      payload: 'visible',
+    });
+
+    const validated = await validatePackage(server, created.package.packageId);
+    assert.equal(validated.candidate.validation.status, 'passed');
+    const approved = await approvePackage(server, created.package.packageId, validated.candidate.candidateId);
+    assert.equal(approved.approval.approvedByAccountId, ADMIN_ID);
+
+    const published = await publishPackage(server, created.package.packageId, {
+      proof: {
+        surfaces: {
+          spellingSetup: { evidence: 'setup-smoke' },
+          wordBank: { evidence: 'word-bank-smoke' },
+        },
+      },
+    });
+    assert.equal(published.release.history.productionProof.status, 'partial');
+    assert.ok(
+      published.release.history.productionProof.missingSurfaces.some((entry) => entry.key === 'heroCodex'),
+      'field-level pool visibility changes must require Hero / Codex production proof',
+    );
+    assert.equal(published.release.history.productionProof.activation.status, 'active');
   } finally {
     server.close();
   }

--- a/tests/content-operations-audio-readiness.test.js
+++ b/tests/content-operations-audio-readiness.test.js
@@ -111,6 +111,26 @@ test('audio readiness scanner plans word, variant, and sentence profiles with st
   assert.equal(variantSentence.sentenceIndex, 0);
 });
 
+test('audio readiness treats deferred learner-visible pool words as required before activation', async () => {
+  const scheduledBundle = spellingBundle();
+  scheduledBundle.draft.pools[0].visibility = {
+    state: 'scheduled',
+    scheduledAt: Date.UTC(2026, 5, 18, 12, 0, 0),
+  };
+  const scheduled = await scanSpellingAudioReadiness(scheduledBundle, { scope: 'all' });
+  assert.equal(scheduled.status, 'blocked');
+  assert.equal(scheduled.totalRequired, 12);
+
+  const flaggedBundle = spellingBundle();
+  flaggedBundle.draft.pools[0].visibility = {
+    state: 'rollout-flagged',
+    rolloutFlag: 'SPELLING_AUDIO_DEFERRED_POOL',
+  };
+  const flagged = await scanSpellingAudioReadiness(flaggedBundle, { scope: 'all' });
+  assert.equal(flagged.status, 'blocked');
+  assert.equal(flagged.totalRequired, 12);
+});
+
 test('audio readiness scanner marks inventory hits present and same-scope old content keys stale', async () => {
   const baseline = await scanSpellingAudioReadiness(spellingBundle(), { scope: 'all' });
   const presentItem = baseline.items.find((item) => item.lane === 'word' && item.profileId === 'male.natural');

--- a/tests/spelling-content-operations-model.test.js
+++ b/tests/spelling-content-operations-model.test.js
@@ -14,6 +14,7 @@ import {
 } from '../src/subjects/spelling/content/operations-model.js';
 import {
   buildPublishedSnapshotFromDraft,
+  resolveLearnerVisibleSpellingSnapshot,
   validateSpellingContentBundle,
 } from '../src/subjects/spelling/content/model.js';
 import {
@@ -181,6 +182,8 @@ function addFuturePoolWord(bundle, {
   poolId,
   title,
   visibilityState = 'hidden',
+  scheduledAt = 0,
+  rolloutFlag = '',
   slug,
   word,
   noRewardException = null,
@@ -192,7 +195,7 @@ function addFuturePoolWord(bundle, {
       id: poolId,
       title,
       type: 'extension',
-      visibility: { state: visibilityState },
+      visibility: { state: visibilityState, scheduledAt, rolloutFlag },
       sourceNote: `${title} test fixture.`,
       provenance: { source: 'spelling-content-operations-model-test' },
       ...(noRewardException ? { noRewardException } : {}),
@@ -361,7 +364,7 @@ test('spelling content operations browse exposes active word counts for hidden r
   assert.equal(securePool.totalWordCount, 1);
 });
 
-test('spelling published snapshot filters hidden and staged pool words but keeps visible approved pool words', () => {
+test('spelling published snapshot stores deferred pool words and resolves learner visibility at request time', () => {
   const bundle = contentBundle();
   addFuturePoolWord(bundle, {
     poolId: 'secure-hidden',
@@ -371,11 +374,22 @@ test('spelling published snapshot filters hidden and staged pool words but keeps
     word: 'hiddenword',
   });
   addFuturePoolWord(bundle, {
-    poolId: 'secure-staged',
-    title: 'Secure staged',
-    visibilityState: 'staged',
-    slug: 'stagedword',
-    word: 'stagedword',
+    poolId: 'secure-scheduled',
+    title: 'Secure scheduled',
+    visibilityState: 'scheduled',
+    scheduledAt: NOW + 60_000,
+    slug: 'scheduledword',
+    word: 'scheduledword',
+    noRewardException: { approved: true, reason: 'Deferred visibility fixture.' },
+  });
+  addFuturePoolWord(bundle, {
+    poolId: 'secure-flagged',
+    title: 'Secure flagged',
+    visibilityState: 'rollout-flagged',
+    rolloutFlag: 'SPELLING_SECURE_FLAGGED',
+    slug: 'flaggedword',
+    word: 'flaggedword',
+    noRewardException: { approved: true, reason: 'Flagged visibility fixture.' },
   });
   addFuturePoolWord(bundle, {
     poolId: 'secure-rewarded',
@@ -387,12 +401,26 @@ test('spelling published snapshot filters hidden and staged pool words but keeps
   });
 
   const validation = validateSpellingContentBundle(bundle);
-  const snapshot = buildPublishedSnapshotFromDraft(validation.bundle.draft, { generatedAt: NOW });
+  const snapshot = buildPublishedSnapshotFromDraft(validation.bundle.draft, {
+    generatedAt: NOW,
+    includeDeferredVisibility: true,
+  });
+  const beforeActivation = resolveLearnerVisibleSpellingSnapshot(snapshot, { now: NOW });
+  const afterSchedule = resolveLearnerVisibleSpellingSnapshot(snapshot, { now: NOW + 60_000 });
+  const afterFlag = resolveLearnerVisibleSpellingSnapshot(snapshot, {
+    now: NOW,
+    env: { SPELLING_SECURE_FLAGGED: 'true' },
+  });
 
   assert.equal(validation.ok, true);
   assert.equal(snapshot.wordBySlug.hiddenword, undefined);
-  assert.equal(snapshot.wordBySlug.stagedword, undefined);
+  assert.equal(snapshot.wordBySlug.scheduledword.spellingPool, 'secure-scheduled');
+  assert.equal(snapshot.wordBySlug.flaggedword.spellingPool, 'secure-flagged');
   assert.equal(snapshot.wordBySlug.rewardedword.spellingPool, 'secure-rewarded');
+  assert.equal(beforeActivation.wordBySlug.scheduledword, undefined);
+  assert.equal(beforeActivation.wordBySlug.flaggedword, undefined);
+  assert.equal(afterSchedule.wordBySlug.scheduledword.spellingPool, 'secure-scheduled');
+  assert.equal(afterFlag.wordBySlug.flaggedword.spellingPool, 'secure-flagged');
 });
 
 test('spelling pool editor allows hidden future pools and blocks visible pools without reward exception', () => {

--- a/tests/worker-subject-runtime.test.js
+++ b/tests/worker-subject-runtime.test.js
@@ -24,6 +24,9 @@ import {
   readSeededSpellingPublishedSnapshot,
 } from '../worker/src/generated-spelling-content-seed.js';
 import {
+  encodeContentOperationSnapshot,
+} from '../src/subjects/spelling/content/release-snapshot-codec.js';
+import {
   isStatutoryCoreWord,
 } from '../src/subjects/spelling/content/taxonomy.js';
 import {
@@ -395,6 +398,91 @@ test('repository serves spelling runtime from the global content operations rele
     assert.equal(runtime.content.draft.words.length, seeded.draft.words.length);
     assert.equal(runtime.summary.runtimeWordCount, seeded.releases.at(-1).snapshot.words.length);
     assert.equal(accountContentReads.length, 0);
+  } finally {
+    DB.close();
+  }
+});
+
+test('repository runtime activates scheduled spelling pool visibility at request time', async () => {
+  const DB = createMigratedSqliteD1Database();
+  let currentNow = 1_777_000_000_000;
+  const repository = createWorkerRepository({ env: { DB }, now: () => currentNow });
+  try {
+    const content = JSON.parse(JSON.stringify(await readSeededSpellingContentBundle()));
+    content.draft.pools.push({
+      id: 'scheduled-runtime',
+      title: 'Scheduled runtime',
+      type: 'extension',
+      visibility: { state: 'scheduled', scheduledAt: currentNow + 60_000 },
+      noRewardException: { approved: true, reason: 'Runtime visibility regression fixture.' },
+      sourceNote: 'Runtime visibility regression fixture.',
+      provenance: { source: 'worker-subject-runtime-test' },
+      sortIndex: content.draft.pools.length,
+    });
+    content.draft.wordLists.push({
+      id: 'scheduled-runtime-list',
+      title: 'Scheduled runtime list',
+      spellingPool: 'scheduled-runtime',
+      coverageTier: 'secure-extension',
+      yearGroups: [],
+      wordSlugs: ['scheduledfocus'],
+      sourceNote: 'Runtime visibility regression fixture.',
+      provenance: { source: 'worker-subject-runtime-test' },
+      sortIndex: content.draft.wordLists.length,
+    });
+    content.draft.words.push({
+      slug: 'scheduledfocus',
+      word: 'scheduledfocus',
+      family: 'scheduled-runtime-family',
+      listId: 'scheduled-runtime-list',
+      spellingPool: 'scheduled-runtime',
+      coverageTier: 'secure-extension',
+      yearGroups: [],
+      accepted: ['scheduledfocus'],
+      tags: ['scheduled-runtime'],
+      explanation: 'Scheduledfocus is a runtime visibility regression fixture.',
+      sentenceEntryIds: ['scheduledfocus-s1'],
+      sourceNote: 'Runtime visibility regression fixture.',
+      provenance: { source: 'worker-subject-runtime-test' },
+      progressKey: 'scheduledfocus',
+      sortIndex: content.draft.words.length,
+    });
+    content.draft.sentences.push({
+      id: 'scheduledfocus-s1',
+      wordSlug: 'scheduledfocus',
+      text: 'Scheduledfocus appears only after the pool activation time.',
+      variantLabel: 'default',
+      sourceNote: 'Runtime visibility regression fixture.',
+      provenance: { source: 'worker-subject-runtime-test' },
+      sortIndex: content.draft.sentences.length,
+    });
+
+    DB.db.prepare(`
+      INSERT INTO content_operation_releases (
+        release_id, subject_id, status, snapshot_json, snapshot_hash,
+        base_release_id, package_id, published_at, published_by_account_id,
+        rollback_of_release_id, proof_json, created_at
+      )
+      VALUES (?, 'spelling', 'published', ?, ?, NULL, NULL, ?, 'admin-a', NULL, NULL, ?)
+    `).run(
+      'corel-scheduled-runtime',
+      await encodeContentOperationSnapshot(content),
+      'scheduled-runtime-hash',
+      currentNow,
+      currentNow,
+    );
+
+    const beforeActivation = await repository.readSpellingRuntimeContent('adult-a', 'spelling', {
+      includeAccountContent: false,
+    });
+    assert.equal(beforeActivation.content.draft.words.some((word) => word.slug === 'scheduledfocus'), true);
+    assert.equal(beforeActivation.snapshot.wordBySlug.scheduledfocus, undefined);
+
+    currentNow += 60_000;
+    const afterActivation = await repository.readSpellingRuntimeContent('adult-a', 'spelling', {
+      includeAccountContent: false,
+    });
+    assert.equal(afterActivation.snapshot.wordBySlug.scheduledfocus.word, 'scheduledfocus');
   } finally {
     DB.close();
   }

--- a/worker/src/content-operations/repository.js
+++ b/worker/src/content-operations/repository.js
@@ -13,8 +13,15 @@ import {
 } from '../../../src/subjects/spelling/content/operations-model.js';
 import {
   buildSpellingContentSummary,
+  isSpellingPoolLearnerVisible,
+  normalisePoolVisibility,
   validateSpellingContentBundle,
 } from '../../../src/subjects/spelling/content/model.js';
+import {
+  HERO_EXPOSURE_SURFACES,
+  isHeroExposureVisible,
+  normaliseHeroExposure,
+} from '../../../src/platform/game/reward-track-config.js';
 import {
   audioReadinessHasBlockingItems,
 } from '../../../src/subjects/spelling/content/audio-readiness.js';
@@ -708,7 +715,15 @@ function surfaceCaptureDescriptor(key, capture = null) {
 
 function isPoolVisibilityChange(operation = {}) {
   if (operation.entityType !== 'spelling.pool') return false;
-  if (operation.fieldPath === 'visibility' || operation.fieldPath === 'rewardTrack' || operation.fieldPath === 'noRewardException') return true;
+  const fieldPath = normaliseString(operation.fieldPath);
+  if (
+    fieldPath === 'visibility'
+      || fieldPath.startsWith('visibility.')
+      || fieldPath === 'rewardTrack'
+      || fieldPath.startsWith('rewardTrack.')
+      || fieldPath === 'noRewardException'
+      || fieldPath.startsWith('noRewardException.')
+  ) return true;
   return isPlainObject(operation.payload)
     && (
       isPlainObject(operation.payload.visibility)
@@ -742,6 +757,97 @@ function requiredProductionProofSurfaceKeys(operations = [], release = {}) {
     required.add('monsterRendering');
   }
   return [...required];
+}
+
+function poolVisibilityFromOperation(operation = {}) {
+  const entityType = normaliseString(operation.entityType);
+  if (entityType !== 'spelling.pool') return null;
+  const fieldPath = normaliseString(operation.fieldPath);
+  if (isPlainObject(operation.payload?.visibility)) return normalisePoolVisibility(operation.payload.visibility);
+  if (fieldPath === 'visibility' && isPlainObject(operation.payload)) return normalisePoolVisibility(operation.payload);
+  if (fieldPath === 'visibility.state') return normalisePoolVisibility({ state: operation.payload });
+  if (fieldPath === 'visibility.scheduledAt') return normalisePoolVisibility({ state: 'scheduled', scheduledAt: operation.payload });
+  if (fieldPath === 'visibility.rolloutFlag') return normalisePoolVisibility({ state: 'rollout-flagged', rolloutFlag: operation.payload });
+  return null;
+}
+
+function heroExposureFromOperation(operation = {}) {
+  const entityType = normaliseString(operation.entityType);
+  const fieldPath = normaliseString(operation.fieldPath);
+  if (entityType === 'spelling.heroExposure') return normaliseHeroExposure(operation.payload);
+  if (entityType !== 'spelling.rewardTrack') return null;
+  if (isPlainObject(operation.payload?.heroExposure)) return normaliseHeroExposure(operation.payload.heroExposure);
+  if (fieldPath === 'heroExposure' && isPlainObject(operation.payload)) return normaliseHeroExposure(operation.payload);
+  if (fieldPath === 'heroExposure.state') return normaliseHeroExposure({ state: operation.payload });
+  if (fieldPath === 'heroExposure.scheduledAt') return normaliseHeroExposure({ state: 'scheduled', scheduledAt: operation.payload });
+  if (fieldPath === 'heroExposure.rolloutFlag') return normaliseHeroExposure({ state: 'rollout-flagged', rolloutFlag: operation.payload });
+  return null;
+}
+
+function activationDescriptorFromState({ entityType, entityId, state, scheduledAt = 0, rolloutFlag = '', learnerVisible = false }) {
+  let status = 'inactive';
+  if (learnerVisible) status = 'active';
+  else if (state === 'scheduled') status = 'scheduled';
+  else if (state === 'rollout-flagged') status = 'rollout_flagged';
+  else if (state === 'hidden') status = 'hidden';
+  return {
+    entityType,
+    entityId,
+    state,
+    status,
+    learnerVisible: Boolean(learnerVisible),
+    scheduledAt: Number(scheduledAt) || null,
+    rolloutFlag: normaliseString(rolloutFlag) || null,
+  };
+}
+
+function isHeroExposureLearnerVisible(exposure, { now = Date.now(), env = {} } = {}) {
+  return HERO_EXPOSURE_SURFACES.some((surface) => isHeroExposureVisible(exposure, { surface, now, env }));
+}
+
+function buildVisibilityActivationSummary(operations = [], {
+  now = Date.now(),
+  env = {},
+} = {}) {
+  const entries = [];
+  for (const operation of operations) {
+    const poolVisibility = poolVisibilityFromOperation(operation);
+    if (poolVisibility) {
+      entries.push(activationDescriptorFromState({
+        entityType: operation.entityType,
+        entityId: operation.entityId,
+        state: poolVisibility.state,
+        scheduledAt: poolVisibility.scheduledAt,
+        rolloutFlag: poolVisibility.rolloutFlag,
+        learnerVisible: isSpellingPoolLearnerVisible(poolVisibility, { now, env }),
+      }));
+      continue;
+    }
+    const heroExposure = heroExposureFromOperation(operation);
+    if (heroExposure) {
+      entries.push(activationDescriptorFromState({
+        entityType: operation.entityType,
+        entityId: operation.entityId,
+        state: heroExposure.state,
+        scheduledAt: heroExposure.scheduledAt,
+        rolloutFlag: heroExposure.rolloutFlag,
+        learnerVisible: isHeroExposureLearnerVisible(heroExposure, { now, env }),
+      }));
+    }
+  }
+
+  let status = 'not_applicable';
+  if (entries.some((entry) => entry.learnerVisible)) status = 'active';
+  else if (entries.some((entry) => entry.status === 'scheduled')) status = 'scheduled';
+  else if (entries.some((entry) => entry.status === 'rollout_flagged')) status = 'rollout_flagged';
+  else if (entries.length) status = 'inactive';
+
+  return {
+    status,
+    checkedAt: Number(now) || null,
+    activated: status === 'active',
+    entries,
+  };
 }
 
 function summariseContentOperationChanges(operations = []) {
@@ -809,12 +915,16 @@ function summariseReleaseAssetChanges(release = {}) {
   };
 }
 
-function buildProductionProofSummary(release = {}, operations = []) {
+function buildProductionProofSummary(release = {}, operations = [], {
+  now = Date.now(),
+  env = {},
+} = {}) {
   const requiredKeys = requiredProductionProofSurfaceKeys(operations, release);
   const capture = productionProofCaptureForRelease(release.proof, release);
   const linkedKeys = productionProofSurfaceKeys(release.proof, release);
   const missingKeys = requiredKeys.filter((key) => !linkedKeys.includes(key));
   const hasCallerProof = proofHasCallerMetadata(release.proof);
+  const activation = buildVisibilityActivationSummary(operations, { now, env });
   let status = 'not_required';
   if (requiredKeys.length) {
     if (!missingKeys.length) {
@@ -827,6 +937,14 @@ function buildProductionProofSummary(release = {}, operations = []) {
   } else if (hasCallerProof) {
     status = 'recorded';
   }
+  const warnings = [];
+  if (missingKeys.length && activation.activated) {
+    warnings.push({
+      code: 'production_proof_missing_after_visibility_activation',
+      message: 'Learner-visible activation has occurred but production proof is incomplete.',
+      missingSurfaces: missingKeys.map(surfaceDescriptor),
+    });
+  }
   return {
     status,
     hasCallerProof,
@@ -835,6 +953,8 @@ function buildProductionProofSummary(release = {}, operations = []) {
     requiredSurfaces: requiredKeys.map(surfaceDescriptor),
     linkedSurfaces: linkedKeys.map((key) => surfaceCaptureDescriptor(key, capture)),
     missingSurfaces: missingKeys.map(surfaceDescriptor),
+    activation,
+    warnings,
   };
 }
 
@@ -905,6 +1025,8 @@ function buildReleaseHistorySummary({
   contentPackage = null,
   approval = null,
   operations = [],
+  now = Date.now(),
+  env = {},
 } = {}) {
   if (!release) return null;
   return {
@@ -924,7 +1046,7 @@ function buildReleaseHistorySummary({
     publishedAt: release.publishedAt ?? null,
     changedEntities: summariseContentOperationChanges(operations),
     assetChanges: summariseReleaseAssetChanges(release),
-    productionProof: buildProductionProofSummary(release, operations),
+    productionProof: buildProductionProofSummary(release, operations, { now, env }),
   };
 }
 
@@ -1075,12 +1197,12 @@ async function readPackageRevertSource(db, packageId) {
   };
 }
 
-async function attachReleaseHistorySummary(db, release = null) {
+async function attachReleaseHistorySummary(db, release = null, context = {}) {
   if (!release) return null;
   if (!release.packageId) {
     return {
       ...release,
-      history: buildReleaseHistorySummary({ release }),
+      history: buildReleaseHistorySummary({ release, ...context }),
     };
   }
   const [packageRow, approvalRow, operations] = await Promise.all([
@@ -1105,17 +1227,18 @@ async function attachReleaseHistorySummary(db, release = null) {
       contentPackage: packageRow ? packageRowToRecord(packageRow) : null,
       approval: approvalRowToRecord(approvalRow),
       operations,
+      ...context,
     }),
   };
 }
 
-async function attachReleaseHistorySummaries(db, releases = []) {
+async function attachReleaseHistorySummaries(db, releases = [], context = {}) {
   if (!releases.length) return releases;
   const packageIds = uniqueStrings(releases.map((release) => release?.packageId).filter(Boolean));
   if (!packageIds.length) {
     return releases.map((release) => ({
       ...release,
-      history: buildReleaseHistorySummary({ release }),
+      history: buildReleaseHistorySummary({ release, ...context }),
     }));
   }
   const placeholders = packageIds.map(() => '?').join(', ');
@@ -1155,7 +1278,7 @@ async function attachReleaseHistorySummaries(db, releases = []) {
     if (!release?.packageId) {
       return {
         ...release,
-        history: buildReleaseHistorySummary({ release }),
+        history: buildReleaseHistorySummary({ release, ...context }),
       };
     }
     return {
@@ -1165,6 +1288,7 @@ async function attachReleaseHistorySummaries(db, releases = []) {
         contentPackage: packagesById.get(release.packageId) || null,
         approval: approvalsByPackageId.get(release.packageId) || null,
         operations: operationsByPackageId.get(release.packageId) || [],
+        ...context,
       }),
     };
   });
@@ -2903,6 +3027,8 @@ export function createContentOperationsRepository({ db, env = {}, now }) {
           },
           approval,
           operations,
+          now: nowTs,
+          env,
         }),
       };
     },
@@ -3125,13 +3251,13 @@ export function createContentOperationsRepository({ db, env = {}, now }) {
       return attachReleaseHistorySummary(db, {
         ...release,
         proof: nextProof,
-      });
+      }, { now: nowTs, env });
     },
 
     async readLatestContentOperationRelease(subjectId = CONTENT_OPERATION_SUBJECT_ID, { includeSnapshot = false, includeHistory = false } = {}) {
       const row = await readLatestReleaseRow(db, normaliseSubjectId(subjectId), { includeSnapshot });
       const release = await releaseRowToRecordAsync(row, { includeSnapshot });
-      return includeHistory ? attachReleaseHistorySummary(db, release) : release;
+      return includeHistory ? attachReleaseHistorySummary(db, release, { now: nowFactory(), env }) : release;
     },
 
     async readContentOperationRelease(subjectId = CONTENT_OPERATION_SUBJECT_ID, releaseId, { includeSnapshot = false, includeHistory = false } = {}) {
@@ -3139,7 +3265,7 @@ export function createContentOperationsRepository({ db, env = {}, now }) {
         includeSnapshot,
       });
       const release = await releaseRowToRecordAsync(row, { includeSnapshot });
-      return includeHistory ? attachReleaseHistorySummary(db, release) : release;
+      return includeHistory ? attachReleaseHistorySummary(db, release, { now: nowFactory(), env }) : release;
     },
 
     async listContentOperationReleases({
@@ -3161,7 +3287,7 @@ export function createContentOperationsRepository({ db, env = {}, now }) {
         LIMIT ?
       `, [normaliseSubjectId(subjectId), safeLimit]);
       const releases = await Promise.all(rows.map((row) => releaseRowToRecordAsync(row, { includeSnapshot })));
-      return includeHistory ? attachReleaseHistorySummaries(db, releases) : releases;
+      return includeHistory ? attachReleaseHistorySummaries(db, releases, { now: nowFactory(), env }) : releases;
     },
 
     async listContentOperationEvents({ packageId = null, releaseId = null, subjectId = CONTENT_OPERATION_SUBJECT_ID, limit = 50 } = {}) {

--- a/worker/src/content-operations/serialisers.js
+++ b/worker/src/content-operations/serialisers.js
@@ -426,6 +426,15 @@ function serialiseReleaseHistory(history = null) {
       requiredSurfaces: Array.isArray(productionProof.requiredSurfaces) ? productionProof.requiredSurfaces : [],
       linkedSurfaces: Array.isArray(productionProof.linkedSurfaces) ? productionProof.linkedSurfaces : [],
       missingSurfaces: Array.isArray(productionProof.missingSurfaces) ? productionProof.missingSurfaces : [],
+      activation: productionProof.activation && typeof productionProof.activation === 'object' && !Array.isArray(productionProof.activation)
+        ? {
+            status: productionProof.activation.status || 'not_applicable',
+            checkedAt: Number(productionProof.activation.checkedAt) || null,
+            activated: Boolean(productionProof.activation.activated),
+            entries: Array.isArray(productionProof.activation.entries) ? productionProof.activation.entries : [],
+          }
+        : null,
+      warnings: Array.isArray(productionProof.warnings) ? productionProof.warnings : [],
     } : null,
   };
 }

--- a/worker/src/repository.js
+++ b/worker/src/repository.js
@@ -14,8 +14,10 @@ import {
 import { stableHash, uid } from '../../src/platform/core/utils.js';
 import {
   backfillSpellingWordExplanations,
+  buildPublishedSnapshotFromDraft,
   buildSpellingContentSummary,
   normaliseSpellingContentBundle,
+  resolveLearnerVisibleSpellingSnapshot,
   resolveRuntimeSnapshot,
   validateSpellingContentBundle,
 } from '../../src/subjects/spelling/content/model.js';
@@ -494,7 +496,10 @@ async function mergePublicSpellingCodexState(db, accountId, subjectRows, gameSta
   const spellingRows = subjectRows.filter((row) => row.subject_id === 'spelling');
   if (!spellingRows.length) return gameState;
 
-  const snapshot = runtimeSnapshot || (await readSpellingContentForReadModels(db, accountId)).runtimeSnapshot;
+  const snapshot = runtimeSnapshot || (await readSpellingContentForReadModels(db, accountId, 'spelling', {
+    nowMs: now,
+    env,
+  })).runtimeSnapshot;
 
   for (const row of spellingRows) {
     const progress = spellingProgressFromSubjectRow(row);
@@ -790,12 +795,15 @@ function attachRuntimeMonsterAssetReferencesToVisualConfig(monsterVisualConfig, 
 async function readSpellingRuntimeContentBundle(db, accountId, subjectId = 'spelling', {
   includeAccountContent = true,
   includeGlobalContent = true,
+  nowMs = Date.now(),
+  env = {},
 } = {}) {
   if (includeGlobalContent) {
     const releaseRow = await readResolvedContentOperationReleaseRow(db, accountId, subjectId);
     if (releaseRow) {
       const cachePrefix = releaseRow.release_source === 'override' ? 'override' : 'release';
-      return readSpellingRuntimeContentReleaseBundle(db, subjectId, releaseRow, cachePrefix);
+      const runtimeContent = await readSpellingRuntimeContentReleaseBundle(db, subjectId, releaseRow, cachePrefix);
+      return resolveLearnerVisibleRuntimeContent(runtimeContent, { nowMs, env });
     }
   }
 
@@ -835,7 +843,8 @@ async function readSpellingRuntimeContentBundle(db, accountId, subjectId = 'spel
   if (includeGlobalContent) {
     const releaseRow = await readPublishedContentOperationReleaseRow(db, subjectId);
     if (releaseRow) {
-      return readSpellingRuntimeContentReleaseBundle(db, subjectId, releaseRow);
+      const runtimeContent = await readSpellingRuntimeContentReleaseBundle(db, subjectId, releaseRow);
+      return resolveLearnerVisibleRuntimeContent(runtimeContent, { nowMs, env });
     }
   }
 
@@ -1092,6 +1101,28 @@ function runtimeContentSummary(content, snapshot) {
   };
 }
 
+function resolveLearnerVisibleRuntimeContent(runtimeContent, {
+  nowMs = Date.now(),
+  env = {},
+} = {}) {
+  if (!runtimeContent?.snapshot) return runtimeContent;
+  const snapshot = resolveLearnerVisibleSpellingSnapshot(runtimeContent.snapshot, {
+    now: nowMs,
+    env,
+  });
+  return {
+    ...runtimeContent,
+    snapshot,
+    summary: runtimeContent.summary
+      ? {
+          ...runtimeContent.summary,
+          runtimeWordCount: snapshot.words.length,
+          runtimeSentenceCount: runtimeSentenceCount(snapshot),
+        }
+      : runtimeContent.summary,
+  };
+}
+
 async function buildSpellingRuntimeContent(row, subjectId) {
   if (!row) {
     return buildSeededSpellingRuntimeContent(subjectId);
@@ -1117,15 +1148,22 @@ async function buildSpellingRuntimeContentFromRelease(row, subjectId) {
   }
 
   try {
-    const seededBundle = await readSeededSpellingContentBundle();
     const snapshotJson = await decodeContentOperationSnapshot(row.snapshot_json);
     const content = normaliseSpellingContentBundle(JSON.parse(snapshotJson));
-    const snapshot = runtimeSnapshotForBundle(content, seededBundle);
+    const snapshot = buildPublishedSnapshotFromDraft(content.draft, {
+      generatedAt: Number(row.published_at) || Date.now(),
+      includeDeferredVisibility: true,
+    });
+    const baseSummary = runtimeContentSummary(content, snapshot);
     return {
       subjectId,
       content,
       snapshot,
-      summary: runtimeContentSummary(content, snapshot),
+      summary: {
+        ...baseSummary,
+        publishedReleaseId: row.release_id || baseSummary.publishedReleaseId || '',
+        publishedAt: Number(row.published_at) || baseSummary.publishedAt || 0,
+      },
     };
   } catch (error) {
     logMutation('warn', 'content_operation_release.runtime_fallback', {
@@ -2380,7 +2418,7 @@ const CONTENT_OVERVIEW_SUBJECTS = [
   { subjectKey: 'reading', displayName: 'Reading', queryLive: true },
 ];
 
-async function readSubjectContentOverviewData(db, { now, actorAccountId, actor = null } = {}) {
+async function readSubjectContentOverviewData(db, { now, actorAccountId, actor = null, env = {} } = {}) {
   if (!actor) {
     await assertAdminHubActor(db, actorAccountId);
   }
@@ -2391,7 +2429,10 @@ async function readSubjectContentOverviewData(db, { now, actorAccountId, actor =
   // and uses existing tables. We soft-fail on missing tables so the hub
   // loads before the relevant migrations land.
 
-  const spellingContentP = readSpellingContentForReadModels(db, actorAccountId).catch(() => null);
+  const spellingContentP = readSpellingContentForReadModels(db, actorAccountId, 'spelling', {
+    nowMs: nowTs,
+    env,
+  }).catch(() => null);
 
   const spellingErrorsP = scalarCountSafe(db, `
     SELECT COUNT(*) AS value
@@ -2601,10 +2642,16 @@ async function safeSignalSection(label, fn) {
   }
 }
 
-async function readContentQualitySignalsData(db, { actorAccountId, actor = null } = {}) {
+async function readContentQualitySignalsData(db, {
+  actorAccountId,
+  actor = null,
+  now,
+  env = {},
+} = {}) {
   if (!actor) {
     await assertAdminHubActor(db, actorAccountId);
   }
+  const nowTs = Number.isFinite(Number(now)) ? Number(now) : Date.now();
 
   // Grammar signals: concept coverage from GRAMMAR_AGGREGATE_CONCEPTS (18 concepts)
   // and per-concept attempt counts from the mastery_evidence table.
@@ -2687,7 +2734,10 @@ async function readContentQualitySignalsData(db, { actorAccountId, actor = null 
   const spellingSignals = await safeSignalSection('spelling', async () => {
     let wordCount = 0;
     let runtimeCoreCount = 0;
-    const spellingContent = await readSpellingContentForReadModels(db, actorAccountId);
+    const spellingContent = await readSpellingContentForReadModels(db, actorAccountId, 'spelling', {
+      nowMs: nowTs,
+      env,
+    });
     const words = Array.isArray(spellingContent.runtimeSnapshot?.words)
       ? spellingContent.runtimeSnapshot.words
       : [];
@@ -2750,7 +2800,7 @@ async function readContentQualitySignalsData(db, { actorAccountId, actor = null 
     .filter(Boolean);
 
   return {
-    generatedAt: Date.now(),
+    generatedAt: nowTs,
     subjectSignals,
   };
 }
@@ -7808,6 +7858,7 @@ async function bootstrapBundle(db, accountId, {
         ORDER BY created_at ASC, id ASC
       `, queryLearnerIds)
   ));
+  const publicReadModelNow = Date.now();
   const publicSpellingContent = await measureBootstrapPhase(capacity, BOOTSTRAP_PHASE_TIMING.readModel, () => (
     publicReadModels && subjectRows.some((row) => row.subject_id === 'spelling')
       ? (spellingContentReleaseRow
@@ -7816,11 +7867,13 @@ async function bootstrapBundle(db, accountId, {
           'spelling',
           spellingContentReleaseRow,
           spellingContentReleaseRow.release_source === 'override' ? 'override' : 'release',
-        )
+        ).then((runtimeContent) => resolveLearnerVisibleRuntimeContent(runtimeContent, {
+          nowMs: publicReadModelNow,
+          env,
+        }))
         : readSeededSpellingRuntimeContentBundle('spelling'))
       : null
   ));
-  const publicReadModelNow = Date.now();
   const subjectStates = {};
   await measureBootstrapPhase(capacity, BOOTSTRAP_PHASE_TIMING.readModel, async () => {
     for (const row of subjectRows) {
@@ -7996,7 +8049,7 @@ async function readSubjectRuntimeBundle(db, accountId, learnerId, subjectId = 's
   };
 }
 
-async function readSpellingWordBankBundle(db, accountId, learnerId, filters, nowTs) {
+async function readSpellingWordBankBundle(db, accountId, learnerId, filters, nowTs, env = {}) {
   if (!(typeof learnerId === 'string' && learnerId)) {
     throw new BadRequestError('Learner id is required for the spelling word bank.', {
       code: 'learner_id_required',
@@ -8005,6 +8058,8 @@ async function readSpellingWordBankBundle(db, accountId, learnerId, filters, now
   const runtimeRecord = await readSubjectRuntimeBundle(db, accountId, learnerId, 'spelling');
   const { snapshot } = await readSpellingRuntimeContentBundle(db, accountId, 'spelling', {
     includeAccountContent: false,
+    nowMs: nowTs,
+    env,
   });
   return buildSpellingWordBankReadModel({
     learnerId,
@@ -9792,10 +9847,14 @@ export function createWorkerRepository({ env = {}, now = Date.now, capacity = nu
       };
     },
     async readSpellingRuntimeContent(accountId, subjectId = 'spelling', options = {}) {
-      return readSpellingRuntimeContentBundle(db, accountId, subjectId, options);
+      return readSpellingRuntimeContentBundle(db, accountId, subjectId, {
+        ...options,
+        nowMs: nowFactory(),
+        env,
+      });
     },
     async readSpellingWordBank(accountId, learnerId, filters = {}) {
-      return readSpellingWordBankBundle(db, accountId, learnerId, filters, nowFactory());
+      return readSpellingWordBankBundle(db, accountId, learnerId, filters, nowFactory(), env);
     },
     // U9 → P7-U6: Punctuation telemetry read. Fires the same
     // `requireLearnerReadAccess` gate the spelling word-bank read uses
@@ -9935,7 +9994,10 @@ export function createWorkerRepository({ env = {}, now = Date.now, capacity = nu
         FROM learner_profiles l
         WHERE l.id = ?
       `, [resolvedLearnerId]);
-      const spellingContent = await readSpellingContentForReadModels(db, accountId);
+      const spellingContent = await readSpellingContentForReadModels(db, accountId, 'spelling', {
+        nowMs: nowFactory(),
+        env,
+      });
       const learnerBundle = await loadLearnerReadBundle(db, resolvedLearnerId);
       const model = buildParentHubReadModel({
         learner: learnerRowToRecord(learnerRow),
@@ -9966,7 +10028,10 @@ export function createWorkerRepository({ env = {}, now = Date.now, capacity = nu
       // depend on membership list, spelling content is an independent read
       // but must complete before buildAdminHubReadModel.
       const memberships = await listMembershipRows(db, accountId, { writableOnly: false });
-      const spellingContent = await readSpellingContentForReadModels(db, accountId);
+      const spellingContent = await readSpellingContentForReadModels(db, accountId, 'spelling', {
+        nowMs: nowFactory(),
+        env,
+      });
       const learnerBundles = {};
       for (const row of memberships) {
         learnerBundles[row.id] = await loadLearnerReadBundle(db, row.id);
@@ -10129,14 +10194,17 @@ export function createWorkerRepository({ env = {}, now = Date.now, capacity = nu
         now: nowFactory(),
         actorAccountId: accountId,
         actor,
+        env,
       });
     },
     // U7 (P6): content quality signals. Read-only; R16 compliant.
     async readContentQualitySignals(accountId) {
       const actor = await assertAdminHubActor(db, accountId);
       return readContentQualitySignalsData(db, {
+        now: nowFactory(),
         actorAccountId: accountId,
         actor,
+        env,
       });
     },
     // U8 (P3): narrow read for the denial log panel in Debugging section.
@@ -10411,6 +10479,8 @@ export function createWorkerRepository({ env = {}, now = Date.now, capacity = nu
         ? await readSpellingRuntimeContentBundle(db, accountId, 'spelling', {
           includeAccountContent: false,
           includeGlobalContent: true,
+          nowMs: now,
+          env,
         })
         : null;
       for (const row of rows) {


### PR DESCRIPTION
## Summary
- Add shared spelling pool visibility helpers for visible, hidden, scheduled, and rollout-flagged states.
- Keep scheduled and rollout content available to admin/audio workflows while filtering learner runtime snapshots at request time.
- Surface activation-aware production proof warnings in release history for Spelling setup, Word Bank, Hero/Codex, and related visibility changes.
- Extend admin UI and regression coverage for deferred pool visibility, audio readiness, runtime activation, and field-level proof requirements.

## Validation
- `node --test tests/content-operations-audio-readiness.test.js tests/content-operations-api.test.js`
- `node --test tests/spelling-content-operations-model.test.js tests/spelling-reward-tracks.test.js tests/worker-subject-runtime.test.js tests/content-operations-audio-readiness.test.js tests/content-operations-api.test.js`
- `node --test tests/spelling-content-api.test.js`
- `npm test`
- `npm run check`
- `git diff --check`

## Notes
- Pre-push hook reran `npm test` successfully: 111876 pass, 0 fail, 12 skipped.