### PR TITLE
Harden spelling cutover compatibility migration

### DIFF
--- a/docs/spelling-content-model.md
+++ b/docs/spelling-content-model.md
@@ -236,18 +236,26 @@ updated_at
 updated_by_account_id
 ```
 
-Current use:
+Pre-cutover use:
 
 - `subject_id = 'spelling'`
 - account-scoped draft/release content storage
 - content writes protected by the same account revision / idempotency mutation policy already introduced in Pass 9
 
-New Worker routes:
+Compatibility Worker routes:
 
 - `GET /api/content/spelling`
 - `PUT /api/content/spelling`
 
-The Worker validates incoming content bundles and rejects invalid ones with explicit validation details.
+After the first published global content operations release exists, `account_subject_content` is no longer the effective production spelling content source. Learner runtime, admin hubs, content-quality signals, and the legacy export route resolve the published global release first. `account_subject_content` remains only as a pre-cutover fallback and as diagnostic legacy storage.
+
+The compatibility route state after cutover is:
+
+- `GET /api/content/spelling` is retained for export and diagnostics. It returns the current global release bundle and a `compatibility` block with the release id, snapshot hash, and `legacyWriteDisabled: true`.
+- `PUT /api/content/spelling` is disabled once a published global release exists. It returns `409 subject_content_legacy_write_cutover` with the release id, snapshot hash, published time, and the required mutation path.
+- New learner-visible spelling content changes must go through content operations packages, approval, and publish into immutable global releases.
+
+The seed helper `scripts/migrate-spelling-content-to-global-release.mjs` generates first-release-only SQL. Re-running it against an environment that already has a published spelling global release is a no-op; local or remote dry-runs report the detected release and the post-cutover compatibility policy.
 
 ## Repository and service boundary
 
@@ -265,11 +273,13 @@ The content layer is deliberately separate from the subject engine.
 `createApiSpellingContentRepository()`
 
 - hydrates from `/api/content/spelling`
-- writes with account-scoped mutation metadata
+- writes with account-scoped mutation metadata only before global-release cutover
 - tracks the current account revision for replay-safe writes
 
-Accounts with no stored spelling content receive the current seeded bundle, including the Extra expansion, on first read.
-Accounts that already have stored account-scoped content are not silently overwritten by newer seeds; operators should import/publish the updated bundle, or intentionally reset to seeded content after taking a backup.
+Accounts with no stored spelling content receive the current seeded bundle, including the Extra expansion, on first read before cutover.
+Accounts that already have stored account-scoped content are not silently overwritten by newer seeds before cutover; operators should import/publish the updated bundle, or intentionally reset to seeded content after taking a backup.
+
+After cutover, operators should not use this repository as an editorial publish surface. It is kept so older tools can hydrate/export the effective content, while the write path fails closed instead of bypassing package approval.
 
 ### Content service
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "content:operations:seed": "node scripts/migrate-spelling-content-to-global-release.mjs",
     "db:migration:create": "node ./scripts/wrangler-oauth.mjs d1 migrations create ks2-mastery-db",
     "db:migrate:local": "node ./scripts/wrangler-oauth.mjs d1 migrations apply ks2-mastery-db --local",
-    "db:migrate:remote": "CI=true node ./scripts/wrangler-oauth.mjs d1 migrations apply ks2-mastery-db --remote",
+    "db:migrate:remote": "node ./scripts/wrangler-ci.mjs d1 migrations apply ks2-mastery-db --remote",
     "db:migrate:remote:oauth": "npm run db:migrate:remote",
     "db:migrations:list:local": "node ./scripts/wrangler-oauth.mjs d1 migrations list ks2-mastery-db --local",
     "db:migrations:list:remote": "node ./scripts/wrangler-oauth.mjs d1 migrations list ks2-mastery-db --remote",

--- a/scripts/migrate-spelling-content-to-global-release.mjs
+++ b/scripts/migrate-spelling-content-to-global-release.mjs
@@ -4,8 +4,8 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
-import { uid } from '../src/platform/core/utils.js';
 import {
+  backfillSpellingWordExplanations,
   buildSpellingContentSummary,
   validateSpellingContentBundle,
 } from '../src/subjects/spelling/content/model.js';
@@ -24,6 +24,14 @@ const __dirname = path.dirname(__filename);
 const rootDir = path.resolve(__dirname, '..');
 const scriptRelativePath = 'scripts/migrate-spelling-content-to-global-release.mjs';
 const remoteConfirmation = 'seed-first-global-release';
+const compatibilityPolicy = Object.freeze({
+  legacyExportRoute: '/api/content/spelling',
+  legacyExportMode: 'read_only_after_global_release',
+  legacyWriteRoute: '/api/content/spelling',
+  legacyWriteMode: 'disabled_after_global_release',
+  mutationPath: 'content_operations_package_approval',
+  firstReleaseInsertPolicy: 'only_when_no_published_spelling_release_exists',
+});
 
 function readOptionValue(argv, index, flag) {
   if (index + 1 >= argv.length) throw new Error(`${flag} requires a value.`);
@@ -62,6 +70,26 @@ function parseJson(value, fallback = null) {
   }
 }
 
+function summariseValidation(validation, issueLimit = 12) {
+  const toIssues = (issues) => (Array.isArray(issues) ? issues : [])
+    .slice(0, issueLimit)
+    .map((issue) => ({
+      severity: issue.severity,
+      code: issue.code,
+      path: issue.path,
+      message: issue.message,
+    }));
+  const errors = Array.isArray(validation?.errors) ? validation.errors : [];
+  const warnings = Array.isArray(validation?.warnings) ? validation.warnings : [];
+  return {
+    ok: Boolean(validation?.ok),
+    errorCount: errors.length,
+    warningCount: warnings.length,
+    errors: toIssues(errors),
+    warnings: toIssues(warnings),
+  };
+}
+
 function chunkString(value, chunkSize = 80_000) {
   const chunks = [];
   const text = String(value || '');
@@ -71,26 +99,38 @@ function chunkString(value, chunkSize = 80_000) {
   return chunks.length ? chunks : [''];
 }
 
-function snapshotSqlExpression(snapshotValue) {
+function snapshotSqlExpression(snapshotValue, releaseId) {
   const chunks = chunkString(snapshotValue);
   if (chunks.length === 1 && chunks[0].length < 80_000) {
     return {
       setupSql: [],
       valueExpression: sqlString(chunks[0]),
+      appendSql: [],
       teardownSql: [],
       chunkCount: chunks.length,
+      charLength: chunks[0].length,
     };
   }
+  let prefixLength = 0;
+  const appendSql = chunks.map((chunk) => {
+    const sql = [
+      'UPDATE content_operation_releases',
+      `SET snapshot_json = snapshot_json || ${sqlString(chunk)}`,
+      `WHERE release_id = ${sqlString(releaseId)}`,
+      "  AND subject_id = 'spelling'",
+      "  AND status = 'seeding'",
+      `  AND length(snapshot_json) = ${sqlInteger(prefixLength)};`,
+    ].join('\n');
+    prefixLength += chunk.length;
+    return sql;
+  });
   return {
-    setupSql: [
-      'CREATE TEMP TABLE _content_operation_seed_snapshot_chunks (chunk_index INTEGER PRIMARY KEY, chunk_value TEXT NOT NULL);',
-      ...chunks.map((chunk, index) => (
-        `INSERT INTO _content_operation_seed_snapshot_chunks (chunk_index, chunk_value) VALUES (${sqlInteger(index)}, ${sqlString(chunk)});`
-      )),
-    ],
-    valueExpression: "(SELECT group_concat(chunk_value, '') FROM (SELECT chunk_value FROM _content_operation_seed_snapshot_chunks ORDER BY chunk_index ASC))",
-    teardownSql: ['DROP TABLE _content_operation_seed_snapshot_chunks;'],
+    setupSql: [],
+    valueExpression: "''",
+    appendSql,
+    teardownSql: [],
     chunkCount: chunks.length,
+    charLength: prefixLength,
   };
 }
 
@@ -218,10 +258,91 @@ function readLatestLegacyContentSource(options) {
   };
 }
 
+function readPublishedSpellingReleaseState(options) {
+  const resultSets = runWranglerD1Json(`
+    SELECT release_id, subject_id, status, snapshot_hash, published_at, published_by_account_id, created_at
+    FROM content_operation_releases
+    WHERE subject_id = 'spelling' AND status = 'published'
+    ORDER BY published_at DESC, created_at DESC, rowid DESC
+    LIMIT 1
+  `, options);
+  const row = resultSets.flatMap((entry) => Array.isArray(entry?.results) ? entry.results : [])[0] || null;
+  if (!row) return null;
+  return {
+    releaseId: row.release_id || null,
+    subjectId: row.subject_id || 'spelling',
+    status: row.status || 'published',
+    snapshotHash: row.snapshot_hash || null,
+    publishedAt: Number(row.published_at) || 0,
+    publishedByAccountId: row.published_by_account_id || null,
+    createdAt: Number(row.created_at) || 0,
+  };
+}
+
+export function buildCutoverState({ publishedRelease = null, plannedRelease = null } = {}) {
+  const hasPublishedRelease = Boolean(publishedRelease?.releaseId);
+  return {
+    publishedReleasePresent: hasPublishedRelease,
+    effectiveReleaseId: hasPublishedRelease
+      ? publishedRelease.releaseId
+      : plannedRelease?.releaseId || null,
+    effectiveSnapshotHash: hasPublishedRelease
+      ? publishedRelease.snapshotHash
+      : plannedRelease?.snapshotHash || null,
+    seedSqlWillInsert: !hasPublishedRelease,
+    seedSqlWillNoop: hasPublishedRelease,
+    legacyExportMode: compatibilityPolicy.legacyExportMode,
+    legacyWriteMode: compatibilityPolicy.legacyWriteMode,
+    mutationPath: compatibilityPolicy.mutationPath,
+    firstReleaseInsertPolicy: compatibilityPolicy.firstReleaseInsertPolicy,
+    publishedRelease: hasPublishedRelease ? publishedRelease : null,
+  };
+}
+
+export async function resolveFirstGlobalReleaseSeedSource({
+  legacySource = null,
+  fallbackBundle = null,
+} = {}) {
+  const bundledFallback = fallbackBundle || await readSeededSpellingContentBundle();
+  const bundledSource = {
+    type: 'bundled_fallback',
+    script: scriptRelativePath,
+  };
+  if (!legacySource?.bundle) {
+    return {
+      bundle: bundledFallback,
+      source: bundledSource,
+    };
+  }
+
+  const backfilledLegacyBundle = backfillSpellingWordExplanations(legacySource.bundle, bundledFallback);
+  const legacyValidation = validateSpellingContentBundle(backfilledLegacyBundle);
+  if (legacyValidation.ok) {
+    return {
+      bundle: legacyValidation.bundle,
+      source: {
+        ...(legacySource.source || {}),
+        type: legacySource.source?.type || 'account_subject_content',
+        backfillReference: 'bundled_spelling_seed',
+      },
+    };
+  }
+
+  return {
+    bundle: bundledFallback,
+    source: {
+      ...bundledSource,
+      fallbackReason: 'legacy_content_invalid',
+      rejectedLegacySource: legacySource.source || null,
+      rejectedLegacyValidation: summariseValidation(legacyValidation),
+    },
+  };
+}
+
 export async function buildFirstGlobalReleaseSeedPlan({
   now = () => Date.now(),
-  releaseId = uid('corel'),
-  eventId = uid('coevt'),
+  releaseId = null,
+  eventId = null,
   actorAccountId = 'content-operations-seed-script',
   sourceBundle = null,
   source = null,
@@ -238,6 +359,8 @@ export async function buildFirstGlobalReleaseSeedPlan({
 
   const summary = buildSpellingContentSummary(validation.bundle);
   const snapshotHash = contentOperationHash(validation.bundle, 'release');
+  const resolvedReleaseId = releaseId || `corel-seed-${snapshotHash}`;
+  const resolvedEventId = eventId || `coevt-seed-${snapshotHash}`;
   const seedSource = source || {
     type: 'bundled_fallback',
     script: scriptRelativePath,
@@ -246,21 +369,21 @@ export async function buildFirstGlobalReleaseSeedPlan({
     seed: {
       source: seedSource,
       summary,
+      compatibilityPolicy,
     },
   };
   const snapshotJson = await encodeContentOperationSnapshot(validation.bundle);
   const proofJson = JSON.stringify(proof);
   const eventJson = JSON.stringify({
-    releaseId,
+    releaseId: resolvedReleaseId,
     snapshotHash,
     source: seedSource,
     summary,
+    compatibilityPolicy,
   });
-  const snapshotSql = snapshotSqlExpression(snapshotJson);
+  const snapshotSql = snapshotSqlExpression(snapshotJson, resolvedReleaseId);
 
   const sql = [
-    'BEGIN TRANSACTION;',
-    '',
     ...snapshotSql.setupSql,
     ...(snapshotSql.setupSql.length ? [''] : []),
     'INSERT INTO content_operation_releases (',
@@ -269,39 +392,55 @@ export async function buildFirstGlobalReleaseSeedPlan({
     '  rollback_of_release_id, proof_json, created_at',
     ')',
     'SELECT',
-    `  ${sqlString(releaseId)}, 'spelling', 'published', ${snapshotSql.valueExpression}, ${sqlString(snapshotHash)},`,
-    `  NULL, NULL, ${sqlInteger(nowTs)}, ${sqlString(actorAccountId)},`,
+    `  ${sqlString(resolvedReleaseId)}, 'spelling', 'seeding', ${snapshotSql.valueExpression}, ${sqlString(snapshotHash)},`,
+    `  NULL, NULL, NULL, NULL,`,
     `  NULL, ${sqlString(proofJson)}, ${sqlInteger(nowTs)}`,
     'WHERE NOT EXISTS (',
     "  SELECT 1 FROM content_operation_releases WHERE subject_id = 'spelling' AND status = 'published'",
+    ')',
+    'AND NOT EXISTS (',
+    `  SELECT 1 FROM content_operation_releases WHERE release_id = ${sqlString(resolvedReleaseId)}`,
     ');',
+    '',
+    ...snapshotSql.appendSql,
+    ...(snapshotSql.appendSql.length ? [''] : []),
+    'UPDATE content_operation_releases',
+    "SET status = 'published',",
+    `    published_at = ${sqlInteger(nowTs)},`,
+    `    published_by_account_id = ${sqlString(actorAccountId)}`,
+    `WHERE release_id = ${sqlString(resolvedReleaseId)}`,
+    "  AND subject_id = 'spelling'",
+    "  AND status = 'seeding'",
+    `  AND length(snapshot_json) = ${sqlInteger(snapshotSql.charLength)}`,
+    '  AND NOT EXISTS (',
+    "    SELECT 1 FROM content_operation_releases WHERE subject_id = 'spelling' AND status = 'published'",
+    '  );',
     '',
     'INSERT INTO content_operation_events (',
     '  event_id, package_id, release_id, subject_id, event_type,',
     '  actor_account_id, event_json, created_at',
     ')',
     'SELECT',
-    `  ${sqlString(eventId)}, NULL, ${sqlString(releaseId)}, 'spelling', 'release.seeded',`,
+    `  ${sqlString(resolvedEventId)}, NULL, ${sqlString(resolvedReleaseId)}, 'spelling', 'release.seeded',`,
     `  ${sqlString(actorAccountId)}, ${sqlString(eventJson)}, ${sqlInteger(nowTs)}`,
     'WHERE EXISTS (',
-    `  SELECT 1 FROM content_operation_releases WHERE release_id = ${sqlString(releaseId)}`,
+    `  SELECT 1 FROM content_operation_releases WHERE release_id = ${sqlString(resolvedReleaseId)} AND status = 'published' AND length(snapshot_json) = ${sqlInteger(snapshotSql.charLength)}`,
     ')',
     'AND NOT EXISTS (',
-    `  SELECT 1 FROM content_operation_releases WHERE subject_id = 'spelling' AND status = 'published' AND release_id <> ${sqlString(releaseId)}`,
+    `  SELECT 1 FROM content_operation_releases WHERE subject_id = 'spelling' AND status = 'published' AND release_id <> ${sqlString(resolvedReleaseId)}`,
     ')',
     'AND NOT EXISTS (',
-    `  SELECT 1 FROM content_operation_events WHERE event_id = ${sqlString(eventId)}`,
+    `  SELECT 1 FROM content_operation_events WHERE event_id = ${sqlString(resolvedEventId)}`,
     ');',
     '',
     ...snapshotSql.teardownSql,
     ...(snapshotSql.teardownSql.length ? [''] : []),
-    'COMMIT;',
     '',
   ].join('\n');
 
   return {
     release: {
-      releaseId,
+      releaseId: resolvedReleaseId,
       subjectId: 'spelling',
       publishedAt: nowTs,
       publishedByAccountId: actorAccountId,
@@ -310,6 +449,7 @@ export async function buildFirstGlobalReleaseSeedPlan({
     summary,
     proof,
     source: seedSource,
+    compatibilityPolicy,
     snapshotStorage: {
       encoding: 'gzip-base64',
       byteLength: Buffer.byteLength(snapshotJson, 'utf8'),
@@ -366,11 +506,19 @@ async function runCli(argv = process.argv.slice(2)) {
   const legacySource = (options.apply || options.local || options.remote)
     ? readLatestLegacyContentSource(options)
     : null;
+  const publishedRelease = (options.apply || options.local || options.remote)
+    ? readPublishedSpellingReleaseState(options)
+    : null;
+  const resolvedSource = await resolveFirstGlobalReleaseSeedSource({ legacySource });
 
   const plan = await buildFirstGlobalReleaseSeedPlan({
     actorAccountId: options.actorAccountId,
-    sourceBundle: legacySource?.bundle || null,
-    source: legacySource?.source || null,
+    sourceBundle: resolvedSource.bundle,
+    source: resolvedSource.source,
+  });
+  const cutover = buildCutoverState({
+    publishedRelease,
+    plannedRelease: plan.release,
   });
 
   if (options.outFile) {
@@ -385,6 +533,8 @@ async function runCli(argv = process.argv.slice(2)) {
     release: plan.release,
     summary: plan.summary,
     source: plan.source,
+    compatibilityPolicy: plan.compatibilityPolicy,
+    cutover,
     snapshotStorage: plan.snapshotStorage,
     sqlFile: options.outFile,
     remoteConfirmation: options.remote && options.apply ? remoteConfirmation : null,

--- a/scripts/wrangler-ci.mjs
+++ b/scripts/wrangler-ci.mjs
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+process.env.CI = process.env.CI || 'true';
+
+await import('./wrangler-oauth.mjs');

--- a/tests/content-operations-seed-script.test.js
+++ b/tests/content-operations-seed-script.test.js
@@ -2,8 +2,10 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
+  buildCutoverState,
   buildFirstGlobalReleaseSeedPlan,
   parseArgs,
+  resolveFirstGlobalReleaseSeedSource,
 } from '../scripts/migrate-spelling-content-to-global-release.mjs';
 import {
   decodeContentOperationSnapshot,
@@ -16,6 +18,14 @@ import {
   readSeededSpellingContentBundle,
 } from '../worker/src/generated-spelling-content-seed.js';
 import { createMigratedSqliteD1Database } from './helpers/sqlite-d1.js';
+
+function splitSqlStatements(sql) {
+  return String(sql || '')
+    .split(/;\s*\n/)
+    .map((statement) => statement.trim())
+    .filter(Boolean)
+    .map((statement) => `${statement};`);
+}
 
 test('content operations seed script builds idempotent first-release SQL', async () => {
   const DB = createMigratedSqliteD1Database();
@@ -35,20 +45,33 @@ test('content operations seed script builds idempotent first-release SQL', async
     assert.ok(plan.snapshotStorage.byteLength < 2_000_000);
     assert.ok(plan.snapshotStorage.sqlChunkCount > 1);
     assert.ok(plan.summary.wordCount > 0);
+    assert.deepEqual(plan.compatibilityPolicy, {
+      legacyExportRoute: '/api/content/spelling',
+      legacyExportMode: 'read_only_after_global_release',
+      legacyWriteRoute: '/api/content/spelling',
+      legacyWriteMode: 'disabled_after_global_release',
+      mutationPath: 'content_operations_package_approval',
+      firstReleaseInsertPolicy: 'only_when_no_published_spelling_release_exists',
+    });
     assert.match(plan.sql, /INSERT INTO content_operation_releases/);
     assert.match(plan.sql, /WHERE NOT EXISTS/);
-    assert.match(plan.sql, /_content_operation_seed_snapshot_chunks/);
+    assert.doesNotMatch(plan.sql, /BEGIN TRANSACTION|COMMIT/);
+    assert.doesNotMatch(plan.sql, /CREATE TEMP TABLE|DROP TABLE/);
+    assert.match(plan.sql, /UPDATE content_operation_releases\s+SET snapshot_json = snapshot_json \|\|/);
+    assert.match(plan.sql, /length\(snapshot_json\) = 0/);
+    assert.match(plan.sql, /SET status = 'published'/);
 
     DB.db.exec(plan.sql);
     DB.db.exec(plan.sql);
 
     const releaseRows = DB.db.prepare(`
