### PR TITLE
Harden content operations capacity and redaction

### DIFF
--- a/src/platform/hubs/admin-safe-copy.js
+++ b/src/platform/hubs/admin-safe-copy.js
@@ -22,6 +22,8 @@ export const COPY_AUDIENCE = Object.freeze({
 // ---------------------------------------------------------------------------
 
 const SENSITIVE_HEADER_KEYS = ['cookie', 'authorization', 'x-auth-token', 'set-cookie'];
+const ACCOUNT_ID_FIELD_RE = /(?:^accountId$|AccountId$|_account_id$|^account_id$)/;
+const LEARNER_ID_FIELD_RE = /(?:^learnerId$|LearnerId$|^learner_id$|_learner_id$|^childId$|ChildId$|^child_id$|_child_id$)/;
 
 function isSensitiveHeaderKey(key) {
   return SENSITIVE_HEADER_KEYS.includes(String(key).toLowerCase());
@@ -140,7 +142,7 @@ function maskAllAccountIds(obj) {
     return obj;
   }
   for (const key of Object.keys(obj)) {
-    if (key === 'accountId' && typeof obj[key] === 'string') {
+    if (ACCOUNT_ID_FIELD_RE.test(key) && typeof obj[key] === 'string') {
       obj[key] = maskId(obj[key]);
     } else if (typeof obj[key] === 'object') {
       maskAllAccountIds(obj[key]);
@@ -157,7 +159,7 @@ function stripChildIds(obj) {
     return obj;
   }
   for (const key of Object.keys(obj)) {
-    if (key === 'learnerId' || key === 'learner_id' || key === 'childId') {
+    if (LEARNER_ID_FIELD_RE.test(key)) {
       delete obj[key];
     } else if (typeof obj[key] === 'object') {
       stripChildIds(obj[key]);
@@ -356,6 +358,9 @@ export function prepareSafeCopy(data, audience) {
 
       stripInternalNotes(working);
       redactedFields.push('internal_notes');
+
+      stripChildIds(working);
+      redactedFields.push('child_ids');
     }
     let text = typeof working === 'string' ? working : JSON.stringify(working, null, 2);
     // Defence-in-depth: scan serialised output for PII in non-canonical keys.

--- a/src/platform/hubs/api.js
+++ b/src/platform/hubs/api.js
@@ -484,12 +484,14 @@ export function createHubApi({
       }, authSession);
     },
     async readContentOperationReleases({ limit = 20, includeSnapshot = false, includeHistory = false } = {}) {
+      if (includeSnapshot) {
+        throw new TypeError('Content operation release lists cannot include snapshots. Use readContentOperationRelease with includeSnapshot for release detail.');
+      }
       const url = buildRequestUrl(
         baseUrl,
         '/api/admin/content-operations/subjects/spelling/releases',
         {
           limit,
-          includeSnapshot: includeSnapshot ? 'true' : null,
           includeHistory: includeHistory ? 'true' : null,
         },
       );

--- a/tests/admin-content-operations-v2.test.js
+++ b/tests/admin-content-operations-v2.test.js
@@ -1128,7 +1128,11 @@ describe('Content Operations Centre hub API client', () => {
     });
     await api.readContentOperationSpellingWord({ slug: 'meta/morphosis', packageId: 'pkg/with/slash' });
     await api.readContentOperationSpellingSentence({ sentenceId: 'sentence/1', packageId: 'pkg/with/slash' });
-    await api.readContentOperationReleases({ limit: 5, includeSnapshot: true });
+    await api.readContentOperationReleases({ limit: 5 });
+    await assert.rejects(
+      () => api.readContentOperationReleases({ includeSnapshot: true }),
+      /cannot include snapshots/,
+    );
     await api.readContentOperationRelease({ releaseId: 'rel/with/slash', includeSnapshot: true });
     await api.readContentOperationReleases({ limit: 6, includeHistory: true });
     await api.readContentOperationRelease({ releaseId: 'rel/with/slash', includeHistory: true });
@@ -1151,7 +1155,7 @@ describe('Content Operations Centre hub API client', () => {
     assert.equal(new URL(calls[5].url).searchParams.get('packageId'), 'pkg/with/slash');
     assert.equal(new URL(calls[6].url).pathname, '/api/admin/content-operations/subjects/spelling/sentences/sentence%2F1');
     assert.equal(new URL(calls[7].url).pathname, '/api/admin/content-operations/subjects/spelling/releases');
-    assert.equal(new URL(calls[7].url).searchParams.get('includeSnapshot'), 'true');
+    assert.equal(new URL(calls[7].url).searchParams.get('includeSnapshot'), null);
     assert.equal(new URL(calls[7].url).searchParams.get('includeHistory'), null);
     assert.equal(new URL(calls[8].url).pathname, '/api/admin/content-operations/subjects/spelling/releases/rel%2Fwith%2Fslash');
     assert.equal(new URL(calls[8].url).searchParams.get('includeSnapshot'), 'true');

--- a/tests/admin-safe-copy.test.js
+++ b/tests/admin-safe-copy.test.js
@@ -88,6 +88,55 @@ test('admin_only audience preserves content operations blocker envelopes', () =>
   assert.deepEqual(parsed.blockers.audio.blockers, ['word_audio_missing']);
 });
 
+test('ops_safe redacts content operations package and release history identifiers', () => {
+  const data = {
+    title: 'Content operations release export',
+    package: {
+      packageId: 'copkg-release-export',
+      createdByAccountId: 'adult-created-account-123456',
+      updatedByAccountId: 'adult-updated-account-123456',
+      targetLearnerId: 'learner-target-123456',
+    },
+    release: {
+      releaseId: 'corel-release-export',
+      publishedByAccountId: 'adult-published-account-123456',
+      selectedLearnerId: 'lrn-selected-abc123',
+      history: {
+        approvedByAccountId: 'adult-approved-account-123456',
+        productionProof: {
+          capturedByAccountId: 'adult-proof-account-123456',
+          linkedSurfaces: [{
+            key: 'spellingSetup',
+            learnerId: 'learner-sensitive-123456',
+            linkedLearnerId: 'lrn-linked-abc123',
+            evidenceEmail: 'parent@example.test',
+          }],
+        },
+      },
+    },
+  };
+
+  const result = prepareSafeCopy(data, COPY_AUDIENCE.OPS_SAFE);
+
+  assert.equal(result.ok, true);
+  const parsed = JSON.parse(result.text);
+  assert.equal(parsed.package.packageId, 'copkg-release-export');
+  assert.equal(parsed.release.releaseId, 'corel-release-export');
+  assert.equal(parsed.package.createdByAccountId, '****t-123456');
+  assert.equal(parsed.package.updatedByAccountId, '****t-123456');
+  assert.equal(parsed.release.publishedByAccountId, '****t-123456');
+  assert.equal(parsed.release.history.approvedByAccountId, '****t-123456');
+  assert.equal(parsed.release.history.productionProof.capturedByAccountId, '****t-123456');
+  assert.equal(parsed.package.targetLearnerId, undefined);
+  assert.equal(parsed.release.selectedLearnerId, undefined);
+  assert.equal(parsed.release.history.productionProof.linkedSurfaces[0].learnerId, undefined);
+  assert.equal(parsed.release.history.productionProof.linkedSurfaces[0].linkedLearnerId, undefined);
+  assert.equal(parsed.release.history.productionProof.linkedSurfaces[0].evidenceEmail, '****e.test');
+  assert.ok(result.redactedFields.includes('account_ids_masked'));
+  assert.ok(result.redactedFields.includes('child_ids'));
+  assert.ok(result.redactedFields.includes('emails_masked'));
+});
+
 // ---------------------------------------------------------------------------
 // 2. ops_safe — masked email, masked account ID, no internal notes
 // ---------------------------------------------------------------------------

--- a/tests/content-operations-api.test.js
+++ b/tests/content-operations-api.test.js
@@ -767,6 +767,118 @@ test('content operations generate-audio records provider failures as retryable f
   assert.equal(failedItem.error.providerStatus, 429);
 });
 
+test('content operations generate-audio is account rate limited before extra provider calls', async (t) => {
+  const originalFetch = globalThis.fetch;
+  let providerCalls = 0;
+  globalThis.fetch = async () => {
+    providerCalls += 1;
+    return geminiAudioResponse([providerCalls, 2, 3, 4]);
+  };
+  const server = createWorkerRepositoryServer({
+    now: () => NOW,
+    env: {
+      GEMINI_API_KEY: 'test-gemini-key',
+      SPELLING_AUDIO_BUCKET: createMemoryR2Bucket(),
+    },
+  });
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+    server.close();
+  });
+
+  seedAdultAccount(server.DB, { accountId: ADMIN_ID, platformRole: 'admin' });
+  const repository = createWorkerRepository({
+    env: server.env,
+    now: () => NOW,
+  });
+  await repository.seedFirstContentOperationRelease({
+    seededByAccountId: ADMIN_ID,
+    proof: { source: 'content-operations-api-generate-audio-rate-limit-test' },
+  });
+
+  const created = await createPackage(server, { title: 'Rate-limited audio package' });
+  const packageId = created.package.packageId;
+  await appendContentOperation(server, packageId, {
+    entityType: 'spelling.audioRequirementProfile',
+    entityId: 'default',
+    fieldPath: '',
+    action: 'replace',
+    payload: { wordProfiles: ['male.natural'] },
+  });
+  const validated = await validatePackage(server, packageId, { includeSnapshot: true });
+  const target = validated.candidate.audioScan.items.find((item) => item.lane === 'word' && item.required);
+
+  const body = {
+    candidateId: validated.candidate.candidateId,
+    itemIds: [target.itemId],
+    limit: 1,
+    override: true,
+    reason: 'Rate-limit regression test.',
+  };
+  for (let i = 0; i < 4; i += 1) {
+    const response = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/packages/${packageId}/generate-audio`,
+      jsonInit('POST', body),
+      adminHeaders(),
+    );
+    assert.equal(response.status, 200);
+  }
+
+  const blockedResponse = await server.fetchAs(
+    ADMIN_ID,
+    `${BASE_URL}/api/admin/content-operations/packages/${packageId}/generate-audio`,
+    jsonInit('POST', body),
+    adminHeaders(),
+  );
+  const blocked = await readPayload(blockedResponse);
+  assert.equal(blockedResponse.status, 429);
+  assert.equal(blocked.code, 'content_operation_rate_limited');
+  assert.equal(blocked.action, 'generate-audio');
+  assert.equal(blocked.bucket, 'content-operations-audio-generation');
+  assert.equal(blockedResponse.headers.get('retry-after'), String(blocked.retryAfterSeconds));
+  assert.equal(providerCalls, 4);
+});
+
+test('content operations upload-monster-asset is account rate limited before multipart parsing', async () => {
+  const server = createWorkerRepositoryServer({
+    now: () => NOW,
+    env: { SPELLING_AUDIO_BUCKET: createMemoryR2Bucket() },
+  });
+  try {
+    seedAdultAccount(server.DB, { accountId: ADMIN_ID, platformRole: 'admin' });
+    const created = await createPackage(server, { title: 'Rate-limited asset package' });
+    const url = `${BASE_URL}/api/admin/content-operations/packages/${created.package.packageId}/upload-monster-asset`;
+
+    for (let i = 0; i < 12; i += 1) {
+      const response = await server.fetchAs(
+        ADMIN_ID,
+        url,
+        jsonInit('POST', { notMultipart: true }),
+        adminHeaders(),
+      );
+      const payload = await readPayload(response);
+      assert.equal(response.status, 400);
+      assert.equal(payload.code, 'content_operation_monster_asset_multipart_required');
+    }
+
+    const blockedResponse = await server.fetchAs(
+      ADMIN_ID,
+      url,
+      jsonInit('POST', { notMultipart: true }),
+      adminHeaders(),
+    );
+    const blocked = await readPayload(blockedResponse);
+    assert.equal(blockedResponse.status, 429);
+    assert.equal(blocked.code, 'content_operation_rate_limited');
+    assert.equal(blocked.action, 'upload-monster-asset');
+    assert.equal(blocked.bucket, 'content-operations-asset-upload');
+    assert.equal(blockedResponse.headers.get('retry-after'), String(blocked.retryAfterSeconds));
+  } finally {
+    server.close();
+  }
+});
+
 test('content operations API requires the admin platform role', async () => {
   const server = createWorkerRepositoryServer({ now: () => NOW });
   try {
@@ -787,6 +899,82 @@ test('content operations API requires the admin platform role', async () => {
     assert.equal(payload.code, 'content_operations_forbidden');
     assert.equal(payload.capability, 'content_operations.view');
     assert.equal(payload.required, 'platform_role:admin');
+  } finally {
+    server.close();
+  }
+});
+
+test('content operations API rejects oversized package JSON bodies', async () => {
+  const server = createWorkerRepositoryServer({ now: () => NOW });
+  try {
+    seedAdultAccount(server.DB, { accountId: ADMIN_ID, platformRole: 'admin' });
+    const response = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/subjects/spelling/packages`,
+      jsonInit('POST', {
+        title: 'Oversized package body',
+        description: 'x'.repeat(40 * 1024),
+      }),
+      adminHeaders(),
+    );
+    const payload = await readPayload(response);
+
+    assert.equal(response.status, 413);
+    assert.equal(payload.code, 'content_operation_payload_too_large');
+    assert.equal(payload.surface, 'package_create');
+    assert.equal(payload.maxBytes, 32 * 1024);
+  } finally {
+    server.close();
+  }
+});
+
+test('content operations API rejects oversized package operation JSON bodies', async () => {
+  const server = createWorkerRepositoryServer({ now: () => NOW });
+  try {
+    seedAdultAccount(server.DB, { accountId: ADMIN_ID, platformRole: 'admin' });
+    const created = await createPackage(server, { title: 'Oversized operation package' });
+    const response = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/packages/${created.package.packageId}/operations`,
+      jsonInit('POST', {
+        operation: {
+          entityType: 'spelling.word',
+          entityId: 'accommodate',
+          fieldPath: 'explanation',
+          action: 'set',
+          payload: 'x'.repeat(300 * 1024),
+        },
+      }),
+      adminHeaders(),
+    );
+    const payload = await readPayload(response);
+
+    assert.equal(response.status, 413);
+    assert.equal(payload.code, 'content_operation_payload_too_large');
+    assert.equal(payload.surface, 'package_operation');
+    assert.equal(payload.packageId, created.package.packageId);
+    assert.equal(payload.maxBytes, 256 * 1024);
+  } finally {
+    server.close();
+  }
+});
+
+test('content operations API keeps release lists compact by rejecting snapshot expansion', async () => {
+  const server = createWorkerRepositoryServer({ now: () => NOW });
+  try {
+    seedAdultAccount(server.DB, { accountId: ADMIN_ID, platformRole: 'admin' });
+
+    const response = await server.fetchAs(
+      ADMIN_ID,
+      `${BASE_URL}/api/admin/content-operations/subjects/spelling/releases?includeSnapshot=true`,
+      { method: 'GET', headers: { 'sec-fetch-site': 'same-origin' } },
+      adminHeaders(),
+    );
+    const payload = await readPayload(response);
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.code, 'content_operation_snapshot_list_forbidden');
+    assert.equal(payload.surface, 'release_list');
   } finally {
     server.close();
   }
@@ -1364,6 +1552,20 @@ test('content operations API supports admin package lifecycle through separate a
         status: 'warning',
         blockers: [],
         warnings: ['slow_sentence_missing'],
+        items: [{
+          itemId: 'word:accommodate:male:natural',
+          itemText: 'accommodate',
+          status: 'missing',
+        }],
+        strictAudioReadiness: {
+          status: 'blocked',
+          blockers: ['missing_required_audio'],
+          affectedCount: 1,
+          items: [{
+            itemId: 'word:accommodate:male:natural',
+            r2Key: 'content-operations/private/audio-key.wav',
+          }],
+        },
       }),
       validated.candidate.candidateId,
     );
@@ -1377,8 +1579,12 @@ test('content operations API supports admin package lifecycle through separate a
     const packageList = await readPayload(packageListResponse);
     assert.equal(packageListResponse.status, 200);
     const packageSummary = packageList.packages.find((entry) => entry.packageId === packageId);
+    assert.equal(packageSummary.latestCandidate.audioScan, undefined);
+    assert.equal(packageSummary.latestCandidate.assetScan, undefined);
+    assert.equal(packageSummary.latestCandidate.conflicts, undefined);
     assert.deepEqual(packageSummary.blockers.audio.blockers, []);
     assert.deepEqual(packageSummary.blockers.audio.warnings, ['slow_sentence_missing']);
+    assert.equal(packageSummary.blockers.audio.strictAudioReadiness.items, undefined);
 
     const approved = await approvePackage(server, packageId, validated.candidate.candidateId);
     assert.equal(approved.approval.candidateId, validated.candidate.candidateId);
@@ -1563,8 +1769,12 @@ test('content operations API supports admin package lifecycle through separate a
     const overview = await readPayload(overviewResponse);
     assert.equal(overviewResponse.status, 200);
     assert.equal(overview.overview.latestRelease.releaseId, published.release.releaseId);
+    assert.equal(overview.overview.latestRelease.proof, undefined);
     assert.equal(overview.overview.latestRelease.history.productionProof.status, 'recorded');
+    assert.equal(overview.overview.latestRelease.history.productionProof.linkedSurfaces, undefined);
+    assert.equal(overview.overview.latestRelease.history.productionProof.linkedSurfaceCount, 3);
     assert.equal(overview.overview.lanes.recentReleases[0].history.changedEntities.preview[0].entityId, word.slug);
+    assert.equal(overview.overview.lanes.recentReleases[0].proof, undefined);
     assert.equal(overview.overview.actor.capabilities['content_operations.approve'], true);
     assert.equal(overview.overview.actor.capabilities['content_operations.publish'], true);
 
@@ -1577,7 +1787,10 @@ test('content operations API supports admin package lifecycle through separate a
     const releaseList = await readPayload(releaseListResponse);
     assert.equal(releaseListResponse.status, 200);
     assert.equal(releaseList.releases[0].history.releaseId, captured.release.releaseId);
+    assert.equal(releaseList.releases[0].proof, undefined);
     assert.equal(releaseList.releases[0].history.productionProof.status, 'recorded');
+    assert.equal(releaseList.releases[0].history.productionProof.linkedSurfaces, undefined);
+    assert.equal(releaseList.releases[0].history.productionProof.linkedSurfaceCount, 3);
     assert.equal(releaseList.releases[0].history.assetChanges.preview[0].monsterId, 'inklet');
 
     const defaultReleaseListResponse = await server.fetchAs(

--- a/worker/src/content-operations/routes.js
+++ b/worker/src/content-operations/routes.js
@@ -7,8 +7,13 @@ import { requireSameOrigin } from '../demo/sessions.js';
 import {
   BadRequestError,
   ForbiddenError,
+  HttpError,
 } from '../errors.js';
-import { json, readJson } from '../http.js';
+import { json, readJsonBounded } from '../http.js';
+import {
+  consumeRateLimit,
+  rateLimitResponse,
+} from '../rate-limit.js';
 import {
   CONTENT_OPERATION_CAPABILITIES,
   serialiseContentOperation,
@@ -38,6 +43,20 @@ import {
 
 const CONTENT_OPERATIONS_ROUTE_PREFIX = '/api/admin/content-operations';
 const CONTENT_OPERATIONS_SUBJECT_ID = 'spelling';
+const CONTENT_OPERATION_PACKAGE_BODY_MAX_BYTES = 32 * 1024;
+const CONTENT_OPERATION_OPERATION_BODY_MAX_BYTES = 256 * 1024;
+const CONTENT_OPERATION_ACTION_BODY_MAX_BYTES = 128 * 1024;
+const CONTENT_OPERATION_PROOF_BODY_MAX_BYTES = 64 * 1024;
+const CONTENT_OPERATION_AUDIO_GENERATION_RATE_LIMIT = Object.freeze({
+  bucket: 'content-operations-audio-generation',
+  limit: 4,
+  windowMs: 60 * 1000,
+});
+const CONTENT_OPERATION_ASSET_UPLOAD_RATE_LIMIT = Object.freeze({
+  bucket: 'content-operations-asset-upload',
+  limit: 12,
+  windowMs: 10 * 60 * 1000,
+});
 const STUBBED_CONTENT_OPERATION_ROUTES = Object.freeze({
   rebase: { ticket: 'T6', capability: CONTENT_OPERATION_CAPABILITIES.EDIT },
   'scan-audio': { ticket: 'T7', capability: CONTENT_OPERATION_CAPABILITIES.EDIT },
@@ -69,6 +88,14 @@ function includeSnapshot(url, body = {}) {
 function includeHistory(url, body = {}) {
   const value = url.searchParams.get('includeHistory') ?? body.includeHistory;
   return value === true || value === 'true' || value === '1';
+}
+
+function assertNoSnapshotOnList(url, surface) {
+  if (!includeSnapshot(url)) return;
+  throw new BadRequestError('Content operation snapshots are only available from release or candidate detail endpoints.', {
+    code: 'content_operation_snapshot_list_forbidden',
+    surface,
+  });
 }
 
 function optionalQueryString(url, key) {
@@ -113,6 +140,70 @@ function operationPayloadFromBody(body) {
     beforeHash: body.beforeHash,
     afterHash: body.afterHash,
   };
+}
+
+function contentOperationBodyLimitForAction(action) {
+  switch (action) {
+    case 'resolve-conflict':
+      return CONTENT_OPERATION_OPERATION_BODY_MAX_BYTES;
+    case 'validate':
+    case 'approve':
+    case 'publish':
+    case 'create-revert':
+    case 'generate-audio':
+      return CONTENT_OPERATION_ACTION_BODY_MAX_BYTES;
+    default:
+      return CONTENT_OPERATION_ACTION_BODY_MAX_BYTES;
+  }
+}
+
+async function readContentOperationJson(request, {
+  maxBytes = CONTENT_OPERATION_ACTION_BODY_MAX_BYTES,
+  action = '',
+  packageId = '',
+  surface = '',
+} = {}) {
+  try {
+    return normaliseBody(await readJsonBounded(request, maxBytes));
+  } catch (error) {
+    if (error?.code === 'ops_error_payload_too_large') {
+      throw new HttpError(413, 'Content operation request body is too large.', {
+        ok: false,
+        code: 'content_operation_payload_too_large',
+        maxBytes,
+        action,
+        packageId,
+        surface,
+      });
+    }
+    throw error;
+  }
+}
+
+async function consumeContentOperationActionLimit(env, actor, limitConfig, {
+  action = '',
+  packageId = '',
+} = {}) {
+  const accountId = actor?.id || actor?.accountId || '';
+  const result = await consumeRateLimit(env, {
+    bucket: limitConfig.bucket,
+    identifier: accountId,
+    limit: limitConfig.limit,
+    windowMs: limitConfig.windowMs,
+  });
+  if (result.allowed) return null;
+  return rateLimitResponse({
+    code: 'content_operation_rate_limited',
+    retryAfterSeconds: result.retryAfterSeconds,
+    extra: {
+      message: 'Content operation action rate limit exceeded.',
+      action,
+      packageId,
+      bucket: limitConfig.bucket,
+      limit: limitConfig.limit,
+      windowMs: limitConfig.windowMs,
+    },
+  });
 }
 
 function proofFromRequest(body, request, action) {
@@ -216,6 +307,7 @@ export async function handleContentOperationsAdminRequest({
     });
     const limit = normaliseLimit(url.searchParams.get('limit'), 30, 100);
     const history = includeHistory(url);
+    assertNoSnapshotOnList(url, 'spelling_overview');
     const [packages, releases] = await Promise.all([
       repository.listContentOperationPackages({ subjectId: CONTENT_OPERATIONS_SUBJECT_ID, limit }),
       repository.listContentOperationReleases({ subjectId: CONTENT_OPERATIONS_SUBJECT_ID, includeHistory: history, limit: 10 }),
@@ -336,18 +428,17 @@ export async function handleContentOperationsAdminRequest({
       env,
       capability: CONTENT_OPERATION_CAPABILITIES.VIEW,
     });
+    assertNoSnapshotOnList(url, 'release_list');
     const releases = await repository.listContentOperationReleases({
       subjectId: CONTENT_OPERATIONS_SUBJECT_ID,
-      includeSnapshot: includeSnapshot(url),
+      includeSnapshot: false,
       includeHistory: includeHistory(url),
       limit: normaliseLimit(url.searchParams.get('limit'), 20, 100),
     });
     return json({
       ok: true,
       actor: serialiseContentOperationActor(actor),
-      releases: releases.map((release) => serialiseContentOperationRelease(release, {
-        includeSnapshot: includeSnapshot(url),
-      })),
+      releases: releases.map((release) => serialiseContentOperationRelease(release, { compact: true })),
     });
   }
 
@@ -387,7 +478,11 @@ export async function handleContentOperationsAdminRequest({
         mutation: true,
       });
       const releaseId = decodePathSegment(releaseProofMatch[1], 'release_id');
-      const body = normaliseBody(await readJson(request));
+      const body = await readContentOperationJson(request, {
+        maxBytes: CONTENT_OPERATION_PROOF_BODY_MAX_BYTES,
+        action: 'capture-production-proof',
+        surface: 'release_proof',
+      });
       const release = await repository.captureContentOperationReleaseProof(CONTENT_OPERATIONS_SUBJECT_ID, releaseId, {
         capturedByAccountId: actor.id,
         proof: proofFromRequest(body, request, 'capture-production-proof'),
@@ -411,7 +506,11 @@ export async function handleContentOperationsAdminRequest({
       capability: CONTENT_OPERATION_CAPABILITIES.EDIT,
       mutation: true,
     });
-    const body = normaliseBody(await readJson(request));
+    const body = await readContentOperationJson(request, {
+      maxBytes: CONTENT_OPERATION_PACKAGE_BODY_MAX_BYTES,
+      action: 'create-package',
+      surface: 'package_create',
+    });
     const contentPackage = await repository.createContentOperationPackage({
       subjectId: CONTENT_OPERATIONS_SUBJECT_ID,
       templateId: body.templateId,
@@ -476,7 +575,12 @@ export async function handleContentOperationsAdminRequest({
         mutation: true,
       });
       const packageId = decodePathSegment(packageDetailMatch[1], 'package_id');
-      const body = normaliseBody(await readJson(request));
+      const body = await readContentOperationJson(request, {
+        maxBytes: CONTENT_OPERATION_PACKAGE_BODY_MAX_BYTES,
+        action: 'update-package',
+        packageId,
+        surface: 'package_update',
+      });
       const contentPackage = await repository.updateContentOperationPackage(packageId, {
         templateId: body.templateId,
         title: body.title,
@@ -504,7 +608,12 @@ export async function handleContentOperationsAdminRequest({
         mutation: true,
       });
       const packageId = decodePathSegment(operationsMatch[1], 'package_id');
-      const body = normaliseBody(await readJson(request));
+      const body = await readContentOperationJson(request, {
+        maxBytes: CONTENT_OPERATION_OPERATION_BODY_MAX_BYTES,
+        action: 'append-operation',
+        packageId,
+        surface: 'package_operation',
+      });
       try {
         const operation = await repository.appendContentOperation(packageId, operationPayloadFromBody(body), {
           actorAccountId: actor.id,
@@ -633,6 +742,11 @@ export async function handleContentOperationsAdminRequest({
       }
 
       if (action === 'upload-monster-asset') {
+        const rateLimited = await consumeContentOperationActionLimit(env, actor, CONTENT_OPERATION_ASSET_UPLOAD_RATE_LIMIT, {
+          action,
+          packageId,
+        });
+        if (rateLimited) return rateLimited;
         const upload = await uploadContentOperationMonsterAsset({
           db: routeDatabase(env, capacity),
           env,
@@ -647,7 +761,12 @@ export async function handleContentOperationsAdminRequest({
         }, 201);
       }
 
-      const body = normaliseBody(await readJson(request));
+      const body = await readContentOperationJson(request, {
+        maxBytes: contentOperationBodyLimitForAction(action),
+        action,
+        packageId,
+        surface: 'package_action',
+      });
       if (action === 'create-revert') {
         const result = await repository.createContentOperationPackageRevert(packageId, {
           createdByAccountId: actor.id,
@@ -715,6 +834,11 @@ export async function handleContentOperationsAdminRequest({
       }
 
       if (action === 'generate-audio') {
+        const rateLimited = await consumeContentOperationActionLimit(env, actor, CONTENT_OPERATION_AUDIO_GENERATION_RATE_LIMIT, {
+          action,
+          packageId,
+        });
+        if (rateLimited) return rateLimited;
         let candidate;
         try {
           candidate = await repository.buildContentOperationCandidate(packageId, {
@@ -816,7 +940,12 @@ export async function handleContentOperationsAdminRequest({
         mutation: true,
       });
       const releaseId = decodePathSegment(rollbackMatch[1], 'release_id');
-      const body = normaliseBody(await readJson(request));
+      const body = await readContentOperationJson(request, {
+        maxBytes: CONTENT_OPERATION_PROOF_BODY_MAX_BYTES,
+        action: 'rollback',
+        packageId: releaseId,
+        surface: 'release_rollback',
+      });
       const release = await repository.rollbackContentOperationRelease(CONTENT_OPERATIONS_SUBJECT_ID, releaseId, {
         rolledBackByAccountId: actor.id,
         reason: body.reason,

--- a/worker/src/content-operations/serialisers.js
+++ b/worker/src/content-operations/serialisers.js
@@ -58,7 +58,7 @@ function normaliseValidation(validation = null) {
   };
 }
 
-function normaliseConflictSection(conflicts = null) {
+function normaliseConflictSection(conflicts = null, { compact = false } = {}) {
   if (!Array.isArray(conflicts)) {
     return {
       status: 'not_run',
@@ -69,11 +69,11 @@ function normaliseConflictSection(conflicts = null) {
   return {
     status: conflicts.length ? 'blocked' : 'passed',
     count: conflicts.length,
-    items: conflicts,
+    items: compact ? [] : conflicts,
   };
 }
 
-function normaliseReadinessSection(value = null, fallbackStatus = 'not_scanned') {
+function normaliseReadinessSection(value = null, fallbackStatus = 'not_scanned', { compact = false } = {}) {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     return {
       status: fallbackStatus,
@@ -100,7 +100,7 @@ function normaliseReadinessSection(value = null, fallbackStatus = 'not_scanned')
         : 'not_scanned',
       blockers: asArray(value.strictAudioReadiness.blockers),
       affectedCount: Number(value.strictAudioReadiness.affectedCount) || 0,
-      items: asArray(value.strictAudioReadiness.items),
+      ...(compact ? {} : { items: asArray(value.strictAudioReadiness.items) }),
     };
   }
   return section;
@@ -115,14 +115,15 @@ export function buildContentOperationBlockerEnvelope({
   visibility = null,
   exposure = null,
   publishReadiness = null,
+  compact = false,
 } = {}) {
   const validationSection = normaliseValidation(validation);
-  const conflictSection = normaliseConflictSection(conflicts);
-  const audioSection = normaliseReadinessSection(audio);
-  const assetSection = normaliseReadinessSection(assets);
-  const rewardSection = normaliseReadinessSection(rewards);
-  const visibilitySection = normaliseReadinessSection(visibility);
-  const exposureSection = normaliseReadinessSection(exposure);
+  const conflictSection = normaliseConflictSection(conflicts, { compact });
+  const audioSection = normaliseReadinessSection(audio, 'not_scanned', { compact });
+  const assetSection = normaliseReadinessSection(assets, 'not_scanned', { compact });
+  const rewardSection = normaliseReadinessSection(rewards, 'not_scanned', { compact });
+  const visibilitySection = normaliseReadinessSection(visibility, 'not_scanned', { compact });
+  const exposureSection = normaliseReadinessSection(exposure, 'not_scanned', { compact });
   const blockingSections = [
     validationSection.errorCount ? 'validation' : null,
     conflictSection.count ? 'conflicts' : null,
@@ -133,7 +134,7 @@ export function buildContentOperationBlockerEnvelope({
     exposureSection.blockers.length ? 'exposure' : null,
   ].filter(Boolean);
   const readinessSection = publishReadiness
-    ? normaliseReadinessSection(publishReadiness, 'not_ready')
+    ? normaliseReadinessSection(publishReadiness, 'not_ready', { compact })
     : {
       status: blockingSections.length ? 'blocked' : 'not_ready',
       blockers: blockingSections,
@@ -217,6 +218,7 @@ export function serialiseContentOperationPackage(contentPackage = {}, { compact 
     rewards: latestCandidate?.rewardScan || null,
     visibility: latestCandidate?.visibilityScan || null,
     publishReadiness: packagePublishReadiness(contentPackage),
+    compact,
   });
   const base = {
     packageId: contentPackage.packageId,
@@ -235,7 +237,7 @@ export function serialiseContentOperationPackage(contentPackage = {}, { compact 
     publishedAt: contentPackage.publishedAt ?? null,
     supersededByPackageId: contentPackage.supersededByPackageId || null,
     operationCount: Array.isArray(contentPackage.operations) ? contentPackage.operations.length : undefined,
-    latestCandidate: latestCandidate ? serialiseContentOperationCandidate(latestCandidate) : null,
+    latestCandidate: latestCandidate ? serialiseContentOperationCandidate(latestCandidate, { compact }) : null,
     blockers: envelope,
   };
   if (!compact && Array.isArray(contentPackage.operations)) {
@@ -261,8 +263,8 @@ export function serialiseContentOperation(operation = {}) {
   };
 }
 
-export function serialiseContentOperationCandidate(candidate = {}, { includeSnapshot = false } = {}) {
-  return {
+export function serialiseContentOperationCandidate(candidate = {}, { includeSnapshot = false, compact = false } = {}) {
+  const base = {
     candidateId: candidate.candidateId,
     packageId: candidate.packageId,
     baseReleaseId: candidate.baseReleaseId || null,
@@ -270,8 +272,6 @@ export function serialiseContentOperationCandidate(candidate = {}, { includeSnap
     operationsHash: candidate.operationsHash || '',
     candidateHash: candidate.candidateHash || '',
     validation: normaliseValidation(candidate.validation),
-    audioScan: candidate.audioScan || null,
-    assetScan: candidate.assetScan || null,
     blockers: buildContentOperationBlockerEnvelope({
       validation: candidate.validation,
       conflicts: candidate.conflicts,
@@ -279,11 +279,17 @@ export function serialiseContentOperationCandidate(candidate = {}, { includeSnap
       assets: candidate.assetScan,
       rewards: candidate.rewardScan,
       visibility: candidate.visibilityScan,
+      compact,
     }),
-    conflicts: asArray(candidate.conflicts),
     createdAt: Number(candidate.createdAt) || 0,
     ...(includeSnapshot ? { candidate: candidate.candidate || null } : {}),
   };
+  if (!compact) {
+    base.audioScan = candidate.audioScan || null;
+    base.assetScan = candidate.assetScan || null;
+    base.conflicts = asArray(candidate.conflicts);
+  }
+  return base;
 }
 
 export function serialiseContentOperationAssetUpload(upload = {}) {
@@ -373,7 +379,27 @@ function releaseHasCallerProof(proof = null) {
   ));
 }
 
-function serialiseReleaseHistory(history = null) {
+function serialiseProductionProofSummary(productionProof = {}) {
+  return {
+    status: productionProof.status || 'unknown',
+    hasCallerProof: Boolean(productionProof.hasCallerProof),
+    capturedAt: Number(productionProof.capturedAt) || null,
+    requiredSurfaceCount: Array.isArray(productionProof.requiredSurfaces) ? productionProof.requiredSurfaces.length : 0,
+    linkedSurfaceCount: Array.isArray(productionProof.linkedSurfaces) ? productionProof.linkedSurfaces.length : 0,
+    missingSurfaceCount: Array.isArray(productionProof.missingSurfaces) ? productionProof.missingSurfaces.length : 0,
+    warningCount: Array.isArray(productionProof.warnings) ? productionProof.warnings.length : 0,
+    activation: productionProof.activation && typeof productionProof.activation === 'object' && !Array.isArray(productionProof.activation)
+      ? {
+          status: productionProof.activation.status || 'not_applicable',
+          checkedAt: Number(productionProof.activation.checkedAt) || null,
+          activated: Boolean(productionProof.activation.activated),
+          entryCount: Array.isArray(productionProof.activation.entries) ? productionProof.activation.entries.length : 0,
+        }
+      : null,
+  };
+}
+
+function serialiseReleaseHistory(history = null, { compact = false } = {}) {
   if (!history || typeof history !== 'object' || Array.isArray(history)) return null;
   const productionProof = history.productionProof && typeof history.productionProof === 'object' && !Array.isArray(history.productionProof)
     ? history.productionProof
@@ -418,7 +444,7 @@ function serialiseReleaseHistory(history = null) {
       hash: assetChanges.hash || '',
       preview: Array.isArray(assetChanges.preview) ? assetChanges.preview : [],
     } : null,
-    productionProof: productionProof ? {
+    productionProof: productionProof ? (compact ? serialiseProductionProofSummary(productionProof) : {
       status: productionProof.status || 'unknown',
       hasCallerProof: Boolean(productionProof.hasCallerProof),
       capturedAt: Number(productionProof.capturedAt) || null,
@@ -435,15 +461,15 @@ function serialiseReleaseHistory(history = null) {
           }
         : null,
       warnings: Array.isArray(productionProof.warnings) ? productionProof.warnings : [],
-    } : null,
+    }) : null,
   };
 }
 
-export function serialiseContentOperationRelease(release = {}, { includeSnapshot = false } = {}) {
+export function serialiseContentOperationRelease(release = {}, { includeSnapshot = false, compact = false } = {}) {
   const proof = release.proof ?? null;
   const proofAudio = releaseAudioProofFromProof(proof);
   const proofAssets = releaseAssetProofFromProof(proof);
-  return {
+  const base = {
     releaseId: release.releaseId,
     subjectId: release.subjectId || CONTENT_OPERATION_SUBJECT_ID,
     status: release.status || 'unknown',
@@ -453,16 +479,17 @@ export function serialiseContentOperationRelease(release = {}, { includeSnapshot
     publishedAt: release.publishedAt ?? null,
     publishedByAccountId: release.publishedByAccountId || null,
     rollbackOfReleaseId: release.rollbackOfReleaseId || null,
-    proof,
+    proof: compact ? undefined : proof,
     hasCallerProof: releaseHasCallerProof(proof),
     audioFallback: release.audioFallback ?? proofAudio.audioFallback,
     audioWarnings: release.audioWarnings ?? proofAudio.audioWarnings,
     assetSummary: release.assetSummary ?? proofAssets.assetSummary,
     assetReferenceManifest: release.assetReferenceManifest ?? proofAssets.assetReferenceManifest,
-    history: serialiseReleaseHistory(release.history),
+    history: serialiseReleaseHistory(release.history, { compact }),
     createdAt: Number(release.createdAt) || 0,
     ...(includeSnapshot ? { snapshot: release.snapshot || null } : {}),
   };
+  return Object.fromEntries(Object.entries(base).filter(([, value]) => value !== undefined));
 }
 
 export function serialiseContentOperationEvent(event = {}) {
@@ -493,14 +520,14 @@ export function serialiseContentOperationOverview({
 
   return {
     subjectId,
-    latestRelease: latestRelease ? serialiseContentOperationRelease(latestRelease) : null,
+    latestRelease: latestRelease ? serialiseContentOperationRelease(latestRelease, { compact: true }) : null,
     packageCounts,
     lanes: {
       blocked: packages.filter((entry) => entry.state === CONTENT_OPERATION_PACKAGE_STATES.BLOCKED).map((entry) => serialiseContentOperationPackage(entry, { compact: true })),
       readyForApproval: packages.filter((entry) => entry.state === CONTENT_OPERATION_PACKAGE_STATES.READY_FOR_APPROVAL).map((entry) => serialiseContentOperationPackage(entry, { compact: true })),
       approvedPendingPublish: packages.filter((entry) => entry.state === CONTENT_OPERATION_PACKAGE_STATES.APPROVED).map((entry) => serialiseContentOperationPackage(entry, { compact: true })),
       drafts: packages.filter((entry) => entry.state === CONTENT_OPERATION_PACKAGE_STATES.DRAFT).map((entry) => serialiseContentOperationPackage(entry, { compact: true })),
-      recentReleases: releases.map((entry) => serialiseContentOperationRelease(entry)),
+      recentReleases: releases.map((entry) => serialiseContentOperationRelease(entry, { compact: true })),
     },
     actor: actor ? serialiseContentOperationActor(actor) : null,
     sections: [...CONTENT_OPERATION_SECTION_KEYS],

--- a/worker/src/http.js
+++ b/worker/src/http.js
@@ -17,29 +17,62 @@ export async function readJson(request) {
   }
 }
 
+function payloadTooLargeError() {
+  const error = new Error('Payload exceeds maximum allowed size.');
+  error.code = 'ops_error_payload_too_large';
+  error.status = 400;
+  return error;
+}
+
 // Public-endpoint JSON reader with byte-level size enforcement (R23).
-// Reading the body as ArrayBuffer first means a crafted client cannot bypass
-// the cap by omitting or lying on `content-length` — the header is advisory.
+// The content-length header is advisory; the actual stream is capped while it
+// is being read so oversized bodies can be rejected before full buffering.
 // Throws an object with `code: 'ops_error_payload_too_large'` when oversized
 // so callers can surface it as a 400 without a full HttpError subclass.
 export async function readJsonBounded(request, maxBytes) {
   const cap = Number.isFinite(Number(maxBytes)) && Number(maxBytes) > 0
     ? Number(maxBytes)
     : 0;
-  let buffer;
+  let bytes;
   try {
-    buffer = await request.arrayBuffer();
-  } catch {
+    const reader = request.body?.getReader?.();
+    if (reader) {
+      const chunks = [];
+      let total = 0;
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          const chunk = value instanceof Uint8Array ? value : new Uint8Array(value);
+          total += chunk.byteLength;
+          if (cap > 0 && total > cap) {
+            await reader.cancel().catch(() => {});
+            throw payloadTooLargeError();
+          }
+          chunks.push(chunk);
+        }
+      } finally {
+        reader.releaseLock?.();
+      }
+      bytes = new Uint8Array(total);
+      let offset = 0;
+      for (const chunk of chunks) {
+        bytes.set(chunk, offset);
+        offset += chunk.byteLength;
+      }
+    } else {
+      const buffer = await request.arrayBuffer();
+      if (cap > 0 && buffer.byteLength > cap) {
+        throw payloadTooLargeError();
+      }
+      bytes = new Uint8Array(buffer);
+    }
+  } catch (error) {
+    if (error?.code === 'ops_error_payload_too_large') throw error;
     return {};
   }
-  if (cap > 0 && buffer.byteLength > cap) {
-    const error = new Error('Payload exceeds maximum allowed size.');
-    error.code = 'ops_error_payload_too_large';
-    error.status = 400;
-    throw error;
-  }
   try {
-    const text = new TextDecoder().decode(buffer);
+    const text = new TextDecoder().decode(bytes);
     if (!text) return {};
     return JSON.parse(text);
   } catch {


### PR DESCRIPTION
## Summary
- Add bounded Content Operations JSON reads with streaming oversize cancellation and per-surface payload caps.
- Compact list/overview/release payloads so heavy scan, proof, and conflict bodies stay on detail endpoints.
- Add account-scoped rate limits for audio generation and monster asset uploads, plus broader admin safe-copy redaction for account, learner, and child identifiers.

## Validation
- `node --test --test-name-pattern "generate-audio is account rate limited|upload-monster-asset is account rate limited|oversized package JSON bodies|oversized package operation JSON bodies|release lists compact|admin platform role|package and release history identifiers" tests/content-operations-api.test.js tests/admin-safe-copy.test.js`
- `node --test --test-name-pattern "calls read-only Content Operations Centre endpoints" tests/admin-content-operations-v2.test.js`
- `node --test tests/content-operations-api.test.js`
- `node --test tests/admin-safe-copy.test.js tests/admin-content-operations-v2.test.js`
- `node --test tests/worker-ops-error-capture.test.js tests/worker-bootstrap-v2.test.js`
- `npm run check`
- `npm test`
- pre-push `npm test` hook: 111,890 pass / 0 fail
- `git diff --check`

## Reviewer closure
- Closed list-surface snapshot/proof exposure by rejecting release-list snapshots and compacting release summaries.
- Closed package-list heavy payload exposure by omitting raw audio scans, asset scans, and conflict arrays from compact serialisation.
- Closed redaction gaps for selected learner/child/account identifiers in OPS-safe responses.
- Closed pre-buffer body cap concern by enforcing limits during stream reads when the runtime exposes a reader.