-      SELECT release_id, published_at, published_by_account_id, snapshot_json
+      SELECT release_id, status, published_at, published_by_account_id, snapshot_json
       FROM content_operation_releases
       WHERE subject_id = 'spelling'
     `).all();
     assert.equal(releaseRows.length, 1);
     assert.equal(releaseRows[0].release_id, 'corel-seed-script-test');
+    assert.equal(releaseRows[0].status, 'published');
     assert.equal(releaseRows[0].published_at, 1_777_000_000_000);
     assert.equal(releaseRows[0].published_by_account_id, 'admin-a');
     assert.equal(isEncodedContentOperationSnapshot(releaseRows[0].snapshot_json), true);
@@ -68,6 +91,148 @@ test('content operations seed script builds idempotent first-release SQL', async
   } finally {
     DB.close();
   }
+});
+
+test('content operations seed script resumes interrupted chunked snapshot appends', async () => {
+  const DB = createMigratedSqliteD1Database();
+  try {
+    const plan = await buildFirstGlobalReleaseSeedPlan({
+      now: () => 1_777_000_000_000,
+      releaseId: 'corel-interrupted-seed-retry',
+      eventId: 'coevt-interrupted-seed-retry',
+      actorAccountId: 'admin-a',
+    });
+    assert.ok(plan.snapshotStorage.sqlChunkCount > 1);
+
+    const statements = splitSqlStatements(plan.sql);
+    const releaseInsert = statements.find((statement) => statement.includes('INSERT INTO content_operation_releases'));
+    const appendStatements = statements.filter((statement) => statement.includes('snapshot_json = snapshot_json ||'));
+    assert.ok(releaseInsert);
+    assert.ok(appendStatements.length > 1);
+
+    DB.db.exec(releaseInsert);
+    DB.db.exec(appendStatements[0]);
+
+    const interrupted = DB.db.prepare(`
+      SELECT status, published_at, length(snapshot_json) AS snapshot_length
+      FROM content_operation_releases
+      WHERE release_id = ?
+    `).get('corel-interrupted-seed-retry');
+    assert.equal(interrupted.status, 'seeding');
+    assert.equal(interrupted.published_at, null);
+    assert.ok(interrupted.snapshot_length > 0);
+    assert.ok(interrupted.snapshot_length < plan.snapshotStorage.byteLength);
+    assert.equal(DB.db.prepare(`
+      SELECT COUNT(*) AS release_count
+      FROM content_operation_releases
+      WHERE subject_id = 'spelling' AND status = 'published'
+    `).get().release_count, 0);
+    assert.equal(DB.db.prepare(`
+      SELECT COUNT(*) AS event_count
+      FROM content_operation_events
+      WHERE release_id = ?
+    `).get('corel-interrupted-seed-retry').event_count, 0);
+
+    DB.db.exec(plan.sql);
+    DB.db.exec(plan.sql);
+
+    const recovered = DB.db.prepare(`
+      SELECT status, length(snapshot_json) AS snapshot_length, snapshot_hash
+      FROM content_operation_releases
+      WHERE release_id = ?
+    `).get('corel-interrupted-seed-retry');
+    assert.equal(recovered.status, 'published');
+    assert.equal(recovered.snapshot_length, plan.snapshotStorage.byteLength);
+    assert.equal(recovered.snapshot_hash, plan.release.snapshotHash);
+    assert.equal(DB.db.prepare(`
+      SELECT COUNT(*) AS event_count
+      FROM content_operation_events
+      WHERE release_id = ?
+    `).get('corel-interrupted-seed-retry').event_count, 1);
+  } finally {
+    DB.close();
+  }
+});
+
+test('content operations seed script uses deterministic default ids for remote retries', async () => {
+  const plan = await buildFirstGlobalReleaseSeedPlan({
+    now: () => 1_777_000_000_000,
+  });
+
+  assert.equal(plan.release.releaseId, `corel-seed-${plan.release.snapshotHash}`);
+  assert.match(plan.sql, new RegExp(`coevt-seed-${plan.release.snapshotHash}`));
+});
+
+test('content operations seed script leaves an existing published release intact', async () => {
+  const DB = createMigratedSqliteD1Database();
+  try {
+    const existingPlan = await buildFirstGlobalReleaseSeedPlan({
+      now: () => 1_777_000_000_100,
+      releaseId: 'corel-existing-global-release',
+      eventId: 'coevt-existing-global-release',
+      actorAccountId: 'admin-a',
+    });
+    const replayPlan = await buildFirstGlobalReleaseSeedPlan({
+      now: () => 1_777_000_000_200,
+      releaseId: 'corel-replay-should-noop',
+      eventId: 'coevt-replay-should-noop',
+      actorAccountId: 'admin-b',
+    });
+
+    DB.db.exec(existingPlan.sql);
+    DB.db.exec(replayPlan.sql);
+
+    const releaseRows = DB.db.prepare(`
+      SELECT release_id, published_at, published_by_account_id
+      FROM content_operation_releases
+      WHERE subject_id = 'spelling'
+      ORDER BY published_at ASC
+    `).all();
+    assert.equal(releaseRows.length, 1);
+    assert.equal(releaseRows[0].release_id, 'corel-existing-global-release');
+    assert.equal(releaseRows[0].published_at, 1_777_000_000_100);
+    assert.equal(releaseRows[0].published_by_account_id, 'admin-a');
+
+    const eventRows = DB.db.prepare(`
+      SELECT event_id, release_id, actor_account_id
+      FROM content_operation_events
+      WHERE subject_id = 'spelling'
+      ORDER BY created_at ASC
+    `).all();
+    assert.equal(eventRows.length, 1);
+    assert.equal(eventRows[0].event_id, 'coevt-existing-global-release');
+    assert.equal(eventRows[0].release_id, 'corel-existing-global-release');
+    assert.equal(eventRows[0].actor_account_id, 'admin-a');
+  } finally {
+    DB.close();
+  }
+});
+
+test('content operations seed script reports cutover no-op state for an existing release', () => {
+  const cutover = buildCutoverState({
+    publishedRelease: {
+      releaseId: 'corel-existing-global-release',
+      subjectId: 'spelling',
+      status: 'published',
+      snapshotHash: 'release-hash-existing',
+      publishedAt: 1_777_000_000_100,
+      publishedByAccountId: 'admin-a',
+      createdAt: 1_777_000_000_100,
+    },
+    plannedRelease: {
+      releaseId: 'corel-replay-should-noop',
+      snapshotHash: 'release-hash-replay',
+    },
+  });
+
+  assert.equal(cutover.publishedReleasePresent, true);
+  assert.equal(cutover.effectiveReleaseId, 'corel-existing-global-release');
+  assert.equal(cutover.effectiveSnapshotHash, 'release-hash-existing');
+  assert.equal(cutover.seedSqlWillInsert, false);
+  assert.equal(cutover.seedSqlWillNoop, true);
+  assert.equal(cutover.legacyExportMode, 'read_only_after_global_release');
+  assert.equal(cutover.legacyWriteMode, 'disabled_after_global_release');
+  assert.equal(cutover.mutationPath, 'content_operations_package_approval');
 });
 
 test('content operations seed script can seed from supplied legacy content source', async () => {
@@ -106,6 +271,43 @@ test('content operations seed script can seed from supplied legacy content sourc
   } finally {
     DB.close();
   }
+});
+
+test('content operations seed script falls back to bundled seed when legacy content is invalid', async () => {
+  const bundledContent = await readSeededSpellingContentBundle();
+  const invalidLegacyContent = structuredClone(bundledContent);
+  invalidLegacyContent.draft.words[0].spellingPool = 'missing-cutover-pool';
+
+  const resolved = await resolveFirstGlobalReleaseSeedSource({
+    fallbackBundle: bundledContent,
+    legacySource: {
+      bundle: invalidLegacyContent,
+      source: {
+        type: 'account_subject_content',
+        accountId: 'adult-a',
+        updatedAt: 1_777_000_000_111,
+        updatedByAccountId: 'admin-a',
+        script: 'test',
+      },
+    },
+  });
+
+  assert.equal(resolved.source.type, 'bundled_fallback');
+  assert.equal(resolved.source.fallbackReason, 'legacy_content_invalid');
+  assert.equal(resolved.source.rejectedLegacySource.accountId, 'adult-a');
+  assert.ok(resolved.source.rejectedLegacyValidation.errorCount > 0);
+  assert.ok(resolved.source.rejectedLegacyValidation.errors.length <= 12);
+
+  const plan = await buildFirstGlobalReleaseSeedPlan({
+    now: () => 1_777_000_000_123,
+    releaseId: 'corel-invalid-legacy-fallback-test',
+    eventId: 'coevt-invalid-legacy-fallback-test',
+    actorAccountId: 'admin-a',
+    sourceBundle: resolved.bundle,
+    source: resolved.source,
+  });
+  assert.equal(plan.proof.seed.source.type, 'bundled_fallback');
+  assert.equal(plan.proof.seed.source.fallbackReason, 'legacy_content_invalid');
 });
 
 test('content operations seed script defaults apply target to local D1', () => {

--- a/tests/deploy-scripts.test.js
+++ b/tests/deploy-scripts.test.js
@@ -33,3 +33,12 @@ test('Cloudflare tail scripts keep package-script OAuth routing and explicit for
     assert.equal(script.match(/--format\b/g)?.length, 1, `${name} must set exactly one tail format`);
   }
 });
+
+test('remote D1 migration script is Windows compatible and OAuth routed', async () => {
+  const pkg = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'));
+  const script = pkg.scripts?.['db:migrate:remote'] || '';
+
+  assert.equal(script, 'node ./scripts/wrangler-ci.mjs d1 migrations apply ks2-mastery-db --remote');
+  assert.doesNotMatch(script, /\bCI=true\b/);
+  assert.doesNotMatch(script, /\bnpx\s+wrangler\b/);
+});

--- a/tests/hero-pA7-wrangler-oauth.test.js
+++ b/tests/hero-pA7-wrangler-oauth.test.js
@@ -20,6 +20,7 @@ function createFakeWrangler() {
       'writeFileSync(process.env.WRANGLER_FAKE_CAPTURE_PATH, JSON.stringify({',
       '  argv: process.argv.slice(2),',
       "  token: Object.hasOwn(process.env, 'CLOUDFLARE_API_TOKEN') ? process.env.CLOUDFLARE_API_TOKEN : null,",
+      "  ci: process.env.CI || null,",
       "  workersCi: process.env.WORKERS_CI || null,",
       '}));',
     ].join('\n'),
@@ -66,6 +67,39 @@ function runWrapper(fake, extraEnv = {}) {
   );
 }
 
+function runCiWrapper(fake, extraEnv = {}) {
+  const env = {
+    ...process.env,
+    ...extraEnv,
+    WRANGLER_FAKE_CAPTURE_PATH: fake.capturePath,
+    WRANGLER_OAUTH_WRANGLER_JS: fake.scriptPath,
+  };
+
+  if (!('CI' in extraEnv)) {
+    delete env.CI;
+  }
+  if (!('WORKERS_CI' in extraEnv)) {
+    delete env.WORKERS_CI;
+  }
+
+  return spawnSync(
+    process.execPath,
+    [
+      'scripts/wrangler-ci.mjs',
+      'd1',
+      'migrations',
+      'apply',
+      'ks2-mastery-db',
+      '--remote',
+    ],
+    {
+      cwd: ROOT,
+      env,
+      encoding: 'utf8',
+    },
+  );
+}
+
 describe('Hero Mode pA7 Wrangler OAuth wrapper', () => {
   it('preserves argv boundaries for D1 --command SQL and strips API tokens locally', () => {
     const fake = createFakeWrangler();
@@ -101,6 +135,27 @@ describe('Hero Mode pA7 Wrangler OAuth wrapper', () => {
       assert.equal(result.status, 0, result.stderr || result.stdout);
       assert.equal(fake.readCapture().token, 'workers-build-token');
       assert.equal(fake.readCapture().workersCi, '1');
+    } finally {
+      fake.cleanup();
+    }
+  });
+
+  it('sets CI for remote migration scripts without leaking local API tokens', () => {
+    const fake = createFakeWrangler();
+    try {
+      const result = runCiWrapper(fake, { CLOUDFLARE_API_TOKEN: 'must-not-leak' });
+
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      const capture = fake.readCapture();
+      assert.equal(capture.ci, 'true');
+      assert.equal(capture.token, null);
+      assert.deepEqual(capture.argv.slice(0, 6), [
+        'd1',
+        'migrations',
+        'apply',
+        'ks2-mastery-db',
+        '--remote',
+      ]);
     } finally {
       fake.cleanup();
     }

--- a/tests/spelling-content-api.test.js
+++ b/tests/spelling-content-api.test.js
@@ -346,6 +346,15 @@ test('worker spelling content legacy write route is frozen after global release 
     assert.equal(response.status, 409);
     assert.equal(payload.code, 'subject_content_legacy_write_cutover');
     assert.equal(payload.releaseId, seedRelease.releaseId);
+    assert.equal(payload.snapshotHash, seedRelease.snapshotHash);
+    assert.equal(payload.publishedAt, seedRelease.publishedAt);
+    assert.deepEqual(payload.compatibility, {
+      legacyExportRoute: '/api/content/spelling',
+      legacyExportMode: 'read_only_after_global_release',
+      legacyWriteRoute: '/api/content/spelling',
+      legacyWriteMode: 'disabled_after_global_release',
+      mutationPath: 'content_operations_package_approval',
+    });
   } finally {
     server.close();
   }

--- a/worker/src/repository.js
+++ b/worker/src/repository.js
@@ -252,6 +252,13 @@ const MONSTER_VISUAL_SCOPE_TYPE = 'platform';
 const MONSTER_VISUAL_SCOPE_ID = 'monster-visual-config';
 const CONTENT_OPERATION_ASSET_PROOF_KEY = 'contentOperationsAssets';
 const CONTENT_OPERATION_MONSTER_ASSET_RUNTIME_ROUTE = '/api/content-operations/assets/monster-image';
+const LEGACY_SPELLING_CONTENT_CUTOVER_COMPATIBILITY = Object.freeze({
+  legacyExportRoute: '/api/content/spelling',
+  legacyExportMode: 'read_only_after_global_release',
+  legacyWriteRoute: '/api/content/spelling',
+  legacyWriteMode: 'disabled_after_global_release',
+  mutationPath: 'content_operations_package_approval',
+});
 
 // safeJsonParse, asTs, isMissingTableError → repository-helpers.js
 
@@ -9809,6 +9816,7 @@ export function createWorkerRepository({ env = {}, now = Date.now, capacity = nu
             releaseId: globalRelease.release_id,
             snapshotHash: globalRelease.snapshot_hash,
             legacyWriteDisabled: true,
+            ...LEGACY_SPELLING_CONTENT_CUTOVER_COMPATIBILITY,
           },
           mutation: {
             policyVersion: MUTATION_POLICY_VERSION,
@@ -9926,6 +9934,9 @@ export function createWorkerRepository({ env = {}, now = Date.now, capacity = nu
           code: 'subject_content_legacy_write_cutover',
           subjectId,
           releaseId: globalRelease.release_id,
+          snapshotHash: globalRelease.snapshot_hash,
+          publishedAt: Number(globalRelease.published_at) || 0,
+          compatibility: LEGACY_SPELLING_CONTENT_CUTOVER_COMPATIBILITY,
         });
       }
       const seededBundle = await readSeededSpellingContentBundle();


### PR DESCRIPTION
## Summary
- harden the first global spelling release seed path with seeding-status staging, guarded chunk appends, and full-length publish flip
- add compatibility metadata for frozen legacy spelling content writes after global-release cutover
- add a Windows-safe CI wrapper for remote D1 migrations while keeping the OAuth wrapper path

## Production data operations
- remote D1 backup completed before migration: backups/d1/ks2-mastery-db-remote-2026-06-12T20-52-57-992Z.sql
- remote migrations 0020 and 0021 applied successfully
- first global spelling release seeded on remote D1 as corel-seed-release-ukg5cp with snapshot hash release-ukg5cp
- remote dry-run after seed reports publishedReleasePresent=true and seedSqlWillNoop=true

## Validation
- node --test tests/content-operations-repository.test.js tests/content-operations-api.test.js tests/content-operations-seed-script.test.js tests/spelling-content-api.test.js tests/worker-subject-runtime.test.js tests/hero-pA7-wrangler-oauth.test.js tests/deploy-scripts.test.js
- npm test
- npm run check
- pre-push npm test
- git diff --check
- Tesla adversarial re-review: prior P1 closed, no remaining findings